### PR TITLE
EES-2786 EES-2808 reorder filters and indicators frontend

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
@@ -2,6 +2,7 @@ import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext'
 import ReleaseDataUploadsSection from '@admin/pages/release/data/components/ReleaseDataUploadsSection';
 import ReleaseFileUploadsSection from '@admin/pages/release/data/components/ReleaseFileUploadsSection';
 import ReleaseDataGuidanceSection from '@admin/pages/release/data/components/ReleaseDataGuidanceSection';
+import ReleaseDataReorderSection from '@admin/pages/release/data/components/ReleaseDataReorderSection';
 import permissionService from '@admin/services/permissionService';
 import { DataFile } from '@admin/services/releaseDataFileService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -65,6 +66,13 @@ const ReleaseDataPage = () => {
             canUpdateRelease={canUpdateRelease}
           />
         </TabsSection>
+        {/* EES-1243 
+        <TabsSection id="test-id" title="Reorder filters and indicators">
+          <ReleaseDataReorderSection
+            releaseId={releaseId}
+            canUpdateRelease={canUpdateRelease}
+          />
+        </TabsSection> */}
       </Tabs>
     </LoadingSpinner>
   );

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataReorderSection.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataReorderSection.module.scss
@@ -1,0 +1,5 @@
+@import '~govuk-frontend/govuk/base';
+
+.table td {
+  vertical-align: middle;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataReorderSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataReorderSection.tsx
@@ -30,12 +30,8 @@ const ReleaseDataReorderSection = ({ releaseId, canUpdateRelease }: Props) => {
     () => tableBuilderService.listReleaseSubjects(releaseId),
     [releaseId],
   );
-  const [reorderingFilters, setReorderingFilters] = useState<
-    Subject | undefined
-  >();
-  const [reorderingIndicators, setReorderingIndicators] = useState<
-    Subject | undefined
-  >();
+  const [reorderingFilters, setReorderingFilters] = useState<Subject>();
+  const [reorderingIndicators, setReorderingIndicators] = useState<Subject>();
 
   const handleSaveFilters = (updatedFilters: UpdateFiltersRequest) => {
     setReorderingFilters(undefined);
@@ -52,8 +48,9 @@ const ReleaseDataReorderSection = ({ releaseId, canUpdateRelease }: Props) => {
       <InsetText>
         <h3>Before you start</h3>
         <p>
-          Reorder the groups and options for filters and indicators here. This
-          order will be reflected in the table tool on the public website.
+          Reorder the groups and options for filters and indicators on this
+          page. This order will be reflected in the table tool on the public
+          website.
         </p>
       </InsetText>
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataReorderSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataReorderSection.tsx
@@ -1,0 +1,133 @@
+import ReorderFiltersList, {
+  UpdateFiltersRequest,
+} from '@admin/pages/release/data/components/ReorderFiltersList';
+import ReorderIndicatorsList, {
+  UpdateIndicatorsRequest,
+} from '@admin/pages/release/data/components/ReorderIndicatorsList';
+import styles from '@admin/pages/release/data/components/ReleaseDataReorderSection.module.scss';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import tableBuilderService, {
+  Subject,
+} from '@common/services/tableBuilderService';
+import Button from '@common/components/Button';
+import InsetText from '@common/components/InsetText';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import WarningMessage from '@common/components/WarningMessage';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+
+import React, { useState } from 'react';
+
+interface Props {
+  releaseId: string;
+  canUpdateRelease: boolean;
+}
+
+const ReleaseDataReorderSection = ({ releaseId, canUpdateRelease }: Props) => {
+  const {
+    value: subjects,
+    isLoading: isLoadingSubjects,
+  } = useAsyncHandledRetry(
+    () => tableBuilderService.listReleaseSubjects(releaseId),
+    [releaseId],
+  );
+  const [reorderingFilters, setReorderingFilters] = useState<
+    Subject | undefined
+  >();
+  const [reorderingIndicators, setReorderingIndicators] = useState<
+    Subject | undefined
+  >();
+
+  const handleSaveFilters = (updatedFilters: UpdateFiltersRequest) => {
+    setReorderingFilters(undefined);
+    // TO DO: send the update request.
+  };
+  const handleSaveIndicators = (updatedIndicators: UpdateIndicatorsRequest) => {
+    setReorderingIndicators(undefined);
+    // TO DO: send the update request.
+  };
+
+  return (
+    <>
+      <h2>Reorder filters and indicators</h2>
+      <InsetText>
+        <h3>Before you start</h3>
+        <p>
+          Reorder the groups and options for filters and indicators here. This
+          order will be reflected in the table tool on the public website.
+        </p>
+      </InsetText>
+
+      {!canUpdateRelease ? (
+        <WarningMessage>
+          This release has been approved, and can no longer be updated.
+        </WarningMessage>
+      ) : (
+        <>
+          <LoadingSpinner loading={isLoadingSubjects}>
+            <>
+              {subjects?.length === 0 && <p>No data files uploaded.</p>}
+
+              {subjects?.length !== 0 &&
+                !reorderingFilters &&
+                !reorderingIndicators && (
+                  <table className={styles.table}>
+                    <thead>
+                      <tr>
+                        <th>Data file</th>
+                        <th>
+                          <VisuallyHidden>Actions</VisuallyHidden>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {subjects?.map(subject => {
+                        return (
+                          <tr key={subject.id}>
+                            <td className="govuk-!-width-two-thirds">
+                              {subject.name}
+                            </td>
+                            <td className="dfe-align--right">
+                              <Button
+                                className="govuk-!-margin-bottom-0 govuk-!-margin-right-2"
+                                onClick={() => setReorderingFilters(subject)}
+                              >
+                                Reorder filters
+                              </Button>
+                              <Button
+                                className="govuk-!-margin-bottom-0"
+                                onClick={() => setReorderingIndicators(subject)}
+                              >
+                                Reorder indicators
+                              </Button>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                )}
+            </>
+          </LoadingSpinner>
+          <div aria-live="polite">
+            {reorderingFilters && (
+              <ReorderFiltersList
+                subject={reorderingFilters}
+                onCancel={() => setReorderingFilters(undefined)}
+                onSave={handleSaveFilters}
+              />
+            )}
+            {reorderingIndicators && (
+              <ReorderIndicatorsList
+                subject={reorderingIndicators}
+                onCancel={() => setReorderingIndicators(undefined)}
+                onSave={handleSaveIndicators}
+              />
+            )}
+          </div>
+        </>
+      )}
+    </>
+  );
+};
+
+export default ReleaseDataReorderSection;

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderFiltersList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderFiltersList.tsx
@@ -113,7 +113,7 @@ const testSubjectMeta: SubjectMeta = {
 
 interface UpdatedFilter {
   id?: string;
-  filterGroups: { id?: string; filterItems: (string | undefined)[] }[];
+  filterGroups: { id?: string; filterItems: (string | undefined)[] }[]; // EES-1243 - won't need the undefined when ids exist
 }
 export type UpdateFiltersRequest = UpdatedFilter[];
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderFiltersList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderFiltersList.tsx
@@ -1,0 +1,242 @@
+import ReorderList, {
+  FormattedGroup,
+  FormattedFilters,
+  ReorderProps,
+} from '@admin/pages/release/data/components/ReorderList';
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import tableBuilderService, {
+  Subject,
+  SubjectMeta,
+} from '@common/services/tableBuilderService';
+import orderBy from 'lodash/orderBy';
+import React, { useEffect, useState } from 'react';
+
+// EES-1243 - remove this when the backend is done
+const testSubjectMeta: SubjectMeta = {
+  filters: {
+    Category1: {
+      id: 'category-1-id',
+      legend: 'Category 1',
+      name: 'category-1',
+      options: {
+        Category1Group1: {
+          id: 'category-1-group-1-id',
+          label: 'Category 1 Group 1',
+          options: [
+            {
+              label: 'Category 1 Group 1 Item 1',
+              value: 'category-1-group-1-item-1',
+              id: 'category-1-group-1-item-1-id',
+            },
+          ],
+          order: 1,
+        },
+        Category1Group2: {
+          id: 'category-1-group-2-id',
+          label: 'Category 1 Group 2',
+          options: [
+            {
+              label: 'Category 1 Group 2 Item 1',
+              value: 'category-1-group-2-item-1',
+              id: 'category-1-group-2-item-1-id',
+            },
+            {
+              label: 'Category 1 Group 2 Item 2',
+              value: 'category-1-group-2-item-2',
+              id: 'category-1-group-2-item-2-id',
+            },
+            {
+              label: 'Category 1 Group 2 Item 3',
+              value: 'category-1-group-2-item-3',
+              id: 'category-1-group-2-item-3-id',
+            },
+          ],
+          order: 0,
+        },
+        Category1Group3: {
+          id: 'category-1-group-3-id',
+          label: 'Category 1 Group 3',
+          options: [
+            {
+              label: 'Category 1 Group 3 Item 1',
+              value: 'category-1-group-3-item-1',
+              id: 'category-1-group-3-item-1-id',
+            },
+            {
+              label: 'Category 1 Group 3 Item 2',
+              value: 'category-1-group-3-item-2',
+              id: 'category-1-group-3-item-2-id',
+            },
+          ],
+          order: 2,
+        },
+      },
+      order: 1,
+    },
+    Category2: {
+      id: 'category-2-id',
+      legend: 'Category 2',
+      name: 'category-2',
+      options: {
+        Category2Group1: {
+          id: 'category-2-group-1-id',
+          label: 'Category 2 Group 1',
+          options: [
+            {
+              label: 'Category 2 Group 1 Item 1',
+              value: 'category-2-group-1-item-1',
+              id: 'category-2-group-1-item-1-id',
+            },
+            {
+              label: 'Category 2 Group 1 Item 2',
+              value: 'category-2-group-1-item-2',
+              id: 'category-2-group-1-item-2-id',
+            },
+          ],
+          order: 0,
+        },
+      },
+      order: 0,
+    },
+  },
+  indicators: {},
+  locations: {},
+  timePeriod: {
+    hint: '',
+    legend: '',
+    options: [],
+  },
+};
+
+interface UpdatedFilter {
+  id?: string;
+  filterGroups: { id?: string; filterItems: (string | undefined)[] }[];
+}
+export type UpdateFiltersRequest = UpdatedFilter[];
+
+interface Props {
+  subject: Subject;
+  onCancel: () => void;
+  onSave: (requestFilters: UpdateFiltersRequest) => void;
+}
+
+const ReorderFiltersList = ({ subject, onCancel, onSave }: Props) => {
+  const { value: subjectMeta, isLoading } = useAsyncHandledRetry(
+    () => tableBuilderService.getSubjectMeta(subject.id),
+    [subject.id],
+  );
+
+  const [filters, setFilters] = useState<FormattedFilters[]>([]);
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+    // EES-1243 - restore this line to use the real filters.
+    // const filtersMeta = subjectMeta?.filters || {};
+    const filtersMeta = testSubjectMeta.filters;
+
+    // Transforming the filters to be nested arrays rather than keyed objects.
+    // Order by the order fields.
+    const formattedFilters = orderBy(
+      Object.entries(filtersMeta).map(([, group]) => {
+        return {
+          id: group.id,
+          label: group.legend,
+          order: group.order,
+          groups: orderBy(
+            Object.entries(group.options).map(([, item]) => {
+              return {
+                id: item.id,
+                label: item.label,
+                order: item.order,
+                items: item.options,
+              };
+            }),
+            'order',
+          ),
+        };
+      }),
+      'order',
+    );
+    setFilters(formattedFilters);
+  }, [isLoading, subjectMeta?.filters]);
+
+  const handleReorder = ({
+    reordered,
+    parentCategoryId,
+    parentGroupId,
+  }: ReorderProps) => {
+    // reordering filters
+    if (!parentCategoryId && !parentGroupId) {
+      setFilters(reordered as FormattedFilters[]);
+      return;
+    }
+
+    const reorderedFilters = filters.map(filter => {
+      if (filter.id !== parentCategoryId) {
+        return filter;
+      }
+      // Reordering groups
+      if (!parentGroupId || parentGroupId === parentCategoryId) {
+        return { ...filter, groups: reordered };
+      }
+      // Reordering items
+      const updatedFilterGroups = filter.groups.map(
+        (filterGroup: FormattedGroup) => {
+          if (filterGroup.id !== parentGroupId) {
+            return filterGroup;
+          }
+          return {
+            ...filterGroup,
+            items: reordered,
+          };
+        },
+      );
+
+      return { ...filter, groups: updatedFilterGroups };
+    }) as FormattedFilters[];
+
+    setFilters(reorderedFilters);
+  };
+
+  const handleSave = () => {
+    const updateFiltersRequest: UpdateFiltersRequest = filters.map(filter => {
+      return {
+        id: filter.id,
+        filterGroups: filter.groups.map(group => {
+          return {
+            id: group.id,
+            filterItems: group.items.map(item => item.id),
+          };
+        }),
+      };
+    });
+    onSave(updateFiltersRequest);
+  };
+
+  return (
+    <>
+      <h3>Reorder filters for {subject.name}</h3>
+      <LoadingSpinner loading={isLoading}>
+        {filters.length === 0 ? (
+          <p>No filters available.</p>
+        ) : (
+          <ReorderList listItems={filters} onReorder={handleReorder} />
+        )}
+        <ButtonGroup>
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+          {filters.length > 0 && (
+            <Button onClick={handleSave}>Save order</Button>
+          )}
+        </ButtonGroup>
+      </LoadingSpinner>
+    </>
+  );
+};
+export default ReorderFiltersList;

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderIndicatorsList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderIndicatorsList.tsx
@@ -1,0 +1,165 @@
+import ReorderList, {
+  FormattedIndicators,
+  ReorderProps,
+} from '@admin/pages/release/data/components/ReorderList';
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import tableBuilderService, {
+  Subject,
+  SubjectMeta,
+} from '@common/services/tableBuilderService';
+import orderBy from 'lodash/orderBy';
+import React, { useEffect, useState } from 'react';
+
+// EES-1243 - remove this when the backend is done
+const testSubjectMeta: SubjectMeta = {
+  filters: {},
+  indicators: {
+    Category1: {
+      id: 'category-1-id',
+      label: 'Category 1',
+      options: [
+        {
+          id: 'category-1-item-1-id',
+          value: 'category-1-item-1',
+          label: 'Category 1 Item 1',
+          unit: '',
+          name: 'category_1_item_1',
+        },
+        {
+          id: 'category-1-item-2-id',
+          value: 'category-1-item-2',
+          label: 'Category 1 Item 2',
+          unit: '',
+          name: 'category_1_item_2',
+        },
+        {
+          id: 'category-1-item-3-id',
+          value: 'category-1-item-3',
+          label: 'Category 1 Item 3',
+          unit: '',
+          name: 'category_1_item_3',
+        },
+      ],
+      order: 1,
+    },
+    Category2: {
+      id: 'category-2-id',
+      label: 'Category 2',
+      options: [
+        {
+          id: 'category-2-item-1-id',
+          value: 'category-2-item-1',
+          label: 'Category 2 Item 1',
+          unit: '',
+          name: 'category_2_item_1',
+        },
+      ],
+      order: 0,
+    },
+  },
+  locations: {},
+  timePeriod: {
+    hint: '',
+    legend: '',
+    options: [],
+  },
+};
+
+interface UpdatedIndicator {
+  id?: string;
+  indicatorItems: (string | undefined)[];
+}
+export type UpdateIndicatorsRequest = UpdatedIndicator[];
+
+interface Props {
+  subject: Subject;
+  onCancel: () => void;
+  onSave: (orderedIndicators: UpdateIndicatorsRequest) => void;
+}
+
+const ReorderIndicatorsList = ({ subject, onCancel, onSave }: Props) => {
+  const { value: subjectMeta, isLoading } = useAsyncHandledRetry(
+    () => tableBuilderService.getSubjectMeta(subject.id),
+    [subject.id],
+  );
+
+  const [indicators, setIndicators] = useState<FormattedIndicators[]>([]);
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+    // EES-1243 - restore this line to use the real indicators
+    // const indicatorsMeta = subjectMeta?.indicators || {};
+    const indicatorsMeta = testSubjectMeta.indicators;
+
+    // Transforming the indicators to be nested arrays rather than keyed objects.
+    // Order by the order field.
+    const formattedIndicators = orderBy(
+      Object.entries(indicatorsMeta).map(([, item]) => {
+        return {
+          id: item.id,
+          label: item.label,
+          order: item.order,
+          items: item.options,
+        };
+      }),
+      'order',
+    );
+
+    setIndicators(formattedIndicators);
+  }, [isLoading, subjectMeta?.indicators]);
+
+  const handleReorder = ({ reordered, parentCategoryId }: ReorderProps) => {
+    // reordering indicators
+    if (!parentCategoryId) {
+      setIndicators(reordered as FormattedIndicators[]);
+      return;
+    }
+    // reordering indicator items
+    const reorderedIndicators = indicators.map(indicator =>
+      indicator.id !== parentCategoryId
+        ? indicator
+        : { ...indicator, items: reordered },
+    ) as FormattedIndicators[];
+
+    setIndicators(reorderedIndicators);
+  };
+
+  const handleSave = () => {
+    const updateIndicatorsRequest: UpdateIndicatorsRequest = indicators.map(
+      indicator => {
+        return {
+          id: indicator.id,
+          indicatorItems: indicator.items.map(item => item.id),
+        };
+      },
+    );
+    onSave(updateIndicatorsRequest);
+  };
+
+  return (
+    <>
+      <h3>Reorder indicators for {subject.name}</h3>
+      <LoadingSpinner loading={isLoading}>
+        {indicators.length === 0 ? (
+          <p>No indicators available.</p>
+        ) : (
+          <ReorderList listItems={indicators} onReorder={handleReorder} />
+        )}
+        <ButtonGroup>
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+          {indicators.length > 0 && (
+            <Button onClick={handleSave}>Save order</Button>
+          )}
+        </ButtonGroup>
+      </LoadingSpinner>
+    </>
+  );
+};
+export default ReorderIndicatorsList;

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.module.scss
@@ -1,0 +1,72 @@
+@import '~govuk-frontend/govuk/base';
+
+.dropArea {
+  background: govuk-colour('light-grey');
+  list-style: none;
+  margin: 0 govuk-spacing(2) govuk-spacing(2) 0;
+  padding: 0;
+}
+
+.dropAreaActive {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+}
+
+.draggable {
+  background: govuk-colour('white');
+  border-bottom: 1px solid govuk-colour('dark-grey');
+  margin-bottom: 0;
+  padding: 0 0 0 govuk-spacing(7);
+  position: relative;
+
+  &::before {
+    color: govuk-colour('dark-grey');
+    content: '\2630';
+    cursor: grab;
+    font-size: 1.6rem;
+    left: 4px;
+    position: absolute;
+    top: 7px;
+  }
+
+  &:focus,
+  &.isDragging {
+    @include govuk-focused-text;
+  }
+
+  &.isDraggedOutside {
+    opacity: 0.7;
+  }
+}
+
+.draggable.isDisabled {
+  &::before {
+    content: none;
+  }
+}
+
+.draggable.isExpanded {
+  background: govuk-colour('light-grey');
+
+  &::before {
+    content: '\25BC';
+    font-size: 1rem;
+    left: 8px;
+    top: 12px;
+  }
+
+  .isExpanded {
+    background: lighten(govuk-colour('light-grey'), 2);
+  }
+}
+
+.draggableInner {
+  display: flex;
+  flex-grow: 1;
+  justify-content: space-between;
+  padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+}
+.optionLabel {
+  &.isExpanded {
+    font-weight: $govuk-font-weight-bold;
+  }
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.tsx
@@ -1,0 +1,209 @@
+import styles from '@admin/pages/release/data/components/ReorderList.module.scss';
+import ButtonText from '@common/components/ButtonText';
+import {
+  FilterOption,
+  IndicatorOption,
+} from '@common/services/tableBuilderService';
+import reorder from '@common/utils/reorder';
+import classNames from 'classnames';
+import React, { useState } from 'react';
+import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
+
+export interface FormattedGroup {
+  id?: string;
+  label: string;
+  items: FilterOption[];
+}
+export interface FormattedFilters {
+  id?: string;
+  label: string;
+  groups: FormattedGroup[];
+}
+export interface FormattedIndicators {
+  id?: string;
+  label: string;
+  items: IndicatorOption[];
+}
+export interface ReorderProps {
+  reordered: (
+    | FormattedIndicators
+    | IndicatorOption
+    | FormattedFilters
+    | FilterOption
+    | FormattedGroup
+  )[];
+  parentCategoryId?: string;
+  parentGroupId?: string;
+}
+
+const getChildItems = (
+  option:
+    | FormattedFilters
+    | FormattedGroup
+    | FilterOption
+    | IndicatorOption
+    | FormattedIndicators,
+): (IndicatorOption | FilterOption | FormattedGroup)[] | undefined => {
+  if ('groups' in option && option.groups.length > 1) {
+    return option.groups;
+  }
+  if ('groups' in option && option.groups.length === 1) {
+    return option.groups[0].items;
+  }
+  if ('items' in option && option.items.length > 1) {
+    return option.items;
+  }
+  return undefined;
+};
+
+interface ReorderListProps {
+  listItems: (
+    | FormattedIndicators
+    | IndicatorOption
+    | FormattedFilters
+    | FilterOption
+    | FormattedGroup
+  )[];
+  categoryId?: string;
+  groupId?: string;
+  onReorder: ({
+    reordered,
+    parentCategoryId,
+    parentGroupId,
+  }: ReorderProps) => void;
+}
+const ReorderList = ({
+  listItems,
+  categoryId,
+  groupId,
+  onReorder,
+}: ReorderListProps) => {
+  const [reorderingGroups, setReorderingGroups] = useState<string[]>([]);
+
+  // If category has only one group, just show its options not the group.
+  const options =
+    listItems.length === 1 && 'items' in listItems[0]
+      ? listItems[0].items
+      : listItems;
+
+  const parentGroupId =
+    listItems.length === 1 && 'items' in listItems[0]
+      ? listItems[0].id
+      : groupId;
+
+  return (
+    <DragDropContext
+      onDragEnd={result => {
+        if (!result.destination) {
+          return;
+        }
+
+        const reordered = reorder(
+          options,
+          result.source.index,
+          result.destination.index,
+        );
+
+        // Update the order property if it's a category or group, don't if it's items
+        onReorder({
+          reordered: reordered.map((option, index) => {
+            if ('order' in reordered[0]) {
+              return {
+                ...option,
+                order: index,
+              };
+            }
+            return option;
+          }),
+          parentCategoryId: categoryId,
+          parentGroupId,
+        });
+      }}
+    >
+      <Droppable droppableId="droppablegroups">
+        {(droppableProvided, droppableSnapshot) => (
+          <ol
+            className={classNames(styles.dropArea, {
+              [styles.dropAreaActive]: droppableSnapshot.isDraggingOver,
+            })}
+            data-testid="reorder-list"
+            ref={droppableProvided.innerRef}
+          >
+            {options.map((option, index) => {
+              const key = option.id || `key-${index}`; // EES-1243 - temp key here while the id is optional
+              const isExpanded = reorderingGroups.includes(key);
+              const childOptions = getChildItems(option);
+              return (
+                <Draggable
+                  draggableId={key}
+                  isDragDisabled={reorderingGroups.length !== 0}
+                  key={key}
+                  index={index}
+                >
+                  {(draggableProvided, draggableSnapshot) => {
+                    return (
+                      <li
+                        // eslint-disable-next-line react/jsx-props-no-spreading
+                        {...draggableProvided.draggableProps}
+                        // eslint-disable-next-line react/jsx-props-no-spreading
+                        {...draggableProvided.dragHandleProps}
+                        className={classNames(styles.draggable, {
+                          [styles.isDisabled]:
+                            reorderingGroups.length && !isExpanded,
+                          [styles.isExpanded]: isExpanded,
+                          [styles.isDragging]: draggableSnapshot.isDragging,
+                          [styles.isDraggedOutside]:
+                            draggableSnapshot.isDragging &&
+                            !draggableSnapshot.draggingOver,
+                        })}
+                        ref={draggableProvided.innerRef}
+                      >
+                        <span className={styles.draggableInner}>
+                          <span
+                            className={classNames(styles.optionLabel, {
+                              [styles.isExpanded]: isExpanded,
+                            })}
+                          >
+                            {option.label}
+                          </span>
+                          {childOptions && (
+                            <ButtonText
+                              className="govuk-!-margin-bottom-0"
+                              onClick={() => {
+                                setReorderingGroups(
+                                  isExpanded
+                                    ? reorderingGroups.filter(
+                                        item => item !== key,
+                                      )
+                                    : [...reorderingGroups, key],
+                                );
+                              }}
+                            >
+                              {isExpanded
+                                ? 'Done'
+                                : 'Reorder options within this group'}
+                            </ButtonText>
+                          )}
+                        </span>
+                        {childOptions && isExpanded && (
+                          <ReorderList
+                            listItems={childOptions}
+                            categoryId={categoryId || option.id}
+                            groupId={option.id}
+                            onReorder={onReorder}
+                          />
+                        )}
+                      </li>
+                    );
+                  }}
+                </Draggable>
+              );
+            })}
+            {droppableProvided.placeholder}
+          </ol>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+};
+export default ReorderList;

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderFiltersList.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderFiltersList.test.tsx
@@ -1,0 +1,453 @@
+import ReorderFiltersList from '@admin/pages/release/data/components/ReorderFiltersList';
+import _tableBuilderService, {
+  Subject,
+  SubjectMeta,
+} from '@common/services/tableBuilderService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import React from 'react';
+
+jest.mock('@common/services/tableBuilderService');
+
+const tableBuilderService = _tableBuilderService as jest.Mocked<
+  typeof _tableBuilderService
+>;
+
+const testSubject = {
+  id: 'subject-id',
+  name: 'Subject Name',
+} as Subject;
+
+const testSubjectMeta: SubjectMeta = {
+  filters: {
+    Category1: {
+      id: 'category-1-id',
+      legend: 'Category 1',
+      name: 'category-1',
+      options: {
+        Category1Group1: {
+          id: 'category-1-group-1-id',
+          label: 'Category 1 Group 1',
+          options: [
+            {
+              label: 'Category 1 Group 1 Item 1',
+              value: 'category-1-group-1-item-1',
+              id: 'category-1-group-1-item-1-id',
+            },
+          ],
+          order: 1,
+        },
+        Category1Group2: {
+          id: 'category-1-group-2-id',
+          label: 'Category 1 Group 2',
+          options: [
+            {
+              label: 'Category 1 Group 2 Item 1',
+              value: 'category-1-group-2-item-1',
+              id: 'category-1-group-2-item-1-id',
+            },
+            {
+              label: 'Category 1 Group 2 Item 2',
+              value: 'category-1-group-2-item-2',
+              id: 'category-1-group-2-item-2-id',
+            },
+            {
+              label: 'Category 1 Group 2 Item 3',
+              value: 'category-1-group-2-item-3',
+              id: 'category-1-group-2-item-3-id',
+            },
+          ],
+          order: 0,
+        },
+        Category1Group3: {
+          id: 'category-1-group-3-id',
+          label: 'Category 1 Group 3',
+          options: [
+            {
+              label: 'Category 1 Group 3 Item 1',
+              value: 'category-1-group-3-item-1',
+              id: 'category-1-group-3-item-1-id',
+            },
+            {
+              label: 'Category 1 Group 3 Item 2',
+              value: 'category-1-group-3-item-2',
+              id: 'category-1-group-3-item-2-id',
+            },
+          ],
+          order: 2,
+        },
+      },
+      order: 1,
+    },
+    Category2: {
+      id: 'category-2-id',
+      legend: 'Category 2',
+      name: 'category-2',
+      options: {
+        Category2Group1: {
+          id: 'category-2-group-1-id',
+          label: 'Category 2 Group 1',
+          options: [
+            {
+              label: 'Category 2 Group 1 Item 1',
+              value: 'category-2-group-1-item-1',
+              id: 'category-2-group-1-item-1-id',
+            },
+            {
+              label: 'Category 2 Group 1 Item 2',
+              value: 'category-2-group-1-item-2',
+              id: 'category-2-group-1-item-2-id',
+            },
+          ],
+          order: 0,
+        },
+      },
+      order: 0,
+    },
+  },
+  indicators: {},
+  locations: {},
+  timePeriod: {
+    hint: '',
+    legend: '',
+    options: [],
+  },
+};
+
+describe('ReorderFiltersList', () => {
+  test('renders a list of filters for the subject ordered by the order property', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderFiltersList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Reorder filters for Subject Name' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+
+    const filters = within(screen.getByTestId('reorder-list')).getAllByRole(
+      'button',
+    );
+
+    // the listitems are given role 'button' by react-dnd
+    expect(within(filters[0]).getByText('Category 2'));
+    expect(
+      within(filters[0]).getByRole('button', {
+        name: 'Reorder options within this group',
+      }),
+    );
+    expect(within(filters[2]).getByText('Category 1'));
+    expect(
+      within(filters[2]).getByRole('button', {
+        name: 'Reorder options within this group',
+      }),
+    );
+  });
+
+  test('shows a message if there are no filters', async () => {
+    const testNoFiltersSubjectMeta = {
+      filters: {},
+      indicators: {},
+      locations: {},
+      timePeriod: {
+        hint: '',
+        legend: '',
+        options: [],
+      },
+    };
+    tableBuilderService.getSubjectMeta.mockResolvedValue(
+      testNoFiltersSubjectMeta,
+    );
+    render(
+      <ReorderFiltersList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No filters available.'));
+      expect(screen.queryByTestId('reorder-list')).not.toBeInTheDocument();
+    });
+  });
+
+  test('clicking the `reorder options` button on a filter shows the filter groups for the filter ordered by the order property', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderFiltersList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+    const filtersList = screen.getByTestId('reorder-list');
+    userEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Reorder options within this group',
+      })[1],
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Category 1 Group 2'));
+    });
+    const groupsList = within(filtersList).getByRole('list');
+    const groups = within(groupsList).getAllByRole('button');
+    expect(within(groups[0]).getByText('Category 1 Group 2'));
+    expect(within(groups[2]).getByText('Category 1 Group 1'));
+    expect(within(groups[3]).getByText('Category 1 Group 3'));
+  });
+
+  test('filter groups have a `reorder options` button if they have more than one filter item', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderFiltersList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+    const filtersList = screen.getByTestId('reorder-list');
+    userEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Reorder options within this group',
+      })[1],
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Category 1 Group 2'));
+    });
+
+    const groupsList = within(filtersList).getByRole('list');
+    const groups = within(groupsList).getAllByRole('button');
+    expect(within(groups[0]).getByText('Category 1 Group 2'));
+    expect(
+      within(groups[0]).getByRole('button', {
+        name: 'Reorder options within this group',
+      }),
+    );
+    expect(within(groups[2]).getByText('Category 1 Group 1'));
+    expect(
+      within(groups[2]).queryByRole('button', {
+        name: 'Reorder options within this group',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(within(groups[3]).getByText('Category 1 Group 3'));
+    expect(
+      within(groups[3]).getByRole('button', {
+        name: 'Reorder options within this group',
+      }),
+    );
+  });
+
+  test('clicking the `done` button on a filter hides the groups for the filter', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderFiltersList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+    const filtersList = screen.getByTestId('reorder-list');
+    userEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Reorder options within this group',
+      })[1],
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Category 1 Group 2'));
+    });
+
+    expect(within(filtersList).getByRole('list'));
+    userEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(screen.queryByText('Category 1 Group 2')).not.toBeInTheDocument();
+    expect(within(filtersList).queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  test('clicking the `reorder options` button on a filter group shows the options for that group', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderFiltersList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+    const filtersList = screen.getByTestId('reorder-list');
+    userEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Reorder options within this group',
+      })[1],
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Category 1 Group 2'));
+    });
+    const buttons = within(within(filtersList).getByRole('list')).getAllByRole(
+      'button',
+    );
+    userEvent.click(
+      within(buttons[0]).getByRole('button', {
+        name: 'Reorder options within this group',
+      }),
+    );
+
+    const options = within(buttons[0]).getAllByRole('button');
+    expect(within(options[1]).getByText('Category 1 Group 2 Item 1'));
+    expect(within(options[2]).getByText('Category 1 Group 2 Item 2'));
+    expect(within(options[3]).getByText('Category 1 Group 2 Item 3'));
+  });
+
+  test('clicking the `done` button on a filter group hides the options for the group', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderFiltersList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+    const filtersList = screen.getByTestId('reorder-list');
+    userEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Reorder options within this group',
+      })[1],
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Category 1 Group 2'));
+    });
+
+    const groupsList = within(filtersList).getByRole('list');
+    const groups = within(groupsList).getAllByRole('button');
+
+    userEvent.click(
+      within(groups[0]).getByRole('button', {
+        name: 'Reorder options within this group',
+      }),
+    );
+
+    const options = within(groups[0]).getAllByRole('button');
+
+    expect(within(options[1]).getByText('Category 1 Group 2 Item 1'));
+
+    userEvent.click(within(groups[0]).getByRole('button', { name: 'Done' }));
+
+    expect(
+      screen.queryByText('Category 1 Group 2 Item 1'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('if the filter only has one group, clicking the `reorder options` button on the filter shows the options for the group', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderFiltersList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+    const filtersList = screen.getByTestId('reorder-list');
+    userEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Reorder options within this group',
+      })[0],
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Category 2 Group 1 Item 1'));
+    });
+
+    const optionsList = within(filtersList).getByRole('list');
+    const options = within(optionsList).getAllByRole('button');
+    expect(within(options[0]).getByText('Category 2 Group 1 Item 1'));
+    expect(within(options[1]).getByText('Category 2 Group 1 Item 2'));
+  });
+
+  test('clicking the `save` button calls handleSave with the redoreded list formatted for the update request', async () => {
+    const handleSave = jest.fn();
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderFiltersList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={handleSave}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+    userEvent.click(screen.getByRole('button', { name: 'Save order' }));
+
+    const expectedRequest = [
+      {
+        id: 'category-2-id',
+        filterGroups: [
+          {
+            filterItems: [
+              'category-2-group-1-item-1-id',
+              'category-2-group-1-item-2-id',
+            ],
+            id: 'category-2-group-1-id',
+          },
+        ],
+      },
+      {
+        id: 'category-1-id',
+        filterGroups: [
+          {
+            id: 'category-1-group-2-id',
+            filterItems: [
+              'category-1-group-2-item-1-id',
+              'category-1-group-2-item-2-id',
+              'category-1-group-2-item-3-id',
+            ],
+          },
+          {
+            id: 'category-1-group-1-id',
+            filterItems: ['category-1-group-1-item-1-id'],
+          },
+          {
+            id: 'category-1-group-3-id',
+            filterItems: [
+              'category-1-group-3-item-1-id',
+              'category-1-group-3-item-2-id',
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(handleSave).toHaveBeenCalledWith(expectedRequest);
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderIndicatorsList.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderIndicatorsList.test.tsx
@@ -1,0 +1,254 @@
+import ReorderIndicatorsList from '@admin/pages/release/data/components/ReorderIndicatorsList';
+import _tableBuilderService, {
+  Subject,
+  SubjectMeta,
+} from '@common/services/tableBuilderService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import React from 'react';
+
+jest.mock('@common/services/tableBuilderService');
+
+const tableBuilderService = _tableBuilderService as jest.Mocked<
+  typeof _tableBuilderService
+>;
+
+const testSubject = {
+  id: 'subject-id',
+  name: 'Subject Name',
+} as Subject;
+
+const testSubjectMeta: SubjectMeta = {
+  filters: {},
+  indicators: {
+    Category1: {
+      id: 'category-1-id',
+      label: 'Category 1',
+      options: [
+        {
+          id: 'category-1-item-1-id',
+          value: 'category-1-item-1',
+          label: 'Category 1 Item 1',
+          unit: '',
+          name: 'category_1_item_1',
+        },
+        {
+          id: 'category-1-item-2-id',
+          value: 'category-1-item-2',
+          label: 'Category 1 Item 2',
+          unit: '',
+          name: 'category_1_item_2',
+        },
+        {
+          id: 'category-1-item-3-id',
+          value: 'category-1-item-3',
+          label: 'Category 1 Item 3',
+          unit: '',
+          name: 'category_1_item_3',
+        },
+      ],
+      order: 1,
+    },
+    Category2: {
+      id: 'category-2-id',
+      label: 'Category 2',
+      options: [
+        {
+          id: 'category-2-item-1-id',
+          value: 'category-2-item-1',
+          label: 'Category 2 Item 1',
+          unit: '',
+          name: 'category_2_item_1',
+        },
+      ],
+      order: 0,
+    },
+  },
+  locations: {},
+  timePeriod: {
+    hint: '',
+    legend: '',
+    options: [],
+  },
+};
+
+describe('ReorderIndicatorsList', () => {
+  test('renders a list of indicators for the subject ordered by the order property', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderIndicatorsList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Reorder indicators for Subject Name',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+
+    // the listitems are given role 'button' by react-dnd
+    const indicators = within(screen.getByTestId('reorder-list')).getAllByRole(
+      'button',
+    );
+    expect(within(indicators[0]).getByText('Category 2'));
+    expect(within(indicators[1]).getByText('Category 1'));
+  });
+
+  test('shows a message if there are no indicators', async () => {
+    const testNoFiltersSubjectMeta = {
+      filters: {},
+      indicators: {},
+      locations: {},
+      timePeriod: {
+        hint: '',
+        legend: '',
+        options: [],
+      },
+    };
+    tableBuilderService.getSubjectMeta.mockResolvedValue(
+      testNoFiltersSubjectMeta,
+    );
+    render(
+      <ReorderIndicatorsList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No indicators available.'));
+      expect(screen.queryByTestId('reorder-list')).not.toBeInTheDocument();
+    });
+  });
+
+  test('indicators have a `reorder options` button if they have more than one item', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderIndicatorsList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+    const indicatorsList = screen.getByTestId('reorder-list');
+
+    const buttons = within(indicatorsList).getAllByRole('button');
+
+    expect(within(buttons[0]).getByText('Category 2'));
+    expect(
+      within(buttons[0]).queryByRole('button', {
+        name: 'Reorder options within this group',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(within(buttons[1]).getByText('Category 1'));
+    expect(
+      within(buttons[1]).getByRole('button', {
+        name: 'Reorder options within this group',
+      }),
+    );
+  });
+
+  test('clicking the `reorder options` button on a indicator shows the items for the indicator', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderIndicatorsList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+    const indicatorsList = screen.getByTestId('reorder-list');
+    userEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Reorder options within this group',
+      })[0],
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Category 1 Item 1'));
+    });
+    const itemsList = within(indicatorsList).getByRole('list');
+    const items = within(itemsList).getAllByRole('button');
+    expect(within(items[0]).getByText('Category 1 Item 1'));
+    expect(within(items[1]).getByText('Category 1 Item 2'));
+    expect(within(items[2]).getByText('Category 1 Item 3'));
+  });
+
+  test('clicking the `done` button on a indicator hides the items for the indicator', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderIndicatorsList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={noop}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+    const indicatorsList = screen.getByTestId('reorder-list');
+    userEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Reorder options within this group',
+      })[0],
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Category 1 Item 1'));
+    });
+
+    expect(within(indicatorsList).getByRole('list'));
+    userEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(screen.queryByText('Category 1 Item 1')).not.toBeInTheDocument();
+    expect(within(indicatorsList).queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  test('clicking the `save` button calls handleSave with the redoreded list formatted for the update request', async () => {
+    const handleSave = jest.fn();
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <ReorderIndicatorsList
+        subject={testSubject}
+        onCancel={noop}
+        onSave={handleSave}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('reorder-list'));
+    });
+    userEvent.click(screen.getByRole('button', { name: 'Save order' }));
+
+    const expectedRequest = [
+      {
+        id: 'category-2-id',
+        indicatorItems: ['category-2-item-1-id'],
+      },
+      {
+        id: 'category-1-id',
+        indicatorItems: [
+          'category-1-item-1-id',
+          'category-1-item-2-id',
+          'category-1-item-3-id',
+        ],
+      },
+    ];
+
+    expect(handleSave).toHaveBeenCalledWith(expectedRequest);
+  });
+});

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -10,6 +10,7 @@ import {
 export interface FilterOption {
   label: string;
   value: string;
+  id?: string; // EES-1243 - not optional when backend done?
 }
 
 export interface IndicatorOption extends FilterOption {
@@ -24,11 +25,15 @@ export interface TimePeriodOption {
   year: number;
 }
 
+export interface FilterOptionGroup {
+  id?: string; // EES-1243 - not optional when backend done?
+  label: string;
+  options: FilterOption[];
+  order?: number; // EES-1243 - not optional when backend done?
+}
+
 export interface GroupedFilterOptions {
-  [groupKey: string]: {
-    label: string;
-    options: FilterOption[];
-  };
+  [groupKey: string]: FilterOptionGroup;
 }
 
 export interface BoundaryLevel {
@@ -92,13 +97,17 @@ export interface SubjectMeta {
   filters: Dictionary<{
     legend: string;
     hint?: string;
+    id?: string; // EES-1243 - not optional when backend done?
     options: GroupedFilterOptions;
+    order?: number; // EES-1243 - not optional when backend done?
     totalValue?: string;
     name: string;
   }>;
   indicators: Dictionary<{
+    id?: string; // EES-1243 - not optional when backend done?
     label: string;
     options: IndicatorOption[];
+    order?: number; // EES-1243 - not optional when backend done?
   }>;
   locations: Dictionary<{
     legend: string;


### PR DESCRIPTION
Adds a tab in the 'Data and Files' section of a release for reordering filters and indicators.

- The tab is commented out, uncomment it in  [ReleaseDataPage.tsx](https://github.com/dfe-analytical-services/explore-education-statistics/compare/EES-2786?expand=1#diff-9b79898fb4082e2a782056d92cd17b0c5dfddede02ad88ec96f019a08cbd225a) to see it in action
- Uses test data for now as the code assumes an id and order will be added to filters and indicators on subjectMeta. Some types will need to be updated for this.
- Transforms the filters and indictors into arrays instead of keyed objects and strips out unnecessary fields before submitting the request to update them. The shape of this data is based on discussions with @benoutram, see the tests for what it will look like.
- The save request will need to be hooked up once the endpoint exists

## Screenshots
![reorder1](https://user-images.githubusercontent.com/81572860/155518896-1cfbb7c6-e48a-432a-b4ce-ef0275dc909f.PNG)
![reorder2](https://user-images.githubusercontent.com/81572860/155518902-f02da27f-7d2b-48dd-8807-e7f7f2efbd70.PNG)

