### PR TITLE
EES-3203 Add Id and Location Id to ObservationViewModel

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
@@ -39,10 +39,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             {
                 new()
                 {
+                    Id = Guid.NewGuid(),
                     Filters = new List<Guid>
                     {
                         Guid.NewGuid()
                     },
+                    LocationId = Guid.NewGuid(),
                     Location = new LocationViewModel
                     {
                         Country = new CodeNameViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/FastTrackControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/FastTrackControllerTests.cs
@@ -117,7 +117,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
         }
 
         [Fact]
-        public void FastTrackViewModel_SerialiseAndDeserialise()
+        public void FastTrackViewModel_SerialiseAndDeserialize()
         {
             var original = new FastTrackViewModel
             {
@@ -172,10 +172,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                     {
                         new()
                         {
+                            Id = Guid.NewGuid(),
                             Filters = new List<Guid>
                             {
                                 Guid.NewGuid()
                             },
+                            LocationId = Guid.NewGuid(),
                             Location = new LocationViewModel
                             {
                                 Country = new CodeNameViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
@@ -49,6 +49,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             var indicator1Id = Guid.NewGuid();
             var indicator2Id = Guid.NewGuid();
+            var location1Id = Guid.NewGuid();
+            var location2Id = Guid.NewGuid();
+            var location3Id = Guid.NewGuid();
 
             var query = new ObservationQueryContext
             {
@@ -77,6 +80,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     Id = Guid.NewGuid(),
                     Location = new Location
                     {
+                        Id = location1Id,
                         GeographicLevel = GeographicLevel.Country
                     },
                     Measures = new Dictionary<Guid, string>
@@ -96,6 +100,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     Id = Guid.NewGuid(),
                     Location = new Location
                     {
+                        Id = location2Id,
                         GeographicLevel = GeographicLevel.Institution
                     },
                     Measures = new Dictionary<Guid, string>
@@ -114,6 +119,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     Id = Guid.NewGuid(),
                     Location = new Location
                     {
+                        Id = location3Id,
                         GeographicLevel = GeographicLevel.Provider
                     },
                     Measures = new Dictionary<Guid, string>
@@ -209,14 +215,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 Assert.Equal(2, observationResults.Count);
 
+                Assert.Equal(observations[0].Id, observationResults[0].Id);
                 Assert.Equal(GeographicLevel.Country, observationResults[0].GeographicLevel);
+                Assert.Equal(location1Id, observationResults[0].LocationId);
                 Assert.Equal("2019_AY", observationResults[0].TimePeriod);
                 Assert.Equal(2, observationResults[0].Measures.Count);
                 Assert.Equal("123", observationResults[0].Measures[indicator1Id]);
                 Assert.Equal("456", observationResults[0].Measures[indicator2Id]);
                 Assert.Equal(ListOf(observations[0].FilterItems.ToList()[0].FilterItemId), observationResults[0].Filters);
 
+                Assert.Equal(observations[2].Id, observationResults[1].Id);
                 Assert.Equal(GeographicLevel.Provider, observationResults[1].GeographicLevel);
+                Assert.Equal(location3Id, observationResults[1].LocationId);
                 Assert.Equal("2020_AY", observationResults[1].TimePeriod);
                 Assert.Single(observationResults[1].Measures);
                 Assert.Equal("789", observationResults[1].Measures[indicator1Id]);
@@ -432,6 +442,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             var indicator1Id = Guid.NewGuid();
             var indicator2Id = Guid.NewGuid();
+            var location1Id = Guid.NewGuid();
+            var location2Id = Guid.NewGuid();
+            var location3Id = Guid.NewGuid();
 
             var query = new ObservationQueryContext
             {
@@ -460,6 +473,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     Id = Guid.NewGuid(),
                     Location = new Location
                     {
+                        Id = location1Id,
                         GeographicLevel = GeographicLevel.Country
                     },
                     Measures = new Dictionary<Guid, string>
@@ -479,6 +493,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     Id = Guid.NewGuid(),
                     Location = new Location
                     {
+                        Id = location2Id,
                         GeographicLevel = GeographicLevel.Institution
                     },
                     Measures = new Dictionary<Guid, string>
@@ -497,6 +512,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     Id = Guid.NewGuid(),
                     Location = new Location
                     {
+                        Id = location3Id,
                         GeographicLevel = GeographicLevel.Provider
                     },
                     Measures = new Dictionary<Guid, string>
@@ -577,14 +593,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 Assert.Equal(2, observationResults.Count);
 
+                Assert.Equal(observations[0].Id, observationResults[0].Id);
                 Assert.Equal(GeographicLevel.Country, observationResults[0].GeographicLevel);
+                Assert.Equal(location1Id, observationResults[0].LocationId);
                 Assert.Equal("2019_AY", observationResults[0].TimePeriod);
                 Assert.Equal(2, observationResults[0].Measures.Count);
                 Assert.Equal("123", observationResults[0].Measures[indicator1Id]);
                 Assert.Equal("456", observationResults[0].Measures[indicator2Id]);
                 Assert.Equal(ListOf(observations[0].FilterItems.ToList()[0].FilterItemId), observationResults[0].Filters);
 
-                Assert.Equal(GeographicLevel.Country, observationResults[0].GeographicLevel);
+                Assert.Equal(observations[2].Id, observationResults[1].Id);
+                Assert.Equal(GeographicLevel.Provider, observationResults[1].GeographicLevel);
+                Assert.Equal(location3Id, observationResults[1].LocationId);
                 Assert.Equal("2020_AY", observationResults[1].TimePeriod);
                 Assert.Single(observationResults[1].Measures);
                 Assert.Equal("789", observationResults[1].Measures[indicator1Id]);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultBuilder.cs
@@ -21,10 +21,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         public ObservationViewModel BuildResult(Observation observation, IEnumerable<Guid> indicators)
         {
-            return new()
+            return new ObservationViewModel
             {
+                Id = observation.Id,
                 Filters = FilterItems(observation),
                 GeographicLevel = observation.Location.GeographicLevel,
+                LocationId = observation.LocationId,
                 Location = _mapper.Map<LocationViewModel>(observation.Location),
                 Measures = Measures(observation, indicators.ToList()),
                 TimePeriod = observation.GetTimePeriod()

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/ObservationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/ObservationViewModel.cs
@@ -9,10 +9,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
 {
     public record ObservationViewModel
     {
+        public Guid Id { get; set; }
+
         public List<Guid> Filters { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter), typeof(CamelCaseNamingStrategy))]
         public GeographicLevel GeographicLevel { get; set; }
+
+        public Guid LocationId { get; set; }
 
         public LocationViewModel Location { get; set; }
 


### PR DESCRIPTION
This PR adds new `Id` and `LocationId` fields to `ObservationViewModel` so that they are present in all table responses.

Sample of how a Observation result in the table `results` field will now appear:
```
{
  "id": "71ff5069-a6ac-4b9c-f530-08d9f78ec0af",
  "filters": [],
  "geographicLevel": "country",
  "locationId": "62424e77-ff57-4a7c-f52a-08d9f78ec0af",
  "location": {
    "country": {
      "code": "E92000001",
      "name": "England"
    }
  },
  "measures": {
    "b5b12479-90cf-44dd-f525-08d9f78ec0af": "607928"
  },
  "timePeriod": "2022_CY"
}
```

`LocationId` is being added anyway by https://github.com/dfe-analytical-services/explore-education-statistics/pull/3179 (EES-2955) but having it in the response early along with `Id` means that we can more reliably test table responses for equality.

The 'full' `Location` field will be dropped by EES-2955 at a later date when `LocationId` will be depended on instead. It won't be possible to compare a 'before' set of table responses containing the `Location` object with an 'after' set of responses containing `LocationId`. By adding `LocationId` early we will be able to compare the locations before and afterwards for equality based on location id.

Adding the Observation Id means we also ensure we are comparing results for equality where it's currently be possible (albeit unlilkely) that they are different results for different CSV rows identical by all fields except Id.

A further ticket EES-3204 will amend the `get_data_block_responses` to ignore the `Location` object in responses so that we can compare response json documents for equality before and afterwards when `Location` is removed.

### Other changes

* Fixes a problem in `TableBuilderServiceTests` where a result was being accessed with the incorrect index and the wrong GeographicLevel was being compared.