### PR TITLE
EES-2842 default line chart symbol to none

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
@@ -115,7 +115,7 @@ const ChartLegendConfiguration = ({
     );
 
     const defaultConfig: Partial<LegendItemConfiguration> = {
-      symbol: capabilities.hasSymbols ? 'circle' : undefined,
+      symbol: capabilities.hasSymbols ? 'none' : undefined,
       lineStyle: capabilities.hasLineStyle ? 'solid' : undefined,
     };
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
@@ -110,7 +110,7 @@ describe('ChartLegendConfiguration', () => {
       'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, Barnet)',
     );
     expect(legendItem1.getByLabelText('Colour')).toHaveValue('#1d70b8');
-    expect(legendItem1.getByLabelText('Symbol')).toHaveValue('circle');
+    expect(legendItem1.getByLabelText('Symbol')).toHaveValue('none');
     expect(legendItem1.getByLabelText('Style')).toHaveValue('solid');
   });
 
@@ -154,7 +154,7 @@ describe('ChartLegendConfiguration', () => {
       'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, Barnet)',
     );
     expect(legendItem1.getByLabelText('Colour')).toHaveValue('#1d70b8');
-    expect(legendItem1.getByLabelText('Symbol')).toHaveValue('circle');
+    expect(legendItem1.getByLabelText('Symbol')).toHaveValue('none');
     expect(legendItem1.getByLabelText('Style')).toHaveValue('solid');
 
     const legendItem2 = within(legendItems[1]);
@@ -163,7 +163,7 @@ describe('ChartLegendConfiguration', () => {
       'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, Barnsley)',
     );
     expect(legendItem2.getByLabelText('Colour')).toHaveValue('#912b88');
-    expect(legendItem2.getByLabelText('Symbol')).toHaveValue('circle');
+    expect(legendItem2.getByLabelText('Symbol')).toHaveValue('none');
     expect(legendItem2.getByLabelText('Style')).toHaveValue('solid');
   });
 


### PR DESCRIPTION
Changes the default symbol option on line charts to none.