### PR TITLE
EES-3086 EES-3060 move map indicator tile

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.module.scss
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.module.scss
@@ -25,19 +25,9 @@
   width: 100%;
 }
 
-.tooltipList {
-  list-style: none;
+.tooltipContent {
+  font-size: 0.9rem;
   margin-bottom: 0;
-  padding-left: 0;
-
-  li {
-    font-size: 0.9rem;
-    margin-bottom: govuk-spacing(2);
-  }
-
-  li:last-of-type {
-    margin-bottom: 0;
-  }
 }
 
 .legend {

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -414,16 +414,10 @@ export const MapBlockInternal = ({
 
   const [legendEntries, setLegendEntries] = useState<LegendEntry[]>([]);
 
-  const selectedDataSetConfiguration =
-    dataSetCategoryConfigs[selectedDataSetKey];
+  const selectedDataSetConfig = dataSetCategoryConfigs[selectedDataSetKey];
 
   const selectedDataSet =
     selectedFeature?.properties?.dataSets[selectedDataSetKey];
-
-  const {
-    config: selectedDataSetConfig,
-    dataSet: expandedSelectedDataSet,
-  } = dataSetCategoryConfigs[selectedDataSetKey];
 
   // initialise
   useEffect(() => {
@@ -455,14 +449,11 @@ export const MapBlockInternal = ({
 
   // Rebuild the geometry if the selection has changed
   useEffect(() => {
-    if (dataSetCategories.length && selectedDataSetConfiguration) {
+    if (dataSetCategories.length && selectedDataSetConfig) {
       const {
         geometry: newGeometry,
         legend: newLegendEntries,
-      } = generateGeometryAndLegend(
-        selectedDataSetConfiguration,
-        dataSetCategories,
-      );
+      } = generateGeometryAndLegend(selectedDataSetConfig, dataSetCategories);
 
       setGeometry(newGeometry);
       setLegendEntries(newLegendEntries);
@@ -471,7 +462,7 @@ export const MapBlockInternal = ({
     dataSetCategories,
     dataSetCategoryConfigs,
     meta,
-    selectedDataSetConfiguration,
+    selectedDataSetConfig,
     selectedDataSetKey,
   ]);
 
@@ -553,13 +544,12 @@ export const MapBlockInternal = ({
 
       featureLayer.bindTooltip(() => {
         if (feature.properties) {
-          const dataSetConfig = dataSetCategoryConfigs[selectedDataSetKey];
           const dataSetValue = formatPretty(
             feature.properties.dataSets[selectedDataSetKey].value,
-            dataSetConfig.dataSet.indicator.unit,
-            dataSetConfig.dataSet.indicator.decimalPlaces,
+            selectedDataSetConfig.dataSet.indicator.unit,
+            selectedDataSetConfig.dataSet.indicator.decimalPlaces,
           );
-          const content = `${dataSetConfig.config.label}: ${dataSetValue}`;
+          const content = `${selectedDataSetConfig.config.label}: ${dataSetValue}`;
 
           const mapWidth = mapRef.current?.container?.clientWidth;
 
@@ -682,10 +672,10 @@ export const MapBlockInternal = ({
             </Map>
           )}
         </div>
-        {selectedDataSetConfiguration && (
+        {selectedDataSetConfig && (
           <div className="govuk-grid-column-one-third">
             <h3 className="govuk-heading-s">
-              Key to {selectedDataSetConfiguration?.config?.label}
+              Key to {selectedDataSetConfig?.config?.label}
             </h3>
             <ul className="govuk-list">
               {legendEntries.map(({ min, max, colour }) => (
@@ -709,7 +699,7 @@ export const MapBlockInternal = ({
             <div
               aria-live="polite"
               className="govuk-!-margin-top-5"
-              data-testId="mapBlock-indicator"
+              data-testid="mapBlock-indicator"
             >
               {selectedFeature && (
                 <>
@@ -720,11 +710,11 @@ export const MapBlockInternal = ({
                   {selectedDataSet && (
                     <KeyStatTile
                       testId="mapBlock-indicatorTile"
-                      title={selectedDataSetConfig.label}
+                      title={selectedDataSetConfig.config.label}
                       value={formatPretty(
                         selectedDataSet.value,
-                        expandedSelectedDataSet.indicator.unit,
-                        expandedSelectedDataSet.indicator.decimalPlaces,
+                        selectedDataSetConfig.dataSet.indicator.unit,
+                        selectedDataSetConfig.dataSet.indicator.decimalPlaces,
                       )}
                     />
                   )}

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
@@ -205,7 +205,7 @@ describe('MapBlockInternal', () => {
     expect(paths[3]).toHaveClass('selected');
   });
 
-  test('changing selected location renders its indicator tiles', async () => {
+  test('changing selected location renders its indicator tile', async () => {
     render(<MapBlockInternal {...testBlockProps} />);
 
     await waitFor(() => {
@@ -222,26 +222,14 @@ describe('MapBlockInternal', () => {
 
     userEvent.selectOptions(select, group1Options[0]);
 
-    const indicators = screen.getAllByTestId('mapBlock-indicator');
+    const indicator = screen.getByTestId('mapBlock-indicator');
+    const tile = within(indicator);
 
-    expect(indicators).toHaveLength(2);
-
-    const tile1 = within(indicators[0]);
-
-    expect(tile1.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
+    expect(tile.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
       'Authorised absence rate (2016/17)',
     );
-    expect(tile1.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
+    expect(tile.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
       '3.5%',
-    );
-
-    const tile2 = within(indicators[1]);
-
-    expect(tile2.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
-      'Overall absence rate (2016/17)',
-    );
-    expect(tile2.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
-      '4.8%',
     );
   });
 
@@ -277,7 +265,7 @@ describe('MapBlockInternal', () => {
 
     userEvent.selectOptions(select, group1Options[0]);
 
-    const tile1 = within(screen.getAllByTestId('mapBlock-indicator')[0]);
+    const tile1 = within(screen.getByTestId('mapBlock-indicator'));
     expect(tile1.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
       'Authorised absence rate (2016/17)',
     );
@@ -287,7 +275,7 @@ describe('MapBlockInternal', () => {
 
     userEvent.selectOptions(select, group1Options[1]);
 
-    const tile2 = within(screen.getAllByTestId('mapBlock-indicator')[0]);
+    const tile2 = within(screen.getByTestId('mapBlock-indicator'));
     expect(tile2.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
       'Authorised absence rate (2016/17)',
     );
@@ -297,7 +285,7 @@ describe('MapBlockInternal', () => {
 
     userEvent.selectOptions(select, group1Options[2]);
 
-    const tile3 = within(screen.getAllByTestId('mapBlock-indicator')[0]);
+    const tile3 = within(screen.getByTestId('mapBlock-indicator'));
     expect(tile3.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
       'Authorised absence rate (2016/17)',
     );

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -645,18 +645,9 @@ Validate basic geographic chart preview
     user chooses select option    id:chartBuilderPreview-map-selectedLocation    Nailsea Youngwood
 
     user mouses over selected map feature    id:chartBuilderPreview
-    user checks chart tooltip label contains    id:chartBuilderPreview    Nailsea Youngwood
-    user checks chart tooltip item contains    id:chartBuilderPreview    1    Admissions in 2005: 3,612
-    user checks chart tooltip item contains    id:chartBuilderPreview    2    Admissions in 2010: 9,304
-    user checks chart tooltip item contains    id:chartBuilderPreview    3    Admissions in 2011: 9,603
-    user checks chart tooltip item contains    id:chartBuilderPreview    4    Admissions in 2012: 8,150
-    user checks chart tooltip item contains    id:chartBuilderPreview    5    Admissions in 2016: 4,198
+    user checks map tooltip label contains    id:chartBuilderPreview    Nailsea Youngwood
 
-    user checks map chart indicator tile contains    id:chartBuilderPreview    1    Admissions in 2005    3,612
-    user checks map chart indicator tile contains    id:chartBuilderPreview    2    Admissions in 2010    9,304
-    user checks map chart indicator tile contains    id:chartBuilderPreview    3    Admissions in 2011    9,603
-    user checks map chart indicator tile contains    id:chartBuilderPreview    4    Admissions in 2012    8,150
-    user checks map chart indicator tile contains    id:chartBuilderPreview    5    Admissions in 2016    4,198
+    user checks map chart indicator tile contains    id:chartBuilderPreview    Admissions in 2005    3,612
 
 Save and validate geographic chart embeds correctly
     user scrolls to the bottom of the page
@@ -680,18 +671,9 @@ Save and validate geographic chart embeds correctly
     user chooses select option    ${datablock} >> name:selectedLocation    Nailsea Youngwood
 
     user mouses over selected map feature    ${datablock}
-    user checks chart tooltip label contains    ${datablock}    Nailsea Youngwood
-    user checks chart tooltip item contains    ${datablock}    1    Admissions in 2005: 3,612
-    user checks chart tooltip item contains    ${datablock}    2    Admissions in 2010: 9,304
-    user checks chart tooltip item contains    ${datablock}    3    Admissions in 2011: 9,603
-    user checks chart tooltip item contains    ${datablock}    4    Admissions in 2012: 8,150
-    user checks chart tooltip item contains    ${datablock}    5    Admissions in 2016: 4,198
+    user checks map tooltip label contains    ${datablock}    Nailsea Youngwood
 
-    user checks map chart indicator tile contains    ${datablock}    1    Admissions in 2005    3,612
-    user checks map chart indicator tile contains    ${datablock}    2    Admissions in 2010    9,304
-    user checks map chart indicator tile contains    ${datablock}    3    Admissions in 2011    9,603
-    user checks map chart indicator tile contains    ${datablock}    4    Admissions in 2012    8,150
-    user checks map chart indicator tile contains    ${datablock}    5    Admissions in 2016    4,198
+    user checks map chart indicator tile contains    ${datablock}    Admissions in 2005    3,612
 
 Configure basic infographic chart
     user navigates to admin frontend    ${DATABLOCK_URL}

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -272,28 +272,20 @@ Validate Regional and local authority (LA) breakdown chart
     user waits until element does not contain chart tooltip    ${datablock}
 
     user mouses over selected map feature    ${datablock}
-    user checks chart tooltip label contains    ${datablock}    Vale of White Horse
-    user checks chart tooltip item contains    ${datablock}    1    Unauthorised absence rate: 0.9%
-    user checks chart tooltip item contains    ${datablock}    2    Overall absence rate: 4.3%
-    user checks chart tooltip item contains    ${datablock}    3    Authorised absence rate: 3.4%
+    user checks map tooltip label contains    ${datablock}    Vale of White Horse
+    user checks map tooltip item contains    ${datablock}    Unauthorised absence rate: 0.9%
 
-    user checks map chart indicator tile contains    ${datablock}    1    Unauthorised absence rate    0.9%
-    user checks map chart indicator tile contains    ${datablock}    2    Overall absence rate    4.3%
-    user checks map chart indicator tile contains    ${datablock}    3    Authorised absence rate    3.4%
+    user checks map chart indicator tile contains    ${datablock}    Unauthorised absence rate    0.9%
 
     user mouses over element    ${datablock} select[name="selectedLocation"]
     user chooses select option    ${datablock} select[name="selectedLocation"]    Harlow
     user waits until element does not contain chart tooltip    ${datablock}
 
     user mouses over selected map feature    ${datablock}
-    user checks chart tooltip label contains    ${datablock}    Harlow
-    user checks chart tooltip item contains    ${datablock}    1    Unauthorised absence rate: 1.1%
-    user checks chart tooltip item contains    ${datablock}    2    Overall absence rate: 4.2%
-    user checks chart tooltip item contains    ${datablock}    3    Authorised absence rate: 3.1%
+    user checks map tooltip label contains    ${datablock}    Harlow
+    user checks map tooltip item contains    ${datablock}    Unauthorised absence rate: 1.1%
 
-    user checks map chart indicator tile contains    ${datablock}    1    Unauthorised absence rate    1.1%
-    user checks map chart indicator tile contains    ${datablock}    2    Overall absence rate    4.2%
-    user checks map chart indicator tile contains    ${datablock}    3    Authorised absence rate    3.1%
+    user checks map chart indicator tile contains    ${datablock}    Unauthorised absence rate    1.1%
 
     user mouses over element    ${datablock} select[name="selectedLocation"]
     user chooses select option    ${datablock} select[name="selectedLocation"]    Newham
@@ -301,13 +293,9 @@ Validate Regional and local authority (LA) breakdown chart
 
     user mouses over selected map feature    ${datablock}
     user checks chart tooltip label contains    ${datablock}    Newham
-    user checks chart tooltip item contains    ${datablock}    1    Unauthorised absence rate: 1.7%
-    user checks chart tooltip item contains    ${datablock}    2    Overall absence rate: 4.4%
-    user checks chart tooltip item contains    ${datablock}    3    Authorised absence rate: 2.7%
+    user checks chart tooltip item contains    ${datablock}    Unauthorised absence rate: 1.7%
 
-    user checks map chart indicator tile contains    ${datablock}    1    Unauthorised absence rate    1.7%
-    user checks map chart indicator tile contains    ${datablock}    2    Overall absence rate    4.4%
-    user checks map chart indicator tile contains    ${datablock}    3    Authorised absence rate    2.7%
+    user checks map chart indicator tile contains    ${datablock}    Unauthorised absence rate    1.7%
 
 Clicking "Create tables" takes user to Table Tool page with absence publication selected
     [Documentation]    DFE-898

--- a/tests/robot-tests/tests/libs/charts.robot
+++ b/tests/robot-tests/tests/libs/charts.robot
@@ -141,11 +141,26 @@ user checks chart tooltip item contains
     user waits until element is visible    ${element}
     user waits until element contains    ${element}    ${text}
 
-user checks map chart indicator tile contains
-    [Arguments]    ${locator}    ${number}    ${title}    ${value}
+user checks map tooltip label contains
+    [Arguments]    ${locator}    ${text}
+    user waits until parent contains element    ${locator}    css:[data-testid="chartTooltip-label"]
+    ${element}=    get child element    ${locator}    css:[data-testid="chartTooltip-label"]
+    user waits until element is visible    ${element}
+    user waits until element contains    ${element}    ${text}
+
+user checks map tooltip item contains
+    [Arguments]    ${locator}    ${text}
     user waits until parent contains element    ${locator}
-    ...    css:[data-testid="mapBlock-indicator"]:nth-of-type(${number})
-    ${indicator}=    get child element    ${locator}    css:[data-testid="mapBlock-indicator"]:nth-of-type(${number})
+    ...    css:[data-testid="chartTooltip-content"])
+    ${element}=    get child element    ${locator}    css:[data-testid="chartTooltip-content"])
+    user waits until element is visible    ${element}
+    user waits until element contains    ${element}    ${text}
+
+user checks map chart indicator tile contains
+    [Arguments]    ${locator}    ${title}    ${value}
+    user waits until parent contains element    ${locator}
+    ...    css:[data-testid="mapBlock-indicator"]
+    ${indicator}=    get child element    ${locator}    css:[data-testid="mapBlock-indicator"]
 
     ${indicator_title}=    get child element    ${indicator}    css:[data-testid="mapBlock-indicatorTile-title"]
     user waits until element is visible    ${indicator_title}

--- a/tests/robot-tests/tests/libs/charts.robot
+++ b/tests/robot-tests/tests/libs/charts.robot
@@ -36,11 +36,11 @@ user waits until element does not contain infographic chart
 
 user waits until element contains chart tooltip
     [Arguments]    ${locator}
-    user waits until parent contains element    ${locator}    css:[data-testid="chartTooltip"]
+    user waits until parent contains element    ${locator}    testid:chartTooltip
 
 user waits until element does not contain chart tooltip
     [Arguments]    ${locator}
-    user waits until parent does not contain element    ${locator}    css:[data-testid="chartTooltip"]
+    user waits until parent does not contain element    ${locator}    testid:chartTooltip
 
 user checks chart title contains
     [Arguments]    ${locator}    ${text}
@@ -121,15 +121,15 @@ user mouses over chart bar
 
 user mouses over selected map feature
     [Arguments]    ${locator}
-    user waits until parent contains element    ${locator}    css:[data-testid="mapBlock-selectedFeature"]
-    ${element}=    get child element    ${locator}    css:[data-testid="mapBlock-selectedFeature"]
+    user waits until parent contains element    ${locator}    testid:mapBlock-selectedFeature
+    ${element}=    get child element    ${locator}    testid:mapBlock-selectedFeature
     user waits until element is visible    ${element}
     user mouses over element    ${element}
 
 user checks chart tooltip label contains
     [Arguments]    ${locator}    ${text}
-    user waits until parent contains element    ${locator}    css:[data-testid="chartTooltip-label"]
-    ${element}=    get child element    ${locator}    css:[data-testid="chartTooltip-label"]
+    user waits until parent contains element    ${locator}    testid:chartTooltip-label
+    ${element}=    get child element    ${locator}    testid:chartTooltip-label
     user waits until element is visible    ${element}
     user waits until element contains    ${element}    ${text}
 
@@ -143,30 +143,30 @@ user checks chart tooltip item contains
 
 user checks map tooltip label contains
     [Arguments]    ${locator}    ${text}
-    user waits until parent contains element    ${locator}    css:[data-testid="chartTooltip-label"]
-    ${element}=    get child element    ${locator}    css:[data-testid="chartTooltip-label"]
+    user waits until parent contains element    ${locator}    testid:chartTooltip-label
+    ${element}=    get child element    ${locator}    testid:chartTooltip-label
     user waits until element is visible    ${element}
     user waits until element contains    ${element}    ${text}
 
 user checks map tooltip item contains
     [Arguments]    ${locator}    ${text}
     user waits until parent contains element    ${locator}
-    ...    css:[data-testid="chartTooltip-content"])
-    ${element}=    get child element    ${locator}    css:[data-testid="chartTooltip-content"])
+    ...    testid:chartTooltip-content
+    ${element}=    get child element    ${locator}    testid:chartTooltip-content
     user waits until element is visible    ${element}
     user waits until element contains    ${element}    ${text}
 
 user checks map chart indicator tile contains
     [Arguments]    ${locator}    ${title}    ${value}
     user waits until parent contains element    ${locator}
-    ...    css:[data-testid="mapBlock-indicator"]
-    ${indicator}=    get child element    ${locator}    css:[data-testid="mapBlock-indicator"]
+    ...    testid:mapBlock-indicator
+    ${indicator}=    get child element    ${locator}    testid:mapBlock-indicator
 
-    ${indicator_title}=    get child element    ${indicator}    css:[data-testid="mapBlock-indicatorTile-title"]
+    ${indicator_title}=    get child element    ${indicator}    testid:mapBlock-indicatorTile-title
     user waits until element is visible    ${indicator_title}
     user waits until element contains    ${indicator_title}    ${title}
 
-    ${indicator_value}=    get child element    ${indicator}    css:[data-testid="mapBlock-indicatorTile-value"]
+    ${indicator_value}=    get child element    ${indicator}    testid:mapBlock-indicatorTile-value
     user waits until element is visible    ${indicator_value}
     user waits until element contains    ${indicator_value}    ${value}
 


### PR DESCRIPTION
The ticket was to move the indicator tiles to above maps so they are more noticeable.  However, doing this resulted in the map being pushed down the page, potentially off screen, when there were several tiles.

Chatted to Cam about it, he realised that all datasets were shown in the indicator tiles, not just the one that's selected. The same was true of the tooltip when you hover over the map.

So this PR:
- only shows the selected data set as an indicator tile and in the tooltip
- moves the indicator tile to under the map legend to make it more noticeable
- adds aria-live="polite" so that screen readers are informed when it changes
- removes aria-live="assertive" from the map legend to prevent useless information being shouted at screen reader users (https://dfedigital.atlassian.net/browse/EES-3060)

## Screenshots

![map2](https://user-images.githubusercontent.com/81572860/155568328-13fff5bc-c9e8-4be6-a81c-ce19bf9d7579.PNG)

