### PR TITLE
EES-3167 Restrict get_data_block_responses CSV query to only include Data Blocks from the latest published Release

### DIFF
--- a/useful-scripts/get_data_block_responses/get_data_block_responses.py
+++ b/useful-scripts/get_data_block_responses/get_data_block_responses.py
@@ -9,16 +9,30 @@ import argparse
 """
 To generate datablocks.csv, use this SQL query against the Content DB:
 
-SELECT ContentBlock.Id AS ContentBlockId, Releases.Id AS ReleaseId, JSON_VALUE([DataBlock_Query], '$.SubjectId') AS SubjectId, ContentBlock.DataBlock_Query AS Query
-  FROM ContentBlock
-  JOIN ReleaseContentBlocks ON ContentBlock.Id = ReleaseContentBlocks.ContentBlockId
-  JOIN Releases ON ReleaseContentBlocks.ReleaseId = Releases.Id
-  Where ContentBlock.Type = 'DataBlock'
+SELECT ContentBlock.Id                              AS ContentBlockId,
+       Releases.Id                                  AS ReleaseId,
+       JSON_VALUE([DataBlock_Query], '$.SubjectId') AS SubjectId,
+       ContentBlock.DataBlock_Query                 AS Query
+FROM ContentBlock
+JOIN ReleaseContentBlocks ON ContentBlock.Id = ReleaseContentBlocks.ContentBlockId
+JOIN Releases ON ReleaseContentBlocks.ReleaseId = Releases.Id
+WHERE ContentBlock.Type = 'DataBlock'
   AND Releases.Published IS NOT NULL
-  AND SoftDeleted = 0
+  AND Releases.SoftDeleted = 0
+  -- Restrict DataBlocks that aren't featured tables or linked to content sections
   AND (ContentSectionId IS NOT NULL
-	   OR (DataBlock_HighlightName IS NOT NULL
-	       AND DataBlock_HighlightName != ''));
+    OR (DataBlock_HighlightName IS NOT NULL
+        AND DataBlock_HighlightName <> ''))
+  -- Restrict DataBlocks that aren't from the latest published Release
+  AND NOT EXISTS(
+    SELECT 1
+    FROM Releases PublicationReleases
+    WHERE PublicationReleases.PublicationId = Releases.PublicationId
+      AND PublicationReleases.Published IS NOT NULL
+      AND PublicationReleases.SoftDeleted = 0
+      AND PublicationReleases.Id <> Releases.Id
+      AND PublicationReleases.PreviousVersionId = Releases.Id
+  );
 
 And then save the results as a CSV in MS SQL Server Management Studio.
 Place it in the same directory as this script.


### PR DESCRIPTION
When running the `get_data_block_responses` script I noticed that there are quite a lot of 404 responses being saved.

This is because we post the data block query with the 'ReleaseId' and if this param is present there's a security check which makes sure the subject belongs to the latest published release.

This PR amends the query we use to populate the data blocks CSV which drives the script to only include data blocks from the latest published release.

This eliminates all of the 404 'noise' being generated by the script.
