### PR TITLE
EES-3207 Handle possibility of a null Locations object in table builder queries

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
@@ -156,8 +156,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
             return TableBuilderUtils.MaximumTableCellCount(
                 countOfIndicators: queryContext.Indicators.Count(),
-                countOfLocations: queryContext.Locations.CountItems(),
-                countOfTimePeriods: TimePeriodUtil.Range(queryContext.TimePeriod).Count(),
+                countOfLocations: queryContext.Locations?.CountItems() ?? (queryContext.LocationIds?.Count() ?? 0),
+                countOfTimePeriods: TimePeriodUtil.Range(queryContext.TimePeriod).Count,
                 countsOfFilterItemsByFilter: countsOfFilterItemsByFilter
             );
         }


### PR DESCRIPTION
This PR handles the possibility of a null `Locations` object when `LocationIds` is populated instead during a table query. This is possible in the testing of EES-3167 where an alternative version of all the data block queries with `LocationIds` are being used.

The Locations object will eventually not be populated in queries when it's removed by the EES-3167 migration and switched over to being used by EES-2955.