### PR TITLE
EES-3205 Address PR feedback of EES-3167

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/Data/Query/ObservationQueryContextTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/Data/Query/ObservationQueryContextTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
@@ -57,6 +58,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model.Data.Que
             };
 
             var clone = original.Clone();
+
+            clone.AssertDeepEqualTo(original);
 
             clone.SubjectId = Guid.NewGuid();
             clone.BoundaryLevel = 2;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/Data/TableBuilderConfigurationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/Data/TableBuilderConfigurationTests.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model.Data
@@ -40,6 +41,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model.Data
             };
 
             var clone = original.Clone();
+
+            clone.AssertDeepEqualTo(original);
 
             clone.TableHeaders.Columns[0].Value = "updated";
             clone.TableHeaders.Rows[0].Value = "updated";


### PR DESCRIPTION
This PR addresses a couple of feedback comments of https://github.com/dfe-analytical-services/explore-education-statistics/pull/3180 (EES-3167) which has already been accepted and merged.

In unit testing that the `Clone` methods of `ObservationQueryContext` and `TableBuilderConfiguration` are performing a deep copy, we now assert that all of the fields in the clones are the same as the originals, prior to the updates that we make to the clones.