### PR TITLE
🐛 EES-3167 Add distinct when retrieving data block query codes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataBlockMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataBlockMigrationService.cs
@@ -130,7 +130,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 // Iterate over every level and lookup any codes that exist in that field 
                 EnumUtil.GetEnumValues<GeographicLevel>().ForEach(geographicLevel =>
                 {
-                    var codes = GetQueryLocationCodesForLevel(dataBlock.Query.Locations, geographicLevel);
+                    var codes = GetDistinctQueryLocationCodesForLevel(dataBlock.Query.Locations, geographicLevel);
                     if (codes.Any())
                     {
                         var targets = locationsMap.GetValueOrDefault(geographicLevel) ??
@@ -447,7 +447,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             return migrated;
         }
 
-        private static List<string> GetQueryLocationCodesForLevel(
+        private static List<string> GetDistinctQueryLocationCodesForLevel(
             LocationQuery locations,
             GeographicLevel geographicLevel)
         {
@@ -461,7 +461,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             var codes = (
                 queryProperty.GetMethod.Invoke(locations, new object[] { }) as IEnumerable<string> ??
                 new List<string>()
-            ).ToList();
+            ).Distinct().ToList();
 
             return codes;
         }


### PR DESCRIPTION
This PR adds in a `distinct` when retrieving data block query codes for a particular geographic level so that we only resolve a single id for each code.

In Pre-prod we see one or two datablocks containing duplicate codes e.g.

```
  "Locations": {
    "LocalAuthority": [
      "E09000002",
      "E09000002",
      "E08000016",
      "E06000022",
      "E06000055"]
  }
```

These were previously being resolved multiple times so the resulting array of location id's also contained duplicate Guid's.