### PR TITLE
EE-3237 - updated get_data_block_responses.py script for easier testing

### DIFF
--- a/useful-scripts/get_data_block_responses/get_data_block_responses.py
+++ b/useful-scripts/get_data_block_responses/get_data_block_responses.py
@@ -22,7 +22,7 @@ WHERE ContentBlock.Type = 'DataBlock'
   AND (
     -- Include DataBlocks that are linked to Content Sections
     ContentSectionId IS NOT NULL
-    -- Include DataBlocks that are linked to Content Sections
+    -- Include DataBlocks that are Featured Tables
     OR (DataBlock_HighlightName IS NOT NULL
         AND DataBlock_HighlightName <> ''))
   -- Include only DataBlocks that are from the latest published Release

--- a/useful-scripts/get_data_block_responses/get_data_block_responses.py
+++ b/useful-scripts/get_data_block_responses/get_data_block_responses.py
@@ -44,7 +44,7 @@ grep -r "time for response: [0-9][0-9][0-9]*" * | awk '{split($0,a,":"); print a
 
 Compare two result directories for differences, but ignoring response time (and any responses that are both Not Found
 responses, as they contain unique traceIds):
-diff -I"^time for response:.*" -I "Not Found" -r results_dev1/ results_dev2/
+diff -I"^time for response:.*" -I "Not Found" -r results_dev1/responses results_dev2/responses
 """
 
 parser = argparse.ArgumentParser(prog="python get_data_block_responses.py",

--- a/useful-scripts/get_data_block_responses/get_data_block_responses.py
+++ b/useful-scripts/get_data_block_responses/get_data_block_responses.py
@@ -112,22 +112,23 @@ def write_block_to_file(
         response_time,
         response_dict):
     try:
+        with open(f'{requests_dir}/block_{block_guid}_request', 'w') as block_request_file:
+            block_request_file.write(
+                f'block: {block_guid}\n'
+                f'release: {release_guid}\n'
+                f'subject: {subject_guid}\n'
+                f'request:\n{json.dumps(request_dict, sort_keys=True, indent=2)}'
+            )
+
         with open(f'{responses_dir}/block_{block_guid}_response', 'w') as block_response_file:
-            with open(f'{requests_dir}/block_{block_guid}_request', 'w') as block_request_file:
-                block_request_file.write(
-                    f'block: {block_guid}\n'
-                    f'release: {release_guid}\n'
-                    f'subject: {subject_guid}\n'
-                    f'request:\n{json.dumps(request_dict, sort_keys=True, indent=2)}'
-                )
-                block_response_file.write(
-                    f'block: {block_guid}\n'
-                    f'release: {release_guid}\n'
-                    f'subject: {subject_guid}\n'
-                    f'response status: {status_code}\n'
-                    f'time for response: {response_time}\n'
-                    f'response:\n{json.dumps(response_dict, sort_keys=True, indent=2)}'
-                )
+            block_response_file.write(
+                f'block: {block_guid}\n'
+                f'release: {release_guid}\n'
+                f'subject: {subject_guid}\n'
+                f'response status: {status_code}\n'
+                f'time for response: {response_time}\n'
+                f'response:\n{json.dumps(response_dict, sort_keys=True, indent=2)}'
+            )
         print_to_console(f'Successfully processed block {block_guid} for subject {subject_guid}!')
     except Exception as exception:
         print_to_console(f'block_file.write failed with block {block_guid} subject {subject_guid}\n'


### PR DESCRIPTION
This PR:
- separates out requests and responses for datablocks into separate files for easier comparison in cases where we expect the requests to change
- adds additional helpful metrics to script output
- captures the response bodies of non-200 responses to aid in determining the reason behind failures