### PR TITLE
EES-3250 Fix UI tests in create_data_block_with_chart.robot

### DIFF
--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -336,6 +336,9 @@ Configure basic line chart
     user chooses select option    id:chartDataSetsConfigurationForm-location    Nailsea Youngwood
     user clicks button    Add data set
 
+    user clicks link    Legend
+    user chooses select option    id:chartLegendConfigurationForm-items-0-symbol    Circle
+
 Validate basic line chart preview
     user waits until element contains line chart    id:chartBuilderPreview
 


### PR DESCRIPTION
This PR is a quick fix for the UI tests in `create_data_block_with_chart.robot` which are now failing since the chart line symbol now defaults to 'None' after  EES-2842.

This fix configures a line symbol as expected by the verifications in `charts.robot - user mouses over line chart point` 

```
    user waits until parent contains element    ${locator}
    ...    css:.recharts-line-dots:nth-of-type(${line}) .recharts-symbols:nth-of-type(${number})
```

The seeded Absence Release is still configured with line symbols. Happy to enhance this PR to cater for no symbols but any additional change will need to take the tests on that seeded Release into account.

![image](https://user-images.githubusercontent.com/4147126/157438751-17baa55a-8113-4dc7-b556-36b0746f8628.png)
