### PR TITLE
Hotfix/ees 3228 remove dictionary duplicate key issue with replacements

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -762,7 +762,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(_england.Code, dataBlockLocationPlan.Code);
                 Assert.Equal(_england.Name, dataBlockLocationPlan.Label);
-                Assert.Empty(dataBlockLocationPlan.Target);
+                Assert.Empty(dataBlockLocationPlan.TargetCode);
+                Assert.Empty(dataBlockLocationPlan.TargetName);
                 Assert.False(dataBlockLocationPlan.Valid);
 
                 Assert.NotNull(dataBlockPlan.TimePeriods);
@@ -2224,7 +2225,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(_england.Code, dataBlockLocationPlan.Code);
                 Assert.Equal(_england.Name, dataBlockLocationPlan.Label);
-                Assert.Equal(_england.Code, dataBlockLocationPlan.Target);
+                Assert.Equal(_england.Code, dataBlockLocationPlan.TargetCode);
+                Assert.Equal(_england.Name, dataBlockLocationPlan.TargetName);
                 Assert.True(dataBlockLocationPlan.Valid);
 
                 Assert.NotNull(dataBlockPlan.TimePeriods);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Admin.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
@@ -533,9 +532,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             }
 
             var locations = _locationRepository.GetLocationAttributes(geographicLevel, originalCodes);
-            var replacementLocations = replacementSubjectMeta.ObservationalUnits
-                .GetValueOrDefault(geographicLevel)
-                ?.ToDictionary(location => location.Code) ?? new Dictionary<string, ILocationAttribute>();
+            var replacementLocations = replacementSubjectMeta
+                .ObservationalUnits
+                .GetValueOrDefault(geographicLevel) ?? new List<ILocationAttribute>();
 
             return new LocationReplacementViewModel(
                 label: geographicLevel.GetEnumLabel(),
@@ -547,12 +546,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         private static ObservationalUnitReplacementViewModel ValidateLocationForReplacement(
             ILocationAttribute location,
-            IReadOnlyDictionary<string, ILocationAttribute> replacementLocations)
+            IEnumerable<ILocationAttribute> replacementLocations)
         {
+            var replacementLocation = replacementLocations
+                .SingleOrDefault(replacement => 
+                    replacement.Name == location.Name 
+                    && replacement.Code == location.Code);
+            
             return new ObservationalUnitReplacementViewModel(
                 label: location.Name,
                 code: location.Code,
-                target: replacementLocations.GetValueOrDefault(location.Code)?.Code ?? string.Empty
+                targetCode: replacementLocation?.Code ?? string.Empty,
+                targetName: replacementLocation?.Name ?? string.Empty
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -268,15 +268,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
     {
         public string Code { get; }
         public string Label { get; }
-        public string Target { get; }
+        public string TargetCode { get; }
+        
+        public string TargetName { get; }
 
-        public bool Valid => !Target.IsNullOrEmpty();
+        public bool Valid => !TargetCode.IsNullOrEmpty() && !TargetName.IsNullOrEmpty();
 
-        public ObservationalUnitReplacementViewModel(string code, string label, string target)
+        public ObservationalUnitReplacementViewModel(string code, string label, string targetCode, string targetName)
         {
             Code = code;
             Label = label;
-            Target = target;
+            TargetCode = targetCode;
+            TargetName = targetName;
         }
     }
 


### PR DESCRIPTION
This PR:
- amends the building of Replacement plans for Data Blocks to look up replacement Locations by Code AND Name, rather than by code alone, thus preventing the previous code from exploding with a duplicate key issue when attempting to look up replacement Locations by Code alone.