### PR TITLE
EES-3237 Flag whether the table header count has changed during data blocks migration

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220309154956_EES3237_AddDataBlockColumnForLocationsMigration.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220309154956_EES3237_AddDataBlockColumnForLocationsMigration.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220309154956_EES3237_AddDataBlockColumnForLocationsMigration")]
+    partial class EES3237_AddDataBlockColumnForLocationsMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220309154956_EES3237_AddDataBlockColumnForLocationsMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220309154956_EES3237_AddDataBlockColumnForLocationsMigration.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES3237_AddDataBlockColumnForLocationsMigration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "DataBlock_TableHeaderCountChanged",
+                table: "ContentBlock",
+                type: "bit",
+                nullable: true,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataBlock_TableHeaderCountChanged",
+                table: "ContentBlock");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220309154956_EES3237_AddDataBlockColumnForLocationsMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220309154956_EES3237_AddDataBlockColumnForLocationsMigration.cs
@@ -14,6 +14,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                 type: "bit",
                 nullable: true,
                 defaultValue: false);
+
+            // We will need to re-run the migration of data blocks to calculate a value for 'TableHeaderCountChanged'.
+            // Reset the migration status of all data blocks that are already migrated.
+            // Migrating them again will be safe since the chart/query/table pre-migration remain the same post-migration.
+            // The new values are written to temporary columns which are safe to overwrite until EES-2955.
+            migrationBuilder.Sql(
+                "UPDATE dbo.ContentBlock SET DataBlock_LocationsMigrated = 0 WHERE Type = 'DataBlock' AND DataBlock_LocationsMigrated = 1");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
@@ -132,6 +132,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public List<IChart> ChartsMigrated { get; set; } = new();
         public ObservationQueryContext QueryMigrated { get; set; }
         public TableBuilderConfiguration TableMigrated { get; set; }
+        public bool TableHeaderCountChanged { get; set; }
         public bool LocationsMigrated { get; set; }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -379,6 +379,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     v => JsonConvert.SerializeObject(v),
                     v => JsonConvert.DeserializeObject<TableBuilderConfiguration>(v));
             modelBuilder.Entity<DataBlock>()
+                .Property(block => block.TableHeaderCountChanged)
+                .HasColumnName("DataBlock_TableHeaderCountChanged")
+                .HasDefaultValue(false)
+                .IsRequired();
+            modelBuilder.Entity<DataBlock>()
                 .Property(block => block.LocationsMigrated)
                 .HasColumnName("DataBlock_LocationsMigrated")
                 .HasDefaultValue(false)


### PR DESCRIPTION
This PR makes a change to the data blocks migration added by https://github.com/dfe-analytical-services/explore-education-statistics/pull/3180.

It adds a new `ContentBlock` column `DataBlock_TableHeaderCountChanged`, used to flag whether the table header count has changed as a result of additional headers being inserted. 

This allows us to easily spot tables that have had additional headers inserted which need checking carefully.

It also allows us to know in advance of testing which tables we should expect visual differences to occur for.

The migration status of all data blocks is reset which will force us to re-run the migration so that this value is calculated. Migrating them again will be safe since the chart/query/table pre-migration remain the same post-migration. The new values are written to temporary columns which are safe to overwrite until EES-2955.

ℹ️ New developer test data file `ees-mssql-data-42.zip` has been prepared which has had the data block migration run and it already includes this change.

### Other changes

- Adds an additional unit test `Migrate_QueryHasLaWithNoCodesOnlyOldCodes` to test that a Subject file with Local Authority locations that have either a `null` code or an empty code, but have an 'old' code instead, get migrated correctly when a data block query contains those 'old' codes.