### PR TITLE
EES-3228 - only use replacement Locations from original Subject

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -652,7 +652,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(new Dictionary<GeographicLevel, IEnumerable<ILocationAttribute>>());
 
             mocks.locationRepository
-                .Setup(s => s.GetLocationAttributes(GeographicLevel.Country, new[] {CountryCodeEngland}))
+                .Setup(s => s.GetLocationAttributes(
+                    GeographicLevel.Country, 
+                    new[] {CountryCodeEngland}, 
+                    originalSubject.Id))
                 .Returns(ListOf(_england));
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
@@ -1109,7 +1112,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.locationRepository
-                .Setup(service => service.GetLocationAttributes(GeographicLevel.Country, new[] {CountryCodeEngland}))
+                .Setup(service => service.GetLocationAttributes(
+                    GeographicLevel.Country, 
+                    new[] {CountryCodeEngland}, 
+                    originalSubject.Id))
                 .Returns(ListOf(_england));
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
@@ -1375,7 +1381,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.locationRepository
-                .Setup(service => service.GetLocationAttributes(GeographicLevel.Country, new[] {CountryCodeEngland}))
+                .Setup(service => service.GetLocationAttributes(
+                    GeographicLevel.Country, 
+                    new[] {CountryCodeEngland}, 
+                    originalSubject.Id))
                 .Returns(ListOf(_england));
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
@@ -1666,7 +1675,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.locationRepository
-                .Setup(service => service.GetLocationAttributes(GeographicLevel.Country, new[] {CountryCodeEngland}))
+                .Setup(service => service.GetLocationAttributes(
+                    GeographicLevel.Country, 
+                    new[] {CountryCodeEngland}, 
+                    originalSubject.Id))
                 .Returns(ListOf(_england));
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
@@ -2079,7 +2091,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.locationRepository
-                .Setup(service => service.GetLocationAttributes(GeographicLevel.Country, new[] {CountryCodeEngland}))
+                .Setup(service => service.GetLocationAttributes(
+                    GeographicLevel.Country, 
+                    new[] {CountryCodeEngland}, 
+                    originalSubject.Id))
                 .Returns(ListOf(_england));
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
@@ -2458,7 +2473,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(new Dictionary<GeographicLevel, IEnumerable<ILocationAttribute>>());
 
             mocks.locationRepository
-                .Setup(service => service.GetLocationAttributes(GeographicLevel.Country, new[] {CountryCodeEngland}))
+                .Setup(service => service.GetLocationAttributes(
+                    GeographicLevel.Country, 
+                    new[] {CountryCodeEngland}, 
+                    originalSubject.Id))
                 .Returns(ListOf(_england));
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
@@ -2900,7 +2918,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.locationRepository
-                .Setup(service => service.GetLocationAttributes(GeographicLevel.Country, new[] {CountryCodeEngland}))
+                .Setup(service => service.GetLocationAttributes(
+                    GeographicLevel.Country, 
+                    new[] {CountryCodeEngland}, 
+                    originalSubject.Id))
                 .Returns(ListOf(_england));
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -430,8 +430,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return GetEnumValues<GeographicLevel>()
                 .ToDictionary(geographicLevel => geographicLevel.ToString(),
                     geographicLevel =>
-                        ValidateLocationLevelForReplacement(dataBlock.Query.Locations,
+                        ValidateLocationLevelForReplacement(
+                            dataBlock.Query.Locations,
                             geographicLevel,
+                            dataBlock.Query.SubjectId,
                             replacementSubjectMeta))
                 .Filter(pair => pair.Value.Any);
         }
@@ -506,9 +508,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             );
         }
 
-        private LocationReplacementViewModel ValidateLocationLevelForReplacement(
-            LocationQuery locationQuery,
+        private LocationReplacementViewModel ValidateLocationLevelForReplacement(LocationQuery locationQuery,
             GeographicLevel geographicLevel,
+            Guid subjectId,
             ReplacementSubjectMeta replacementSubjectMeta)
         {
             var queryProperty = typeof(LocationQuery).GetProperty(geographicLevel.ToString());
@@ -531,7 +533,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 );
             }
 
-            var locations = _locationRepository.GetLocationAttributes(geographicLevel, originalCodes);
+            var locations = _locationRepository.GetLocationAttributes(
+                geographicLevel, 
+                originalCodes,
+                subjectId);
+            
             var replacementLocations = replacementSubjectMeta
                 .ObservationalUnits
                 .GetValueOrDefault(geographicLevel) ?? new List<ILocationAttribute>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/ILocationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/ILocationRepository.cs
@@ -13,8 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Inter
 
         Task<Dictionary<GeographicLevel, IEnumerable<ILocationAttribute>>> GetLocationAttributes(Guid subjectId);
 
-        IEnumerable<ILocationAttribute> GetLocationAttributes(
-            GeographicLevel level,
-            IEnumerable<string> codes);
+        IEnumerable<ILocationAttribute> GetLocationAttributes(GeographicLevel level,
+            IEnumerable<string> codes, Guid subjectId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/LocationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/LocationRepository.cs
@@ -44,99 +44,115 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
                 );
         }
 
-        public IEnumerable<ILocationAttribute> GetLocationAttributes(GeographicLevel level, IEnumerable<string> codes)
+        public IEnumerable<ILocationAttribute> GetLocationAttributes(
+            GeographicLevel level, 
+            IEnumerable<string> codes,
+            Guid subjectId)
         {
+            var subjectLocationsIds = _context
+                .Observation
+                .Where(observation => observation.SubjectId == subjectId)
+                .Select(observation => observation.LocationId)
+                .Distinct()
+                .ToList();
+
+            var baseLocationQuery = _context
+                .Location
+                .Where(location => 
+                    subjectLocationsIds.Contains(location.Id) && 
+                    location.GeographicLevel == level);
+            
             IQueryable<ILocationAttribute> query = level switch
             {
                 GeographicLevel.EnglishDevolvedArea =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.EnglishDevolvedArea_Code))
                         .GroupBy(q => new {q.EnglishDevolvedArea_Code, q.EnglishDevolvedArea_Name})
                         .Select(q =>
                             new EnglishDevolvedArea(q.Key.EnglishDevolvedArea_Code, q.Key.EnglishDevolvedArea_Name)),
                 GeographicLevel.LocalAuthority =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.LocalAuthority_Code))
                         .GroupBy(q => new {q.LocalAuthority_Code, q.LocalAuthority_OldCode, q.LocalAuthority_Name})
                         .Select(q => new LocalAuthority(q.Key.LocalAuthority_Code, q.Key.LocalAuthority_OldCode,
                             q.Key.LocalAuthority_Name)),
                 GeographicLevel.LocalAuthorityDistrict =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.LocalAuthorityDistrict_Code))
                         .GroupBy(q => new {q.LocalAuthorityDistrict_Code, q.LocalAuthorityDistrict_Name})
                         .Select(q =>
                             new LocalAuthorityDistrict(q.Key.LocalAuthorityDistrict_Code,
                                 q.Key.LocalAuthorityDistrict_Name)),
                 GeographicLevel.LocalEnterprisePartnership =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.LocalEnterprisePartnership_Code))
                         .GroupBy(q => new {q.LocalEnterprisePartnership_Code, q.LocalEnterprisePartnership_Name})
                         .Select(q => new LocalEnterprisePartnership(q.Key.LocalEnterprisePartnership_Code,
                             q.Key.LocalEnterprisePartnership_Name)),
                 GeographicLevel.Institution =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.Institution_Code))
                         .GroupBy(q => new {q.Institution_Code, q.Institution_Name})
                         .Select(q => new Institution(q.Key.Institution_Code, q.Key.Institution_Name)),
                 GeographicLevel.MayoralCombinedAuthority =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.MayoralCombinedAuthority_Code))
                         .GroupBy(q => new {q.MayoralCombinedAuthority_Code, q.MayoralCombinedAuthority_Name})
                         .Select(q => new MayoralCombinedAuthority(q.Key.MayoralCombinedAuthority_Code,
                             q.Key.MayoralCombinedAuthority_Name)),
                 GeographicLevel.MultiAcademyTrust =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.MultiAcademyTrust_Code))
                         .GroupBy(q => new {q.MultiAcademyTrust_Code, q.MultiAcademyTrust_Name})
                         .Select(q => new Mat(q.Key.MultiAcademyTrust_Code, q.Key.MultiAcademyTrust_Name)),
                 GeographicLevel.Country =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.Country_Code))
                         .GroupBy(q => new {q.Country_Code, q.Country_Name})
                         .Select(q => new Country(q.Key.Country_Code, q.Key.Country_Name)),
                 GeographicLevel.OpportunityArea =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.OpportunityArea_Code))
                         .GroupBy(q => new {q.OpportunityArea_Code, q.OpportunityArea_Name})
                         .Select(q => new OpportunityArea(q.Key.OpportunityArea_Code, q.Key.OpportunityArea_Name)),
                 GeographicLevel.ParliamentaryConstituency =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.ParliamentaryConstituency_Code))
                         .GroupBy(q => new {q.ParliamentaryConstituency_Code, q.ParliamentaryConstituency_Name})
                         .Select(q => new ParliamentaryConstituency(q.Key.ParliamentaryConstituency_Code,
                             q.Key.ParliamentaryConstituency_Name)),
                 GeographicLevel.Provider =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.Provider_Code))
                         .GroupBy(q => new {q.Provider_Code, q.Provider_Name})
                         .Select(q => new Provider(q.Key.Provider_Code, q.Key.Provider_Name)),
                 GeographicLevel.Region =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.Region_Code))
                         .GroupBy(q => new {q.Region_Code, q.Region_Name})
                         .Select(q => new Region(q.Key.Region_Code, q.Key.Region_Name)),
                 GeographicLevel.RscRegion =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.RscRegion_Code))
                         .GroupBy(q => new {q.RscRegion_Code})
                         .Select(q => new RscRegion(q.Key.RscRegion_Code)),
                 GeographicLevel.School =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.School_Code))
                         .GroupBy(q => new {q.School_Code, q.School_Name})
                         .Select(q => new School(q.Key.School_Code, q.Key.School_Name)),
                 GeographicLevel.Sponsor =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.Sponsor_Code))
                         .GroupBy(q => new {q.Sponsor_Code, q.Sponsor_Name})
                         .Select(q => new Sponsor(q.Key.Sponsor_Code, q.Key.Sponsor_Name)),
                 GeographicLevel.Ward =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.Ward_Code))
                         .GroupBy(q => new {q.Ward_Code, q.Ward_Name})
                         .Select(q => new Ward(q.Key.Ward_Code, q.Key.Ward_Name)),
                 GeographicLevel.PlanningArea =>
-                    _context.Location
+                    baseLocationQuery
                         .Where(q => codes.Contains(q.PlanningArea_Code))
                         .GroupBy(q => new {q.PlanningArea_Code, q.PlanningArea_Name})
                         .Select(q => new PlanningArea(q.Key.PlanningArea_Code, q.Key.PlanningArea_Name)),


### PR DESCRIPTION
This PR:
- adds an additional constraint to the lookup of Locations for use in Data Block replacements by restricting to the Locations that were in the original Subject