### PR TITLE
EES-3259 Increase size of Prod content db and parameterise size as variable

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -71,7 +71,10 @@
     "branch": {
        "value": "dev"
     },
-    "maxDbSizeBytes": {
+    "maxContentDbSizeBytes": {
+      "value": 322122547200
+    },
+    "maxStatsDbSizeBytes": {
       "value": 322122547200
     },
     "dataFactoryConcurrency": {

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -49,6 +49,12 @@
     },
     "tableBuilderMaxTableCellsAllowed": {
       "value": 1000000
+    },
+    "maxContentDbSizeBytes": {
+      "value": 1073741824
+    },
+    "maxStatsDbSizeBytes": {
+      "value": 268435456000
     }
   }
 }

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -71,7 +71,10 @@
     "tableBuilderMaxTableCellsAllowed": {
       "value": 1000000
     },
-    "maxDbSizeBytes": {
+    "maxContentDbSizeBytes": {
+      "value": 2147483648
+    },
+    "maxStatsDbSizeBytes": {
       "value": 375809638400
     }
   }

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -55,6 +55,12 @@
     },
     "tableBuilderMaxTableCellsAllowed": {
       "value": 1000000
+    },
+    "maxContentDbSizeBytes": {
+      "value": 1073741824
+    },
+    "maxStatsDbSizeBytes": {
+      "value": 268435456000
     }
   }
 }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -558,7 +558,11 @@
       "type": "string",
       "defaultValue": "deploy"
     },
-    "maxDbSizeBytes": {
+    "maxContentDbSizeBytes": {
+      "type": "int",
+      "defaultValue": 1073741824
+    },
+    "maxStatsDbSizeBytes": {
       "type": "int",
       "defaultValue": 268435456000
     },
@@ -2034,7 +2038,7 @@
           "kind": "v12.0,user,vcore,serverless",
           "properties": {
             "collation": "SQL_Latin1_General_CP1_CI_AS",
-            "maxSizeBytes": "[parameters('maxDbSizeBytes')]",
+            "maxSizeBytes": "[parameters('maxStatsDbSizeBytes')]",
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,
             "readScale": "Disabled",
@@ -2073,7 +2077,7 @@
           "kind": "v12.0,user,vcore,serverless",
           "properties": {
             "collation": "SQL_Latin1_General_CP1_CI_AS",
-            "maxSizeBytes": "1073741824",
+            "maxSizeBytes": "[parameters('maxContentDbSizeBytes')]",
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,
             "readScale": "Disabled",
@@ -2283,7 +2287,7 @@
           "kind": "v12.0,user,vcore,serverless",
           "properties": {
             "collation": "SQL_Latin1_General_CP1_CI_AS",
-            "maxSizeBytes": "[parameters('maxDbSizeBytes')]",
+            "maxSizeBytes": "[parameters('maxStatsDbSizeBytes')]",
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,
             "readScale": "Disabled",


### PR DESCRIPTION
This PR makes ARM template changes with the overall aim intending to increase the capacity of the Content database in the Prod environment from 1Gb to 2Gb.

The actual changes are:

- Rename variable `maxDbSizeBytes` to `maxStatsDbSizeBytes`.
- Add variable `maxStatsDbSizeBytes` with default value to all environment files where it's missing (Test and Pre-Prod).
- Add variable `maxContentDbSizeBytes` with default 1Gb to replace current value which was 1Gb (1073741824 bytes).
- Override variable `maxContentDbSizeBytes` in the Prod environment file to 2Gb (2147483648 bytes).