### PR TITLE
EES-3259 Correct maxContentDbSizeBytes in dev.parameters.json

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -72,7 +72,7 @@
        "value": "dev"
     },
     "maxContentDbSizeBytes": {
-      "value": 322122547200
+      "value": 1073741824
     },
     "maxStatsDbSizeBytes": {
       "value": 322122547200


### PR DESCRIPTION
This PR corrects the `maxContentDbSizeBytes` in the environment file `dev.parameters.json` for the Dev environment.

This was a mistake made in https://github.com/dfe-analytical-services/explore-education-statistics/pull/3207.