### PR TITLE
    EES-3268 - add health checks to admin, content & data APIs

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -103,6 +103,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+
+            services.AddHealthChecks();
+            
             services.AddApplicationInsightsTelemetry()
                 .AddApplicationInsightsTelemetryProcessor<SensitiveDataTelemetryProcessor>();
 
@@ -467,7 +470,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            // Enable caching and register any caching services.
+        // Enable caching and register any caching services.
             CacheAspect.Enabled = true;
             BlobCacheAttribute.AddService("default", app.ApplicationServices.GetService<IBlobCacheService>());
 
@@ -533,6 +536,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             app.UseAuthentication();
             app.UseIdentityServer();
             app.UseAuthorization();
+            app.UseRouting();
+            app.UseHealthChecks("/api/health");
 
             // deny access to all Identity routes other than /Identity/Account/Login and
             // /Identity/Account/ExternalLogin

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
@@ -15,10 +15,9 @@
         <requestLimits maxAllowedContentLength="104857600" />
       </requestFiltering>
     </security>
-   <applicationInitialization
-      doAppInitAfterRestart="true"
-    >
-      <add initializationPage="/"/> 
+
+    <applicationInitialization doAppInitAfterRestart="true">
+      <add initializationPage="/api/health" />
     </applicationInitialization>
     <rewrite>
       <rules>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -58,6 +58,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddHealthChecks();
+            
             services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 
             services.AddApplicationInsightsTelemetry()
@@ -199,6 +201,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
                 .AllowAnyHeader());
 
             app.UseMvc();
+            app.UseHealthChecks("/api/health");
         }
 
         /**

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/web.config
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/web.config
@@ -15,10 +15,8 @@
         <requestLimits maxAllowedContentLength="104857600" />
       </requestFiltering>
     </security>
-  <applicationInitialization
-      doAppInitAfterRestart="true"
-    >
-      <add initializationPage="/"/> 
+    <applicationInitialization doAppInitAfterRestart="true">      
+      <add initializationPage="/api/health"/>
     </applicationInitialization>
   </system.webServer>
 </configuration>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -60,6 +60,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddHealthChecks();
+
             services.AddApplicationInsightsTelemetry()
                 .AddApplicationInsightsTelemetryProcessor<SensitiveDataTelemetryProcessor>();
             
@@ -236,6 +238,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
                 .AllowAnyHeader());
 
             app.UseMvc();
+            app.UseHealthChecks("/api/health");
         }
 
         private static void UpdateDatabase(IApplicationBuilder app)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/web.config
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/web.config
@@ -15,10 +15,8 @@
         <requestLimits maxAllowedContentLength="104857600" />
       </requestFiltering>
     </security>
-  <applicationInitialization
-      doAppInitAfterRestart="true"
-    >
-      <add initializationPage="/"/> 
+  <applicationInitialization doAppInitAfterRestart="true">
+      <add initializationPage="/api/health"/> 
     </applicationInitialization>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
This PR adds health checks to the admin, data & content API. This has been added in order to provide an endpoint that Azure can use during deployments (in an attempt to fix EES-949) 