### PR TITLE
EES-3270 pre-release methodology view frontend / EES-3271 pre-release methodology view backend permissions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseRoleRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseRoleRepositoryTests.cs
@@ -4,9 +4,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
@@ -356,7 +358,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var service = new UserReleaseRoleRepository(contentDbContext);
+                var service = SetupUserReleaseRoleRepository(contentDbContext);
                 await service.Remove(userReleaseRole, deletedById);
 
                 var updatedReleaseRole = contentDbContext.UserReleaseRoles
@@ -389,7 +391,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var service = new UserReleaseRoleRepository(contentDbContext);
+                var service = SetupUserReleaseRoleRepository(contentDbContext);
                 await service.Remove(userReleaseRole, deletedById);
 
                 var updatedReleaseRole = contentDbContext.UserReleaseRoles
@@ -452,7 +454,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var service = new UserReleaseRoleRepository(contentDbContext);
+                var service = SetupUserReleaseRoleRepository(contentDbContext);
                 await service.RemoveMany(
                     ListOf(userReleaseRole1, userReleaseRole2, userReleaseRole3),
                     deletedById);
@@ -511,7 +513,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var service = new UserReleaseRoleRepository(contentDbContext);
+                var service = SetupUserReleaseRoleRepository(contentDbContext);
                 await service.RemoveMany(
                     ListOf(userReleaseRole1, userReleaseRole2, userReleaseRole3),
                     deletedById);
@@ -612,7 +614,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var service = new UserReleaseRoleRepository(contentDbContext);
+                var service = SetupUserReleaseRoleRepository(contentDbContext);
                 await service.RemoveAllForPublication(user.Id, publication, Contributor,
                     deletedById);
 
@@ -1040,6 +1042,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var latestReleaseOtherPublication = new Release
             {
                 Publication = new Publication(),
+                ApprovalStatus = Approved,
                 ReleaseName = "2020",
                 TimePeriodCoverage = CalendarYear
             };
@@ -1115,6 +1118,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var latestReleaseOtherPublication = new Release
             {
                 Publication = new Publication(),
+                ApprovalStatus = Approved,
                 ReleaseName = "2020",
                 TimePeriodCoverage = CalendarYear
             };
@@ -1190,6 +1194,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var latestReleaseOtherPublication = new Release
             {
                 Publication = new Publication(),
+                ApprovalStatus = Approved,
                 ReleaseName = "2020",
                 TimePeriodCoverage = CalendarYear
             };
@@ -1265,6 +1270,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var latestReleaseOtherPublication = new Release
             {
                 Publication = new Publication(),
+                ApprovalStatus = Approved,
                 ReleaseName = "2020",
                 TimePeriodCoverage = CalendarYear
             };
@@ -1588,7 +1594,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         private static UserReleaseRoleRepository SetupUserReleaseRoleRepository(
-            ContentDbContext contentDbContext)
+            ContentDbContext contentDbContext,
+            IPreReleaseService? preReleaseService = null)
         {
             return new(contentDbContext);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseRoleRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseRoleRepositoryTests.cs
@@ -1593,9 +1593,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             }
         }
 
-        private static UserReleaseRoleRepository SetupUserReleaseRoleRepository(
-            ContentDbContext contentDbContext,
-            IPreReleaseService? preReleaseService = null)
+        private static UserReleaseRoleRepository SetupUserReleaseRoleRepository(ContentDbContext contentDbContext)
         {
             return new(contentDbContext);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlers.cs
@@ -70,8 +70,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 context.Succeed(requirement);
             }
 
-            // If the user is an PrereleaseViewer of the latest non-Live, Approved Release of the owning Publication
-            // of this Methodology, and the methodology is approved, and the latest release under that publication
+            // If the user is a PrereleaseViewer of the latest non-Live, Approved Release of any Publication
+            // using this Methodology, and the methodology is approved, and the latest release under that publication
             // is within the prerelease time window, they can view it
             if (methodologyVersion.Approved)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlers.cs
@@ -59,6 +59,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             {
                 context.Succeed(requirement);
             }
+
+            // If the user is an PrereleaseViewer of the latest non-Live, Approved Release of the owning Publication
+            // of this Methodology, and the methodology is approved, they can view it
+            if (await _userReleaseRoleRepository.IsUserPrereleaseViewerOnLatestPreReleaseRelease(
+                context.User.GetUserId(),
+                owningPublication.Id)
+                && methodologyVersion.Approved)
+            {
+                context.Succeed(requirement);
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlers.cs
@@ -1,10 +1,14 @@
 #nullable enable
+using System;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
@@ -15,18 +19,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
     public class ViewSpecificMethodologyAuthorizationHandler :
         AuthorizationHandler<ViewSpecificMethodologyRequirement, MethodologyVersion>
     {
+        private readonly ContentDbContext _contentDbContext;
         private readonly IMethodologyRepository _methodologyRepository;
         private readonly IUserPublicationRoleRepository _userPublicationRoleRepository;
         private readonly IUserReleaseRoleRepository _userReleaseRoleRepository;
+        private readonly IPreReleaseService _preReleaseService;
 
         public ViewSpecificMethodologyAuthorizationHandler(
+            ContentDbContext contentDbContext,
             IMethodologyRepository methodologyRepository,
             IUserPublicationRoleRepository userPublicationRoleRepository,
-            IUserReleaseRoleRepository userReleaseRoleRepository)
+            IUserReleaseRoleRepository userReleaseRoleRepository,
+            IPreReleaseService preReleaseService)
         {
+            _contentDbContext = contentDbContext;
             _methodologyRepository = methodologyRepository;
             _userPublicationRoleRepository = userPublicationRoleRepository;
             _userReleaseRoleRepository = userReleaseRoleRepository;
+            _preReleaseService = preReleaseService;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
@@ -61,13 +71,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             }
 
             // If the user is an PrereleaseViewer of the latest non-Live, Approved Release of the owning Publication
-            // of this Methodology, and the methodology is approved, they can view it
-            if (await _userReleaseRoleRepository.IsUserPrereleaseViewerOnLatestPreReleaseRelease(
-                context.User.GetUserId(),
-                owningPublication.Id)
-                && methodologyVersion.Approved)
+            // of this Methodology, and the methodology is approved, and the latest release under that publication
+            // is within the prerelease time window, they can view it
+            if (methodologyVersion.Approved)
             {
-                context.Succeed(requirement);
+                var publicationIds = await _methodologyRepository
+                    .GetAllPublicationIds(methodologyVersion.MethodologyId);
+                foreach (var publicationId in publicationIds)
+                {
+                    if (await _userReleaseRoleRepository.IsUserPrereleaseViewerOnLatestPreReleaseRelease(
+                            context.User.GetUserId(),
+                            publicationId))
+                    {
+                        var publication = await _contentDbContext.Publications
+                            .Include(p => p.Releases)
+                            .SingleAsync(p => p.Id == publicationId);
+                        var latestRelease = publication.LatestRelease();
+                        if (latestRelease != null
+                            && _preReleaseService
+                                .GetPreReleaseWindowStatus(latestRelease, DateTime.UtcNow)
+                                .Access == PreReleaseAccess.Within)
+                        {
+                            context.Succeed(requirement);
+                            break;
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserReleaseRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserReleaseRoleRepository.cs
@@ -43,6 +43,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<bool> IsUserEditorOrApproverOnLatestRelease(Guid userId, Guid publicationId);
 
+        Task<bool> IsUserPrereleaseViewerOnLatestPreReleaseRelease(Guid userId, Guid publicationId);
+
         Task<UserReleaseRole?> GetUserReleaseRole(Guid userId,
             Guid releaseId,
             ReleaseRole role);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseRoleRepository.cs
@@ -193,12 +193,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 return false;
             }
 
-            return await _contentDbContext.UserReleaseRoles
-                .AsQueryable()
-                .AnyAsync(r =>
-                    r.UserId == userId &&
-                    r.ReleaseId == latestRelease.Id &&
-                    r.Role == ReleaseRole.PrereleaseViewer);
+            return await HasUserReleaseRole(
+                userId,
+                latestRelease.Id,
+                ReleaseRole.PrereleaseViewer);
         }
 
         public async Task<UserReleaseRole?> GetUserReleaseRole(Guid userId, Guid releaseId, ReleaseRole role)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyRepository.cs
@@ -7,10 +7,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 {
     public interface IMethodologyRepository
     {
-        public Task<List<Methodology>> GetByPublication(Guid publicationId);
+        Task<List<Methodology>> GetByPublication(Guid publicationId);
 
         Task<Publication> GetOwningPublication(Guid methodologyId);
 
-        public Task<List<Methodology>> GetUnrelatedToPublication(Guid publicationId);
+        Task<List<Guid>> GetAllPublicationIds(Guid methodologyId);
+
+        Task<List<Methodology>> GetUnrelatedToPublication(Guid publicationId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
@@ -42,6 +42,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
             return owningPublicationLink.Publication;
         }
 
+        public Task<List<Guid>> GetAllPublicationIds(Guid methodologyId)
+        {
+            return _contentDbContext.PublicationMethodologies
+                .Where(pm => pm.MethodologyId == methodologyId)
+                .Select(pm => pm.PublicationId)
+                .ToListAsync();
+        }
+
         public async Task<List<Methodology>> GetUnrelatedToPublication(Guid publicationId)
         {
             return await _contentDbContext.Methodologies

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/MethodologyContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/MethodologyContentPage.tsx
@@ -1,5 +1,6 @@
 import BrowserWarning from '@admin/components/BrowserWarning';
 import EditablePageModeToggle from '@admin/components/editable/EditablePageModeToggle';
+import PageTitle from '@admin/components/PageTitle';
 import { EditingContextProvider } from '@admin/contexts/EditingContext';
 import PrintThisPage from '@admin/components/PrintThisPage';
 import { MethodologyRouteParams } from '@admin/routes/methodologyRoutes';
@@ -22,11 +23,15 @@ import SummaryListItem from '@common/components/SummaryListItem';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
-const MethodologyContentPageInternal = () => {
-  const { methodology, canUpdateMethodology } = useMethodologyContentState();
+export const MethodologyContentPageInternal = () => {
+  const {
+    methodology,
+    canUpdateMethodology,
+    isPreRelease,
+  } = useMethodologyContentState();
 
   const canUpdateContent =
-    canUpdateMethodology && methodology.status === 'Draft';
+    !isPreRelease && canUpdateMethodology && methodology.status === 'Draft';
 
   return (
     <EditingContextProvider editingMode={canUpdateContent ? 'edit' : 'preview'}>
@@ -48,13 +53,17 @@ const MethodologyContentPageInternal = () => {
                 </BrowserWarning>
               )}
 
-              <h2
-                aria-hidden
-                className="govuk-heading-lg"
-                data-testid="page-title"
-              >
-                {methodology.title}
-              </h2>
+              {isPreRelease ? (
+                <PageTitle caption="Methodology" title={methodology.title} />
+              ) : (
+                <h2
+                  aria-hidden
+                  className="govuk-heading-lg"
+                  data-testid="page-title"
+                >
+                  {methodology.title}
+                </h2>
+              )}
 
               <SummaryList>
                 <SummaryListItem term="Publish date">
@@ -68,8 +77,8 @@ const MethodologyContentPageInternal = () => {
               </SummaryList>
               {editingMode !== 'edit' && (
                 <>
-                  <PrintThisPage />
                   <PageSearchForm inputLabel="Search in this methodology page." />
+                  <PrintThisPage />
                 </>
               )}
 

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesSection.tsx
@@ -200,7 +200,7 @@ const MethodologyNotesSection = ({ methodology }: Props) => {
             id="methodologyNotes"
             open={editingMode === 'edit'}
           >
-            <ol className="govuk-list">
+            <ol className="govuk-list" data-testid="notes">
               {orderedNotes.map(note => (
                 <li key={note.id}>
                   {editingMode === 'edit' &&
@@ -209,10 +209,13 @@ const MethodologyNotesSection = ({ methodology }: Props) => {
                     renderEditForm()
                   ) : (
                     <>
-                      <FormattedDate className="govuk-body govuk-!-font-weight-bold">
+                      <FormattedDate
+                        className="govuk-body govuk-!-font-weight-bold"
+                        data-testId="note-displayDate"
+                      >
                         {note.displayDate}
                       </FormattedDate>
-                      <p>{note.content}</p>
+                      <p data-testid="note-content">{note.content}</p>
 
                       {editingMode === 'edit' && (
                         <ButtonGroup>

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/MethodologyContentContext.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/MethodologyContentContext.tsx
@@ -12,6 +12,7 @@ export type MethodologyContextDispatch = (
 export type MethodologyContextState = {
   methodology: MethodologyContent;
   canUpdateMethodology: boolean;
+  isPreRelease?: boolean;
 };
 
 const MethodologyStateContext = createContext<

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
@@ -1,0 +1,98 @@
+import Link from '@admin/components/Link';
+import PageTitle from '@admin/components/PageTitle';
+import {
+  PreReleaseMethodologyRouteParams,
+  preReleaseMethodologyRoute,
+} from '@admin/routes/preReleaseRoutes';
+import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
+import publicationService from '@admin/services/publicationService';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import Tag from '@common/components/Tag';
+import TagGroup from '@common/components/TagGroup';
+import WarningMessage from '@common/components/WarningMessage';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import React from 'react';
+import { generatePath, RouteComponentProps } from 'react-router';
+
+const PreReleaseMethodologiesPage = ({
+  match,
+}: RouteComponentProps<ReleaseRouteParams>) => {
+  const { publicationId, releaseId } = match.params;
+
+  const { value: publication, isLoading } = useAsyncHandledRetry(
+    () => publicationService.getMyPublication(publicationId),
+    [publicationId],
+  );
+
+  const methodologies = publication?.methodologies.filter(
+    ({ methodology }) =>
+      methodology.status !== 'Draft' ||
+      (methodology.status === 'Draft' && methodology.amendment),
+  );
+
+  return (
+    <div className="govuk-width-container">
+      <>
+        <PageTitle title="Methodologies" />
+        <LoadingSpinner loading={isLoading}>
+          {publication && (
+            <>
+              {methodologies?.length === 0 &&
+              !publication.externalMethodology ? (
+                <WarningMessage>No Methodologies available.</WarningMessage>
+              ) : (
+                <ul className="govuk-list">
+                  {methodologies?.map(({ methodology, owner }) => (
+                    <li key={methodology.id}>
+                      <>
+                        <Link
+                          to={generatePath<PreReleaseMethodologyRouteParams>(
+                            preReleaseMethodologyRoute.path,
+                            {
+                              publicationId,
+                              releaseId,
+                              methodologyId:
+                                methodology.status === 'Draft' &&
+                                methodology.previousVersionId
+                                  ? methodology.previousVersionId
+                                  : methodology.id,
+                            },
+                          )}
+                        >
+                          {methodology.title} {owner ? '(Owned)' : '(Adopted)'}
+                        </Link>
+                        <TagGroup className="govuk-!-margin-left-2">
+                          {methodology.status === 'Approved' &&
+                            !methodology.published && <Tag>Approved</Tag>}
+
+                          {((methodology.amendment &&
+                            methodology.status === 'Draft') ||
+                            methodology.published) && <Tag>Published</Tag>}
+
+                          {methodology.amendment &&
+                            methodology.status === 'Approved' && (
+                              <Tag>Amendment</Tag>
+                            )}
+                        </TagGroup>
+                      </>
+                    </li>
+                  ))}
+
+                  {publication.externalMethodology && (
+                    <li>
+                      <Link to={publication.externalMethodology.url}>
+                        {publication.externalMethodology.title} (External)
+                      </Link>
+                    </li>
+                  )}
+                </ul>
+              )}
+            </>
+          )}
+        </LoadingSpinner>
+      </>
+    </div>
+  );
+};
+
+export default PreReleaseMethodologiesPage;

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
@@ -26,8 +26,7 @@ const PreReleaseMethodologiesPage = ({
 
   const methodologies = publication?.methodologies.filter(
     ({ methodology }) =>
-      methodology.status !== 'Draft' ||
-      (methodology.status === 'Draft' && methodology.amendment),
+      methodology.status !== 'Draft' || methodology.amendment,
   );
 
   return (
@@ -39,7 +38,7 @@ const PreReleaseMethodologiesPage = ({
             <>
               {methodologies?.length === 0 &&
               !publication.externalMethodology ? (
-                <WarningMessage>No Methodologies available.</WarningMessage>
+                <WarningMessage>No methodologies available.</WarningMessage>
               ) : (
                 <ul className="govuk-list">
                   {methodologies?.map(({ methodology, owner }) => (

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologyPage.tsx
@@ -1,0 +1,66 @@
+import Link from '@admin/components/Link';
+import { MethodologyContentPageInternal } from '@admin/pages/methodology/edit-methodology/content/MethodologyContentPage';
+import {
+  MethodologyContextState,
+  MethodologyContentProvider,
+} from '@admin/pages/methodology/edit-methodology/content/context/MethodologyContentContext';
+import {
+  PreReleaseMethodologyRouteParams,
+  preReleaseMethodologiesRoute,
+} from '@admin/routes/preReleaseRoutes';
+import methodologyContentService from '@admin/services/methodologyContentService';
+import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import WarningMessage from '@common/components/WarningMessage';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import React from 'react';
+import { generatePath, RouteComponentProps } from 'react-router';
+
+const PreReleaseMethodologyPage = ({
+  match,
+}: RouteComponentProps<PreReleaseMethodologyRouteParams>) => {
+  const { methodologyId, publicationId, releaseId } = match.params;
+
+  const { value, isLoading } = useAsyncHandledRetry<
+    MethodologyContextState
+  >(async () => {
+    const methodology = await methodologyContentService.getMethodologyContent(
+      methodologyId,
+    );
+
+    return {
+      methodology,
+      canUpdateMethodology: false,
+      isPreRelease: true,
+    };
+  }, [methodologyId]);
+
+  return (
+    <div className="govuk-width-container">
+      <LoadingSpinner loading={isLoading}>
+        <Link
+          back
+          className="govuk-!-margin-bottom-6"
+          to={generatePath<ReleaseRouteParams>(
+            preReleaseMethodologiesRoute.path,
+            {
+              publicationId,
+              releaseId,
+            },
+          )}
+        >
+          Back
+        </Link>
+        {value ? (
+          <MethodologyContentProvider value={value}>
+            <MethodologyContentPageInternal />
+          </MethodologyContentProvider>
+        ) : (
+          <WarningMessage>Could not load methodology</WarningMessage>
+        )}
+      </LoadingSpinner>
+    </div>
+  );
+};
+
+export default PreReleaseMethodologyPage;

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -2,7 +2,10 @@ import NavBar from '@admin/components/NavBar';
 import Page from '@admin/components/Page';
 import { useAuthContext } from '@admin/contexts/AuthContext';
 import { useConfig } from '@admin/contexts/ConfigContext';
-import { preReleaseNavRoutes } from '@admin/routes/preReleaseRoutes';
+import {
+  preReleaseNavRoutes,
+  preReleaseRoutes,
+} from '@admin/routes/preReleaseRoutes';
 import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
 import permissionService, {
   PreReleaseWindowStatus,
@@ -145,7 +148,7 @@ const PreReleasePageContainer = ({
           />
 
           <Switch>
-            {preReleaseNavRoutes.map(route => (
+            {preReleaseRoutes.map(route => (
               <Route key={route.path} {...route} />
             ))}
           </Switch>

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
@@ -1,0 +1,386 @@
+import PreReleaseMethodologiesPage from '@admin/pages/release/pre-release/PreReleaseMethodologiesPage';
+import { preReleaseMethodologiesRoute } from '@admin/routes/preReleaseRoutes';
+import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
+import _publicationService, {
+  MyPublication,
+} from '@admin/services/publicationService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router';
+import { generatePath } from 'react-router-dom';
+
+jest.mock('@admin/services/publicationService');
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+
+describe('PreReleaseMethodologiesPage', () => {
+  const testPublicationNoMethodologies: MyPublication = {
+    id: 'pub-1-id',
+    title: 'Publication 1',
+    releases: [],
+    methodologies: [],
+    legacyReleases: [],
+    topicId: 'topic-id',
+    themeId: 'theme-id',
+    permissions: {
+      canAdoptMethodologies: false,
+      canCreateMethodologies: false,
+      canCreateReleases: false,
+      canManageExternalMethodology: false,
+      canUpdatePublication: false,
+      canUpdatePublicationTitle: false,
+    },
+  };
+
+  const methodologyPermissions = {
+    canApproveMethodology: false,
+    canDeleteMethodology: false,
+    canMakeAmendmentOfMethodology: false,
+    canMarkMethodologyAsDraft: false,
+    canUpdateMethodology: false,
+  };
+
+  test('renders correctly with no methodologies', async () => {
+    publicationService.getMyPublication.mockResolvedValue(
+      testPublicationNoMethodologies,
+    );
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: 'Methodologies' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No Methodologies available.'));
+    });
+  });
+
+  test('renders correctly with published owned and adopted methodologies and external methodologies', async () => {
+    const testPublication: MyPublication = {
+      ...testPublicationNoMethodologies,
+      externalMethodology: {
+        title: 'An external methodology',
+        url: 'http://hiveit.co.uk',
+      },
+      methodologies: [
+        {
+          methodology: {
+            id: 'methodology-1-id',
+            methodologyId: 'methodologyId-1',
+            title: 'Methodology 1',
+            slug: 'methodology-1',
+            owningPublication: {
+              id: 'owning-publication-1-id',
+              title: 'Owning publication 1',
+            },
+            permissions: methodologyPermissions,
+            amendment: false,
+            published: '2018-03-22T00:00:00',
+            status: 'Approved',
+          },
+          owner: true,
+          permissions: {
+            canDropMethodology: false,
+          },
+        },
+        {
+          methodology: {
+            id: 'methodology-2-id',
+            methodologyId: 'methodologyId-2',
+            title: 'Methodology 2',
+            slug: 'methodology-2',
+            owningPublication: {
+              id: 'owning-publication-2-id',
+              title: 'Owning publication 2',
+            },
+            permissions: methodologyPermissions,
+            amendment: false,
+            published: '2018-03-22T00:00:00',
+            status: 'Approved',
+          },
+          owner: false,
+          permissions: {
+            canDropMethodology: false,
+          },
+        },
+      ],
+    };
+    publicationService.getMyPublication.mockResolvedValue(testPublication);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Methodology 1 (Owned)'));
+    });
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+
+    expect(
+      within(items[0]).getByRole('link', { name: 'Methodology 1 (Owned)' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/prerelease/methodologies/methodology-1-id',
+    );
+    expect(within(items[0]).getByText('Published'));
+
+    expect(
+      within(items[1]).getByRole('link', { name: 'Methodology 2 (Adopted)' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/prerelease/methodologies/methodology-2-id',
+    );
+    expect(within(items[1]).getByText('Published'));
+
+    expect(
+      within(items[2]).getByRole('link', {
+        name: 'An external methodology (External)',
+      }),
+    ).toHaveAttribute('href', 'http://hiveit.co.uk');
+  });
+
+  test('renders approved and scheduled methodologies correctly', async () => {
+    const testPublication: MyPublication = {
+      ...testPublicationNoMethodologies,
+      methodologies: [
+        {
+          methodology: {
+            id: 'methodology-1-id',
+            methodologyId: 'methodologyId-1',
+            title: 'Methodology 1',
+            slug: 'methodology-1',
+            owningPublication: {
+              id: 'owning-publication-1-id',
+              title: 'Owning publication 1',
+            },
+            permissions: methodologyPermissions,
+            amendment: false,
+            status: 'Approved',
+          },
+          owner: true,
+          permissions: {
+            canDropMethodology: false,
+          },
+        },
+      ],
+    };
+    publicationService.getMyPublication.mockResolvedValue(testPublication);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Methodology 1 (Owned)'));
+    });
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+
+    expect(
+      within(items[0]).getByRole('link', { name: 'Methodology 1 (Owned)' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/prerelease/methodologies/methodology-1-id',
+    );
+    expect(within(items[0]).getByText('Approved'));
+  });
+
+  test('does not show unapproved draft methodologies', async () => {
+    const testPublication: MyPublication = {
+      ...testPublicationNoMethodologies,
+      methodologies: [
+        {
+          methodology: {
+            id: 'methodology-1-id',
+            methodologyId: 'methodologyId-1',
+            title: 'Methodology 1',
+            slug: 'methodology-1',
+            owningPublication: {
+              id: 'owning-publication-1-id',
+              title: 'Owning publication 1',
+            },
+            permissions: methodologyPermissions,
+            amendment: false,
+            status: 'Draft',
+          },
+          owner: true,
+          permissions: {
+            canDropMethodology: false,
+          },
+        },
+      ],
+    };
+    publicationService.getMyPublication.mockResolvedValue(testPublication);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('No Methodologies available.'));
+    });
+
+    expect(
+      screen.queryByRole('link', { name: 'Methodology 1 (Owned)' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly and links to the previous approved version for draft amendments', async () => {
+    const testPublication: MyPublication = {
+      ...testPublicationNoMethodologies,
+      methodologies: [
+        {
+          methodology: {
+            id: 'methodology-1-id',
+            methodologyId: 'methodologyId-1',
+            title: 'Methodology 1',
+            slug: 'methodology-1',
+            owningPublication: {
+              id: 'owning-publication-1-id',
+              title: 'Owning publication 1',
+            },
+            permissions: methodologyPermissions,
+            previousVersionId: 'methodology-1-previous-id',
+            amendment: true,
+            status: 'Draft',
+          },
+          owner: true,
+          permissions: {
+            canDropMethodology: false,
+          },
+        },
+      ],
+    };
+    publicationService.getMyPublication.mockResolvedValue(testPublication);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Methodology 1 (Owned)'));
+    });
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+
+    expect(
+      within(items[0]).getByRole('link', { name: 'Methodology 1 (Owned)' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/prerelease/methodologies/methodology-1-previous-id',
+    );
+
+    expect(within(items[0]).getByText('Published'));
+  });
+
+  test('renders the correctly for approved amendments', async () => {
+    const testPublication: MyPublication = {
+      ...testPublicationNoMethodologies,
+      methodologies: [
+        {
+          methodology: {
+            id: 'methodology-1-id',
+            methodologyId: 'methodologyId-1',
+            title: 'Methodology 1',
+            slug: 'methodology-1',
+            owningPublication: {
+              id: 'owning-publication-1-id',
+              title: 'Owning publication 1',
+            },
+            permissions: methodologyPermissions,
+            previousVersionId: 'methodology-1-previous-id',
+            amendment: true,
+            status: 'Approved',
+          },
+          owner: true,
+          permissions: {
+            canDropMethodology: false,
+          },
+        },
+        {
+          methodology: {
+            id: 'methodology-2-id',
+            methodologyId: 'methodologyId-2',
+            title: 'Methodology 2',
+            slug: 'methodology-2',
+            owningPublication: {
+              id: 'owning-publication-2-id',
+              title: 'Owning publication 2',
+            },
+            permissions: methodologyPermissions,
+            previousVersionId: 'methodology-2-previous-id',
+            published: '2018-03-22T00:00:00',
+            amendment: true,
+            status: 'Approved',
+          },
+          owner: false,
+          permissions: {
+            canDropMethodology: false,
+          },
+        },
+      ],
+    };
+    publicationService.getMyPublication.mockResolvedValue(testPublication);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Methodology 1 (Owned)'));
+    });
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+
+    expect(
+      within(items[0]).getByRole('link', { name: 'Methodology 1 (Owned)' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/prerelease/methodologies/methodology-1-id',
+    );
+    expect(within(items[0]).getByText('Approved'));
+    expect(within(items[0]).getByText('Amendment'));
+
+    expect(
+      within(items[1]).getByRole('link', { name: 'Methodology 2 (Adopted)' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/prerelease/methodologies/methodology-2-id',
+    );
+    expect(within(items[1]).getByText('Published'));
+    expect(within(items[1]).getByText('Amendment'));
+  });
+
+  test('renders when there is only a external methodology', async () => {
+    const testPublication: MyPublication = {
+      ...testPublicationNoMethodologies,
+      externalMethodology: {
+        title: 'An external methodology',
+        url: 'http://hiveit.co.uk',
+      },
+    };
+
+    publicationService.getMyPublication.mockResolvedValue(testPublication);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('An external methodology (External)'));
+    });
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+
+    expect(
+      within(items[0]).getByRole('link', {
+        name: 'An external methodology (External)',
+      }),
+    ).toHaveAttribute('href', 'http://hiveit.co.uk');
+  });
+
+  const renderPage = (
+    initialEntries: string[] = [
+      generatePath<ReleaseRouteParams>(preReleaseMethodologiesRoute.path, {
+        publicationId: 'publication-1',
+        releaseId: 'release-1',
+      }),
+    ],
+  ) => {
+    return render(
+      <MemoryRouter initialEntries={initialEntries}>
+        <Route
+          component={PreReleaseMethodologiesPage}
+          path={preReleaseMethodologiesRoute.path}
+        />
+      </MemoryRouter>,
+    );
+  };
+});

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
@@ -50,7 +50,7 @@ describe('PreReleaseMethodologiesPage', () => {
     expect(screen.getByRole('heading', { name: 'Methodologies' }));
 
     await waitFor(() => {
-      expect(screen.getByText('No Methodologies available.'));
+      expect(screen.getByText('No methodologies available.'));
     });
   });
 
@@ -210,7 +210,7 @@ describe('PreReleaseMethodologiesPage', () => {
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getByText('No Methodologies available.'));
+      expect(screen.getByText('No methodologies available.'));
     });
 
     expect(

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologyPage.test.tsx
@@ -1,0 +1,332 @@
+import PreReleaseMethodologyPage from '@admin/pages/release/pre-release/PreReleaseMethodologyPage';
+import {
+  preReleaseMethodologyRoute,
+  PreReleaseMethodologyRouteParams,
+} from '@admin/routes/preReleaseRoutes';
+import _methodologyContentService, {
+  MethodologyContent,
+} from '@admin/services/methodologyContentService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router';
+import { generatePath } from 'react-router-dom';
+
+jest.mock('@admin/services/methodologyContentService');
+const methodologyContentService = _methodologyContentService as jest.Mocked<
+  typeof _methodologyContentService
+>;
+
+describe('PreReleaseMethodologyPage', () => {
+  const testMethodology: MethodologyContent = {
+    id: 'methodology-1',
+    title: 'Pupil absence statistics: methodology',
+    published: '2021-02-16T15:32:01',
+    status: 'Approved',
+    slug: 'pupil-absence-in-schools-in-england',
+    content: [
+      {
+        id: 'content-1',
+        order: 0,
+        heading: 'Section 1',
+        caption: 'Section 1 caption',
+        content: [
+          {
+            body: '<p>section 1 content</p>',
+            id: 'section-1-content',
+            order: 0,
+            type: 'HtmlBlock',
+            comments: [],
+          },
+        ],
+      },
+      {
+        id: 'content-2',
+        order: 1,
+        heading: 'Section 2',
+        caption: 'Section 2 caption',
+        content: [
+          {
+            body: '<p>section 2 content</p>',
+            id: 'section-2-content',
+            order: 0,
+            type: 'HtmlBlock',
+            comments: [],
+          },
+        ],
+      },
+    ],
+    annexes: [
+      {
+        id: 'annex-1',
+        order: 0,
+        heading: 'Annex 1',
+        caption: 'Annex 1 caption',
+        content: [
+          {
+            body: '<p>annex 1 content</p>',
+            id: 'annex-1-content',
+            order: 0,
+            type: 'HtmlBlock',
+            comments: [],
+          },
+        ],
+      },
+      {
+        id: 'annex-2',
+        order: 1,
+        heading: 'Annex 2',
+        caption: 'Annex 2 caption',
+        content: [
+          {
+            body: '<p>annex 2 content</p>',
+            id: 'annex-2-content',
+            order: 0,
+            type: 'HtmlBlock',
+            comments: [],
+          },
+        ],
+      },
+      {
+        id: 'annex-3',
+        order: 2,
+        heading: 'Annex 3',
+        caption: 'Annex 3 caption',
+        content: [
+          {
+            body: '<p>annex 3 content</p>',
+            id: 'annex-3-content',
+            order: 0,
+            type: 'HtmlBlock',
+            comments: [],
+          },
+        ],
+      },
+    ],
+    notes: [
+      {
+        id: 'note-1',
+        displayDate: new Date('2021-09-15T00:00:00'),
+        content: 'Latest note',
+      },
+      {
+        id: 'note-2',
+        displayDate: new Date('2021-04-19T00:00:00'),
+        content: 'Other note',
+      },
+      {
+        id: 'note-3',
+        displayDate: new Date('2021-03-01T00:00:00'),
+        content: 'Earliest note',
+      },
+    ],
+  };
+
+  test('renders the basic info', async () => {
+    methodologyContentService.getMethodologyContent.mockResolvedValue(
+      testMethodology,
+    );
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Pupil absence statistics: methodology'));
+    });
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Pupil absence statistics: methodology',
+      }),
+    );
+
+    expect(screen.getByTestId('Publish date-value')).toHaveTextContent(
+      '16 February 2021',
+    );
+
+    expect(screen.getByLabelText('Search in this methodology page.'));
+
+    expect(screen.getByRole('button', { name: 'Print this page' }));
+  });
+
+  test('renders the content', async () => {
+    methodologyContentService.getMethodologyContent.mockResolvedValue(
+      testMethodology,
+    );
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Pupil absence statistics: methodology'));
+    });
+
+    const contentAccordion = screen.getAllByTestId('accordion')[0];
+    const contentAccordionSections = within(contentAccordion).getAllByTestId(
+      'accordionSection',
+    );
+
+    expect(contentAccordionSections).toHaveLength(2);
+
+    expect(
+      within(contentAccordionSections[0]).getByRole('button', {
+        name: 'Section 1',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(contentAccordionSections[0]).getByText('Section 1 caption'),
+    ).toBeInTheDocument();
+    expect(
+      within(contentAccordionSections[0]).getByText('section 1 content'),
+    ).toBeInTheDocument();
+
+    expect(
+      within(contentAccordionSections[1]).getByRole('button', {
+        name: 'Section 2',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(contentAccordionSections[1]).getByText('Section 2 caption'),
+    ).toBeInTheDocument();
+    expect(
+      within(contentAccordionSections[1]).getByText('section 2 content'),
+    ).toBeInTheDocument();
+  });
+
+  test('renders the annexes', async () => {
+    methodologyContentService.getMethodologyContent.mockResolvedValue(
+      testMethodology,
+    );
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Pupil absence statistics: methodology'));
+    });
+
+    const annexAccordion = screen.getAllByTestId('accordion')[1];
+    const annexAccordionSections = within(annexAccordion).getAllByTestId(
+      'accordionSection',
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Annexes' }),
+    ).toBeInTheDocument();
+
+    expect(annexAccordionSections).toHaveLength(3);
+
+    expect(
+      within(annexAccordionSections[0]).getByRole('button', {
+        name: 'Annex 1',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(annexAccordionSections[0]).getByText('Annex 1 caption'),
+    ).toBeInTheDocument();
+    expect(
+      within(annexAccordionSections[0]).getByText('annex 1 content'),
+    ).toBeInTheDocument();
+
+    expect(
+      within(annexAccordionSections[1]).getByRole('button', {
+        name: 'Annex 2',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(annexAccordionSections[1]).getByText('Annex 2 caption'),
+    ).toBeInTheDocument();
+    expect(
+      within(annexAccordionSections[1]).getByText('annex 2 content'),
+    ).toBeInTheDocument();
+
+    expect(
+      within(annexAccordionSections[2]).getByRole('button', {
+        name: 'Annex 3',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(annexAccordionSections[2]).getByText('Annex 3 caption'),
+    ).toBeInTheDocument();
+    expect(
+      within(annexAccordionSections[2]).getByText('annex 3 content'),
+    ).toBeInTheDocument();
+  });
+
+  describe('update notes', () => {
+    test(`renders 'TBA' for 'Last updated' if there are no notes`, async () => {
+      methodologyContentService.getMethodologyContent.mockResolvedValue({
+        ...testMethodology,
+        notes: [],
+      });
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Pupil absence statistics: methodology'));
+      });
+
+      expect(screen.getByTestId('Last updated-value')).toHaveTextContent('TBA');
+    });
+
+    test(`renders 'Last updated' with the date of the most recent note`, async () => {
+      methodologyContentService.getMethodologyContent.mockResolvedValue(
+        testMethodology,
+      );
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Pupil absence statistics: methodology'));
+      });
+
+      expect(screen.getByTestId('Last updated-value')).toHaveTextContent(
+        '15 September 2021',
+      );
+    });
+
+    test(`renders the list of all notes`, async () => {
+      methodologyContentService.getMethodologyContent.mockResolvedValue(
+        testMethodology,
+      );
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Pupil absence statistics: methodology'));
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'See all notes (3)' }),
+      );
+
+      const notes = within(screen.getByTestId('notes')).getAllByRole(
+        'listitem',
+      );
+
+      expect(notes).toHaveLength(3);
+
+      expect(within(notes[0]).getByText('15 September 2021'));
+      expect(within(notes[0]).getByText('Latest note'));
+
+      expect(within(notes[1]).getByText('19 April 2021'));
+      expect(within(notes[1]).getByText('Other note'));
+
+      expect(within(notes[2]).getByText('1 March 2021'));
+      expect(within(notes[2]).getByText('Earliest note'));
+    });
+  });
+
+  const renderPage = (
+    initialEntries: string[] = [
+      generatePath<PreReleaseMethodologyRouteParams>(
+        preReleaseMethodologyRoute.path,
+        {
+          publicationId: 'publication-1',
+          releaseId: 'release-1',
+          methodologyId: 'methodology-1',
+        },
+      ),
+    ],
+  ) => {
+    return render(
+      <MemoryRouter initialEntries={initialEntries}>
+        <Route
+          component={PreReleaseMethodologyPage}
+          path={preReleaseMethodologyRoute.path}
+        />
+      </MemoryRouter>,
+    );
+  };
+});

--- a/src/explore-education-statistics-admin/src/routes/preReleaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/preReleaseRoutes.ts
@@ -1,4 +1,6 @@
 import PreReleaseContentPage from '@admin/pages/release/pre-release/PreReleaseContentPage';
+import PreReleaseMethodologiesPage from '@admin/pages/release/pre-release/PreReleaseMethodologiesPage';
+import PreReleaseMethodologyPage from '@admin/pages/release/pre-release/PreReleaseMethodologyPage';
 import PreReleaseTableToolPage from '@admin/pages/release/pre-release/PreReleaseTableToolPage';
 import {
   ReleaseRouteParams,
@@ -9,10 +11,30 @@ export type PreReleaseTableToolRouteParams = ReleaseRouteParams & {
   dataBlockId?: string;
 };
 
+export type PreReleaseMethodologyRouteParams = ReleaseRouteParams & {
+  methodologyId: string;
+};
+
 export const preReleaseContentRoute: ReleaseRouteProps = {
   path: '/publication/:publicationId/release/:releaseId/prerelease/content',
   title: 'Content',
   component: PreReleaseContentPage,
+  exact: true,
+};
+
+export const preReleaseMethodologiesRoute: ReleaseRouteProps = {
+  path:
+    '/publication/:publicationId/release/:releaseId/prerelease/methodologies',
+  title: 'Methodologies',
+  component: PreReleaseMethodologiesPage,
+  exact: true,
+};
+
+export const preReleaseMethodologyRoute: ReleaseRouteProps = {
+  path:
+    '/publication/:publicationId/release/:releaseId/prerelease/methodologies/:methodologyId',
+  title: 'Methodology',
+  component: PreReleaseMethodologyPage,
   exact: true,
 };
 
@@ -27,4 +49,12 @@ export const preReleaseTableToolRoute: ReleaseRouteProps = {
 export const preReleaseNavRoutes = [
   preReleaseContentRoute,
   preReleaseTableToolRoute,
+  // preReleaseMethodologiesRoute,  EES-3034 - uncomment when permissions are done.
+];
+
+export const preReleaseRoutes = [
+  preReleaseContentRoute,
+  preReleaseTableToolRoute,
+  preReleaseMethodologiesRoute,
+  preReleaseMethodologyRoute,
 ];

--- a/src/explore-education-statistics-admin/src/routes/preReleaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/preReleaseRoutes.ts
@@ -49,7 +49,7 @@ export const preReleaseTableToolRoute: ReleaseRouteProps = {
 export const preReleaseNavRoutes = [
   preReleaseContentRoute,
   preReleaseTableToolRoute,
-  // preReleaseMethodologiesRoute,  EES-3034 - uncomment when permissions are done.
+  preReleaseMethodologiesRoute,
 ];
 
 export const preReleaseRoutes = [

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -366,7 +366,7 @@ Create and validate custom table
     user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
 
  Validate no methodologies
-    user waits until page contains    No Methodologies available
+    user waits until page contains    No methodologies available
 
  Create and validate methodology
     user creates methodology for publication    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -361,22 +361,21 @@ Create and validate custom table
     user chooses location, time period and filters
     user validates table rows
 
-# EES-3034 - awaiting permissions change
-# Go to prerelease methodology page
-#    user clicks link    Methodologies
-#    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
+ Go to prerelease methodology page
+    user clicks link    Methodologies
+    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
 
-# Validate no methodologies
-#    user waits until page contains    No Methodologies available
+ Validate no methodologies
+    user waits until page contains    No Methodologies available
 
-# Create and validate methodology
-#    user creates methodology for publication    ${PUBLICATION_NAME}
-#    approve methodology from methodology view
-#    user navigates to admin frontend    ${RELEASE_URL}/prerelease/methodologies
-#    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
-#    user waits until page contains    ${PUBLICATION_NAME} (Owned)
-#    user clicks link    ${PUBLICATION_NAME} (Owned)
-#    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+ Create and validate methodology
+    user creates methodology for publication    ${PUBLICATION_NAME}
+    approve methodology from methodology view
+    user navigates to admin frontend    ${RELEASE_URL}/prerelease/methodologies
+    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
+    user waits until page contains    ${PUBLICATION_NAME} (Owned)
+    user clicks link    ${PUBLICATION_NAME} (Owned)
+    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
 
 Validate prerelease has started for Analyst user
     user changes to analyst1
@@ -481,15 +480,14 @@ Create and validate custom table as Analyst user
     user chooses location, time period and filters
     user validates table rows
 
-# EES-3034 - awaiting permissions change
-# Go to prerelease methodology page as Analyst user
-#    user clicks link    Methodologies
-#    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
+Go to prerelease methodology page as Analyst user
+    user clicks link    Methodologies
+    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
 
-# Validate methodology as Analyst user
-#    user waits until page contains    ${PUBLICATION_NAME} (Owned)
-#    user clicks link    ${PUBLICATION_NAME} (Owned)
-#    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+Validate methodology as Analyst user
+    user waits until page contains    ${PUBLICATION_NAME} (Owned)
+    user clicks link    ${PUBLICATION_NAME} (Owned)
+    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
 
 Unschedule release
     [Documentation]    EES-2826

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -361,6 +361,23 @@ Create and validate custom table
     user chooses location, time period and filters
     user validates table rows
 
+# EES-3034 - awaiting permissions change
+# Go to prerelease methodology page
+#    user clicks link    Methodologies
+#    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
+
+# Validate no methodologies
+#    user waits until page contains    No Methodologies available
+
+# Create and validate methodology
+#    user creates methodology for publication    ${PUBLICATION_NAME}
+#    approve methodology from methodology view
+#    user navigates to admin frontend    ${RELEASE_URL}/prerelease/methodologies
+#    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
+#    user waits until page contains    ${PUBLICATION_NAME} (Owned)
+#    user clicks link    ${PUBLICATION_NAME} (Owned)
+#    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+
 Validate prerelease has started for Analyst user
     user changes to analyst1
     user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
@@ -463,6 +480,16 @@ Create and validate custom table as Analyst user
 
     user chooses location, time period and filters
     user validates table rows
+
+# EES-3034 - awaiting permissions change
+# Go to prerelease methodology page as Analyst user
+#    user clicks link    Methodologies
+#    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
+
+# Validate methodology as Analyst user
+#    user waits until page contains    ${PUBLICATION_NAME} (Owned)
+#    user clicks link    ${PUBLICATION_NAME} (Owned)
+#    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
 
 Unschedule release
     [Documentation]    EES-2826


### PR DESCRIPTION
Adds methodologies to the pre-releases:
- adds a methodologies tab to the pre-release screen which lists methodologies associated with the publication
- these link to a read only view of the methodology or directly to the url in the case of external methodologies

Methodologies are shown when they are:
- published
- published amendments
- approved & scheduled
- approved  & scheduled amendments

If a methodology has a unapproved draft amendment the previous published version is shown.

This PR also includes the required permission changes (by @markhiveit )

## Screenshots

![prereleasemeths](https://user-images.githubusercontent.com/81572860/159691292-deff18ac-cbbd-40c7-9f8d-2c984d2dd0d9.PNG)

![prereleasemeth](https://user-images.githubusercontent.com/81572860/159691280-86c1fc9a-666c-4148-aef1-e0c0f78d3be0.PNG)


