### PR TITLE
🐛 EES-3273 Ensure location codes are returned in downloadable CSV file

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/expandDataSet.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/expandDataSet.test.ts
@@ -83,8 +83,8 @@ describe('expandDataSet', () => {
       ],
       locations: {
         localAuthority: [
-          { id: 'barnsley', label: 'Barnsley', value: 'barnsley' },
-          { id: 'barnet', label: 'Barnet', value: 'barnet' },
+          { id: 'barnsley-id', label: 'Barnsley', value: 'barnsley' },
+          { id: 'barnet-id', label: 'Barnet', value: 'barnet' },
         ],
       },
       boundaryLevels: [
@@ -115,7 +115,7 @@ describe('expandDataSet', () => {
       timePeriod: '2014_AY',
       location: {
         level: 'localAuthority',
-        value: 'barnet',
+        value: 'barnet-id',
       },
     };
 
@@ -149,6 +149,7 @@ describe('expandDataSet', () => {
         order: 1,
       }),
       location: new LocationFilter({
+        id: 'barnet-id',
         level: 'localAuthority',
         value: 'barnet',
         label: 'Barnet',
@@ -163,7 +164,7 @@ describe('expandDataSet', () => {
       timePeriod: '2014_AY',
       location: {
         level: 'localAuthority',
-        value: 'barnet',
+        value: 'barnet-id',
       },
     };
 
@@ -179,7 +180,7 @@ describe('expandDataSet', () => {
       timePeriod: '2014_AY',
       location: {
         level: 'localAuthority',
-        value: 'barnet',
+        value: 'barnet-id',
       },
     };
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getCsvData.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getCsvData.test.ts
@@ -45,7 +45,8 @@ describe('getCsvData', () => {
     ],
     locations: [
       {
-        value: 'england',
+        code: 'england',
+        value: 'england-id',
         label: 'England',
         level: 'country',
       } as WorkerLocationFilter,
@@ -86,7 +87,8 @@ describe('getCsvData', () => {
         locations: [
           ...testTableMeta.locations,
           {
-            value: 'barnsley',
+            code: 'barnsley',
+            value: 'barnsley-id',
             label: 'Barnsley',
             level: 'localAuthority',
           } as WorkerLocationFilter,
@@ -97,7 +99,7 @@ describe('getCsvData', () => {
           filters: ['gender_female', 'school_primary'],
           timePeriod: '2015_AY',
           geographicLevel: 'country',
-          locationId: 'england',
+          locationId: 'england-id',
           measures: {
             authAbsRate: '111',
             authAbsSess: '222',
@@ -107,7 +109,7 @@ describe('getCsvData', () => {
           filters: ['gender_female', 'school_secondary'],
           timePeriod: '2015_AY',
           geographicLevel: 'country',
-          locationId: 'england',
+          locationId: 'england-id',
           measures: {
             authAbsRate: '333',
             authAbsSess: '444',
@@ -117,7 +119,7 @@ describe('getCsvData', () => {
           filters: ['gender_female', 'school_primary'],
           timePeriod: '2015_AY',
           geographicLevel: 'localAuthority',
-          locationId: 'barnsley',
+          locationId: 'barnsley-id',
           measures: {
             authAbsRate: '555',
             authAbsSess: '666',
@@ -127,7 +129,7 @@ describe('getCsvData', () => {
           filters: ['gender_female', 'school_secondary'],
           timePeriod: '2015_AY',
           geographicLevel: 'localAuthority',
-          locationId: 'barnsley',
+          locationId: 'barnsley-id',
           measures: {
             authAbsRate: '777',
             authAbsSess: '888',
@@ -141,18 +143,30 @@ describe('getCsvData', () => {
     expect(data[0]).toHaveLength(8);
 
     expect(data[1]).toHaveLength(8);
+    expect(data[1][0]).toBe('England');
+    expect(data[1][1]).toBe('england');
+    expect(data[1][2]).toBe('country');
     expect(data[1][6]).toBe('111');
     expect(data[1][7]).toBe('222');
 
     expect(data[2]).toHaveLength(8);
+    expect(data[2][0]).toBe('England');
+    expect(data[2][1]).toBe('england');
+    expect(data[2][2]).toBe('country');
     expect(data[2][6]).toBe('333');
     expect(data[2][7]).toBe('444');
 
     expect(data[3]).toHaveLength(8);
+    expect(data[3][0]).toBe('Barnsley');
+    expect(data[3][1]).toBe('barnsley');
+    expect(data[3][2]).toBe('localAuthority');
     expect(data[3][6]).toBe('555');
     expect(data[3][7]).toBe('666');
 
     expect(data[4]).toHaveLength(8);
+    expect(data[4][0]).toBe('Barnsley');
+    expect(data[4][1]).toBe('barnsley');
+    expect(data[4][2]).toBe('localAuthority');
     expect(data[4][6]).toBe('777');
     expect(data[4][7]).toBe('888');
 
@@ -187,7 +201,7 @@ describe('getCsvData', () => {
           filters: ['gender_female', 'school_primary'],
           timePeriod: '2015_AY',
           geographicLevel: 'country',
-          locationId: 'england',
+          locationId: 'england-id',
           measures: {
             authAbsRate: '111',
           },
@@ -196,7 +210,7 @@ describe('getCsvData', () => {
           filters: ['gender_female', 'school_secondary'],
           timePeriod: '2015_AY',
           geographicLevel: 'country',
-          locationId: 'england',
+          locationId: 'england-id',
           measures: {
             authAbsSess: '222',
           },
@@ -247,7 +261,7 @@ describe('getCsvData', () => {
           filters: ['gender_female', 'school_primary'],
           timePeriod: '2015_AY',
           geographicLevel: 'country',
-          locationId: 'england',
+          locationId: 'england-id',
           measures: {
             authAbsRate: '111',
             authAbsSess: '222',
@@ -288,7 +302,7 @@ describe('getCsvData', () => {
           filters: ['gender_female'],
           timePeriod: '2015_AY',
           geographicLevel: 'country',
-          locationId: 'england',
+          locationId: 'england-id',
           measures: {
             authAbsSess: '111',
           },
@@ -315,7 +329,7 @@ describe('getCsvData', () => {
           filters: ['gender_female'],
           timePeriod: '2015_AY',
           geographicLevel: 'country',
-          locationId: 'england',
+          locationId: 'england-id',
           measures: {
             authAbsRate: '12300000',
             authAbsSess: '44255667.2356',
@@ -343,7 +357,7 @@ describe('getCsvData', () => {
           filters: ['gender_female'],
           timePeriod: '2015_AY',
           geographicLevel: 'country',
-          locationId: 'england',
+          locationId: 'england-id',
           measures: {
             authAbsRate: '13.4',
             authAbsSess: 'x',
@@ -386,13 +400,20 @@ describe('getCsvData', () => {
           },
         },
         locations: [
-          ...testTableMeta.locations,
           {
+            code: 'england',
+            value: 'england',
+            label: 'England',
+            level: 'country',
+          } as WorkerLocationFilter,
+          {
+            code: 'barnet',
             value: 'barnet',
             label: 'Barnet',
             level: 'localAuthority',
           } as WorkerLocationFilter,
           {
+            code: 'barnsley',
             value: 'barnsley',
             label: 'Barnsley',
             level: 'localAuthority',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/getCsvData.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/getCsvData.ts
@@ -93,7 +93,7 @@ export default function getCsvData(fullTable: WorkerFullTable): string[][] {
 
       return [
         location.label,
-        location.value,
+        location.code,
         location.level,
         timePeriod.label.replace(/\//g, ''),
         ...filterOptions.map(column => column.label),

--- a/src/explore-education-statistics-common/src/modules/table-tool/types/filters.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/types/filters.ts
@@ -61,6 +61,8 @@ export interface LocationCompositeId {
 }
 
 export class LocationFilter extends Filter {
+  public readonly code: string;
+
   public readonly level: string;
 
   public readonly geoJson?: GeoJsonFeature[];
@@ -73,9 +75,12 @@ export class LocationFilter extends Filter {
     geoJson,
     group,
   }: GroupedFilterOption & { level: string; geoJson?: GeoJsonFeature[] }) {
+    // Fallback to using the code if there's no id.
+    // This is the case for historical Permalinks created prior to EES-2955.
     const idOrFallback = id ?? value;
     super({ value: idOrFallback, label, group });
-
+    // Always set the code so that it can be included in the downloadable CSV file.
+    this.code = value;
     this.level = level;
     this.geoJson = geoJson;
   }

--- a/src/explore-education-statistics-common/src/modules/table-tool/types/workerFullTable.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/types/workerFullTable.ts
@@ -22,6 +22,7 @@ export interface WorkerCategoryFilter extends WorkerFilter {
 }
 
 export interface WorkerLocationFilter extends WorkerFilter {
+  code: string;
   level: string;
   geoJson: GeoJsonFeature;
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableHeadersConfig.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableHeadersConfig.test.ts
@@ -216,12 +216,14 @@ describe('mapTableHeadersConfig', () => {
       ],
       [
         new LocationFilter({
-          value: 'b63e4d6d-973c-4c29-9b49-2fbc83eff666',
+          id: 'b63e4d6d-973c-4c29-9b49-2fbc83eff666',
+          value: 'E09000003',
           label: 'Barnet',
           level: 'localAuthority',
         }),
         new LocationFilter({
-          value: 'c6f2a76f-d959-452f-a8e5-593066c7d6d4',
+          id: 'c6f2a76f-d959-452f-a8e5-593066c7d6d4',
+          value: 'E08000016',
           label: 'Barnsley',
           level: 'localAuthority',
         }),
@@ -278,15 +280,15 @@ describe('mapTableHeadersConfig', () => {
           localAuthority: [
             {
               id: 'b63e4d6d-973c-4c29-9b49-2fbc83eff666',
+              value: 'E09000003',
               label: 'Barnet (local authority)',
-              value: 'barnet',
             },
           ],
           localAuthorityDistrict: [
             {
               id: '61a57251-cca7-4a87-df80-08d82d586d38',
+              value: 'E09000003',
               label: 'Barnet (local authority district)',
-              value: 'barnet',
             },
           ],
         },
@@ -334,12 +336,14 @@ describe('mapTableHeadersConfig', () => {
     expect(headers.rowGroups).toEqual([
       [
         new LocationFilter({
-          value: '61a57251-cca7-4a87-df80-08d82d586d38',
+          id: '61a57251-cca7-4a87-df80-08d82d586d38',
+          value: 'E09000003',
           label: 'Barnet (local authority district)',
           level: 'localAuthorityDistrict',
         }),
         new LocationFilter({
-          value: 'b63e4d6d-973c-4c29-9b49-2fbc83eff666',
+          id: 'b63e4d6d-973c-4c29-9b49-2fbc83eff666',
+          value: 'E09000003',
           label: 'Barnet (local authority)',
           level: 'localAuthority',
         }),
@@ -348,12 +352,14 @@ describe('mapTableHeadersConfig', () => {
 
     expect(headers.rows).toEqual([
       new LocationFilter({
-        value: 'b63e4d6d-973c-4c29-9b49-2fbc83eff666',
+        id: 'b63e4d6d-973c-4c29-9b49-2fbc83eff666',
+        value: 'E09000003',
         label: 'Barnet (local authority)',
         level: 'localAuthority',
       }),
       new LocationFilter({
-        value: '61a57251-cca7-4a87-df80-08d82d586d38',
+        id: '61a57251-cca7-4a87-df80-08d82d586d38',
+        value: 'E09000003',
         label: 'Barnet (local authority district)',
         level: 'localAuthorityDistrict',
       }),

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
@@ -73,7 +73,8 @@ export const testTable: FullTable = {
     ],
     locations: [
       new LocationFilter({
-        value: 'dd590fcf-b0c1-4fa3-8599-d13c0f540793',
+        id: 'dd590fcf-b0c1-4fa3-8599-d13c0f540793',
+        value: 'england',
         label: 'England',
         level: 'country',
       }),


### PR DESCRIPTION
This PR fixes a bug where we see unique location id's being included in the `location_code` column of the public downloadable CSV files.

Whilst working for historical Permalinks which only contain location codes, the CSV files are wrong when downloaded from newly built tables, table highlights or fast tracks.

This PR adds a new class member `code` to WorkerLocationFilter which should only ever contain the code which is then used for the value of the `location_code` column in the CSV data.