### PR TITLE
EES-3258 fix table layout when missing region

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
@@ -3,6 +3,7 @@ import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import { OmitStrict } from '@common/types';
 import React, { forwardRef, ReactNode, Ref, useEffect, useRef } from 'react';
 import styles from './FixedMultiHeaderDataTable.module.scss';
+import multiHeaderStyles from './MultiHeaderTable.module.scss';
 import MultiHeaderTable, { MultiHeaderTableProps } from './MultiHeaderTable';
 
 const mobileWidth = 1024;
@@ -74,8 +75,14 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
               mainTableRef.current
                 .querySelectorAll<HTMLTableCellElement>('thead td')
                 .forEach(el => {
-                  // eslint-disable-next-line no-param-reassign
-                  el.style.transform = `translate(${scrollLeft}px, ${scrollTop}px)`;
+                  if (
+                    !el.classList.contains(
+                      multiHeaderStyles.emptyColumnHeaderCell,
+                    )
+                  ) {
+                    // eslint-disable-next-line no-param-reassign
+                    el.style.transform = `translate(${scrollLeft}px, ${scrollTop}px)`;
+                  }
                 });
 
               mainTableRef.current
@@ -86,7 +93,25 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
                 });
 
               mainTableRef.current
+                .querySelectorAll<HTMLTableCellElement>(
+                  `.${multiHeaderStyles.emptyColumnHeaderCell}`,
+                )
+                .forEach(el => {
+                  // eslint-disable-next-line no-param-reassign
+                  el.style.transform = `translate(0, ${scrollTop}px)`;
+                });
+
+              mainTableRef.current
                 .querySelectorAll<HTMLTableCellElement>('tbody th')
+                .forEach(el => {
+                  // eslint-disable-next-line no-param-reassign
+                  el.style.transform = `translate(${scrollLeft}px, 0)`;
+                });
+
+              mainTableRef.current
+                .querySelectorAll<HTMLTableCellElement>(
+                  `.${multiHeaderStyles.emptyRowHeaderCell}`,
+                )
                 .forEach(el => {
                   // eslint-disable-next-line no-param-reassign
                   el.style.transform = `translate(${scrollLeft}px, 0)`;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.module.scss
@@ -21,6 +21,11 @@ $border-width: 1px;
     z-index: 1;
   }
 
+  .emptyRowHeaderCell {
+    background: #fff;
+    min-width: 100px;
+  }
+
   @media print {
     font-size: 0.8rem;
     max-height: none;
@@ -54,6 +59,12 @@ $border-width: 1px;
     background: #fff;
     position: relative;
     z-index: 3;
+  }
+
+  .emptyColumnHeaderCell {
+    background: govuk-colour('light-grey');
+    height: 46px;
+    z-index: 1;
   }
 
   th {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
@@ -161,9 +161,9 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
       >
         <thead className={styles.tableHead}>
           {expandedColumnHeaders.map((columns, rowIndex) => {
+            const headingRowKey = `row-${rowIndex}`;
             return (
-              // eslint-disable-next-line react/no-array-index-key
-              <tr key={rowIndex}>
+              <tr key={headingRowKey}>
                 {rowIndex === 0 && (
                   <td
                     colSpan={rowHeaderColumnLength}
@@ -174,6 +174,17 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
 
                 {columns.map((column, columnIndex) => {
                   const key = `${column.text}_${columnIndex}`;
+                  // Add an empty td instead of a th for empty group headers
+                  if (column.id === '') {
+                    return (
+                      <td
+                        key={key}
+                        colSpan={column.span}
+                        rowSpan={column.crossSpan}
+                        className={styles.emptyColumnHeaderCell}
+                      />
+                    );
+                  }
 
                   return (
                     <th
@@ -197,40 +208,63 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
         </thead>
 
         <tbody>
-          {rows.map((row, rowIndex) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <tr key={rowIndex}>
-              {expandedRowHeaders[rowIndex]?.map((header, headerIndex) => {
-                return (
-                  <th
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={headerIndex}
-                    className={classNames({
-                      [styles.borderBottom]: header.isGroup,
-                    })}
-                    rowSpan={header.span}
-                    colSpan={header.crossSpan}
-                    scope={header.isGroup ? 'rowgroup' : 'row'}
-                  >
-                    {header.text}
-                  </th>
-                );
-              })}
+          {rows.map((row, rowIndex) => {
+            const rowKey = `row-${rowIndex}`;
+            return (
+              <tr key={rowKey}>
+                {expandedRowHeaders[rowIndex]?.map((header, headerIndex) => {
+                  const key = `header-${headerIndex}`;
 
-              {row.map((cell, cellIndex) => (
-                <td
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={cellIndex}
-                  className={classNames('govuk-table__cell--numeric', {
-                    [styles.borderBottom]:
-                      (rowIndex + 1) % rowHeaders.length === 0,
-                  })}
-                >
-                  {cell}
-                </td>
-              ))}
-            </tr>
-          ))}
+                  // Add an empty td instead of a th for empty group headers
+                  if (header.id === '') {
+                    return (
+                      <td
+                        key={key}
+                        className={classNames(
+                          styles.emptyRowHeaderCell,
+                          // 'fixed',
+                          {
+                            [styles.borderBottom]: header.isGroup,
+                          },
+                        )}
+                        rowSpan={header.span}
+                        colSpan={header.crossSpan}
+                      />
+                    );
+                  }
+
+                  return (
+                    <th
+                      key={key}
+                      className={classNames({
+                        [styles.borderBottom]: header.isGroup,
+                      })}
+                      rowSpan={header.span}
+                      colSpan={header.crossSpan}
+                      scope={header.isGroup ? 'rowgroup' : 'row'}
+                    >
+                      {header.text}
+                    </th>
+                  );
+                })}
+
+                {row.map((cell, cellIndex) => {
+                  const cellKey = `cell-${cellIndex}`;
+                  return (
+                    <td
+                      key={cellKey}
+                      className={classNames('govuk-table__cell--numeric', {
+                        [styles.borderBottom]:
+                          (rowIndex + 1) % rowHeaders.length === 0,
+                      })}
+                    >
+                      {cell}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     );

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
@@ -220,13 +220,9 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
                     return (
                       <td
                         key={key}
-                        className={classNames(
-                          styles.emptyRowHeaderCell,
-                          // 'fixed',
-                          {
-                            [styles.borderBottom]: header.isGroup,
-                          },
-                        )}
+                        className={classNames(styles.emptyRowHeaderCell, {
+                          [styles.borderBottom]: header.isGroup,
+                        })}
                         rowSpan={header.span}
                         colSpan={header.crossSpan}
                       />

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -125,8 +125,10 @@ function optimizeFilters(filters: Filter[], headerConfig: Filter[][]) {
           header => header.group !== firstSubGroup,
         );
 
-        // LADs can be added without regions, which results as an empty string for `group` and can cause table layout problems.
-        // So include it as an empty group and change to a td later so don't have empty header cells
+        // The location hierarchy expects grouping, for example the LAD attribute is grouped by Region.
+        // However, the screener does not require the data to have all attributes of the hierarchy.
+        // When this data is missing the backend returns an empty string, this causes table layout problems as there is a missing header cell where the group would have been.
+        // To fix this an empty header for the missing group data is added, When the table is rendered these empty header cells are converted to <td> as empty <th>'s cause accessibility problems.
         const isMissingLocationGroup =
           filter instanceof LocationFilter && filter.group === '';
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -125,9 +125,14 @@ function optimizeFilters(filters: Filter[], headerConfig: Filter[][]) {
           header => header.group !== firstSubGroup,
         );
 
+        // LADs can be added without regions, which results as an empty string for `group` and can cause table layout problems.
+        // So include it as an empty group and change to a td later so don't have empty header cells
+        const isMissingLocationGroup =
+          filter instanceof LocationFilter && filter.group === '';
+
         return hasMultipleSubGroups &&
-          filter.group &&
-          filter.group !== 'Default'
+          ((filter.group && filter.group !== 'Default') ||
+            isMissingLocationGroup)
           ? [new FilterGroup(filter.group), filter]
           : filter;
       })

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
@@ -717,6 +717,185 @@ describe('TimePeriodDataTable', () => {
     expect(screen.getByRole('table')).toMatchSnapshot();
   });
 
+  test('renders table with empty cells when region group is missing', () => {
+    const fullTable = mapFullTable({
+      subjectMeta: {
+        filters: {},
+        footnotes: [],
+        indicators: [
+          {
+            value: 'authorised-absence-rate',
+            label: 'Authorised absence rate',
+            unit: '%',
+            name: 'sess_authorised_percent',
+            decimalPlaces: 1,
+          },
+        ],
+        // LADs without region info
+        locations: {
+          country: [
+            {
+              id: 'dd590fcf-b0c1-4fa3-8599-d13c0f540793',
+              value: 'england',
+              label: 'England',
+            },
+          ],
+          localAuthorityDistrict: [
+            {
+              value: '',
+              label: '',
+              level: 'region',
+              options: [
+                {
+                  id: 'c6f2a76f-d959-452f-a8e5-593066c7d6d4',
+                  value: 'barnsley',
+                  label: 'Barnsley',
+                },
+                {
+                  id: 'b63e4d6d-973c-4c29-9b49-2fbc83eff666',
+                  value: 'barnet',
+                  label: 'Barnet',
+                },
+              ],
+            },
+          ],
+        },
+        boundaryLevels: [],
+        publicationName: 'Pupil absence in schools in England',
+        subjectName: 'Absence in prus',
+        timePeriodRange: [{ label: '2014/15', code: 'AY', year: 2014 }],
+        geoJsonAvailable: false,
+      },
+      results: [
+        {
+          filters: [],
+          geographicLevel: 'country',
+          locationId: 'dd590fcf-b0c1-4fa3-8599-d13c0f540793',
+          measures: { 'authorised-absence-rate': '18.3' },
+          timePeriod: '2014_AY',
+        },
+        {
+          filters: [],
+          geographicLevel: 'localAuthorityDistrict',
+          locationId: 'b63e4d6d-973c-4c29-9b49-2fbc83eff666',
+          measures: { 'authorised-absence-rate': '20.2' },
+          timePeriod: '2014_AY',
+        },
+        {
+          filters: [],
+          geographicLevel: 'localAuthorityDistrict',
+          locationId: 'c6f2a76f-d959-452f-a8e5-593066c7d6d4',
+          measures: { 'authorised-absence-rate': '21.5' },
+          timePeriod: '2014_AY',
+        },
+      ],
+    } as TableDataResponse);
+
+    const tableHeadersConfig = mapTableHeadersConfig(
+      {
+        columnGroups: [],
+        rowGroups: [
+          [
+            {
+              value: 'dd590fcf-b0c1-4fa3-8599-d13c0f540793',
+              level: 'country',
+              type: 'Location',
+            },
+            {
+              value: 'c6f2a76f-d959-452f-a8e5-593066c7d6d4',
+              level: 'localAuthorityDistrict',
+              type: 'Location',
+            },
+            {
+              value: 'b63e4d6d-973c-4c29-9b49-2fbc83eff666',
+              level: 'localAuthorityDistrict',
+              type: 'Location',
+            },
+          ],
+        ],
+        columns: [{ value: '2014_AY', type: 'TimePeriod' }],
+        rows: [
+          {
+            value: 'authorised-absence-rate',
+            type: 'Indicator',
+          },
+        ],
+      },
+      fullTable,
+    );
+
+    render(
+      <TimePeriodDataTable
+        fullTable={fullTable}
+        tableHeadersConfig={tableHeadersConfig}
+      />,
+    );
+
+    const table = screen.getByRole('table');
+
+    expect(table.querySelectorAll('thead tr')).toHaveLength(1);
+    expect(table.querySelectorAll('thead th')).toHaveLength(1);
+    expect(table.querySelectorAll('thead th[scope="colgroup"]')).toHaveLength(
+      0,
+    );
+    expect(table.querySelectorAll('thead th[scope="col"]')).toHaveLength(1);
+    expect(table.querySelector('thead th[scope="col"]')).toHaveTextContent(
+      '2014/15',
+    );
+    expect(table.querySelectorAll('thead td')).toHaveLength(1);
+
+    const rows = table.querySelectorAll('tbody tr');
+
+    expect(rows).toHaveLength(3);
+
+    // Row 1
+
+    const row1Headers = rows[0].querySelectorAll('th');
+    const row1Cells = rows[0].querySelectorAll('td');
+
+    expect(row1Headers).toHaveLength(1);
+
+    // England should take up two columns so that we don't get an
+    // asymmetric table due to the local authority options having hierarchies
+    expect(row1Headers[0]).toHaveAttribute('scope', 'row');
+    expect(row1Headers[0]).toHaveAttribute('colspan', '2');
+    expect(row1Headers[0]).toHaveTextContent('England');
+
+    expect(row1Cells).toHaveLength(1);
+    expect(row1Cells[0]).toHaveTextContent('18.3%');
+
+    // Row 2
+
+    const row2Headers = rows[1].querySelectorAll('th');
+    const row2Cells = rows[1].querySelectorAll('td');
+
+    expect(row2Headers).toHaveLength(1);
+
+    expect(row2Headers[0]).toHaveAttribute('scope', 'row');
+    expect(row2Headers[0]).toHaveAttribute('colspan', '1');
+    expect(row2Headers[0]).toHaveTextContent('Barnsley');
+
+    expect(row2Cells).toHaveLength(2);
+    expect(row2Cells[0]).toHaveTextContent('');
+    expect(row2Cells[0]).toHaveAttribute('rowspan', '2');
+    expect(row2Cells[1]).toHaveTextContent('21.5%');
+
+    // Row 3
+    const row3Headers = rows[2].querySelectorAll('th');
+    const row3Cells = rows[2].querySelectorAll('td');
+
+    expect(row3Headers).toHaveLength(1);
+
+    expect(row3Headers[0]).toHaveAttribute('scope', 'row');
+    expect(row3Headers[0]).toHaveAttribute('colspan', '1');
+    expect(row3Headers[0]).toHaveTextContent('Barnet');
+
+    expect(row3Cells).toHaveLength(1);
+    expect(row3Cells[0]).toHaveTextContent('20.2%');
+
+    expect(screen.getByRole('table')).toMatchSnapshot();
+  });
+
   test('renders table with completely empty rows removed', () => {
     const fullTable = mapFullTable(testDataFiltersWithNoResults.fullTable);
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/TimePeriodDataTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/TimePeriodDataTable.test.tsx.snap
@@ -460,6 +460,85 @@ exports[`TimePeriodDataTable renders table with completely empty rows removed 1`
 </table>
 `;
 
+exports[`TimePeriodDataTable renders table with empty cells when region group is missing 1`] = `
+<table
+  aria-labelledby="dataTableCaption"
+  class="govuk-table table"
+  data-testid="dataTableCaption-table"
+>
+  <thead
+    class="tableHead"
+  >
+    <tr>
+      <td
+        class="borderBottom"
+        colspan="2"
+        rowspan="1"
+      />
+      <th
+        colspan="1"
+        rowspan="1"
+        scope="col"
+      >
+        2014/15
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th
+        class=""
+        colspan="2"
+        rowspan="1"
+        scope="row"
+      >
+        England
+      </th>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        18.3%
+      </td>
+    </tr>
+    <tr>
+      <td
+        class="emptyRowHeaderCell borderBottom"
+        colspan="1"
+        rowspan="2"
+      />
+      <th
+        class=""
+        colspan="1"
+        rowspan="1"
+        scope="row"
+      >
+        Barnsley
+      </th>
+      <td
+        class="govuk-table__cell--numeric borderBottom"
+      >
+        21.5%
+      </td>
+    </tr>
+    <tr>
+      <th
+        class=""
+        colspan="1"
+        rowspan="1"
+        scope="row"
+      >
+        Barnet
+      </th>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        20.2%
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`TimePeriodDataTable renders table with location hierarchies 1`] = `
 <table
   aria-labelledby="dataTableCaption"


### PR DESCRIPTION
Fixes table layout when LADs don't have regions, which causes rows to be mis-aligned.

The fix:
- adds an empty header in the case of a location filter with an empty string for group (when a group isn't expected group is undefined)
- when the table is rendered converts this header into an empty <td> as empty <th> cause accessibility problems
- adds some styling to make it look ok.

For testing
- the original files are attached to the ticket
- please test with reordering the rows and columns, including moving the locations into columns
- please check there are no problems with other location groupings / combinations