### PR TITLE
EES-3296 - fix create_data_block_with_chart UI test

### DIFF
--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -197,14 +197,12 @@ Embed data block into release content
 Check footnote is displayed in content Tab
     user checks accordion section contains x blocks    ${CONTENT_SECTION_NAME}    1    id:releaseMainContent
     user scrolls to accordion section content    ${CONTENT_SECTION_NAME}    id:releaseMainContent
-    user waits until results table appears  %{WAIT_SMALL}
-    user waits until page does not contain loading spinner
-    # Avoid: Element with locator 'testid:footnotes' not found error when running full test suite with pabot
-    user scrolls down  500
-
+    user scrolls to element  //*[@data-testid="Data block - ${DATABLOCK_NAME}"]
+    user waits until table is visible  //*[@data-testid="Data block - ${DATABLOCK_NAME}"]  10
+    user scrolls to element  testid:footnotes
     user checks list has x items    testid:footnotes    1
     user checks list item contains    testid:footnotes    1    ${FOOTNOTE_1}
-
+    
 Update footnote
     [Documentation]    EES-3136
     user clicks link    Footnotes


### PR DESCRIPTION
This PR: 
- fixes a flaky test when tests are run using `pabot`. I've run the entire suite of tests a few times locally with high concurrency so I'm pretty certain that these changes are solid & the flakiness has been fixed 

![image](https://user-images.githubusercontent.com/55030296/161585518-17fcd46d-f92f-4c48-adf5-2ec1035f0c92.png)
