### PR TITLE
EES-3298 fix filter reordering

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderFiltersList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderFiltersList.tsx
@@ -29,7 +29,6 @@ const testSubjectMeta: SubjectMeta = {
             {
               label: 'Category 1 Group 1 Item 1',
               value: 'category-1-group-1-item-1',
-              id: 'category-1-group-1-item-1-id',
             },
           ],
           order: 1,
@@ -41,17 +40,14 @@ const testSubjectMeta: SubjectMeta = {
             {
               label: 'Category 1 Group 2 Item 1',
               value: 'category-1-group-2-item-1',
-              id: 'category-1-group-2-item-1-id',
             },
             {
               label: 'Category 1 Group 2 Item 2',
               value: 'category-1-group-2-item-2',
-              id: 'category-1-group-2-item-2-id',
             },
             {
               label: 'Category 1 Group 2 Item 3',
               value: 'category-1-group-2-item-3',
-              id: 'category-1-group-2-item-3-id',
             },
           ],
           order: 0,
@@ -63,12 +59,10 @@ const testSubjectMeta: SubjectMeta = {
             {
               label: 'Category 1 Group 3 Item 1',
               value: 'category-1-group-3-item-1',
-              id: 'category-1-group-3-item-1-id',
             },
             {
               label: 'Category 1 Group 3 Item 2',
               value: 'category-1-group-3-item-2',
-              id: 'category-1-group-3-item-2-id',
             },
           ],
           order: 2,
@@ -88,12 +82,10 @@ const testSubjectMeta: SubjectMeta = {
             {
               label: 'Category 2 Group 1 Item 1',
               value: 'category-2-group-1-item-1',
-              id: 'category-2-group-1-item-1-id',
             },
             {
               label: 'Category 2 Group 1 Item 2',
               value: 'category-2-group-1-item-2',
-              id: 'category-2-group-1-item-2-id',
             },
           ],
           order: 0,
@@ -113,7 +105,7 @@ const testSubjectMeta: SubjectMeta = {
 
 interface UpdatedFilter {
   id?: string;
-  filterGroups: { id?: string; filterItems: (string | undefined)[] }[]; // EES-1243 - won't need the undefined when ids exist
+  filterGroups: { id?: string; filterItems: string[] }[];
 }
 export type UpdateFiltersRequest = UpdatedFilter[];
 
@@ -153,7 +145,10 @@ const ReorderFiltersList = ({ subject, onCancel, onSave }: Props) => {
                 id: item.id,
                 label: item.label,
                 order: item.order,
-                items: item.options,
+                items: item.options.map(option => ({
+                  id: option.value,
+                  label: option.label,
+                })),
               };
             }),
             'order',
@@ -181,7 +176,7 @@ const ReorderFiltersList = ({ subject, onCancel, onSave }: Props) => {
         return filter;
       }
       // Reordering groups
-      if (!parentGroupId || parentGroupId === parentCategoryId) {
+      if (!parentGroupId) {
         return { ...filter, groups: reordered };
       }
       // Reordering items

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderIndicatorsList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderIndicatorsList.tsx
@@ -22,21 +22,18 @@ const testSubjectMeta: SubjectMeta = {
       label: 'Category 1',
       options: [
         {
-          id: 'category-1-item-1-id',
           value: 'category-1-item-1',
           label: 'Category 1 Item 1',
           unit: '',
           name: 'category_1_item_1',
         },
         {
-          id: 'category-1-item-2-id',
           value: 'category-1-item-2',
           label: 'Category 1 Item 2',
           unit: '',
           name: 'category_1_item_2',
         },
         {
-          id: 'category-1-item-3-id',
           value: 'category-1-item-3',
           label: 'Category 1 Item 3',
           unit: '',
@@ -50,7 +47,6 @@ const testSubjectMeta: SubjectMeta = {
       label: 'Category 2',
       options: [
         {
-          id: 'category-2-item-1-id',
           value: 'category-2-item-1',
           label: 'Category 2 Item 1',
           unit: '',
@@ -70,7 +66,7 @@ const testSubjectMeta: SubjectMeta = {
 
 interface UpdatedIndicator {
   id?: string;
-  indicatorItems: (string | undefined)[];
+  indicatorItems: string[];
 }
 export type UpdateIndicatorsRequest = UpdatedIndicator[];
 
@@ -104,7 +100,10 @@ const ReorderIndicatorsList = ({ subject, onCancel, onSave }: Props) => {
           id: item.id,
           label: item.label,
           order: item.order,
-          items: item.options,
+          items: item.options.map(option => ({
+            id: option.value,
+            label: option.label,
+          })),
         };
       }),
       'order',

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderFiltersList.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderFiltersList.test.tsx
@@ -33,7 +33,6 @@ const testSubjectMeta: SubjectMeta = {
             {
               label: 'Category 1 Group 1 Item 1',
               value: 'category-1-group-1-item-1',
-              id: 'category-1-group-1-item-1-id',
             },
           ],
           order: 1,
@@ -45,17 +44,14 @@ const testSubjectMeta: SubjectMeta = {
             {
               label: 'Category 1 Group 2 Item 1',
               value: 'category-1-group-2-item-1',
-              id: 'category-1-group-2-item-1-id',
             },
             {
               label: 'Category 1 Group 2 Item 2',
               value: 'category-1-group-2-item-2',
-              id: 'category-1-group-2-item-2-id',
             },
             {
               label: 'Category 1 Group 2 Item 3',
               value: 'category-1-group-2-item-3',
-              id: 'category-1-group-2-item-3-id',
             },
           ],
           order: 0,
@@ -67,12 +63,10 @@ const testSubjectMeta: SubjectMeta = {
             {
               label: 'Category 1 Group 3 Item 1',
               value: 'category-1-group-3-item-1',
-              id: 'category-1-group-3-item-1-id',
             },
             {
               label: 'Category 1 Group 3 Item 2',
               value: 'category-1-group-3-item-2',
-              id: 'category-1-group-3-item-2-id',
             },
           ],
           order: 2,
@@ -92,12 +86,10 @@ const testSubjectMeta: SubjectMeta = {
             {
               label: 'Category 2 Group 1 Item 1',
               value: 'category-2-group-1-item-1',
-              id: 'category-2-group-1-item-1-id',
             },
             {
               label: 'Category 2 Group 1 Item 2',
               value: 'category-2-group-1-item-2',
-              id: 'category-2-group-1-item-2-id',
             },
           ],
           order: 0,
@@ -394,7 +386,7 @@ describe('ReorderFiltersList', () => {
     expect(within(options[1]).getByText('Category 2 Group 1 Item 2'));
   });
 
-  test('clicking the `save` button calls handleSave with the redoreded list formatted for the update request', async () => {
+  test('clicking the `save` button calls handleSave with the reordeded list formatted for the update request', async () => {
     const handleSave = jest.fn();
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
@@ -415,8 +407,8 @@ describe('ReorderFiltersList', () => {
         filterGroups: [
           {
             filterItems: [
-              'category-2-group-1-item-1-id',
-              'category-2-group-1-item-2-id',
+              'category-2-group-1-item-1',
+              'category-2-group-1-item-2',
             ],
             id: 'category-2-group-1-id',
           },
@@ -428,20 +420,20 @@ describe('ReorderFiltersList', () => {
           {
             id: 'category-1-group-2-id',
             filterItems: [
-              'category-1-group-2-item-1-id',
-              'category-1-group-2-item-2-id',
-              'category-1-group-2-item-3-id',
+              'category-1-group-2-item-1',
+              'category-1-group-2-item-2',
+              'category-1-group-2-item-3',
             ],
           },
           {
             id: 'category-1-group-1-id',
-            filterItems: ['category-1-group-1-item-1-id'],
+            filterItems: ['category-1-group-1-item-1'],
           },
           {
             id: 'category-1-group-3-id',
             filterItems: [
-              'category-1-group-3-item-1-id',
-              'category-1-group-3-item-2-id',
+              'category-1-group-3-item-1',
+              'category-1-group-3-item-2',
             ],
           },
         ],

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderIndicatorsList.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderIndicatorsList.test.tsx
@@ -27,21 +27,18 @@ const testSubjectMeta: SubjectMeta = {
       label: 'Category 1',
       options: [
         {
-          id: 'category-1-item-1-id',
           value: 'category-1-item-1',
           label: 'Category 1 Item 1',
           unit: '',
           name: 'category_1_item_1',
         },
         {
-          id: 'category-1-item-2-id',
           value: 'category-1-item-2',
           label: 'Category 1 Item 2',
           unit: '',
           name: 'category_1_item_2',
         },
         {
-          id: 'category-1-item-3-id',
           value: 'category-1-item-3',
           label: 'Category 1 Item 3',
           unit: '',
@@ -55,7 +52,6 @@ const testSubjectMeta: SubjectMeta = {
       label: 'Category 2',
       options: [
         {
-          id: 'category-2-item-1-id',
           value: 'category-2-item-1',
           label: 'Category 2 Item 1',
           unit: '',
@@ -237,14 +233,14 @@ describe('ReorderIndicatorsList', () => {
     const expectedRequest = [
       {
         id: 'category-2-id',
-        indicatorItems: ['category-2-item-1-id'],
+        indicatorItems: ['category-2-item-1'],
       },
       {
         id: 'category-1-id',
         indicatorItems: [
-          'category-1-item-1-id',
-          'category-1-item-2-id',
-          'category-1-item-3-id',
+          'category-1-item-1',
+          'category-1-item-2',
+          'category-1-item-3',
         ],
       },
     ];

--- a/src/explore-education-statistics-common/src/modules/table-tool/types/filters.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/types/filters.ts
@@ -74,7 +74,11 @@ export class LocationFilter extends Filter {
     level,
     geoJson,
     group,
-  }: GroupedFilterOption & { level: string; geoJson?: GeoJsonFeature[] }) {
+  }: GroupedFilterOption & {
+    id?: string;
+    level: string;
+    geoJson?: GeoJsonFeature[];
+  }) {
     // Fallback to using the code if there's no id.
     // This is the case for historical Permalinks created prior to EES-2955.
     const idOrFallback = id ?? value;

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -6,7 +6,6 @@ import { Feature, Geometry } from 'geojson';
 export interface FilterOption {
   label: string;
   value: string;
-  id?: string; // EES-1243 - not optional when backend done?
 }
 
 export interface IndicatorOption extends FilterOption {


### PR DESCRIPTION
Fixes reordering filters when there's only one filter group.

Also, uses the value for filter/indicator items instead of expecting an id.