### PR TITLE
EES-3302 fix refreshing reordering tab and ungrouped indicators

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
@@ -15,6 +15,7 @@ export const releaseDataPageTabIds = {
   dataUploads: 'data-uploads',
   fileUploads: 'file-uploads',
   dataGuidance: 'data-guidance',
+  reordering: 'reordering',
 };
 
 const ReleaseDataPage = () => {
@@ -67,8 +68,13 @@ const ReleaseDataPage = () => {
           />
         </TabsSection>
         {/* EES-1243 
-        <TabsSection id="test-id" title="Reorder filters and indicators">
+        <TabsSection
+          id={releaseDataPageTabIds.reordering}
+          title="Reorder filters and indicators"
+          lazy
+        >
           <ReleaseDataReorderSection
+            key={dataFiles.filter(file => file.status === 'COMPLETE').length}
             releaseId={releaseId}
             canUpdateRelease={canUpdateRelease}
           />

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.tsx
@@ -89,6 +89,11 @@ const ReorderList = ({
       ? listItems[0].items
       : listItems;
 
+  const parentCategoryId =
+    listItems.length === 1 && 'items' in listItems[0]
+      ? listItems[0].id
+      : categoryId;
+
   return (
     <DragDropContext
       onDragEnd={result => {
@@ -113,7 +118,7 @@ const ReorderList = ({
             }
             return option;
           }),
-          parentCategoryId: categoryId,
+          parentCategoryId: categoryId || parentCategoryId,
           parentGroupId: groupId,
         });
       }}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.tsx
@@ -118,7 +118,7 @@ const ReorderList = ({
             }
             return option;
           }),
-          parentCategoryId: categoryId || parentCategoryId,
+          parentCategoryId,
           parentGroupId: groupId,
         });
       }}


### PR DESCRIPTION
Fixes:
- refreshing the subjects list on the reordering filters & indicators tab when data files change.
- reordering ungrouped indicators