### PR TITLE
EES-3303 - add UI test to assert bau & analyst users can authenticate…

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
@@ -15,6 +15,7 @@ export const releaseDataPageTabIds = {
   dataUploads: 'data-uploads',
   fileUploads: 'file-uploads',
   dataGuidance: 'data-guidance',
+  reordering: 'reordering',
 };
 
 const ReleaseDataPage = () => {
@@ -67,8 +68,13 @@ const ReleaseDataPage = () => {
           />
         </TabsSection>
         {/* EES-1243 
-        <TabsSection id="test-id" title="Reorder filters and indicators">
+        <TabsSection
+          id={releaseDataPageTabIds.reordering}
+          title="Reorder filters and indicators"
+          lazy
+        >
           <ReleaseDataReorderSection
+            key={dataFiles.filter(file => file.status === 'COMPLETE').length}
             releaseId={releaseId}
             canUpdateRelease={canUpdateRelease}
           />

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.tsx
@@ -89,6 +89,11 @@ const ReorderList = ({
       ? listItems[0].items
       : listItems;
 
+  const parentCategoryId =
+    listItems.length === 1 && 'items' in listItems[0]
+      ? listItems[0].id
+      : categoryId;
+
   return (
     <DragDropContext
       onDragEnd={result => {
@@ -113,7 +118,7 @@ const ReorderList = ({
             }
             return option;
           }),
-          parentCategoryId: categoryId,
+          parentCategoryId,
           parentGroupId: groupId,
         });
       }}

--- a/tests/robot-tests/tests/admin/bau/login.robot
+++ b/tests/robot-tests/tests/admin/bau/login.robot
@@ -1,0 +1,18 @@
+*** Settings *** 
+Resource            ../../libs/admin-common.robot
+Force Tags          Admin  Test  PreProd  Prod 
+
+Suite Setup         user signs in as bau1
+Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
+
+
+*** Test Cases *** 
+Check that bau users can login & authenticate succesfully
+    [Documentation]    EES-3303
+    user changes to bau1
+
+
+Check that analyst users can login & authenticate succesfully
+    [Documentation]    EES-3303
+    user changes to analyst1


### PR DESCRIPTION
This PR: 

Adds authentication tests that are intended to run against test, pre-prod & production environments. This piece of work mainly came about as a result of a temporary infra problem that occurred on production (after a deploy) which resulted in roughly 1h 30mins of authentication downtime which prevented analyst & bau users from logging into the admin app. As a result of now having access to dfe test accounts, we can now run admin tests against test, pre-prod & production