### PR TITLE
Change Python/RF commit hooks to just use `pipenv run`

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,10 +70,10 @@
       "prettier --write"
     ],
     "*.robot": [
-      "python3 -m pipenv run robotidy --config tests/robot-tests/robotidy.toml"
+      "pipenv run robotidy --config tests/robot-tests/robotidy.toml"
     ],
     "*.py": [
-      "python3 -m pipenv run autopep8"
+      "pipenv run autopep8"
     ]
   }
 }


### PR DESCRIPTION
This PR changes the pre-commit hooks for Python and Robot Framework files to use `pipenv run` instead of `python3 -m pipenv`. 

This change is required to stop errors when committing via the IntelliJ GUI (due to not being able to locate `pipenv` in the virtualenv packages).