### PR TITLE
EES-3303 - add authentication tests

### DIFF
--- a/tests/robot-tests/tests/admin/bau/login.robot
+++ b/tests/robot-tests/tests/admin/bau/login.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Resource            ../../libs/admin-common.robot
+Force Tags          Admin    Test    PreProd    Prod
+
+Suite Setup         user signs in as bau1
+Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
+
+*** Test Cases ***
+Check that bau users can login & authenticate succesfully
+    [Documentation]    EES-3303
+    user changes to bau1
+
+Check that analyst users can login & authenticate succesfully
+    [Documentation]    EES-3303
+    user changes to analyst1


### PR DESCRIPTION
This PR:

Adds authentication tests that are intended to run against test, pre-prod & production environments. This piece of work mainly came about as a result of a temporary infra problem that occurred on production (after a deploy) which resulted in roughly 1h 30mins of authentication downtime which prevented analyst & bau users from logging into the admin app. As a result of now having access to dfe test accounts, we can now run admin tests against test, pre-prod & production