### PR TITLE
EES-3315 Add admin SignalR service to ARM template

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -82,6 +82,30 @@
         "S3 Standard"
       ]
     },
+    "skuAdminSignalR": {
+      "type": "string",
+      "defaultValue": "Free_F1",
+      "allowedValues": [
+        "Free_F1",
+        "Standard_S1"
+      ]
+    },
+    "adminSignalRCapacity": {
+      "type": "int",
+      "metadata": {
+        "description": "The number of SignalR units."
+      },
+      "defaultValue": 1,
+      "allowedValues": [
+        1,
+        2,
+        5,
+        10,
+        20,
+        50,
+        100
+      ]
+    },
     "adminFirewallRules": {
       "type": "array",
       "metadata": {
@@ -590,6 +614,8 @@
     "contentAppInsights": "[concat(parameters('subscription'), '-ai-', parameters('environment'), '-content')]",
     "adminAppName": "[concat(parameters('subscription'), '-as-', parameters('environment'), '-admin')]",
     "adminPlanName": "[concat(parameters('subscription'), '-asp-', parameters('environment'), '-admin')]",
+    "adminSignalRName": "[concat(parameters('subscription'), '-sr-', parameters('environment'), '-admin')]",
+    "adminSignalRPrivateEndpointName": "[concat(parameters('subscription'), '-srpe-', parameters('environment'), '-admin')]",
     "adminAppInsights": "[concat(parameters('subscription'), '-ai-', parameters('environment'), '-admin')]",
     "publicAppName": "[concat(parameters('subscription'), '-as-', parameters('environment'), '-public')]",
     "publicAppUrl": "[concat('https://', parameters('domain'))]",
@@ -1780,6 +1806,76 @@
         "reserved": false,
         "numberOfWorkers": "1",
         "hostingEnvironment": ""
+      }
+    },
+    {
+      "type": "Microsoft.SignalRService/signalR",
+      "apiVersion": "2021-10-01",
+      "name": "[parameters('adminSignalRName')]",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "capacity": "[parameters('adminSignalRCapacity')]",
+        "name": "[parameters('skuAdminSignalR')]"
+      },
+      "kind": "SignalR",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "tls": {
+          "clientCertEnabled": false
+        },
+        "features": [
+          {
+            "flag": "ServiceMode",
+            "value": "Default"
+          },
+          {
+            "flag": "EnableConnectivityLogs",
+            "value": "true"
+          },
+          {
+            "flag": "EnableMessagingLogs",
+            "value": "true"
+          },
+          {
+            "flag": "EnableLiveTrace",
+            "value": "true"
+          }
+        ],
+        "cors": {
+          "allowedOrigins": [
+            "[parameters('adminUri')]",
+            "https://localhost:3000",
+            "http://localhost:3000"
+          ]
+        },
+        "networkACLs": {
+          "defaultAction": "deny",
+          "publicNetwork": {
+            "allow": [
+              "ClientConnection"
+            ]
+          },
+          "privateEndpoints": [
+            {
+              "name": "[parameters('adminSignalRPrivateEndpointName')]",
+              "allow": [
+                "ServerConnection"
+              ]
+            }
+          ]
+        },
+        "upstream": {
+          "templates": [
+            {
+              "categoryPattern": "*",
+              "eventPattern": "*",
+              "hubPattern": "*",
+              "urlTemplate": "[concat('https://', parameters('adminUri'), '/hubs/{hub}/{event}')]"
+            }
+          ]
+        }
       }
     },
     {


### PR DESCRIPTION
This PR adds a SignalR Service instance for the admin. We need to deploy this to:

- Test if this infrastructure change is even possible
- Get the connection string once it's deployed to connect the admin to it