### PR TITLE
EES-3316 - fix legacy release UI test

### DIFF
--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -197,12 +197,12 @@ Embed data block into release content
 Check footnote is displayed in content Tab
     user checks accordion section contains x blocks    ${CONTENT_SECTION_NAME}    1    id:releaseMainContent
     user scrolls to accordion section content    ${CONTENT_SECTION_NAME}    id:releaseMainContent
-    user scrolls to element  //*[@data-testid="Data block - ${DATABLOCK_NAME}"]
-    user waits until table is visible  //*[@data-testid="Data block - ${DATABLOCK_NAME}"]  10
-    user scrolls to element  testid:footnotes
+    user scrolls to element    //*[@data-testid="Data block - ${DATABLOCK_NAME}"]
+    user waits until table is visible    //*[@data-testid="Data block - ${DATABLOCK_NAME}"]    10
+    user scrolls to element    testid:footnotes
     user checks list has x items    testid:footnotes    1
     user checks list item contains    testid:footnotes    1    ${FOOTNOTE_1}
-    
+
 Update footnote
     [Documentation]    EES-3136
     user clicks link    Footnotes

--- a/tests/robot-tests/tests/admin/bau/legacy_releases.robot
+++ b/tests/robot-tests/tests/admin/bau/legacy_releases.robot
@@ -24,9 +24,10 @@ Go to manage publication page
     user opens accordion section    ${PUBLICATION_NAME}
     user clicks element    testid:Edit publication link for ${PUBLICATION_NAME}
     user waits until page contains title caption    ${PUBLICATION_NAME}
-    user waits until h1 is visible    Manage publication
+    user waits until h1 is visible    Manage publication    %{WAIT_SMALL}
 
 Create legacy release
+    user scrolls to element    //*[button[contains(text(),'Create legacy release')]]
     user clicks button    Create legacy release
     user waits until modal is visible    Create legacy release
     user clicks button    OK


### PR DESCRIPTION
This PR:
 - fixes a small issue in the legacy release suite whereby the following error consistently happened when the tests are run in a CI environment: 
 ```bash
Parent 'css:body' did not contain 'xpath:.//button[text()="Create legacy release"]' in 45 seconds.
```

Other changes:
- runs RF lint command to fix `create_data_block_with_chart.robot` lint issues that were missed during the python upgrade

![image](https://user-images.githubusercontent.com/55030296/162443054-d915103e-08e1-4bd3-ae18-de35138dcce0.png)