### PR TITLE
EES 3317 - deduplicate webdriver directories

### DIFF
--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -11,21 +11,21 @@ import cProfile
 import datetime
 import json
 import os
-import platform
 import pstats
 import shutil
 from pathlib import Path
-
-import pyderman
 import requests
 from dotenv import load_dotenv
 from pabot.pabot import main as pabot_run_cli
 from robot import rebot_cli as robot_rebot_cli
 from robot import run_cli as robot_run_cli
+from scripts.get_webdriver import get_webdriver
 import scripts.keyword_profile as kp
 from tests.libs.setup_auth_variables import setup_auth_variables
 from tests.libs.slack import send_slack_report
 from tests.libs.create_emulator_release_files import ReleaseFilesGenerator
+
+
 current_dir = Path(__file__).absolute().parent
 os.chdir(current_dir)
 
@@ -174,15 +174,7 @@ if args.analyst_pass:
     os.environ['ANALYST_PASSWORD'] = args.analyst_pass
 
 # Install chromedriver and add it to PATH
-chromedriver_filename = 'chromedriver.exe' if platform.system() == "Windows" else 'chromedriver'
-pyderman.install(file_directory='./webdriver/',
-                 filename=chromedriver_filename,
-                 verbose=True,
-                 chmod=True,
-                 overwrite=False,
-                 version=args.chromedriver_version)
-
-os.environ["PATH"] += os.pathsep + str(Path('webdriver').absolute())
+get_webdriver(args.chromedriver_version or "latest")
 
 output_file = "rerun.xml" if args.rerun_failed_tests or args.rerun_failed_suites else "output.xml"
 

--- a/tests/robot-tests/scripts/get_auth_tokens.py
+++ b/tests/robot-tests/scripts/get_auth_tokens.py
@@ -3,7 +3,8 @@ import time
 import argparse
 import json
 from selenium import webdriver
-import pyderman
+from typing import Union
+from .get_webdriver import get_webdriver
 
 
 def wait_until_page_contains_xpath(context, selector):
@@ -21,27 +22,21 @@ def wait_until_page_contains_xpath(context, selector):
 
 
 def get_identity_info(url, email, password, first_name="Bau1", last_name="EESADMIN",
-                      driver=None) -> (str, str):
-    os.environ["PATH"] += os.pathsep + os.getcwd() + os.sep + 'webdriver'
+                      driver=None) -> Union[str, str]:
 
     using_existing_driver = driver is not None
 
     if not driver:
-        pyderman.install(file_directory="../webdriver/",
-                         filename='chromedriver',
-                         verbose=False,
-                         chmod=True,
-                         overwrite=False,
-                         version="latest")
+        get_webdriver("latest")
 
-        chrome_options = webdriver.ChromeOptions()
-        chrome_options.add_argument('--no-sandbox')
-        chrome_options.add_argument('--headless')
-        chrome_options.add_argument('--disable-gpu')
-        chrome_options.add_argument('--ignore-certificate-errors')
-        chrome_options.add_argument('--disable-logging')
-        chrome_options.add_argument('--log-level=\3')
-        driver = webdriver.Chrome(options=chrome_options)
+    chrome_options = webdriver.ChromeOptions()
+    chrome_options.add_argument('--no-sandbox')
+    chrome_options.add_argument('--headless')
+    chrome_options.add_argument('--disable-gpu')
+    chrome_options.add_argument('--ignore-certificate-errors')
+    chrome_options.add_argument('--disable-logging')
+    chrome_options.add_argument('--log-level=\3')
+    driver = webdriver.Chrome(options=chrome_options)
 
     try:
         driver.get(url)

--- a/tests/robot-tests/scripts/get_webdriver.py
+++ b/tests/robot-tests/scripts/get_webdriver.py
@@ -1,0 +1,20 @@
+import pyderman
+import platform
+from pathlib import Path
+import os
+
+
+def get_webdriver(version: str) -> None:
+    chromedriver_filename = 'chromedriver.exe' if platform.system() == "Windows" else 'chromedriver'
+    pyderman.install(file_directory='./webdriver/',
+                     filename=chromedriver_filename,
+                     verbose=True,
+                     chmod=True,
+                     overwrite=False,
+                     version=version)
+
+    os.environ["PATH"] += os.pathsep + str(Path('./webdriver').absolute())
+
+
+if __name__ == '__main__':
+    get_webdriver('latest')

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -197,12 +197,12 @@ Embed data block into release content
 Check footnote is displayed in content Tab
     user checks accordion section contains x blocks    ${CONTENT_SECTION_NAME}    1    id:releaseMainContent
     user scrolls to accordion section content    ${CONTENT_SECTION_NAME}    id:releaseMainContent
-    user scrolls to element  //*[@data-testid="Data block - ${DATABLOCK_NAME}"]
-    user waits until table is visible  //*[@data-testid="Data block - ${DATABLOCK_NAME}"]  10
-    user scrolls to element  testid:footnotes
+    user scrolls to element    //*[@data-testid="Data block - ${DATABLOCK_NAME}"]
+    user waits until table is visible    //*[@data-testid="Data block - ${DATABLOCK_NAME}"]    10
+    user scrolls to element    testid:footnotes
     user checks list has x items    testid:footnotes    1
     user checks list item contains    testid:footnotes    1    ${FOOTNOTE_1}
-    
+
 Update footnote
     [Documentation]    EES-3136
     user clicks link    Footnotes

--- a/tests/robot-tests/tests/admin/bau/legacy_releases.robot
+++ b/tests/robot-tests/tests/admin/bau/legacy_releases.robot
@@ -24,9 +24,10 @@ Go to manage publication page
     user opens accordion section    ${PUBLICATION_NAME}
     user clicks element    testid:Edit publication link for ${PUBLICATION_NAME}
     user waits until page contains title caption    ${PUBLICATION_NAME}
-    user waits until h1 is visible    Manage publication
+    user waits until h1 is visible    Manage publication    %{WAIT_SMALL}
 
 Create legacy release
+    user scrolls to element    //*[button[contains(text(),'Create legacy release')]]
     user clicks button    Create legacy release
     user waits until modal is visible    Create legacy release
     user clicks button    OK


### PR DESCRIPTION
This PR: 
- fixes an issue where UI tests downloaded chromedriver into two separate directories (because pyderman is being called in both `run_tests.py` & in `get_auth_tokens.py`

Other changes: 
- changes return type of `get_identity_info` to `Union[str, str]`
- fixes  arguments made to pyderman when downloading chromedriver