### PR TITLE
EES-3030 Fix `WizardStep` re-focusing on initial page render

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.tsx
@@ -29,7 +29,9 @@ const WizardStep = ({
   const ref = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
-    if (isActive && shouldScroll) {
+    // Don't re-focus on initial page render as this is confusing
+    // for screen reader users (initial focus should be on the body)
+    if (isActive && shouldScroll && document.activeElement !== document.body) {
       setTimeout(() => {
         if (ref.current) {
           ref.current.scrollIntoView({

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/Wizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/Wizard.test.tsx
@@ -630,7 +630,7 @@ describe('Wizard', () => {
     expect(step3).not.toHaveFocus();
   });
 
-  test('scrolls to and focuses first step when `scrollOnMount` is true', () => {
+  test('does not scroll and focus first step when `scrollOnMount` is true', () => {
     jest.useFakeTimers();
 
     render(
@@ -647,8 +647,8 @@ describe('Wizard', () => {
 
     jest.runAllTimers();
 
-    expect(step1).toHaveFocus();
-    expect(step1).toHaveScrolledIntoView();
+    expect(step1).not.toHaveFocus();
+    expect(step1).not.toHaveScrolledIntoView();
 
     expect(step2).not.toHaveScrolledIntoView();
     expect(step2).not.toHaveFocus();


### PR DESCRIPTION
This PR fixes the initial focus for table tool not being on `document.body` due to `WizardStep` re-focusing to the active step (i.e. step 1). We have this behaviour to move the focus after each step is completed, but it's unnecessary on the initial page render and is unexpected behaviour for screen reader users.