### PR TITLE
EES-3142 - added additional way to look up Created date for Data Bloc…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockMigrationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockMigrationServicePermissionTests.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
@@ -46,7 +47,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             return new DataBlockMigrationService(
                 contentDbContext,
                 statisticsDbContext,
-                userService ?? Mock.Of<IUserService>(Strict)
+                userService ?? Mock.Of<IUserService>(Strict),
+                Mock.Of<ILogger<DataBlockMigrationService>>()
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockMigrationServiceTests.cs
@@ -14,6 +14,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Services.DataBlockMigrationService.DataBlockMapMigrationPlan.MigrationStrategy;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
@@ -1796,7 +1798,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             return new DataBlockMigrationService(
                 contentDbContext,
                 statisticsDbContext,
-                userService ?? MockUtils.AlwaysTrueUserService().Object
+                userService ?? MockUtils.AlwaysTrueUserService().Object,
+                Mock.Of<ILogger<DataBlockMigrationService>>()
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockMigrationServiceTests.cs
@@ -957,7 +957,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
         
         [Fact]
-        public async Task MigrateAllMaps_ChooseCorrectBoundaryLevelIdToMatchReleaseCreationTime()
+        public async Task MigrateAllMaps_ChooseCorrectBoundaryLevelIdToMatchReleaseCreationTime_ViaReleaseContentBlock()
         {
             var singleGeographicLevelInDataSets = GeographicLevel.LocalAuthority;
             var matchingGeoLevelBoundaryLevelId = 2;
@@ -965,7 +965,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var dataBlock = new DataBlock
             {
                 // This Data Block has no Created Date.  It will be inferred from its owning Release's Creation date
-                // instead.
+                // instead, as found via ReleaseContentBlock -> ContentBlock.
                 Query = new ObservationQueryContext(),
                 Charts = new List<IChart> {
                     new MapChart
@@ -1013,6 +1013,251 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 // There are several Boundary Levels available for the given Geographic Level.  The matching one
                 // will be identified using the Created date on the Data Block's owning Release.
+                await statisticsDbContext.BoundaryLevel.AddRangeAsync(new List<BoundaryLevel>
+                {
+                    new()
+                    {
+                        Id = 1,
+                        Label = "Boundary Level 1",
+                        Level = singleGeographicLevelInDataSets,
+                        Created = DateTime.UtcNow.AddYears(-2)
+                    },
+                    new()
+                    {
+                        Id = matchingGeoLevelBoundaryLevelId,
+                        Label = "Boundary Level 2",
+                        Level = singleGeographicLevelInDataSets,
+                        Created = DateTime.UtcNow.AddYears(-1)
+                    },
+                    new()
+                    {
+                        Id = 3,
+                        Label = "Boundary Level 3",
+                        Level = singleGeographicLevelInDataSets,
+                        Created = DateTime.UtcNow.AddYears(1)
+                    },
+                    new()
+                    {
+                        Id = 4,
+                        Label = "Boundary Level 4",
+                        Level = GeographicLevel.Region,
+                        Created = DateTime.UtcNow.AddYears(-1)
+                    }
+                });
+                await statisticsDbContext.SaveChangesAsync();
+            }
+            
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+                {
+                    var service = SetupService(contentDbContext, statisticsDbContext);
+                    var result = await service.MigrateMaps(dryRun: false);
+                    var mapMigrationPlans = result.AssertRight();
+                    var mapMigrationPlan = Assert.Single(mapMigrationPlans);
+
+                    Assert.Equal(dataBlock.Id, mapMigrationPlan.DataBlockId);
+                    Assert.Equal(SetBoundaryLevelToMatchSingleDataSetGeoLevel, mapMigrationPlan.Strategy);
+                    Assert.Equal(matchingGeoLevelBoundaryLevelId, mapMigrationPlan.BoundaryLevelId);
+                    Assert.Equal(singleGeographicLevelInDataSets, mapMigrationPlan.GeographicLevel);
+                }
+            }
+            
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var updatedDataBlock = await contentDbContext
+                    .DataBlocks
+                    .SingleAsync(db => db.Id == dataBlock.Id);
+
+                var updatedMap = (updatedDataBlock.Charts[0] as MapChart)!;
+                
+                Assert.Equal(matchingGeoLevelBoundaryLevelId, updatedDataBlock.Query.BoundaryLevel);
+                Assert.Equal(matchingGeoLevelBoundaryLevelId, updatedMap.BoundaryLevel);
+            }
+        }
+        
+        [Fact]
+        public async Task MigrateAllMaps_ChooseCorrectBoundaryLevelIdToMatchReleaseCreationTime_ViaReleaseContentSection()
+        {
+            var singleGeographicLevelInDataSets = GeographicLevel.LocalAuthority;
+            var matchingGeoLevelBoundaryLevelId = 1;
+            
+            var dataBlock = new DataBlock
+            {
+                // This Data Block has no Created Date.  It will be inferred from its owning Release's Creation date
+                // instead, as found via ReleaseContentSection -> ContentSection -> ContentBlock.
+                Query = new ObservationQueryContext(),
+                Charts = new List<IChart> {
+                    new MapChart
+                    {
+                        Axes = new Dictionary<string, ChartAxisConfiguration>
+                        {
+                            {"Key1", new()
+                            {
+                                DataSets = new List<ChartDataSet>
+                                {
+                                    new()
+                                    {
+                                        Location = new ChartDataSetLocation
+                                        {
+                                            Level = singleGeographicLevelInDataSets.ToString()
+                                        }
+                                    }
+                                }
+                            }}
+                        }
+                    }
+                }
+            };
+
+            var releaseContentSection = new ReleaseContentSection
+            {
+                Release = new Release
+                {
+                    Created = DateTime.UtcNow.AddDays(-400)
+                },
+                ContentSection = new ContentSection
+                {
+                    Content = new List<ContentBlock>
+                    {
+                        new HtmlBlock
+                        {
+                            Id = Guid.NewGuid()
+                        },
+                        dataBlock,
+                        new HtmlBlock
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                }
+            };
+            
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.DataBlocks.AddAsync(dataBlock);
+                await contentDbContext.ReleaseContentSections.AddAsync(releaseContentSection);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                // There are several Boundary Levels available for the given Geographic Level.  The matching one
+                // will be identified using the Created date on the Data Block's owning Release.
+                await statisticsDbContext.BoundaryLevel.AddRangeAsync(new List<BoundaryLevel>
+                {
+                    new()
+                    {
+                        Id = matchingGeoLevelBoundaryLevelId,
+                        Label = "Boundary Level 1",
+                        Level = singleGeographicLevelInDataSets,
+                        Created = DateTime.UtcNow.AddYears(-2)
+                    },
+                    new()
+                    {
+                        Id = 2,
+                        Label = "Boundary Level 2",
+                        Level = singleGeographicLevelInDataSets,
+                        Created = DateTime.UtcNow.AddYears(-1)
+                    },
+                    new()
+                    {
+                        Id = 3,
+                        Label = "Boundary Level 3",
+                        Level = singleGeographicLevelInDataSets,
+                        Created = DateTime.UtcNow.AddYears(1)
+                    },
+                    new()
+                    {
+                        Id = 4,
+                        Label = "Boundary Level 4",
+                        Level = GeographicLevel.Region,
+                        Created = DateTime.UtcNow.AddYears(-1)
+                    }
+                });
+                await statisticsDbContext.SaveChangesAsync();
+            }
+            
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+                {
+                    var service = SetupService(contentDbContext, statisticsDbContext);
+                    var result = await service.MigrateMaps(dryRun: false);
+                    var mapMigrationPlans = result.AssertRight();
+                    var mapMigrationPlan = Assert.Single(mapMigrationPlans);
+
+                    Assert.Equal(dataBlock.Id, mapMigrationPlan.DataBlockId);
+                    Assert.Equal(SetBoundaryLevelToMatchSingleDataSetGeoLevel, mapMigrationPlan.Strategy);
+                    Assert.Equal(matchingGeoLevelBoundaryLevelId, mapMigrationPlan.BoundaryLevelId);
+                    Assert.Equal(singleGeographicLevelInDataSets, mapMigrationPlan.GeographicLevel);
+                }
+            }
+            
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var updatedDataBlock = await contentDbContext
+                    .DataBlocks
+                    .SingleAsync(db => db.Id == dataBlock.Id);
+
+                var updatedMap = (updatedDataBlock.Charts[0] as MapChart)!;
+                
+                Assert.Equal(matchingGeoLevelBoundaryLevelId, updatedDataBlock.Query.BoundaryLevel);
+                Assert.Equal(matchingGeoLevelBoundaryLevelId, updatedMap.BoundaryLevel);
+            }
+        }
+        
+        [Fact]
+        public async Task MigrateAllMaps_ChooseCorrectBoundaryLevelIdToMatchReleaseCreationTime_NoPathToRelease()
+        {
+            var singleGeographicLevelInDataSets = GeographicLevel.LocalAuthority;
+            var matchingGeoLevelBoundaryLevelId = 2;
+            
+            var dataBlock = new DataBlock
+            {
+                // This Data Block has no Created Date.  It also can't be inferred from an owning Release's created date
+                // as no path back to the owning Release is available.  Therefore it will default to using UtcNow as the
+                // created date.
+                Query = new ObservationQueryContext(),
+                Charts = new List<IChart> {
+                    new MapChart
+                    {
+                        Axes = new Dictionary<string, ChartAxisConfiguration>
+                        {
+                            {"Key1", new()
+                            {
+                                DataSets = new List<ChartDataSet>
+                                {
+                                    new()
+                                    {
+                                        Location = new ChartDataSetLocation
+                                        {
+                                            Level = singleGeographicLevelInDataSets.ToString()
+                                        }
+                                    }
+                                }
+                            }}
+                        }
+                    }
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.DataBlocks.AddAsync(dataBlock);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                // There are several Boundary Levels available for the given Geographic Level.  The matching one
+                // will be identified using UtcNow as the fallback Created date.
                 await statisticsDbContext.BoundaryLevel.AddRangeAsync(new List<BoundaryLevel>
                 {
                     new()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockMigrationService.cs
@@ -15,6 +15,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Services.DataBlockMigrationService.DataBlockMapMigrationPlan.MigrationStrategy;
@@ -28,15 +29,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly ContentDbContext _contentDbContext;
         private readonly StatisticsDbContext _statisticsDbContext;
         private readonly IUserService _userService;
+        private readonly ILogger<DataBlockMigrationService> _logger;
 
         public DataBlockMigrationService(
             ContentDbContext contentDbContext,
             StatisticsDbContext statisticsDbContext, 
-            IUserService userService)
+            IUserService userService, 
+            ILogger<DataBlockMigrationService> logger)
         {
             _contentDbContext = contentDbContext;
             _statisticsDbContext = statisticsDbContext;
             _userService = userService;
+            _logger = logger;
         }
 
         public async Task<Either<ActionResult, List<DataBlockMapMigrationPlan>>> GetMigrateMapPlans()
@@ -91,83 +95,98 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .ToAsyncEnumerable()
                         .SelectAwait(async plan =>
                         {
-                            var dataBlock = await _contentDbContext
-                                .DataBlocks
-                                .SingleAsync(db => db.Id == plan.DataBlockId);
-
-                            var map = (MapChart)dataBlock.Charts[0];
-
-                            switch (plan.Strategy)
+                            try
                             {
-                                case RetainChosenBoundaryLevel:
+                                var dataBlock = await _contentDbContext
+                                    .DataBlocks
+                                    .SingleAsync(db => db.Id == plan.DataBlockId);
+
+                                var map = (MapChart) dataBlock.Charts[0];
+
+                                switch (plan.Strategy)
                                 {
-                                    map.BoundaryLevel = dataBlock.Query.BoundaryLevel ?? 0;
-                                    await SaveChanges(dataBlock, dryRun);
-                                    return new MapMigrationResult(
-                                        plan.DataBlockId,
-                                        plan.Type,
-                                        plan.Strategy,
-                                        map.BoundaryLevel,
-                                        boundaryLevels.Single(level => level.Id == map.BoundaryLevel).Level);
+                                    case RetainChosenBoundaryLevel:
+                                    {
+                                        map.BoundaryLevel = dataBlock.Query.BoundaryLevel ?? 0;
+                                        await SaveChanges(dataBlock, dryRun);
+                                        return new MapMigrationResult(
+                                            plan.DataBlockId,
+                                            plan.Type,
+                                            plan.Strategy,
+                                            map.BoundaryLevel,
+                                            boundaryLevels.Single(level => level.Id == map.BoundaryLevel).Level);
+                                    }
+                                    case SetBoundaryLevelToMatchSingleDataSetGeoLevel:
+                                    {
+                                        var geographicLevel = plan
+                                            .DataSetGeographicLevels
+                                            .Single();
+
+                                        var createdDate = await GetDataBlockCreatedDate(dataBlock);
+
+                                        var boundaryLevel = GetLatestBoundaryLevelAtCreationTime(
+                                            createdDate,
+                                            geographicLevel,
+                                            boundaryLevels);
+
+                                        dataBlock.Query.BoundaryLevel = boundaryLevel.Id;
+                                        map.BoundaryLevel = boundaryLevel.Id;
+                                        await SaveChanges(dataBlock, dryRun);
+                                        return new MapMigrationResult(
+                                            plan.DataBlockId,
+                                            plan.Type,
+                                            plan.Strategy,
+                                            map.BoundaryLevel,
+                                            boundaryLevels.Single(level => level.Id == map.BoundaryLevel).Level);
+                                    }
+                                    case SetBoundaryLevelToMatchSingleNonCountryDataSetLevel:
+                                    {
+                                        var nonCountryGeographicLevel = plan
+                                            .DataSetGeographicLevels
+                                            .Single(geographicLevel => geographicLevel != GeographicLevel.Country);
+
+                                        var createdDate = await GetDataBlockCreatedDate(dataBlock);
+
+                                        var boundaryLevel = GetLatestBoundaryLevelAtCreationTime(
+                                            createdDate,
+                                            nonCountryGeographicLevel,
+                                            boundaryLevels);
+
+                                        dataBlock.Query.BoundaryLevel = boundaryLevel.Id;
+                                        map.BoundaryLevel = boundaryLevel.Id;
+                                        await SaveChanges(dataBlock, dryRun);
+                                        return new MapMigrationResult(
+                                            plan.DataBlockId,
+                                            plan.Type,
+                                            plan.Strategy,
+                                            map.BoundaryLevel,
+                                            boundaryLevels.Single(level => level.Id == map.BoundaryLevel).Level);
+                                    }
+                                    case QuestionWhichCorrectGeoLevelToSelect:
+                                    case FixMapConfigNoDataSetGeographicLevels:
+                                    case FixMapConfigInvalidDataSetGeographicLevels:
+                                        return new MapMigrationResult(
+                                            plan.DataBlockId,
+                                            plan.Type,
+                                            plan.Strategy,
+                                            null,
+                                            null);
+                                    default:
+                                        throw new ArgumentOutOfRangeException(
+                                            $"Unknown migration strategy {plan.Strategy}");
                                 }
-                                case SetBoundaryLevelToMatchSingleDataSetGeoLevel:
+                            }
+                            catch (Exception e)
+                            {
+                                return new MapMigrationResult(
+                                    plan.DataBlockId,
+                                    plan.Type,
+                                    UnknownErrorEncountered,
+                                    null,
+                                    null)
                                 {
-                                    var geographicLevel = plan
-                                        .DataSetGeographicLevels
-                                        .Single();
-
-                                    var createdDate = await GetDataBlockCreatedDate(dataBlock);
-
-                                    var boundaryLevel = GetLatestBoundaryLevelAtCreationTime(
-                                        createdDate,
-                                        geographicLevel,
-                                        boundaryLevels);
-
-                                    dataBlock.Query.BoundaryLevel = boundaryLevel.Id;
-                                    map.BoundaryLevel = boundaryLevel.Id;
-                                    await SaveChanges(dataBlock, dryRun);
-                                    return new MapMigrationResult(
-                                        plan.DataBlockId,
-                                        plan.Type,
-                                        plan.Strategy,
-                                        map.BoundaryLevel,
-                                        boundaryLevels.Single(level => level.Id == map.BoundaryLevel).Level);
-                                }
-                                case SetBoundaryLevelToMatchSingleNonCountryDataSetLevel:
-                                {
-                                    var nonCountryGeographicLevel = plan
-                                        .DataSetGeographicLevels
-                                        .Single(geographicLevel => geographicLevel != GeographicLevel.Country);
-
-                                    var createdDate = await GetDataBlockCreatedDate(dataBlock);
-
-                                    var boundaryLevel = GetLatestBoundaryLevelAtCreationTime(
-                                        createdDate,
-                                        nonCountryGeographicLevel,
-                                        boundaryLevels);
-
-                                    dataBlock.Query.BoundaryLevel = boundaryLevel.Id;
-                                    map.BoundaryLevel = boundaryLevel.Id;
-                                    await SaveChanges(dataBlock, dryRun);
-                                    return new MapMigrationResult(
-                                        plan.DataBlockId,
-                                        plan.Type,
-                                        plan.Strategy,
-                                        map.BoundaryLevel,
-                                        boundaryLevels.Single(level => level.Id == map.BoundaryLevel).Level);
-                                }
-                                case QuestionWhichCorrectGeoLevelToSelect:
-                                case FixMapConfigNoDataSetGeographicLevels:
-                                case FixMapConfigInvalidDataSetGeographicLevels:
-                                    return new MapMigrationResult(
-                                        plan.DataBlockId,
-                                        plan.Type,
-                                        plan.Strategy,
-                                        null,
-                                        null);
-                                default:
-                                    throw new ArgumentOutOfRangeException(
-                                        $"Unknown migration strategy {plan.Strategy}");
+                                    ExceptionMessage = e.Message
+                                };
                             }
                         })
                         .ToListAsync();
@@ -187,37 +206,45 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         private async Task<DateTime?> GetDataBlockCreatedDate(DataBlock dataBlock)
         {
-            if (dataBlock.Created != null)
+            try
             {
-                return dataBlock.Created.Value;
-            }
-            
-            var owningReleaseByReleaseContentBlocks = (await _contentDbContext
-                .ReleaseContentBlocks
-                .Include(rcb => rcb.Release)
-                .SingleOrDefaultAsync(rcb => rcb.ContentBlockId == dataBlock.Id))
-                ?.Release;
+                if (dataBlock.Created != null)
+                {
+                    return dataBlock.Created.Value;
+                }
 
-            if (owningReleaseByReleaseContentBlocks != null)
+                var owningReleaseByReleaseContentBlocks = (await _contentDbContext
+                        .ReleaseContentBlocks
+                        .Include(rcb => rcb.Release)
+                        .SingleOrDefaultAsync(rcb => rcb.ContentBlockId == dataBlock.Id))
+                    ?.Release;
+
+                if (owningReleaseByReleaseContentBlocks != null)
+                {
+                    return owningReleaseByReleaseContentBlocks.Created;
+                }
+
+                var owningReleaseByContentSection = (await _contentDbContext
+                        .ReleaseContentSections
+                        .Include(rcs => rcs.Release)
+                        .Include(rcs => rcs.ContentSection)
+                        .ThenInclude(cs => cs.Content)
+                        .Where(rcs => rcs.ContentSection.Content.Contains(dataBlock))
+                        .FirstOrDefaultAsync())
+                    ?.Release;
+
+                if (owningReleaseByContentSection != null)
+                {
+                    return owningReleaseByContentSection.Created;
+                }
+
+                return null;
+            }
+            catch (Exception e)
             {
-                return owningReleaseByReleaseContentBlocks.Created;
+                _logger.LogError(e, "Unable to determine CreatedDate for DataBlock {DataBlockId}", dataBlock.Id);
+                return null;
             }
-            
-            var owningReleaseByContentSection = (await _contentDbContext
-                    .ReleaseContentSections
-                    .Include(rcs => rcs.Release)
-                    .Include(rcs => rcs.ContentSection)
-                    .ThenInclude(cs => cs.Content)
-                    .Where(rcs => rcs.ContentSection.Content.Contains(dataBlock))
-                    .FirstOrDefaultAsync())
-                ?.Release;
-
-            if (owningReleaseByContentSection != null)
-            {
-                return owningReleaseByContentSection.Created;
-            }
-
-            return null;
         }
 
         private 
@@ -326,6 +353,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 QuestionWhichCorrectGeoLevelToSelect,
                 FixMapConfigNoDataSetGeographicLevels,
                 FixMapConfigInvalidDataSetGeographicLevels,
+                UnknownErrorEncountered,
             }
             
             public Guid DataBlockId { get; }
@@ -435,6 +463,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             [JsonConverter(typeof(StringEnumConverter))]
             public GeographicLevel? GeographicLevel { get; }
+            
+            public string ExceptionMessage { get; init; }
 
             public MapMigrationResult(
                 Guid dataBlockId, 


### PR DESCRIPTION
This PR is raised in reaction to hitting some data in the Dev environment whereby there's no route from a ContentBlock back to its owning Release via the ReleaseContentBlock join table.

Now we have an alternative route via ReleaseContentSection, and failing that, we fall back to using UtcNow.

We also have a try-catch surrounding the migration process to allow us to continue if any exceptions occur.