### PR TITLE
EES-3149 Find Stats page should show publications with live releases …

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ThemeService.cs
@@ -81,7 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                 .Where(publication => publication
                                           .Releases
                                           .Any(r => r.IsLatestPublishedVersionOfRelease())
-                                      || !string.IsNullOrEmpty(publication.LegacyPublicationUrl?.ToString()))
+                                      || publication.LegacyPublicationUrl != null)
                 .SelectAwait(async publication =>
                     await BuildPublicationNode(publication))
                 .OrderBy(publication => publication.Title)
@@ -110,6 +110,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                     ? publication.LegacyPublicationUrl?.ToString()
                     : null,
                 IsSuperseded = IsSuperseded(publication),
+                HasLiveRelease = latestRelease != null,
                 LatestReleaseHasData = latestRelease != null && await HasAnyDataFiles(latestRelease),
                 AnyLiveReleaseHasData = await publication.Releases
                     .ToAsyncEnumerable()
@@ -164,8 +165,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             {
                 case PublicationTreeFilter.FindStatistics:
                     return !publicationTreeNode.IsSuperseded
-                           && (publicationTreeNode.LatestReleaseHasData ||
-                               !string.IsNullOrEmpty(publicationTreeNode.LegacyPublicationUrl));
+                           && (publicationTreeNode.HasLiveRelease
+                               || publicationTreeNode.Type == PublicationType.Legacy);
                 case PublicationTreeFilter.DataTables:
                     return publicationTreeNode.LatestReleaseHasData
                            && !publicationTreeNode.IsSuperseded;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationTreeNode.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationTreeNode.cs
@@ -13,6 +13,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 
         public bool IsSuperseded { get; set; }
 
+        public bool HasLiveRelease { get; set; }
+
         public bool LatestReleaseHasData { get; set; }
 
         public bool AnyLiveReleaseHasData { get; set; }


### PR DESCRIPTION
The Find Statistics page should display publications that have live releases without any data.

Also added more unit tests to ensure something like this doesn't get missed in the future.