### PR TITLE
EES-3136 Invalidate Admin data blocks cache files after footnotes get updated

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServicePermissionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -107,6 +108,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 _,
                 releaseHelper,
                 userService,
+                dataBlockService,
                 footnoteService,
                 footnoteHelper,
                 guidGenerator
@@ -117,6 +119,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 context,
                 releaseHelper.Object,
                 userService.Object,
+                dataBlockService.Object,
                 footnoteService.Object,
                 footnoteHelper.Object,
                 guidGenerator.Object
@@ -129,6 +132,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             Mock<ILogger<FootnoteService>>,
             Mock<IPersistenceHelper<ContentDbContext>>,
             Mock<IUserService>,
+            Mock<IDataBlockService>,
             Mock<IFootnoteRepository>,
             Mock<IPersistenceHelper<StatisticsDbContext>>,
             Mock<IGuidGenerator>) Mocks()
@@ -140,6 +144,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 new Mock<ILogger<FootnoteService>>(),
                 contentPersistenceHelper,
                 new Mock<IUserService>(),
+                new Mock<IDataBlockService>(),
                 new Mock<IFootnoteRepository>(),
                 MockUtils.MockPersistenceHelper<StatisticsDbContext, Footnote>(Footnote.Id, Footnote),
                 new Mock<IGuidGenerator>());

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -445,9 +446,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .Returns(newFootnote1.Id)
                     .Returns(newFootnote2.Id);
 
+                var dataBlockService = new Mock<IDataBlockService>(Strict);
+
+                dataBlockService.Setup(mock => mock.InvalidateCachedDataBlocks(amendment.Id))
+                    .Returns(Task.CompletedTask);
+
                 var service = SetupFootnoteService(
                     statisticsDbContext,
                     contentDbContext,
+                    dataBlockService: dataBlockService.Object,
                     footnoteRepository: footnoteRepository.Object,
                     guidGenerator: guidGenerator.Object);
 
@@ -543,6 +550,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             ContentDbContext contentDbContext = null,
             IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
             IUserService userService = null,
+            IDataBlockService dataBlockService = null,
             IFootnoteRepository footnoteRepository = null,
             IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper = null,
             IGuidGenerator guidGenerator = null)
@@ -553,6 +561,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 statisticsDbContext,
                 contentPersistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentContext),
                 userService ?? MockUtils.AlwaysTrueUserService().Object,
+                dataBlockService ?? Mock.Of<IDataBlockService>(Strict),
                 footnoteRepository ?? new FootnoteRepository(statisticsDbContext),
                 statisticsPersistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext),
                 guidGenerator ?? new SequentialGuidGenerator()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServiceTests.cs
@@ -549,19 +549,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var release = new Release();
 
-            var subject = new Subject
-            {
-                Id = Guid.NewGuid(),
-            };
+            var subject = new Subject();
 
-            var filterItem = new FilterItem
-            {
-                Id = Guid.NewGuid(),
-            };
+            var filterItem = new FilterItem();
 
             var filterGroup = new FilterGroup
             {
-                Id = Guid.NewGuid(),
                 FilterItems = new List<FilterItem>
                 {
                     filterItem,
@@ -570,18 +563,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var filter = new Filter
             {
-                Id = Guid.NewGuid(),
-                SubjectId = subject.Id,
+                Subject = subject,
                 FilterGroups = new List<FilterGroup>
                 {
                     filterGroup,
                 },
             };
 
-            var indicator = new Indicator
-            {
-                Id = Guid.NewGuid(),
-            };
+            var indicator = new Indicator();
 
             var indicatorGroup = new IndicatorGroup
             {
@@ -613,28 +602,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     new FilterFootnote
                     {
-                        FilterId = filter.Id,
+                        Filter = filter,
                     }
                 },
                 FilterGroups = new List<FilterGroupFootnote>
                 {
                     new FilterGroupFootnote
                     {
-                        FilterGroupId =  filterGroup.Id,
+                        FilterGroup =  filterGroup,
                     }
                 },
                 FilterItems = new List<FilterItemFootnote>
                 {
                     new FilterItemFootnote
                     {
-                        FilterItemId = filterItem.Id,
+                        FilterItem = filterItem,
                     }
                 },
                 Indicators = new List<IndicatorFootnote>
                 {
                     new IndicatorFootnote
                     {
-                        IndicatorId = indicator.Id,
+                        Indicator = indicator,
                     }
                 },
             };
@@ -702,24 +691,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task UpdateFootnote_AddCriteria()
         {
-            var release = new Release
-            {
-                Id = Guid.NewGuid(),
-            };
+            var release = new Release();
 
-            var subject = new Subject
-            {
-                Id = Guid.NewGuid(),
-            };
+            var subject = new Subject();
 
-            var filterItem = new FilterItem
-            {
-                Id = Guid.NewGuid(),
-            };
+            var filterItem = new FilterItem();
 
             var filterGroup = new FilterGroup
             {
-                Id = Guid.NewGuid(),
                 FilterItems = new List<FilterItem>
                 {
                     filterItem,
@@ -728,18 +707,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var filter = new Filter
             {
-                Id = Guid.NewGuid(),
-                SubjectId = subject.Id,
+                Subject = subject,
                 FilterGroups = new List<FilterGroup>
                 {
                     filterGroup,
                 },
             };
 
-            var indicator = new Indicator
-            {
-                Id = Guid.NewGuid(),
-            };
+            var indicator = new Indicator();
 
             var indicatorGroup = new IndicatorGroup
             {
@@ -757,7 +732,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     new ReleaseFootnote
                     {
-                        ReleaseId = release.Id,
+                        Release = release,
                     }
                 },
                 Subjects = new List<SubjectFootnote>(),
@@ -824,33 +799,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
             {
-                var dbFootnote = Assert.Single(statisticsDbContext.Footnote.ToList());
-                Assert.Equal(footnote.Id, dbFootnote.Id);
-                Assert.Equal("Updated footnote", dbFootnote.Content);
+                var savedFootnote = Assert.Single(statisticsDbContext.Footnote.ToList());
+                Assert.Equal(footnote.Id, savedFootnote.Id);
+                Assert.Equal("Updated footnote", savedFootnote.Content);
 
-                var dbReleaseFootnote = Assert.Single(statisticsDbContext.ReleaseFootnote.ToList());
-                Assert.Equal(release.Id, dbReleaseFootnote.ReleaseId);
-                Assert.Equal(footnote.Id, dbReleaseFootnote.FootnoteId);
+                var savedReleaseFootnote = Assert.Single(statisticsDbContext.ReleaseFootnote.ToList());
+                Assert.Equal(release.Id, savedReleaseFootnote.ReleaseId);
+                Assert.Equal(footnote.Id, savedReleaseFootnote.FootnoteId);
 
-                var dbSubjectFootnote = Assert.Single(statisticsDbContext.SubjectFootnote.ToList());
-                Assert.Equal(subject.Id, dbSubjectFootnote.SubjectId);
-                Assert.Equal(footnote.Id, dbSubjectFootnote.FootnoteId);
+                var savedSubjectFootnote = Assert.Single(statisticsDbContext.SubjectFootnote.ToList());
+                Assert.Equal(subject.Id, savedSubjectFootnote.SubjectId);
+                Assert.Equal(footnote.Id, savedSubjectFootnote.FootnoteId);
 
-                var dbFilterFootnote = Assert.Single(statisticsDbContext.FilterFootnote.ToList());
-                Assert.Equal(filter.Id, dbFilterFootnote.FilterId);
-                Assert.Equal(footnote.Id, dbFilterFootnote.FootnoteId);
+                var savedFilterFootnote = Assert.Single(statisticsDbContext.FilterFootnote.ToList());
+                Assert.Equal(filter.Id, savedFilterFootnote.FilterId);
+                Assert.Equal(footnote.Id, savedFilterFootnote.FootnoteId);
 
-                var dbFilterGroupFootnote = Assert.Single(statisticsDbContext.FilterGroupFootnote.ToList());
-                Assert.Equal(filterGroup.Id, dbFilterGroupFootnote.FilterGroupId);
-                Assert.Equal(footnote.Id, dbFilterGroupFootnote.FootnoteId);
+                var savedFilterGroupFootnote = Assert.Single(statisticsDbContext.FilterGroupFootnote.ToList());
+                Assert.Equal(filterGroup.Id, savedFilterGroupFootnote.FilterGroupId);
+                Assert.Equal(footnote.Id, savedFilterGroupFootnote.FootnoteId);
 
-                var dbFilterItemFootnote = Assert.Single(statisticsDbContext.FilterItemFootnote.ToList());
-                Assert.Equal(filterItem.Id, dbFilterItemFootnote.FilterItemId);
-                Assert.Equal(footnote.Id, dbFilterItemFootnote.FootnoteId);
+                var savedFilterItemFootnote = Assert.Single(statisticsDbContext.FilterItemFootnote.ToList());
+                Assert.Equal(filterItem.Id, savedFilterItemFootnote.FilterItemId);
+                Assert.Equal(footnote.Id, savedFilterItemFootnote.FootnoteId);
 
-                var dbIndicatorFootnote = Assert.Single(statisticsDbContext.IndicatorFootnote.ToList());
-                Assert.Equal(indicator.Id, dbIndicatorFootnote.IndicatorId);
-                Assert.Equal(footnote.Id, dbIndicatorFootnote.FootnoteId);
+                var savedIndicatorFootnote = Assert.Single(statisticsDbContext.IndicatorFootnote.ToList());
+                Assert.Equal(indicator.Id, savedIndicatorFootnote.IndicatorId);
+                Assert.Equal(footnote.Id, savedIndicatorFootnote.FootnoteId);
             }
         }
 
@@ -859,19 +834,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var release = new Release();
 
-            var subject = new Subject
-            {
-                Id = Guid.NewGuid(),
-            };
+            var subject = new Subject();
 
-            var filterItem = new FilterItem
-            {
-                Id = Guid.NewGuid(),
-            };
+            var filterItem = new FilterItem();
 
             var filterGroup = new FilterGroup
             {
-                Id = Guid.NewGuid(),
                 FilterItems = new List<FilterItem>
                 {
                     filterItem,
@@ -880,18 +848,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var filter = new Filter
             {
-                Id = Guid.NewGuid(),
-                SubjectId = subject.Id,
+                Subject = subject,
                 FilterGroups = new List<FilterGroup>
                 {
                     filterGroup,
                 },
             };
 
-            var indicator = new Indicator
-            {
-                Id = Guid.NewGuid(),
-            };
+            var indicator = new Indicator();
 
             var indicatorGroup = new IndicatorGroup
             {
@@ -923,28 +887,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     new FilterFootnote
                     {
-                        FilterId = filter.Id,
+                        Filter = filter,
                     }
                 },
                 FilterGroups = new List<FilterGroupFootnote>
                 {
                     new FilterGroupFootnote
                     {
-                        FilterGroupId =  filterGroup.Id,
+                        FilterGroup =  filterGroup,
                     }
                 },
                 FilterItems = new List<FilterItemFootnote>
                 {
                     new FilterItemFootnote
                     {
-                        FilterItemId = filterItem.Id,
+                        FilterItem = filterItem,
                     }
                 },
                 Indicators = new List<IndicatorFootnote>
                 {
                     new IndicatorFootnote
                     {
-                        IndicatorId = indicator.Id,
+                        Indicator = indicator,
                     }
                 },
             };
@@ -1006,13 +970,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
             {
-                var dbFootnote = Assert.Single(statisticsDbContext.Footnote.ToList());
-                Assert.Equal(footnote.Id, dbFootnote.Id);
-                Assert.Equal("Updated footnote", dbFootnote.Content);
+                var savedFootnote = Assert.Single(statisticsDbContext.Footnote.ToList());
+                Assert.Equal(footnote.Id, savedFootnote.Id);
+                Assert.Equal("Updated footnote", savedFootnote.Content);
 
-                var dbReleaseFootnote = Assert.Single(statisticsDbContext.ReleaseFootnote.ToList());
-                Assert.Equal(release.Id, dbReleaseFootnote.ReleaseId);
-                Assert.Equal(footnote.Id, dbReleaseFootnote.FootnoteId);
+                var savedReleaseFootnote = Assert.Single(statisticsDbContext.ReleaseFootnote.ToList());
+                Assert.Equal(release.Id, savedReleaseFootnote.ReleaseId);
+                Assert.Equal(footnote.Id, savedReleaseFootnote.FootnoteId);
 
                 Assert.Empty(statisticsDbContext.SubjectFootnote.ToList());
                 Assert.Empty(statisticsDbContext.FilterFootnote.ToList());

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -149,7 +149,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             _context.DataBlocks.Update(dataBlock);
                             await _context.SaveChangesAsync();
                         })
-                        .OnSuccessDo(() => InvalidateDataBlockCache(rcb.ReleaseId, rcb.ContentBlockId)))
+                        .OnSuccessDo(() => InvalidateCachedDataBlock(rcb.ReleaseId, rcb.ContentBlockId)))
                     .OnSuccess(() => Get(id));
         }
 
@@ -327,7 +327,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             return deletePlan
                 .DependentDataBlocks
-                .ForEachAsync(dataBlock => InvalidateDataBlockCache(deletePlan.ReleaseId, dataBlock.Id))
+                .ForEachAsync(dataBlock => InvalidateCachedDataBlock(deletePlan.ReleaseId, dataBlock.Id))
                 .OnSuccessVoid();
         }
 
@@ -336,11 +336,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var dataBlocks = GetDataBlocks(releaseId);
             foreach (var dataBlock in dataBlocks)
             {
-                 await InvalidateDataBlockCache(releaseId, dataBlock.Id);
+                 await InvalidateCachedDataBlock(releaseId, dataBlock.Id);
             }
         }
 
-        private Task<Either<ActionResult, Unit>> InvalidateDataBlockCache(Guid releaseId, Guid dataBlockId)
+        private Task<Either<ActionResult, Unit>> InvalidateCachedDataBlock(Guid releaseId, Guid dataBlockId)
         {
             return _cacheKeyService
                 .CreateCacheKeyForDataBlock(releaseId, dataBlockId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FootnoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FootnoteService.cs
@@ -26,6 +26,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IPersistenceHelper<ContentDbContext> _contentPersistenceHelper;
         private readonly IPersistenceHelper<StatisticsDbContext> _statisticsPersistenceHelper;
         private readonly IUserService _userService;
+        private readonly IDataBlockService _dataBlockService;
         private readonly IFootnoteRepository _footnoteRepository;
         private readonly IGuidGenerator _guidGenerator;
 
@@ -33,6 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             StatisticsDbContext context,
             IPersistenceHelper<ContentDbContext> contentPersistenceHelper,
             IUserService userService,
+            IDataBlockService dataBlockService,
             IFootnoteRepository footnoteRepository,
             IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper, 
             IGuidGenerator guidGenerator)
@@ -40,6 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _context = context;
             _contentPersistenceHelper = contentPersistenceHelper;
             _userService = userService;
+            _dataBlockService = dataBlockService;
             _footnoteRepository = footnoteRepository;
             _statisticsPersistenceHelper = statisticsPersistenceHelper;
             _guidGenerator = guidGenerator;
@@ -75,14 +78,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     await _context.Footnote.AddAsync(footnote);
 
                     await _context.ReleaseFootnote.AddAsync(new ReleaseFootnote
-                        {
-                            ReleaseId = releaseId,
-                            Footnote = footnote
-                        });
+                    {
+                        ReleaseId = releaseId,
+                        Footnote = footnote
+                    });
 
                     await _context.SaveChangesAsync();
-                    return await GetFootnote(releaseId, footnote.Id);
-                });
+                    return footnote;
+                })
+                .OnSuccessDo(async _ => await _dataBlockService.InvalidateCachedDataBlocks(releaseId))
+                .OnSuccess(async footnote => await GetFootnote(releaseId, footnote.Id)
+                );
         }
 
         public async Task<Either<ActionResult, List<Footnote>>> CopyFootnotes(Guid sourceReleaseId, Guid destinationReleaseId)
@@ -122,6 +128,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     await _footnoteRepository.DeleteFootnote(releaseId, footnote.Id);
                     await _context.SaveChangesAsync();
+
+                    await _dataBlockService.InvalidateCachedDataBlocks(releaseId);
                     return Unit.Instance;
                 }));
         }
@@ -170,7 +178,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         filterItemIds,
                         indicatorIds,
                         subjectIds);
-                }));
+                })
+                .OnSuccessDo(async _ => await _dataBlockService.InvalidateCachedDataBlocks(releaseId)));
         }
 
         public Task<Either<ActionResult, Footnote>> GetFootnote(Guid releaseId, Guid id)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FootnoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FootnoteService.cs
@@ -150,6 +150,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(_ => _statisticsPersistenceHelper.CheckEntityExists<Footnote>(id, HydrateFootnote)
                 .OnSuccess(async footnote =>
                 {
+                    // NOTE: At the time of writing, footnotes are now always exclusive to a particular release, but
+                    // in the past this wasn't always the case. It's unclear whether this is still necessary for
+                    // the sake of older footnotes.
                     if (await _footnoteRepository.IsFootnoteExclusiveToReleaseAsync(releaseId, footnote.Id))
                     {
                         _context.Update(footnote);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataBlockService.cs
@@ -32,5 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<DeleteDataBlockPlan> GetDeletePlan(Guid releaseId, Subject? subject);
 
         Task<Either<ActionResult, Unit>> RemoveChartFile(Guid releaseId, Guid id);
+
+        Task InvalidateCachedDataBlocks(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/FilterItem.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/FilterItem.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -220,12 +220,11 @@ Navigate to content tab
 
 Check updated footnote is displayed in content Tab
     [Documentation]    EES-3136
-    [Tags]    Failing
     user clicks button    Test data block section
     ${section}=    user gets accordion section content element    Test data block section
     ...    //*[@data-testid="editableAccordionSection"]
 
-    user scrolls to element    //*[@data-testid="editableAccordionSection"]//*[@data-testid="footnotes"]
+    user scrolls to element    ${section}
 
     user checks list has x items    testid:footnotes    1
     user checks list item contains    testid:footnotes    1    ${FOOTNOTE_UPDATED}


### PR DESCRIPTION
This PR fixes a bug where Admin data block cache files wouldn't get invalidated after updating footnotes. This meant that if a data block has been cached and then someone updated footnotes associated with that data block, in Admin Content the data block would display the wrong footnotes.

We now delete all data block cache files associated with a release whenever a footnote is added, updated, or removed. This was for speed and simplicity of implementing it. Also, ascertaining what specific data blocks are affected by a footnote change will probably be an expensive operation, so it isn't clear that doing that is actually preferable.

This PR also adds unit tests for `FootnoteService#DeleteFootnote` and `FootnoteService#UpdateFootnote`, and enables a `Failing` UI test that checks that this PR actually fixes the bug.