### PR TITLE
EES-3345 Validate all filters and indicators for subject are present on update

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -110,55 +111,57 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                         .ToList()
                 );
 
-            filterRepository.Setup(s => s.GetFiltersIncludingItems(It.IsIn(subjectIds))).Returns(
-                new List<Filter>
-                {
-                    new Filter
+            filterRepository.Setup(s => s.GetFiltersIncludingItems(It.IsIn(subjectIds)))
+                .ReturnsAsync(
+                    new List<Filter>
                     {
-                        Id = Guid.NewGuid(),
-                        Hint = "Filter Hint",
-                        Label = "Filter label",
-                        Name = "Filter name",
-                        FilterGroups = new List<FilterGroup>
+                        new()
                         {
-                            new FilterGroup
+                            Id = Guid.NewGuid(),
+                            Hint = "Filter Hint",
+                            Label = "Filter label",
+                            Name = "Filter name",
+                            FilterGroups = new List<FilterGroup>
                             {
-                                Id = Guid.NewGuid(),
-                                Label = "Filter group",
-                                FilterItems = new List<FilterItem>
+                                new()
                                 {
-                                    new FilterItem
+                                    Id = Guid.NewGuid(),
+                                    Label = "Filter group",
+                                    FilterItems = new List<FilterItem>
                                     {
-                                        Id = Guid.NewGuid(),
-                                        Label = "Filter item",
+                                        new()
+                                        {
+                                            Id = Guid.NewGuid(),
+                                            Label = "Filter item",
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }
-            );
+                );
 
-            indicatorGroupRepository.Setup(s => s.GetIndicatorGroups(It.IsIn(subjectIds))).Returns(
-                new List<IndicatorGroup>
-                {
-                    new IndicatorGroup
+            indicatorGroupRepository.Setup(s => s.GetIndicatorGroups(It.IsIn(subjectIds)))
+                .ReturnsAsync(
+                    new List<IndicatorGroup>
                     {
-                        Id = Guid.NewGuid(),
-                        Label = "Indicator group",
-                        Indicators = new List<Indicator>
+                        new()
                         {
-                            new Indicator
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator group",
+                            Indicators = new List<Indicator>
                             {
-                                Id = Guid.NewGuid(),
-                                Label = "Indicator label",
-                                Name = "Indicator name",
-                                Unit = Data.Model.Unit.Percent,
-                                DecimalPlaces = 2
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Indicator label",
+                                    Name = "Indicator name",
+                                    Unit = Data.Model.Unit.Percent,
+                                    DecimalPlaces = 2
+                                }
                             }
                         }
-                    }
-                });
+                    });
 
             _controller = new FootnoteController(filterRepository.Object,
                 footnoteService.Object,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/FootnoteController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/FootnoteController.cs
@@ -113,8 +113,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
                         .SelectAsync(async subject =>
                             new FootnotesSubjectMetaViewModel
                             {
-                                Filters = GetFilters(subject.Id),
-                                Indicators = GetIndicators(subject.Id),
+                                Filters = await GetFilters(subject.Id),
+                                Indicators = await GetIndicators(subject.Id),
                                 SubjectId = subject.Id,
                                 SubjectName = (await _releaseDataFileRepository.GetBySubject(releaseId, subject.Id)).Name,
                             }
@@ -131,9 +131,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
                 .HandleFailuresOrOk();
         }
 
-        private Dictionary<Guid, FootnotesIndicatorsMetaViewModel> GetIndicators(Guid subjectId)
+        private async Task<Dictionary<Guid, FootnotesIndicatorsMetaViewModel>> GetIndicators(Guid subjectId)
         {
-            return _indicatorGroupRepository.GetIndicatorGroups(subjectId)
+            return (await _indicatorGroupRepository.GetIndicatorGroups(subjectId))
                 .OrderBy(group => group.Label, LabelComparer)
                 .ToDictionary(
                     group => group.Id,
@@ -148,9 +148,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
                 );
         }
 
-        private Dictionary<Guid, FootnotesFilterMetaViewModel> GetFilters(Guid subjectId)
+        private async Task<Dictionary<Guid, FootnotesFilterMetaViewModel>> GetFilters(Guid subjectId)
         {
-            return _filterRepository.GetFiltersIncludingItems(subjectId)
+            return (await _filterRepository.GetFiltersIncludingItems(subjectId))
                 .ToDictionary(
                     filter => filter.Id,
                     filter => new FootnotesFilterMetaViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -163,7 +163,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         private async Task<ReplacementSubjectMeta> GetReplacementSubjectMeta(Guid subjectId)
         {
-            var filtersIncludingItems = _filterRepository.GetFiltersIncludingItems(subjectId);
+            var filtersIncludingItems = await _filterRepository.GetFiltersIncludingItems(subjectId);
 
             var filters = filtersIncludingItems
                 .ToDictionary(filter => filter.Name, filter => filter);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
@@ -57,6 +57,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             AssertBadRequestWithValidationErrors(result, expectedValidationErrors);
         }
 
+        public static void AssertBadRequest(this ActionResult result, string expectedError)
+        {
+            var badRequest = Assert.IsAssignableFrom<BadRequestObjectResult>(result);
+            var error = Assert.IsAssignableFrom<string>(badRequest.Value);
+            Assert.Equal(expectedError, error);
+        }
+
         public static void AssertNotModified<T>(this ActionResult<T> result)
         {
             var statusCodeResult = Assert.IsType<StatusCodeResult>(result.Result);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTestExtensions.cs
@@ -68,6 +68,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             return either.Left;
         }
 
+        public static ActionResult AssertBadRequest<TRight>(this Either<ActionResult, TRight> either, string expectedError)
+        {
+            var badRequest = either.AssertActionResultOfType<BadRequestObjectResult, TRight>();
+            badRequest.AssertBadRequest(expectedError);
+            return either.Left;
+        }
+
         private static TActionResult AssertActionResultOfType<TActionResult, TRight>(this Either<ActionResult, TRight> result)
             where TActionResult : ActionResult
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTestExtensions.cs
@@ -68,13 +68,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             return either.Left;
         }
 
-        public static ActionResult AssertBadRequest<TRight>(this Either<ActionResult, TRight> either, string expectedError)
-        {
-            var badRequest = either.AssertActionResultOfType<BadRequestObjectResult, TRight>();
-            badRequest.AssertBadRequest(expectedError);
-            return either.Left;
-        }
-
         private static TActionResult AssertActionResultOfType<TActionResult, TRight>(this Either<ActionResult, TRight> result)
             where TActionResult : ActionResult
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -63,11 +63,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
         public static implicit operator Either<TL, TR>(TR right) => new(right);
     }
-    
-    public static class EitherExtensions {
-        public static T Result<T>(this Either<T, T> either)
+
+    public static class EitherExtensions
+    {
+        public static Either<TFailure, List<TSuccess>> OnSuccessAll<TFailure, TSuccess>(
+            this IEnumerable<Either<TFailure, TSuccess>> items)
         {
-            return either.IsLeft ? either.Left : either.Right;
+            var result = new List<TSuccess>();
+            foreach (var either in items)
+            {
+                if (either.IsLeft)
+                {
+                    return either.Left;
+                }
+
+                result.Add(either.Right);
+            }
+            return result;
+        }
+
+        public static Either<TFailure, Unit> OnSuccessVoid<TFailure, TSuccess>(
+            this Either<TFailure, TSuccess> either)
+        {
+            if (either.IsLeft)
+            {
+                return either.Left;
+            }
+
+            return Unit.Instance;
         }
     }
 
@@ -106,14 +129,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             this Task<Either<TFailure, TSuccess1>> task,
             Func<Either<TFailure, TSuccess2>> successTask)
         {
-            return await task.OnSuccessDo(async _=> await Task.FromResult(successTask()));
+            return await task.OnSuccessDo(async _ => await Task.FromResult(successTask()));
         }
 
         public static async Task<Either<TFailure, TSuccess1>> OnSuccessDo<TFailure, TSuccess1, TSuccess2>(
             this Task<Either<TFailure, TSuccess1>> task,
             Func<TSuccess1, Either<TFailure, TSuccess2>> successTask)
         {
-            return await task.OnSuccessDo(async result=> await Task.FromResult(successTask(result)));
+            return await task.OnSuccessDo(async result => await Task.FromResult(successTask(result)));
         }
 
         public static async Task<Either<TFailure, TSuccess1>> OnSuccessDo<TFailure, TSuccess1, TSuccess2>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -47,6 +47,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
         public Either<TL, T> OnSuccess<T>(Func<T> func) => Map(_ => func.Invoke());
 
+        public Either<TL, T> OnSuccess<T>(Func<TR, Either<TL, T>> func) => IsLeft ? Left : func.Invoke(Right);
+
         public Either<TL, TR> OrElse(Func<TR> func) => IsLeft ? func() : Right;
 
         public Either<TL, TR> OrElse(Func<TL, TR> func) => IsLeft ? func(Left) : Right;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/IPersistenceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/IPersistenceHelper.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,21 +12,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
     {
         Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity, TEntityId>(
             TEntityId id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null)
-        where TEntity : class;
+            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
+            where TEntity : class;
 
         Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
             Guid id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null)
+            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
             where TEntity : class;
 
         Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
             Func<IQueryable<TEntity>, IQueryable<TEntity>> query)
             where TEntity : class;
 
-        Task<Either<ActionResult, TEntity>> CheckOptionalEntityExists<TEntity>(
+        Task<Either<ActionResult, TEntity?>> CheckOptionalEntityExists<TEntity>(
             Guid? id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null)
+            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
             where TEntity : class;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/PersistenceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/PersistenceHelper.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -21,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
 
         public async Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity, TEntityId>(
             TEntityId id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null)
+            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
             where TEntity : class
         {
             var queryableEntities = _context.Set<TEntity>()
@@ -41,7 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
 
         public Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
             Guid id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null)
+            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
             where TEntity : class
         {
             return CheckEntityExists<TEntity, Guid>(id, hydrateEntityFn);
@@ -61,8 +62,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
                 : new Either<ActionResult, TEntity>(entity);
         }
 
-        public async Task<Either<ActionResult, TEntity>> CheckOptionalEntityExists<TEntity>(Guid? id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null) where TEntity : class
+        public async Task<Either<ActionResult, TEntity?>> CheckOptionalEntityExists<TEntity>(Guid? id,
+            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null) where TEntity : class
         {
             return id.HasValue
                 ? await CheckEntityExists(id.Value, hydrateEntityFn)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/AbstractRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/AbstractRepository.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -28,32 +26,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
             return _context.Set<TEntity>();
         }
 
-        protected TEntity Find(TKey id)
-        {
-            return DbSet().Find(id);
-        }
-
         private async Task<TEntity> FindAsync(TKey id)
         {
             return await DbSet().FindAsync(id);
         }
 
-        public Either<ActionResult, TEntity> FindOrNotFound(TKey id)
-        {
-            return Find(id) ?? new Either<ActionResult, TEntity>(new NotFoundResult());
-        }
-
         public async Task<Either<ActionResult, TEntity>> FindOrNotFoundAsync(TKey id)
         {
             return await FindAsync(id) ?? new Either<ActionResult, TEntity>(new NotFoundResult());
-        }
-
-        public IQueryable<TEntity> FindMany(Expression<Func<TEntity, bool>> expression,
-            List<Expression<Func<TEntity, object>>> include = null)
-        {
-            var queryable = DbSet().Where(expression);
-            include?.ForEach(i => queryable = queryable.Include(i));
-            return queryable;
         }
 
         protected async Task<TEntity> RemoveAsync(TKey id)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/BoundaryLevelRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/BoundaryLevelRepository.cs
@@ -1,44 +1,41 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
+using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
 {
-    public class BoundaryLevelRepository : AbstractRepository<BoundaryLevel, long>, IBoundaryLevelRepository
+    public class BoundaryLevelRepository : IBoundaryLevelRepository
     {
-        private readonly DataServiceMemoryCache<BoundaryLevel> _cache;
+        private readonly StatisticsDbContext _context;
 
-        public BoundaryLevelRepository(
-            StatisticsDbContext context,
-            DataServiceMemoryCache<BoundaryLevel> cache)
-            : base(context)
+        public BoundaryLevelRepository(StatisticsDbContext context)
         {
-            _cache = cache;
+            _context = context;
         }
 
-        private IEnumerable<BoundaryLevel> FindByGeographicLevel(GeographicLevel geographicLevel)
+        public Task<BoundaryLevel?> Get(long id)
         {
-            return FindMany(level => level.Level == geographicLevel)
-                .OrderByDescending(level => level.Published);
+            return _context.BoundaryLevel.SingleOrDefaultAsync(level => level.Id == id);
         }
 
         public IEnumerable<BoundaryLevel> FindByGeographicLevels(IEnumerable<GeographicLevel> geographicLevels)
         {
-            return FindMany(level => geographicLevels.Contains(level.Level))
+            return _context.BoundaryLevel
+                .Where(level => geographicLevels.Contains(level.Level))
                 .OrderByDescending(level => level.Published);
         }
 
         public BoundaryLevel? FindLatestByGeographicLevel(GeographicLevel geographicLevel)
         {
-            var boundaryLevel = FindMany(level => level.Level == geographicLevel)
+            return _context.BoundaryLevel
+                .Where(level => level.Level == geographicLevel)
                 .OrderByDescending(level => level.Published)
                 .FirstOrDefault();
-
-            return boundaryLevel;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/FilterRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/FilterRepository.cs
@@ -2,24 +2,29 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
 {
-    public class FilterRepository : AbstractRepository<Filter, Guid>, IFilterRepository
+    public class FilterRepository : IFilterRepository
     {
-        public FilterRepository(StatisticsDbContext context) : base(context)
+        private readonly StatisticsDbContext _context;
+
+        public FilterRepository(StatisticsDbContext context)
         {
+            _context = context;
         }
 
-        public List<Filter> GetFiltersIncludingItems(Guid subjectId)
+        public Task<List<Filter>> GetFiltersIncludingItems(Guid subjectId)
         {
-            return FindMany(filter => filter.SubjectId == subjectId)
+            return _context.Filter
                 .Include(filter => filter.FilterGroups)
                 .ThenInclude(group => group.FilterItems)
-                .ToList();
+                .Where(filter => filter.SubjectId == subjectId)
+                .ToListAsync();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/IndicatorGroupRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/IndicatorGroupRepository.cs
@@ -2,23 +2,28 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
+using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
 {
-    public class IndicatorGroupRepository : AbstractRepository<IndicatorGroup, Guid>, IIndicatorGroupRepository
+    public class IndicatorGroupRepository : IIndicatorGroupRepository
     {
-        public IndicatorGroupRepository(StatisticsDbContext context) : base(context)
+        private readonly StatisticsDbContext _context;
+
+        public IndicatorGroupRepository(StatisticsDbContext context)
         {
+            _context = context;
         }
 
-        public List<IndicatorGroup> GetIndicatorGroups(Guid subjectId)
+        public async Task<List<IndicatorGroup>> GetIndicatorGroups(Guid subjectId)
         {
-            return FindMany(group => group.SubjectId == subjectId,
-                    new List<Expression<Func<IndicatorGroup, object>>> {group => group.Indicators})
-                .ToList();
+            return await _context.IndicatorGroup
+                .Include(group => group.Indicators)
+                .Where(indicatorGroup => indicatorGroup.SubjectId == subjectId)
+                .ToListAsync();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IBoundaryLevelRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IBoundaryLevelRepository.cs
@@ -1,12 +1,16 @@
 #nullable enable
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces
 {
-    public interface IBoundaryLevelRepository : IRepository<BoundaryLevel, long>
+    public interface IBoundaryLevelRepository
     {
+        Task<BoundaryLevel?> Get(long id);
+
         IEnumerable<BoundaryLevel> FindByGeographicLevels(IEnumerable<GeographicLevel> geographicLevels);
+
         BoundaryLevel? FindLatestByGeographicLevel(GeographicLevel geographicLevel);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IFilterRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IFilterRepository.cs
@@ -1,11 +1,12 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces
 {
-    public interface IFilterRepository : IRepository<Filter, Guid>
+    public interface IFilterRepository
     {
-        List<Filter> GetFiltersIncludingItems(Guid subjectId);
+        Task<List<Filter>> GetFiltersIncludingItems(Guid subjectId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IIndicatorGroupRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IIndicatorGroupRepository.cs
@@ -1,11 +1,12 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces
 {
-    public interface IIndicatorGroupRepository : IRepository<IndicatorGroup, Guid>
+    public interface IIndicatorGroupRepository
     {
-        List<IndicatorGroup> GetIndicatorGroups(Guid subjectId);
+        Task<List<IndicatorGroup>> GetIndicatorGroups(Guid subjectId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IRepository.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
+#nullable enable
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
@@ -10,11 +7,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Inter
 {
     public interface IRepository<TEntity, in TKey> where TEntity : class
     {
-        Either<ActionResult, TEntity> FindOrNotFound(TKey id);
-        
         Task<Either<ActionResult, TEntity>> FindOrNotFoundAsync(TKey id);
-        
-        IQueryable<TEntity> FindMany(Expression<Func<TEntity, bool>> expression,
-            List<Expression<Func<TEntity, object>>> include = null);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/DataGuidanceSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/DataGuidanceSubjectServiceTests.cs
@@ -1010,7 +1010,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
         private static DataGuidanceSubjectService SetupService(
             StatisticsDbContext statisticsDbContext,
-            IFilterRepository? filterRepository = null,
             IIndicatorRepository? indicatorRepository = null,
             IPersistenceHelper<StatisticsDbContext>? persistenceHelper = null,
             ContentDbContext? contentDbContext = null,
@@ -1018,7 +1017,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             ITimePeriodService? timePeriodService = null)
         {
             return new (
-                filterRepository ?? new FilterRepository(statisticsDbContext),
                 indicatorRepository ?? new IndicatorRepository(statisticsDbContext),
                 statisticsDbContext,
                 persistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ResultSubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ResultSubjectMetaServiceTests.cs
@@ -779,8 +779,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             boundaryLevelRepository.Setup(s => s.FindLatestByGeographicLevel(GeographicLevel.Region))
                 .Returns(_regionsBoundaryLevel);
 
-            boundaryLevelRepository.Setup(s => s.FindOrNotFound(query.BoundaryLevel.Value))
-                .Returns(_regionsBoundaryLevel);
+            boundaryLevelRepository.Setup(s => s.Get(query.BoundaryLevel.Value))
+                .ReturnsAsync(_regionsBoundaryLevel);
 
             boundaryLevelRepository.Setup(s => s.FindByGeographicLevels(ItIs.ListSequenceEqualTo(ListOf(GeographicLevel.Region))))
                 .Returns(ListOf(_regionsBoundaryLevel));

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
@@ -23,6 +23,7 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Services.Collecti
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using Unit = GovUk.Education.ExploreEducationStatistics.Data.Model.Unit;
 using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.StatisticsDbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Data.Services.ValidationErrorMessages;
 using Release = GovUk.Education.ExploreEducationStatistics.Data.Model.Release;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
@@ -1789,7 +1790,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 VerifyAllMocks(filterRepository);
 
-                result.AssertBadRequest("Requested filters do not match subject filters");
+                result.AssertBadRequest(FiltersDifferFromSubject);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -1891,8 +1892,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 VerifyAllMocks(filterRepository);
 
-                result.AssertBadRequest(
-                    $"Requested filter groups do not match subject filter groups for filter: {filters[0].Id}");
+                result.AssertBadRequest(FilterGroupsDifferFromSubject);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -1987,8 +1987,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 VerifyAllMocks(filterRepository);
 
-                result.AssertBadRequest(
-                    $"Requested filter items do not match subject for filter group: {filters[0].FilterGroups[0].Id}");
+                result.AssertBadRequest(FilterItemsDifferFromSubject);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -2094,7 +2093,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 VerifyAllMocks(filterRepository);
 
-                result.AssertBadRequest("Requested filters do not match subject filters");
+                result.AssertBadRequest(FiltersDifferFromSubject);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -2193,8 +2192,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 VerifyAllMocks(filterRepository);
 
-                result.AssertBadRequest(
-                    $"Requested filter groups do not match subject filter groups for filter: {filters[0].Id}");
+                result.AssertBadRequest(FilterGroupsDifferFromSubject);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -2286,8 +2284,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 VerifyAllMocks(filterRepository);
 
-                result.AssertBadRequest(
-                    $"Requested filter items do not match subject for filter group: {filters[0].FilterGroups[0].Id}");
+                result.AssertBadRequest(FilterItemsDifferFromSubject);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -2575,7 +2572,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 VerifyAllMocks(indicatorGroupRepository);
 
-                result.AssertBadRequest("Requested indicator groups do not match subject indicator groups");
+                result.AssertBadRequest(IndicatorGroupsDifferFromSubject);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -2656,8 +2653,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 VerifyAllMocks(indicatorGroupRepository);
 
-                result.AssertBadRequest(
-                    $"Requested indicators do not match subject for indicator group: {indicatorGroups[0].Id}");
+                result.AssertBadRequest(IndicatorsDifferFromSubject);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -2742,7 +2738,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 VerifyAllMocks(indicatorGroupRepository);
 
-                result.AssertBadRequest("Requested indicator groups do not match subject indicator groups");
+                result.AssertBadRequest(IndicatorGroupsDifferFromSubject);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -2820,8 +2816,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 VerifyAllMocks(indicatorGroupRepository);
 
-                result.AssertBadRequest(
-                    $"Requested indicators do not match subject for indicator group: {indicatorGroups[0].Id}");
+                result.AssertBadRequest(IndicatorsDifferFromSubject);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
@@ -78,11 +78,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             filterRepository
                 .Setup(s => s.GetFiltersIncludingItems(releaseSubject.SubjectId))
-                .Returns(new List<Filter>());
+                .ReturnsAsync(new List<Filter>());
 
             indicatorGroupRepository
                 .Setup(s => s.GetIndicatorGroups(releaseSubject.SubjectId))
-                .Returns(new List<IndicatorGroup>());
+                .ReturnsAsync(new List<IndicatorGroup>());
 
             timePeriodService
                 .Setup(s => s.GetTimePeriods(releaseSubject.SubjectId))
@@ -206,11 +206,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             filterRepository
                 .Setup(s => s.GetFiltersIncludingItems(releaseSubject.SubjectId))
-                .Returns(new List<Filter>());
+                .ReturnsAsync(new List<Filter>());
 
             indicatorGroupRepository
                 .Setup(s => s.GetIndicatorGroups(releaseSubject.SubjectId))
-                .Returns(new List<IndicatorGroup>());
+                .ReturnsAsync(new List<IndicatorGroup>());
 
             timePeriodService
                 .Setup(s => s.GetTimePeriods(releaseSubject.SubjectId))
@@ -384,11 +384,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             filterRepository
                 .Setup(s => s.GetFiltersIncludingItems(releaseSubject.SubjectId))
-                .Returns(new List<Filter>());
+                .ReturnsAsync(new List<Filter>());
 
             indicatorGroupRepository
                 .Setup(s => s.GetIndicatorGroups(releaseSubject.SubjectId))
-                .Returns(new List<IndicatorGroup>());
+                .ReturnsAsync(new List<IndicatorGroup>());
 
             timePeriodService
                 .Setup(s => s.GetTimePeriods(releaseSubject.SubjectId))
@@ -503,11 +503,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             filterRepository
                 .Setup(s => s.GetFiltersIncludingItems(releaseSubject.SubjectId))
-                .Returns(new List<Filter>());
+                .ReturnsAsync(new List<Filter>());
 
             indicatorGroupRepository
                 .Setup(s => s.GetIndicatorGroups(releaseSubject.SubjectId))
-                .Returns(new List<IndicatorGroup>());
+                .ReturnsAsync(new List<IndicatorGroup>());
 
             timePeriodService
                 .Setup(s => s.GetTimePeriods(releaseSubject.SubjectId))
@@ -604,11 +604,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             filterRepository
                 .Setup(s => s.GetFiltersIncludingItems(subject.Id))
-                .Returns(new List<Filter>());
+                .ReturnsAsync(new List<Filter>());
 
             indicatorGroupRepository
                 .Setup(s => s.GetIndicatorGroups(subject.Id))
-                .Returns(new List<IndicatorGroup>());
+                .ReturnsAsync(new List<IndicatorGroup>());
 
             timePeriodService
                 .Setup(s => s.GetTimePeriods(subject.Id))
@@ -742,11 +742,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             filterRepository
                 .Setup(s => s.GetFiltersIncludingItems(subject.Id))
-                .Returns(new List<Filter>());
+                .ReturnsAsync(new List<Filter>());
 
             indicatorGroupRepository
                 .Setup(s => s.GetIndicatorGroups(subject.Id))
-                .Returns(new List<IndicatorGroup>());
+                .ReturnsAsync(new List<IndicatorGroup>());
 
             timePeriodService
                 .Setup(s => s.GetTimePeriods(subject.Id))
@@ -907,11 +907,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             filterRepository
                 .Setup(s => s.GetFiltersIncludingItems(subject.Id))
-                .Returns(new List<Filter>());
+                .ReturnsAsync(new List<Filter>());
 
             indicatorGroupRepository
                 .Setup(s => s.GetIndicatorGroups(subject.Id))
-                .Returns(new List<IndicatorGroup>());
+                .ReturnsAsync(new List<IndicatorGroup>());
 
             timePeriodService
                 .Setup(s => s.GetTimePeriods(subject.Id))
@@ -1380,7 +1380,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 indicatorGroupRepository
                     .Setup(s => s.GetIndicatorGroups(subject.Id))
-                    .Returns(indicatorGroups);
+                    .ReturnsAsync(indicatorGroups);
 
                 var service = BuildSubjectMetaService(
                     statisticsDbContext,
@@ -1538,6 +1538,1396 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 Assert.Equal("Unable to determine which SubjectMeta information has requested " +
                              "(Parameter 'subjectMetaStep')", exception.Message);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectFilters()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var filters = new List<Filter>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                            }
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                }
+                            }
+                        }
+                    }
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Create a request with identical filters, filter groups and filter items
+            var request = filters.Select(filter =>
+                new FilterUpdateViewModel
+                {
+                    Id = filter.Id,
+                    FilterGroups = filter.FilterGroups.Select(filterGroup => new FilterGroupUpdateViewModel
+                    {
+                        Id = filterGroup.Id,
+                        FilterItems = filterGroup.FilterItems.Select(filterItem => filterItem.Id).ToList()
+                    }).ToList()
+                }).ToList();
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
+
+            filterRepository.Setup(mock => mock.GetFiltersIncludingItems(releaseSubject.SubjectId))
+                .ReturnsAsync(filters);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    filterRepository: filterRepository.Object);
+
+                var result = await service.UpdateSubjectFilters(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(filterRepository);
+
+                result.AssertRight();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                var savedSequence = savedReleaseSubject.FilterSequence;
+
+                Assert.NotNull(savedSequence);
+                Assert.Equal(2, savedSequence!.Count);
+
+                // Filter 1
+                var savedFilter1 = savedSequence[0];
+                Assert.Equal(request[0].Id, savedFilter1.Id);
+
+                Assert.Equal(2, savedFilter1.ChildSequence.Count);
+                var savedFilter1Group1 = savedFilter1.ChildSequence[0];
+                var savedFilter1Group2 = savedFilter1.ChildSequence[1];
+
+                Assert.Equal(request[0].FilterGroups[0].Id, savedFilter1Group1.Id);
+                Assert.Equal(request[0].FilterGroups[1].Id, savedFilter1Group2.Id);
+
+                Assert.Equal(2, savedFilter1Group1.ChildSequence.Count);
+                Assert.Equal(request[0].FilterGroups[0].FilterItems[0], savedFilter1Group1.ChildSequence[0]);
+                Assert.Equal(request[0].FilterGroups[0].FilterItems[1], savedFilter1Group1.ChildSequence[1]);
+
+                Assert.Equal(2, savedFilter1Group2.ChildSequence.Count);
+                Assert.Equal(request[0].FilterGroups[1].FilterItems[0], savedFilter1Group2.ChildSequence[0]);
+                Assert.Equal(request[0].FilterGroups[1].FilterItems[1], savedFilter1Group2.ChildSequence[1]);
+
+                // Filter 2
+                var savedFilter2 = savedSequence[1];
+                Assert.Equal(request[1].Id, savedFilter2.Id);
+
+                Assert.Single(savedFilter2.ChildSequence);
+                var savedFilter2Group1 = savedFilter2.ChildSequence[0];
+
+                Assert.Equal(request[1].FilterGroups[0].Id, savedFilter2Group1.Id);
+
+                Assert.Single(savedFilter2Group1.ChildSequence);
+                Assert.Equal(request[1].FilterGroups[0].FilterItems[0], savedFilter2Group1.ChildSequence[0]);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectFilters_FilterMissing()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var filters = new List<Filter>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                }
+                            }
+                        }
+                    }
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Request has the second filter missing
+            var request = new List<FilterUpdateViewModel>
+            {
+                new()
+                {
+                    Id = filters[0].Id,
+                    FilterGroups = new List<FilterGroupUpdateViewModel>
+                    {
+                        new()
+                        {
+                            Id = filters[0].FilterGroups[0].Id,
+                            FilterItems = new List<Guid>
+                            {
+                                filters[0].FilterGroups[0].FilterItems[0].Id
+                            }
+                        }
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
+
+            filterRepository.Setup(mock => mock.GetFiltersIncludingItems(releaseSubject.SubjectId))
+                .ReturnsAsync(filters);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    filterRepository: filterRepository.Object);
+
+                var result = await service.UpdateSubjectFilters(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(filterRepository);
+
+                result.AssertBadRequest("Requested filters do not match subject filters");
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.FilterSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectFilters_FilterGroupMissing()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var filters = new List<Filter>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                }
+                            }
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Request has the second filter group missing
+            var request = new List<FilterUpdateViewModel>
+            {
+                new()
+                {
+                    Id = filters[0].Id,
+                    FilterGroups = new List<FilterGroupUpdateViewModel>
+                    {
+                        new()
+                        {
+                            Id = filters[0].FilterGroups[0].Id,
+                            FilterItems = new List<Guid>
+                            {
+                                filters[0].FilterGroups[0].FilterItems[0].Id
+                            }
+                        }
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
+
+            filterRepository.Setup(mock => mock.GetFiltersIncludingItems(releaseSubject.SubjectId))
+                .ReturnsAsync(filters);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    filterRepository: filterRepository.Object);
+
+                var result = await service.UpdateSubjectFilters(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(filterRepository);
+
+                result.AssertBadRequest(
+                    $"Requested filter groups do not match subject filter groups for filter: {filters[0].Id}");
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.FilterSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectFilters_FilterItemMissing()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var filters = new List<Filter>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Request has the second filter item missing
+            var request = new List<FilterUpdateViewModel>
+            {
+                new()
+                {
+                    Id = filters[0].Id,
+                    FilterGroups = new List<FilterGroupUpdateViewModel>
+                    {
+                        new()
+                        {
+                            Id = filters[0].FilterGroups[0].Id,
+                            FilterItems = new List<Guid>
+                            {
+                                filters[0].FilterGroups[0].FilterItems[0].Id
+                            }
+                        }
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
+
+            filterRepository.Setup(mock => mock.GetFiltersIncludingItems(releaseSubject.SubjectId))
+                .ReturnsAsync(filters);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    filterRepository: filterRepository.Object);
+
+                var result = await service.UpdateSubjectFilters(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(filterRepository);
+
+                result.AssertBadRequest(
+                    $"Requested filter items do not match subject for filter group: {filters[0].FilterGroups[0].Id}");
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.FilterSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectFilters_FilterNotForSubject()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var filters = new List<Filter>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Request has a filter not for this subject
+            var request = new List<FilterUpdateViewModel>
+            {
+                new()
+                {
+                    Id = filters[0].Id,
+                    FilterGroups = new List<FilterGroupUpdateViewModel>
+                    {
+                        new()
+                        {
+                            Id = filters[0].FilterGroups[0].Id,
+                            FilterItems = new List<Guid>
+                            {
+                                filters[0].FilterGroups[0].FilterItems[0].Id
+                            }
+                        }
+                    }
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    FilterGroups = new List<FilterGroupUpdateViewModel>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<Guid>
+                            {
+                                Guid.NewGuid()
+                            }
+                        }
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
+
+            filterRepository.Setup(mock => mock.GetFiltersIncludingItems(releaseSubject.SubjectId))
+                .ReturnsAsync(filters);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    filterRepository: filterRepository.Object);
+
+                var result = await service.UpdateSubjectFilters(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(filterRepository);
+
+                result.AssertBadRequest("Requested filters do not match subject filters");
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.FilterSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectFilters_FilterGroupNotForSubject()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var filters = new List<Filter>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Request has a filter group not for this subject
+            var request = new List<FilterUpdateViewModel>
+            {
+                new()
+                {
+                    Id = filters[0].Id,
+                    FilterGroups = new List<FilterGroupUpdateViewModel>
+                    {
+                        new()
+                        {
+                            Id = filters[0].FilterGroups[0].Id,
+                            FilterItems = new List<Guid>
+                            {
+                                filters[0].FilterGroups[0].FilterItems[0].Id
+                            }
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<Guid>
+                            {
+                                Guid.NewGuid()
+                            }
+                        }
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
+
+            filterRepository.Setup(mock => mock.GetFiltersIncludingItems(releaseSubject.SubjectId))
+                .ReturnsAsync(filters);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    filterRepository: filterRepository.Object);
+
+                var result = await service.UpdateSubjectFilters(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(filterRepository);
+
+                result.AssertBadRequest(
+                    $"Requested filter groups do not match subject filter groups for filter: {filters[0].Id}");
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.FilterSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectFilters_FilterItemNotForSubject()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var filters = new List<Filter>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid()
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Request has a filter item not for this subject
+            var request = new List<FilterUpdateViewModel>
+            {
+                new()
+                {
+                    Id = filters[0].Id,
+                    FilterGroups = new List<FilterGroupUpdateViewModel>
+                    {
+                        new()
+                        {
+                            Id = filters[0].FilterGroups[0].Id,
+                            FilterItems = new List<Guid>
+                            {
+                                filters[0].FilterGroups[0].FilterItems[0].Id,
+                                Guid.NewGuid()
+                            }
+                        }
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
+
+            filterRepository.Setup(mock => mock.GetFiltersIncludingItems(releaseSubject.SubjectId))
+                .ReturnsAsync(filters);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    filterRepository: filterRepository.Object);
+
+                var result = await service.UpdateSubjectFilters(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(filterRepository);
+
+                result.AssertBadRequest(
+                    $"Requested filter items do not match subject for filter group: {filters[0].FilterGroups[0].Id}");
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.FilterSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectFilters_ReleaseNotFound()
+        {
+            // Create a ReleaseSubject but for a different release than the one which will be used in the update
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext);
+
+                var result = await service.UpdateSubjectFilters(
+                    releaseId: Guid.NewGuid(),
+                    subjectId: releaseSubject.SubjectId,
+                    new List<FilterUpdateViewModel>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                );
+
+                result.AssertNotFound();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.FilterSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectFilters_SubjectNotFound()
+        {
+            // Create a ReleaseSubject but for a different release than the one which will be used in the update
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext);
+
+                var result = await service.UpdateSubjectFilters(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: Guid.NewGuid(),
+                    new List<FilterUpdateViewModel>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                );
+
+                result.AssertNotFound();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.FilterSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectIndicators()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var indicatorGroups = new List<IndicatorGroup>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                }
+            };
+
+            // Create a request with identical indicator groups and indicators
+            var request = indicatorGroups.Select(indicatorGroup =>
+                new IndicatorGroupUpdateViewModel
+                {
+                    Id = indicatorGroup.Id,
+                    Indicators = indicatorGroup.Indicators.Select(indicator => indicator.Id).ToList()
+                }).ToList();
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var indicatorGroupRepository = new Mock<IIndicatorGroupRepository>(MockBehavior.Strict);
+
+            indicatorGroupRepository.Setup(mock => mock.GetIndicatorGroups(releaseSubject.SubjectId))
+                .ReturnsAsync(indicatorGroups);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    indicatorGroupRepository: indicatorGroupRepository.Object);
+
+                var result = await service.UpdateSubjectIndicators(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(indicatorGroupRepository);
+
+                result.AssertRight();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                var savedSequence = savedReleaseSubject.IndicatorSequence;
+
+                Assert.NotNull(savedSequence);
+                Assert.Equal(2, savedSequence!.Count);
+
+                // Indicator Group 1
+                var savedIndicatorGroup1 = savedSequence[0];
+                Assert.Equal(request[0].Id, savedIndicatorGroup1.Id);
+
+                Assert.Equal(2, savedIndicatorGroup1.ChildSequence.Count);
+                Assert.Equal(request[0].Indicators[0], savedIndicatorGroup1.ChildSequence[0]);
+                Assert.Equal(request[0].Indicators[1], savedIndicatorGroup1.ChildSequence[1]);
+
+                // Indicator Group 2
+                var savedIndicatorGroup2 = savedSequence[1];
+                Assert.Equal(request[1].Id, savedIndicatorGroup2.Id);
+
+                Assert.Single(savedIndicatorGroup2.ChildSequence);
+                Assert.Equal(request[1].Indicators[0], savedIndicatorGroup2.ChildSequence[0]);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectIndicators_IndicatorGroupMissing()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var indicatorGroups = new List<IndicatorGroup>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                }
+            };
+
+            // Request has the second indicator group missing
+            var request = new List<IndicatorGroupUpdateViewModel>
+            {
+                new()
+                {
+                    Id = indicatorGroups[0].Id,
+                    Indicators = new List<Guid>
+                    {
+                        indicatorGroups[0].Indicators[0].Id
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var indicatorGroupRepository = new Mock<IIndicatorGroupRepository>(MockBehavior.Strict);
+
+            indicatorGroupRepository.Setup(mock => mock.GetIndicatorGroups(releaseSubject.SubjectId))
+                .ReturnsAsync(indicatorGroups);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    indicatorGroupRepository: indicatorGroupRepository.Object);
+
+                var result = await service.UpdateSubjectIndicators(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(indicatorGroupRepository);
+
+                result.AssertBadRequest("Requested indicator groups do not match subject indicator groups");
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.IndicatorSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectIndicators_IndicatorMissing()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var indicatorGroups = new List<IndicatorGroup>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                }
+            };
+
+            // Request has the second indicator missing
+            var request = new List<IndicatorGroupUpdateViewModel>
+            {
+                new()
+                {
+                    Id = indicatorGroups[0].Id,
+                    Indicators = new List<Guid>
+                    {
+                        indicatorGroups[0].Indicators[0].Id
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var indicatorGroupRepository = new Mock<IIndicatorGroupRepository>(MockBehavior.Strict);
+
+            indicatorGroupRepository.Setup(mock => mock.GetIndicatorGroups(releaseSubject.SubjectId))
+                .ReturnsAsync(indicatorGroups);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    indicatorGroupRepository: indicatorGroupRepository.Object);
+
+                var result = await service.UpdateSubjectIndicators(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(indicatorGroupRepository);
+
+                result.AssertBadRequest(
+                    $"Requested indicators do not match subject for indicator group: {indicatorGroups[0].Id}");
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.IndicatorSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectIndicators_IndicatorGroupNotForSubject()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var indicatorGroups = new List<IndicatorGroup>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                }
+            };
+
+            // Request has an indicator group not for this subject
+            var request = new List<IndicatorGroupUpdateViewModel>
+            {
+                new()
+                {
+                    Id = indicatorGroups[0].Id,
+                    Indicators = new List<Guid>
+                    {
+                        indicatorGroups[0].Indicators[0].Id
+                    }
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Indicators = new List<Guid>
+                    {
+                        Guid.NewGuid()
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var indicatorGroupRepository = new Mock<IIndicatorGroupRepository>(MockBehavior.Strict);
+
+            indicatorGroupRepository.Setup(mock => mock.GetIndicatorGroups(releaseSubject.SubjectId))
+                .ReturnsAsync(indicatorGroups);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    indicatorGroupRepository: indicatorGroupRepository.Object);
+
+                var result = await service.UpdateSubjectIndicators(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(indicatorGroupRepository);
+
+                result.AssertBadRequest("Requested indicator groups do not match subject indicator groups");
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.IndicatorSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectIndicators_IndicatorNotForSubject()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var indicatorGroups = new List<IndicatorGroup>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                }
+            };
+
+            // Request has an indicator not for this subject
+            var request = new List<IndicatorGroupUpdateViewModel>
+            {
+                new()
+                {
+                    Id = indicatorGroups[0].Id,
+                    Indicators = new List<Guid>
+                    {
+                        indicatorGroups[0].Indicators[0].Id,
+                        Guid.NewGuid()
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var indicatorGroupRepository = new Mock<IIndicatorGroupRepository>(MockBehavior.Strict);
+
+            indicatorGroupRepository.Setup(mock => mock.GetIndicatorGroups(releaseSubject.SubjectId))
+                .ReturnsAsync(indicatorGroups);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext,
+                    indicatorGroupRepository: indicatorGroupRepository.Object);
+
+                var result = await service.UpdateSubjectIndicators(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    request
+                );
+
+                VerifyAllMocks(indicatorGroupRepository);
+
+                result.AssertBadRequest(
+                    $"Requested indicators do not match subject for indicator group: {indicatorGroups[0].Id}");
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.IndicatorSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectIndicators_ReleaseNotFound()
+        {
+            // Create a ReleaseSubject but for a different release than the one which will be used in the update
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext);
+
+                var result = await service.UpdateSubjectIndicators(
+                    releaseId: Guid.NewGuid(),
+                    subjectId: releaseSubject.SubjectId,
+                    new List<IndicatorGroupUpdateViewModel>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                );
+
+                result.AssertNotFound();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.IndicatorSequence);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubjectIndicators_SubjectNotFound()
+        {
+            // Create a ReleaseSubject but for a different release than the one which will be used in the update
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject()
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildSubjectMetaService(statisticsDbContext);
+
+                var result = await service.UpdateSubjectIndicators(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: Guid.NewGuid(),
+                    new List<IndicatorGroupUpdateViewModel>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
+                    }
+                );
+
+                result.AssertNotFound();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
+                    rs.ReleaseId == releaseSubject.ReleaseId
+                    && rs.SubjectId == releaseSubject.SubjectId);
+
+                // Verify that the ReleaseSubject remains untouched
+                Assert.Null(savedReleaseSubject.IndicatorSequence);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/DataGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/DataGuidanceSubjectService.cs
@@ -19,7 +19,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 {
     public class DataGuidanceSubjectService : IDataGuidanceSubjectService
     {
-        private readonly IFilterRepository _filterRepository;
         private readonly IIndicatorRepository _indicatorRepository;
         private readonly StatisticsDbContext _context;
         private readonly IPersistenceHelper<StatisticsDbContext> _statisticsPersistenceHelper;
@@ -27,15 +26,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         private readonly IFootnoteRepository _footnoteRepository;
         private readonly ITimePeriodService _timePeriodService;
 
-        public DataGuidanceSubjectService(IFilterRepository filterRepository,
-            IIndicatorRepository indicatorRepository,
+        public DataGuidanceSubjectService(IIndicatorRepository indicatorRepository,
             StatisticsDbContext context,
             IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper,
             IReleaseDataFileRepository releaseDataFileRepository,
             IFootnoteRepository footnoteRepository,
             ITimePeriodService timePeriodService)
         {
-            _filterRepository = filterRepository;
             _indicatorRepository = indicatorRepository;
             _context = context;
             _statisticsPersistenceHelper = statisticsPersistenceHelper;
@@ -109,7 +106,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         private List<LabelValue> GetVariables(Guid subjectId)
         {
-            var filters = _filterRepository.FindMany(filter => filter.SubjectId == subjectId)
+            var filters = _context.Filter
+                .Where(filter => filter.SubjectId == subjectId)
                 .Select(filter =>
                     new LabelValue(
                         string.IsNullOrWhiteSpace(filter.Hint) ? filter.Label : $"{filter.Label} - {filter.Hint}",

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
@@ -128,7 +128,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                         _boundaryLevelRepository,
                         _geoJsonRepository);
 
-                    var locationViewModels = locationsHelper.GetLocationViewModels();
+                    var locationViewModels = await locationsHelper.GetLocationViewModels();
                     _logger.LogTrace("Got Location view models in {Time} ms", stopwatch.Elapsed.TotalMilliseconds);
                     stopwatch.Stop();
 
@@ -226,10 +226,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     .ToList();
             }
 
-            public Dictionary<string, List<LocationAttributeViewModel>> GetLocationViewModels()
+            public async Task<Dictionary<string, List<LocationAttributeViewModel>>> GetLocationViewModels()
             {
                 var allGeoJson = _query.BoundaryLevel != null
-                    ? GetGeoJson(_query.BoundaryLevel.Value, _locationAttributes)
+                    ? await GetGeoJson(_query.BoundaryLevel.Value, _locationAttributes)
                     : new Dictionary<GeographicLevel, Dictionary<string, GeoJson>>();
 
                 return _locationAttributes.ToDictionary(
@@ -295,14 +295,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 };
             }
 
-            private Dictionary<GeographicLevel, Dictionary<string, GeoJson>> GetGeoJson(
+            private async Task<Dictionary<GeographicLevel, Dictionary<string, GeoJson>>> GetGeoJson(
                 long boundaryLevelId,
                 Dictionary<GeographicLevel, List<LocationAttributeNode>> locations)
             {
-                var selectedBoundaryLevel = _boundaryLevelRepository
-                    .FindOrNotFound(boundaryLevelId)
-                    .OrElse(() => null!)
-                    .Right;
+                var selectedBoundaryLevel = await _boundaryLevelRepository.Get(boundaryLevelId);
 
                 if (selectedBoundaryLevel == null || !locations.ContainsKey(selectedBoundaryLevel.Level))
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -347,12 +347,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 "Requested filters do not match subject filters").OnSuccess(_ =>
             {
                 var requestMap = requestFilters.ToDictionary(filter => filter.Id);
-                var results = filters.Select(filter =>
+                return filters.Select(filter =>
                         ValidateFilterGroupsForSubject(filter, requestMap[filter.Id].FilterGroups))
-                    .ToList();
-
-                var failure = results.FirstOrDefault(result => result.IsLeft)?.Left;
-                return failure ?? new Either<ActionResult, Unit>(Unit.Instance);
+                    .OnSuccessAll()
+                    .OnSuccessVoid();
             });
         }
 
@@ -368,15 +366,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 .OnSuccess(_ =>
                 {
                     var requestMap = requestFilterGroups.ToDictionary(filterGroup => filterGroup.Id);
-                    var results = filter.FilterGroups.Select(filterGroup =>
+                    return filter.FilterGroups.Select(filterGroup =>
                             AssertCollectionsAreSameIgnoringOrder(
                                 filterGroup.FilterItems.Select(filterItem => filterItem.Id),
                                 requestMap[filterGroup.Id].FilterItems,
                                 $"Requested filter items do not match subject for filter group: {filterGroup.Id}"))
-                        .ToList();
-
-                    var failure = results.FirstOrDefault(result => result.IsLeft)?.Left;
-                    return failure ?? new Either<ActionResult, Unit>(Unit.Instance);
+                        .OnSuccessAll()
+                        .OnSuccessVoid();
                 });
         }
 
@@ -393,15 +389,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 .OnSuccess(_ =>
                 {
                     var requestMap = requestIndicatorGroups.ToDictionary(indicatorGroup => indicatorGroup.Id);
-                    var results = indicatorGroups.Select(indicatorGroup =>
+                    return indicatorGroups.Select(indicatorGroup =>
                             AssertCollectionsAreSameIgnoringOrder(
                                 indicatorGroup.Indicators.Select(indicator => indicator.Id),
                                 requestMap[indicatorGroup.Id].Indicators,
                                 $"Requested indicators do not match subject for indicator group: {indicatorGroup.Id}"))
-                        .ToList();
-
-                    var failure = results.FirstOrDefault(result => result.IsLeft)?.Left;
-                    return failure ?? new Either<ActionResult, Unit>(Unit.Instance);
+                        .OnSuccessAll()
+                        .OnSuccessVoid();
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ValidationErrorMessages.cs
@@ -3,7 +3,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 {
     public enum ValidationErrorMessages
     {
+        // Table builder queries
         QueryExceedsMaxAllowableTableSize,
-        RequestCancelled
+
+        // Updating Filters
+        FiltersDifferFromSubject,
+        FilterGroupsDifferFromSubject,
+        FilterItemsDifferFromSubject,
+
+        // Updating Indicators
+        IndicatorGroupsDifferFromSubject,
+        IndicatorsDifferFromSubject
     }
 }


### PR DESCRIPTION
This PR builds upon https://github.com/dfe-analytical-services/explore-education-statistics/pull/3270 adding validation to ensure that when filters, filter groups, filter items, indicator groups and indicators are updated that the request contains all elements for the subject and that there are no unexpected elements.

When the update request is processed the sequence of filters and indicators groups is set based on the order in the request along with the sequences of their respective filter groups, filter items, and indicators. It's important to make sure that no elements are missing and that no elements unknown to the subject are included.

### Other changes

* Add async support to `FilterRepository` and `IndicatorGroupRepository`.