### PR TITLE
EES-2825 hide pre-release users tab for amendments

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
@@ -39,53 +39,55 @@ const ReleasePreReleaseAccessPage = () => {
     <LoadingSpinner loading={isLoading}>
       {release && (
         <Tabs id="preReleaseAccess">
-          <TabsSection
-            id={releasePreReleaseAccessPageTabs.users}
-            title="Pre-release users"
-          >
-            <h2>Manage pre-release user access</h2>
-            <InsetText>
-              <h3>Before you start</h3>
-              <p>
-                Pre-release users will receive an email with a link to preview
-                the publication for pre-release as soon as you add them. The
-                preview will show a holding page until 24 hours before the
-                scheduled publication date.
-              </p>
-              <p>
-                Pre-release access via Explore Education Statistics is currently
-                limited to DFE users only, if you need to share your release
-                with external users you will need to do so outside of the
-                system.
-              </p>
-            </InsetText>
-
-            {!release.live && (
-              <>
+          {!release.amendment && (
+            <TabsSection
+              id={releasePreReleaseAccessPageTabs.users}
+              title="Pre-release users"
+            >
+              <h2>Manage pre-release user access</h2>
+              <InsetText>
+                <h3>Before you start</h3>
                 <p>
-                  The <strong>pre-release</strong> will be accessible at:
+                  Pre-release users will receive an email with a link to preview
+                  the publication for pre-release as soon as you add them. The
+                  preview will show a holding page until 24 hours before the
+                  scheduled publication date.
                 </p>
-
                 <p>
-                  <UrlContainer
-                    data-testid="prerelease-url"
-                    url={`${window.location.origin}${generatePath<
-                      ReleaseRouteParams
-                    >(preReleaseContentRoute.path, {
-                      publicationId: release.publicationId,
-                      releaseId: release.id,
-                    })}`}
-                  />
+                  Pre-release access via Explore Education Statistics is
+                  currently limited to DFE users only, if you need to share your
+                  release with external users you will need to do so outside of
+                  the system.
                 </p>
-              </>
-            )}
+              </InsetText>
 
-            <PreReleaseUserAccessForm
-              releaseId={release.id}
-              isReleaseApproved={release.approvalStatus === 'Approved'}
-              isReleaseLive={release.live}
-            />
-          </TabsSection>
+              {!release.live && (
+                <>
+                  <p>
+                    The <strong>pre-release</strong> will be accessible at:
+                  </p>
+
+                  <p>
+                    <UrlContainer
+                      data-testid="prerelease-url"
+                      url={`${window.location.origin}${generatePath<
+                        ReleaseRouteParams
+                      >(preReleaseContentRoute.path, {
+                        publicationId: release.publicationId,
+                        releaseId: release.id,
+                      })}`}
+                    />
+                  </p>
+                </>
+              )}
+
+              <PreReleaseUserAccessForm
+                releaseId={release.id}
+                isReleaseApproved={release.approvalStatus === 'Approved'}
+                isReleaseLive={release.live}
+              />
+            </TabsSection>
+          )}
           <TabsSection
             id={releasePreReleaseAccessPageTabs.publicAccessList}
             title="Public access list"

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
@@ -2,13 +2,24 @@ import { testRelease } from '@admin/pages/release/__data__/testRelease';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import _releaseService, { Release } from '@admin/services/releaseService';
+import _permissionService from '@admin/services/permissionService';
+import _preReleaseUserService from '@admin/services/preReleaseUserService';
 import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
 import { MemoryRouter } from 'react-router';
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
 import ReleasePreReleaseAccessPage from '@admin/pages/release/pre-release/ReleasePreReleaseAccessPage';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('@admin/services/releaseService');
 const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
+jest.mock('@admin/services/permissionService');
+const permissionService = _permissionService as jest.Mocked<
+  typeof _permissionService
+>;
+jest.mock('@admin/services/preReleaseUserService');
+const preReleaseUserService = _preReleaseUserService as jest.Mocked<
+  typeof _preReleaseUserService
+>;
 
 const releaseData: Release = {
   id: 'release-1',
@@ -41,18 +52,39 @@ const releaseData: Release = {
 };
 
 describe('ReleasePreReleaseAccessPage', () => {
-  test('renders prerelease page link correctly', async () => {
+  test('renders the pre-release users tab', async () => {
     releaseService.getRelease.mockResolvedValue(releaseData);
+    permissionService.canUpdateRelease.mockResolvedValue(true);
+    preReleaseUserService.getUsers.mockResolvedValue([]);
 
-    render(
-      <MemoryRouter>
-        <TestConfigContextProvider>
-          <ReleaseContextProvider release={testRelease}>
-            <ReleasePreReleaseAccessPage />
-          </ReleaseContextProvider>
-        </TestConfigContextProvider>
-      </MemoryRouter>,
-    );
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Manage pre-release user access'),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('tab', { name: 'Pre-release users' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByLabelText('Url')).toBeInTheDocument();
+
+    expect(
+      screen.getByLabelText('Invite new users by email'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Invite new users' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders pre-release page link correctly', async () => {
+    releaseService.getRelease.mockResolvedValue(releaseData);
+    permissionService.canUpdateRelease.mockResolvedValue(true);
+
+    renderPage();
 
     await waitFor(() => {
       expect(screen.queryByTestId('prerelease-url')).toBeInTheDocument();
@@ -62,4 +94,65 @@ describe('ReleasePreReleaseAccessPage', () => {
       'http://localhost/publication/publication-1/release/release-1/prerelease/content',
     );
   });
+
+  test('does not render the pre-release users tab for amendments', async () => {
+    const amendmentRelease = { ...releaseData, amendment: true };
+    releaseService.getRelease.mockResolvedValue(amendmentRelease);
+    permissionService.canUpdateRelease.mockResolvedValue(true);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Public pre-release access list'),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('tab', { name: 'Pre-release users' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('tab', { name: 'Public access list' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders the public access list tab', async () => {
+    releaseService.getRelease.mockResolvedValue(releaseData);
+    permissionService.canUpdateRelease.mockResolvedValue(true);
+    preReleaseUserService.getUsers.mockResolvedValue([]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Manage pre-release user access'),
+      ).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByRole('tab', { name: 'Public access list' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Public pre-release access list'),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Create public pre-release access list',
+      }),
+    ).toBeInTheDocument();
+  });
 });
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <TestConfigContextProvider>
+        <ReleaseContextProvider release={testRelease}>
+          <ReleasePreReleaseAccessPage />
+        </ReleaseContextProvider>
+      </TestConfigContextProvider>
+    </MemoryRouter>,
+  );
+}


### PR DESCRIPTION
Hides the pre-release users tab for amendments as invites are only sent for original releases.