### PR TITLE
EES-3230 add edit data block links on release content tab

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableBlockWrapper.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableBlockWrapper.tsx
@@ -1,3 +1,4 @@
+import ButtonLink from '@admin/components/ButtonLink';
 import styles from '@admin/components/editable/EditableBlockWrapper.module.scss';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
@@ -6,12 +7,14 @@ import useToggle from '@common/hooks/useToggle';
 import React, { ReactNode } from 'react';
 
 export interface EditableBlockProps {
+  dataBlockEditLink?: string;
   onEdit?: () => void;
   onDelete?: () => void;
 }
 
 const EditableBlockWrapper = ({
   children,
+  dataBlockEditLink,
   onEdit,
   onDelete,
 }: EditableBlockProps & { children: ReactNode }) => {
@@ -26,6 +29,12 @@ const EditableBlockWrapper = ({
           <Button variant="secondary" onClick={() => onEdit()}>
             Edit block
           </Button>
+        )}
+
+        {dataBlockEditLink && (
+          <ButtonLink to={dataBlockEditLink} variant="secondary">
+            Edit data block
+          </ButtonLink>
         )}
 
         {onDelete && (

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableBlockWrapper.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableBlockWrapper.test.tsx
@@ -23,9 +23,7 @@ describe('EditableBlockWrapper', () => {
       </EditableBlockWrapper>,
     );
 
-    expect(
-      screen.getByRole('button', { name: 'Edit block' }),
-    ).toBeInTheDocument();
+    expect(handleEdit).not.toHaveBeenCalled();
     userEvent.click(screen.getByRole('button', { name: 'Edit block' }));
     expect(handleEdit).toHaveBeenCalled();
   });
@@ -96,6 +94,7 @@ describe('EditableBlockWrapper', () => {
       expect(modal.getByText('Remove block')).toBeInTheDocument();
     });
 
+    expect(handleDelete).not.toHaveBeenCalled();
     userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
     expect(handleDelete).toHaveBeenCalled();
   });

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableBlockWrapper.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableBlockWrapper.test.tsx
@@ -1,0 +1,114 @@
+import EditableBlockWrapper from '@admin/components/editable/EditableBlockWrapper';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+describe('EditableBlockWrapper', () => {
+  test('renders the child block', () => {
+    render(
+      <EditableBlockWrapper>
+        <div>Child block</div>
+      </EditableBlockWrapper>,
+    );
+
+    expect(screen.getByText('Child block')).toBeInTheDocument();
+  });
+
+  test('renders the edit block button and calls `onEdit` when clicked when `onEdit` is provided', () => {
+    const handleEdit = jest.fn();
+    render(
+      <EditableBlockWrapper onEdit={handleEdit}>
+        <div>Child block</div>
+      </EditableBlockWrapper>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Edit block' }),
+    ).toBeInTheDocument();
+    userEvent.click(screen.getByRole('button', { name: 'Edit block' }));
+    expect(handleEdit).toHaveBeenCalled();
+  });
+
+  test('does not render the edit block button when `onEdit` is not provided', () => {
+    render(
+      <EditableBlockWrapper>
+        <div>Child block</div>
+      </EditableBlockWrapper>,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Edit block' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders the edit data block link when `dataBlockEditLink` is provided', () => {
+    render(
+      <MemoryRouter>
+        <EditableBlockWrapper dataBlockEditLink="/test-url">
+          <div>Child block</div>
+        </EditableBlockWrapper>
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Edit data block' });
+    expect(link).toHaveAttribute('href', '/test-url');
+  });
+
+  test('does not render the edit data block link when `dataBlockEditLink` is not provided', () => {
+    render(
+      <EditableBlockWrapper>
+        <div>Child block</div>
+      </EditableBlockWrapper>,
+    );
+
+    expect(
+      screen.queryByRole('link', { name: 'Edit data block' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders the remove block button when `onDelete` is provided', () => {
+    const handleDelete = jest.fn();
+    render(
+      <EditableBlockWrapper onDelete={handleDelete}>
+        <div>Child block</div>
+      </EditableBlockWrapper>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Remove block' }),
+    ).toBeInTheDocument();
+  });
+
+  test('when the remove block button is clicked a modal is shown which calls `onDelete` on confirm', async () => {
+    const handleDelete = jest.fn();
+    render(
+      <EditableBlockWrapper onDelete={handleDelete}>
+        <div>Child block</div>
+      </EditableBlockWrapper>,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Remove block' }));
+
+    const modal = within(screen.getByRole('dialog'));
+
+    await waitFor(() => {
+      expect(modal.getByText('Remove block')).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(handleDelete).toHaveBeenCalled();
+  });
+
+  test('does not render the remove block button when `onDelete` is not provided', () => {
+    render(
+      <EditableBlockWrapper>
+        <div>Child block</div>
+      </EditableBlockWrapper>,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Remove block' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -165,6 +165,7 @@ const ReleaseContent = () => {
                     <ReleaseEditableBlock
                       allowComments
                       block={block}
+                      publicationId={release.publication.id}
                       releaseId={release.id}
                       sectionId={release.summarySection.id}
                       onSave={updateBlock}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -183,6 +183,7 @@ const ReleaseContentAccordionSection = ({
                 block={block}
                 sectionId={sectionId}
                 editable={!isReordering}
+                publicationId={release.publication.id}
                 releaseId={release.id}
                 visible={open}
                 onSave={updateBlock}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseEditableBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseEditableBlock.tsx
@@ -4,6 +4,10 @@ import EditableContentBlock from '@admin/components/editable/EditableContentBloc
 import { useEditingContext } from '@admin/contexts/EditingContext';
 import useGetChartFile from '@admin/hooks/useGetChartFile';
 import useReleaseImageUpload from '@admin/pages/release/hooks/useReleaseImageUpload';
+import {
+  releaseDataBlockEditRoute,
+  ReleaseDataBlockRouteParams,
+} from '@admin/routes/releaseRoutes';
 import { Comment, EditableBlock } from '@admin/services/types/content';
 import releaseContentCommentService, {
   AddComment,
@@ -12,15 +16,17 @@ import DataBlockTabs from '@common/modules/find-statistics/components/DataBlockT
 import Gate from '@common/components/Gate';
 import useReleaseImageAttributeTransformer from '@common/modules/release/hooks/useReleaseImageAttributeTransformer';
 import isBrowser from '@common/utils/isBrowser';
-import React, { useCallback } from 'react';
 import { insertReleaseIdPlaceholders } from '@common/modules/release/utils/releaseImageUrls';
 import useToggle from '@common/hooks/useToggle';
+import React, { useCallback } from 'react';
+import { generatePath } from 'react-router';
 
 interface Props {
   allowComments?: boolean;
   allowImages?: boolean;
   block: EditableBlock;
   editable?: boolean;
+  publicationId: string;
   releaseId: string;
   sectionId: string;
   visible?: boolean;
@@ -32,8 +38,9 @@ const ReleaseEditableBlock = ({
   allowComments = false,
   allowImages = false,
   block,
-  releaseId,
   editable = true,
+  publicationId,
+  releaseId,
   sectionId,
   visible,
   onDelete,
@@ -113,7 +120,17 @@ const ReleaseEditableBlock = ({
     case 'DataBlock':
       return (
         <div className="dfe-content-overflow">
-          <EditableBlockWrapper onDelete={editable ? handleDelete : undefined}>
+          <EditableBlockWrapper
+            dataBlockEditLink={generatePath<ReleaseDataBlockRouteParams>(
+              releaseDataBlockEditRoute.path,
+              {
+                publicationId,
+                releaseId,
+                dataBlockId: block.id,
+              },
+            )}
+            onDelete={editable ? handleDelete : undefined}
+          >
             <Gate condition={!!visible}>
               <DataBlockTabs
                 releaseId={releaseId}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
@@ -77,8 +77,9 @@ const ReleaseHeadlines = ({ release }: Props) => {
             <ReleaseEditableBlock
               allowComments
               block={block}
-              sectionId={release.headlinesSection.id}
+              publicationId={release.publication.id}
               releaseId={release.id}
+              sectionId={release.headlinesSection.id}
               onSave={updateBlock}
               onDelete={removeBlock}
             />

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseEditableBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseEditableBlock.test.tsx
@@ -29,6 +29,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseContentProvider value={testValue}>
         <ReleaseEditableBlock
+          publicationId="publication-1"
           releaseId="release-1"
           sectionId="section-1"
           block={testHtmlBlock}
@@ -61,6 +62,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseContentProvider value={testValue}>
         <ReleaseEditableBlock
+          publicationId="publication-1"
           releaseId="release-1"
           sectionId="section-1"
           block={{


### PR DESCRIPTION
Adds an 'Edit data block' link to data blocks on the edit release content tab.