### PR TITLE
EES-3320 Update chart colour options to match ONS recommendations

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
@@ -109,7 +109,7 @@ describe('ChartLegendConfiguration', () => {
     expect(legendItem1.getByLabelText('Label')).toHaveValue(
       'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, Barnet)',
     );
-    expect(legendItem1.getByLabelText('Colour')).toHaveValue('#1d70b8');
+    expect(legendItem1.getByLabelText('Colour')).toHaveValue('#12436d');
     expect(legendItem1.getByLabelText('Symbol')).toHaveValue('none');
     expect(legendItem1.getByLabelText('Style')).toHaveValue('solid');
   });
@@ -153,7 +153,7 @@ describe('ChartLegendConfiguration', () => {
     expect(legendItem1.getByLabelText('Label')).toHaveValue(
       'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, Barnet)',
     );
-    expect(legendItem1.getByLabelText('Colour')).toHaveValue('#1d70b8');
+    expect(legendItem1.getByLabelText('Colour')).toHaveValue('#12436d');
     expect(legendItem1.getByLabelText('Symbol')).toHaveValue('none');
     expect(legendItem1.getByLabelText('Style')).toHaveValue('solid');
 
@@ -162,7 +162,7 @@ describe('ChartLegendConfiguration', () => {
     expect(legendItem2.getByLabelText('Label')).toHaveValue(
       'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, Barnsley)',
     );
-    expect(legendItem2.getByLabelText('Colour')).toHaveValue('#912b88');
+    expect(legendItem2.getByLabelText('Colour')).toHaveValue('#f46a25');
     expect(legendItem2.getByLabelText('Symbol')).toHaveValue('none');
     expect(legendItem2.getByLabelText('Style')).toHaveValue('solid');
   });

--- a/src/explore-education-statistics-common/src/modules/charts/util/chartUtils.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/chartUtils.ts
@@ -2,19 +2,13 @@ import { ChartSymbol, LineStyle } from '@common/modules/charts/types/chart';
 import { LegendPosition } from '@common/modules/charts/types/legend';
 
 export const colours: string[] = [
-  '#1d70b8',
-  '#912b88',
-  '#d53880',
-  '#f499be',
-  '#f47738',
-  '#b58840',
-  '#85994b',
-  '#28a197',
-  '#505a5f',
-  '#0b0c0c',
-  '#d4351c',
-  '#ffdd00',
-  '#00703c',
+  '#12436D',
+  '#F46A25',
+  '#801650',
+  '#28A197',
+  '#2073BC',
+  '#6BACE6',
+  '#BFBFBF',
 ];
 
 export const legendPositions: LegendPosition[] = ['bottom', 'top', 'none'];


### PR DESCRIPTION
This PR simply updates the colour choices in chart builder to match ONS recommendations.

Note that the ticket suggests that the colours should be grouped by their use-case, however, this isn't really possible using the native colour selector. Discussed with @cjrace and for now we're not going add groupings for now.