### PR TITLE
EES-3016 remove hidden link on data block tabs

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -67,16 +67,6 @@ const DataBlockTabs = ({
 
             {fullTable && (
               <ErrorBoundary fallback={errorMessage}>
-                <a
-                  className="govuk-visually-hidden"
-                  href={`#${id}-tables`}
-                  aria-live="assertive"
-                >
-                  If you are using a keyboard or a screen reader you may wish to
-                  view the accessible table instead. Press enter to switch to
-                  the data tables tab.
-                </a>
-
                 {dataBlock.charts.map((chart, index) => {
                   const key = index;
 


### PR DESCRIPTION
Removes the hidden link to switch to the Table tab on data blocks. 

This was recommended by the DAC report as the link was confusing to keyboard users and the tab controls already provide an accessible way to switch between charts and tables.