### PR TITLE
EES-3381 - fix click interception in release content authoring test

### DIFF
--- a/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
@@ -241,8 +241,10 @@ Switch back to analyst1 to resolve second text block
     ${comment}=    user gets unresolved comment    Test comment 3    ${block}
     ${author}=    get child element    ${comment}    testid:comment-author
     user waits until element contains    ${author}    Bau1 User1
+
     # resolve the comment left by bau1
-    user clicks button    Resolve    ${comment}
+    user sets focus to element    xpath://button[text()="Resolve"]    ${block}
+    user clicks button    Resolve
 
     user waits until parent contains element
     ...    ${block}


### PR DESCRIPTION

Fixes a click interception in the release content authoring UI test 


![image](https://user-images.githubusercontent.com/55030296/168325732-36d7ad96-9ee2-49f5-b5ce-4ea39278f276.png)