### PR TITLE
EES-2793 Retain ordering of Filters and Indicators when data is replaced

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
@@ -1,0 +1,722 @@
+﻿using System;
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+public class ReplacementServiceHelperTests
+{
+    [Fact]
+    public void ReplaceFilterSequence()
+    {
+        // Define a set of filters, filter groups and filter items belonging to the original subject
+        var originalFilters = new List<Filter>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Filter a",
+                Name = "filter_a",
+                FilterGroups = new List<FilterGroup>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Group a",
+                        FilterItems = new List<FilterItem>
+                        {
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item a"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item b"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item c"
+                            }
+                        }
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Group b",
+                        FilterItems = new List<FilterItem>
+                        {
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item d"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item e"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item f"
+                            }
+                        }
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Group c",
+                        FilterItems = new List<FilterItem>
+                        {
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item g"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item h"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item i"
+                            }
+                        }
+                    }
+                }
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Filter b",
+                Name = "filter_b",
+                FilterGroups = new List<FilterGroup>()
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Filter c",
+                Name = "filter_c",
+                FilterGroups = new List<FilterGroup>()
+            }
+        };
+
+        // Define a sequence for the original subject which is expected to be updated after the replacement
+        var originalReleaseSubject = new ReleaseSubject
+        {
+            FilterSequence = new List<FilterSequenceEntry>
+            {
+                // Filter c
+                new(
+                    originalFilters[2].Id,
+                    new List<FilterGroupSequenceEntry>()
+                ),
+                // Filter a
+                new(originalFilters[0].Id,
+                    new List<FilterGroupSequenceEntry>
+                    {
+                        // Group c
+                        new(
+                            originalFilters[0].FilterGroups[2].Id,
+                            new List<Guid>
+                            {
+                                // Item i, Item g, Item h
+                                originalFilters[0].FilterGroups[2].FilterItems[2].Id,
+                                originalFilters[0].FilterGroups[2].FilterItems[0].Id,
+                                originalFilters[0].FilterGroups[2].FilterItems[1].Id
+                            }
+                        ),
+                        // Group a
+                        new(
+                            originalFilters[0].FilterGroups[0].Id,
+                            new List<Guid>
+                            {
+                                // Item c, Indicator a, Indicator b
+                                originalFilters[0].FilterGroups[0].FilterItems[2].Id,
+                                originalFilters[0].FilterGroups[0].FilterItems[0].Id,
+                                originalFilters[0].FilterGroups[0].FilterItems[1].Id
+                            }
+                        ),
+                        // Group b
+                        new(
+                            originalFilters[0].FilterGroups[1].Id,
+                            new List<Guid>
+                            {
+                                // Item f, Item d, Item e
+                                originalFilters[0].FilterGroups[1].FilterItems[2].Id,
+                                originalFilters[0].FilterGroups[1].FilterItems[0].Id,
+                                originalFilters[0].FilterGroups[1].FilterItems[1].Id
+                            }
+                        )
+                    }
+                ),
+                // Filter b
+                new(
+                    originalFilters[1].Id,
+                    new List<FilterGroupSequenceEntry>()
+                )
+            }
+        };
+
+        // Define the set of filters, filter groups and filter items belonging to the replacement subject
+        var replacementFilters = new List<Filter>
+        {
+            // 'Filter a' is updated
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Filter a",
+                Name = "filter_a",
+                FilterGroups = new List<FilterGroup>
+                {
+                    // 'Group a' is removed
+                    // 'Group e' is added
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Group e",
+                        FilterItems = new List<FilterItem>()
+                    },
+                    // Group 'Total' is added
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Total",
+                        FilterItems = new List<FilterItem>
+                        {
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item m"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Total"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item l"
+                            }
+                        }
+                    },
+                    // 'Group d' is added
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Group d",
+                        FilterItems = new List<FilterItem>()
+                    },
+                    // 'Group b' is updated
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Group b",
+                        FilterItems = new List<FilterItem>
+                        {
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item d"
+                            },
+                            // 'Item e' is removed
+                            // 'Item k' is added
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item k"
+                            },
+                            // 'Item j' is added
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item j"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item f"
+                            }
+                        }
+                    },
+                    // 'Group c' remains identical
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Group c",
+                        FilterItems = new List<FilterItem>
+                        {
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item g"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item h"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item i"
+                            }
+                        }
+                    }
+                }
+            },
+            // 'Filter b' is removed
+            // 'Filter e' is added
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Filter e",
+                Name = "filter_e",
+                FilterGroups = new List<FilterGroup>()
+            },
+            // 'Filter d' is added
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Filter d",
+                Name = "filter_d",
+                FilterGroups = new List<FilterGroup>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Group g",
+                        FilterItems = new List<FilterItem>()
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Total",
+                        FilterItems = new List<FilterItem>
+                        {
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item o"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Total"
+                            },
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                Label = "Item n"
+                            }
+                        }
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Group f",
+                        FilterItems = new List<FilterItem>()
+                    }
+                }
+            },
+            // 'Filter c' remains identical
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Filter c",
+                Name = "filter_c",
+                FilterGroups = new List<FilterGroup>()
+            }
+        };
+
+        var updatedSequence = ReplacementServiceHelper.ReplaceFilterSequence(
+            originalFilters: originalFilters,
+            replacementFilters: replacementFilters,
+            originalReleaseSubject);
+
+        // Verify the updated sequence of filters
+        Assert.NotNull(updatedSequence);
+
+        Assert.Equal(4, updatedSequence!.Count);
+
+        // 'Filter c' was first in the original sequence and is identical in the replacement subject so it should be first
+        var filterC = updatedSequence[0];
+        Assert.Equal(replacementFilters[3].Id, filterC.Id);
+        Assert.Empty(filterC.ChildSequence);
+
+        // 'Filter a' should be next in the sequence
+        var filterA = updatedSequence[1];
+        Assert.Equal(replacementFilters[0].Id, filterA.Id);
+
+        var filterAGroups = filterA.ChildSequence;
+        Assert.Equal(5, filterAGroups.Count);
+
+        // 'Group c' was first in the original sequence and is untouched in the replacement subject so it should be first
+        var filterAGroupC = filterAGroups[0];
+        Assert.Equal(replacementFilters[0].FilterGroups[4].Id, filterAGroupC.Id);
+        Assert.Equal(3, filterAGroupC.ChildSequence.Count);
+        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[2].Id, filterAGroupC.ChildSequence[0]);
+        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[0].Id, filterAGroupC.ChildSequence[1]);
+        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[1].Id, filterAGroupC.ChildSequence[2]);
+
+        // 'Group a' would've been the next group but has been removed
+
+        // 'Group b' should be second based on the original sequence
+        // Check 'Item e' was removed and both 'Item j' and 'Item k' have been appended in order
+        var filterAGroupB = filterAGroups[1];
+        Assert.Equal(replacementFilters[0].FilterGroups[3].Id, filterAGroupB.Id);
+        Assert.Equal(4, filterAGroupB.ChildSequence.Count);
+        // 'Item f' is first from the original sequence
+        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[3].Id, filterAGroupB.ChildSequence[0]);
+        // 'Item d' is second from the original sequence
+        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[0].Id, filterAGroupB.ChildSequence[1]);
+        // 'Item j' is appended first alphabetically
+        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[2].Id, filterAGroupB.ChildSequence[2]);
+        // 'Item k' is appended second alphabetically
+        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[1].Id, filterAGroupB.ChildSequence[3]);
+
+        // Group 'Total' is new so it should be appended first and its filter items should be ordered by label
+        var filterAGroupTotal = filterAGroups[2];
+        Assert.Equal(replacementFilters[0].FilterGroups[1].Id, filterAGroupTotal.Id);
+        // Item 'Total' should be first
+        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[1].Id, filterAGroupTotal.ChildSequence[0]);
+        // 'Item l' should be second alphabetically
+        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[2].Id, filterAGroupTotal.ChildSequence[1]);
+        // 'Item m' should be third alphabetically
+        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[0].Id, filterAGroupTotal.ChildSequence[2]);
+
+        // 'Group d' is new so it should be appended in order and its filter items should be ordered by label
+        var filterAGroupD = filterAGroups[3];
+        Assert.Equal(replacementFilters[0].FilterGroups[2].Id, filterAGroupD.Id);
+        Assert.Empty(filterAGroupD.ChildSequence);
+
+        // 'Group e' is new so it should be appended in order
+        var filterAGroupE = filterAGroups[4];
+        Assert.Equal(replacementFilters[0].FilterGroups[0].Id, filterAGroupE.Id);
+        Assert.Empty(filterAGroupE.ChildSequence);
+
+        // 'Filter b' would've been the next filter but has been removed
+
+        // 'Filter d' is new so it should be appended in order and its filter groups and filter items should be ordered by label
+        var filterD = updatedSequence[2];
+        Assert.Equal(replacementFilters[2].Id, filterD.Id);
+
+        var filterDGroups = filterD.ChildSequence;
+        Assert.Equal(3, filterDGroups.Count);
+
+        // Group 'Total' should be first and its filter items should be ordered by label
+        var filterDGroupTotal = filterDGroups[0];
+        Assert.Equal(replacementFilters[2].FilterGroups[1].Id, filterDGroupTotal.Id);
+        Assert.Equal(3, filterDGroupTotal.ChildSequence.Count);
+        // Item 'Total' should be first
+        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[1].Id, filterDGroupTotal.ChildSequence[0]);
+        // 'Item n' should be second alphabetically
+        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[2].Id, filterDGroupTotal.ChildSequence[1]);
+        // 'Item o' should be third alphabetically
+        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[0].Id, filterDGroupTotal.ChildSequence[2]);
+
+        // 'Group f' should be second alphabetically
+        var filterDGroupF = filterDGroups[1];
+        Assert.Equal(replacementFilters[2].FilterGroups[2].Id, filterDGroupF.Id);
+        Assert.Empty(filterDGroupF.ChildSequence);
+
+        // 'Group g' should be third alphabetically
+        var filterDGroupG = filterDGroups[2];
+        Assert.Equal(replacementFilters[2].FilterGroups[0].Id, filterDGroupG.Id);
+        Assert.Empty(filterDGroupG.ChildSequence);
+
+        // 'Filter e' is new so it should be appended in order
+        var filterE = updatedSequence[3];
+        Assert.Equal(replacementFilters[1].Id, filterE.Id);
+        Assert.Empty(filterE.ChildSequence);
+    }
+
+    [Fact]
+    public void ReplaceIndicatorSequence()
+    {
+        // Define a set of indicator groups and indicators belonging to the original subject
+        var originalGroups = new List<IndicatorGroup>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Group a",
+                Indicators = new List<Indicator>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator a",
+                        Name = "indicator_a"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator b",
+                        Name = "indicator_b"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator c",
+                        Name = "indicator_c"
+                    }
+                }
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Group b",
+                Indicators = new List<Indicator>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator d",
+                        Name = "indicator_d"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator e",
+                        Name = "indicator_e"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator f",
+                        Name = "indicator_f"
+                    }
+                }
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Group c",
+                Indicators = new List<Indicator>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator g",
+                        Name = "indicator_g"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator h",
+                        Name = "indicator_h"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator i",
+                        Name = "indicator_i"
+                    }
+                }
+            }
+        };
+
+        // Define a sequence for the original subject which is expected to be updated after the replacement
+        var originalReleaseSubject = new ReleaseSubject
+        {
+            IndicatorSequence = new List<IndicatorGroupSequenceEntry>
+            {
+                // Group c
+                new(
+                    originalGroups[2].Id,
+                    new List<Guid>
+                    {
+                        // Indicator i, Indicator g, Indicator h
+                        originalGroups[2].Indicators[2].Id,
+                        originalGroups[2].Indicators[0].Id,
+                        originalGroups[2].Indicators[1].Id
+                    }
+                ),
+                // Group a
+                new(
+                    originalGroups[0].Id,
+                    new List<Guid>
+                    {
+                        // Indicator c, Indicator a, Indicator b
+                        originalGroups[0].Indicators[2].Id,
+                        originalGroups[0].Indicators[0].Id,
+                        originalGroups[0].Indicators[1].Id
+                    }
+                ),
+                // Group b
+                new(
+                    originalGroups[1].Id,
+                    new List<Guid>
+                    {
+                        // Indicator f, Indicator d, Indicator e
+                        originalGroups[1].Indicators[2].Id,
+                        originalGroups[1].Indicators[0].Id,
+                        originalGroups[1].Indicators[1].Id
+                    }
+                )
+            }
+        };
+
+        // Define the set of indicator groups and indicators belonging to the replacement subject
+        var replacementGroups = new List<IndicatorGroup>
+        {
+            // 'Group a' is removed
+            // 'Group e' is added
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Group e",
+                Indicators = new List<Indicator>()
+            },
+            // 'Group d' is added
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Group d",
+                Indicators = new List<Indicator>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator n",
+                        Name = "indicator_n"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator l",
+                        Name = "indicator_l"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator m",
+                        Name = "indicator_m"
+                    }
+                }
+            },
+            // 'Group b' is updated
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Group b",
+                Indicators = new List<Indicator>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator d",
+                        Name = "indicator_d"
+                    },
+                    // 'Indicator e' is removed
+                    // 'Indicator k' is added
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator k",
+                        Name = "indicator_k"
+                    },
+                    // 'Indicator j' is added
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator j",
+                        Name = "indicator_j"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator f",
+                        Name = "indicator_f"
+                    }
+                }
+            },
+            // 'Group c' remains identical
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Label = "Group c",
+                Indicators = new List<Indicator>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator g",
+                        Name = "indicator_g"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator h",
+                        Name = "indicator_h"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Label = "Indicator i",
+                        Name = "indicator_i"
+                    }
+                }
+            }
+        };
+
+        var updatedSequence = ReplacementServiceHelper.ReplaceIndicatorSequence(
+            originalIndicatorGroups: originalGroups,
+            replacementIndicatorGroups: replacementGroups,
+            originalReleaseSubject);
+
+        // Verify the updated sequence of indicators
+        Assert.NotNull(updatedSequence);
+
+        Assert.Equal(4, updatedSequence!.Count);
+
+        // 'Group c' was first in the original sequence and is identical in the replacement subject so it should be first
+        var groupC = updatedSequence[0];
+        Assert.Equal(replacementGroups[3].Id, groupC.Id);
+        Assert.Equal(3, groupC.ChildSequence.Count);
+        Assert.Equal(replacementGroups[3].Indicators[2].Id, groupC.ChildSequence[0]);
+        Assert.Equal(replacementGroups[3].Indicators[0].Id, groupC.ChildSequence[1]);
+        Assert.Equal(replacementGroups[3].Indicators[1].Id, groupC.ChildSequence[2]);
+
+        // 'Group a' would've been the next group but has been removed
+
+        // 'Group b' should be second based on the original sequence
+        // Check 'Indicator e' was removed and both 'Indicator j' and 'Indicator k' have been appended in order
+        var groupB = updatedSequence[1];
+        Assert.Equal(replacementGroups[2].Id, groupB.Id);
+        Assert.Equal(4, groupB.ChildSequence.Count);
+        // 'Indicator f' is first from the original sequence
+        Assert.Equal(replacementGroups[2].Indicators[3].Id, groupB.ChildSequence[0]);
+        // 'Indicator d' is second from the original sequence 
+        Assert.Equal(replacementGroups[2].Indicators[0].Id, groupB.ChildSequence[1]);
+        // 'Indicator j' is appended first alphabetically
+        Assert.Equal(replacementGroups[2].Indicators[2].Id, groupB.ChildSequence[2]);
+        // 'Indicator k' is appended second alphabetically
+        Assert.Equal(replacementGroups[2].Indicators[1].Id, groupB.ChildSequence[3]);
+
+        // 'Group d' is new so it should be appended in order and its indicators should be ordered by label
+        var groupD = updatedSequence[2];
+        Assert.Equal(replacementGroups[1].Id, groupD.Id);
+        Assert.Equal(3, groupD.ChildSequence.Count);
+        // 'Indicator l' should be first alphabetically
+        Assert.Equal(replacementGroups[1].Indicators[1].Id, groupD.ChildSequence[0]);
+        // 'Indicator m' should be second alphabetically
+        Assert.Equal(replacementGroups[1].Indicators[2].Id, groupD.ChildSequence[1]);
+        // 'Indicator n' should be third alphabetically
+        Assert.Equal(replacementGroups[1].Indicators[0].Id, groupD.ChildSequence[2]);
+
+        // 'Group e' is new so it should be appended in order
+        var groupE = updatedSequence[3];
+        Assert.Equal(replacementGroups[0].Id, groupE.Id);
+        Assert.Empty(groupE.ChildSequence);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -3247,6 +3247,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task Replace_FilterSequenceIsReplaced()
         {
+            // Basic test replacing a filter sequence, exercising the service with in-memory data and dependencies.  
+            // See ReplaceServiceHelperTests.ReplaceFilterSequence for a more comprehensive test of the actual replacement.
+
             var originalSubject = new Subject
             {
                 Id = Guid.NewGuid()
@@ -3340,138 +3343,38 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                                 {
                                     Id = Guid.NewGuid(),
                                     Label = "Item b"
-                                },
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item c"
-                                }
-                            }
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Group b",
-                            FilterItems = new List<FilterItem>
-                            {
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item d"
-                                },
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item e"
-                                },
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item f"
-                                }
-                            }
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Group c",
-                            FilterItems = new List<FilterItem>
-                            {
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item g"
-                                },
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item h"
-                                },
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item i"
                                 }
                             }
                         }
                     }
-                },
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    Label = "Filter b",
-                    Name = "filter_b",
-                    Subject = originalSubject,
-                    FilterGroups = new List<FilterGroup>()
-                },
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    Label = "Filter c",
-                    Name = "filter_c",
-                    Subject = originalSubject,
-                    FilterGroups = new List<FilterGroup>()
                 }
             };
 
             // Define a sequence for the original subject which is expected to be updated after the replacement
             originalReleaseSubject.FilterSequence = new List<FilterSequenceEntry>
             {
-                // Filter c
-                new(
-                    originalFilters[2].Id,
-                    new List<FilterGroupSequenceEntry>()
-                ),
                 // Filter a
                 new(originalFilters[0].Id,
                     new List<FilterGroupSequenceEntry>
                     {
-                        // Group c
-                        new(
-                            originalFilters[0].FilterGroups[2].Id,
-                            new List<Guid>
-                            {
-                                // Item i, Item g, Item h
-                                originalFilters[0].FilterGroups[2].FilterItems[2].Id,
-                                originalFilters[0].FilterGroups[2].FilterItems[0].Id,
-                                originalFilters[0].FilterGroups[2].FilterItems[1].Id
-                            }
-                        ),
                         // Group a
                         new(
                             originalFilters[0].FilterGroups[0].Id,
                             new List<Guid>
                             {
-                                // Item c, Indicator a, Indicator b
-                                originalFilters[0].FilterGroups[0].FilterItems[2].Id,
-                                originalFilters[0].FilterGroups[0].FilterItems[0].Id,
-                                originalFilters[0].FilterGroups[0].FilterItems[1].Id
-                            }
-                        ),
-                        // Group b
-                        new(
-                            originalFilters[0].FilterGroups[1].Id,
-                            new List<Guid>
-                            {
-                                // Item f, Item d, Item e
-                                originalFilters[0].FilterGroups[1].FilterItems[2].Id,
-                                originalFilters[0].FilterGroups[1].FilterItems[0].Id,
-                                originalFilters[0].FilterGroups[1].FilterItems[1].Id
+                                // Item b, Indicator a
+                                originalFilters[0].FilterGroups[0].FilterItems[1].Id,
+                                originalFilters[0].FilterGroups[0].FilterItems[0].Id
                             }
                         )
                     }
-                ),
-                // Filter b
-                new(
-                    originalFilters[1].Id,
-                    new List<FilterGroupSequenceEntry>()
                 )
             };
 
             // Define the set of filters, filter groups and filter items belonging to the replacement subject
             var replacementFilters = new List<Filter>
             {
-                // 'Filter a' is updated
+                // 'Filter a' is identical
                 new()
                 {
                     Id = Guid.NewGuid(),
@@ -3480,167 +3383,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Subject = replacementSubject,
                     FilterGroups = new List<FilterGroup>
                     {
-                        // 'Group a' is removed
-                        // 'Group e' is added
+                        // 'Group a' is identical
                         new()
                         {
                             Id = Guid.NewGuid(),
-                            Label = "Group e",
-                            FilterItems = new List<FilterItem>()
-                        },
-                        // Group 'Total' is added
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Total",
+                            Label = "Group a",
                             FilterItems = new List<FilterItem>
                             {
                                 new()
                                 {
                                     Id = Guid.NewGuid(),
-                                    Label = "Item m"
+                                    Label = "Item a"
                                 },
                                 new()
                                 {
                                     Id = Guid.NewGuid(),
-                                    Label = "Total"
-                                },
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item l"
-                                }
-                            }
-                        },
-                        // 'Group d' is added
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Group d",
-                            FilterItems = new List<FilterItem>()
-                        },
-                        // 'Group b' is updated
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Group b",
-                            FilterItems = new List<FilterItem>
-                            {
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item d"
-                                },
-                                // 'Item e' is removed
-                                // 'Item k' is added
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item k"
-                                },
-                                // 'Item j' is added
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item j"
-                                },
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item f"
-                                }
-                            }
-                        },
-                        // 'Group c' remains identical
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Group c",
-                            FilterItems = new List<FilterItem>
-                            {
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item g"
-                                },
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item h"
-                                },
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item i"
+                                    Label = "Item b"
                                 }
                             }
                         }
                     }
-                },
-                // 'Filter b' is removed
-                // 'Filter e' is added
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    Label = "Filter e",
-                    Name = "filter_e",
-                    Subject = replacementSubject,
-                    FilterGroups = new List<FilterGroup>()
-                },
-                // 'Filter d' is added
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    Label = "Filter d",
-                    Name = "filter_d",
-                    Subject = replacementSubject,
-                    FilterGroups = new List<FilterGroup>
-                    {
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Group g",
-                            FilterItems = new List<FilterItem>()
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Total",
-                            FilterItems = new List<FilterItem>
-                            {
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item o"
-                                },
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Total"
-                                },
-                                new()
-                                {
-                                    Id = Guid.NewGuid(),
-                                    Label = "Item n"
-                                }
-                            }
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Group f",
-                            FilterItems = new List<FilterItem>()
-                        }
-                    }
-                },
-                // 'Filter c' remains identical
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    Label = "Filter c",
-                    Name = "filter_c",
-                    Subject = replacementSubject,
-                    FilterGroups = new List<FilterGroup>()
                 }
             };
 
@@ -3699,108 +3461,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                                        && rs.SubjectId == replacementSubject.Id);
 
                 // Verify the updated sequence of filters on the replacement subject
-
                 var updatedSequence = replacedReleaseSubject.FilterSequence;
                 Assert.NotNull(updatedSequence);
 
-                Assert.Equal(4, updatedSequence!.Count);
-
-                // 'Filter c' was first in the original sequence and is identical in the replacement subject so it should be first
-                var filterC = updatedSequence[0];
-                Assert.Equal(replacementFilters[3].Id, filterC.Id);
-                Assert.Empty(filterC.ChildSequence);
-
-                // 'Filter a' should be next in the sequence
-                var filterA = updatedSequence[1];
+                // 'Filter a' should be the only filter in the sequence
+                var filterA = Assert.Single(updatedSequence);
                 Assert.Equal(replacementFilters[0].Id, filterA.Id);
-
                 var filterAGroups = filterA.ChildSequence;
-                Assert.Equal(5, filterAGroups.Count);
 
-                // 'Group c' was first in the original sequence and is untouched in the replacement subject so it should be first
-                var filterAGroupC = filterAGroups[0];
-                Assert.Equal(replacementFilters[0].FilterGroups[4].Id, filterAGroupC.Id);
-                Assert.Equal(3, filterAGroupC.ChildSequence.Count);
-                Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[2].Id, filterAGroupC.ChildSequence[0]);
-                Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[0].Id, filterAGroupC.ChildSequence[1]);
-                Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[1].Id, filterAGroupC.ChildSequence[2]);
+                // 'Group a' should be the only group in the sequence
+                var filterAGroupA = Assert.Single(filterAGroups);
+                Assert.Equal(replacementFilters[0].FilterGroups[0].Id, filterAGroupA.Id);
 
-                // 'Group a' would've been the next group but has been removed
-
-                // 'Group b' should be second based on the original sequence
-                // Check 'Item e' was removed and both 'Item j' and 'Item k' have been appended in order
-                var filterAGroupB = filterAGroups[1];
-                Assert.Equal(replacementFilters[0].FilterGroups[3].Id, filterAGroupB.Id);
-                Assert.Equal(4, filterAGroupB.ChildSequence.Count);
-                // 'Item f' is first from the original sequence
-                Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[3].Id, filterAGroupB.ChildSequence[0]);
-                // 'Item d' is second from the original sequence
-                Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[0].Id, filterAGroupB.ChildSequence[1]);
-                // 'Item j' is appended first alphabetically
-                Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[2].Id, filterAGroupB.ChildSequence[2]);
-                // 'Item k' is appended second alphabetically
-                Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[1].Id, filterAGroupB.ChildSequence[3]);
-
-                // Group 'Total' is new so it should be appended first and its filter items should be ordered by label
-                var filterAGroupTotal = filterAGroups[2];
-                Assert.Equal(replacementFilters[0].FilterGroups[1].Id, filterAGroupTotal.Id);
-                // Item 'Total' should be first
-                Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[1].Id, filterAGroupTotal.ChildSequence[0]);
-                // 'Item l' should be second alphabetically
-                Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[2].Id, filterAGroupTotal.ChildSequence[1]);
-                // 'Item m' should be third alphabetically
-                Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[0].Id, filterAGroupTotal.ChildSequence[2]);
-
-                // 'Group d' is new so it should be appended in order and its filter items should be ordered by label
-                var filterAGroupD = filterAGroups[3];
-                Assert.Equal(replacementFilters[0].FilterGroups[2].Id, filterAGroupD.Id);
-                Assert.Empty( filterAGroupD.ChildSequence);
-
-                // 'Group e' is new so it should be appended in order
-                var filterAGroupE = filterAGroups[4];
-                Assert.Equal(replacementFilters[0].FilterGroups[0].Id, filterAGroupE.Id);
-                Assert.Empty(filterAGroupE.ChildSequence);
-
-                // 'Filter b' would've been the next filter but has been removed
-
-                // 'Filter d' is new so it should be appended in order and its filter groups and filter items should be ordered by label
-                var filterD = updatedSequence[2];
-                Assert.Equal(replacementFilters[2].Id, filterD.Id);
-
-                var filterDGroups = filterD.ChildSequence;
-                Assert.Equal(3, filterDGroups.Count);
-
-                // Group 'Total' should be first and its filter items should be ordered by label
-                var filterDGroupTotal = filterDGroups[0];
-                Assert.Equal(replacementFilters[2].FilterGroups[1].Id, filterDGroupTotal.Id);
-                Assert.Equal(3, filterDGroupTotal.ChildSequence.Count);
-                // Item 'Total' should be first
-                Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[1].Id, filterDGroupTotal.ChildSequence[0]);
-                // 'Item n' should be second alphabetically
-                Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[2].Id, filterDGroupTotal.ChildSequence[1]);
-                // 'Item o' should be third alphabetically
-                Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[0].Id, filterDGroupTotal.ChildSequence[2]);
-
-                // 'Group f' should be second alphabetically
-                var filterDGroupF = filterDGroups[1];
-                Assert.Equal(replacementFilters[2].FilterGroups[2].Id, filterDGroupF.Id);
-                Assert.Empty(filterDGroupF.ChildSequence);
-
-                // 'Group g' should be third alphabetically
-                var filterDGroupG = filterDGroups[2];
-                Assert.Equal(replacementFilters[2].FilterGroups[0].Id, filterDGroupG.Id);
-                Assert.Empty(filterDGroupG.ChildSequence);
-
-                // 'Filter e' is new so it should be appended in order
-                var filterE = updatedSequence[3];
-                Assert.Equal(replacementFilters[1].Id, filterE.Id);
-                Assert.Empty(filterE.ChildSequence);
+                // 'Group a' should still have two filter items in the same order as the original sequence
+                Assert.Equal(2, filterAGroupA.ChildSequence.Count);
+                Assert.Equal(replacementFilters[0].FilterGroups[0].FilterItems[1].Id, filterAGroupA.ChildSequence[0]);
+                Assert.Equal(replacementFilters[0].FilterGroups[0].FilterItems[0].Id, filterAGroupA.ChildSequence[1]);
             }
         }
 
         [Fact]
         public async Task Replace_IndicatorSequenceIsReplaced()
         {
+            // Basic test replacing an indicator sequence, exercising the service with in-memory data and dependencies.  
+            // See ReplaceServiceHelperTests.ReplaceIndicatorSequence for a more comprehensive test of the actual replacement.
+
             var originalSubject = new Subject
             {
                 Id = Guid.NewGuid()
@@ -3889,66 +3574,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             Id = Guid.NewGuid(),
                             Label = "Indicator b",
                             Name = "indicator_b"
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator c",
-                            Name = "indicator_c"
-                        }
-                    }
-                },
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    Label = "Group b",
-                    Subject = originalSubject,
-                    Indicators = new List<Indicator>
-                    {
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator d",
-                            Name = "indicator_d"
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator e",
-                            Name = "indicator_e"
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator f",
-                            Name = "indicator_f"
-                        }
-                    }
-                },
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    Label = "Group c",
-                    Subject = originalSubject,
-                    Indicators = new List<Indicator>
-                    {
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator g",
-                            Name = "indicator_g"
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator h",
-                            Name = "indicator_h"
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator i",
-                            Name = "indicator_i"
                         }
                     }
                 }
@@ -3957,37 +3582,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             // Define a sequence for the original subject which is expected to be updated after the replacement
             originalReleaseSubject.IndicatorSequence = new List<IndicatorGroupSequenceEntry>
             {
-                // Group c
-                new(
-                    originalGroups[2].Id,
-                    new List<Guid>
-                    {
-                        // Indicator i, Indicator g, Indicator h
-                        originalGroups[2].Indicators[2].Id,
-                        originalGroups[2].Indicators[0].Id,
-                        originalGroups[2].Indicators[1].Id
-                    }
-                ),
                 // Group a
                 new(
                     originalGroups[0].Id,
                     new List<Guid>
                     {
-                        // Indicator c, Indicator a, Indicator b
-                        originalGroups[0].Indicators[2].Id,
-                        originalGroups[0].Indicators[0].Id,
-                        originalGroups[0].Indicators[1].Id
-                    }
-                ),
-                // Group b
-                new(
-                    originalGroups[1].Id,
-                    new List<Guid>
-                    {
-                        // Indicator f, Indicator d, Indicator e
-                        originalGroups[1].Indicators[2].Id,
-                        originalGroups[1].Indicators[0].Id,
-                        originalGroups[1].Indicators[1].Id
+                        // Indicator b, Indicator a
+                        originalGroups[0].Indicators[1].Id,
+                        originalGroups[0].Indicators[0].Id
                     }
                 )
             };
@@ -3995,105 +3597,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             // Define the set of indicator groups and indicators belonging to the replacement subject
             var replacementGroups = new List<IndicatorGroup>
             {
-                // 'Group a' is removed
-                // 'Group e' is added
+                // 'Group a' is identical
                 new()
                 {
                     Id = Guid.NewGuid(),
-                    Label = "Group e",
-                    Subject = replacementSubject,
-                    Indicators = new List<Indicator>()
-                },
-                // 'Group d' is added
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    Label = "Group d",
+                    Label = "Group a",
                     Subject = replacementSubject,
                     Indicators = new List<Indicator>
                     {
                         new()
                         {
                             Id = Guid.NewGuid(),
-                            Label = "Indicator n",
-                            Name = "indicator_n"
+                            Label = "Indicator a",
+                            Name = "indicator_a"
                         },
                         new()
                         {
                             Id = Guid.NewGuid(),
-                            Label = "Indicator l",
-                            Name = "indicator_l"
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator m",
-                            Name = "indicator_m"
-                        }
-                    }
-                },
-                // 'Group b' is updated
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    Label = "Group b",
-                    Subject = replacementSubject,
-                    Indicators = new List<Indicator>
-                    {
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator d",
-                            Name = "indicator_d"
-                        },
-                        // 'Indicator e' is removed
-                        // 'Indicator k' is added
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator k",
-                            Name = "indicator_k"
-                        },
-                        // 'Indicator j' is added
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator j",
-                            Name = "indicator_j"
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator f",
-                            Name = "indicator_f"
-                        }
-                    }
-                },
-                // 'Group c' remains identical
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    Label = "Group c",
-                    Subject = replacementSubject,
-                    Indicators = new List<Indicator>
-                    {
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator g",
-                            Name = "indicator_g"
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator h",
-                            Name = "indicator_h"
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            Label = "Indicator i",
-                            Name = "indicator_i"
+                            Label = "Indicator b",
+                            Name = "indicator_b"
                         }
                     }
                 }
@@ -4154,51 +3676,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                                        && rs.SubjectId == replacementSubject.Id);
 
                 // Verify the updated sequence of indicators on the replacement subject
-
                 var updatedSequence = replacedReleaseSubject.IndicatorSequence;
                 Assert.NotNull(updatedSequence);
 
-                Assert.Equal(4, updatedSequence!.Count);
+                // 'Group a' should be the only group in the sequence
+                var groupA = Assert.Single(updatedSequence);
+                Assert.Equal(replacementGroups[0].Id, groupA.Id);
 
-                // 'Group c' was first in the original sequence and is identical in the replacement subject so it should be first
-                var groupC = updatedSequence[0];
-                Assert.Equal(replacementGroups[3].Id, groupC.Id);
-                Assert.Equal(3, groupC.ChildSequence.Count);
-                Assert.Equal(replacementGroups[3].Indicators[2].Id, groupC.ChildSequence[0]);
-                Assert.Equal(replacementGroups[3].Indicators[0].Id, groupC.ChildSequence[1]);
-                Assert.Equal(replacementGroups[3].Indicators[1].Id, groupC.ChildSequence[2]);
-
-                // 'Group a' would've been the next group but has been removed
-
-                // 'Group b' should be second based on the original sequence
-                // Check 'Indicator e' was removed and both 'Indicator j' and 'Indicator k' have been appended in order
-                var groupB = updatedSequence[1];
-                Assert.Equal(replacementGroups[2].Id, groupB.Id);
-                Assert.Equal(4, groupB.ChildSequence.Count);
-                // 'Indicator f' is first from the original sequence
-                Assert.Equal(replacementGroups[2].Indicators[3].Id, groupB.ChildSequence[0]);
-                // 'Indicator d' is second from the original sequence 
-                Assert.Equal(replacementGroups[2].Indicators[0].Id, groupB.ChildSequence[1]);
-                // 'Indicator j' is appended first alphabetically
-                Assert.Equal(replacementGroups[2].Indicators[2].Id, groupB.ChildSequence[2]);
-                // 'Indicator k' is appended second alphabetically
-                Assert.Equal(replacementGroups[2].Indicators[1].Id, groupB.ChildSequence[3]);
-
-                // 'Group d' is new so it should be appended in order and its indicators should be ordered by label
-                var groupD = updatedSequence[2];
-                Assert.Equal(replacementGroups[1].Id, groupD.Id);
-                Assert.Equal(3, groupD.ChildSequence.Count);
-                // 'Indicator l' should be first alphabetically
-                Assert.Equal(replacementGroups[1].Indicators[1].Id, groupD.ChildSequence[0]);
-                // 'Indicator m' should be second alphabetically
-                Assert.Equal(replacementGroups[1].Indicators[2].Id, groupD.ChildSequence[1]);
-                // 'Indicator n' should be third alphabetically
-                Assert.Equal(replacementGroups[1].Indicators[0].Id, groupD.ChildSequence[2]);
-
-                // 'Group e' is new so it should be appended in order
-                var groupE = updatedSequence[3];
-                Assert.Equal(replacementGroups[0].Id, groupE.Id);
-                Assert.Empty(groupE.ChildSequence);
+                // 'Group a' should still have two indicators in the same order as the original sequence
+                Assert.Equal(2, groupA.ChildSequence.Count);
+                Assert.Equal(replacementGroups[0].Indicators[1].Id, groupA.ChildSequence[0]);
+                Assert.Equal(replacementGroups[0].Indicators[0].Id, groupA.ChildSequence[1]);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1751,7 +1751,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Query = new ObservationQueryContext
                 {
                     SubjectId = originalSubject.Id,
-                    Filters = new[] { originalFilterItem.Id},
+                    Filters = new[] {originalFilterItem.Id},
                     Indicators = new[] {originalIndicator.Id},
                     LocationIds = ListOf(originalLocation.Id),
                     TimePeriod = timePeriod
@@ -2282,6 +2282,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(2, dataBlockSchoolTypeFilterPlan.Value.Groups.Count);
 
                 var dataBlockIndividualSchoolTypeFilterGroupPlan =
+                    dataBlockSchoolTypeFilterPlan.Value.Groups.First(g =>
+                        g.Key == originalIndividualSchoolTypeFilterGroup.Id);
                     dataBlockSchoolTypeFilterPlan.Value.Groups.First(g => g.Key == originalIndividualSchoolTypeFilterGroup.Id);
 
                 Assert.Equal(originalIndividualSchoolTypeFilterGroup.Id,
@@ -3229,14 +3231,974 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(replacementSubject.Id, replacedFootnoteForSubject.Subjects.First().Subject.Id);
 
-                // Check the original guidance has been retained on the replacement
                 var replacedReleaseSubject = await statisticsDbContext.ReleaseSubject
-                    .AsQueryable()
-                    .Where(rs => rs.ReleaseId == statsReleaseVersion2.Id
-                                 && rs.SubjectId == replacementSubject.Id)
-                    .FirstAsync();
+                    .SingleAsync(rs => rs.ReleaseId == statsReleaseVersion2.Id
+                                       && rs.SubjectId == replacementSubject.Id);
 
+                // Check the original guidance has been retained on the replacement
                 Assert.Equal("Original guidance version 2", replacedReleaseSubject.DataGuidance);
+
+                // Check the sequence of filters and indicators remains untouched
+                Assert.Null(replacedReleaseSubject.FilterSequence);
+                Assert.Null(replacedReleaseSubject.IndicatorSequence);
+            }
+        }
+
+        [Fact]
+        public async Task Replace_FilterSequenceIsReplaced()
+        {
+            var originalSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var replacementSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var publication = new Publication
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var contentRelease = new Content.Model.Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication
+            };
+
+            var statsRelease = new Release
+            {
+                Id = contentRelease.Id
+            };
+
+            var originalFile = new File
+            {
+                Filename = "original.csv",
+                Type = FileType.Data,
+                SubjectId = originalSubject.Id
+            };
+
+            var replacementFile = new File
+            {
+                Filename = "replacement.csv",
+                Type = FileType.Data,
+                SubjectId = replacementSubject.Id,
+                Replacing = originalFile
+            };
+
+            originalFile.ReplacedBy = replacementFile;
+
+            var originalReleaseFile = new ReleaseFile
+            {
+                Release = contentRelease,
+                File = originalFile
+            };
+
+            var replacementReleaseFile = new ReleaseFile
+            {
+                Release = contentRelease,
+                File = replacementFile
+            };
+
+            var originalReleaseSubject = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = originalSubject
+            };
+
+            var replacementReleaseSubject = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = replacementSubject
+            };
+
+            // Define a set of filters, filter groups and filter items belonging to the original subject
+            var originalFilters = new List<Filter>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Filter a",
+                    Name = "filter_a",
+                    Subject = originalSubject,
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Group a",
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item a"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item b"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item c"
+                                }
+                            }
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Group b",
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item d"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item e"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item f"
+                                }
+                            }
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Group c",
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item g"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item h"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item i"
+                                }
+                            }
+                        }
+                    }
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Filter b",
+                    Name = "filter_b",
+                    Subject = originalSubject,
+                    FilterGroups = new List<FilterGroup>()
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Filter c",
+                    Name = "filter_c",
+                    Subject = originalSubject,
+                    FilterGroups = new List<FilterGroup>()
+                }
+            };
+
+            // Define a sequence for the original subject which is expected to be updated after the replacement
+            originalReleaseSubject.FilterSequence = new List<FilterSequenceEntry>
+            {
+                // Filter c
+                new(
+                    originalFilters[2].Id,
+                    new List<FilterGroupSequenceEntry>()
+                ),
+                // Filter a
+                new(originalFilters[0].Id,
+                    new List<FilterGroupSequenceEntry>
+                    {
+                        // Group c
+                        new(
+                            originalFilters[0].FilterGroups[2].Id,
+                            new List<Guid>
+                            {
+                                // Item i, Item g, Item h
+                                originalFilters[0].FilterGroups[2].FilterItems[2].Id,
+                                originalFilters[0].FilterGroups[2].FilterItems[0].Id,
+                                originalFilters[0].FilterGroups[2].FilterItems[1].Id
+                            }
+                        ),
+                        // Group a
+                        new(
+                            originalFilters[0].FilterGroups[0].Id,
+                            new List<Guid>
+                            {
+                                // Item c, Indicator a, Indicator b
+                                originalFilters[0].FilterGroups[0].FilterItems[2].Id,
+                                originalFilters[0].FilterGroups[0].FilterItems[0].Id,
+                                originalFilters[0].FilterGroups[0].FilterItems[1].Id
+                            }
+                        ),
+                        // Group b
+                        new(
+                            originalFilters[0].FilterGroups[1].Id,
+                            new List<Guid>
+                            {
+                                // Item f, Item d, Item e
+                                originalFilters[0].FilterGroups[1].FilterItems[2].Id,
+                                originalFilters[0].FilterGroups[1].FilterItems[0].Id,
+                                originalFilters[0].FilterGroups[1].FilterItems[1].Id
+                            }
+                        )
+                    }
+                ),
+                // Filter b
+                new(
+                    originalFilters[1].Id,
+                    new List<FilterGroupSequenceEntry>()
+                )
+            };
+
+            // Define the set of filters, filter groups and filter items belonging to the replacement subject
+            var replacementFilters = new List<Filter>
+            {
+                // 'Filter a' is updated
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Filter a",
+                    Name = "filter_a",
+                    Subject = replacementSubject,
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        // 'Group a' is removed
+                        // 'Group e' is added
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Group e",
+                            FilterItems = new List<FilterItem>()
+                        },
+                        // Group 'Total' is added
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Total",
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item m"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Total"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item l"
+                                }
+                            }
+                        },
+                        // 'Group d' is added
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Group d",
+                            FilterItems = new List<FilterItem>()
+                        },
+                        // 'Group b' is updated
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Group b",
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item d"
+                                },
+                                // 'Item e' is removed
+                                // 'Item k' is added
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item k"
+                                },
+                                // 'Item j' is added
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item j"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item f"
+                                }
+                            }
+                        },
+                        // 'Group c' remains identical
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Group c",
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item g"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item h"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item i"
+                                }
+                            }
+                        }
+                    }
+                },
+                // 'Filter b' is removed
+                // 'Filter e' is added
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Filter e",
+                    Name = "filter_e",
+                    Subject = replacementSubject,
+                    FilterGroups = new List<FilterGroup>()
+                },
+                // 'Filter d' is added
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Filter d",
+                    Name = "filter_d",
+                    Subject = replacementSubject,
+                    FilterGroups = new List<FilterGroup>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Group g",
+                            FilterItems = new List<FilterItem>()
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Total",
+                            FilterItems = new List<FilterItem>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item o"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Total"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Label = "Item n"
+                                }
+                            }
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Group f",
+                            FilterItems = new List<FilterItem>()
+                        }
+                    }
+                },
+                // 'Filter c' remains identical
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Filter c",
+                    Name = "filter_c",
+                    Subject = replacementSubject,
+                    FilterGroups = new List<FilterGroup>()
+                }
+            };
+
+            var mocks = Mocks();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.Releases.AddAsync(contentRelease);
+                await contentDbContext.Files.AddRangeAsync(originalFile, replacementFile);
+                await contentDbContext.ReleaseFiles.AddRangeAsync(originalReleaseFile, replacementReleaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.Release.AddAsync(statsRelease);
+                await statisticsDbContext.Subject.AddRangeAsync(originalSubject, replacementSubject);
+                await statisticsDbContext.Filter.AddRangeAsync(originalFilters);
+                await statisticsDbContext.Filter.AddRangeAsync(replacementFilters);
+                await statisticsDbContext.ReleaseSubject.AddRangeAsync(originalReleaseSubject,
+                    replacementReleaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            mocks.locationRepository.Setup(service => service.GetDistinctForSubject(replacementSubject.Id))
+                .ReturnsAsync(new List<Location>());
+
+            mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
+                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+
+            mocks.ReleaseService.Setup(service => service.RemoveDataFiles(
+                contentRelease.Id, originalFile.Id)).ReturnsAsync(Unit.Instance);
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var replacementService = BuildReplacementService(contentDbContext, statisticsDbContext, mocks);
+
+                var result = await replacementService.Replace(
+                    releaseId: contentRelease.Id,
+                    originalFileId: originalFile.Id,
+                    replacementFileId: replacementFile.Id);
+
+                VerifyAllMocks(mocks);
+
+                result.AssertRight();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var replacedReleaseSubject = await statisticsDbContext.ReleaseSubject
+                    .SingleAsync(rs => rs.ReleaseId == statsRelease.Id
+                                       && rs.SubjectId == replacementSubject.Id);
+
+                // Verify the updated sequence of filters on the replacement subject
+
+                var updatedSequence = replacedReleaseSubject.FilterSequence;
+                Assert.NotNull(updatedSequence);
+
+                Assert.Equal(4, updatedSequence!.Count);
+
+                // 'Filter c' was first in the original sequence and is identical in the replacement subject so it should be first
+                var filterC = updatedSequence[0];
+                Assert.Equal(replacementFilters[3].Id, filterC.Id);
+                Assert.Empty(filterC.ChildSequence);
+
+                // 'Filter a' should be next in the sequence
+                var filterA = updatedSequence[1];
+                Assert.Equal(replacementFilters[0].Id, filterA.Id);
+
+                var filterAGroups = filterA.ChildSequence;
+                Assert.Equal(5, filterAGroups.Count);
+
+                // 'Group c' was first in the original sequence and is untouched in the replacement subject so it should be first
+                var filterAGroupC = filterAGroups[0];
+                Assert.Equal(replacementFilters[0].FilterGroups[4].Id, filterAGroupC.Id);
+                Assert.Equal(3, filterAGroupC.ChildSequence.Count);
+                Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[2].Id, filterAGroupC.ChildSequence[0]);
+                Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[0].Id, filterAGroupC.ChildSequence[1]);
+                Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[1].Id, filterAGroupC.ChildSequence[2]);
+
+                // 'Group a' would've been the next group but has been removed
+
+                // 'Group b' should be second based on the original sequence
+                // Check 'Item e' was removed and both 'Item j' and 'Item k' have been appended in order
+                var filterAGroupB = filterAGroups[1];
+                Assert.Equal(replacementFilters[0].FilterGroups[3].Id, filterAGroupB.Id);
+                Assert.Equal(4, filterAGroupB.ChildSequence.Count);
+                // 'Item f' is first from the original sequence
+                Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[3].Id, filterAGroupB.ChildSequence[0]);
+                // 'Item d' is second from the original sequence
+                Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[0].Id, filterAGroupB.ChildSequence[1]);
+                // 'Item j' is appended first alphabetically
+                Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[2].Id, filterAGroupB.ChildSequence[2]);
+                // 'Item k' is appended second alphabetically
+                Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[1].Id, filterAGroupB.ChildSequence[3]);
+
+                // Group 'Total' is new so it should be appended first and its filter items should be ordered by label
+                var filterAGroupTotal = filterAGroups[2];
+                Assert.Equal(replacementFilters[0].FilterGroups[1].Id, filterAGroupTotal.Id);
+                // Item 'Total' should be first
+                Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[1].Id, filterAGroupTotal.ChildSequence[0]);
+                // 'Item l' should be second alphabetically
+                Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[2].Id, filterAGroupTotal.ChildSequence[1]);
+                // 'Item m' should be third alphabetically
+                Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[0].Id, filterAGroupTotal.ChildSequence[2]);
+
+                // 'Group d' is new so it should be appended in order and its filter items should be ordered by label
+                var filterAGroupD = filterAGroups[3];
+                Assert.Equal(replacementFilters[0].FilterGroups[2].Id, filterAGroupD.Id);
+                Assert.Empty( filterAGroupD.ChildSequence);
+
+                // 'Group e' is new so it should be appended in order
+                var filterAGroupE = filterAGroups[4];
+                Assert.Equal(replacementFilters[0].FilterGroups[0].Id, filterAGroupE.Id);
+                Assert.Empty(filterAGroupE.ChildSequence);
+
+                // 'Filter b' would've been the next filter but has been removed
+
+                // 'Filter d' is new so it should be appended in order and its filter groups and filter items should be ordered by label
+                var filterD = updatedSequence[2];
+                Assert.Equal(replacementFilters[2].Id, filterD.Id);
+
+                var filterDGroups = filterD.ChildSequence;
+                Assert.Equal(3, filterDGroups.Count);
+
+                // Group 'Total' should be first and its filter items should be ordered by label
+                var filterDGroupTotal = filterDGroups[0];
+                Assert.Equal(replacementFilters[2].FilterGroups[1].Id, filterDGroupTotal.Id);
+                Assert.Equal(3, filterDGroupTotal.ChildSequence.Count);
+                // Item 'Total' should be first
+                Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[1].Id, filterDGroupTotal.ChildSequence[0]);
+                // 'Item n' should be second alphabetically
+                Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[2].Id, filterDGroupTotal.ChildSequence[1]);
+                // 'Item o' should be third alphabetically
+                Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[0].Id, filterDGroupTotal.ChildSequence[2]);
+
+                // 'Group f' should be second alphabetically
+                var filterDGroupF = filterDGroups[1];
+                Assert.Equal(replacementFilters[2].FilterGroups[2].Id, filterDGroupF.Id);
+                Assert.Empty(filterDGroupF.ChildSequence);
+
+                // 'Group g' should be third alphabetically
+                var filterDGroupG = filterDGroups[2];
+                Assert.Equal(replacementFilters[2].FilterGroups[0].Id, filterDGroupG.Id);
+                Assert.Empty(filterDGroupG.ChildSequence);
+
+                // 'Filter e' is new so it should be appended in order
+                var filterE = updatedSequence[3];
+                Assert.Equal(replacementFilters[1].Id, filterE.Id);
+                Assert.Empty(filterE.ChildSequence);
+            }
+        }
+
+        [Fact]
+        public async Task Replace_IndicatorSequenceIsReplaced()
+        {
+            var originalSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var replacementSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var publication = new Publication
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var contentRelease = new Content.Model.Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication
+            };
+
+            var statsRelease = new Release
+            {
+                Id = contentRelease.Id
+            };
+
+            var originalFile = new File
+            {
+                Filename = "original.csv",
+                Type = FileType.Data,
+                SubjectId = originalSubject.Id
+            };
+
+            var replacementFile = new File
+            {
+                Filename = "replacement.csv",
+                Type = FileType.Data,
+                SubjectId = replacementSubject.Id,
+                Replacing = originalFile
+            };
+
+            originalFile.ReplacedBy = replacementFile;
+
+            var originalReleaseFile = new ReleaseFile
+            {
+                Release = contentRelease,
+                File = originalFile
+            };
+
+            var replacementReleaseFile = new ReleaseFile
+            {
+                Release = contentRelease,
+                File = replacementFile
+            };
+
+            var originalReleaseSubject = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = originalSubject
+            };
+
+            var replacementReleaseSubject = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = replacementSubject
+            };
+
+            // Define a set of indicator groups and indicators belonging to the original subject
+            var originalGroups = new List<IndicatorGroup>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Group a",
+                    Subject = originalSubject,
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator a",
+                            Name = "indicator_a"
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator b",
+                            Name = "indicator_b"
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator c",
+                            Name = "indicator_c"
+                        }
+                    }
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Group b",
+                    Subject = originalSubject,
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator d",
+                            Name = "indicator_d"
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator e",
+                            Name = "indicator_e"
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator f",
+                            Name = "indicator_f"
+                        }
+                    }
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Group c",
+                    Subject = originalSubject,
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator g",
+                            Name = "indicator_g"
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator h",
+                            Name = "indicator_h"
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator i",
+                            Name = "indicator_i"
+                        }
+                    }
+                }
+            };
+
+            // Define a sequence for the original subject which is expected to be updated after the replacement
+            originalReleaseSubject.IndicatorSequence = new List<IndicatorGroupSequenceEntry>
+            {
+                // Group c
+                new(
+                    originalGroups[2].Id,
+                    new List<Guid>
+                    {
+                        // Indicator i, Indicator g, Indicator h
+                        originalGroups[2].Indicators[2].Id,
+                        originalGroups[2].Indicators[0].Id,
+                        originalGroups[2].Indicators[1].Id
+                    }
+                ),
+                // Group a
+                new(
+                    originalGroups[0].Id,
+                    new List<Guid>
+                    {
+                        // Indicator c, Indicator a, Indicator b
+                        originalGroups[0].Indicators[2].Id,
+                        originalGroups[0].Indicators[0].Id,
+                        originalGroups[0].Indicators[1].Id
+                    }
+                ),
+                // Group b
+                new(
+                    originalGroups[1].Id,
+                    new List<Guid>
+                    {
+                        // Indicator f, Indicator d, Indicator e
+                        originalGroups[1].Indicators[2].Id,
+                        originalGroups[1].Indicators[0].Id,
+                        originalGroups[1].Indicators[1].Id
+                    }
+                )
+            };
+
+            // Define the set of indicator groups and indicators belonging to the replacement subject
+            var replacementGroups = new List<IndicatorGroup>
+            {
+                // 'Group a' is removed
+                // 'Group e' is added
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Group e",
+                    Subject = replacementSubject,
+                    Indicators = new List<Indicator>()
+                },
+                // 'Group d' is added
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Group d",
+                    Subject = replacementSubject,
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator n",
+                            Name = "indicator_n"
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator l",
+                            Name = "indicator_l"
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator m",
+                            Name = "indicator_m"
+                        }
+                    }
+                },
+                // 'Group b' is updated
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Group b",
+                    Subject = replacementSubject,
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator d",
+                            Name = "indicator_d"
+                        },
+                        // 'Indicator e' is removed
+                        // 'Indicator k' is added
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator k",
+                            Name = "indicator_k"
+                        },
+                        // 'Indicator j' is added
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator j",
+                            Name = "indicator_j"
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator f",
+                            Name = "indicator_f"
+                        }
+                    }
+                },
+                // 'Group c' remains identical
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Group c",
+                    Subject = replacementSubject,
+                    Indicators = new List<Indicator>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator g",
+                            Name = "indicator_g"
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator h",
+                            Name = "indicator_h"
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Label = "Indicator i",
+                            Name = "indicator_i"
+                        }
+                    }
+                }
+            };
+
+            var mocks = Mocks();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.Releases.AddAsync(contentRelease);
+                await contentDbContext.Files.AddRangeAsync(originalFile, replacementFile);
+                await contentDbContext.ReleaseFiles.AddRangeAsync(originalReleaseFile, replacementReleaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.Release.AddAsync(statsRelease);
+                await statisticsDbContext.Subject.AddRangeAsync(originalSubject, replacementSubject);
+                await statisticsDbContext.IndicatorGroup.AddRangeAsync(originalGroups);
+                await statisticsDbContext.IndicatorGroup.AddRangeAsync(replacementGroups);
+                await statisticsDbContext.ReleaseSubject.AddRangeAsync(originalReleaseSubject,
+                    replacementReleaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            mocks.locationRepository.Setup(service => service.GetDistinctForSubject(replacementSubject.Id))
+                .ReturnsAsync(new List<Location>());
+
+            mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
+                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+
+            mocks.ReleaseService.Setup(service => service.RemoveDataFiles(
+                contentRelease.Id, originalFile.Id)).ReturnsAsync(Unit.Instance);
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var replacementService = BuildReplacementService(contentDbContext, statisticsDbContext, mocks);
+
+                var result = await replacementService.Replace(
+                    releaseId: contentRelease.Id,
+                    originalFileId: originalFile.Id,
+                    replacementFileId: replacementFile.Id);
+
+                VerifyAllMocks(mocks);
+
+                result.AssertRight();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var replacedReleaseSubject = await statisticsDbContext.ReleaseSubject
+                    .SingleAsync(rs => rs.ReleaseId == statsRelease.Id
+                                       && rs.SubjectId == replacementSubject.Id);
+
+                // Verify the updated sequence of indicators on the replacement subject
+
+                var updatedSequence = replacedReleaseSubject.IndicatorSequence;
+                Assert.NotNull(updatedSequence);
+
+                Assert.Equal(4, updatedSequence!.Count);
+
+                // 'Group c' was first in the original sequence and is identical in the replacement subject so it should be first
+                var groupC = updatedSequence[0];
+                Assert.Equal(replacementGroups[3].Id, groupC.Id);
+                Assert.Equal(3, groupC.ChildSequence.Count);
+                Assert.Equal(replacementGroups[3].Indicators[2].Id, groupC.ChildSequence[0]);
+                Assert.Equal(replacementGroups[3].Indicators[0].Id, groupC.ChildSequence[1]);
+                Assert.Equal(replacementGroups[3].Indicators[1].Id, groupC.ChildSequence[2]);
+
+                // 'Group a' would've been the next group but has been removed
+
+                // 'Group b' should be second based on the original sequence
+                // Check 'Indicator e' was removed and both 'Indicator j' and 'Indicator k' have been appended in order
+                var groupB = updatedSequence[1];
+                Assert.Equal(replacementGroups[2].Id, groupB.Id);
+                Assert.Equal(4, groupB.ChildSequence.Count);
+                // 'Indicator f' is first from the original sequence
+                Assert.Equal(replacementGroups[2].Indicators[3].Id, groupB.ChildSequence[0]);
+                // 'Indicator d' is second from the original sequence 
+                Assert.Equal(replacementGroups[2].Indicators[0].Id, groupB.ChildSequence[1]);
+                // 'Indicator j' is appended first alphabetically
+                Assert.Equal(replacementGroups[2].Indicators[2].Id, groupB.ChildSequence[2]);
+                // 'Indicator k' is appended second alphabetically
+                Assert.Equal(replacementGroups[2].Indicators[1].Id, groupB.ChildSequence[3]);
+
+                // 'Group d' is new so it should be appended in order and its indicators should be ordered by label
+                var groupD = updatedSequence[2];
+                Assert.Equal(replacementGroups[1].Id, groupD.Id);
+                Assert.Equal(3, groupD.ChildSequence.Count);
+                // 'Indicator l' should be first alphabetically
+                Assert.Equal(replacementGroups[1].Indicators[1].Id, groupD.ChildSequence[0]);
+                // 'Indicator m' should be second alphabetically
+                Assert.Equal(replacementGroups[1].Indicators[2].Id, groupD.ChildSequence[1]);
+                // 'Indicator n' should be third alphabetically
+                Assert.Equal(replacementGroups[1].Indicators[0].Id, groupD.ChildSequence[2]);
+
+                // 'Group e' is new so it should be appended in order
+                var groupE = updatedSequence[3];
+                Assert.Equal(replacementGroups[0].Id, groupE.Id);
+                Assert.Empty(groupE.ChildSequence);
             }
         }
 
@@ -3306,6 +4268,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 statisticsDbContext,
                 new FilterRepository(statisticsDbContext),
                 new IndicatorRepository(statisticsDbContext),
+                new IndicatorGroupRepository(statisticsDbContext),
                 locationRepository.Object,
                 new FootnoteRepository(statisticsDbContext),
                 releaseService.Object,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -25,7 +25,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using IReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseService;
 using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
 using Unit = GovUk.Education.ExploreEducationStatistics.Common.Model.Unit;
@@ -1039,137 +1038,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 return null;
             }
 
-            var originalFilters = (await _filterRepository.GetFiltersIncludingItems(originalReleaseSubject.SubjectId))
-                .ToDictionary(filter => filter.Name, filter => filter);
+            var originalFilters = 
+                await _filterRepository.GetFiltersIncludingItems(originalReleaseSubject.SubjectId);
             var replacementFilters =
                 await _filterRepository.GetFiltersIncludingItems(replacementReleaseSubject.SubjectId);
 
-            // Step 1: Create id to replacement-id maps and work out newly added filters, filter groups and filter items
-
-            var filtersMap = new Dictionary<Guid, Guid>();
-            var filterGroupsMap = new Dictionary<Guid, Guid>();
-            var filterItemsMap = new Dictionary<Guid, Guid>();
-            var newlyAddedFilters = new List<Filter>();
-            var newlyAddedFilterGroups = new Dictionary<Guid, List<FilterGroup>>();
-            var newlyAddedFilterItems = new Dictionary<Guid, List<FilterItem>>();
-
-            replacementFilters.ForEach(replacementFilter =>
-            {
-                if (originalFilters.TryGetValue(replacementFilter.Name, out var originalFilter))
-                {
-                    filtersMap.Add(originalFilter.Id, replacementFilter.Id);
-                    var originalFilterGroups = originalFilter.FilterGroups.ToDictionary(fg => fg.Label);
-                    replacementFilter.FilterGroups.ForEach(replacementFilterGroup =>
-                    {
-                        if (originalFilterGroups.TryGetValue(replacementFilterGroup.Label, out var originalFilterGroup))
-                        {
-                            filterGroupsMap.Add(originalFilterGroup.Id, replacementFilterGroup.Id);
-                            var originalFilterItems = originalFilterGroup.FilterItems.ToDictionary(fi => fi.Label);
-                            replacementFilterGroup.FilterItems.ForEach(replacementFilterItem =>
-                            {
-                                if (originalFilterItems.TryGetValue(replacementFilterItem.Label,
-                                        out var originalFilterItem))
-                                {
-                                    filterItemsMap.Add(originalFilterItem.Id, replacementFilterItem.Id);
-                                }
-                                else
-                                {
-                                    if (newlyAddedFilterItems.TryGetValue(originalFilterGroup.Id,
-                                            out var newlyAddedFilterItemList))
-                                    {
-                                        newlyAddedFilterItemList.Add(replacementFilterItem);
-                                    }
-                                    else
-                                    {
-                                        newlyAddedFilterItems.Add(originalFilterGroup.Id,
-                                            ListOf(replacementFilterItem));
-                                    }
-                                }
-                            });
-                        }
-                        else
-                        {
-                            if (newlyAddedFilterGroups.TryGetValue(originalFilter.Id,
-                                    out var newlyAddedFilterGroupList))
-                            {
-                                newlyAddedFilterGroupList.Add(replacementFilterGroup);
-                            }
-                            else
-                            {
-                                newlyAddedFilterGroups.Add(originalFilter.Id, ListOf(replacementFilterGroup));
-                            }
-                        }
-                    });
-                }
-                else
-                {
-                    newlyAddedFilters.Add(replacementFilter);
-                }
-            });
-
-            // Step 2: Create a new sequence based on the original:
-            // - Remove any entries that don't exist in the replacement
-            // - Swap the remaining id's with their replacements
-            // - Append new entries that were added in the replacement
-
-            var filterSequence = originalReleaseSubject.FilterSequence
-                .Where(filter => filtersMap.ContainsKey(filter.Id))
-                .Select(filter =>
-                {
-                    var newFilterSequenceEntry = new FilterSequenceEntry(
-                        filtersMap[filter.Id],
-                        filter.ChildSequence
-                            .Where(filterGroup => filterGroupsMap.ContainsKey(filterGroup.Id))
-                            .Select(filterGroup =>
-                            {
-                                var newFilterGroupSequenceEntry = new FilterGroupSequenceEntry(
-                                    filterGroupsMap[filterGroup.Id],
-                                    filterGroup.ChildSequence
-                                        .Where(filterItem => filterItemsMap.ContainsKey(filterItem))
-                                        .Select(filterItem => filterItemsMap[filterItem])
-                                        .ToList());
-
-                                if (newlyAddedFilterItems.TryGetValue(filterGroup.Id, out var newlyAddedFilterItemList))
-                                {
-                                    newFilterGroupSequenceEntry.ChildSequence.AddRange(
-                                        newlyAddedFilterItemList
-                                            .OrderBy(fi => !IsTotal(fi.Label))
-                                            .ThenBy(fi => fi.Label, LabelComparer)
-                                            .Select(fi => fi.Id));
-                                }
-
-                                return newFilterGroupSequenceEntry;
-                            }).ToList());
-
-                    if (newlyAddedFilterGroups.TryGetValue(filter.Id, out var newlyAddedFilterGroupList))
-                    {
-                        newFilterSequenceEntry.ChildSequence.AddRange(newlyAddedFilterGroupList
-                            .OrderBy(fg => !IsTotal(fg.Label))
-                            .ThenBy(fg => fg.Label, LabelComparer)
-                            .Select(fg => new FilterGroupSequenceEntry(fg.Id,
-                                fg.FilterItems
-                                    .OrderBy(fi => !IsTotal(fi.Label))
-                                    .ThenBy(fi => fi.Label, LabelComparer)
-                                    .Select(fi => fi.Id).ToList()))
-                        );
-                    }
-
-                    return newFilterSequenceEntry;
-                }).ToList();
-
-            filterSequence.AddRange(newlyAddedFilters
-                .OrderBy(f => f.Label, LabelComparer)
-                .Select(f => new FilterSequenceEntry(f.Id,
-                    f.FilterGroups
-                        .OrderBy(fg => !IsTotal(fg.Label))
-                        .ThenBy(fg => fg.Label, LabelComparer)
-                        .Select(fg =>
-                            new FilterGroupSequenceEntry(fg.Id, fg.FilterItems
-                                .OrderBy(fi => !IsTotal(fi.Label))
-                                .ThenBy(fi => fi.Label, LabelComparer)
-                                .Select(fi => fi.Id).ToList())).ToList())));
-
-            return filterSequence;
+            return ReplacementServiceHelper.ReplaceFilterSequence(
+                originalFilters: originalFilters,
+                replacementFilters: replacementFilters,
+                originalReleaseSubject);
         }
 
         private async Task<List<IndicatorGroupSequenceEntry>?> ReplaceIndicatorSequence(
@@ -1183,86 +1060,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             }
 
             var originalIndicatorGroups =
-                (await _indicatorGroupRepository.GetIndicatorGroups(originalReleaseSubject.SubjectId))
-                .ToDictionary(indicatorGroup => indicatorGroup.Label, indicatorGroup => indicatorGroup);
+                await _indicatorGroupRepository.GetIndicatorGroups(originalReleaseSubject.SubjectId);
             var replacementIndicatorGroups =
                 await _indicatorGroupRepository.GetIndicatorGroups(replacementReleaseSubject.SubjectId);
 
-            // Step 1: Create id to replacement-id maps and work out newly added indicator groups and indicators
-
-            var indicatorGroupsMap = new Dictionary<Guid, Guid>();
-            var indicatorsMap = new Dictionary<Guid, Guid>();
-            var newlyAddedIndicatorGroups = new List<IndicatorGroup>();
-            var newlyAddedIndicators = new Dictionary<Guid, List<Indicator>>();
-
-            replacementIndicatorGroups.ForEach(replacementIndicatorGroup =>
-            {
-                if (originalIndicatorGroups.TryGetValue(replacementIndicatorGroup.Label,
-                        out var originalIndicatorGroup))
-                {
-                    indicatorGroupsMap.Add(originalIndicatorGroup.Id, replacementIndicatorGroup.Id);
-                    var originalIndicators = originalIndicatorGroup.Indicators.ToDictionary(i => i.Name);
-                    replacementIndicatorGroup.Indicators.ForEach(replacementIndicator =>
-                    {
-                        if (originalIndicators.TryGetValue(replacementIndicator.Name, out var originalIndicator))
-                        {
-                            indicatorsMap.Add(originalIndicator.Id, replacementIndicator.Id);
-                        }
-                        else
-                        {
-                            if (newlyAddedIndicators.TryGetValue(originalIndicatorGroup.Id,
-                                    out var newlyAddedIndicatorList))
-                            {
-                                newlyAddedIndicatorList.Add(replacementIndicator);
-                            }
-                            else
-                            {
-                                newlyAddedIndicators.Add(originalIndicatorGroup.Id, ListOf(replacementIndicator));
-                            }
-                        }
-                    });
-                }
-                else
-                {
-                    newlyAddedIndicatorGroups.Add(replacementIndicatorGroup);
-                }
-            });
-
-            // Step 2: Create a new sequence based on the original:
-            // - Remove any entries that don't exist in the replacement
-            // - Swap the remaining id's with their replacements
-            // - Append new entries that were added in the replacement
-
-            var indicatorSequence = originalReleaseSubject.IndicatorSequence
-                .Where(indicatorGroup => indicatorGroupsMap.ContainsKey(indicatorGroup.Id))
-                .Select(indicatorGroup =>
-                {
-                    var newIndicatorGroupSequenceEntry = new IndicatorGroupSequenceEntry(
-                        indicatorGroupsMap[indicatorGroup.Id],
-                        indicatorGroup.ChildSequence
-                            .Where(indicator => indicatorsMap.ContainsKey(indicator))
-                            .Select(indicator => indicatorsMap[indicator])
-                            .ToList());
-
-                    if (newlyAddedIndicators.TryGetValue(indicatorGroup.Id, out var newlyAddedIndicatorList))
-                    {
-                        newIndicatorGroupSequenceEntry.ChildSequence.AddRange(
-                            newlyAddedIndicatorList
-                                .OrderBy(i => i.Label, LabelComparer)
-                                .Select(i => i.Id));
-                    }
-
-                    return newIndicatorGroupSequenceEntry;
-                }).ToList();
-
-            indicatorSequence.AddRange(newlyAddedIndicatorGroups
-                .OrderBy(ig => ig.Label, LabelComparer)
-                .Select(ig => new IndicatorGroupSequenceEntry(ig.Id,
-                    ig.Indicators
-                        .OrderBy(i => i.Label, LabelComparer)
-                        .Select(i => i.Id).ToList())));
-
-            return indicatorSequence;
+            return ReplacementServiceHelper.ReplaceIndicatorSequence(
+                originalIndicatorGroups: originalIndicatorGroups,
+                replacementIndicatorGroups: replacementIndicatorGroups,
+                originalReleaseSubject);
         }
 
         private async Task<Either<ActionResult, Unit>> RemoveOriginalSubjectAndFileFromRelease(
@@ -1303,11 +1108,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return _cacheKeyService
                 .CreateCacheKeyForDataBlock(releaseId, plan.Id)
                 .OnSuccessVoid(_cacheService.DeleteItem);
-        }
-
-        private static bool IsTotal(string input)
-        {
-            return input.Equals("Total", StringComparison.OrdinalIgnoreCase);
         }
 
         private static Guid ReplacementPlanOriginalId(TargetableReplacementViewModel plan)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
@@ -1,0 +1,252 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Services;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+public class ReplacementServiceHelper
+{
+    private static IComparer<string> LabelComparer { get; } = new LabelRelationalComparer();
+
+    public static List<FilterSequenceEntry>? ReplaceFilterSequence(
+        List<Filter> originalFilters,
+        List<Filter> replacementFilters,
+        ReleaseSubject originalReleaseSubject)
+    {
+        // If the sequence is undefined then leave it so we continue to fallback to ordering by label alphabetically
+        if (originalReleaseSubject.FilterSequence == null)
+        {
+            return null;
+        }
+
+        var originalFiltersLabelMap = originalFilters.ToDictionary(filter => filter.Name, filter => filter);
+
+        // Step 1: Create id to replacement-id maps and work out newly added filters, filter groups and filter items
+
+        var filtersMap = new Dictionary<Guid, Guid>();
+        var filterGroupsMap = new Dictionary<Guid, Guid>();
+        var filterItemsMap = new Dictionary<Guid, Guid>();
+        var newlyAddedFilters = new List<Filter>();
+        var newlyAddedFilterGroups = new Dictionary<Guid, List<FilterGroup>>();
+        var newlyAddedFilterItems = new Dictionary<Guid, List<FilterItem>>();
+
+        replacementFilters.ForEach(replacementFilter =>
+        {
+            if (originalFiltersLabelMap.TryGetValue(replacementFilter.Name, out var originalFilter))
+            {
+                filtersMap.Add(originalFilter.Id, replacementFilter.Id);
+                var originalFilterGroupsLabelMap = originalFilter.FilterGroups.ToDictionary(fg => fg.Label);
+                replacementFilter.FilterGroups.ForEach(replacementFilterGroup =>
+                {
+                    if (originalFilterGroupsLabelMap.TryGetValue(replacementFilterGroup.Label,
+                            out var originalFilterGroup))
+                    {
+                        filterGroupsMap.Add(originalFilterGroup.Id, replacementFilterGroup.Id);
+                        var originalFilterItemsLabelMap = originalFilterGroup.FilterItems.ToDictionary(fi => fi.Label);
+                        replacementFilterGroup.FilterItems.ForEach(replacementFilterItem =>
+                        {
+                            if (originalFilterItemsLabelMap.TryGetValue(replacementFilterItem.Label,
+                                    out var originalFilterItem))
+                            {
+                                filterItemsMap.Add(originalFilterItem.Id, replacementFilterItem.Id);
+                            }
+                            else
+                            {
+                                if (newlyAddedFilterItems.TryGetValue(originalFilterGroup.Id,
+                                        out var newlyAddedFilterItemList))
+                                {
+                                    newlyAddedFilterItemList.Add(replacementFilterItem);
+                                }
+                                else
+                                {
+                                    newlyAddedFilterItems.Add(originalFilterGroup.Id,
+                                        ListOf(replacementFilterItem));
+                                }
+                            }
+                        });
+                    }
+                    else
+                    {
+                        if (newlyAddedFilterGroups.TryGetValue(originalFilter.Id,
+                                out var newlyAddedFilterGroupList))
+                        {
+                            newlyAddedFilterGroupList.Add(replacementFilterGroup);
+                        }
+                        else
+                        {
+                            newlyAddedFilterGroups.Add(originalFilter.Id, ListOf(replacementFilterGroup));
+                        }
+                    }
+                });
+            }
+            else
+            {
+                newlyAddedFilters.Add(replacementFilter);
+            }
+        });
+
+        // Step 2: Create a new sequence based on the original:
+        // - Remove any entries that don't exist in the replacement
+        // - Swap the remaining id's with their replacements
+        // - Append new entries that were added in the replacement
+
+        var filterSequence = originalReleaseSubject.FilterSequence
+            .Where(filter => filtersMap.ContainsKey(filter.Id))
+            .Select(filter =>
+            {
+                var newFilterSequenceEntry = new FilterSequenceEntry(
+                    filtersMap[filter.Id],
+                    filter.ChildSequence
+                        .Where(filterGroup => filterGroupsMap.ContainsKey(filterGroup.Id))
+                        .Select(filterGroup =>
+                        {
+                            var newFilterGroupSequenceEntry = new FilterGroupSequenceEntry(
+                                filterGroupsMap[filterGroup.Id],
+                                filterGroup.ChildSequence
+                                    .Where(filterItem => filterItemsMap.ContainsKey(filterItem))
+                                    .Select(filterItem => filterItemsMap[filterItem])
+                                    .ToList());
+
+                            if (newlyAddedFilterItems.TryGetValue(filterGroup.Id, out var newlyAddedFilterItemList))
+                            {
+                                newFilterGroupSequenceEntry.ChildSequence.AddRange(
+                                    newlyAddedFilterItemList
+                                        .OrderBy(fi => !IsTotal(fi.Label))
+                                        .ThenBy(fi => fi.Label, LabelComparer)
+                                        .Select(fi => fi.Id));
+                            }
+
+                            return newFilterGroupSequenceEntry;
+                        }).ToList());
+
+                if (newlyAddedFilterGroups.TryGetValue(filter.Id, out var newlyAddedFilterGroupList))
+                {
+                    newFilterSequenceEntry.ChildSequence.AddRange(newlyAddedFilterGroupList
+                        .OrderBy(fg => !IsTotal(fg.Label))
+                        .ThenBy(fg => fg.Label, LabelComparer)
+                        .Select(fg => new FilterGroupSequenceEntry(fg.Id,
+                            fg.FilterItems
+                                .OrderBy(fi => !IsTotal(fi.Label))
+                                .ThenBy(fi => fi.Label, LabelComparer)
+                                .Select(fi => fi.Id).ToList()))
+                    );
+                }
+
+                return newFilterSequenceEntry;
+            }).ToList();
+
+        filterSequence.AddRange(newlyAddedFilters
+            .OrderBy(f => f.Label, LabelComparer)
+            .Select(f => new FilterSequenceEntry(f.Id,
+                f.FilterGroups
+                    .OrderBy(fg => !IsTotal(fg.Label))
+                    .ThenBy(fg => fg.Label, LabelComparer)
+                    .Select(fg =>
+                        new FilterGroupSequenceEntry(fg.Id, fg.FilterItems
+                            .OrderBy(fi => !IsTotal(fi.Label))
+                            .ThenBy(fi => fi.Label, LabelComparer)
+                            .Select(fi => fi.Id).ToList())).ToList())));
+
+        return filterSequence;
+    }
+
+    public static List<IndicatorGroupSequenceEntry>? ReplaceIndicatorSequence(
+        List<IndicatorGroup> originalIndicatorGroups,
+        List<IndicatorGroup> replacementIndicatorGroups,
+        ReleaseSubject originalReleaseSubject)
+    {
+        // If the sequence is undefined then leave it so we continue to fallback to ordering by label alphabetically
+        if (originalReleaseSubject.IndicatorSequence == null)
+        {
+            return null;
+        }
+
+        var originalIndicatorGroupsLabelMap = originalIndicatorGroups
+            .ToDictionary(indicatorGroup => indicatorGroup.Label, indicatorGroup => indicatorGroup);
+
+        // Step 1: Create id to replacement-id maps and work out newly added indicator groups and indicators
+
+        var indicatorGroupsMap = new Dictionary<Guid, Guid>();
+        var indicatorsMap = new Dictionary<Guid, Guid>();
+        var newlyAddedIndicatorGroups = new List<IndicatorGroup>();
+        var newlyAddedIndicators = new Dictionary<Guid, List<Indicator>>();
+
+        replacementIndicatorGroups.ForEach(replacementIndicatorGroup =>
+        {
+            if (originalIndicatorGroupsLabelMap.TryGetValue(replacementIndicatorGroup.Label,
+                    out var originalIndicatorGroup))
+            {
+                indicatorGroupsMap.Add(originalIndicatorGroup.Id, replacementIndicatorGroup.Id);
+                var originalIndicatorsNameMap = originalIndicatorGroup.Indicators.ToDictionary(i => i.Name);
+                replacementIndicatorGroup.Indicators.ForEach(replacementIndicator =>
+                {
+                    if (originalIndicatorsNameMap.TryGetValue(replacementIndicator.Name, out var originalIndicator))
+                    {
+                        indicatorsMap.Add(originalIndicator.Id, replacementIndicator.Id);
+                    }
+                    else
+                    {
+                        if (newlyAddedIndicators.TryGetValue(originalIndicatorGroup.Id,
+                                out var newlyAddedIndicatorList))
+                        {
+                            newlyAddedIndicatorList.Add(replacementIndicator);
+                        }
+                        else
+                        {
+                            newlyAddedIndicators.Add(originalIndicatorGroup.Id, ListOf(replacementIndicator));
+                        }
+                    }
+                });
+            }
+            else
+            {
+                newlyAddedIndicatorGroups.Add(replacementIndicatorGroup);
+            }
+        });
+
+        // Step 2: Create a new sequence based on the original:
+        // - Remove any entries that don't exist in the replacement
+        // - Swap the remaining id's with their replacements
+        // - Append new entries that were added in the replacement
+
+        var indicatorSequence = originalReleaseSubject.IndicatorSequence
+            .Where(indicatorGroup => indicatorGroupsMap.ContainsKey(indicatorGroup.Id))
+            .Select(indicatorGroup =>
+            {
+                var newIndicatorGroupSequenceEntry = new IndicatorGroupSequenceEntry(
+                    indicatorGroupsMap[indicatorGroup.Id],
+                    indicatorGroup.ChildSequence
+                        .Where(indicator => indicatorsMap.ContainsKey(indicator))
+                        .Select(indicator => indicatorsMap[indicator])
+                        .ToList());
+
+                if (newlyAddedIndicators.TryGetValue(indicatorGroup.Id, out var newlyAddedIndicatorList))
+                {
+                    newIndicatorGroupSequenceEntry.ChildSequence.AddRange(
+                        newlyAddedIndicatorList
+                            .OrderBy(i => i.Label, LabelComparer)
+                            .Select(i => i.Id));
+                }
+
+                return newIndicatorGroupSequenceEntry;
+            }).ToList();
+
+        indicatorSequence.AddRange(newlyAddedIndicatorGroups
+            .OrderBy(ig => ig.Label, LabelComparer)
+            .Select(ig => new IndicatorGroupSequenceEntry(ig.Id,
+                ig.Indicators
+                    .OrderBy(i => i.Label, LabelComparer)
+                    .Select(i => i.Id).ToList())));
+
+        return indicatorSequence;
+    }
+
+    private static bool IsTotal(string input)
+    {
+        return input.Equals("Total", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/FiltersViewModelBuilderTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/FiltersViewModelBuilderTests.cs
@@ -9,7 +9,7 @@ using static GovUk.Education.ExploreEducationStatistics.Data.Services.FilterAndI
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests;
 
-public class FiltersBuilderTests
+public class FiltersViewModelBuilderTests
 {
     [Fact]
     public void GetFiltersFromFilterItems_NoFilterItems()
@@ -660,10 +660,10 @@ public class FiltersBuilderTests
         // - Filter c
         // - Filter a
         //   - Group c
+        //   - Group a
         //     - Item c
         //     - Item a
         //     - Item b
-        //   - Group a
         //   - Group b
         // - Filter b
         var ordering = new List<FilterSequenceEntry>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/IndicatorsViewModelBuilderTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/IndicatorsViewModelBuilderTests.cs
@@ -8,7 +8,7 @@ using static GovUk.Education.ExploreEducationStatistics.Data.Services.FilterAndI
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests;
 
-public class IndicatorsBuilderTests
+public class IndicatorsViewModelBuilderTests
 {
     [Fact]
     public void GetIndicatorGroups_NoIndicatorGroups()
@@ -306,17 +306,17 @@ public class IndicatorsBuilderTests
         // Include some random elements not in the input list since an ordering configuration contains all
         // groups / indicators belonging to the Subject, whereas the input list is usually filtered:
         // - Group c
-        //   - Indicator c
-        //   - Indicator a
-        //   - Indicator b
-        // - Group a
-        //   - Indicator f
-        //   - Indicator d
-        //   - Indicator e
-        // - Group b
         //   - Indicator i
         //   - Indicator g
         //   - Indicator h
+        // - Group a
+        //   - Indicator c
+        //   - Indicator a
+        //   - Indicator b
+        // - Group b
+        //   - Indicator f
+        //   - Indicator d
+        //   - Indicator e
         var ordering = new List<IndicatorGroupSequenceEntry>
         {
             // A group that does not exist in the input list
@@ -332,7 +332,7 @@ public class IndicatorsBuilderTests
                 indicatorGroups[2].Id,
                 new List<Guid>
                 {
-                    // Indicator c, Indicator a, Indicator b
+                    // Indicator i, Indicator g, Indicator h
                     indicatorGroups[2].Indicators[2].Id,
                     indicatorGroups[2].Indicators[0].Id,
                     indicatorGroups[2].Indicators[1].Id
@@ -343,7 +343,7 @@ public class IndicatorsBuilderTests
                 indicatorGroups[0].Id,
                 new List<Guid>
                 {
-                    //Indicator f, Indicator d, Indicator e
+                    //Indicator c, Indicator a, Indicator b
                     indicatorGroups[0].Indicators[2].Id,
                     indicatorGroups[0].Indicators[0].Id,
                     indicatorGroups[0].Indicators[1].Id
@@ -354,7 +354,7 @@ public class IndicatorsBuilderTests
                 indicatorGroups[1].Id,
                 new List<Guid>
                 {
-                    // Indicator i, Indicator g, Indicator h
+                    // Indicator f, Indicator d, Indicator e
                     indicatorGroups[1].Indicators[2].Id,
                     indicatorGroups[1].Indicators[0].Id,
                     indicatorGroups[1].Indicators[1].Id

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/FilterAndIndicatorViewModelBuilders.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/FilterAndIndicatorViewModelBuilders.cs
@@ -152,7 +152,7 @@ public class FilterAndIndicatorViewModelBuilders
 
     private static bool IsLabelTotal<T>(T input, Func<T, string> labelSelector)
     {
-        return labelSelector(input).Equals("Total", StringComparison.InvariantCultureIgnoreCase);
+        return labelSelector(input).Equals("Total", StringComparison.OrdinalIgnoreCase);
     }
 
     private static IEnumerable<Ordered<TValue, TSequence>> OrderByLabel<TValue, TSequence>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/FilterAndIndicatorViewModelBuilders.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/FilterAndIndicatorViewModelBuilders.cs
@@ -69,7 +69,8 @@ public class FilterAndIndicatorViewModelBuilders
 
         private static FilterItem? GetTotal(Filter filter)
         {
-            return GetTotalGroup(filter)?.FilterItems.FirstOrDefault(IsFilterItemTotal);
+            return GetTotalGroup(filter)?.FilterItems.FirstOrDefault(filterItem =>
+                IsLabelTotal(filterItem, item => item.Label));
         }
 
         private static FilterGroup? GetTotalGroup(Filter filter)
@@ -79,17 +80,7 @@ public class FilterAndIndicatorViewModelBuilders
             // Return the group if there is only one, otherwise the 'Total' group if it exists
             return filterGroups.Count == 1
                 ? filterGroups.First()
-                : filterGroups.FirstOrDefault(IsFilterGroupTotal);
-        }
-
-        private static bool IsFilterItemTotal(FilterItem filterItem)
-        {
-            return IsLabelTotal(filterItem, item => item.Label);
-        }
-
-        private static bool IsFilterGroupTotal(FilterGroup filterGroup)
-        {
-            return IsLabelTotal(filterGroup, group => group.Label);
+                : filterGroups.FirstOrDefault(filterGroup => IsLabelTotal(filterGroup, group => group.Label));
         }
 
         private static List<Filter> GroupFilterItemsByFilter(IEnumerable<FilterItem> filterItems)

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
@@ -67,7 +67,6 @@ const ReleaseDataPage = () => {
             canUpdateRelease={canUpdateRelease}
           />
         </TabsSection>
-        {/* TODO Depends on EES-2793 Data replacement support for reordering
         <TabsSection
           id={releaseDataPageTabIds.reordering}
           title="Reorder filters and indicators"
@@ -78,7 +77,7 @@ const ReleaseDataPage = () => {
             releaseId={releaseId}
             canUpdateRelease={canUpdateRelease}
           />
-        </TabsSection> */}
+        </TabsSection>
       </Tabs>
     </LoadingSpinner>
   );


### PR DESCRIPTION
This PR makes a change to the Admin data replacement service to make it aware that a `ReleaseSubject` being replaced can now contain the ordering of filters and indicators (as chosen by analysts) and that it needs to be retained on the replacement `ReleaseSubject` if the replacement is requested.

Replacement subjects are temporarily staged while a replacement plan is reviewed. Analysts can choose to request the replacement if the plan is valid or cancel it in which case the replacement subject is removed.

No `FilterSequence` or`IndicatorSequence` will be set on the replacement `ReleaseSubject` until the replacement is requested.

If they are not set on the original `ReleaseSubject` they will remain unset on the replacement.

If a `FilterSequence` or `IndicatorSequence` is set on the original, the id's of `Filter`, `FilterGroup`, `FilterItem`, `IndicatorGroup` and `Indicator`'s must be transformed to their equivalent id's on the replacement subject.

We detect any elements in the original subject which have been removed in the replacement subject and strip them from the sequence.

Any elements which are new in the replacement subject are appended to the sequence in alphabetical order.

Any new 'Total' filter groups or 'Total' filter items are ordered first.

Simple example limited to some filter groups changing within a single filter:

```
A filter has 3 groups A, B, C which have been ordered on the original subject B, C, A.

The replacement subject adds groups E, and D and removes group C from the filter.

The replacement is requested.

The order of the groups for the filter becomes B, A (respected from the original sequence) followed by D, E.

Any filter items of the new groups are also ordered alphabetically.

The id’s of all filters, filter groups, filter items in the sequence are updated to those of the replacement subject.
```

Analysts can review and reorder the elements including any new ones using the Filters and Indicators Reordering tab after the replacement is complete.

### Other changes
- Correct the class names and some of the comments in `FiltersViewModelBuilderTests` and `IndicatorsViewModelBuilderTests`.
- Enable the Filters and Indicators reordering tab in the Admin UI. This has been hidden up until now due to the dependency on this work to make sure the ordering is retained with the id transformation during data replacements.