### PR TITLE
EES-3394 - add VisualTesting tag to visual UI test

### DIFF
--- a/tests/robot-tests/tests/visual_testing/visually_check_tables_and_charts.seed_data.robot
+++ b/tests/robot-tests/tests/visual_testing/visually_check_tables_and_charts.seed_data.robot
@@ -2,11 +2,12 @@
 Resource            tables_and_charts.robot
 Library             tables_and_charts.py
 
-Force Tags          GeneralPublic    Local    Dev
+Force Tags          GeneralPublic    Local    Dev    VisualTesting
 
 Suite Setup         do suite setup
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
+
 
 *** Test Cases ***
 Check release /find-statistics/permanent-and-fixed-period-exclusions-in-england/2016-17
@@ -16,6 +17,7 @@ Check release /find-statistics/permanent-and-fixed-period-exclusions-in-england/
 Check release /find-statistics/pupil-absence-in-schools-in-england/2016-17
     ${release}=    get release by url    /find-statistics/pupil-absence-in-schools-in-england/2016-17
     Check release    ${release}
+
 
 *** Keywords ***
 do suite setup


### PR DESCRIPTION
This PR: 
- adds the `VisualTesting` tag to a visual test that was being included as part of the standard UI tests. When the VisualTesting tag is added, it is excluded from the standard run of UI tests