### PR TITLE
EES-3015 EES-3026 improve table header reordering accessibility

### DIFF
--- a/src/explore-education-statistics-common/package-lock.json
+++ b/src/explore-education-statistics-common/package-lock.json
@@ -2758,15 +2758,12 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.0.tgz",
-			"integrity": "sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+			"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
 			"dev": true,
 			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			},
-			"engines": {
-				"node": ">=6.9.0"
+				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
@@ -4244,6 +4241,15 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@testing-library/dom/node_modules/@babel/runtime": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
 		"node_modules/@testing-library/dom/node_modules/chalk": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -4333,6 +4339,15 @@
 				"node": ">=8",
 				"npm": ">=6",
 				"yarn": ">=1"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/@babel/runtime": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
@@ -4469,6 +4484,24 @@
 				"react-test-renderer": ">=16.9.0"
 			}
 		},
+		"node_modules/@testing-library/react-hooks/node_modules/@babel/runtime": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"node_modules/@testing-library/react/node_modules/@babel/runtime": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
 		"node_modules/@testing-library/user-event": {
 			"version": "12.1.7",
 			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.7.tgz",
@@ -4483,6 +4516,15 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
+			}
+		},
+		"node_modules/@testing-library/user-event/node_modules/@babel/runtime": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/@types/aria-query": {
@@ -5231,6 +5273,15 @@
 				"node": ">=6.0"
 			}
 		},
+		"node_modules/aria-query/node_modules/@babel/runtime": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
 		"node_modules/arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -5628,6 +5679,15 @@
 				"@babel/runtime": "^7.7.2",
 				"cosmiconfig": "^6.0.0",
 				"resolve": "^1.12.0"
+			}
+		},
+		"node_modules/babel-plugin-macros/node_modules/@babel/runtime": {
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/babel-plugin-macros/node_modules/resolve": {
@@ -15932,6 +15992,15 @@
 				"react-dom": "^16.8.5"
 			}
 		},
+		"node_modules/react-beautiful-dnd/node_modules/@babel/runtime": {
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
 		"node_modules/react-beautiful-dnd/node_modules/memoize-one": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
@@ -16036,6 +16105,15 @@
 				"react-dom": "^16.8.0"
 			}
 		},
+		"node_modules/react-leaflet/node_modules/@babel/runtime": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
 		"node_modules/react-leaflet/node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -16124,6 +16202,15 @@
 				"react-native": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/react-redux/node_modules/@babel/runtime": {
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/react-redux/node_modules/react-is": {
@@ -16359,6 +16446,15 @@
 			"dependencies": {
 				"@babel/runtime": "^7.8.4",
 				"private": "^0.1.8"
+			}
+		},
+		"node_modules/regenerator-transform/node_modules/@babel/runtime": {
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/regex-not": {
@@ -19945,6 +20041,15 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/yaml/node_modules/@babel/runtime": {
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
 		"node_modules/yargs": {
 			"version": "15.4.1",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -20037,6 +20142,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/yup/node_modules/@babel/runtime": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/zwitch": {
@@ -22530,12 +22644,12 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.0.tgz",
-			"integrity": "sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+			"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
 			"dev": true,
 			"requires": {
-				"regenerator-runtime": "^0.13.4"
+				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/runtime-corejs3": {
@@ -23706,6 +23820,15 @@
 				"pretty-format": "^26.4.2"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.11.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
 				"chalk": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -23775,6 +23898,15 @@
 				"redent": "^3.0.0"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.11.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -23867,6 +23999,17 @@
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"@testing-library/dom": "^7.24.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.11.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"@testing-library/react-hooks": {
@@ -23877,6 +24020,17 @@
 			"requires": {
 				"@babel/runtime": "^7.5.4",
 				"@types/testing-library__react-hooks": "^3.4.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.11.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"@testing-library/user-event": {
@@ -23886,6 +24040,17 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.10.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.11.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"@types/aria-query": {
@@ -24552,6 +24717,17 @@
 			"requires": {
 				"@babel/runtime": "^7.10.2",
 				"@babel/runtime-corejs3": "^7.10.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.11.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"arr-diff": {
@@ -24861,6 +25037,15 @@
 				"resolve": "^1.12.0"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.9.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
 				"resolve": {
 					"version": "1.15.1",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
@@ -32987,6 +33172,15 @@
 				"use-memo-one": "^1.1.1"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.9.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
 				"memoize-one": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
@@ -33080,6 +33274,15 @@
 				"warning": "^4.0.3"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.11.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
 				"fast-deep-equal": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -33150,6 +33353,15 @@
 				"react-is": "^16.9.0"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.9.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
 				"react-is": {
 					"version": "16.13.1",
 					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -33352,6 +33564,17 @@
 			"requires": {
 				"@babel/runtime": "^7.8.4",
 				"private": "^0.1.8"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.9.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"regex-not": {
@@ -36205,6 +36428,17 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.8.7"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.9.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"yargs": {
@@ -36280,6 +36514,17 @@
 				"property-expr": "^2.0.2",
 				"synchronous-promise": "^2.0.13",
 				"toposort": "^2.0.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.11.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"zwitch": {

--- a/src/explore-education-statistics-common/package-lock.json
+++ b/src/explore-education-statistics-common/package-lock.json
@@ -2758,12 +2758,15 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
-			"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.0.tgz",
+			"integrity": "sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==",
 			"dev": true,
 			"dependencies": {
-				"regenerator-runtime": "^0.13.2"
+				"regenerator-runtime": "^0.13.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
@@ -4241,15 +4244,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@testing-library/dom/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/@testing-library/dom/node_modules/chalk": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -4339,15 +4333,6 @@
 				"node": ">=8",
 				"npm": ">=6",
 				"yarn": ">=1"
-			}
-		},
-		"node_modules/@testing-library/jest-dom/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
@@ -4484,24 +4469,6 @@
 				"react-test-renderer": ">=16.9.0"
 			}
 		},
-		"node_modules/@testing-library/react-hooks/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
-		"node_modules/@testing-library/react/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/@testing-library/user-event": {
 			"version": "12.1.7",
 			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.7.tgz",
@@ -4516,15 +4483,6 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
-			}
-		},
-		"node_modules/@testing-library/user-event/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/@types/aria-query": {
@@ -5273,15 +5231,6 @@
 				"node": ">=6.0"
 			}
 		},
-		"node_modules/aria-query/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -5679,15 +5628,6 @@
 				"@babel/runtime": "^7.7.2",
 				"cosmiconfig": "^6.0.0",
 				"resolve": "^1.12.0"
-			}
-		},
-		"node_modules/babel-plugin-macros/node_modules/@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/babel-plugin-macros/node_modules/resolve": {
@@ -15992,15 +15932,6 @@
 				"react-dom": "^16.8.5"
 			}
 		},
-		"node_modules/react-beautiful-dnd/node_modules/@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/react-beautiful-dnd/node_modules/memoize-one": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
@@ -16105,15 +16036,6 @@
 				"react-dom": "^16.8.0"
 			}
 		},
-		"node_modules/react-leaflet/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/react-leaflet/node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -16202,15 +16124,6 @@
 				"react-native": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/react-redux/node_modules/@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/react-redux/node_modules/react-is": {
@@ -16446,15 +16359,6 @@
 			"dependencies": {
 				"@babel/runtime": "^7.8.4",
 				"private": "^0.1.8"
-			}
-		},
-		"node_modules/regenerator-transform/node_modules/@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/regex-not": {
@@ -20041,15 +19945,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/yaml/node_modules/@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/yargs": {
 			"version": "15.4.1",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -20142,15 +20037,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/yup/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/zwitch": {
@@ -22644,12 +22530,12 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
-			"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.0.tgz",
+			"integrity": "sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==",
 			"dev": true,
 			"requires": {
-				"regenerator-runtime": "^0.13.2"
+				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/runtime-corejs3": {
@@ -23820,15 +23706,6 @@
 				"pretty-format": "^26.4.2"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"chalk": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -23898,15 +23775,6 @@
 				"redent": "^3.0.0"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -23999,17 +23867,6 @@
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"@testing-library/dom": "^7.24.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"@testing-library/react-hooks": {
@@ -24020,17 +23877,6 @@
 			"requires": {
 				"@babel/runtime": "^7.5.4",
 				"@types/testing-library__react-hooks": "^3.4.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"@testing-library/user-event": {
@@ -24040,17 +23886,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.10.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"@types/aria-query": {
@@ -24717,17 +24552,6 @@
 			"requires": {
 				"@babel/runtime": "^7.10.2",
 				"@babel/runtime-corejs3": "^7.10.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"arr-diff": {
@@ -25037,15 +24861,6 @@
 				"resolve": "^1.12.0"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.9.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"resolve": {
 					"version": "1.15.1",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
@@ -33172,15 +32987,6 @@
 				"use-memo-one": "^1.1.1"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.9.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"memoize-one": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
@@ -33274,15 +33080,6 @@
 				"warning": "^4.0.3"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"fast-deep-equal": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -33353,15 +33150,6 @@
 				"react-is": "^16.9.0"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.9.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"react-is": {
 					"version": "16.13.1",
 					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -33564,17 +33352,6 @@
 			"requires": {
 				"@babel/runtime": "^7.8.4",
 				"private": "^0.1.8"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.9.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"regex-not": {
@@ -36428,17 +36205,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.8.7"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.9.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"yargs": {
@@ -36514,17 +36280,6 @@
 				"property-expr": "^2.0.2",
 				"synchronous-promise": "^2.0.13",
 				"toposort": "^2.0.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"zwitch": {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DragIcon.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DragIcon.tsx
@@ -1,19 +1,13 @@
 import React from 'react';
 
-const DragIcon = ({
-  className,
-  ariaHidden = true,
-}: {
-  ariaHidden?: boolean;
-  className?: string;
-}) => (
+const DragIcon = ({ className }: { className?: string }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     version="1.1"
     width="32"
     height="32"
     viewBox="0 0 32 32"
-    aria-hidden={ariaHidden}
+    aria-hidden
     className={className}
   >
     <path d="M17.984 5.921v8.063h8v-4l6.016 6.016-6.016 6.015v-4.093h-8v8.063h4.031l-6.015 6.015-6.016-6.015h4v-8.063h-8v4.062l-5.984-5.984 5.984-5.984v3.968h8v-8.063h-3.906l5.922-5.921 5.922 5.921h-3.938z" />

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DragIcon.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DragIcon.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const DragIcon = ({
+  className,
+  ariaHidden = true,
+}: {
+  ariaHidden?: boolean;
+  className?: string;
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    version="1.1"
+    width="32"
+    height="32"
+    viewBox="0 0 32 32"
+    aria-hidden={ariaHidden}
+    className={className}
+  >
+    <path d="M17.984 5.921v8.063h8v-4l6.016 6.016-6.016 6.015v-4.093h-8v8.063h4.031l-6.015 6.015-6.016-6.015h4v-8.063h-8v4.062l-5.984-5.984 5.984-5.984v3.968h8v-8.063h-3.906l5.922-5.921 5.922 5.921h-3.938z" />
+  </svg>
+);
+
+export default DragIcon;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.module.scss
@@ -60,7 +60,9 @@
   }
 
   legend {
-    padding-right: govuk-spacing(4);
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
   }
 }
 
@@ -90,11 +92,10 @@
   .dragIcon {
     display: block;
     fill: currentColor;
-    height: 18px;
-    position: absolute;
-    right: 16px;
-    top: 12px;
-    width: 18px;
+    flex-shrink: 0;
+    height: 1rem;
+    margin-top: 0.2rem;
+    width: 1rem;
   }
 }
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.module.scss
@@ -1,59 +1,118 @@
 @import '~govuk-frontend/govuk/base';
 
-.groupsFieldset {
-  border: 4px solid govuk-colour('light-grey');
-  padding: govuk-spacing(2);
-  width: 100%;
-}
-
-.isDraggingOver {
+.container {
   background-color: govuk-colour('mid-grey');
-  border-color: $govuk-focus-colour;
+  border: 4px solid govuk-colour('light-grey');
+  overflow-x: auto;
+  padding: govuk-spacing(2);
+  position: relative;
+  width: 100%;
+
+  &.isDragDisabled {
+    background: none;
+  }
+
+  &.isDraggingOver {
+    border-color: $govuk-focus-colour;
+  }
 }
 
-.listsContainer {
+.toggleReorderGroups {
+  @include govuk-media-query($from: desktop) {
+    position: absolute;
+    right: govuk-spacing(2);
+    top: govuk-spacing(2);
+
+    &:active {
+      top: govuk-spacing(2);
+    }
+  }
+}
+
+.groupsContainer {
   display: flex;
   flex-direction: column;
-  padding: govuk-spacing(2);
   width: 100%;
 
   @include govuk-media-query($from: desktop) {
     flex-direction: row;
   }
+
+  &.isActive {
+    position: relative;
+  }
 }
 
-.list {
+.groupContainer {
+  padding: 0 govuk-spacing(1);
+}
+
+.group {
   background: govuk-colour('light-grey');
+  box-sizing: border-box;
   display: block;
-  flex-basis: 100%;
   margin-bottom: govuk-spacing(2);
-  margin-right: govuk-spacing(2);
   padding: govuk-spacing(2);
+  position: relative;
 
   @include govuk-media-query($from: desktop) {
-    flex-basis: 33%;
+    width: 320px;
   }
 
-  &:focus {
-    border: $govuk-focus-width solid #000;
+  legend {
+    padding-right: govuk-spacing(4);
+  }
+}
+
+.dragIcon {
+  display: none;
+}
+
+.groupIsActive {
+  background: govuk-colour('white');
+
+  &:focus-visible {
     outline: $govuk-focus-colour solid $govuk-focus-width;
   }
 
   &:hover {
-    background: govuk-colour('mid-grey');
-
+    background: govuk-colour('light-grey');
     // Fallback if grab is unsupported
     cursor: move;
     cursor: grab;
   }
+
+  &.isDragging {
+    background: govuk-colour('blue');
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+  }
+
+  .dragIcon {
+    display: block;
+    fill: currentColor;
+    height: 18px;
+    position: absolute;
+    right: 16px;
+    top: 12px;
+    width: 18px;
+  }
 }
 
 .isDragging {
-  outline: $govuk-focus-width solid $govuk-focus-colour;
-  outline-offset: 0;
+  legend {
+    color: govuk-colour('white');
+  }
 }
 
-.optionDraggedOutside {
+.isDraggedOutside {
   opacity: 0.4;
   outline: none;
+}
+
+.moveButton {
+  max-width: 100%;
+
+  @include govuk-media-query($from: desktop) {
+    width: 320px;
+  }
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.tsx
@@ -90,7 +90,6 @@ function FormFieldSortableListGroup<FormValues>({
               className={classNames(styles.groupsContainer, {
                 [styles.isActive]: !isDragDisabled,
               })}
-              id="groupsContainer"
             >
               {field.value.length === 0 && (
                 <div className="govuk-inset-text govuk-!-margin-0">

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.tsx
@@ -1,31 +1,59 @@
+import Button from '@common/components/Button';
 import { FormFieldset } from '@common/components/form';
 import { useFormContext } from '@common/components/form/contexts/FormContext';
+import DragIcon from '@common/modules/table-tool/components/DragIcon';
+import FormFieldSortableList from '@common/modules/table-tool/components/FormFieldSortableList';
+import styles from '@common/modules/table-tool/components/FormFieldSortableListGroup.module.scss';
+import {
+  CategoryFilter,
+  LocationFilter,
+  TimePeriodFilter,
+  Filter,
+} from '@common/modules/table-tool/types/filters';
 import useToggle from '@common/hooks/useToggle';
 import classNames from 'classnames';
 import { useField } from 'formik';
 import React from 'react';
 import { Draggable, Droppable } from 'react-beautiful-dnd';
-import FormFieldSortableList from './FormFieldSortableList';
-import styles from './FormFieldSortableListGroup.module.scss';
+
+const getGroupLegend = (group: Filter[]) => {
+  if (group[0] instanceof CategoryFilter) {
+    return group[0].category;
+  }
+  if (group[0] instanceof LocationFilter) {
+    return 'Locations';
+  }
+  if (group[0] instanceof TimePeriodFilter) {
+    return 'Time periods';
+  }
+  return 'Indicators';
+};
 
 interface Props<FormValues> {
   id?: string;
   name: FormValues extends Record<string, unknown> ? keyof FormValues : string;
   legend: string;
-  groupLegend: string;
+  isDraggingGroup: boolean;
+  onChangeReorderingType: (
+    axisName: string,
+    isReorderingGroups: boolean,
+  ) => void;
+  onMoveGroupToOtherAxis: (index: number) => void;
 }
 
 function FormFieldSortableListGroup<FormValues>({
   id: customId,
   name,
   legend,
-  groupLegend,
+  isDraggingGroup = false,
+  onChangeReorderingType,
+  onMoveGroupToOtherAxis,
 }: Props<FormValues>) {
   const { prefixFormId, fieldId } = useFormContext();
   const id = customId ? prefixFormId(customId) : fieldId(name as string);
 
   const [field, meta] = useField(name as string);
-  const [isDragDisabled, toggleDragDisabled] = useToggle(false);
+  const [isDragDisabled, toggleDragDisabled] = useToggle(true);
 
   return (
     <Droppable droppableId={name as string} direction="horizontal">
@@ -34,9 +62,11 @@ function FormFieldSortableListGroup<FormValues>({
           // eslint-disable-next-line react/jsx-props-no-spreading
           {...droppableProvided.droppableProps}
           ref={droppableProvided.innerRef}
-          className={classNames(styles.groupsFieldset, {
+          className={classNames(styles.container, {
             [styles.isDraggingOver]: droppableSnapshot.isDraggingOver,
+            [styles.isDragDisabled]: isDragDisabled,
           })}
+          data-testid={id}
         >
           <FormFieldset
             id={id}
@@ -44,49 +74,88 @@ function FormFieldSortableListGroup<FormValues>({
             error={meta.error}
             legendSize="m"
           >
-            <div className={styles.listsContainer}>
+            <Button
+              className={styles.toggleReorderGroups}
+              variant="secondary"
+              onClick={() => {
+                onChangeReorderingType(legend, isDragDisabled);
+                toggleDragDisabled();
+              }}
+            >
+              {isDragDisabled
+                ? `Re-order ${legend.toLowerCase()}`
+                : 'Re-order items'}
+            </Button>
+            <div
+              className={classNames(styles.groupsContainer, {
+                [styles.isActive]: !isDragDisabled,
+              })}
+              id="groupsContainer"
+            >
               {field.value.length === 0 && (
                 <div className="govuk-inset-text govuk-!-margin-0">
                   Add groups by dragging them here
                 </div>
               )}
 
-              {field.value.map((_: string, index: number) => (
-                <Draggable
+              {field.value.map((group: Filter[], index: number) => (
+                <div
+                  className={styles.groupContainer}
                   // eslint-disable-next-line react/no-array-index-key
                   key={index}
-                  draggableId={`${name}-${index}`}
-                  isDragDisabled={isDragDisabled}
-                  index={index}
                 >
-                  {(draggableProvided, draggableSnapshot) => (
-                    <div
-                      // eslint-disable-next-line react/jsx-props-no-spreading
-                      {...draggableProvided.draggableProps}
-                      // eslint-disable-next-line react/jsx-props-no-spreading
-                      {...draggableProvided.dragHandleProps}
-                      className={classNames(styles.list, {
-                        [styles.isDragging]: draggableSnapshot.isDragging,
-                        [styles.optionDraggedOutside]:
-                          draggableSnapshot.isDragging &&
-                          !draggableSnapshot.draggingOver,
-                      })}
-                      ref={draggableProvided.innerRef}
-                      role="button"
-                      tabIndex={0}
+                  <Draggable
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={index}
+                    draggableId={`${name}-${index}`}
+                    isDragDisabled={isDragDisabled}
+                    index={index}
+                  >
+                    {(draggableProvided, draggableSnapshot) => (
+                      <div
+                        // eslint-disable-next-line react/jsx-props-no-spreading
+                        {...draggableProvided.draggableProps}
+                        // eslint-disable-next-line react/jsx-props-no-spreading
+                        {...draggableProvided.dragHandleProps}
+                        className={classNames(styles.group, {
+                          [styles.isDragging]: draggableSnapshot.isDragging,
+                          [styles.isDraggedOutside]:
+                            draggableSnapshot.isDragging &&
+                            !draggableSnapshot.draggingOver,
+                          [styles.groupIsActive]: !isDragDisabled,
+                        })}
+                        ref={draggableProvided.innerRef}
+                        role={isDragDisabled ? '' : 'button'}
+                        tabIndex={isDragDisabled ? -1 : 0}
+                      >
+                        <FormFieldSortableList
+                          isGroupDragDisabled={isDragDisabled}
+                          name={`${name}[${index}]`}
+                          legend={
+                            <>
+                              {getGroupLegend(group)}
+                              <DragIcon className={styles.dragIcon} />
+                            </>
+                          }
+                          legendSize="s"
+                        />
+                      </div>
+                    )}
+                  </Draggable>
+                  {!isDragDisabled && !isDraggingGroup && (
+                    <Button
+                      className={styles.moveButton}
+                      onClick={e => {
+                        e.preventDefault();
+                        onMoveGroupToOtherAxis(index);
+                      }}
                     >
-                      <FormFieldSortableList
-                        name={`${name}[${index}]`}
-                        legend={`${groupLegend} ${index + 1}`}
-                        legendSize="s"
-                        onBlur={toggleDragDisabled.off}
-                        onFocus={toggleDragDisabled.on}
-                        onMouseEnter={toggleDragDisabled.on}
-                        onMouseLeave={toggleDragDisabled.off}
-                      />
-                    </div>
+                      {`Move ${getGroupLegend(group)} group to ${
+                        name === 'rowGroups' ? 'columns' : 'rows'
+                      }`}
+                    </Button>
                   )}
-                </Draggable>
+                </div>
               ))}
               {droppableProvided.placeholder}
             </div>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormSortableList.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormSortableList.module.scss
@@ -24,7 +24,6 @@
   background: govuk-colour('white');
   border-bottom: 1px solid govuk-colour('mid-grey');
   padding: govuk-spacing(2);
-  position: relative;
   user-select: none;
 
   &:hover {
@@ -51,7 +50,7 @@
 
 .isDragging {
   background: govuk-colour('blue');
-  border: $govuk-focus-width solid govuk-colour('black');
+  box-shadow: inset 0 0 0 $govuk-focus-width govuk-colour('black');
   color: govuk-colour('white');
   outline: $govuk-focus-colour solid $govuk-focus-width;
 }
@@ -69,17 +68,16 @@
 .dragIcon {
   display: block;
   fill: currentColor;
-  height: 18px;
-  position: absolute;
-  right: 0;
-  top: 2px;
-  width: 18px;
+  flex-shrink: 0;
+  height: 1rem;
+  margin-top: 0.2rem;
+  width: 1rem;
 }
 
 .optionLabel {
+  display: flex;
   font-weight: $govuk-font-weight-bold;
-  padding-right: govuk-spacing(6);
-  position: relative;
+  justify-content: space-between;
   word-break: break-word;
 }
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormSortableList.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormSortableList.module.scss
@@ -5,14 +5,23 @@
   overflow: auto;
 }
 
-.listDraggingOver {
+.listIsDisabled {
+  opacity: 0.5;
+  overflow: hidden;
+
+  .option:hover {
+    background: govuk-colour('white');
+  }
+}
+
+.isDraggingOver {
   background: govuk-colour('light-grey');
   outline: $govuk-focus-width solid $govuk-focus-colour;
   outline-offset: 0;
 }
 
-.optionRow {
-  background: #fff;
+.option {
+  background: govuk-colour('white');
   border-bottom: 1px solid govuk-colour('mid-grey');
   padding: govuk-spacing(2);
   position: relative;
@@ -26,29 +35,12 @@
   }
 
   &:focus {
-    border: $govuk-focus-width solid govuk-colour('black');
     outline: $govuk-focus-colour solid $govuk-focus-width;
+    outline-offset: $govuk-focus-width * -1;
   }
 }
 
-.optionText {
-  display: flex;
-  justify-content: space-between;
-}
-
-.optionActions {
-  display: flex;
-  flex-direction: column;
-}
-
-.optionDragging {
-  background: govuk-colour('blue');
-  border: $govuk-focus-width solid govuk-colour('black');
-  color: govuk-colour('white');
-  outline: $govuk-focus-colour solid $govuk-focus-width;
-}
-
-.optionSelected {
+.isSelected {
   background: govuk-colour('blue');
   color: govuk-colour('white');
 
@@ -57,14 +49,44 @@
   }
 }
 
-.optionGhosted {
+.isDragging {
+  background: govuk-colour('blue');
+  border: $govuk-focus-width solid govuk-colour('black');
+  color: govuk-colour('white');
+  outline: $govuk-focus-colour solid $govuk-focus-width;
+}
+
+.isGhosted {
   opacity: 0.5;
 }
 
-.optionDraggedOutside {
+.isDraggedOutside {
   border: 0;
   opacity: 0.2;
   outline: none;
+}
+
+.dragIcon {
+  display: block;
+  fill: currentColor;
+  height: 18px;
+  position: absolute;
+  right: 0;
+  top: 2px;
+  width: 18px;
+}
+
+.optionLabel {
+  font-weight: $govuk-font-weight-bold;
+  padding-right: govuk-spacing(6);
+  position: relative;
+  word-break: break-word;
+}
+
+.listIsDisabled {
+  .dragIcon {
+    display: none;
+  }
 }
 
 .selectedCount {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersForm.tsx
@@ -1,15 +1,17 @@
 import Button from '@common/components/Button';
 import Details from '@common/components/Details';
 import { FormGroup } from '@common/components/form';
+import useMounted from '@common/hooks/useMounted';
+import useToggle from '@common/hooks/useToggle';
 import { Filter } from '@common/modules/table-tool/types/filters';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import { PickByType } from '@common/types';
 import reorder from '@common/utils/reorder';
 import Yup from '@common/validation/yup';
-import { Form, Formik } from 'formik';
+import { Form, Formik, FormikProps } from 'formik';
 import compact from 'lodash/compact';
 import last from 'lodash/last';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { DragDropContext } from 'react-beautiful-dnd';
 import FormFieldSortableListGroup from './FormFieldSortableListGroup';
 
@@ -34,6 +36,10 @@ const TableHeadersForm = ({
     rows: [],
   },
 }: Props) => {
+  const { isMounted } = useMounted();
+  const [isDraggingGroup, toggleIsDraggingGroup] = useToggle(false);
+  const [screenReaderMessage, setScreenReaderMessage] = useState('');
+
   const handleSubmit = useCallback(
     (values: FormValues) => {
       onSubmit({
@@ -50,113 +56,202 @@ const TableHeadersForm = ({
     [onSubmit],
   );
 
+  const handleMoveGroupToOtherAxis = useMemo(
+    () => (
+      sourceId: keyof FormValues,
+      groupIndex: number,
+      form: FormikProps<FormValues>,
+    ) => {
+      const destinationId: keyof FormValues =
+        sourceId === 'rowGroups' ? 'columnGroups' : 'rowGroups';
+
+      const nextSourceValue = [...form.values[sourceId]];
+      const sourceItem = nextSourceValue.splice(groupIndex, 1);
+      const nextDestinationValue = [...form.values[destinationId]].concat(
+        sourceItem,
+      );
+
+      form.setFieldValue(sourceId, nextSourceValue);
+      form.setFieldValue(destinationId, nextDestinationValue);
+      form.setFieldTouched(sourceId);
+      form.setFieldTouched(destinationId);
+
+      const message =
+        sourceId === 'rowGroups'
+          ? ' You have moved the group from row groups to column groups'
+          : 'You have moved the group from column groups to row groups';
+
+      // Clear the message then repopulate to ensure the new message is read,
+      // and only read once.
+      setScreenReaderMessage('');
+      setTimeout(() => {
+        setScreenReaderMessage(message);
+      }, 200);
+    },
+    [],
+  );
+
+  const handleSwitchReorderingType = (
+    axisName: string,
+    reorderingGroups: boolean,
+  ) => {
+    const message = reorderingGroups
+      ? `Re-order ${axisName} selected, click to change to items`
+      : 'Re-order items selected, click to change to groups';
+
+    // Clear the message then repopulate to ensure the new message is read,
+    // and only read once.
+    setScreenReaderMessage('');
+    setTimeout(() => {
+      setScreenReaderMessage(message);
+    }, 200);
+  };
+
   return (
-    <Details summary="Re-order table headers">
-      <p className="govuk-hint">
-        Drag and drop the options below to re-order the table headers. Hold the
-        Ctrl key and click to select multiple items to drag and drop. For
-        keyboard users, select and deselect a draggable item with space and use
-        the arrow keys to move a selected item.
-      </p>
-      <p className="govuk-visually-hidden">
-        To move an item with your keyboard, select or deselect the item with
-        Space and use the Up and Down arrow keys to move the selected item. To
-        move multiple items, you can press Ctrl and Enter to add an item to your
-        selected items. If you are using a screen reader disable scan mode.
-      </p>
+    <>
+      <Details summary="Re-order table headers">
+        <p className="govuk-hint">
+          Drag and drop the options below to re-order the table headers. Hold
+          the Ctrl key and click to select multiple items to drag and drop. For
+          keyboard users, use the Tab key to navigate to items or groups, select
+          and deselect a draggable item with Space and use the Up and Down arrow
+          keys to move a selected item. To move multiple items, you can press
+          Ctrl and Enter to add an item to your selected items.
+        </p>
+        <p className="govuk-visually-hidden">
+          If you are using a screen reader disable scan mode.
+        </p>
+        {isMounted && (
+          <Formik<FormValues>
+            enableReinitialize
+            initialValues={{
+              columnGroups: compact([
+                ...(initialValues?.columnGroups ?? []),
+                initialValues?.columns,
+              ]),
+              rowGroups: compact([
+                ...(initialValues?.rowGroups ?? []),
+                initialValues?.rows,
+              ]),
+            }}
+            validationSchema={Yup.object<FormValues>({
+              rowGroups: Yup.array()
+                .of(Yup.array().of<Filter>(Yup.object()).ensure())
+                .min(1, 'Must have at least one row group'),
+              columnGroups: Yup.array()
+                .of(Yup.array().of<Filter>(Yup.object()).ensure())
+                .min(1, 'Must have at least one column group'),
+            })}
+            onSubmit={handleSubmit}
+          >
+            {form => {
+              return (
+                <Form id={id}>
+                  <DragDropContext
+                    onDragEnd={result => {
+                      toggleIsDraggingGroup.off();
 
-      <Formik<FormValues>
-        enableReinitialize
-        initialValues={{
-          columnGroups: compact([
-            ...(initialValues?.columnGroups ?? []),
-            initialValues?.columns,
-          ]),
-          rowGroups: compact([
-            ...(initialValues?.rowGroups ?? []),
-            initialValues?.rows,
-          ]),
-        }}
-        validationSchema={Yup.object<FormValues>({
-          rowGroups: Yup.array()
-            .of(Yup.array().of<Filter>(Yup.object()).ensure())
-            .min(1, 'Must have at least one row group'),
-          columnGroups: Yup.array()
-            .of(Yup.array().of<Filter>(Yup.object()).ensure())
-            .min(1, 'Must have at least one column group'),
-        })}
-        onSubmit={handleSubmit}
-      >
-        {form => {
-          return (
-            <Form id={id}>
-              <DragDropContext
-                onDragEnd={result => {
-                  const { source, destination } = result;
+                      const { source, destination } = result;
 
-                  if (!destination) {
-                    return;
-                  }
+                      if (!destination) {
+                        return;
+                      }
 
-                  const destinationId = destination.droppableId as keyof FormValues;
-                  const sourceId = source.droppableId as keyof FormValues;
+                      const destinationId = destination.droppableId as keyof FormValues;
+                      const sourceId = source.droppableId as keyof FormValues;
 
-                  if (destinationId === sourceId) {
-                    form.setFieldTouched(destinationId);
-                    form.setFieldValue(
-                      destinationId,
-                      reorder(
-                        form.values[destinationId] as unknown[],
+                      // Moving group within its axis
+                      if (destinationId === sourceId) {
+                        form.setFieldTouched(destinationId);
+                        form.setFieldValue(
+                          destinationId,
+                          reorder(
+                            form.values[destinationId] as unknown[],
+                            source.index,
+                            destination.index,
+                          ),
+                        );
+
+                        return;
+                      }
+
+                      // Moving group to the other axis
+                      const nextSourceValue = [...form.values[sourceId]];
+                      const nextDestinationValue = [
+                        ...form.values[destinationId],
+                      ];
+                      const [sourceItem] = nextSourceValue.splice(
                         source.index,
+                        1,
+                      );
+                      nextDestinationValue.splice(
                         destination.index,
-                      ),
-                    );
+                        0,
+                        sourceItem,
+                      );
 
-                    return;
-                  }
+                      form.setFieldValue(sourceId, nextSourceValue);
+                      form.setFieldValue(destinationId, nextDestinationValue);
+                      form.setFieldTouched(sourceId);
+                      form.setFieldTouched(destinationId);
+                    }}
+                    onDragStart={toggleIsDraggingGroup.on}
+                  >
+                    <FormGroup>
+                      <div className="govuk-!-margin-bottom-2">
+                        <FormFieldSortableListGroup<
+                          PickByType<TableHeadersConfig, Filter[][]>
+                        >
+                          name="columnGroups"
+                          legend="Column groups"
+                          isDraggingGroup={isDraggingGroup}
+                          onChangeReorderingType={handleSwitchReorderingType}
+                          onMoveGroupToOtherAxis={(groupIndex: number) =>
+                            handleMoveGroupToOtherAxis(
+                              'columnGroups',
+                              groupIndex,
+                              form,
+                            )
+                          }
+                        />
+                      </div>
 
-                  const nextSourceValue = [...form.values[sourceId]];
-                  const nextDestinationValue = [...form.values[destinationId]];
+                      <div className="govuk-!-margin-bottom-2">
+                        <FormFieldSortableListGroup<
+                          PickByType<TableHeadersConfig, Filter[][]>
+                        >
+                          name="rowGroups"
+                          legend="Row groups"
+                          isDraggingGroup={isDraggingGroup}
+                          onChangeReorderingType={handleSwitchReorderingType}
+                          onMoveGroupToOtherAxis={(groupIndex: number) =>
+                            handleMoveGroupToOtherAxis(
+                              'rowGroups',
+                              groupIndex,
+                              form,
+                            )
+                          }
+                        />
+                      </div>
+                    </FormGroup>
+                  </DragDropContext>
 
-                  const [sourceItem] = nextSourceValue.splice(source.index, 1);
-                  nextDestinationValue.splice(destination.index, 0, sourceItem);
-
-                  form.setFieldValue(sourceId, nextSourceValue);
-                  form.setFieldValue(destinationId, nextDestinationValue);
-
-                  form.setFieldTouched(sourceId);
-                  form.setFieldTouched(destinationId);
-                }}
-              >
-                <FormGroup>
-                  <div className="govuk-!-margin-bottom-2">
-                    <FormFieldSortableListGroup<
-                      PickByType<TableHeadersConfig, Filter[][]>
-                    >
-                      name="rowGroups"
-                      legend="Row groups"
-                      groupLegend="Row group"
-                    />
-                  </div>
-
-                  <div className="govuk-!-margin-bottom-2">
-                    <FormFieldSortableListGroup<
-                      PickByType<TableHeadersConfig, Filter[][]>
-                    >
-                      name="columnGroups"
-                      legend="Column groups"
-                      groupLegend="Column group"
-                    />
-                  </div>
-                </FormGroup>
-              </DragDropContext>
-
-              <Button type="submit">Re-order table</Button>
-            </Form>
-          );
-        }}
-      </Formik>
-    </Details>
+                  <Button type="submit">Re-order table</Button>
+                </Form>
+              );
+            }}
+          </Formik>
+        )}
+      </Details>
+      <div
+        aria-live="assertive"
+        aria-atomic="true"
+        aria-relevant="additions"
+        className="govuk-visually-hidden"
+      >
+        {screenReaderMessage}
+      </div>
+    </>
   );
 };
 

--- a/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
@@ -7,7 +7,6 @@ Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Local    Dev    Preprod
 
-
 *** Test Cases ***
 Go to Table Tool page
     user navigates to data tables page on public frontend
@@ -129,22 +128,29 @@ Reorder Gender to be column group
     user opens details dropdown    Re-order table headers
     # Column group needs to be inside the viewport
     user scrolls to element    xpath://button[text()="Re-order table"]
-    user sets focus to element    xpath://legend[text()="Row group 1"]/../../..
+    user clicks button    Re-order row groups
+    user clicks button    Move Characteristic group to columns
+
+Reorder Gender to be first of the column groups
+    user clicks button    Re-order column groups
+    user sets focus to element    xpath://legend[text()="Characteristic"]/../../..
     user presses keys    ${SPACE}
-    user presses keys    ARROW_DOWN
     user presses keys    ARROW_LEFT
     user presses keys    ${SPACE}
 
 Reorder Gender male to be second
+    ${columnGroups}=    user gets testid element    columnGroups
+    user clicks button    Re-order items    columnGroups
     # The /../.. to get to a focusable element
-    user sets focus to element    xpath://strong[text()="Gender male"]/../..
+    user sets focus to element    xpath://span[text()="Gender male"]/../..
     user presses keys    ${SPACE}
     user presses keys    ARROW_DOWN
     user presses keys    ${SPACE}
 
 Reorder Authorised absence rate to be last
+    user clicks button    Re-order items
     # The /../.. to get to a focusable element
-    user sets focus to element    xpath://strong[text()="Authorised absence rate"]/../..
+    user sets focus to element    xpath://span[text()="Authorised absence rate"]/../..
     user presses keys    ${SPACE}
     user presses keys    ARROW_DOWN
     user presses keys    ARROW_DOWN
@@ -153,7 +159,7 @@ Reorder Authorised absence rate to be last
 
 Reorder Overall absence rate to be first
     # The /../.. to get to a focusable element
-    user sets focus to element    xpath://strong[text()="Overall absence rate"]/../..
+    user sets focus to element    xpath://span[text()="Overall absence rate"]/../..
     user presses keys    ${SPACE}
     user presses keys    ${SPACE}
     user presses keys    ARROW_UP
@@ -161,7 +167,7 @@ Reorder Overall absence rate to be first
     user presses keys    ${SPACE}
 
 Reorder 2012/13 to be last
-    user sets focus to element    xpath://strong[text()="2012/13"]/../..    # The /../.. to get to a focusable element
+    user sets focus to element    xpath://span[text()="2012/13"]/../..    # The /../.. to get to a focusable element
     user presses keys    ${SPACE}
     user presses keys    ARROW_DOWN
     user presses keys    ARROW_DOWN

--- a/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
@@ -142,7 +142,7 @@ Reorder Gender male to be second
     ${columnGroups}=    user gets testid element    columnGroups
     user clicks button    Re-order items    columnGroups
     # The /../.. to get to a focusable element
-    user sets focus to element    xpath://span[text()="Gender male"]/../..
+    user sets focus to element    xpath://*[text()="Gender male"]/../..    testId:columnGroups
     user presses keys    ${SPACE}
     user presses keys    ARROW_DOWN
     user presses keys    ${SPACE}
@@ -150,7 +150,7 @@ Reorder Gender male to be second
 Reorder Authorised absence rate to be last
     user clicks button    Re-order items
     # The /../.. to get to a focusable element
-    user sets focus to element    xpath://span[text()="Authorised absence rate"]/../..
+    user sets focus to element    xpath://*[text()="Authorised absence rate"]/../..    testId:rowGroups
     user presses keys    ${SPACE}
     user presses keys    ARROW_DOWN
     user presses keys    ARROW_DOWN
@@ -159,7 +159,7 @@ Reorder Authorised absence rate to be last
 
 Reorder Overall absence rate to be first
     # The /../.. to get to a focusable element
-    user sets focus to element    xpath://span[text()="Overall absence rate"]/../..
+    user sets focus to element    xpath://*[text()="Overall absence rate"]/../..    testId:rowGroups
     user presses keys    ${SPACE}
     user presses keys    ${SPACE}
     user presses keys    ARROW_UP
@@ -167,7 +167,8 @@ Reorder Overall absence rate to be first
     user presses keys    ${SPACE}
 
 Reorder 2012/13 to be last
-    user sets focus to element    xpath://span[text()="2012/13"]/../..    # The /../.. to get to a focusable element
+    # The /../.. to get to a focusable element
+    user sets focus to element    xpath://*[text()="2012/13"]/../..    testId:columnGroups
     user presses keys    ${SPACE}
     user presses keys    ARROW_DOWN
     user presses keys    ARROW_DOWN


### PR DESCRIPTION
Fixes two accessibility problems with reordering table headers:

- EES-3015: Nested active focusable elements in table tool reordering
- EES-3026: Instructions provided to screen reader users do not adequately indicate how to access content

Changes:
- only reordering groups or items can be active at once, when groups or items are inactive they don't have the role of button so there aren't nested active elements any more.
- buttons have been added to row & column groups to switch to/from reordering groups, by default reorder items is selected
- added move to rows / columns buttons to groups to make it clearer that you can do this and because moving them to the other axis with the keyboard doesn't work consistently. 
- swapped columns and rows so column groups is at the top
- used names of indicators etc for groups instead of 'row group x'
- changed the drag icon and added it to groups 
- drag and drop was sometimes failing to load correctly on SSR pages (fast tracks) so have put in a mounted check
- updated the help text and added some screen reader announcements.
- removing the nested active elements means that the drag n drop screen reader announcements work.
- I've fixed the width of the groups and made it scroll horizontally if they don't fit, previously they got squashed and could become unusable if there were several groups on a small screen. Note that there is a warning about nested scroll containers not being supported by react-beautiful-dnd but I've not found it to cause any problems.

## Screenshots

![reorderingpr](https://user-images.githubusercontent.com/81572860/170227894-2f68987d-85ca-441c-8213-c6958da700d3.PNG)

