### PR TITLE
EES-3018 focus main content when click go to top in accordion

### DIFF
--- a/src/explore-education-statistics-common/src/components/GoToTopLink.tsx
+++ b/src/explore-education-statistics-common/src/components/GoToTopLink.tsx
@@ -3,7 +3,10 @@ import React, { FunctionComponent } from 'react';
 const GoToTopLink: FunctionComponent = () => {
   return (
     <div className="dfe-print-hidden">
-      <a href="#" className="govuk-link govuk-link--no-visited-state">
+      <a
+        href="#main-content"
+        className="govuk-link govuk-link--no-visited-state"
+      >
         Go to top
       </a>
     </div>

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`AccordionSection renders correctly with required props 1`] = `
       Test content
     </p>
     <div class="dfe-print-hidden">
-      <a href="#"
+      <a href="#main-content"
          class="govuk-link govuk-link--no-visited-state"
       >
         Go to top
@@ -71,7 +71,7 @@ exports[`AccordionSection renders with caption 1`] = `
       Test content
     </p>
     <div class="dfe-print-hidden">
-      <a href="#"
+      <a href="#main-content"
          class="govuk-link govuk-link--no-visited-state"
       >
         Go to top
@@ -110,7 +110,7 @@ exports[`AccordionSection renders with different heading size 1`] = `
       Test content
     </p>
     <div class="dfe-print-hidden">
-      <a href="#"
+      <a href="#main-content"
          class="govuk-link govuk-link--no-visited-state"
       >
         Go to top


### PR DESCRIPTION
Changes the go to top link in accordions to move the focus to the main content anchor when clicked, previously the focus remained on the link when clicked.