### PR TITLE
EES-3388, EES-3392, EES-1868 - migrate test users

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/MigrationConstants.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/MigrationConstants.cs
@@ -3,6 +3,7 @@
     internal static class MigrationConstants
     {
         internal static readonly string ContentMigrationsPath = $"{MigrationsPath}/ContentMigrations";
+        internal static readonly string UsersAndRolesMigrationsPath = $"{MigrationsPath}/UsersAndRolesMigrations";
         private const string MigrationsPath = "Migrations";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20220527101017_EES3388_RenameTestUserEmails.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20220527101017_EES3388_RenameTestUserEmails.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.UsersAndRolesMigrations
 {
     [DbContext(typeof(UsersAndRolesDbContext))]
-    partial class UsersAndRolesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220527101017_EES3388_RenameTestUserEmails")]
+    partial class EES3388_RenameTestUserEmails
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20220527101017_EES3388_RenameTestUserEmails.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20220527101017_EES3388_RenameTestUserEmails.cs
@@ -1,0 +1,24 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.EntityFrameworkCore.Migrations;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Migrations.MigrationConstants;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.UsersAndRolesMigrations;
+
+public partial class EES3388_RenameTestUserEmails : Migration
+{
+    private const string MigrationId = "20220527101017";
+    private const string RenameTestUserEmailsUpsertSqlFile = $"{MigrationId}_EES3388_RenameTestUserEmails_upsert.sql";
+    private const string RenameTestUserEmailsDownSqlFile = $"{MigrationId}_EES3388_RenameTestUserEmails_down.sql";
+    
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.SqlFromFile(UsersAndRolesMigrationsPath, RenameTestUserEmailsUpsertSqlFile);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.SqlFromFile(UsersAndRolesMigrationsPath, RenameTestUserEmailsDownSqlFile);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20220527101017_EES3388_RenameTestUserEmails_down.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20220527101017_EES3388_RenameTestUserEmails_down.sql
@@ -1,0 +1,21 @@
+UPDATE AspNetUsers SET Email = 'ees-bau1@education.gov.uk', NormalizedEmail = 'EES-BAU1@education.gov.uk', UserName = 'ees-bau1@education.gov.uk', NormalizedUserName = 'EES-BAU1@EDUCATION.GOV.UK'  WHERE UserName = 'ees-test.bau1@education.gov.uk';
+UPDATE Users SET Email = 'ees-bau1@education.gov.uk' WHERE Email = 'ees-test.bau1@education.gov.uk';
+UPDATE UserInvites SET Email = 'bau1@azurehiveitco.onmicrosoft.com' WHERE Email = 'ees-test.bau1@education.gov.uk';
+
+
+UPDATE AspNetUsers SET Email = 'ees-bau2@education.gov.uk', NormalizedEmail = 'EES-BAU2@education.gov.uk', UserName = 'ees-bau2@education.gov.uk', NormalizedUserName = 'EES-BAU2@EDUCATION.GOV.UK'  WHERE UserName = 'ees-test.bau2@education.gov.uk';
+UPDATE Users SET Email = 'ees-bau2@education.gov.uk' WHERE Email = 'ees-test.bau2@education.gov.uk';
+UPDATE UserInvites SET Email = 'bau2@azurehiveitco.onmicrosoft.com' WHERE Email = 'ees-test.bau2@education.gov.uk';
+
+UPDATE AspNetUsers SET Email = 'ees-analyst1@education.gov.uk', NormalizedEmail = 'EES-ANALYST1@EDUCATION.GOV.UK', UserName = 'ees-analyst1@education.gov.uk', NormalizedUserName = 'EES-ANALYST1@education.gov.uk'  WHERE UserName = 'ees-test.analyst1@education.gov.uk';
+UPDATE Users SET Email = 'ees-analyst1@education.gov.uk' WHERE Email = 'ees-test.analyst1@education.gov.uk';
+UPDATE UserInvites SET Email = 'analyst1@azurehiveitco.onmicrosoft.com' WHERE Email = 'ees-test.analyst1@education.gov.uk';
+
+UPDATE AspNetUsers SET Email = 'ees-analyst2@education.gov.uk', NormalizedEmail = 'EES-ANALYST2@EDUCATION.GOV.UK', UserName = 'ees-analyst2@education.gov.uk', NormalizedUserName = 'EES-ANALYST2@education.gov.uk'  WHERE UserName = 'ees-test.analyst2@education.gov.uk';
+UPDATE Users SET Email = 'ees-analyst2@education.gov.uk' WHERE Email = 'ees-test.analyst2@education.gov.uk';
+UPDATE UserInvites SET Email = 'analyst2@azurehiveitco.onmicrosoft.com' WHERE Email = 'ees-test.analyst2@education.gov.uk';
+
+
+UPDATE AspNetUsers SET Email = 'ees-analyst3@education.gov.uk', NormalizedEmail = 'EES-ANALYST3@EDUCATION.GOV.UK', UserName = 'ees-analyst3@education.gov.uk', NormalizedUserName = 'EES-ANALYST3@education.gov.uk'  WHERE UserName = 'ees-test.analyst3@education.gov.uk';
+UPDATE Users SET Email = 'ees-analyst3@education.gov.uk' WHERE Email = 'ees-test.analyst3@education.gov.uk';
+UPDATE UserInvites SET Email = 'analyst3@azurehiveitco.onmicrosoft.com' WHERE Email = 'ees-test.analyst3@education.gov.uk';

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20220527101017_EES3388_RenameTestUserEmails_upsert.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20220527101017_EES3388_RenameTestUserEmails_upsert.sql
@@ -1,0 +1,23 @@
+UPDATE AspNetUsers SET Email = 'EES-test.BAU1@education.gov.uk', NormalizedEmail = 'EES-TEST.BAU1@education.gov.uk', UserName = 'ees-test.bau1@education.gov.uk', NormalizedUserName = 'EES-TEST.BAU1@education.gov.uk'  WHERE UserName = 'ees-bau1@education.gov.uk';
+UPDATE Users SET Email = 'ees-test.bau1@education.gov.uk' WHERE Email = 'ees-bau1@education.gov.uk';
+UPDATE UserInvites SET Email = 'ees-test.bau1@education.gov.uk' WHERE Email = 'bau1@azurehiveitco.onmicrosoft.com';
+
+
+UPDATE AspNetUsers SET Email = 'EES-test.BAU2@education.gov.uk', NormalizedEmail = 'EES-TEST.BAU2@education.gov.uk', UserName = 'ees-test.bau2@education.gov.uk', NormalizedUserName = 'EES-TEST.BAU2@education.gov.uk'  WHERE UserName = 'ees-bau2@education.gov.uk';
+UPDATE Users SET Email = 'ees-test.bau2@education.gov.uk' WHERE Email = 'ees-bau2@education.gov.uk';
+UPDATE UserInvites SET Email = 'ees-test.bau2@education.gov.uk' WHERE Email = 'bau2@azurehiveitco.onmicrosoft.com';
+
+
+UPDATE AspNetUsers SET Email = 'EES-test.ANALYST1@education.gov.uk', NormalizedEmail = 'EES-TEST.ANALYST1@education.gov.uk', UserName = 'ees-test.analyst1@education.gov.uk', NormalizedUserName = 'EES-TEST.ANALYST1@education.gov.uk'  WHERE UserName = 'ees-analyst1@education.gov.uk';
+UPDATE Users SET Email = 'ees-test.analyst1@education.gov.uk' WHERE Email = 'ees-analyst1@education.gov.uk';
+UPDATE UserInvites SET Email = 'ees-test.analyst1@education.gov.uk' WHERE Email = 'analyst1@azurehiveitco.onmicrosoft.com';
+
+
+UPDATE AspNetUsers SET Email = 'EES-test.ANALYST2@education.gov.uk', NormalizedEmail = 'EES-TEST.ANALYST2@education.gov.uk', UserName = 'ees-test.analyst2@education.gov.uk', NormalizedUserName = 'EES-TEST.ANALYST2@education.gov.uk'  WHERE UserName = 'ees-analyst2@education.gov.uk';
+UPDATE Users SET Email = 'ees-test.analyst2@education.gov.uk' WHERE Email = 'ees-analyst2@education.gov.uk';
+UPDATE UserInvites SET Email = 'ees-test.analyst2@education.gov.uk' WHERE Email = 'analyst2@azurehiveitco.onmicrosoft.com';
+
+
+UPDATE AspNetUsers SET Email = 'EES-test.ANALYST3@education.gov.uk', NormalizedEmail = 'EES-TEST.ANALYST3@education.gov.uk', UserName = 'ees-test.analyst3@education.gov.uk', NormalizedUserName = 'EES-TEST.ANALYST3@education.gov.uk'  WHERE UserName = 'ees-analyst3@education.gov.uk';
+UPDATE Users SET Email = 'ees-test.analyst3@education.gov.uk' WHERE Email = 'ees-analyst3@education.gov.uk';
+UPDATE UserInvites SET Email = 'ees-test.analyst3@education.gov.uk' WHERE Email = 'analyst3@azurehiveitco.onmicrosoft.com';

--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -4,12 +4,13 @@ import argparse
 import requests
 from bs4 import BeautifulSoup
 
-""" 
+"""
 Script to check find statistics, table tool, methodologies and data catalogue snapshots.
 
 Usage: python create_snapshots.py <public_url>
 by default, the script will run against production
 """
+
 
 def _gets_parsed_html_from_page(url):
     requests.sessions.HTTPAdapter(

--- a/tests/robot-tests/tests/admin/analyst/invite_contributor_as_publication_owner.robot
+++ b/tests/robot-tests/tests/admin/analyst/invite_contributor_as_publication_owner.robot
@@ -30,10 +30,10 @@ Assign various release access permissions to analysts
     user gives release access to analyst    ${PUBLICATION_NAME} - Academic Year 2000/01    Contributor
 
     user gives release access to analyst    ${PUBLICATION_NAME} - Academic Year 2000/01    Contributor
-    ...    ees-analyst3@education.gov.uk
+    ...    EES-test.ANALYST3@education.gov.uk
 
     user gives release access to analyst    ${PUBLICATION_NAME} - Academic Year 2001/02    Contributor
-    ...    ees-analyst2@education.gov.uk
+    ...    EES-test.ANALYST2@education.gov.uk
 
 Switch to analyst1
     user changes to analyst1
@@ -68,7 +68,7 @@ Validate Select release dropdown
 Invite existing user analyst2 to be a contributor for 2002/03 release
     user clicks link    Invite new users
     user waits until page contains    Invite a user to edit ${PUBLICATION_NAME}
-    user enters text into element    id:email    ees-analyst2@education.gov.uk
+    user enters text into element    id:email    EES-test.ANALYST2@education.gov.uk
 
     user checks checkbox is checked    Academic Year 2002/03
     user checks checkbox is checked    Academic Year 2001/02
@@ -85,65 +85,65 @@ Invite existing user analyst2 to be a contributor for 2002/03 release
     user waits until page contains    Update access for release (Academic Year 2002/03)
 
 Validate contributors for 2002/03 release
-    user waits until page contains    Analyst2 User2 (ees-analyst2@education.gov.uk)
+    user waits until page contains    Analyst2 User2 (ees-test.analyst2@education.gov.uk)
 
-    user checks page does not contain    Analyst1 User1 (ees-analyst1@education.gov.uk)
-    user checks page does not contain    Analyst3 User3 (ees-analyst3@education.gov.uk)
+    user checks page does not contain    Analyst1 User1 (ees-test.analyst@education.gov.uk)
+    user checks page does not contain    Analyst3 User3 (ees-test.analyst@education.gov.uk)
     user checks page does not contain    There are no contributors for this release.
 
 Add new contributors to release
     user clicks link    Add or remove users
     user waits until page contains    Manage release contributors (Academic Year 2002/03)
 
-    user checks checkbox is not checked    Analyst1 User1 (ees-analyst1@education.gov.uk)
-    user checks checkbox is checked    Analyst2 User2 (ees-analyst2@education.gov.uk)
-    user checks checkbox is not checked    Analyst3 User3 (ees-analyst3@education.gov.uk)
+    user checks checkbox is not checked    Analyst1 User1 (ees-test.analyst1@education.gov.uk)
+    user checks checkbox is checked    Analyst2 User2 (ees-test.analyst2@education.gov.uk)
+    user checks checkbox is not checked    Analyst3 User3 (ees-test.analyst3@education.gov.uk)
 
-    user clicks checkbox    Analyst1 User1 (ees-analyst1@education.gov.uk)
-    user clicks checkbox    Analyst2 User2 (ees-analyst2@education.gov.uk)
-    user clicks checkbox    Analyst3 User3 (ees-analyst3@education.gov.uk)
+    user clicks checkbox    Analyst1 User1 (ees-test.analyst1@education.gov.uk)
+    user clicks checkbox    Analyst2 User2 (ees-test.analyst2@education.gov.uk)
+    user clicks checkbox    Analyst3 User3 (ees-test.analyst3@education.gov.uk)
 
-    user checks checkbox is checked    Analyst1 User1 (ees-analyst1@education.gov.uk)
-    user checks checkbox is not checked    Analyst2 User2 (ees-analyst2@education.gov.uk)
-    user checks checkbox is checked    Analyst3 User3 (ees-analyst3@education.gov.uk)
+    user checks checkbox is checked    Analyst1 User1 (ees-test.analyst1@education.gov.uk)
+    user checks checkbox is not checked    Analyst2 User2 (ees-test.analyst2@education.gov.uk)
+    user checks checkbox is checked    Analyst3 User3 (ees-test.analyst3@education.gov.uk)
 
     user clicks button    Update contributors
     user waits until page contains    Update access for release (Academic Year 2002/03)
 
 Validate contributors for 2002/03 release again
-    user waits until page contains    Analyst1 User1 (ees-analyst1@education.gov.uk)
-    user checks page contains    Analyst3 User3 (ees-analyst3@education.gov.uk)
+    user waits until page contains    Analyst1 User1 (ees-test.analyst1@education.gov.uk)
+    user checks page contains    Analyst3 User3 (ees-test.analyst3@education.gov.uk)
 
-    user checks page does not contain    Analyst2 User2 (ees-analyst2@education.gov.uk)
+    user checks page does not contain    Analyst2 User2 (ees-test.analyst2@education.gov.uk)
     user checks page does not contain    There are no contributors for this release.
 
 Remove all analyst3 contributor access to publication
-    user clicks remove user button for row    Analyst3 User3 (ees-analyst3@education.gov.uk)
+    user clicks remove user button for row    Analyst3 User3 (ees-test.analyst3@education.gov.uk)
     user waits until modal is visible    Confirm user removal
     user clicks button    Confirm
     user waits until modal is not visible    Confirm user removal
 
 Validate contributors for 2002/03 release for the third time
-    user waits until page does not contain    Analyst3 User3 (ees-analyst3@education.gov.uk)
+    user waits until page does not contain    Analyst3 User3 (ees-test.analyst3@education.gov.uk)
 
-    user waits until page contains    Analyst1 User1 (ees-analyst1@education.gov.uk)
-    user checks page does not contain    Analyst2 User2 (ees-analyst2@education.gov.uk)
+    user waits until page contains    Analyst1 User1 (ees-test.analyst1@education.gov.uk)
+    user checks page does not contain    Analyst2 User2 (ees-test.analyst2@education.gov.uk)
 
 Validate contributors for 2001/02 release
     user chooses select option    id:currentRelease    Academic Year 2001/02
     user waits until page contains    Update access for release (Academic Year 2001/02)
 
-    user waits until page contains    Analyst2 User2 (ees-analyst2@education.gov.uk)
-    user checks page does not contain    Analyst1 User1 (ees-analyst1@education.gov.uk)
-    user checks page does not contain    Analyst3 User3 (ees-analyst3@education.gov.uk)
+    user waits until page contains    Analyst2 User2 (ees-test.analyst2@education.gov.uk)
+    user checks page does not contain    Analyst1 User1 (ees-test.analyst1@education.gov.uk)
+    user checks page does not contain    Analyst3 User3 (ees-test.analyst3@education.gov.uk)
 
 Validate contributors for 2000/01 release
     user chooses select option    id:currentRelease    Academic Year 2000/01
     user waits until page contains    Update access for release (Academic Year 2000/01)
 
-    user waits until page contains    Analyst1 User1 (ees-analyst1@education.gov.uk)
-    user checks page does not contain    Analyst2 User2 (ees-analyst2@education.gov.uk)
-    user checks page does not contain    Analyst3 User3 (ees-analyst3@education.gov.uk)
+    user waits until page contains    Analyst1 User1 (ees-test.analyst1@education.gov.uk)
+    user checks page does not contain    Analyst2 User2 (ees-test.analyst2@education.gov.uk)
+    user checks page does not contain    Analyst3 User3 (ees-test.analyst3@education.gov.uk)
 
 Invite brand new user
     user clicks link    Invite new users
@@ -154,9 +154,9 @@ Invite brand new user
     user waits until page contains    Update access for release (Academic Year 2000/01)
 
 Validate contributors for 2000/01 release again
-    user waits until page contains    Analyst1 User1 (ees-analyst1@education.gov.uk)
-    user checks page does not contain    Analyst2 User2 (ees-analyst2@education.gov.uk)
-    user checks page does not contain    Analyst3 User3 (ees-analyst3@education.gov.uk)
+    user waits until page contains    Analyst1 User1 (ees-test.analyst1@education.gov.uk)
+    user checks page does not contain    Analyst2 User2 (ees-test.analyst2@education.gov.uk)
+    user checks page does not contain    Analyst3 User3 (ees-test.analyst3@education.gov.uk)
     user waits until page contains    ees-analyst-%{RUN_IDENTIFIER}@education.gov.uk    %{WAIT_SMALL}
     user checks page contains tag    Pending Invite
 

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -96,7 +96,7 @@ Validates Release status table is correct
     table cell should contain    css:table    2    2    HigherLevelReview    # Status
     table cell should contain    css:table    2    3    ready for higher review (publication owner)    # Internal note
     table cell should contain    css:table    2    4    1    # Release version
-    table cell should contain    css:table    2    5    ees-analyst1@education.gov.uk    # By user
+    table cell should contain    css:table    2    5    ees-test.analyst1@education.gov.uk    # By user
 
 Check publication owner can edit release status to "In draft"
     user clicks button    Edit release status
@@ -117,14 +117,14 @@ Validates Release status table is correct again
     # Internal note
     table cell should contain    css:table    2    3    Moving back to Draft state (publication owner)
     table cell should contain    css:table    2    4    1    # Release version
-    table cell should contain    css:table    2    5    ees-analyst1@education.gov.uk    # By user
+    table cell should contain    css:table    2    5    ees-test.analyst1@education.gov.uk    # By user
 
     # Higher review row
     table cell should contain    css:table    3    1    ${datetime}    # Date
     table cell should contain    css:table    3    2    HigherLevelReview    # Status
     table cell should contain    css:table    3    3    ready for higher review (publication owner)    # Internal note
     table cell should contain    css:table    3    4    1    # Release version
-    table cell should contain    css:table    3    5    ees-analyst1@education.gov.uk    # By user
+    table cell should contain    css:table    3    5    ees-test.analyst1@education.gov.uk    # By user
 
 Check that a publication owner can make a new release
     user opens publication on the admin dashboard    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -32,25 +32,24 @@ Assert that test users are present in table
     user checks results table row heading contains    3    1    Analyst3 User3
     user checks results table row heading contains    4    1    Bau1 User1
     user checks results table row heading contains    5    1    Bau2 User2
-    user checks results table row heading contains    6    1    Prerelease3 User3
 
-    user checks results table cell contains    1    1    ees-analyst1@education.gov.uk
+    user checks results table cell contains    1    1    EES-test.ANALYST1@education.gov.uk
     user checks results table cell contains    1    2    Analyst
     user checks results table cell contains    1    3    Manage
 
-    user checks results table cell contains    2    1    ees-analyst2@education.gov.uk
+    user checks results table cell contains    2    1    EES-test.ANALYST2@education.gov.uk
     user checks results table cell contains    2    2    Analyst
     user checks results table cell contains    2    3    Manage
 
-    user checks results table cell contains    3    1    ees-analyst3@education.gov.uk
+    user checks results table cell contains    3    1    EES-test.ANALYST3@education.gov.uk
     user checks results table cell contains    3    2    Analyst
     user checks results table cell contains    3    3    Manage
 
-    user checks results table cell contains    4    1    ees-bau1@education.gov.uk
+    user checks results table cell contains    4    1    EES-test.BAU1@education.gov.uk
     user checks results table cell contains    4    2    BAU User
     user checks results table cell contains    4    3    Manage
 
-    user checks results table cell contains    5    1    ees-bau2@education.gov.uk
+    user checks results table cell contains    5    1    EES-test.BAU2@education.gov.uk
     user checks results table cell contains    5    2    BAU User
     user checks results table cell contains    5    3    Manage
 

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -162,7 +162,7 @@ Validate the invite emails field is required
 
 Validate the invite emails field only accepts @education.gov.uk email addresses
     ${emails}=    Catenate    SEPARATOR=\n
-    ...    ees-analyst1@education.gov.uk
+    ...    EES-test.ANALYST1@education.gov.uk
     ...    test@test.com
     user enters text into element    css:textarea[name="emails"]    ${emails}
     user clicks button    Invite new users
@@ -172,7 +172,7 @@ Validate the invite emails field only accepts @education.gov.uk email addresses
 Invite users to the prerelease
     ${emails}=    Catenate    SEPARATOR=\n
     ...    simulate-delivered@notifications.service.gov.uk
-    ...    ees-analyst1@education.gov.uk
+    ...    EES-test.ANALYST1@education.gov.uk
     user enters text into element    css:textarea[name="emails"]    ${emails}
     user clicks button    Invite new users
     ${modal}=    user waits until modal is visible    Confirm pre-release invitations
@@ -181,16 +181,16 @@ Invite users to the prerelease
     user checks list has x items    testid:invitableList    2    ${modal}
     user checks list item contains    testid:invitableList    1    simulate-delivered@notifications.service.gov.uk
     ...    ${modal}
-    user checks list item contains    testid:invitableList    2    ees-analyst1@education.gov.uk    ${modal}
+    user checks list item contains    testid:invitableList    2    EES-test.ANALYST1@education.gov.uk    ${modal}
     user clicks button    Confirm
     user checks table column heading contains    1    1    User email
     user checks results table cell contains    1    1    simulate-delivered@notifications.service.gov.uk
-    user checks results table cell contains    2    1    ees-analyst1@education.gov.uk
+    user checks results table cell contains    2    1    EES-test.ANALYST1@education.gov.uk
 
 Validate the invite emails field is invalid for addresses that are all already invited or accepted
     ${emails}=    Catenate    SEPARATOR=\n
     ...    simulate-delivered@notifications.service.gov.uk
-    ...    ees-analyst1@education.gov.uk
+    ...    EES-test.ANALYST1@education.gov.uk
     user enters text into element    css:textarea[name="emails"]    ${emails}
     user clicks button    Invite new users
     user waits until element contains    id:preReleaseUserAccessForm-emails-error
@@ -201,7 +201,7 @@ Invite a further list of new users but mixed with existing invitees and accepted
     ...    simulate-delivered@notifications.service.gov.uk
     ...    simulate-delivered-2@notifications.service.gov.uk
     ...    simulate-delivered-3@notifications.service.gov.uk
-    ...    ees-analyst1@education.gov.uk
+    ...    EES-test.ANALYST1@education.gov.uk
     user enters text into element    css:textarea[name="emails"]    ${emails}
     user clicks button    Invite new users
     ${modal}=    user waits until modal is visible    Confirm pre-release invitations
@@ -214,7 +214,7 @@ Invite a further list of new users but mixed with existing invitees and accepted
     ...    ${modal}
 
     user checks list has x items    testid:acceptedList    1    ${modal}
-    user checks list item contains    testid:acceptedList    1    ees-analyst1@education.gov.uk    ${modal}
+    user checks list item contains    testid:acceptedList    1    EES-test.ANALYST1@education.gov.uk    ${modal}
 
     user checks list has x items    testid:invitedList    1    ${modal}
     user checks list item contains    testid:invitedList    1    simulate-delivered@notifications.service.gov.uk
@@ -223,7 +223,7 @@ Invite a further list of new users but mixed with existing invitees and accepted
     user clicks button    Confirm
     user checks table column heading contains    1    1    User email
     user checks results table cell contains    1    1    simulate-delivered@notifications.service.gov.uk
-    user checks results table cell contains    2    1    ees-analyst1@education.gov.uk
+    user checks results table cell contains    2    1    EES-test.ANALYST1@education.gov.uk
     user checks results table cell contains    3    1    simulate-delivered-2@notifications.service.gov.uk
     user checks results table cell contains    4    1    simulate-delivered-3@notifications.service.gov.uk
 

--- a/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
@@ -81,7 +81,7 @@ Switch to bau1 to view release
 Check second text block is locked as bau1
     ${block}=    get accordion section block    First content section    2    id:releaseMainContent
     user checks element contains    ${block}
-    ...    Analyst1 User1 (ees-analyst1@education.gov.uk) is currently editing this block
+    ...    Analyst1 User1 (ees-test.analyst1@education.gov.uk) is currently editing this block
     user checks element contains    ${block}    Analyst1 User1 is editing
 
 Switch to analyst1 to save second text block
@@ -155,7 +155,7 @@ Switch to analyst1 to check second text block is locked
     ${block}=    get accordion section block    First content section    2    id:releaseMainContent
 
     user waits until element contains    ${block}
-    ...    Bau1 User1 (ees-bau1@education.gov.uk) is currently editing this block
+    ...    Bau1 User1 (ees-test.bau1@education.gov.uk) is currently editing this block
     user waits until element contains    ${block}    Bau1 User1 is editing
 
 Switch to bau1 to save second text block
@@ -169,14 +169,14 @@ Switch to analyst1 to start resolving comments
     ${block}=    get accordion section block    First content section    1    id:releaseMainContent
 
     user checks element does not contain    ${block}
-    ...    Bau1 User1 (ees-bau1@education.gov.uk) is currently editing this block
+    ...    Bau1 User1 (ees-test.bau1@education.gov.uk) is currently editing this block
     user checks element does not contain    ${block}    Bau1 User1 is editing
 
     # Start resolving comments
     user clicks button    View comments    ${block}
 
     user checks element does not contain    ${block}
-    ...    Analyst1 User1 (ees-analyst1@education.gov.uk) is currently editing this block
+    ...    Analyst1 User1 (ees-test.analyst1@education.gov.uk) is currently editing this block
     user checks element does not contain    ${block}    Analyst1 User1 is editing
 
     # avoid set page view box getting in the way
@@ -187,7 +187,7 @@ Switch to bau1 to check first text block is locked
     ${block}=    get accordion section block    First content section    1    id:releaseMainContent
 
     user waits until element contains    ${block}
-    ...    Analyst1 User1 (ees-analyst1@education.gov.uk) is currently editing this block
+    ...    Analyst1 User1 (ees-test.analyst1@education.gov.uk) is currently editing this block
     user waits until element contains    ${block}    Analyst1 User1 is editing
 
 Switch to analyst1 to resolve comment for first text block
@@ -226,7 +226,7 @@ Switch to bau1 to check first text block is unlocked
     ${block}=    get accordion section block    First content section    1    id:releaseMainContent
 
     user checks element does not contain    ${block}
-    ...    Analyst1 User1 (ees-analyst1@education.gov.uk) is currently editing this block
+    ...    Analyst1 User1 (ees-test.analyst1@education.gov.uk) is currently editing this block
     user checks element does not contain    ${block}    Analyst1 User1 is editing
 
 Switch back to analyst1 to resolve second text block

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -305,7 +305,7 @@ Validate Release status table row is correct
     table cell should contain    css:table    2    2    Approved    # Status
     table cell should contain    css:table    2    3    Approved by UI tests    # Internal note
     table cell should contain    css:table    2    4    1    # Release version
-    table cell should contain    css:table    2    5    ees-bau1@education.gov.uk    # By user
+    table cell should contain    css:table    2    5    ees-test.bau1@education.gov.uk    # By user
 
 Approve release amendment
     user approves amended release for immediate publication

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -667,7 +667,7 @@ user changes methodology status to Draft
     user checks page contains tag    In Draft
 
 user gives analyst publication owner access
-    [Arguments]    ${PUBLICATION_NAME}    ${ANALYST_EMAIL}=ees-analyst1@education.gov.uk
+    [Arguments]    ${PUBLICATION_NAME}    ${ANALYST_EMAIL}=EES-test.ANALYST1@education.gov.uk
     user goes to manage user    ${ANALYST_EMAIL}
     user chooses select option    css:[name="selectedPublicationId"]    ${PUBLICATION_NAME}
     user waits until element is enabled    css:[name="selectedPublicationRole"]
@@ -676,7 +676,7 @@ user gives analyst publication owner access
     user waits until page does not contain loading spinner
 
 user gives release access to analyst
-    [Arguments]    ${RELEASE_NAME}    ${ROLE}    ${ANALYST_EMAIL}=ees-analyst1@education.gov.uk
+    [Arguments]    ${RELEASE_NAME}    ${ROLE}    ${ANALYST_EMAIL}=EES-test.ANALYST1@education.gov.uk
     user goes to manage user    ${ANALYST_EMAIL}
     user scrolls to element    css:[name="selectedReleaseId"]
     user chooses select option    css:[name="selectedReleaseId"]    ${RELEASE_NAME}
@@ -686,7 +686,7 @@ user gives release access to analyst
     user waits until page does not contain loading spinner
 
 user removes publication owner access from analyst
-    [Arguments]    ${PUBLICATION_NAME}    ${ANALYST_EMAIL}=ees-analyst1@education.gov.uk
+    [Arguments]    ${PUBLICATION_NAME}    ${ANALYST_EMAIL}=EES-test.ANALYST1@education.gov.uk
     user goes to manage user    ${ANALYST_EMAIL}
     ${table}=    user gets testid element    publicationAccessTable
     ${row}=    get child element    ${table}
@@ -695,7 +695,7 @@ user removes publication owner access from analyst
     user waits until page does not contain loading spinner
 
 user removes release access from analyst
-    [Arguments]    ${PUBLICATION_NAME}    ${RELEASE_NAME}    ${ROLE}    ${ANALYST_EMAIL}=ees-analyst1@education.gov.uk
+    [Arguments]    ${PUBLICATION_NAME}    ${RELEASE_NAME}    ${ROLE}    ${ANALYST_EMAIL}=EES-test.ANALYST1@education.gov.uk
     user goes to manage user    ${ANALYST_EMAIL}
     ${table}=    user gets testid element    releaseAccessTable
     ${row}=    get child element    ${table}

--- a/tests/robot-tests/tests/libs/tables-common.robot
+++ b/tests/robot-tests/tests/libs/tables-common.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource    ./common.robot
 
+
 *** Keywords ***
 user waits until table is visible
     [Arguments]    ${parent}=css:body    ${wait}=${timeout}

--- a/tests/robot-tests/tests/visual_testing/permalinks.robot
+++ b/tests/robot-tests/tests/visual_testing/permalinks.robot
@@ -4,9 +4,11 @@ Resource    ../libs/charts.robot
 Library     ../libs/visual.py
 Library     tables_and_charts.py
 
+
 *** Variables ***
 ${SNAPSHOT_FOLDER}=         test-results/snapshots/%{RUN_IDENTIFIER}
 ${PERMALINKS_FOLDER}=       permalinks
+
 
 *** Keywords ***
 Check permalink with id

--- a/tests/robot-tests/tests/visual_testing/visually_check_permalinks.dev.robot
+++ b/tests/robot-tests/tests/visual_testing/visually_check_permalinks.dev.robot
@@ -8,6 +8,7 @@ Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
+
 *** Test Cases ***
 Check permalink bd6a1e7e-445a-40be-9a26-82b3cb827efc
     Check permalink with id    bd6a1e7e-445a-40be-9a26-82b3cb827efc

--- a/tests/robot-tests/tests/visual_testing/visually_check_permalinks.template.robot
+++ b/tests/robot-tests/tests/visual_testing/visually_check_permalinks.template.robot
@@ -8,6 +8,7 @@ Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
+
 *** Test Cases ***
 {{test_case_template}}
 

--- a/tests/robot-tests/tests/visual_testing/visually_check_tables_and_charts.seed_data.robot
+++ b/tests/robot-tests/tests/visual_testing/visually_check_tables_and_charts.seed_data.robot
@@ -8,6 +8,7 @@ Suite Setup         do suite setup
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
+
 *** Test Cases ***
 Check release /find-statistics/permanent-and-fixed-period-exclusions-in-england/2016-17
     ${release}=    get release by url    /find-statistics/permanent-and-fixed-period-exclusions-in-england/2016-17
@@ -16,6 +17,7 @@ Check release /find-statistics/permanent-and-fixed-period-exclusions-in-england/
 Check release /find-statistics/pupil-absence-in-schools-in-england/2016-17
     ${release}=    get release by url    /find-statistics/pupil-absence-in-schools-in-england/2016-17
     Check release    ${release}
+
 
 *** Keywords ***
 do suite setup

--- a/tests/robot-tests/tests/visual_testing/visually_check_tables_and_charts.template.robot
+++ b/tests/robot-tests/tests/visual_testing/visually_check_tables_and_charts.template.robot
@@ -8,6 +8,7 @@ Suite Setup         do suite setup
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
+
 *** Test Cases ***
 {{test_case_template}}
 
@@ -16,6 +17,7 @@ Check release {{release_url}}
     Check release    ${release}
 
 {{/test_case_template}}
+
 
 *** Keywords ***
 do suite setup


### PR DESCRIPTION
This PR: 
- migrates test accounts to EES based accounts 
- updates UI tests to use these new accounts 

Other notes/changes
 - Updates to email & password fields in `.env.*` files will have to be made in order to use these new accounts (locally & on development) 

- lints python & robot test files

![image](https://user-images.githubusercontent.com/55030296/171871753-a6c59ff2-01cc-4b24-86ca-a70ee0e54375.png)
