### PR TITLE
EES-3386 Add ability to assign user release roles when inviting a new user

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
@@ -94,7 +94,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     return await service.InviteUser(
                         "test@test.com",
                         Guid.NewGuid().ToString(),
-                        new List<AddUserReleaseRoleViewModel>());
+                        new List<UserReleaseRoleAddViewModel>());
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
@@ -1,10 +1,12 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -91,7 +93,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     var service = SetupUserManagementService(userService: userService.Object);
                     return await service.InviteUser(
                         "test@test.com",
-                        Guid.NewGuid().ToString());
+                        Guid.NewGuid().ToString(),
+                        new List<AddUserReleaseRoleViewModel>());
                 });
         }
 
@@ -127,7 +130,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IEmailTemplateService? emailTemplateService = null,
             IUserRoleService? userRoleService = null,
             IUserService? userService = null,
-            IUserInviteRepository? userInviteRepository = null)
+            IUserInviteRepository? userInviteRepository = null,
+            IUserReleaseInviteRepository? userReleaseInviteRepository = null)
         {
             contentDbContext ??= InMemoryApplicationDbContext();
             usersAndRolesDbContext ??= InMemoryUserAndRolesDbContext();
@@ -139,7 +143,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 emailTemplateService ?? Mock.Of<IEmailTemplateService>(Strict),
                 userRoleService ?? Mock.Of<IUserRoleService>(Strict),
                 userService ?? AlwaysTrueUserService().Object,
-                userInviteRepository ?? new UserInviteRepository(usersAndRolesDbContext)
+                userInviteRepository ?? new UserInviteRepository(usersAndRolesDbContext),
+                userReleaseInviteRepository ?? new UserReleaseInviteRepository(contentDbContext)
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
@@ -121,6 +121,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await service.GetUser(userId);
 
+                VerifyAllMocks(userRoleService);
+
                 Assert.True(result.IsRight);
                 var userViewModel = result.Right;
 
@@ -136,8 +138,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 userRoleService.Verify(mock => mock.GetPublicationRoles(userId), Times.Once);
                 userRoleService.Verify(mock => mock.GetReleaseRoles(userId), Times.Once);
             }
-
-            VerifyAllMocks(userRoleService);
         }
 
         [Fact]
@@ -153,10 +153,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await service.GetUser(Guid.NewGuid());
 
+                VerifyAllMocks(userRoleService);
+
                 result.AssertNotFound();
             }
-
-            VerifyAllMocks(userRoleService);
         }
 
         [Fact]
@@ -196,14 +196,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await service.UpdateUser(user.Id, role.Id);
 
+                VerifyAllMocks(userRoleService);
+
                 Assert.True(result.IsRight);
 
                 userRoleService.Verify(mock => mock.SetGlobalRole(
                         user.Id, role.Id),
                     Times.Once);
             }
-
-            VerifyAllMocks(userRoleService);
         }
 
         [Fact]
@@ -248,7 +248,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await service.InviteUser("test@test.com",
                     role.Id,
-                    new List<AddUserReleaseRoleViewModel>
+                    new List<UserReleaseRoleAddViewModel>
                     {
                         new ()
                         {
@@ -257,13 +257,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         },
                     });
 
+                VerifyAllMocks(emailTemplateService);
+
                 result.AssertRight();
             }
 
             await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
             {
                 var userInvites = usersAndRolesDbContext.UserInvites
-                    .Where(invite => invite.Email == "test@test.com")
                     .ToList();
 
                 var userInvite = Assert.Single(userInvites);
@@ -277,7 +278,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var userReleaseInvites = contentDbContext.UserReleaseInvites
-                    .Where(invite => invite.Email == "test@test.com")
                     .ToList();
 
                 var userReleaseInvite = Assert.Single(userReleaseInvites);
@@ -289,8 +289,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvite.Created).Milliseconds, 0, 1500);
                 Assert.Equal(_createdById, userReleaseInvite.CreatedById);
             }
-
-            VerifyAllMocks(emailTemplateService);
         }
 
         [Fact]
@@ -333,7 +331,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await service.InviteUser("test@test.com",
                     role.Id,
-                    new List<AddUserReleaseRoleViewModel>());
+                    new List<UserReleaseRoleAddViewModel>());
+
+                VerifyAllMocks(emailTemplateService);
 
                 result.AssertRight();
             }
@@ -341,7 +341,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
             {
                 var userInvites = usersAndRolesDbContext.UserInvites
-                    .Where(invite => invite.Email == "test@test.com")
                     .ToList();
                 var userInvite = Assert.Single(userInvites);
                 Assert.Equal("test@test.com", userInvite.Email);
@@ -353,8 +352,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ToList();
                 Assert.Empty(userReleaseInvites);
             }
-
-            VerifyAllMocks(emailTemplateService);
         }
 
         [Fact]
@@ -379,7 +376,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await service.InviteUser("test@test.com",
                     Guid.NewGuid().ToString(),
-                    new List<AddUserReleaseRoleViewModel>());
+                    new List<UserReleaseRoleAddViewModel>());
 
                 var actionResult = result.AssertLeft();
                 actionResult.AssertBadRequest(ValidationErrorMessages.UserAlreadyExists);
@@ -393,7 +390,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await service.InviteUser("test@test.com",
                     Guid.NewGuid().ToString(),
-                    new List<AddUserReleaseRoleViewModel>());
+                    new List<UserReleaseRoleAddViewModel>());
 
                 var actionResult = result.AssertLeft();
                 actionResult.AssertBadRequest(ValidationErrorMessages.InvalidUserRole);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserInvitesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserInvitesController.cs
@@ -40,7 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.UserM
         public async Task<ActionResult<UserInvite>> InviteUser(UserInviteViewModel userInviteViewModel)
         {
             return await _userManagementService
-                .InviteUser(userInviteViewModel.Email, userInviteViewModel.RoleId)
+                .InviteUser(userInviteViewModel.Email, userInviteViewModel.RoleId, userInviteViewModel.UserReleaseRoles)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserManagementController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserManagementController.cs
@@ -63,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.UserM
 
         [HttpPost("users/{userId:guid}/release-role")]
         [ProducesResponseType(200)]
-        public async Task<ActionResult<Unit>> AddReleaseRole(Guid userId, AddReleaseRoleViewModel request)
+        public async Task<ActionResult<Unit>> AddReleaseRole(Guid userId, AddUserReleaseRoleViewModel request)
         {
             return await _userRoleService
                 .AddReleaseRole(userId, request.ReleaseId, request.ReleaseRole)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserManagementController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserManagementController.cs
@@ -63,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.UserM
 
         [HttpPost("users/{userId:guid}/release-role")]
         [ProducesResponseType(200)]
-        public async Task<ActionResult<Unit>> AddReleaseRole(Guid userId, AddUserReleaseRoleViewModel request)
+        public async Task<ActionResult<Unit>> AddReleaseRole(Guid userId, UserReleaseRoleAddViewModel request)
         {
             return await _userRoleService
                 .AddReleaseRole(userId, request.ReleaseId, request.ReleaseRole)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
@@ -21,7 +21,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, List<UserViewModel>>> ListPendingInvites();
 
-        Task<Either<ActionResult, UserInvite>> InviteUser(string email, string roleId);
+        Task<Either<ActionResult, UserInvite>> InviteUser(
+            string email,
+            string roleId,
+            List<AddUserReleaseRoleViewModel> userReleaseRoles);
 
         Task<Either<ActionResult, Unit>> CancelInvite(string email);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
@@ -24,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, UserInvite>> InviteUser(
             string email,
             string roleId,
-            List<AddUserReleaseRoleViewModel> userReleaseRoles);
+            List<UserReleaseRoleAddViewModel> userReleaseRoles);
 
         Task<Either<ActionResult, Unit>> CancelInvite(string email);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -218,7 +218,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, UserInvite>> InviteUser(
             string email,
             string roleId,
-            List<AddUserReleaseRoleViewModel> userReleaseRoles)
+            List<UserReleaseRoleAddViewModel> userReleaseRoles)
         {
             return await _userService
                 .CheckCanManageAllUsers()
@@ -267,7 +267,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     var invite = await _usersAndRolesDbContext.UserInvites
                         .AsQueryable()
-                        .FirstOrDefaultAsync(i => i.Email == email);
+                        .FirstOrDefaultAsync(i => i.Email.ToLower() == email.ToLower());
 
                     if (invite == null)
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -278,6 +278,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     await _usersAndRolesDbContext.SaveChangesAsync();
 
                     return Unit.Instance;
+                })
+                .OnSuccess(async () =>
+                {
+                    var releaseInvites = await _contentDbContext.UserReleaseInvites
+                        .AsQueryable()
+                        .Where(i => i.Email.ToLower() == email.ToLower())
+                        .ToListAsync();
+
+                    _contentDbContext.UserReleaseInvites.RemoveRange(releaseInvites);
+                    await _contentDbContext.SaveChangesAsync();
+
+                    return Unit.Instance;
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/AddUserReleaseRoleViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/AddUserReleaseRoleViewModel.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
-    public class AddReleaseRoleViewModel
+    public class AddUserReleaseRoleViewModel
     {
         public Guid ReleaseId { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserInviteViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserInviteViewModel.cs
@@ -11,6 +11,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         [Required(AllowEmptyStrings = false)]
         public string RoleId { get; set; } = string.Empty;
 
-        public List<AddUserReleaseRoleViewModel> UserReleaseRoles { get; set; } = new();
+        public List<UserReleaseRoleAddViewModel> UserReleaseRoles { get; set; } = new();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserInviteViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserInviteViewModel.cs
@@ -1,6 +1,7 @@
+#nullable enable
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
-#nullable enable
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
     public class UserInviteViewModel
@@ -9,5 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         [Required(AllowEmptyStrings = false)]
         public string RoleId { get; set; } = string.Empty;
+
+        public List<AddUserReleaseRoleViewModel> UserReleaseRoles { get; set; } = new();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserReleaseRoleAddViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserReleaseRoleAddViewModel.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
-    public class AddUserReleaseRoleViewModel
+    public class UserReleaseRoleAddViewModel
     {
         public Guid ReleaseId { get; set; }
 

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -6,7 +6,6 @@ import userService, {
 } from '@admin/services/userService';
 import Button from '@common/components/Button';
 import ButtonText from '@common/components/ButtonText';
-import { FormFieldset } from '@common/components/form';
 import Form from '@common/components/form/Form';
 import FormFieldSelect from '@common/components/form/FormFieldSelect';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
@@ -21,18 +20,19 @@ import { RouteComponentProps } from 'react-router';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import { IdTitlePair } from '@admin/services/types/common';
+import ButtonGroup from '@common/components/ButtonGroup';
+import InviteUserReleaseRoleForm from '@admin/pages/users/components/InviteUserReleaseRoleForm';
+
+export interface InviteUserReleaseRole {
+  releaseId: string;
+  releaseTitle?: string;
+  releaseRole: string;
+}
 
 interface FormValues {
   userEmail: string;
-  selectedRoleId: string;
-  selectedUserReleaseRoles: {
-    releaseId: string;
-    releaseTitle?: string;
-    releaseRole: string;
-  }[];
-
-  selectedReleaseId: string;
-  selectedReleaseRole: string;
+  roleId: string;
+  userReleaseRoles: InviteUserReleaseRole[];
 }
 
 const errorMappings = [
@@ -69,17 +69,15 @@ const UserInvitePage = ({
   const cancelHandler = () => history.push('/administration/users/invites');
 
   const handleSubmit = useFormSubmit<FormValues>(async values => {
-    const userReleaseRoles = values.selectedUserReleaseRoles.map(
-      userReleaseRole => {
-        return {
-          releaseId: userReleaseRole.releaseId,
-          releaseRole: userReleaseRole.releaseRole,
-        };
-      },
-    );
+    const userReleaseRoles = values.userReleaseRoles.map(userReleaseRole => {
+      return {
+        releaseId: userReleaseRole.releaseId,
+        releaseRole: userReleaseRole.releaseRole,
+      };
+    });
     const submission: UserInvite = {
       email: values.userEmail,
-      roleId: values.selectedRoleId,
+      roleId: values.roleId,
       userReleaseRoles,
     };
 
@@ -91,202 +89,85 @@ const UserInvitePage = ({
   return (
     <LoadingSpinner loading={!model || isLoading}>
       <Page
+        title="Invite user"
+        caption="Manage access to this service"
         wide
         breadcrumbs={[
           { name: 'Platform administration', link: '/administration' },
           { name: 'Invites', link: '/administration/users/invites' },
           { name: 'Invite user' },
         ]}
-        title="Invite user"
       >
-        <div className="govuk-grid-row">
-          <div className="govuk-grid-column-two-thirds">
-            <h1 className="govuk-heading-xl">
-              <span className="govuk-caption-xl">
-                Manage access to the service
-              </span>
-              Invite a new user
-            </h1>
-          </div>
-          {/* EES-2464
-         <div className="govuk-grid-column-one-third">
-          <RelatedInformation heading="Help and guidance">
-            <ul className="govuk-list">
-              <li>
-                <Link to="/documentation/" target="blank">
-                  Inviting new users{' '}
-                </Link>
-              </li>
-            </ul>
-          </RelatedInformation>
-        </div> */}
-        </div>
-        {!isLoading && (
-          <Formik<FormValues>
-            enableReinitialize
-            initialValues={{
-              userEmail: '',
-              selectedRoleId:
-                orderBy(model?.roles, role => role.name)?.[0]?.id ?? '',
-              selectedUserReleaseRoles: [],
+        <Formik<FormValues>
+          enableReinitialize
+          initialValues={{
+            userEmail: '',
+            roleId: orderBy(model?.roles, role => role.name)?.[0]?.id ?? '',
+            userReleaseRoles: [],
+          }}
+          validationSchema={Yup.object<FormValues>({
+            userEmail: Yup.string()
+              .required('Provide the users email')
+              .email('Provide a valid email address'),
+            roleId: Yup.string().required('Choose role for the user'),
+            userReleaseRoles: Yup.array(),
+          })}
+          onSubmit={handleSubmit}
+        >
+          {form => {
+            return (
+              <Form id={formId}>
+                <FormFieldTextInput<FormValues>
+                  label="User email"
+                  name="userEmail"
+                  width={20}
+                  hint="The invited user must be on the DfE AAD. Contact explore.statistics@education.gov.uk if unsure."
+                />
 
-              selectedReleaseId: '',
-              selectedReleaseRole: '',
-            }}
-            validationSchema={Yup.object<FormValues>({
-              userEmail: Yup.string()
-                .required('Provide the users email')
-                .email('Provide a valid email address'),
-              selectedRoleId: Yup.string().required('Choose role for the user'),
-              selectedUserReleaseRoles: Yup.array(),
+                <FormFieldSelect<FormValues>
+                  label="Role"
+                  name="roleId"
+                  hint="The user's role within the service."
+                  placeholder="Choose role"
+                  options={model?.roles?.map(role => ({
+                    label: role.name,
+                    value: role.id,
+                  }))}
+                />
 
-              selectedReleaseId: Yup.string(),
-              selectedReleaseRole: Yup.string(),
-            })}
-            onSubmit={handleSubmit}
-          >
-            {form => {
-              return (
-                <Form id={formId}>
-                  <FormFieldset
-                    id="email-fieldset"
-                    legend="Provide the email address for the user"
-                    legendSize="m"
-                    hint="The invited user must have a @education.gov.uk email address"
-                  >
-                    <FormFieldTextInput<FormValues>
-                      label="User email"
-                      name="userEmail"
-                    />
-                  </FormFieldset>
+                <InviteUserReleaseRoleForm
+                  releases={model?.releases}
+                  releaseRoles={model?.resourceRoles.Release}
+                  userReleaseRoles={form.values.userReleaseRoles}
+                  onAddUserReleaseRole={(
+                    newUserReleaseRole: InviteUserReleaseRole,
+                  ) => {
+                    form.setFieldValue('userReleaseRoles', [
+                      ...form.values.userReleaseRoles,
+                      newUserReleaseRole,
+                    ]);
+                  }}
+                  onRemoveUserReleaseRole={(
+                    userReleaseRoleToRemove: InviteUserReleaseRole,
+                  ) => {
+                    form.setFieldValue(
+                      'userReleaseRoles',
+                      form.values.userReleaseRoles.filter(
+                        userReleaseRole =>
+                          userReleaseRoleToRemove !== userReleaseRole,
+                      ),
+                    );
+                  }}
+                />
 
-                  <FormFieldset
-                    id="role-fieldset"
-                    legend="Role"
-                    legendSize="m"
-                    hint="The user's role within the service."
-                  >
-                    <FormFieldSelect<FormValues>
-                      label="Role"
-                      name="selectedRoleId"
-                      placeholder="Choose role"
-                      options={model?.roles?.map(role => ({
-                        label: role.name,
-                        value: role.id,
-                      }))}
-                    />
-                  </FormFieldset>
-
-                  <FormFieldset
-                    id="release-role-fieldset"
-                    legend="Release roles"
-                    legendSize="m"
-                    hint="The user's release roles within the service."
-                  >
-                    <FormFieldSelect
-                      label="Release"
-                      name="selectedReleaseId"
-                      placeholder="Choose release"
-                      options={model?.releases?.map(release => ({
-                        label: release.title,
-                        value: release.id,
-                      }))}
-                    />
-                    <FormFieldSelect
-                      label="Release role"
-                      name="selectedReleaseRole"
-                      placeholder="Choose release role"
-                      options={model?.resourceRoles?.Release?.map(role => ({
-                        label: role,
-                        value: role,
-                      }))}
-                    />
-                    <Button
-                      type="button"
-                      className="govuk-!-margin-top-6"
-                      onClick={() => {
-                        if (
-                          !form.values.selectedUserReleaseRoles.some(
-                            role =>
-                              role.releaseId ===
-                                form.values.selectedReleaseId &&
-                              role.releaseRole ===
-                                form.values.selectedReleaseRole,
-                          )
-                        ) {
-                          const newUserReleaseRole = {
-                            releaseId: form.values.selectedReleaseId,
-                            releaseTitle: model?.releases.filter(
-                              r => r.id === form.values.selectedReleaseId,
-                            )[0].title,
-                            releaseRole: form.values.selectedReleaseRole,
-                          };
-                          form.setFieldValue('selectedUserReleaseRoles', [
-                            ...form.values.selectedUserReleaseRoles,
-                            newUserReleaseRole,
-                          ]);
-                        }
-                      }}
-                    >
-                      Add release role
-                    </Button>
-
-                    {form.values.selectedUserReleaseRoles.length === 0 ? (
-                      <p>No user release roles added</p>
-                    ) : (
-                      <table>
-                        <thead>
-                          <tr>
-                            <th scope="col">Release Title</th>
-                            <th scope="col">Release Role</th>
-                            <th scope="col">Options</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {form.values.selectedUserReleaseRoles.map(
-                            selectedUserReleaseRole => (
-                              <tr
-                                key={`${selectedUserReleaseRole.releaseId}${selectedUserReleaseRole.releaseRole}`}
-                              >
-                                <td>{selectedUserReleaseRole.releaseTitle}</td>
-                                <td>{selectedUserReleaseRole.releaseRole}</td>
-                                <td>
-                                  <Button
-                                    onClick={() => {
-                                      form.setFieldValue(
-                                        'selectedUserReleaseRoles',
-                                        form.values.selectedUserReleaseRoles.filter(
-                                          userReleaseRole =>
-                                            userReleaseRole.releaseId !==
-                                              selectedUserReleaseRole.releaseId ||
-                                            userReleaseRole.releaseRole !==
-                                              selectedUserReleaseRole.releaseRole,
-                                        ),
-                                      );
-                                    }}
-                                  >
-                                    Remove
-                                  </Button>
-                                </td>
-                              </tr>
-                            ),
-                          )}
-                        </tbody>
-                      </table>
-                    )}
-                  </FormFieldset>
-
-                  <Button type="submit" className="govuk-!-margin-top-6">
-                    Send invite
-                  </Button>
-                  <div className="govuk-!-margin-top-6">
-                    <ButtonText onClick={cancelHandler}>Cancel</ButtonText>
-                  </div>
-                </Form>
-              );
-            }}
-          </Formik>
-        )}
+                <ButtonGroup className="govuk-!-margin-top-6">
+                  <Button type="submit">Send invite</Button>
+                  <ButtonText onClick={cancelHandler}>Cancel</ButtonText>
+                </ButtonGroup>
+              </Form>
+            );
+          }}
+        </Formik>
       </Page>
     </LoadingSpinner>
   );

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -1,5 +1,9 @@
 import Page from '@admin/components/Page';
-import userService, { Role, UserInvite } from '@admin/services/userService';
+import userService, {
+  ResourceRoles,
+  Role,
+  UserInvite,
+} from '@admin/services/userService';
 import Button from '@common/components/Button';
 import ButtonText from '@common/components/ButtonText';
 import { FormFieldset } from '@common/components/form';
@@ -12,12 +16,23 @@ import { mapFieldErrors } from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
 import orderBy from 'lodash/orderBy';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { RouteComponentProps } from 'react-router';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import { IdTitlePair } from '@admin/services/types/common';
 
 interface FormValues {
   userEmail: string;
   selectedRoleId: string;
+  selectedUserReleaseRoles: {
+    releaseId: string;
+    releaseTitle?: string;
+    releaseRole: string;
+  }[];
+
+  selectedReleaseId: string;
+  selectedReleaseRole: string;
 }
 
 const errorMappings = [
@@ -31,28 +46,41 @@ const errorMappings = [
 
 interface InviteUserModel {
   roles: Role[];
+  resourceRoles: ResourceRoles;
+  releases: IdTitlePair[];
 }
 
 const UserInvitePage = ({
   history,
 }: RouteComponentProps & ErrorControlState) => {
-  const [model, setModel] = useState<InviteUserModel>();
   const formId = 'inviteUserForm';
 
-  useEffect(() => {
-    userService.getRoles().then(roles => {
-      setModel({
-        roles,
-      });
-    });
+  const { value: model, isLoading } = useAsyncHandledRetry<
+    InviteUserModel
+  >(async () => {
+    const [roles, resourceRoles, releases] = await Promise.all([
+      userService.getRoles(),
+      userService.getResourceRoles(),
+      userService.getReleases(),
+    ]);
+    return { roles, resourceRoles, releases };
   }, []);
 
   const cancelHandler = () => history.push('/administration/users/invites');
 
   const handleSubmit = useFormSubmit<FormValues>(async values => {
+    const userReleaseRoles = values.selectedUserReleaseRoles.map(
+      userReleaseRole => {
+        return {
+          releaseId: userReleaseRole.releaseId,
+          releaseRole: userReleaseRole.releaseRole,
+        };
+      },
+    );
     const submission: UserInvite = {
       email: values.userEmail,
       roleId: values.selectedRoleId,
+      userReleaseRoles,
     };
 
     await userService.inviteUser(submission);
@@ -61,25 +89,26 @@ const UserInvitePage = ({
   }, errorMappings);
 
   return (
-    <Page
-      wide
-      breadcrumbs={[
-        { name: 'Platform administration', link: '/administration' },
-        { name: 'Invites', link: '/administration/users/invites' },
-        { name: 'Invite user' },
-      ]}
-      title="Invite user"
-    >
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds">
-          <h1 className="govuk-heading-xl">
-            <span className="govuk-caption-xl">
-              Manage access to the service
-            </span>
-            Invite a new user
-          </h1>
-        </div>
-        {/* EES-2464
+    <LoadingSpinner loading={!model || isLoading}>
+      <Page
+        wide
+        breadcrumbs={[
+          { name: 'Platform administration', link: '/administration' },
+          { name: 'Invites', link: '/administration/users/invites' },
+          { name: 'Invite user' },
+        ]}
+        title="Invite user"
+      >
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-two-thirds">
+            <h1 className="govuk-heading-xl">
+              <span className="govuk-caption-xl">
+                Manage access to the service
+              </span>
+              Invite a new user
+            </h1>
+          </div>
+          {/* EES-2464
          <div className="govuk-grid-column-one-third">
           <RelatedInformation heading="Help and guidance">
             <ul className="govuk-list">
@@ -91,67 +120,175 @@ const UserInvitePage = ({
             </ul>
           </RelatedInformation>
         </div> */}
-      </div>
-      {model && (
-        <Formik<FormValues>
-          enableReinitialize
-          initialValues={{
-            userEmail: '',
-            selectedRoleId:
-              orderBy(model.roles, role => role.name)?.[0]?.id ?? '',
-          }}
-          validationSchema={Yup.object<FormValues>({
-            userEmail: Yup.string()
-              .required('Provide the users email')
-              .email('Provide a valid email address'),
-            selectedRoleId: Yup.string().required('Choose role for the user'),
-          })}
-          onSubmit={handleSubmit}
-        >
-          {() => {
-            return (
-              <Form id={formId}>
-                <FormFieldset
-                  id="email-fieldset"
-                  legend="Provide the email address for the user"
-                  legendSize="m"
-                  hint="The invited user must have a @education.gov.uk email address"
-                >
-                  <FormFieldTextInput<FormValues>
-                    label="User email"
-                    name="userEmail"
-                  />
-                </FormFieldset>
+        </div>
+        {!isLoading && (
+          <Formik<FormValues>
+            enableReinitialize
+            initialValues={{
+              userEmail: '',
+              selectedRoleId:
+                orderBy(model?.roles, role => role.name)?.[0]?.id ?? '',
+              selectedUserReleaseRoles: [],
 
-                <FormFieldset
-                  id="role-fieldset"
-                  legend="Role"
-                  legendSize="m"
-                  hint="The users' role within the service."
-                >
-                  <FormFieldSelect<FormValues>
-                    label="Role"
-                    name="selectedRoleId"
-                    placeholder="Choose role"
-                    options={model?.roles.map(role => ({
-                      label: role.name,
-                      value: role.id,
-                    }))}
-                  />
-                </FormFieldset>
+              selectedReleaseId: '',
+              selectedReleaseRole: '',
+            }}
+            validationSchema={Yup.object<FormValues>({
+              userEmail: Yup.string()
+                .required('Provide the users email')
+                .email('Provide a valid email address'),
+              selectedRoleId: Yup.string().required('Choose role for the user'),
+              selectedUserReleaseRoles: Yup.array(),
 
-                <Button type="submit" className="govuk-!-margin-top-6">
-                  Send invite
-                </Button>
-                <div className="govuk-!-margin-top-6">
-                  <ButtonText onClick={cancelHandler}>Cancel</ButtonText>
-                </div>
-              </Form>
-            );
-          }}
-        </Formik>
-      )}
-    </Page>
+              selectedReleaseId: Yup.string(),
+              selectedReleaseRole: Yup.string(),
+            })}
+            onSubmit={handleSubmit}
+          >
+            {form => {
+              return (
+                <Form id={formId}>
+                  <FormFieldset
+                    id="email-fieldset"
+                    legend="Provide the email address for the user"
+                    legendSize="m"
+                    hint="The invited user must have a @education.gov.uk email address"
+                  >
+                    <FormFieldTextInput<FormValues>
+                      label="User email"
+                      name="userEmail"
+                    />
+                  </FormFieldset>
+
+                  <FormFieldset
+                    id="role-fieldset"
+                    legend="Role"
+                    legendSize="m"
+                    hint="The user's role within the service."
+                  >
+                    <FormFieldSelect<FormValues>
+                      label="Role"
+                      name="selectedRoleId"
+                      placeholder="Choose role"
+                      options={model?.roles?.map(role => ({
+                        label: role.name,
+                        value: role.id,
+                      }))}
+                    />
+                  </FormFieldset>
+
+                  <FormFieldset
+                    id="release-role-fieldset"
+                    legend="Release roles"
+                    legendSize="m"
+                    hint="The user's release roles within the service."
+                  >
+                    <FormFieldSelect
+                      label="Release"
+                      name="selectedReleaseId"
+                      placeholder="Choose release"
+                      options={model?.releases?.map(release => ({
+                        label: release.title,
+                        value: release.id,
+                      }))}
+                    />
+                    <FormFieldSelect
+                      label="Release role"
+                      name="selectedReleaseRole"
+                      placeholder="Choose release role"
+                      options={model?.resourceRoles?.Release?.map(role => ({
+                        label: role,
+                        value: role,
+                      }))}
+                    />
+                    <Button
+                      type="button"
+                      className="govuk-!-margin-top-6"
+                      onClick={() => {
+                        if (
+                          !form.values.selectedUserReleaseRoles.some(
+                            role =>
+                              role.releaseId ===
+                                form.values.selectedReleaseId &&
+                              role.releaseRole ===
+                                form.values.selectedReleaseRole,
+                          )
+                        ) {
+                          const newUserReleaseRole = {
+                            releaseId: form.values.selectedReleaseId,
+                            releaseTitle: model?.releases.filter(
+                              r => r.id === form.values.selectedReleaseId,
+                            )[0].title,
+                            releaseRole: form.values.selectedReleaseRole,
+                          };
+                          form.setFieldValue('selectedUserReleaseRoles', [
+                            ...form.values.selectedUserReleaseRoles,
+                            newUserReleaseRole,
+                          ]);
+                        }
+                      }}
+                    >
+                      Add release role
+                    </Button>
+
+                    {form.values.selectedUserReleaseRoles.length === 0 ? (
+                      <p>No user release roles added</p>
+                    ) : (
+                      <table>
+                        <thead>
+                          <tr>
+                            <th scope="col">Release Title</th>
+                            <th scope="col">Release Role</th>
+                            <th scope="col">Options</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {form.values.selectedUserReleaseRoles.map(
+                            selectedUserReleaseRole => (
+                              <tr
+                                key={`${selectedUserReleaseRole.releaseId}${selectedUserReleaseRole.releaseRole}`}
+                              >
+                                <td>{selectedUserReleaseRole.releaseTitle}</td>
+                                <td>{selectedUserReleaseRole.releaseRole}</td>
+                                <td>
+                                  <Button
+                                    onClick={() => {
+                                      form.setFieldValue(
+                                        'selectedUserReleaseRoles',
+                                        form.values.selectedUserReleaseRoles.filter(
+                                          userReleaseRole =>
+                                            userReleaseRole.releaseId !==
+                                              selectedUserReleaseRole.releaseId ||
+                                            userReleaseRole.releaseRole !==
+                                              selectedUserReleaseRole.releaseRole,
+                                        ),
+                                      );
+                                    }}
+                                  >
+                                    Remove
+                                  </Button>
+                                </td>
+                              </tr>
+                            ),
+                          )}
+                        </tbody>
+                      </table>
+                    )}
+                  </FormFieldset>
+
+                  <Button type="submit" className="govuk-!-margin-top-6">
+                    Send invite
+                  </Button>
+                  <div className="govuk-!-margin-top-6">
+                    <ButtonText onClick={cancelHandler}>Cancel</ButtonText>
+                  </div>
+                </Form>
+              );
+            }}
+          </Formik>
+        )}
+      </Page>
+    </LoadingSpinner>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/users/components/InviteUserReleaseRoleForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/InviteUserReleaseRoleForm.tsx
@@ -1,0 +1,140 @@
+import Button from '@common/components/Button';
+import { FormFieldSelect, FormFieldset } from '@common/components/form';
+import Yup from '@common/validation/yup';
+import { Formik } from 'formik';
+import React, { useMemo } from 'react';
+import { IdTitlePair } from '@admin/services/types/common';
+import { InviteUserReleaseRole } from '@admin/pages/users/UserInvitePage';
+import ButtonText from '@common/components/ButtonText';
+import { keyBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
+
+interface FormValues {
+  releaseId: string;
+  releaseRole: string;
+}
+
+interface Props {
+  releases?: IdTitlePair[];
+  releaseRoles?: string[];
+  userReleaseRoles: InviteUserReleaseRole[];
+  onAddUserReleaseRole: (userReleaseRole: InviteUserReleaseRole) => void;
+  onRemoveUserReleaseRole: (userReleaseRole: InviteUserReleaseRole) => void;
+}
+
+const InviteUserReleaseRoleForm = ({
+  releases,
+  releaseRoles,
+  userReleaseRoles,
+  onAddUserReleaseRole,
+  onRemoveUserReleaseRole,
+}: Props) => {
+  const releaseTitlesById = useMemo(() => {
+    return keyBy(releases, release => release.id);
+  }, [releases]);
+
+  return (
+    <Formik<FormValues>
+      enableReinitialize
+      initialValues={{
+        releaseId: '',
+        releaseRole: '',
+      }}
+      validationSchema={Yup.object<FormValues>({
+        releaseId: Yup.string()
+          .required('Choose release to give the user access to')
+          .test(
+            'uniqueReleaseRole',
+            'You can only add one role for each release',
+            function uniqueReleaseRole(releaseId: string) {
+              return !userReleaseRoles.some(
+                userReleaseRole => userReleaseRole.releaseId === releaseId,
+              );
+            },
+          ),
+        releaseRole: Yup.string().required('Choose release role for the user'),
+      })}
+      onSubmit={newUserReleaseRole => onAddUserReleaseRole(newUserReleaseRole)}
+    >
+      {form => {
+        return (
+          <FormFieldset
+            id="release-roles"
+            legend="Release roles"
+            legendSize="m"
+            hint="The user's release roles within the service."
+          >
+            <FormFieldSelect<FormValues>
+              label="Release"
+              name="releaseId"
+              placeholder="Choose release"
+              options={releases?.map(release => ({
+                label: release.title,
+                value: release.id,
+              }))}
+            />
+            <FormFieldSelect<FormValues>
+              label="Release role"
+              name="releaseRole"
+              placeholder="Choose release role"
+              options={releaseRoles?.map(role => ({
+                label: role,
+                value: role,
+              }))}
+            />
+            <Button
+              type="button"
+              className="govuk-!-margin-top-6"
+              onClick={async () => {
+                await form.submitForm();
+              }}
+            >
+              Add release role
+            </Button>
+
+            {userReleaseRoles.length === 0 ? (
+              <p>No user release roles added</p>
+            ) : (
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Release Title</th>
+                    <th scope="col">Release Role</th>
+                    <th scope="col">Options</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {orderBy(
+                    userReleaseRoles,
+                    userReleaseRole =>
+                      releaseTitlesById[userReleaseRole.releaseId].title,
+                  ).map(userReleaseRole => (
+                    <tr
+                      key={`${userReleaseRole.releaseId}_${userReleaseRole.releaseRole}`}
+                    >
+                      <td>
+                        {releaseTitlesById[userReleaseRole.releaseId].title}
+                      </td>
+                      <td>{userReleaseRole.releaseRole}</td>
+                      <td>
+                        <ButtonText
+                          onClick={() => {
+                            onRemoveUserReleaseRole(userReleaseRole);
+                          }}
+                        >
+                          Remove
+                        </ButtonText>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </FormFieldset>
+        );
+      }}
+    </Formik>
+  );
+};
+
+export default InviteUserReleaseRoleForm;

--- a/src/explore-education-statistics-admin/src/services/userService.ts
+++ b/src/explore-education-statistics-admin/src/services/userService.ts
@@ -43,6 +43,7 @@ export interface UserPublicationRoleSubmission {
 export interface UserInvite {
   email: string;
   roleId: string;
+  userReleaseRoles: { releaseId: string; releaseRole: string }[];
 }
 
 export interface UserUpdate {


### PR DESCRIPTION
This work allows a BAU user to assign user release roles when inviting a new user. These user release roles are then created when the user logs in the for the first time.

This work also ensures that if a pending invite is cancelled, any associated user release role invites are also cancelled.

Additional work to change the invite email text to include the user release roles they've been invited to (EES-3403) and listing the user release roles of pending invites on the Pending user invites page (EES-3404) will be done in separate PRs.