### PR TITLE
EES-3394 - updated prods db size from 350GB to 450GB

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -78,7 +78,7 @@
       "value": 2147483648
     },
     "maxStatsDbSizeBytes": {
-      "value": 375809638400
+      "value": 483183820800
     }
   }
 }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -899,6 +899,17 @@
         "criterionType": "StaticThresholdCriterion"
       },
       {
+        "name": "[concat(parameters('subscription'),'PubStatsDBDataSpaceUsedPercentUrgent')]",
+        "description": "Public Statistics DB Data Space Used Percentage - URGENT",
+        "resourceId": "[resourceId('Microsoft.Sql/servers/databases', variables('publicSqlServerName'), 'public-statistics')]",
+        "resourceType": "microsoft.sql/servers/databases",
+        "metricName": "storage_percent",
+        "threshold": 95,
+        "operator": "GreaterThan",
+        "timeAggregation": "Maximum",
+        "criterionType": "StaticThresholdCriterion"
+      },
+      {
         "name": "[concat(parameters('subscription'),'PubStatsDBBlockedByFirewall')]",
         "description": "Public Statistics DB Blocked By Firewall",
         "resourceId": "[resourceId('Microsoft.Sql/servers/databases', variables('publicSqlServerName'), 'public-statistics')]",
@@ -965,6 +976,17 @@
         "criterionType": "StaticThresholdCriterion"
       },
       {
+        "name": "[concat(parameters('subscription'),'StatsDBDataSpaceUsedPercentUrgent')]",
+        "description": "Statistics DB Data Space Used Percentage - URGENT",
+        "resourceId": "[resourceId('Microsoft.Sql/servers/databases', variables('sqlServerName'), 'statistics')]",
+        "resourceType": "microsoft.sql/servers/databases",
+        "metricName": "storage_percent",
+        "threshold": 95,
+        "operator": "GreaterThan",
+        "timeAggregation": "Maximum",
+        "criterionType": "StaticThresholdCriterion"
+      },
+      {
         "name": "[concat(parameters('subscription'),'StatsDBBlockedByFirewall')]",
         "description": "Statistics DB Blocked By Firewall",
         "resourceId": "[resourceId('Microsoft.Sql/servers/databases', variables('sqlServerName'), 'statistics')]",
@@ -1026,6 +1048,17 @@
         "resourceType": "microsoft.sql/servers/databases",
         "metricName": "storage_percent",
         "threshold": 85,
+        "operator": "GreaterThan",
+        "timeAggregation": "Maximum",
+        "criterionType": "StaticThresholdCriterion"
+      },
+      {
+        "name": "[concat(parameters('subscription'),'ContentDBDataSpaceUsedPercentUrgent')]",
+        "description": "Content DB Data Space Used Percentage - URGENT",
+        "resourceId": "[resourceId('Microsoft.Sql/servers/databases', variables('sqlServerName'), 'content')]",
+        "resourceType": "microsoft.sql/servers/databases",
+        "metricName": "storage_percent",
+        "threshold": 95,
         "operator": "GreaterThan",
         "timeAggregation": "Maximum",
         "criterionType": "StaticThresholdCriterion"

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -893,7 +893,7 @@
         "resourceId": "[resourceId('Microsoft.Sql/servers/databases', variables('publicSqlServerName'), 'public-statistics')]",
         "resourceType": "microsoft.sql/servers/databases",
         "metricName": "storage_percent",
-        "threshold": 90,
+        "threshold": 85,
         "operator": "GreaterThan",
         "timeAggregation": "Maximum",
         "criterionType": "StaticThresholdCriterion"
@@ -959,7 +959,7 @@
         "resourceId": "[resourceId('Microsoft.Sql/servers/databases', variables('sqlServerName'), 'statistics')]",
         "resourceType": "microsoft.sql/servers/databases",
         "metricName": "storage_percent",
-        "threshold": 90,
+        "threshold": 85,
         "operator": "GreaterThan",
         "timeAggregation": "Maximum",
         "criterionType": "StaticThresholdCriterion"
@@ -1025,7 +1025,7 @@
         "resourceId": "[resourceId('Microsoft.Sql/servers/databases', variables('sqlServerName'), 'content')]",
         "resourceType": "microsoft.sql/servers/databases",
         "metricName": "storage_percent",
-        "threshold": 90,
+        "threshold": 85,
         "operator": "GreaterThan",
         "timeAggregation": "Maximum",
         "criterionType": "StaticThresholdCriterion"


### PR DESCRIPTION
This PR:
- ups Prod's private Stats DB's capacity from 350GB to 450GB.
- reduces user space warning thresholds from 90% to 85% to allow for 70GB wiggle room in Stats DB for doing reindexing jobs (based on max historical space needed for doing these jobs)
- introduces a second set of used space alerts with "URGENT" in the title for triggering alerts when used space reaches 95%. 