### PR TITLE
EES-3022 improve tabs accessibility

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
@@ -37,7 +37,7 @@ const ReleaseHeadlines = ({ release }: Props) => {
   }, [actions, release.id, release.headlinesSection.id]);
 
   const headlinesTab = (
-    <TabsSection title="Headlines">
+    <TabsSection title="Summary">
       <section id="releaseHeadlines-keyStatistics">
         <KeyStatistics release={release} isEditing={editingMode === 'edit'} />
       </section>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
@@ -9,7 +9,7 @@ import _dataBlockService, {
 import _tableBuilderService, {
   Subject,
 } from '@common/services/tableBuilderService';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import noop from 'lodash/noop';
 import React from 'react';
@@ -93,11 +93,16 @@ describe('DataBlockPageTabs', () => {
         'Step 1 (current) Choose a subject',
       );
 
-      expect(screen.getAllByRole('listitem')).toHaveLength(1);
+      expect(screen.getByTestId('wizardStep-1')).toBeVisible();
+      expect(screen.getByTestId('wizardStep-2')).not.toBeVisible();
 
       const radios = screen.getAllByRole('radio');
       expect(radios).toHaveLength(1);
-      expect(radios[0]).toEqual(screen.getByLabelText('Test subject'));
+      expect(radios[0]).toEqual(
+        within(screen.getByTestId('wizardStep-1')).getByLabelText(
+          'Test subject',
+        ),
+      );
     });
   });
 
@@ -107,7 +112,7 @@ describe('DataBlockPageTabs', () => {
     render(<DataBlockPageTabs releaseId="release-1" onDataBlockSave={noop} />);
 
     await waitFor(() => {
-      const tabs = screen.getAllByRole('tab');
+      const tabs = screen.getAllByRole('tab', { hidden: true });
 
       expect(tabs).toHaveLength(1);
       expect(tabs[0]).toHaveTextContent('Data source');

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
@@ -112,7 +112,7 @@ describe('ReleasePreReleaseAccessPage', () => {
       screen.queryByRole('tab', { name: 'Pre-release users' }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole('tab', { name: 'Public access list' }),
+      screen.getByRole('tab', { name: 'Public access list', hidden: true }),
     ).toBeInTheDocument();
   });
 

--- a/src/explore-education-statistics-common/src/components/Tabs.module.scss
+++ b/src/explore-education-statistics-common/src/components/Tabs.module.scss
@@ -1,3 +1,5 @@
+@import '~govuk-frontend/govuk/base';
+
 .tabs {
   @media print {
     :global(.govuk-tabs__list) {
@@ -11,5 +13,12 @@
     :global(.govuk-tabs__tab) {
       display: none;
     }
+  }
+}
+
+.mobileHidden {
+  display: none;
+  @include govuk-media-query($from: tablet) {
+    display: block;
   }
 }

--- a/src/explore-education-statistics-common/src/components/TabsSection.tsx
+++ b/src/explore-education-statistics-common/src/components/TabsSection.tsx
@@ -17,15 +17,17 @@ export const classes = {
 
 export interface TabsSectionProps {
   children: ReactNode;
+  hasSiblings?: boolean;
   id?: string;
   /**
    * Set to true if children should not be
    * rendered until tab has been selected.
    */
   lazy?: boolean;
-  title: string;
   headingTitle?: string;
   headingTag?: 'h2' | 'h3' | 'h4';
+  tabLabel?: ReactNode;
+  title: string;
 }
 
 const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
@@ -35,6 +37,7 @@ const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
       id,
       headingTitle = '',
       headingTag = 'h3',
+      hasSiblings,
       lazy,
       ...restProps
     }: TabsSectionProps,
@@ -56,14 +59,16 @@ const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
 
     return hasRendered ? (
       <section
-        aria-labelledby={onMedia(tabProps['aria-labelledby'])}
+        aria-labelledby={
+          hasSiblings ? onMedia(tabProps['aria-labelledby']) : undefined
+        }
         hidden={hidden}
         className={classNames(classes.panel, styles.panel, {
           [styles.panelHidden]: hidden,
         })}
         id={id}
         ref={ref}
-        role={onMedia('tabpanel')}
+        role={hasSiblings ? onMedia('tabpanel') : undefined}
         tabIndex={onMedia(-1)}
       >
         {headingTitle && createElement(headingTag, null, headingTitle)}

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Tabs renders multiple tabs correctly with titles 1`] = `
     id="test-tabs"
   >
     <ul
+      aria-hidden="false"
       class="govuk-tabs__list"
       role="tablist"
     >
@@ -82,6 +83,7 @@ exports[`Tabs renders multiple tabs correctly without titles 1`] = `
     id="test-tabs"
   >
     <ul
+      aria-hidden="false"
       class="govuk-tabs__list"
       role="tablist"
     >
@@ -146,14 +148,15 @@ exports[`Tabs renders multiple tabs correctly without titles 1`] = `
 </div>
 `;
 
-exports[`Tabs renders single tab correctly 1`] = `
+exports[`Tabs renders with aria-hidden tabs when there is only one section 1`] = `
 <div>
   <div
     class="govuk-tabs tabs"
     id="test-tabs"
   >
     <ul
-      class="govuk-tabs__list"
+      aria-hidden="true"
+      class="govuk-tabs__list mobileHidden"
       role="tablist"
     >
       <li
@@ -173,14 +176,12 @@ exports[`Tabs renders single tab correctly 1`] = `
       </li>
     </ul>
     <section
-      aria-labelledby="test-tabs-1-tab"
       class="govuk-tabs__panel panel"
       id="test-tabs-1"
-      role="tabpanel"
       tabindex="-1"
     >
       <h3>
-        Tab 1
+        Tab Heading 1
       </h3>
       <p>
         Test section 1 content

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -55,14 +55,24 @@ const DataBlockTabs = ({
     typeof additionalTabContent === 'function'
       ? additionalTabContent({ dataBlock })
       : additionalTabContent;
-
   return (
     <LoadingSpinner loading={isLoading}>
       <Tabs id={id} testId={testId(dataBlock)} onToggle={onToggle}>
         {firstTabs}
 
-        {dataBlock.charts?.length && (
-          <TabsSection id={`${id}-charts`} title="Chart">
+        {!!dataBlock.charts?.length && (
+          <TabsSection
+            id={`${id}-charts`}
+            tabLabel={
+              <>
+                Chart
+                <span className="govuk-visually-hidden">
+                  {` for ${dataBlock.charts[0].title}`}
+                </span>
+              </>
+            }
+            title="Chart"
+          >
             {error && errorMessage}
 
             {fullTable && (
@@ -107,7 +117,20 @@ const DataBlockTabs = ({
         )}
 
         {dataBlock.table && (
-          <TabsSection id={`${id}-tables`} title="Table">
+          <TabsSection
+            id={`${id}-tables`}
+            tabLabel={
+              dataBlock.charts?.length ? (
+                <>
+                  Table
+                  <span className="govuk-visually-hidden">
+                    {` for ${dataBlock.heading}`}
+                  </span>
+                </>
+              ) : undefined
+            }
+            title="Table"
+          >
             {error && errorMessage}
 
             {fullTable && (

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -11,12 +11,10 @@ Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 
-
 *** Variables ***
 ${PUBLICATION_NAME}=    UI tests - publish release %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Financial Year 3000-01
 ${DATABLOCK_NAME}=      Dates data block name
-
 
 *** Test Cases ***
 Create new publication for "UI tests topic" topic
@@ -281,7 +279,6 @@ Verify Test text accordion section contains correct text
     ${section}=    user gets accordion section content element    Test text    id:content
     user waits until parent contains element    ${section}    xpath:.//p[text()="Some test text!"]
     user closes accordion section    Test text    id:content
-    user clicks link    Summary
 
 Return to Admin and Create amendment
     user navigates to admin dashboard    Bau1

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -2,11 +2,9 @@
 Resource    ./common.robot
 Library     admin-utilities.py
 
-
 *** Variables ***
-${BAU1_BROWSER}         bau1
-${ANALYST1_BROWSER}     analyst1
-
+${BAU1_BROWSER}=        bau1
+${ANALYST1_BROWSER}=    analyst1
 
 *** Keywords ***
 user signs in as bau1
@@ -433,7 +431,6 @@ user creates public prerelease access list
 
 user updates public prerelease access list
     [Arguments]    ${content}
-    user clicks link    Public access list
     user waits until h2 is visible    Public pre-release access list
     user clicks button    Edit public pre-release access list
     user presses keys    CTRL+a

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -10,7 +10,6 @@ Library     visual.py
 Resource    ./tables-common.robot
 Resource    ./table_tool.robot
 
-
 *** Variables ***
 ${browser}=                             chrome
 ${headless}=                            1
@@ -21,7 +20,6 @@ ${implicit_wait}=                       %{IMPLICIT_WAIT}
 ${RELEASE_COMPLETE_WAIT}=               %{RELEASE_COMPLETE_WAIT}
 ${prompt_to_continue_on_failure}=       0
 ${FAIL_TEST_SUITES_FAST}=               %{FAIL_TEST_SUITES_FAST}
-
 
 *** Keywords ***
 do this on failure
@@ -475,7 +473,7 @@ user clicks element
 
 user clicks link
     [Arguments]    ${text}    ${parent}=css:body
-    user clicks element    link:${text}    ${parent}
+    user clicks element    xpath:.//a[text()="${text}"]    ${parent}
 
 user clicks button
     [Arguments]    ${text}    ${parent}=css:body


### PR DESCRIPTION
Accessibility improvements for tabs:
- when there's only one tab, for instance when datablocks with just a table are embedded in release content, the tab list is `aria-hidden` to prevent screen readers from seeing it.
- added screen reader only text to the tabs so they make sense when read out of context. This is via a new tabLabel field as the title is used in GA events so had to remain just a string
- changed it so the up and down keys move between tabs and prevented being able to loop over the tabs with the keyboard, this makes it more consistent with expected tabs behaviour and the GDS design system

## Related changes

- changed `user clicks link` to use xpath so that data block tab links can be clicked now that there is adjacent visually hidden text
- I noticed that the Headlines Key Stats block on releases has the title 'Headlines' in the admin and 'Summary' in the frontend, so have changed the admin one to be consistent with the frontend

