### PR TITLE
EES-3405 Fix `useHubState` not managing connections correctly

### DIFF
--- a/src/explore-education-statistics-admin/src/hooks/__tests__/useHubState.test.ts
+++ b/src/explore-education-statistics-admin/src/hooks/__tests__/useHubState.test.ts
@@ -1,0 +1,78 @@
+import useHubState from '@admin/hooks/useHubState';
+import Hub from '@admin/services/hubs/utils/Hub';
+import { HubConnectionState } from '@microsoft/signalr';
+import { waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { mock } from 'jest-mock-extended';
+
+describe('useHubState', () => {
+  const mockHub = mock<Hub>();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('calls `start` on hub when mounted', () => {
+    mockHub.start.mockResolvedValue();
+
+    renderHook(() => useHubState(() => mockHub));
+
+    expect(mockHub.start).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns updated `status` when hub has started', async () => {
+    mockHub.start.mockReturnValue(
+      new Promise(resolve => setTimeout(resolve, 500)),
+    );
+
+    mockHub.status.mockReturnValue(HubConnectionState.Disconnected);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useHubState(() => mockHub),
+    );
+
+    expect(result.current.status).toBe(HubConnectionState.Disconnected);
+
+    mockHub.status.mockReturnValue(HubConnectionState.Connected);
+
+    jest.runOnlyPendingTimers();
+
+    await waitForNextUpdate();
+
+    expect(result.current.status).toBe(HubConnectionState.Connected);
+  });
+
+  test('calls `stop` on hub when unmounted', () => {
+    mockHub.start.mockResolvedValue();
+
+    const { unmount } = renderHook(() => useHubState(() => mockHub));
+
+    expect(mockHub.stop).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(mockHub.stop).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls `stop` when unmounted but hub has only just connected', async () => {
+    mockHub.start.mockReturnValue(
+      new Promise(resolve => setTimeout(resolve, 500)),
+    );
+
+    const { unmount } = renderHook(() => useHubState(() => mockHub));
+
+    unmount();
+
+    expect(mockHub.stop).toHaveBeenCalledTimes(1);
+
+    jest.runOnlyPendingTimers();
+
+    await waitFor(() => {
+      expect(mockHub.stop).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/services/hubs/utils/Hub.ts
+++ b/src/explore-education-statistics-admin/src/services/hubs/utils/Hub.ts
@@ -24,7 +24,7 @@ export default class Hub {
   }
 
   async stop(): Promise<void> {
-    if (this.connection.state !== 'Connected') {
+    if (this.connection.state === 'Connected') {
       await this.connection.stop();
     }
   }


### PR DESCRIPTION
This PR fixes issues where:
- `hub.stop` is prematurely called e.g. whilst connecting. This normally throws an error.
- `hub.stop` is _not_ called if the component unmounts but the hub was still connecting. This could lead to orphaned connections that were still open with the server and lead to over-saturation.