### PR TITLE
EES-3387 Add ability to assign user publication roles when inviting a new user

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
@@ -232,18 +232,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                     {
                         Email = email,
                         Role = ReleaseRole.Approver,
-                        Accepted = false
                     },
                     new UserReleaseInvite
                     {
                         Email = email,
                         Role = ReleaseRole.Lead,
-                        Accepted = false
                     },
                     new UserReleaseInvite
                     {
                         Email = "anotheruser@example.com",
-                        Accepted = false
                     });
                 await contentDbContext.SaveChangesAsync();
             }
@@ -340,14 +337,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                     .SingleAsync(invite => invite.Email != email);
                 Assert.False(otherUsersInvite.Accepted);
                 
-                // Assert that the new user's release role invites have all been accepted.
+                // Assert that the new user's release role invites have all been removed.
                 var newUsersReleaseRoleInvites = await contentDbContext
                     .UserReleaseInvites
                     .AsQueryable()
                     .Where(invite => invite.Email == email)
                     .ToListAsync();
-                Assert.Equal(2, newUsersReleaseRoleInvites.Count);
-                newUsersReleaseRoleInvites.ForEach(invite => Assert.True(invite.Accepted));
+                Assert.Empty(newUsersReleaseRoleInvites);
 
                 // Assert that the other user's release role invites have all been left alone.
                 var otherUsersReleaseRoleInvites = await contentDbContext
@@ -356,7 +352,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                     .Where(invite => invite.Email != email)
                     .ToListAsync();
                 Assert.Single(otherUsersReleaseRoleInvites);
-                otherUsersReleaseRoleInvites.ForEach(invite => Assert.False(invite.Accepted));
 
                 // Assert that the user has been assigned the new release roles.
                 var newUsersReleaseRoles = await contentDbContext

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
@@ -72,14 +72,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Release = release,
                         Email = "invited.2@test.com",
                         Role = ReleaseRole.PrereleaseViewer,
-                        Accepted = false
                     },
                     new UserReleaseInvite
                     {
                         Release = release,
                         Email = "invited.1@test.com",
                         Role = ReleaseRole.PrereleaseViewer,
-                        Accepted = false
                     }
                 );
 
@@ -162,7 +160,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Release = release,
                         Email = "invited.1@test.com",
                         Role = ReleaseRole.Contributor,
-                        Accepted = false
                     },
                     // Different release
                     new UserReleaseInvite
@@ -170,15 +167,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Release = new Release(),
                         Email = "invited.2@test.com",
                         Role = ReleaseRole.PrereleaseViewer,
-                        Accepted = false
-                    },
-                    // Already accepted
-                    new UserReleaseInvite
-                    {
-                        Release = release,
-                        Email = "invited.3@test.com",
-                        Role = ReleaseRole.PrereleaseViewer,
-                        Accepted = true
                     }
                 );
 
@@ -567,14 +555,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(ReleaseRole.PrereleaseViewer, savedUserReleaseRole.Role);
                 Assert.Equal(user.Id, savedUserReleaseRole.UserId);
 
-                var releaseInvite = Assert.Single(context.UserReleaseInvites);
-
-                Assert.NotNull(releaseInvite);
-                Assert.Equal(release.Id, releaseInvite!.ReleaseId);
-                Assert.Equal("test@test.com", releaseInvite.Email);
-                Assert.Equal(ReleaseRole.PrereleaseViewer, releaseInvite.Role);
-                Assert.True(releaseInvite.Accepted); // User already exists, so permission has been applied immediately
-                Assert.True(releaseInvite.EmailSent); // Email sent immediately for approved releases
+                // Accepted UserReleaseInvites are removed
+                Assert.Empty(context.UserReleaseInvites);
             }
         }
 
@@ -708,14 +690,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(ReleaseRole.PrereleaseViewer, savedUserReleaseRole.Role);
                 Assert.Equal(user.Id, savedUserReleaseRole.UserId);
 
-                var releaseInvite = Assert.Single(context.UserReleaseInvites);
-
-                Assert.NotNull(releaseInvite);
-                Assert.Equal(release.Id, releaseInvite!.ReleaseId);
-                Assert.Equal("test@test.com", releaseInvite.Email);
-                Assert.Equal(ReleaseRole.PrereleaseViewer, releaseInvite.Role);
-                Assert.True(releaseInvite.Accepted); // User already exists, so permission has been applied immediately
-                Assert.False(releaseInvite.EmailSent); // Email not sent immediately for unapproved releases
+                // Release invite isn't created for an existing user
+                Assert.Empty(context.UserReleaseInvites);
             }
         }
 
@@ -797,7 +773,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release.Id, releaseInvite!.ReleaseId);
                 Assert.Equal("test@test.com", releaseInvite.Email);
                 Assert.Equal(ReleaseRole.PrereleaseViewer, releaseInvite.Role);
-                Assert.False(releaseInvite.Accepted); // User not yet created
                 Assert.True(releaseInvite.EmailSent); // Email sent immediately for approved release
             }
 
@@ -931,7 +906,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release.Id, releaseInvite!.ReleaseId);
                 Assert.Equal("test@test.com", releaseInvite.Email);
                 Assert.Equal(ReleaseRole.PrereleaseViewer, releaseInvite.Role);
-                Assert.False(releaseInvite.Accepted); // User not yet created
                 Assert.False(releaseInvite.EmailSent); // Email not sent immediately for unapproved releases
             }
 
@@ -1101,7 +1075,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 // Four new release invites should have been created
                 var releaseInvites = await context.UserReleaseInvites.AsQueryable().ToListAsync();
-                Assert.Equal(6, releaseInvites.Count);
+                Assert.Equal(4, releaseInvites.Count);
 
                 Assert.True(releaseInvites.All(invite => invite.ReleaseId == release.Id));
                 Assert.True(releaseInvites.All(invite => invite.Role == ReleaseRole.PrereleaseViewer));
@@ -1114,13 +1088,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 // New release invites
                 Assert.Equal("new.user.1@test.com", releaseInvites[2].Email);
-                Assert.False(releaseInvites[2].Accepted);
                 Assert.Equal("new.user.2@test.com", releaseInvites[3].Email);
-                Assert.False(releaseInvites[3].Accepted);
-                Assert.Equal("existing.user.1@test.com", releaseInvites[4].Email);
-                Assert.True(releaseInvites[4].Accepted);
-                Assert.Equal("existing.user.2@test.com", releaseInvites[5].Email);
-                Assert.True(releaseInvites[5].Accepted);
 
                 // Two new role assignments should have been created corresponding with the two accepted invites
                 var roles = await context.UserReleaseRoles.AsQueryable().ToListAsync();
@@ -1267,7 +1235,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 // Four new release invites should have been created
                 var releaseInvites = await context.UserReleaseInvites.AsQueryable().ToListAsync();
-                Assert.Equal(6, releaseInvites.Count);
+                Assert.Equal(4, releaseInvites.Count);
 
                 Assert.True(releaseInvites.All(invite => invite.ReleaseId == release.Id));
                 Assert.True(releaseInvites.All(invite => invite.Role == ReleaseRole.PrereleaseViewer));
@@ -1280,13 +1248,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 // New release invites
                 Assert.Equal("new.user.1@test.com", releaseInvites[2].Email);
-                Assert.False(releaseInvites[2].Accepted);
                 Assert.Equal("new.user.2@test.com", releaseInvites[3].Email);
-                Assert.False(releaseInvites[3].Accepted);
-                Assert.Equal("existing.user.1@test.com", releaseInvites[4].Email);
-                Assert.True(releaseInvites[4].Accepted);
-                Assert.Equal("existing.user.2@test.com", releaseInvites[5].Email);
-                Assert.True(releaseInvites[5].Accepted);
 
                 // Two new role assignments should have been created corresponding with the two accepted invites
                 var roles = await context.UserReleaseRoles.AsQueryable().ToListAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseInviteServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseInviteServiceTests.cs
@@ -127,7 +127,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release1.Id, userReleaseInvites[0].ReleaseId);
                 Assert.Equal(Contributor, userReleaseInvites[0].Role);
                 Assert.Equal(CreatedById, userReleaseInvites[0].CreatedById);
-                Assert.False(userReleaseInvites[0].Accepted);
                 Assert.True(userReleaseInvites[0].EmailSent);
                 Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvites[0].Created).Milliseconds, 0, 1500);
 
@@ -135,7 +134,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release2.Id, userReleaseInvites[1].ReleaseId);
                 Assert.Equal(Contributor, userReleaseInvites[1].Role);
                 Assert.Equal(CreatedById, userReleaseInvites[1].CreatedById);
-                Assert.False(userReleaseInvites[1].Accepted);
                 Assert.True(userReleaseInvites[1].EmailSent);
                 Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvites[1].Created).Milliseconds, 0, 1500);
             }
@@ -250,15 +248,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .AsQueryable()
                     .ToListAsync();
 
-                Assert.Single(userReleaseInvites); // only create release invite for missing UserReleaseRole
-
-                Assert.Equal("test@test.com", userReleaseInvites[0].Email);
-                Assert.Equal(release2.Id, userReleaseInvites[0].ReleaseId);
-                Assert.Equal(Contributor, userReleaseInvites[0].Role);
-                Assert.Equal(CreatedById, userReleaseInvites[0].CreatedById);
-                Assert.True(userReleaseInvites[0].Accepted);
-                Assert.True(userReleaseInvites[0].EmailSent);
-                Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvites[0].Created).Milliseconds, 0, 1500);
+                Assert.Empty(userReleaseInvites); // no release invite created as user already exists
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleasePermissionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleasePermissionServiceTests.cs
@@ -215,7 +215,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Email = "user1@test.com",
                 Release = release1,
                 Role = Contributor,
-                Accepted = false,
             };
 
             var user2ReleaseInviteIgnored = new UserReleaseInvite
@@ -223,7 +222,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Email = "user2@test.com",
                 Release = release2Amendment, // ignored because not release1
                 Role = Contributor,
-                Accepted = false,
             };
 
             var user3ReleaseInvite = new UserReleaseInvite
@@ -231,7 +229,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Email = "user3@test.com",
                 Release = release1,
                 Role = Contributor,
-                Accepted = false,
             };
 
             var user3ReleaseInviteIgnored = new UserReleaseInvite
@@ -239,15 +236,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Email = "user4@test.com",
                 Release = release1,
                 Role = Lead, // ignored because not a Contributor
-                Accepted = false,
-            };
-
-            var user5ReleaseInviteIgnored = new UserReleaseInvite
-            {
-                Email = "user5@test.com",
-                Release = release1,
-                Role = Contributor,
-                Accepted = true, // ignored because invite already accepted
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -255,7 +243,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 await contentDbContext.AddRangeAsync(release1, release2Original, release2Amendment,
                     user1ReleaseInvite, user2ReleaseInviteIgnored, user3ReleaseInvite,
-                    user3ReleaseInviteIgnored, user5ReleaseInviteIgnored);
+                    user3ReleaseInviteIgnored);
                 await contentDbContext.SaveChangesAsync();
             }
 
@@ -263,7 +251,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var service = SetupReleasePermissionService(contentDbContext);
 
-                var result = await service.ListReleaseContributorInvites(release1.Id, false);
+                var result = await service.ListReleaseContributorInvites(release1.Id);
                 var viewModel = result.AssertRight();
 
                 Assert.Equal(2, viewModel.Count);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
@@ -94,7 +94,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     return await service.InviteUser(
                         "test@test.com",
                         Guid.NewGuid().ToString(),
-                        new List<UserReleaseRoleAddViewModel>());
+                        new List<UserReleaseRoleAddViewModel>(),
+                        new List<UserPublicationRoleAddViewModel>());
                 });
         }
 
@@ -131,7 +132,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IUserRoleService? userRoleService = null,
             IUserService? userService = null,
             IUserInviteRepository? userInviteRepository = null,
-            IUserReleaseInviteRepository? userReleaseInviteRepository = null)
+            IUserReleaseInviteRepository? userReleaseInviteRepository = null,
+            IUserPublicationInviteRepository? userPublicationInviteRepository = null)
         {
             contentDbContext ??= InMemoryApplicationDbContext();
             usersAndRolesDbContext ??= InMemoryUserAndRolesDbContext();
@@ -144,7 +146,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 userRoleService ?? Mock.Of<IUserRoleService>(Strict),
                 userService ?? AlwaysTrueUserService().Object,
                 userInviteRepository ?? new UserInviteRepository(usersAndRolesDbContext),
-                userReleaseInviteRepository ?? new UserReleaseInviteRepository(contentDbContext)
+                userReleaseInviteRepository ?? new UserReleaseInviteRepository(contentDbContext),
+                userPublicationInviteRepository ?? new UserPublicationInviteRepository(contentDbContext)
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
@@ -223,8 +223,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await usersAndRolesDbContext.SaveChangesAsync();
             }
 
-            var release = new Release { Id = Guid.NewGuid() };
-            var publication = new Publication { Id = Guid.NewGuid() };
+            var releaseId = Guid.NewGuid();
+            var publicationId = Guid.NewGuid();
 
             var emailTemplateService = new Mock<IEmailTemplateService>(Strict);
 
@@ -247,7 +247,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         new ()
                         {
-                            ReleaseId = release.Id,
+                            ReleaseId = releaseId,
                             ReleaseRole = Approver,
                         },
                     },
@@ -255,7 +255,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         new ()
                         {
-                          PublicationId = publication.Id,
+                          PublicationId = publicationId,
                           PublicationRole = Owner,
                         },
                     });
@@ -284,9 +284,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ToList();
                 var userReleaseInvite = Assert.Single(userReleaseInvites);
                 Assert.Equal("test@test.com", userReleaseInvite.Email);
-                Assert.Equal(release.Id, userReleaseInvite.ReleaseId);
+                Assert.Equal(releaseId, userReleaseInvite.ReleaseId);
                 Assert.Equal(Approver, userReleaseInvite.Role);
-                Assert.False(userReleaseInvite.Accepted);
                 Assert.True(userReleaseInvite.EmailSent);
                 Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvite.Created).Milliseconds, 0, 1500);
                 Assert.Equal(_createdById, userReleaseInvite.CreatedById);
@@ -295,14 +294,133 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ToList();
                 var userPublicationInvite = Assert.Single(userPublicationInvites);
                 Assert.Equal("test@test.com", userPublicationInvite.Email);
-                Assert.Equal(publication.Id, userPublicationInvite.PublicationId);
+                Assert.Equal(publicationId, userPublicationInvite.PublicationId);
                 Assert.Equal(Owner, userPublicationInvite.Role);
-                Assert.False(userPublicationInvite.Accepted);
-                Assert.True(userPublicationInvite.EmailSent);
                 Assert.InRange(DateTime.UtcNow.Subtract(userPublicationInvite.Created).Milliseconds, 0, 1500);
                 Assert.Equal(_createdById, userPublicationInvite.CreatedById);
+            }
+        }
 
+        [Fact]
+        public async Task InviteUser_MultipleReleaseAndPublicationRoles()
+        {
+            var role = new IdentityRole
+            {
+                Id = Guid.NewGuid().ToString(),
+                Name = "Role 1",
+                NormalizedName = "ROLE 1"
+            };
 
+            var usersAndRolesDbContextId = Guid.NewGuid().ToString();
+            await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
+            {
+                await usersAndRolesDbContext.AddRangeAsync(role);
+                await usersAndRolesDbContext.SaveChangesAsync();
+            }
+
+            var release1Id = Guid.NewGuid();
+            var release2Id = Guid.NewGuid();
+            var publication1Id = Guid.NewGuid();
+            var publication2Id = Guid.NewGuid();
+
+            var emailTemplateService = new Mock<IEmailTemplateService>(Strict);
+
+            emailTemplateService.Setup(mock =>
+                    mock.SendInviteEmail("test@test.com"))
+                .Returns(Unit.Instance);
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var userAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupUserManagementService(
+                    contentDbContext: contentDbContext,
+                    usersAndRolesDbContext: userAndRolesDbContext,
+                    emailTemplateService: emailTemplateService.Object);
+
+                var result = await service.InviteUser("test@test.com",
+                    role.Id,
+                    new List<UserReleaseRoleAddViewModel>
+                    {
+                        new ()
+                        {
+                            ReleaseId = release1Id,
+                            ReleaseRole = Approver,
+                        },
+                        new ()
+                        {
+                            ReleaseId = release2Id,
+                            ReleaseRole = Contributor,
+                        }
+                    },
+                    new List<UserPublicationRoleAddViewModel>
+                    {
+                        new ()
+                        {
+                          PublicationId = publication1Id,
+                          PublicationRole = Owner,
+                        },
+                        new ()
+                        {
+                          PublicationId = publication2Id,
+                          PublicationRole = ReleaseApprover,
+                        },
+                    });
+
+                VerifyAllMocks(emailTemplateService);
+
+                result.AssertRight();
+            }
+
+            await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
+            {
+                var userInvites = usersAndRolesDbContext.UserInvites
+                    .ToList();
+
+                var userInvite = Assert.Single(userInvites);
+                Assert.Equal("test@test.com", userInvite.Email);
+                Assert.False(userInvite.Accepted);
+                Assert.Equal(role.Id, userInvite.RoleId);
+                Assert.InRange(DateTime.UtcNow.Subtract(userInvite.Created).Milliseconds, 0, 1500);
+                Assert.Equal(_createdById.ToString(), userInvite.CreatedById);
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var userReleaseInvites = contentDbContext.UserReleaseInvites
+                    .ToList();
+
+                Assert.Equal(2, userReleaseInvites.Count);
+
+                Assert.Equal("test@test.com", userReleaseInvites[0].Email);
+                Assert.Equal(release1Id, userReleaseInvites[0].ReleaseId);
+                Assert.Equal(Approver, userReleaseInvites[0].Role);
+                Assert.True(userReleaseInvites[0].EmailSent);
+                Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvites[0].Created).Milliseconds, 0, 1500);
+                Assert.Equal(_createdById, userReleaseInvites[0].CreatedById);
+
+                Assert.Equal("test@test.com", userReleaseInvites[1].Email);
+                Assert.Equal(release2Id, userReleaseInvites[1].ReleaseId);
+                Assert.Equal(Contributor, userReleaseInvites[1].Role);
+                Assert.True(userReleaseInvites[1].EmailSent);
+                Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvites[1].Created).Milliseconds, 0, 1500);
+                Assert.Equal(_createdById, userReleaseInvites[1].CreatedById);
+
+                var userPublicationInvites = contentDbContext.UserPublicationInvites
+                    .ToList();
+                Assert.Equal(2, userPublicationInvites.Count);
+
+                Assert.Equal("test@test.com", userPublicationInvites[0].Email);
+                Assert.Equal(publication1Id, userPublicationInvites[0].PublicationId);
+                Assert.Equal(Owner, userPublicationInvites[0].Role);
+                Assert.InRange(DateTime.UtcNow.Subtract(userPublicationInvites[0].Created).Milliseconds, 0, 1500);
+                Assert.Equal(_createdById, userPublicationInvites[0].CreatedById);
+
+                Assert.Equal("test@test.com", userPublicationInvites[1].Email);
+                Assert.Equal(publication2Id, userPublicationInvites[1].PublicationId);
+                Assert.Equal(ReleaseApprover, userPublicationInvites[1].Role);
+                Assert.InRange(DateTime.UtcNow.Subtract(userPublicationInvites[1].Created).Milliseconds, 0, 1500);
+                Assert.Equal(_createdById, userPublicationInvites[1].CreatedById);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPublicationInviteRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPublicationInviteRepositoryTests.cs
@@ -1,0 +1,91 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+{
+    public class UserPublicationInviteRepositoryTests
+    {
+        [Fact]
+        public async Task CreateManyIfNotExists()
+        {
+            var createdById = Guid.NewGuid();
+            var userPublicationRole1 = new UserPublicationRoleAddViewModel
+            {
+                PublicationId = Guid.NewGuid(),
+                PublicationRole = Owner,
+            };
+            var userPublicationRole2 = new UserPublicationRoleAddViewModel
+            {
+                PublicationId = Guid.NewGuid(),
+                PublicationRole = ReleaseApprover,
+            };
+            var existingPublicationInvite = new UserPublicationInvite
+            {
+                Email = "test@test.com",
+                PublicationId = Guid.NewGuid(),
+                Role = Owner,
+                CreatedById = createdById,
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddRangeAsync(existingPublicationInvite);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var repository = new UserPublicationInviteRepository(contentDbContext);
+                await repository.CreateManyIfNotExists(
+                    userPublicationRoles: ListOf(
+                        userPublicationRole1,
+                        userPublicationRole2,
+                        new UserPublicationRoleAddViewModel
+                        {
+                            PublicationId = existingPublicationInvite.PublicationId,
+                            PublicationRole = existingPublicationInvite.Role,
+                        }),
+                    email: "test@test.com",
+                    createdById: createdById);
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var userPublicationInvites = await contentDbContext.UserPublicationInvites
+                    .AsQueryable()
+                    .ToListAsync();
+
+                Assert.Equal(3, userPublicationInvites.Count);
+
+                Assert.Equal(existingPublicationInvite.Id, userPublicationInvites[0].Id);
+                Assert.Equal(existingPublicationInvite.PublicationId, userPublicationInvites[0].PublicationId);
+                Assert.Equal(existingPublicationInvite.Role, userPublicationInvites[0].Role);
+                Assert.Equal("test@test.com", userPublicationInvites[0].Email);
+                Assert.InRange(DateTime.UtcNow.Subtract(userPublicationInvites[0].Created).Milliseconds, 0, 1500);
+                Assert.Equal(createdById, userPublicationInvites[0].CreatedById);
+
+                Assert.Equal(userPublicationRole1.PublicationId, userPublicationInvites[1].PublicationId);
+                Assert.Equal(userPublicationRole1.PublicationRole, userPublicationInvites[1].Role);
+                Assert.Equal("test@test.com", userPublicationInvites[1].Email);
+                Assert.InRange(DateTime.UtcNow.Subtract(userPublicationInvites[1].Created).Milliseconds, 0, 1500);
+                Assert.Equal(createdById, userPublicationInvites[1].CreatedById);
+
+                Assert.Equal(userPublicationRole2.PublicationId, userPublicationInvites[2].PublicationId);
+                Assert.Equal(userPublicationRole2.PublicationRole, userPublicationInvites[2].Role);
+                Assert.Equal("test@test.com", userPublicationInvites[2].Email);
+                Assert.InRange(DateTime.UtcNow.Subtract(userPublicationInvites[2].Created).Milliseconds, 0, 1500);
+                Assert.Equal(createdById, userPublicationInvites[2].CreatedById);
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseInviteRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseInviteRepositoryTests.cs
@@ -44,7 +44,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(userReleaseInvite.EmailSent);
                 Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvite.Created).Milliseconds, 0, 1500);
                 Assert.Equal(createdById, userReleaseInvite.CreatedById);
-                Assert.False(userReleaseInvite.Accepted);
             }
         }
 
@@ -61,7 +60,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Role = Contributor,
                 EmailSent = true,
                 CreatedById = createdById,
-                Accepted = true,
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -98,7 +96,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(userReleaseInvites[0].EmailSent);
                 Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvites[0].Created).Milliseconds, 0, 1500);
                 Assert.Equal(createdById, userReleaseInvites[0].CreatedById);
-                Assert.True(userReleaseInvites[0].Accepted);
 
                 Assert.Equal(releaseId1, userReleaseInvites[1].ReleaseId);
                 Assert.Equal("test@test.com", userReleaseInvites[1].Email);
@@ -106,7 +103,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.False(userReleaseInvites[1].EmailSent);
                 Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvites[1].Created).Milliseconds, 0, 1500);
                 Assert.Equal(createdById, userReleaseInvites[1].CreatedById);
-                Assert.False(userReleaseInvites[1].Accepted);
 
                 Assert.Equal(releaseId2, userReleaseInvites[2].ReleaseId);
                 Assert.Equal("test@test.com", userReleaseInvites[2].Email);
@@ -114,7 +110,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.False(userReleaseInvites[2].EmailSent);
                 Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvites[2].Created).Milliseconds, 0, 1500);
                 Assert.Equal(createdById, userReleaseInvites[2].CreatedById);
-                Assert.False(userReleaseInvites[2].Accepted);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -317,7 +317,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Pages.
                         CreatedById = invite.CreatedById,
                     });
 
-                    invite.Accepted = true;
+                    _contentDbContext.Remove(invite);
                 });
 
                 var publicationInvites = _contentDbContext
@@ -336,7 +336,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Pages.
                         CreatedById = invite.CreatedById,
                     });
 
-                    invite.Accepted = true;
+                    _contentDbContext.Remove(invite);
                 });
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -308,9 +308,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Pages.
 
                 await releaseInvites.ForEachAsync(invite =>
                 {
-                    _contentDbContext.AddAsync(new UserReleaseRole
+                    _contentDbContext.Add(new UserReleaseRole
                     {
                         ReleaseId = invite.ReleaseId,
+                        Role = invite.Role,
+                        UserId = newInternalUser.Id,
+                        Created = DateTime.UtcNow,
+                        CreatedById = invite.CreatedById,
+                    });
+
+                    invite.Accepted = true;
+                });
+
+                var publicationInvites = _contentDbContext
+                    .UserPublicationInvites
+                    .AsQueryable()
+                    .Where(i => i.Email.ToLower() == newAspNetUser.Email.ToLower());
+
+                await publicationInvites.ForEachAsync(invite =>
+                {
+                    _contentDbContext.Add(new UserPublicationRole
+                    {
+                        PublicationId = invite.PublicationId,
                         Role = invite.Role,
                         UserId = newInternalUser.Id,
                         Created = DateTime.UtcNow,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasePermissionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasePermissionsController.cs
@@ -35,10 +35,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 
         [HttpGet("releases/{releaseId}/contributor-invites")]
         public async Task<ActionResult<List<ContributorInviteViewModel>>> ListReleaseContributorInvites(
-            Guid releaseId, [FromQuery] bool? accepted = null)
+            Guid releaseId)
         {
             return await _releasePermissionService
-                .ListReleaseContributorInvites(releaseId, accepted)
+                .ListReleaseContributorInvites(releaseId)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserInvitesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserInvitesController.cs
@@ -40,7 +40,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.UserM
         public async Task<ActionResult<UserInvite>> InviteUser(UserInviteViewModel userInviteViewModel)
         {
             return await _userManagementService
-                .InviteUser(userInviteViewModel.Email, userInviteViewModel.RoleId, userInviteViewModel.UserReleaseRoles)
+                .InviteUser(
+                    userInviteViewModel.Email,
+                    userInviteViewModel.RoleId,
+                    userInviteViewModel.UserReleaseRoles,
+                    userInviteViewModel.UserPublicationRoles)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserManagementController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserManagementController.cs
@@ -54,7 +54,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.UserM
 
         [HttpPost("users/{userId:guid}/publication-role")]
         [ProducesResponseType(200)]
-        public async Task<ActionResult<Unit>> AddPublicationRole(Guid userId, AddPublicationRoleViewModel request)
+        public async Task<ActionResult<Unit>> AddPublicationRole(Guid userId, UserPublicationRoleAddViewModel request)
         {
             return await _userRoleService
                 .AddPublicationRole(userId, request.PublicationId, request.PublicationRole)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220608141805_EES3387CreateUserPublicationInviteTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220608141805_EES3387CreateUserPublicationInviteTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220608141805_EES3387CreateUserPublicationInviteTable")]
+    partial class EES3387CreateUserPublicationInviteTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220608141805_EES3387CreateUserPublicationInviteTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220608141805_EES3387CreateUserPublicationInviteTable.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES3387CreateUserPublicationInviteTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserPublicationInvites",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    PublicationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Role = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Accepted = table.Column<bool>(type: "bit", nullable: false),
+                    EmailSent = table.Column<bool>(type: "bit", nullable: false),
+                    Created = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SoftDeleted = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserPublicationInvites", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserPublicationInvites_Publications_PublicationId",
+                        column: x => x.PublicationId,
+                        principalTable: "Publications",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserPublicationInvites_Users_CreatedById",
+                        column: x => x.CreatedById,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPublicationInvites_CreatedById",
+                table: "UserPublicationInvites",
+                column: "CreatedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPublicationInvites_PublicationId",
+                table: "UserPublicationInvites",
+                column: "PublicationId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserPublicationInvites");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220610082922_EES3387CreateUserPublicationInviteTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220610082922_EES3387CreateUserPublicationInviteTable.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    [Migration("20220608141805_EES3387CreateUserPublicationInviteTable")]
+    [Migration("20220610082922_EES3387CreateUserPublicationInviteTable")]
     partial class EES3387CreateUserPublicationInviteTable
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -824,9 +824,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<bool>("Accepted")
-                        .HasColumnType("bit");
-
                     b.Property<DateTime>("Created")
                         .HasColumnType("datetime2");
 
@@ -837,18 +834,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("EmailSent")
-                        .HasColumnType("bit");
-
                     b.Property<Guid>("PublicationId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("Role")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
-
-                    b.Property<bool>("SoftDeleted")
-                        .HasColumnType("bit");
 
                     b.HasKey("Id");
 
@@ -906,9 +897,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<bool>("Accepted")
-                        .HasColumnType("bit");
-
                     b.Property<DateTime>("Created")
                         .HasColumnType("datetime2");
 
@@ -931,6 +919,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.Property<bool>("SoftDeleted")
                         .HasColumnType("bit");
+
+                    b.Property<DateTime?>("Updated")
+                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220610082922_EES3387CreateUserPublicationInviteTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220610082922_EES3387CreateUserPublicationInviteTable.cs
@@ -9,6 +9,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.Sql("DELETE FROM UserReleaseInvites WHERE Accepted = 1;");
+
+            migrationBuilder.DropColumn(
+                name: "Accepted",
+                table: "UserReleaseInvites");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Updated",
+                table: "UserReleaseInvites",
+                type: "datetime2",
+                nullable: true);
+
             migrationBuilder.CreateTable(
                 name: "UserPublicationInvites",
                 columns: table => new
@@ -17,11 +29,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     Email = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     PublicationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     Role = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    Accepted = table.Column<bool>(type: "bit", nullable: false),
-                    EmailSent = table.Column<bool>(type: "bit", nullable: false),
                     Created = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    SoftDeleted = table.Column<bool>(type: "bit", nullable: false)
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -55,6 +64,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
         {
             migrationBuilder.DropTable(
                 name: "UserPublicationInvites");
+
+            migrationBuilder.DropColumn(
+                name: "Updated",
+                table: "UserReleaseInvites");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Accepted",
+                table: "UserReleaseInvites",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
@@ -822,9 +822,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<bool>("Accepted")
-                        .HasColumnType("bit");
-
                     b.Property<DateTime>("Created")
                         .HasColumnType("datetime2");
 
@@ -835,18 +832,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("EmailSent")
-                        .HasColumnType("bit");
-
                     b.Property<Guid>("PublicationId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("Role")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
-
-                    b.Property<bool>("SoftDeleted")
-                        .HasColumnType("bit");
 
                     b.HasKey("Id");
 
@@ -904,9 +895,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<bool>("Accepted")
-                        .HasColumnType("bit");
-
                     b.Property<DateTime>("Created")
                         .HasColumnType("datetime2");
 
@@ -929,6 +917,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.Property<bool>("SoftDeleted")
                         .HasColumnType("bit");
+
+                    b.Property<DateTime?>("Updated")
+                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleasePermissionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleasePermissionService.cs
@@ -14,7 +14,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             ListReleaseContributors(Guid releaseId);
 
         Task<Either<ActionResult, List<ContributorInviteViewModel>>>
-            ListReleaseContributorInvites(Guid releaseId, bool? accepted = null);
+            ListReleaseContributorInvites(Guid releaseId);
 
         Task<Either<ActionResult, List<ContributorViewModel>>>
             ListPublicationContributors(Guid releaseId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
@@ -24,7 +24,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, UserInvite>> InviteUser(
             string email,
             string roleId,
-            List<UserReleaseRoleAddViewModel> userReleaseRoles);
+            List<UserReleaseRoleAddViewModel> userReleaseRoles,
+            List<UserPublicationRoleAddViewModel> userPublicationRoles);
 
         Task<Either<ActionResult, Unit>> CancelInvite(string email);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserPublicationInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserPublicationInviteRepository.cs
@@ -1,0 +1,18 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
+{
+    public interface IUserPublicationInviteRepository
+    {
+        Task Create(Guid publicationId,
+            string email,
+            PublicationRole publicationRole,
+            bool emailSent,
+            Guid createdById,
+            bool accepted = false);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserPublicationInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserPublicationInviteRepository.cs
@@ -2,17 +2,15 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IUserPublicationInviteRepository
     {
-        Task Create(Guid publicationId,
+        Task CreateManyIfNotExists(
+            List<UserPublicationRoleAddViewModel> userPublicationRoles,
             string email,
-            PublicationRole publicationRole,
-            bool emailSent,
-            Guid createdById,
-            bool accepted = false);
+            Guid createdById);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserReleaseInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserReleaseInviteRepository.cs
@@ -12,15 +12,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             string email,
             ReleaseRole releaseRole,
             bool emailSent,
-            Guid createdById,
-            bool accepted = false);
+            Guid createdById);
 
         Task CreateManyIfNotExists(List<Guid> releaseIds,
             string email,
             ReleaseRole releaseRole,
             bool emailSent,
-            Guid createdById,
-            bool accepted = false);
+            Guid createdById);
 
         Task<bool> UserHasInvite(Guid releaseId, string email, ReleaseRole role);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseUserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseUserService.cs
@@ -88,8 +88,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         var invitedPrereleaseContacts = await _context
                             .UserReleaseInvites
                             .AsQueryable()
-                            .Where(
-                                r => r.Role == PrereleaseViewer && !r.Accepted && r.ReleaseId == releaseId
+                            .Where(r =>
+                                r.Role == PrereleaseViewer && r.ReleaseId == releaseId
                             )
                             .Select(i => i.Email.ToLower())
                             .Distinct()
@@ -341,14 +341,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         return emailResult;
                     }
                 }
-
-                await _userReleaseInviteRepository.Create(
-                    releaseId: release.Id,
-                    email: email,
-                    releaseRole: PrereleaseViewer,
-                    emailSent: sendEmail,
-                    createdById: _userService.GetUserId(),
-                    accepted: true); // accepted as user already exists
 
                 await _userReleaseRoleRepository.CreateIfNotExists(
                     userId: user.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseInviteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseInviteService.cs
@@ -169,14 +169,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 createdById: _userService.GetUserId()
             );
 
-            await _userReleaseInviteRepository.CreateManyIfNotExists(
-                releaseIds: missingReleaseRoleReleaseIds,
-                email: email,
-                releaseRole: Contributor,
-                emailSent: true,
-                createdById: _userService.GetUserId(),
-                accepted: true);
-
             return Unit.Instance;
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleasePermissionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleasePermissionService.cs
@@ -67,7 +67,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         public async Task<Either<ActionResult, List<ContributorInviteViewModel>>>
-            ListReleaseContributorInvites(Guid releaseId, bool? accepted = null)
+            ListReleaseContributorInvites(Guid releaseId)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Release>(releaseId,
@@ -86,7 +86,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .ToListAsync();
 
                     return invites
-                        .Where(i => accepted == null || i.Accepted == accepted)
                         .Select(i => new ContributorInviteViewModel
                         {
                             Email = i.Email,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -288,6 +288,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         return ValidationActionResult(InviteNotFound);
                     }
 
+                    if (invite.Accepted)
+                    {
+                        return ValidationActionResult(InviteAlreadyAccepted);
+                    }
+
                     _usersAndRolesDbContext.UserInvites.Remove(invite);
                     await _usersAndRolesDbContext.SaveChangesAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -32,6 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IUserService _userService;
         private readonly IUserInviteRepository _userInviteRepository;
         private readonly IUserReleaseInviteRepository _userReleaseInviteRepository;
+        private readonly IUserPublicationInviteRepository _userPublicationInviteRepository;
 
         public UserManagementService(UsersAndRolesDbContext usersAndRolesDbContext,
             ContentDbContext contentDbContext,
@@ -40,7 +41,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IUserRoleService userRoleService,
             IUserService userService,
             IUserInviteRepository userInviteRepository,
-            IUserReleaseInviteRepository userReleaseInviteRepository)
+            IUserReleaseInviteRepository userReleaseInviteRepository,
+            IUserPublicationInviteRepository userPublicationInviteRepository)
         {
             _usersAndRolesDbContext = usersAndRolesDbContext;
             _contentDbContext = contentDbContext;
@@ -50,6 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _userService = userService;
             _userInviteRepository = userInviteRepository;
             _userReleaseInviteRepository = userReleaseInviteRepository;
+            _userPublicationInviteRepository = userPublicationInviteRepository;
         }
 
         public async Task<Either<ActionResult, List<UserViewModel>>> ListAllUsers()
@@ -218,7 +221,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, UserInvite>> InviteUser(
             string email,
             string roleId,
-            List<UserReleaseRoleAddViewModel> userReleaseRoles)
+            List<UserReleaseRoleAddViewModel> userReleaseRoles,
+            List<UserPublicationRoleAddViewModel> userPublicationRoles)
         {
             return await _userService
                 .CheckCanManageAllUsers()
@@ -245,6 +249,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             releaseId: userReleaseRole.ReleaseId,
                             email: email,
                             releaseRole: userReleaseRole.ReleaseRole,
+                            emailSent: true, // EES-3403
+                            createdById: _userService.GetUserId());
+                    }
+
+                    foreach (var userPublicationRole in userPublicationRoles)
+                    {
+                        await _userPublicationInviteRepository.Create(
+                            publicationId: userPublicationRole.PublicationId,
+                            email: email,
+                            publicationRole: userPublicationRole.PublicationRole,
                             emailSent: true, // EES-3403
                             createdById: _userService.GetUserId());
                     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -253,15 +253,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             createdById: _userService.GetUserId());
                     }
 
-                    foreach (var userPublicationRole in userPublicationRoles)
-                    {
-                        await _userPublicationInviteRepository.Create(
-                            publicationId: userPublicationRole.PublicationId,
-                            email: email,
-                            publicationRole: userPublicationRole.PublicationRole,
-                            emailSent: true, // EES-3403
-                            createdById: _userService.GetUserId());
-                    }
+                    _userPublicationInviteRepository.CreateManyIfNotExists(
+                        userPublicationRoles,
+                        email,
+                        _userService.GetUserId());
 
                     return userInvite;
                 })

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -285,8 +285,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .AsQueryable()
                         .Where(i => i.Email.ToLower() == email.ToLower())
                         .ToListAsync();
-
                     _contentDbContext.UserReleaseInvites.RemoveRange(releaseInvites);
+
+                    var publicationInvites = await _contentDbContext.UserPublicationInvites
+                        .AsQueryable()
+                        .Where(i => i.Email.ToLower() == email.ToLower())
+                        .ToListAsync();
+                    _contentDbContext.UserPublicationInvites.RemoveRange(publicationInvites);
+
                     await _contentDbContext.SaveChangesAsync();
 
                     return Unit.Instance;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationInviteRepository.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
@@ -20,27 +21,43 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _contentDbContext = contentDbContext;
         }
 
-        public async Task Create(Guid publicationId,
+        public async Task CreateManyIfNotExists(
+            List<UserPublicationRoleAddViewModel> userPublicationRoles,
             string email,
-            PublicationRole publicationRole,
-            bool emailSent,
-            Guid createdById,
-            bool accepted = false)
+            Guid createdById)
         {
-            await _contentDbContext.AddAsync(
-                new UserPublicationInvite
-                {
-                    Email = email.ToLower(),
-                    PublicationId = publicationId,
-                    Role = publicationRole,
-                    Accepted = accepted,
-                    EmailSent = emailSent,
-                    Created = DateTime.UtcNow,
-                    CreatedById = createdById,
-                }
-            );
+            var invites = await userPublicationRoles
+                .ToAsyncEnumerable()
+                .WhereAwait(async userPublicationRole =>
+                    !await UserHasInvite(
+                        userPublicationRole.PublicationId,
+                        userPublicationRole.PublicationRole,
+                        email))
+                .Select(userPublicationRole =>
+                    new UserPublicationInvite()
+                    {
+                        Email = email.ToLower(),
+                        PublicationId = userPublicationRole.PublicationId,
+                        Role = userPublicationRole.PublicationRole,
+                        CreatedById = createdById,
+                    }
+                ).ToListAsync();
 
+            await _contentDbContext.UserPublicationInvites.AddRangeAsync(invites);
             await _contentDbContext.SaveChangesAsync();
+        }
+
+        private async Task<bool> UserHasInvite(
+            Guid publicationId,
+            PublicationRole role,
+            string email)
+        {
+            return await _contentDbContext
+                .UserPublicationInvites
+                .AnyAsync(i =>
+                    i.PublicationId == publicationId
+                    && i.Role == role
+                    && i.Email.ToLower() == email.ToLower());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationInviteRepository.cs
@@ -1,0 +1,46 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.EntityFrameworkCore;
+using Guid = System.Guid;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
+{
+    public class UserPublicationInviteRepository : IUserPublicationInviteRepository
+    {
+        private readonly ContentDbContext _contentDbContext;
+
+        public UserPublicationInviteRepository(ContentDbContext contentDbContext)
+        {
+            _contentDbContext = contentDbContext;
+        }
+
+        public async Task Create(Guid publicationId,
+            string email,
+            PublicationRole publicationRole,
+            bool emailSent,
+            Guid createdById,
+            bool accepted = false)
+        {
+            await _contentDbContext.AddAsync(
+                new UserPublicationInvite
+                {
+                    Email = email.ToLower(),
+                    PublicationId = publicationId,
+                    Role = publicationRole,
+                    Accepted = accepted,
+                    EmailSent = emailSent,
+                    Created = DateTime.UtcNow,
+                    CreatedById = createdById,
+                }
+            );
+
+            await _contentDbContext.SaveChangesAsync();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseInviteRepository.cs
@@ -24,8 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             string email,
             ReleaseRole releaseRole,
             bool emailSent,
-            Guid createdById,
-            bool accepted = false)
+            Guid createdById)
         {
             await _contentDbContext.AddAsync(
                 new UserReleaseInvite
@@ -33,7 +32,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     Email = email.ToLower(),
                     ReleaseId = releaseId,
                     Role = releaseRole,
-                    Accepted = accepted,
                     EmailSent = emailSent,
                     Created = DateTime.UtcNow,
                     CreatedById = createdById,
@@ -47,8 +45,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             string email,
             ReleaseRole releaseRole,
             bool emailSent,
-            Guid createdById,
-            bool accepted = false)
+            Guid createdById)
         {
             var invites = await releaseIds
                 .ToAsyncEnumerable()
@@ -62,7 +59,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         EmailSent = emailSent,
                         Created = DateTime.UtcNow,
                         CreatedById = createdById,
-                        Accepted = accepted,
                     }
                 ).ToListAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -437,6 +437,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IUserPublicationRoleRepository, UserPublicationRoleRepository>();
             services.AddTransient<IUserReleaseRoleRepository, UserReleaseRoleRepository>();
             services.AddTransient<IUserReleaseInviteRepository, UserReleaseInviteRepository>();
+            services.AddTransient<IUserPublicationInviteRepository, UserPublicationInviteRepository>();
 
             services.AddTransient<INotificationClient>(s =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -24,14 +24,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         UserAlreadyHasResourceRole,
 
         // Invite
+        InviteAlreadyAccepted,
         InviteNotFound,
         InvalidEmailAddress,
-        NoInvitableEmails,
         InvalidUserRole,
+        NoInvitableEmails,
         NotAllReleasesBelongToPublication,
         UserAlreadyHasReleaseRoleInvites,
         UserAlreadyHasReleaseRoles,
-        InviteAlreadyAccepted,
 
         // Methodology
         MethodologyMustBeDraft,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -31,6 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         NotAllReleasesBelongToPublication,
         UserAlreadyHasReleaseRoleInvites,
         UserAlreadyHasReleaseRoles,
+        InviteAlreadyAccepted,
 
         // Methodology
         MethodologyMustBeDraft,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserInviteViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserInviteViewModel.cs
@@ -12,5 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public string RoleId { get; set; } = string.Empty;
 
         public List<UserReleaseRoleAddViewModel> UserReleaseRoles { get; set; } = new();
+
+        public List<UserPublicationRoleAddViewModel> UserPublicationRoles { get; set; } = new();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserPublicationRoleAddViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserPublicationRoleAddViewModel.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
-    public class AddPublicationRoleViewModel
+    public class UserPublicationRoleAddViewModel
     {
         public Guid PublicationId { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -452,12 +452,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     v => v,
                     v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
 
+            modelBuilder.Entity<UserReleaseInvite>()
+                .Property(invite => invite.Updated)
+                .HasConversion(
+                    v => v,
+                    v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
+
             modelBuilder.Entity<UserPublicationInvite>()
                 .Property(r => r.Role)
                 .HasConversion(new EnumToStringConverter<PublicationRole>());
-
-            modelBuilder.Entity<UserPublicationInvite>()
-                .HasQueryFilter(r => !r.SoftDeleted);
 
             modelBuilder.Entity<UserPublicationInvite>()
                 .Property(invite => invite.Created)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -70,9 +70,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
         public DbSet<UserPublicationRole> UserPublicationRoles { get; set; }
         public DbSet<UserReleaseRole> UserReleaseRoles { get; set; }
         public DbSet<GlossaryEntry> GlossaryEntries { get; set; }
-
         public DbSet<Comment> Comment { get; set; }
         public DbSet<UserReleaseInvite> UserReleaseInvites { get; set; }
+        public DbSet<UserPublicationInvite> UserPublicationInvites { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -447,6 +447,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .HasQueryFilter(r => !r.SoftDeleted);
 
             modelBuilder.Entity<UserReleaseInvite>()
+                .Property(invite => invite.Created)
+                .HasConversion(
+                    v => v,
+                    v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+
+            modelBuilder.Entity<UserPublicationInvite>()
+                .Property(r => r.Role)
+                .HasConversion(new EnumToStringConverter<PublicationRole>());
+
+            modelBuilder.Entity<UserPublicationInvite>()
+                .HasQueryFilter(r => !r.SoftDeleted);
+
+            modelBuilder.Entity<UserPublicationInvite>()
                 .Property(invite => invite.Created)
                 .HasConversion(
                     v => v,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/UserPublicationInvite.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/UserPublicationInvite.cs
@@ -1,10 +1,11 @@
 #nullable enable
 using System;
 using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
-    public class UserPublicationInvite
+    public class UserPublicationInvite : ICreatedTimestamp<DateTime>
     {
         [Key] 
         [Required]
@@ -19,17 +20,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         
         [Required]
         public PublicationRole Role { get; set; }
-        
-        public bool Accepted { get; set; }
-
-        public bool EmailSent { get; set; }
 
         public DateTime Created { get; set; }
 
         public User CreatedBy { get; set; } = null!;
 
         public Guid CreatedById { get; set; }
-        
-        public bool SoftDeleted { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/UserPublicationInvite.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/UserPublicationInvite.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model
+{
+    public class UserPublicationInvite
+    {
+        [Key] 
+        [Required]
+        public Guid Id { get; set; }
+
+        [Required] public string Email { get; set; } = null!;
+
+        [Required] public Publication Publication { get; set; } = null!;
+
+        [Required]
+        public Guid PublicationId { get; set; }
+        
+        [Required]
+        public PublicationRole Role { get; set; }
+        
+        public bool Accepted { get; set; }
+
+        public bool EmailSent { get; set; }
+
+        public DateTime Created { get; set; }
+
+        public User CreatedBy { get; set; } = null!;
+
+        public Guid CreatedById { get; set; }
+        
+        public bool SoftDeleted { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/UserReleaseInvite.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/UserReleaseInvite.cs
@@ -1,10 +1,11 @@
 #nullable enable
 using System;
 using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
-    public class UserReleaseInvite
+    public class UserReleaseInvite : ICreatedUpdatedTimestamps<DateTime, DateTime?>
     {
         [Key] 
         [Required]
@@ -19,17 +20,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         
         [Required]
         public ReleaseRole Role { get; set; }
-        
-        public bool Accepted { get; set; }
 
         public bool EmailSent { get; set; }
 
         public DateTime Created { get; set; }
 
+        public DateTime? Updated { get; set; }
+
         public User CreatedBy { get; set; } = null!;
 
         public Guid CreatedById { get; set; }
-        
+
         public bool SoftDeleted { get; set; }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationManageTeamAccessTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationManageTeamAccessTab.tsx
@@ -33,7 +33,7 @@ const PublicationManageTeamAccessTab = ({ publication, release }: Props) => {
   } = useAsyncHandledRetry<Model>(async () => {
     const [contributors, invites] = await Promise.all([
       releasePermissionService.listReleaseContributors(release.id),
-      releasePermissionService.listReleaseContributorInvites(release.id, false),
+      releasePermissionService.listReleaseContributorInvites(release.id),
     ]);
     return { contributors, invites };
   }, [publication, release]);

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -162,17 +162,13 @@ const UserInvitePage = ({
                   releases={model?.releases}
                   releaseRoles={model?.resourceRoles.Release}
                   userReleaseRoles={form.values.userReleaseRoles}
-                  onAddUserReleaseRole={(
-                    newUserReleaseRole: InviteUserReleaseRole,
-                  ) => {
+                  onAddUserReleaseRole={newUserReleaseRole => {
                     form.setFieldValue('userReleaseRoles', [
                       ...form.values.userReleaseRoles,
                       newUserReleaseRole,
                     ]);
                   }}
-                  onRemoveUserReleaseRole={(
-                    userReleaseRoleToRemove: InviteUserReleaseRole,
-                  ) => {
+                  onRemoveUserReleaseRole={userReleaseRoleToRemove => {
                     form.setFieldValue(
                       'userReleaseRoles',
                       form.values.userReleaseRoles.filter(
@@ -187,17 +183,13 @@ const UserInvitePage = ({
                   publications={model?.publications}
                   publicationRoles={model?.resourceRoles.Publication}
                   userPublicationRoles={form.values.userPublicationRoles}
-                  onAddUserPublicationRole={(
-                    newUserPublicationRole: InviteUserPublicationRole,
-                  ) => {
+                  onAddUserPublicationRole={newUserPublicationRole => {
                     form.setFieldValue('userPublicationRoles', [
                       ...form.values.userPublicationRoles,
                       newUserPublicationRole,
                     ]);
                   }}
-                  onRemoveUserPublicationRole={(
-                    userPublicationRoleToRemove: InviteUserPublicationRole,
-                  ) => {
+                  onRemoveUserPublicationRole={userPublicationRoleToRemove => {
                     form.setFieldValue(
                       'userPublicationRoles',
                       form.values.userPublicationRoles.filter(

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -22,6 +22,9 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import { IdTitlePair } from '@admin/services/types/common';
 import ButtonGroup from '@common/components/ButtonGroup';
 import InviteUserReleaseRoleForm from '@admin/pages/users/components/InviteUserReleaseRoleForm';
+import publicationService from '@admin/services/publicationService';
+import { PublicationSummary } from '@common/services/publicationService';
+import InviteUserPublicationRoleForm from '@admin/pages/users/components/InviteUserPublicationRoleForm';
 
 export interface InviteUserReleaseRole {
   releaseId: string;
@@ -29,10 +32,17 @@ export interface InviteUserReleaseRole {
   releaseRole: string;
 }
 
+export interface InviteUserPublicationRole {
+  publicationId: string;
+  publicationTitle?: string;
+  publicationRole: string;
+}
+
 interface FormValues {
   userEmail: string;
   roleId: string;
   userReleaseRoles: InviteUserReleaseRole[];
+  userPublicationRoles: InviteUserPublicationRole[];
 }
 
 const errorMappings = [
@@ -48,6 +58,7 @@ interface InviteUserModel {
   roles: Role[];
   resourceRoles: ResourceRoles;
   releases: IdTitlePair[];
+  publications: PublicationSummary[];
 }
 
 const UserInvitePage = ({
@@ -58,12 +69,13 @@ const UserInvitePage = ({
   const { value: model, isLoading } = useAsyncHandledRetry<
     InviteUserModel
   >(async () => {
-    const [roles, resourceRoles, releases] = await Promise.all([
+    const [roles, resourceRoles, releases, publications] = await Promise.all([
       userService.getRoles(),
       userService.getResourceRoles(),
       userService.getReleases(),
+      publicationService.getPublicationSummaries(),
     ]);
-    return { roles, resourceRoles, releases };
+    return { roles, resourceRoles, releases, publications };
   }, []);
 
   const cancelHandler = () => history.push('/administration/users/invites');
@@ -75,10 +87,19 @@ const UserInvitePage = ({
         releaseRole: userReleaseRole.releaseRole,
       };
     });
+    const userPublicationRoles = values.userPublicationRoles.map(
+      userPublicationRole => {
+        return {
+          publicationId: userPublicationRole.publicationId,
+          publicationRole: userPublicationRole.publicationRole,
+        };
+      },
+    );
     const submission: UserInvite = {
       email: values.userEmail,
       roleId: values.roleId,
       userReleaseRoles,
+      userPublicationRoles,
     };
 
     await userService.inviteUser(submission);
@@ -104,6 +125,7 @@ const UserInvitePage = ({
             userEmail: '',
             roleId: orderBy(model?.roles, role => role.name)?.[0]?.id ?? '',
             userReleaseRoles: [],
+            userPublicationRoles: [],
           }}
           validationSchema={Yup.object<FormValues>({
             userEmail: Yup.string()
@@ -111,6 +133,7 @@ const UserInvitePage = ({
               .email('Provide a valid email address'),
             roleId: Yup.string().required('Choose role for the user'),
             userReleaseRoles: Yup.array(),
+            userPublicationRoles: Yup.array(),
           })}
           onSubmit={handleSubmit}
         >
@@ -155,6 +178,31 @@ const UserInvitePage = ({
                       form.values.userReleaseRoles.filter(
                         userReleaseRole =>
                           userReleaseRoleToRemove !== userReleaseRole,
+                      ),
+                    );
+                  }}
+                />
+
+                <InviteUserPublicationRoleForm
+                  publications={model?.publications}
+                  publicationRoles={model?.resourceRoles.Publication}
+                  userPublicationRoles={form.values.userPublicationRoles}
+                  onAddUserPublicationRole={(
+                    newUserPublicationRole: InviteUserPublicationRole,
+                  ) => {
+                    form.setFieldValue('userPublicationRoles', [
+                      ...form.values.userPublicationRoles,
+                      newUserPublicationRole,
+                    ]);
+                  }}
+                  onRemoveUserPublicationRole={(
+                    userPublicationRoleToRemove: InviteUserPublicationRole,
+                  ) => {
+                    form.setFieldValue(
+                      'userPublicationRoles',
+                      form.values.userPublicationRoles.filter(
+                        userPublicationRole =>
+                          userPublicationRoleToRemove !== userPublicationRole,
                       ),
                     );
                   }}

--- a/src/explore-education-statistics-admin/src/pages/users/components/InviteUserPublicationRoleForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/InviteUserPublicationRoleForm.tsx
@@ -1,0 +1,154 @@
+import Button from '@common/components/Button';
+import { FormFieldSelect, FormFieldset } from '@common/components/form';
+import Yup from '@common/validation/yup';
+import { Formik } from 'formik';
+import React, { useMemo } from 'react';
+import { InviteUserPublicationRole } from '@admin/pages/users/UserInvitePage';
+import ButtonText from '@common/components/ButtonText';
+import { keyBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
+import { PublicationSummary } from '@common/services/publicationService';
+
+interface FormValues {
+  publicationId: string;
+  publicationRole: string;
+}
+
+interface Props {
+  publications?: PublicationSummary[];
+  publicationRoles?: string[];
+  userPublicationRoles: InviteUserPublicationRole[];
+  onAddUserPublicationRole: (
+    userPublicationRole: InviteUserPublicationRole,
+  ) => void;
+  onRemoveUserPublicationRole: (
+    userPublicationRole: InviteUserPublicationRole,
+  ) => void;
+}
+
+const InviteUserPublicationRoleForm = ({
+  publications,
+  publicationRoles,
+  userPublicationRoles,
+  onAddUserPublicationRole,
+  onRemoveUserPublicationRole,
+}: Props) => {
+  const publicationTitlesById = useMemo(() => {
+    return keyBy(publications, publication => publication.id);
+  }, [publications]);
+
+  return (
+    <Formik<FormValues>
+      enableReinitialize
+      initialValues={{
+        publicationId: '',
+        publicationRole: '',
+      }}
+      validationSchema={Yup.object<FormValues>({
+        publicationId: Yup.string()
+          .required('Choose publication to give the user access to')
+          .test(
+            'uniquePublicationRole',
+            'You can only add one role for each publication',
+            function uniquePublicationRole(publicationId: string) {
+              return !userPublicationRoles.some(
+                userPublicationRole =>
+                  userPublicationRole.publicationId === publicationId,
+              );
+            },
+          ),
+        publicationRole: Yup.string().required(
+          'Choose publication role for the user',
+        ),
+      })}
+      onSubmit={newUserPublicationRole =>
+        onAddUserPublicationRole(newUserPublicationRole)
+      }
+    >
+      {form => {
+        return (
+          <FormFieldset
+            id="publication-roles"
+            legend="Publication roles"
+            legendSize="m"
+            hint="The user's publication roles within the service."
+          >
+            <FormFieldSelect<FormValues>
+              label="Publication"
+              name="publicationId"
+              placeholder="Choose publication"
+              options={publications?.map(publication => ({
+                label: publication.title,
+                value: publication.id,
+              }))}
+            />
+            <FormFieldSelect<FormValues>
+              label="Publication role"
+              name="publicationRole"
+              placeholder="Choose publication role"
+              options={publicationRoles?.map(role => ({
+                label: role,
+                value: role,
+              }))}
+            />
+            <Button
+              type="button"
+              className="govuk-!-margin-top-6"
+              onClick={async () => {
+                await form.submitForm();
+              }}
+            >
+              Add publication role
+            </Button>
+
+            {userPublicationRoles.length === 0 ? (
+              <p>No user publication roles added</p>
+            ) : (
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Publication Title</th>
+                    <th scope="col">Publication Role</th>
+                    <th scope="col">Options</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {orderBy(
+                    userPublicationRoles,
+                    userPublicationRole =>
+                      publicationTitlesById[userPublicationRole.publicationId]
+                        .title,
+                  ).map(userPublicationRole => (
+                    <tr
+                      key={`${userPublicationRole.publicationId}_${userPublicationRole.publicationRole}`}
+                    >
+                      <td>
+                        {
+                          publicationTitlesById[
+                            userPublicationRole.publicationId
+                          ].title
+                        }
+                      </td>
+                      <td>{userPublicationRole.publicationRole}</td>
+                      <td>
+                        <ButtonText
+                          onClick={() => {
+                            onRemoveUserPublicationRole(userPublicationRole);
+                          }}
+                        >
+                          Remove
+                        </ButtonText>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </FormFieldset>
+        );
+      }}
+    </Formik>
+  );
+};
+
+export default InviteUserPublicationRoleForm;

--- a/src/explore-education-statistics-admin/src/services/releasePermissionService.ts
+++ b/src/explore-education-statistics-admin/src/services/releasePermissionService.ts
@@ -16,13 +16,7 @@ const releasePermissionService = {
   },
   listReleaseContributorInvites(
     releaseId: string,
-    accepted: boolean | undefined = undefined,
   ): Promise<ContributorInvite[]> {
-    if (accepted !== undefined) {
-      return client.get(`/releases/${releaseId}/contributor-invites`, {
-        params: { accepted },
-      });
-    }
     return client.get(`/releases/${releaseId}/contributor-invites`);
   },
   listPublicationContributors(

--- a/src/explore-education-statistics-admin/src/services/userService.ts
+++ b/src/explore-education-statistics-admin/src/services/userService.ts
@@ -44,6 +44,7 @@ export interface UserInvite {
   email: string;
   roleId: string;
   userReleaseRoles: { releaseId: string; releaseRole: string }[];
+  userPublicationRoles: { publicationId: string; publicationRole: string }[];
 }
 
 export interface UserUpdate {


### PR DESCRIPTION
This work allows a BAU user to assign user publication roles when inviting a new user. These user publication roles are then created when the user logs in the for the first time.

![image](https://user-images.githubusercontent.com/44812484/172647910-090d2a17-9fd0-4c94-b75a-e70f7e0fb7c0.png)

This work also ensures that if a pending invite is cancelled, any associated user publication role invites are also cancelled. An additional bug was fixed that meant that an accepted invite could be cancelled / removed from the DB.

Additional work to change the invite email text to include the user release roles and user publication roles they've been invited to (EES-3403) and listing the user release roles and user publication roles of pending invites on the Pending user invites page (EES-3404) will be done in separate PRs.

In changes in response to PR comments commit, this PR now has removed the `Accepted` column from `UserReleaseInvites` - this means that now when any release or publication invite is processed, it is just deleted. To ensure the migration to remove the column doesn't cause issues, we delete all accepted `UserReleaseInvites` before removing the column.

This PR also now adds an `Updated` column to `UserReleaseInvites` for better auditability.