### PR TITLE
EES-3403 EES-3404 Update Pending invite page with roles and include roles in Invite email

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -310,15 +310,22 @@
     },
     "notifyInviteTemplateId": {
       "type": "securestring",
-      "defaultValue": ""
+      "defaultValue": "change-me"
+    },
+    "notifyInviteWithRolesTemplateId": {
+      "type": "securestring",
+      "defaultValue": "change-me",
+      "metadata": {
+        "description": "Gov UK Notify service template Id for "
+      }
     },
     "notifyPublicationRoleTemplateId": {
       "type": "securestring",
-      "defaultValue": ""
+      "defaultValue": "change-me"
     },
     "notifyReleaseRoleTemplateId": {
       "type": "securestring",
-      "defaultValue": ""
+      "defaultValue": "change-me"
     },
     "notifyPreReleaseTemplateId": {
       "type": "securestring",

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -316,7 +316,7 @@
       "type": "securestring",
       "defaultValue": "change-me",
       "metadata": {
-        "description": "Gov UK Notify service template Id for "
+        "description": "Gov UK Notify service template Id for new user invites"
       }
     },
     "notifyPublicationRoleTemplateId": {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/EmailTemplateServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/EmailTemplateServiceTests.cs
@@ -22,11 +22,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void SendInviteEmail()
         {
-            const string expectedTemplateId = "invite-template-id";
+            const string expectedTemplateId = "invite-with-roles-template-id";
 
             var expectedValues = new Dictionary<string, dynamic>
             {
-                {"url", "https://admin-uri"}
+                {"url", "https://admin-uri"},
+                {"release role list", "* No release permissions granted"},
+                {"publication role list" , "* No publication permissions granted"},
             };
 
             var emailService = new Mock<IEmailService>(Strict);
@@ -41,7 +43,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var service = SetupEmailTemplateService(emailService: emailService.Object);
 
-            var result = service.SendInviteEmail("test@test.com");
+            var result = service.SendInviteEmail(
+                "test@test.com",
+                new List<UserReleaseInvite>(),
+                new List<UserPublicationInvite>());
 
             emailService.Verify(
                 s => s.SendEmail(
@@ -156,7 +161,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         private static Mock<IConfiguration> ConfigurationMock()
         {
             return CreateMockConfiguration(
-                TupleOf("NotifyInviteTemplateId", "invite-template-id"),
+                TupleOf("NotifyInviteWithRolesTemplateId", "invite-with-roles-template-id"),
                 TupleOf("NotifyPublicationRoleTemplateId", "publication-role-template-id"),
                 TupleOf("NotifyReleaseRoleTemplateId", "release-role-template-id"),
                 TupleOf("AdminUri", "admin-uri"));

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserInvitesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserInvitesController.cs
@@ -29,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.UserM
         }
 
         [HttpGet("user-management/invites")]
-        public async Task<ActionResult<List<UserViewModel>>> GetInvitedUsers()
+        public async Task<ActionResult<List<PendingInviteViewModel>>> GetInvitedUsers()
         {
             return await _userManagementService
                 .ListPendingInvites()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IEmailTemplateService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IEmailTemplateService.cs
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Mvc;
@@ -7,7 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IEmailTemplateService
     {
-        public Either<ActionResult, Unit> SendInviteEmail(string email);
+        public Either<ActionResult, Unit> SendInviteEmail(
+            string email,
+            List<UserReleaseInvite> userReleaseInvites,
+            List<UserPublicationInvite> userPublicationInvites);
 
         public Either<ActionResult, Unit> SendPublicationRoleEmail(
             string email,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
@@ -19,7 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<List<UserViewModel>> ListPreReleaseUsersAsync();
 
-        Task<Either<ActionResult, List<UserViewModel>>> ListPendingInvites();
+        Task<Either<ActionResult, List<PendingInviteViewModel>>> ListPendingInvites();
 
         Task<Either<ActionResult, UserInvite>> InviteUser(
             string email,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseInviteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseInviteService.cs
@@ -66,15 +66,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(publication => ValidateReleaseIds(publication, releaseIds))
                 .OnSuccess(async publication =>
                 {
-                    email = email.Trim();
+                    var sanitisedEmail = email.Trim();
 
-                    var user = await _userRepository.FindByEmail(email);
+                    var user = await _userRepository.FindByEmail(sanitisedEmail);
                     if (user == null)
                     {
-                        return await CreateNewUserContributorInvite(releaseIds, email, publication.Title);
+                        return await CreateNewUserContributorInvite(releaseIds, sanitisedEmail, publication.Title);
                     }
 
-                    return await CreateExistingUserContributorInvite(releaseIds, user.Id, email, publication.Title);
+                    return await CreateExistingUserContributorInvite(releaseIds, user.Id, sanitisedEmail, publication.Title);
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -229,6 +229,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                 .Select(userReleaseInvite =>
                                     new UserReleaseRoleViewModel
                                     {
+                                        Id = userReleaseInvite.Id,
                                         Publication = userReleaseInvite.Release.Publication.Title,
                                         Release = userReleaseInvite.Release.Title,
                                         Role = userReleaseInvite.Role,
@@ -245,6 +246,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                 .Select(userPublicationInvite =>
                                     new UserPublicationRoleViewModel
                                     {
+                                        Id = userPublicationInvite.Id,
                                         Publication = userPublicationInvite.Publication.Title,
                                         Role = userPublicationInvite.Role,
                                     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PendingInviteViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PendingInviteViewModel.cs
@@ -1,0 +1,20 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
+{
+    public class PendingInviteViewModel
+    {
+        public string Email { get; set; } = string.Empty;
+        
+        public string? Role { get; set; }
+
+        public List<UserPublicationRoleViewModel> UserPublicationRoles { get; set; } = new();
+        
+        public List<UserReleaseRoleViewModel> UserReleaseRoles { get; set; } = new();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "AdminUri": "localhost:5021",
   "NotifyApiKey": "change-me",
-  "NotifyInviteTemplateId": "change-me",
+  "NotifyInviteWithRolesTemplateId": "change-me",
   "NotifyPublicationRoleTemplateId": "change-me",
   "NotifyReleaseRoleTemplateId": "change-me",
   "NotifyPreReleaseTemplateId": "change-me",

--- a/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
@@ -72,7 +72,7 @@ const InvitedUsersPage = () => {
               <tbody className="govuk-table__body">
                 {model.pendingInvites.map(pendingInvite => (
                   <tr className="govuk-table__row" key={pendingInvite.email}>
-                    <td className="govuk-table__cell">{pendingInvite.email}</td>
+                    <th className="govuk-table__cell">{pendingInvite.email}</th>
                     <td className="govuk-table__cell">{pendingInvite.role}</td>
                     <td className="govuk-table__cell">
                       {pendingInvite.userReleaseRoles.length === 0 ? (

--- a/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
@@ -44,48 +44,34 @@ const InvitedUsersPage = () => {
       caption="Manage invites to the service"
     >
       {errorStatus && errorStatus === 404 ? (
-        <p>There are currently no pending user invites</p>
+        'There are currently no pending user invites'
       ) : (
         <LoadingSpinner loading={isLoading} text="Loading invited users">
-          <table className="govuk-table">
+          <table>
             <caption className="govuk-table__caption">Invited users</caption>
-            <thead className="govuk-table__head">
-              <tr className="govuk-table__row">
-                <th scope="col" className="govuk-table__header">
-                  Email
-                </th>
-                <th scope="col" className="govuk-table__header">
-                  Role
-                </th>
-                <th scope="col" className="govuk-table__header">
-                  Release Roles
-                </th>
-                <th scope="col" className="govuk-table__header">
-                  Publication Roles
-                </th>
-                <th scope="col" className="govuk-table__header">
-                  Actions
-                </th>
+            <thead>
+              <tr>
+                <th scope="col">Email</th>
+                <th scope="col">Role</th>
+                <th scope="col">Release Roles</th>
+                <th scope="col">Publication Roles</th>
+                <th scope="col">Actions</th>
               </tr>
             </thead>
             {model && (
-              <tbody className="govuk-table__body">
+              <tbody>
                 {model.pendingInvites.map(pendingInvite => (
-                  <tr className="govuk-table__row" key={pendingInvite.email}>
-                    <th className="govuk-table__cell">{pendingInvite.email}</th>
-                    <td className="govuk-table__cell">{pendingInvite.role}</td>
-                    <td className="govuk-table__cell">
+                  <tr key={pendingInvite.email}>
+                    <td>{pendingInvite.email}</td>
+                    <td>{pendingInvite.role}</td>
+                    <td>
                       {pendingInvite.userReleaseRoles.length === 0 ? (
-                        <p className="govuk-!-margin-0">
-                          No user release roles
-                        </p>
+                        'No user release roles'
                       ) : (
                         <ul className="govuk-!-margin-0">
                           {pendingInvite.userReleaseRoles.map(releaseRole => {
                             return (
-                              <li
-                                key={`${releaseRole.publication}_${releaseRole.release}_${releaseRole.role}`}
-                              >
+                              <li key={releaseRole.id}>
                                 {releaseRole.publication}
                                 <ul>
                                   <li>{releaseRole.release}</li>
@@ -97,19 +83,15 @@ const InvitedUsersPage = () => {
                         </ul>
                       )}
                     </td>
-                    <td className="govuk-table__cell">
+                    <td>
                       {pendingInvite.userPublicationRoles.length === 0 ? (
-                        <p className="govuk-!-margin-0">
-                          No user publication roles
-                        </p>
+                        'No user publication roles'
                       ) : (
                         <ul className="govuk-!-margin-0">
                           {pendingInvite.userPublicationRoles.map(
                             publicationRole => {
                               return (
-                                <li
-                                  key={`${publicationRole.publication}_${publicationRole.role}`}
-                                >
+                                <li key={publicationRole.id}>
                                   {`${publicationRole.publication} - ${publicationRole.role}`}
                                 </li>
                               );
@@ -118,7 +100,7 @@ const InvitedUsersPage = () => {
                         </ul>
                       )}
                     </td>
-                    <td className="govuk-table__cell">
+                    <td>
                       <ButtonText
                         onClick={() => {
                           userService

--- a/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
@@ -1,12 +1,12 @@
 import Link from '@admin/components/Link';
 import Page from '@admin/components/Page';
-import userService, { UserStatus } from '@admin/services/userService';
+import userService, { PendingInvite } from '@admin/services/userService';
 import ButtonText from '@common/components/ButtonText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import React, { useCallback, useEffect, useState } from 'react';
 
 interface Model {
-  users: UserStatus[];
+  pendingInvites: PendingInvite[];
 }
 
 const InvitedUsersPage = () => {
@@ -17,10 +17,10 @@ const InvitedUsersPage = () => {
   const getPendingInvites = useCallback(() => {
     setIsLoading(true);
     userService
-      .getInvitedUsers()
+      .getPendingInvites()
       .then(updatedInvites => {
         setModel({
-          users: updatedInvites,
+          pendingInvites: updatedInvites,
         });
       })
       .catch(error => {
@@ -41,42 +41,88 @@ const InvitedUsersPage = () => {
         { name: 'Pending invites' },
       ]}
       title="Pending invites"
+      caption="Manage invites to the service"
     >
-      <h1 className="govuk-heading-xl">
-        <span className="govuk-caption-xl">Manage access to the service</span>
-        Pending user invites
-      </h1>
-
       {errorStatus && errorStatus === 404 ? (
         <p>There are currently no pending user invites</p>
       ) : (
-        <table className="govuk-table">
-          <caption className="govuk-table__caption">Invited users</caption>
-          <thead className="govuk-table__head">
-            <tr className="govuk-table__row">
-              <th scope="col" className="govuk-table__header">
-                Email
-              </th>
-              <th scope="col" className="govuk-table__header">
-                Role
-              </th>
-              <th scope="col" className="govuk-table__header">
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <LoadingSpinner loading={isLoading} text="Loading invited users">
+        <LoadingSpinner loading={isLoading} text="Loading invited users">
+          <table className="govuk-table">
+            <caption className="govuk-table__caption">Invited users</caption>
+            <thead className="govuk-table__head">
+              <tr className="govuk-table__row">
+                <th scope="col" className="govuk-table__header">
+                  Email
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Role
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Release Roles
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Publication Roles
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Actions
+                </th>
+              </tr>
+            </thead>
             {model && (
               <tbody className="govuk-table__body">
-                {model.users.map(user => (
-                  <tr className="govuk-table__row" key={user.email}>
-                    <td className="govuk-table__cell">{user.email}</td>
-                    <td className="govuk-table__cell">{user.role}</td>
+                {model.pendingInvites.map(pendingInvite => (
+                  <tr className="govuk-table__row" key={pendingInvite.email}>
+                    <td className="govuk-table__cell">{pendingInvite.email}</td>
+                    <td className="govuk-table__cell">{pendingInvite.role}</td>
+                    <td className="govuk-table__cell">
+                      {pendingInvite.userReleaseRoles.length === 0 ? (
+                        <p className="govuk-!-margin-0">
+                          No user release roles
+                        </p>
+                      ) : (
+                        <ul className="govuk-!-margin-0">
+                          {pendingInvite.userReleaseRoles.map(releaseRole => {
+                            return (
+                              <li
+                                key={`${releaseRole.publication}_${releaseRole.release}_${releaseRole.role}`}
+                              >
+                                {releaseRole.publication}
+                                <ul>
+                                  <li>{releaseRole.release}</li>
+                                  <li>{releaseRole.role}</li>
+                                </ul>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      )}
+                    </td>
+                    <td className="govuk-table__cell">
+                      {pendingInvite.userPublicationRoles.length === 0 ? (
+                        <p className="govuk-!-margin-0">
+                          No user publication roles
+                        </p>
+                      ) : (
+                        <ul className="govuk-!-margin-0">
+                          {pendingInvite.userPublicationRoles.map(
+                            publicationRole => {
+                              return (
+                                <li
+                                  key={`${publicationRole.publication}_${publicationRole.role}`}
+                                >
+                                  {`${publicationRole.publication} - ${publicationRole.role}`}
+                                </li>
+                              );
+                            },
+                          )}
+                        </ul>
+                      )}
+                    </td>
                     <td className="govuk-table__cell">
                       <ButtonText
                         onClick={() => {
                           userService
-                            .cancelInvite(user.email)
+                            .cancelInvite(pendingInvite.email)
                             .then(() => getPendingInvites());
                         }}
                       >
@@ -87,8 +133,8 @@ const InvitedUsersPage = () => {
                 ))}
               </tbody>
             )}
-          </LoadingSpinner>
-        </table>
+          </table>
+        </LoadingSpinner>
       )}
       <Link to="/administration/users/invites/create" className="govuk-button">
         Invite a new user

--- a/src/explore-education-statistics-admin/src/pages/users/PreReleaseUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/PreReleaseUsersPage.tsx
@@ -23,33 +23,25 @@ const PreReleaseUsersPage = () => {
         <span className="govuk-caption-xl">Manage pre-release users</span>
         Pre-release users
       </h1>
-      <table className="govuk-table">
+      <table>
         <caption className="govuk-table__caption">
           Users with pre-release access
         </caption>
-        <thead className="govuk-table__head">
-          <tr className="govuk-table__row">
-            <th scope="col" className="govuk-table__header">
-              Name
-            </th>
-            <th scope="col" className="govuk-table__header">
-              Email
-            </th>
-            <th scope="col" className="govuk-table__header">
-              Actions
-            </th>
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Email</th>
+            <th scope="col">Actions</th>
           </tr>
         </thead>
         <LoadingSpinner loading={isLoading} text="Loading pre-release users">
           {value && (
-            <tbody className="govuk-table__body">
+            <tbody>
               {value.map(user => (
-                <tr className="govuk-table__row" key={user.id}>
-                  <th scope="row" className="govuk-table__header">
-                    {user.name}
-                  </th>
-                  <td className="govuk-table__cell">{user.email}</td>
-                  <td className="govuk-table__cell">
+                <tr key={user.id}>
+                  <th scope="row">{user.name}</th>
+                  <td>{user.email}</td>
+                  <td>
                     <Link to={`/administration/users/${user.id}`}>Manage</Link>
                     {/* <ButtonText onClick={removeAccessHander}>Remove</ButtonText> */}
                   </td>

--- a/src/explore-education-statistics-admin/src/pages/users/components/InviteUserPublicationRoleForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/InviteUserPublicationRoleForm.tsx
@@ -104,7 +104,7 @@ const InviteUserPublicationRoleForm = ({
             {userPublicationRoles.length === 0 ? (
               <p>No user publication roles added</p>
             ) : (
-              <table>
+              <table data-testid="publication-role-table">
                 <thead>
                   <tr>
                     <th scope="col">Publication Title</th>
@@ -122,13 +122,13 @@ const InviteUserPublicationRoleForm = ({
                     <tr
                       key={`${userPublicationRole.publicationId}_${userPublicationRole.publicationRole}`}
                     >
-                      <th>
+                      <td>
                         {
                           publicationTitlesById[
                             userPublicationRole.publicationId
                           ].title
                         }
-                      </th>
+                      </td>
                       <td>{userPublicationRole.publicationRole}</td>
                       <td>
                         <ButtonText

--- a/src/explore-education-statistics-admin/src/pages/users/components/InviteUserPublicationRoleForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/InviteUserPublicationRoleForm.tsx
@@ -122,13 +122,13 @@ const InviteUserPublicationRoleForm = ({
                     <tr
                       key={`${userPublicationRole.publicationId}_${userPublicationRole.publicationRole}`}
                     >
-                      <td>
+                      <th>
                         {
                           publicationTitlesById[
                             userPublicationRole.publicationId
                           ].title
                         }
-                      </td>
+                      </th>
                       <td>{userPublicationRole.publicationRole}</td>
                       <td>
                         <ButtonText

--- a/src/explore-education-statistics-admin/src/pages/users/components/InviteUserReleaseRoleForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/InviteUserReleaseRoleForm.tsx
@@ -112,9 +112,9 @@ const InviteUserReleaseRoleForm = ({
                     <tr
                       key={`${userReleaseRole.releaseId}_${userReleaseRole.releaseRole}`}
                     >
-                      <td>
+                      <th>
                         {releaseTitlesById[userReleaseRole.releaseId].title}
-                      </td>
+                      </th>
                       <td>{userReleaseRole.releaseRole}</td>
                       <td>
                         <ButtonText

--- a/src/explore-education-statistics-admin/src/pages/users/components/InviteUserReleaseRoleForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/InviteUserReleaseRoleForm.tsx
@@ -95,7 +95,7 @@ const InviteUserReleaseRoleForm = ({
             {userReleaseRoles.length === 0 ? (
               <p>No user release roles added</p>
             ) : (
-              <table>
+              <table data-testid="release-role-table">
                 <thead>
                   <tr>
                     <th scope="col">Release Title</th>
@@ -112,9 +112,9 @@ const InviteUserReleaseRoleForm = ({
                     <tr
                       key={`${userReleaseRole.releaseId}_${userReleaseRole.releaseRole}`}
                     >
-                      <th>
+                      <td>
                         {releaseTitlesById[userReleaseRole.releaseId].title}
-                      </th>
+                      </td>
                       <td>{userReleaseRole.releaseRole}</td>
                       <td>
                         <ButtonText

--- a/src/explore-education-statistics-admin/src/services/userService.ts
+++ b/src/explore-education-statistics-admin/src/services/userService.ts
@@ -47,6 +47,14 @@ export interface UserInvite {
   userPublicationRoles: { publicationId: string; publicationRole: string }[];
 }
 
+export interface PendingInvite {
+  email: string;
+  name: string;
+  role: string;
+  userPublicationRoles: UserPublicationRole[];
+  userReleaseRoles: UserReleaseRole[];
+}
+
 export interface UserUpdate {
   roleId: string;
 }
@@ -84,7 +92,7 @@ export interface UsersService {
 
   getUsers(): Promise<UserStatus[]>;
   getPreReleaseUsers(): Promise<UserStatus[]>;
-  getInvitedUsers(): Promise<UserStatus[]>;
+  getPendingInvites(): Promise<PendingInvite[]>;
   inviteUser: (invite: UserInvite) => Promise<boolean>;
   inviteContributor: (
     email: string,
@@ -157,8 +165,8 @@ const userService: UsersService = {
     return client.get<UserStatus[]>('/user-management/pre-release');
   },
 
-  getInvitedUsers(): Promise<UserStatus[]> {
-    return client.get<UserStatus[]>('/user-management/invites');
+  getPendingInvites(): Promise<PendingInvite[]> {
+    return client.get<PendingInvite[]>('/user-management/invites');
   },
   inviteUser(invite: UserInvite): Promise<boolean> {
     return client.post(`/user-management/invites`, invite);

--- a/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
+++ b/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
@@ -46,7 +46,7 @@ Enter new publication title
 
 User redirects to the dashboard after saving publication
     user clicks button    Save publication
-    user waits until h1 is visible    Dashboard    %{WAIT_SMALL}
+    user waits until h1 is visible    Dashboard
 
 Verify that new publication has been created
     user opens publication on the admin dashboard    ${PUBLICATION_NAME} (created)

--- a/tests/robot-tests/tests/admin/bau/invite_new_users.robot
+++ b/tests/robot-tests/tests/admin/bau/invite_new_users.robot
@@ -9,12 +9,14 @@ Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 
+
 *** Variables ***
 ${PUBLICATION_NAME}=    UI tests - invite new users %{RUN_IDENTIFIER}
 ${RELEASE1_NAME}=       ${PUBLICATION_NAME} - Academic Year 2000/01
 ${RELEASE2_NAME}=       ${PUBLICATION_NAME} - Academic Year 2001/02
 ${RELEASE3_NAME}=       ${PUBLICATION_NAME} - Academic Year 2002/03
 ${EMAIL}=               ees-ui-test-%{RUN_IDENTIFIER}@education.gov.uk
+
 
 *** Test Cases ***
 Create Publication as bau1
@@ -39,7 +41,7 @@ Invite a new user without any additional roles
     user waits until h1 is visible    Pending invites
 
 Validate newly invited user appears on Pending invites page
-    ${ROW}=    user gets table row with heading    ${EMAIL}
+    ${ROW}=    user gets table row    ${EMAIL}
     set suite variable    ${ROW}
     user checks element contains    ${ROW}    Analyst
     user checks element contains    ${ROW}    No user release roles
@@ -61,7 +63,7 @@ Invite a new user with release and publication roles
     user clicks button    Add release role
 
     user checks table body has x rows    1    testid:release-role-table
-    ${ROW}=    user gets table row with heading    ${RELEASE1_NAME}    testid:release-role-table
+    ${ROW}=    user gets table row    ${RELEASE1_NAME}    testid:release-role-table
     user checks element contains    ${ROW}    Approver
 
     user chooses select option    name:releaseId    ${RELEASE2_NAME}
@@ -69,9 +71,9 @@ Invite a new user with release and publication roles
     user clicks button    Add release role
 
     user checks table body has x rows    2    testid:release-role-table
-    ${ROW}=    user gets table row with heading    ${RELEASE1_NAME}    testid:release-role-table
+    ${ROW}=    user gets table row    ${RELEASE1_NAME}    testid:release-role-table
     user checks element contains    ${ROW}    Approver
-    ${ROW}=    user gets table row with heading    ${RELEASE2_NAME}    testid:release-role-table
+    ${ROW}=    user gets table row    ${RELEASE2_NAME}    testid:release-role-table
     user checks element contains    ${ROW}    Contributor
 
     user chooses select option    name:releaseId    ${RELEASE3_NAME}
@@ -79,7 +81,7 @@ Invite a new user with release and publication roles
     user clicks button    Add release role
 
     user checks table body has x rows    3    testid:release-role-table
-    ${ROW}=    user gets table row with heading    ${RELEASE3_NAME}    testid:release-role-table
+    ${ROW}=    user gets table row    ${RELEASE3_NAME}    testid:release-role-table
     user checks element contains    ${ROW}    PrereleaseViewer
 
     user clicks button    Remove    ${ROW}
@@ -91,14 +93,14 @@ Invite a new user with release and publication roles
     user clicks button    Add publication role
 
     user checks table body has x rows    1    testid:publication-role-table
-    ${ROW}=    user gets table row with heading    ${PUBLICATION_NAME}    testid:publication-role-table
+    ${ROW}=    user gets table row    ${PUBLICATION_NAME}    testid:publication-role-table
     user checks element contains    ${ROW}    ReleaseApprover
 
     user clicks button    Send invite
     user waits until h1 is visible    Pending invites
 
 Validate newly invited user with roles appears on Pending invites page
-    ${ROW}=    user gets table row with heading    ${EMAIL}
+    ${ROW}=    user gets table row    ${EMAIL}
     set suite variable    ${ROW}
     user checks element contains    ${ROW}    Analyst
     user checks element contains    ${ROW}    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin/bau/invite_new_users.robot
+++ b/tests/robot-tests/tests/admin/bau/invite_new_users.robot
@@ -1,0 +1,118 @@
+*** Settings ***
+Library             ../../libs/admin_api.py
+Resource            ../../libs/admin-common.robot
+Resource            ../../libs/tables-common.robot
+
+Suite Setup         user signs in as bau1
+Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
+
+Force Tags          Admin    Local    Dev    AltersData
+
+*** Variables ***
+${PUBLICATION_NAME}=    UI tests - invite new users %{RUN_IDENTIFIER}
+${RELEASE1_NAME}=       ${PUBLICATION_NAME} - Academic Year 2000/01
+${RELEASE2_NAME}=       ${PUBLICATION_NAME} - Academic Year 2001/02
+${RELEASE3_NAME}=       ${PUBLICATION_NAME} - Academic Year 2002/03
+${EMAIL}=               ees-ui-test-%{RUN_IDENTIFIER}@education.gov.uk
+
+*** Test Cases ***
+Create Publication as bau1
+    ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
+    user create test release via api    ${PUBLICATION_ID}    AY    2000
+    user create test release via api    ${PUBLICATION_ID}    AY    2001
+    user create test release via api    ${PUBLICATION_ID}    AY    2002
+
+Navigate to Platform administration, Invite new users page
+    user clicks link    Platform administration
+    user waits until h1 is visible    Platform administration
+
+    user clicks link    Invite new users
+    user waits until h1 is visible    Pending invites
+
+Invite a new user without any additional roles
+    user clicks link    Invite a new user
+    user waits until h1 is visible    Invite user
+
+    user enters text into element    name:userEmail    ${EMAIL}
+    user clicks button    Send invite
+    user waits until h1 is visible    Pending invites
+
+Validate newly invited user appears on Pending invites page
+    ${ROW}=    user gets table row with heading    ${EMAIL}
+    set suite variable    ${ROW}
+    user checks element contains    ${ROW}    Analyst
+    user checks element contains    ${ROW}    No user release roles
+    user checks element contains    ${ROW}    No user publication roles
+
+Cancel invite
+    user clicks button    Cancel invite    ${ROW}
+    user waits until page does not contain    ${EMAIL}
+    user waits until h1 is visible    Pending invites
+
+Invite a new user with release and publication roles
+    user clicks link    Invite a new user
+    user waits until h1 is visible    Invite user
+
+    user enters text into element    name:userEmail    ${EMAIL}
+
+    user chooses select option    name:releaseId    ${RELEASE1_NAME}
+    user chooses select option    name:releaseRole    Approver
+    user clicks button    Add release role
+
+    user checks table body has x rows    1    testid:release-role-table
+    ${ROW}=    user gets table row with heading    ${RELEASE1_NAME}    testid:release-role-table
+    user checks element contains    ${ROW}    Approver
+
+    user chooses select option    name:releaseId    ${RELEASE2_NAME}
+    user chooses select option    name:releaseRole    Contributor
+    user clicks button    Add release role
+
+    user checks table body has x rows    2    testid:release-role-table
+    ${ROW}=    user gets table row with heading    ${RELEASE1_NAME}    testid:release-role-table
+    user checks element contains    ${ROW}    Approver
+    ${ROW}=    user gets table row with heading    ${RELEASE2_NAME}    testid:release-role-table
+    user checks element contains    ${ROW}    Contributor
+
+    user chooses select option    name:releaseId    ${RELEASE3_NAME}
+    user chooses select option    name:releaseRole    PrereleaseViewer
+    user clicks button    Add release role
+
+    user checks table body has x rows    3    testid:release-role-table
+    ${ROW}=    user gets table row with heading    ${RELEASE3_NAME}    testid:release-role-table
+    user checks element contains    ${ROW}    PrereleaseViewer
+
+    user clicks button    Remove    ${ROW}
+    user checks table body has x rows    2    testid:release-role-table
+    user checks element does not contain    testid:release-role-table    ${RELEASE3_NAME}
+
+    user chooses select option    name:publicationId    ${PUBLICATION_NAME}
+    user chooses select option    name:publicationRole    ReleaseApprover
+    user clicks button    Add publication role
+
+    user checks table body has x rows    1    testid:publication-role-table
+    ${ROW}=    user gets table row with heading    ${PUBLICATION_NAME}    testid:publication-role-table
+    user checks element contains    ${ROW}    ReleaseApprover
+
+    user clicks button    Send invite
+    user waits until h1 is visible    Pending invites
+
+Validate newly invited user with roles appears on Pending invites page
+    ${ROW}=    user gets table row with heading    ${EMAIL}
+    set suite variable    ${ROW}
+    user checks element contains    ${ROW}    Analyst
+    user checks element contains    ${ROW}    ${PUBLICATION_NAME}
+
+    user checks element contains    ${ROW}    Academic Year 2000/01
+    user checks element contains    ${ROW}    Approver
+    user checks element contains    ${ROW}    Academic Year 2001/02
+    user checks element contains    ${ROW}    Contributor
+    user checks element does not contain    ${ROW}    Academic Year 2002/03
+    user checks element does not contain    ${ROW}    PrereleaseViewer
+
+    user checks element contains    ${ROW}    ${PUBLICATION_NAME} - ReleaseApprover
+
+Cancel invite with roles
+    user clicks button    Cancel invite    ${ROW}
+    user waits until page does not contain    ${EMAIL}
+    user waits until h1 is visible    Pending invites

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -140,7 +140,7 @@ Navigate to prerelease page
     user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
 
 Validate prerelease has not started
-    user waits until h1 is visible    Pre-release access is not yet available    %{WAIT_SMALL}
+    user waits until h1 is visible    Pre-release access is not yet available
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
@@ -232,7 +232,7 @@ Validate prerelease has not started for Analyst user
     user changes to analyst1
     user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
 
-    user waits until h1 is visible    Pre-release access is not yet available    %{WAIT_SMALL}
+    user waits until h1 is visible    Pre-release access is not yet available
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
@@ -274,7 +274,7 @@ Validate prerelease has started
     user checks nth breadcrumb contains    2    Pre-release access
 
     user waits until page contains title caption    Calendar Year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
 
     user waits until element contains    id:releaseSummary    Test summary text for ${PUBLICATION_NAME}
     ...    %{WAIT_SMALL}
@@ -287,7 +287,7 @@ Validate metadata guidance page
     user clicks link    Data guidance
 
     user waits until page contains title caption    Calendar Year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
 
     user waits until h2 is visible    Data guidance    %{WAIT_SMALL}
     user waits until page contains    Test metadata guidance content    %{WAIT_SMALL}
@@ -317,25 +317,25 @@ Go back to prerelease content page
     user checks nth breadcrumb contains    2    Pre-release access
 
     user waits until page contains title caption    Calendar Year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
 
 Validate public prerelease access list
     user clicks link    Pre-release access list
     user waits until page contains title caption    Calendar Year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
     user waits until h2 is visible    Pre-release access list    %{WAIT_SMALL}
     user waits until page contains    Updated test public access list    %{WAIT_SMALL}
 
 Go back to prerelease content page again
     user clicks link    Back
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
 
 Go to prerelease table tool page
     user clicks link    Table tool
-    user waits until h1 is visible    Create your own tables    %{WAIT_SMALL}
+    user waits until h1 is visible    Create your own tables
     user waits until table tool wizard step is available    1    Choose a subject    %{WAIT_SMALL}
 
 Validate featured tables
@@ -352,7 +352,7 @@ Go to featured table and validate table
 Create and validate custom table
     user clicks link    Table tool
 
-    user waits until h1 is visible    Create your own tables    %{WAIT_SMALL}
+    user waits until h1 is visible    Create your own tables
 
     user clicks link    Create your own table
     user waits until table tool wizard step is available    1    Choose a subject    %{WAIT_SMALL}
@@ -366,7 +366,7 @@ Create and validate custom table
 
 Go to prerelease methodology page
     user clicks link    Methodologies
-    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
+    user waits until h1 is visible    Methodologies
 
 Validate no methodologies
     user waits until page contains    No methodologies available
@@ -375,10 +375,10 @@ Create and validate methodology
     user creates methodology for publication    ${PUBLICATION_NAME}
     approve methodology from methodology view
     user navigates to admin frontend    ${RELEASE_URL}/prerelease/methodologies
-    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
+    user waits until h1 is visible    Methodologies
     user waits until page contains    ${PUBLICATION_NAME} (Owned)
     user clicks link    ${PUBLICATION_NAME} (Owned)
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
 
 Validate prerelease has started for Analyst user
     user changes to analyst1
@@ -389,7 +389,7 @@ Validate prerelease has started for Analyst user
     user checks nth breadcrumb contains    2    Pre-release access
 
     user waits until page contains title caption    Calendar Year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
 
     user waits until element contains    id:releaseSummary    Test summary text for ${PUBLICATION_NAME}
     user waits until element contains    id:releaseHeadlines    Test headlines summary text for ${PUBLICATION_NAME}
@@ -400,7 +400,7 @@ Validate public metdata guidance for Analyst user
     user clicks link    Data guidance
 
     user waits until page contains title caption    Calendar Year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
 
     user waits until h2 is visible    Data guidance    %{WAIT_SMALL}
     user waits until page contains    Test metadata guidance content    %{WAIT_SMALL}
@@ -430,13 +430,13 @@ Go back to prerelease content page as Analyst user
     user checks nth breadcrumb contains    2    Pre-release access
 
     user waits until page contains title caption    Calendar Year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
 
 Validate public prerelease access list as Analyst user
     user clicks link    Pre-release access list
 
     user waits until page contains title caption    Calendar Year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
 
     user waits until h2 is visible    Pre-release access list    %{WAIT_SMALL}
     user waits until page contains    Updated test public access list    %{WAIT_SMALL}
@@ -449,12 +449,12 @@ Go back to prerelease content page again as Analyst user
     user checks nth breadcrumb contains    2    Pre-release access
 
     user waits until page contains title caption    Calendar Year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
 
 Go to prerelease table tool page as Analyst user
     user clicks link    Table tool
 
-    user waits until h1 is visible    Create your own tables    %{WAIT_SMALL}
+    user waits until h1 is visible    Create your own tables
     user waits until table tool wizard step is available    1    Choose a subject    %{WAIT_SMALL}
 
 Validate featured tables as Analyst user
@@ -471,7 +471,7 @@ Go to featured table and validate table as Analyst user
 Create and validate custom table as Analyst user
     user clicks link    Table tool
 
-    user waits until h1 is visible    Create your own tables    %{WAIT_SMALL}
+    user waits until h1 is visible    Create your own tables
 
     user clicks link    Create your own table
     user waits until table tool wizard step is available    1    Choose a subject    %{WAIT_SMALL}
@@ -485,12 +485,12 @@ Create and validate custom table as Analyst user
 
 Go to prerelease methodology page as Analyst user
     user clicks link    Methodologies
-    user waits until h1 is visible    Methodologies    %{WAIT_SMALL}
+    user waits until h1 is visible    Methodologies
 
 Validate methodology as Analyst user
     user waits until page contains    ${PUBLICATION_NAME} (Owned)
     user clicks link    ${PUBLICATION_NAME} (Owned)
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
 
 Unschedule release
     [Documentation]    EES-2826

--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -58,7 +58,7 @@ Set archive-publication to be superseded by superseding-publication
     ${ARCHIVE_ACCORDION}=    user gets accordion section content element    ${PUBLICATION_NAME_ARCHIVE}
     user clicks link    Manage publication    ${ARCHIVE_ACCORDION}
 
-    user waits until h1 is visible    Manage publication    %{WAIT_SMALL}
+    user waits until h1 is visible    Manage publication
     user waits until page contains element    id:publicationForm-supersede
 
     user chooses select option    id:publicationForm-supersededById    ${PUBLICATION_NAME_SUPERSEDE}
@@ -271,7 +271,7 @@ Set archive-publication to be no longer be superseded
     ${ARCHIVE_ACCORDION}=    user gets accordion section content element    ${PUBLICATION_NAME_ARCHIVE}
     user clicks link    Manage publication    ${ARCHIVE_ACCORDION}
 
-    user waits until h1 is visible    Manage publication    %{WAIT_SMALL}
+    user waits until h1 is visible    Manage publication
     user waits until page contains element    id:publicationForm-supersede
 
     user chooses select option    id:publicationForm-supersededById    None selected
@@ -282,7 +282,7 @@ Set archive-publication to be no longer be superseded
     user waits until modal is not visible    Confirm publication changes
 
     # Otherwise gets to Find Stats page before cache is invalidated
-    user waits until h1 is visible    Dashboard    %{WAIT_SMALL}
+    user waits until h1 is visible    Dashboard
 
 Check public Find stats page and check archive-publication is no longer archived
     user navigates to find statistics page on public frontend

--- a/tests/robot-tests/tests/admin_and_public/bau/legacy_releases.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/legacy_releases.robot
@@ -31,7 +31,7 @@ Go to manage publication page
     user opens accordion section    ${PUBLICATION_NAME}
     user clicks element    testid:Edit publication link for ${PUBLICATION_NAME}
     user waits until page contains title caption    ${PUBLICATION_NAME}
-    user waits until h1 is visible    Manage publication    %{WAIT_SMALL}
+    user waits until h1 is visible    Manage publication
 
 Create legacy release
     user scrolls to element    //*[button[contains(text(),'Create legacy release')]]
@@ -83,7 +83,7 @@ Navigate to publication to update legacy releases
     user opens accordion section    ${PUBLICATION_NAME}
     user clicks element    testid:Edit publication link for ${PUBLICATION_NAME}
     user waits until page contains title caption    ${PUBLICATION_NAME}
-    user waits until h1 is visible    Manage publication    %{WAIT_SMALL}
+    user waits until h1 is visible    Manage publication
 
 Update legacy release
     user clicks element    xpath://tr[1]//*[text()="Edit release"]
@@ -125,7 +125,7 @@ Navigate to publication to update legacy releases again
     user opens accordion section    ${PUBLICATION_NAME}
     user clicks element    testid:Edit publication link for ${PUBLICATION_NAME}
     user waits until page contains title caption    ${PUBLICATION_NAME}
-    user waits until h1 is visible    Manage publication    %{WAIT_SMALL}
+    user waits until h1 is visible    Manage publication
 
 Delete legacy release
     user clicks element    xpath://tr[1]//*[text()="Delete release"]

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -10,10 +10,12 @@ Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 
+
 *** Variables ***
 ${PUBLICATION_NAME}=                    UI tests - publish methodology %{RUN_IDENTIFIER}
 ${PUBLIC_METHODOLOGY_URL_ENDING}=       /methodology/ui-tests-publish-methodology-%{RUN_IDENTIFIER}
 ${RELEASE_NAME}=                        Academic Year 2021/22
+
 
 *** Test Cases ***
 Create a draft release

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -10,12 +10,10 @@ Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 
-
 *** Variables ***
 ${PUBLICATION_NAME}=                    UI tests - publish methodology %{RUN_IDENTIFIER}
 ${PUBLIC_METHODOLOGY_URL_ENDING}=       /methodology/ui-tests-publish-methodology-%{RUN_IDENTIFIER}
 ${RELEASE_NAME}=                        Academic Year 2021/22
-
 
 *** Test Cases ***
 Create a draft release
@@ -206,7 +204,7 @@ Verify that the amended methodology is visible on the public methodologies page
     user waits until page contains accordion section    %{TEST_THEME_NAME}
     user opens accordion section    %{TEST_THEME_NAME}
     user opens details dropdown    %{TEST_TOPIC_NAME}
-    user scrolls down    400    # @MarkFix
+    user scrolls down    400
     user checks page contains methodology link
     ...    %{TEST_TOPIC_NAME}
     ...    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -140,7 +140,7 @@ user opens release summary on the admin dashboard
 
 user creates publication
     [Arguments]    ${title}
-    user waits until h1 is visible    Create new publication    %{WAIT_SMALL}
+    user waits until h1 is visible    Create new publication
     user waits until page contains element    id:publicationForm-title    %{WAIT_SMALL}
     user enters text into element    id:publicationForm-title    ${title}
     user enters text into element    id:publicationForm-teamName    Attainment statistics team
@@ -153,7 +153,7 @@ user creates publication
 user creates release for publication
     [Arguments]    ${publication}    ${time_period_coverage}    ${start_year}
     user waits until page contains title caption    ${publication}    %{WAIT_SMALL}
-    user waits until h1 is visible    Create new release    %{WAIT_SMALL}
+    user waits until h1 is visible    Create new release
     user waits until page contains element    id:releaseSummaryForm-timePeriodCoverage    %{WAIT_SMALL}
     user chooses select option    id:releaseSummaryForm-timePeriodCoverageCode    ${time_period_coverage}
     user enters text into element    id:releaseSummaryForm-timePeriodCoverageStartYear    ${start_year}
@@ -749,7 +749,7 @@ user removes release access from analyst
 user goes to manage user
     [Arguments]    ${EMAIL_ADDRESS}
     user navigates to admin frontend    %{ADMIN_URL}/administration/users
-    user waits until h1 is visible    Users    %{WAIT_SMALL}
+    user waits until h1 is visible    Users
     user waits until table is visible
     user clicks link    Manage    xpath://td[text()="${EMAIL_ADDRESS}"]/..
     # stale element exception if you don't wait until it's enabled

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -520,7 +520,7 @@ user waits until h1 is visible
     user waits until element is visible    xpath://h1[text()="${text}"]    ${wait}
 
 user waits until h1 is not visible
-    [Arguments]    ${text}    ${wait}=${timeout}
+    [Arguments]    ${text}    ${wait}=%{WAIT_SMALL}
     user waits until element is not visible    xpath://h1[text()="${text}"]    ${wait}
 
 user waits until h2 is visible

--- a/tests/robot-tests/tests/libs/tables-common.robot
+++ b/tests/robot-tests/tests/libs/tables-common.robot
@@ -46,6 +46,11 @@ user gets table row with heading
     ${elem}=    get child element    ${parent}    xpath:.//tbody/tr/th[text()="${heading}"]/..
     [Return]    ${elem}
 
+user gets table row
+    [Arguments]    ${row_cell_text}    ${parent}=css:table
+    ${elem}=    get child element    ${parent}    xpath:.//tbody/tr/td[text()="${row_cell_text}"]/..
+    [Return]    ${elem}
+
 user checks table body has x rows
     [Arguments]    ${count}    ${parent}=css:table    ${wait}=${timeout}
     user waits until parent contains element    ${parent}    xpath:.//tbody/tr    timeout=${wait}    count=${count}


### PR DESCRIPTION
:rotating_light: The new `Invite with roles` email template id needs adding to preprod and prod before this is deployed to those environments :rotating_light: 

This PR now displays release and publication roles attached to invite on the Pending Invites page, and lists any attached release and publication roles to a new user's invite email.

![image](https://user-images.githubusercontent.com/44812484/173086241-51944f91-ef19-4e7c-83f7-176301c8440e.png)

![image](https://user-images.githubusercontent.com/44812484/173086329-dc5469d5-3282-434f-b18c-9d284b62d641.png)

