### PR TITLE
EES-3017 table tool publication step changes

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormTextSearchInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormTextSearchInput.tsx
@@ -1,9 +1,9 @@
 import { FormTextInputProps } from '@common/components/form/FormTextInput';
 import { FormTextInput } from '@common/components/form/index';
+import styles from '@common/components/form/FormTextSearchInput.module.scss';
 import classNames from 'classnames';
 import debounce from 'lodash/debounce';
-import React, { ChangeEvent } from 'react';
-import styles from './FormTextSearchInput.module.scss';
+import React, { ChangeEvent, useEffect, useState } from 'react';
 
 interface Props extends FormTextInputProps {
   debounce?: number;
@@ -15,6 +15,12 @@ const FormTextSearchInput = ({
   onChange,
   ...props
 }: Props) => {
+  const [value, setValue] = useState<string>(props.value ?? '');
+
+  useEffect(() => {
+    setValue(props.value ?? '');
+  }, [props.value]);
+
   const handleChange = debounce((event: ChangeEvent<HTMLInputElement>) => {
     if (onChange) {
       onChange(event);
@@ -25,8 +31,10 @@ const FormTextSearchInput = ({
     <FormTextInput
       {...props}
       className={classNames(className, styles.searchInput)}
+      value={value}
       onChange={event => {
         event.persist();
+        setValue(event.target.value);
         handleChange(event);
       }}
     />

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.module.scss
@@ -1,0 +1,19 @@
+@import '~govuk-frontend/govuk/base';
+
+.optionsContainer {
+  @include govuk-media-query($from: desktop) {
+    display: flex;
+  }
+}
+
+.publicationsList {
+  @include govuk-media-query($from: desktop) {
+    border-left: 1px solid govuk-colour('mid-grey');
+    margin-left: govuk-spacing(7);
+    padding-left: govuk-spacing(7);
+  }
+
+  :global(.govuk-form-group) {
+    margin-bottom: 0;
+  }
+}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -1,22 +1,23 @@
-import DetailsMenu from '@common/components/DetailsMenu';
 import {
   Form,
   FormFieldRadioGroup,
   FormFieldset,
   FormGroup,
+  FormRadioGroup,
   FormTextSearchInput,
 } from '@common/components/form';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import WizardStepSummary from '@common/modules/table-tool/components/WizardStepSummary';
 import { PublicationSummary, Theme } from '@common/services/themeService';
-import createErrorHelper from '@common/validation/createErrorHelper';
 import Yup from '@common/validation/yup';
+import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
+import WizardStepFormActions from '@common/modules/table-tool/components/WizardStepFormActions';
+import WizardStepHeading from '@common/modules/table-tool/components/WizardStepHeading';
+import styles from '@common/modules/table-tool/components/PublicationForm.module.scss';
+import { orderBy } from 'lodash';
 import { Formik } from 'formik';
-import React, { useState } from 'react';
-import { InjectedWizardProps } from './Wizard';
-import WizardStepFormActions from './WizardStepFormActions';
-import WizardStepHeading from './WizardStepHeading';
+import React, { useMemo, useState } from 'react';
 
 export interface PublicationFormValues {
   publicationId: string;
@@ -30,7 +31,7 @@ const formId = 'publicationForm';
 
 interface Props extends InjectedWizardProps {
   initialValues?: PublicationFormValues;
-  options: Theme[];
+  themes: Theme[];
   onSubmit: PublicationFormSubmitHandler;
 }
 
@@ -38,20 +39,59 @@ const PublicationForm = ({
   initialValues = {
     publicationId: '',
   },
-  options,
+  themes,
   onSubmit,
   ...stepProps
 }: Props) => {
   const { isActive, goToNextStep } = stepProps;
 
   const [searchTerm, setSearchTerm] = useState('');
-  const lowercaseSearchTerm = searchTerm.toLowerCase();
+  const [selectedThemeId, setSelectedThemeId] = useState<string>('');
+
+  const publications = useMemo(() => {
+    if (selectedThemeId) {
+      setSearchTerm('');
+      return (
+        themes
+          .find(theme => theme.id === selectedThemeId)
+          ?.topics.flatMap(topic => topic.publications) ?? []
+      );
+    }
+    if (searchTerm) {
+      setSelectedThemeId('');
+      return themes
+        .flatMap(theme => theme.topics.flatMap(topic => topic.publications))
+        .filter(publication =>
+          publication.title.toLowerCase().includes(searchTerm.toLowerCase()),
+        );
+    }
+
+    return [];
+  }, [themes, searchTerm, selectedThemeId]);
+
+  const getThemeForPublication = (publicationId: string) => {
+    return themes.find(theme =>
+      theme.topics
+        .flatMap(topic => topic.publications)
+        .find(pub => pub.id === publicationId),
+    )?.title;
+  };
+
+  const getSelectedPublication = (publicationId: string) =>
+    themes
+      .flatMap(theme => theme.topics)
+      .flatMap(topic => topic.publications)
+      .find(publication => publication.id === publicationId);
 
   const stepHeading = (
     <WizardStepHeading {...stepProps} fieldsetHeading>
       Choose a publication
     </WizardStepHeading>
   );
+
+  if (!themes.length) {
+    return <p>No publications found</p>;
+  }
 
   return (
     <Formik<PublicationFormValues>
@@ -63,9 +103,6 @@ const PublicationForm = ({
         publicationId: Yup.string().required('Choose publication'),
       })}
       onSubmit={async ({ publicationId }) => {
-        const publications = options.flatMap(theme =>
-          theme.topics.flatMap(topic => topic.publications),
-        );
         const publication = publications.find(p => p.id === publicationId);
 
         if (!publication) {
@@ -78,134 +115,123 @@ const PublicationForm = ({
       }}
     >
       {form => {
-        const { values } = form;
-        const { getError } = createErrorHelper(form);
-
-        const filteredOptions = options
-          .filter(theme =>
-            theme.topics.some(topic =>
-              topic.publications.some(
-                publication =>
-                  publication.id === values.publicationId ||
-                  publication.title.toLowerCase().includes(lowercaseSearchTerm),
-              ),
-            ),
-          )
-          .map(group => ({
-            ...group,
-            topics: group.topics
-              .filter(topic =>
-                topic.publications.some(
-                  publication =>
-                    publication.id === values.publicationId ||
-                    publication.title
-                      .toLowerCase()
-                      .includes(lowercaseSearchTerm),
-                ),
-              )
-              .map(topic => ({
-                ...topic,
-                publications: topic.publications.filter(
-                  publication =>
-                    publication.id === values.publicationId ||
-                    publication.title
-                      .toLowerCase()
-                      .includes(lowercaseSearchTerm),
-                ),
-              })),
-          }));
-
         if (isActive) {
           return (
             <Form {...form} id={formId} showSubmitError>
-              <FormFieldset
-                error={getError('publicationId')}
-                id="publicationId"
-                legend={stepHeading}
-              >
-                <FormGroup>
+              <FormFieldset id="publicationForm" legend={stepHeading}>
+                <p>Search or select a theme to find publications</p>
+                <FormGroup className="govuk-!-margin-bottom-3">
                   <FormTextSearchInput
                     id={`${formId}-publicationIdSearch`}
                     label="Search publications"
                     name="publicationSearch"
-                    onChange={event => setSearchTerm(event.target.value)}
+                    onChange={event => {
+                      setSearchTerm(event.target.value);
+                      setSelectedThemeId('');
+                      if (!event.target.value) {
+                        form.setFieldValue('publicationId', '');
+                      }
+                    }}
                     onKeyPress={event => {
                       if (event.key === 'Enter') {
                         event.preventDefault();
                       }
                     }}
+                    value={searchTerm}
                     width={20}
                   />
+                  {searchTerm && publications.length > 0 && (
+                    <p>
+                      <a
+                        href="#publications"
+                        className="govuk-link govuk-!-margin-top-3 govuk-!-font-size-14"
+                      >
+                        Skip to search results
+                      </a>
+                    </p>
+                  )}
                 </FormGroup>
 
-                <FormGroup>
-                  <div aria-live="assertive">
-                    {filteredOptions.length > 0 ? (
-                      filteredOptions.map(theme => (
-                        <DetailsMenu
-                          jsRequired
-                          summary={theme.title}
-                          key={theme.id}
-                          id={`${formId}-theme-${theme.id}`}
-                          detailsId="theme"
-                          open={
-                            searchTerm !== '' ||
-                            theme.topics.some(topic =>
-                              topic.publications.some(
-                                publication =>
-                                  publication.id === values.publicationId,
-                              ),
-                            )
-                          }
-                        >
-                          {theme.topics.map(topic => (
-                            <DetailsMenu
-                              summary={topic.title}
-                              key={topic.id}
-                              id={`${formId}-topic-${topic.id}`}
-                              detailsId="topic"
-                              open={
-                                searchTerm !== '' ||
-                                topic.publications.some(
-                                  publication =>
-                                    publication.id === values.publicationId,
-                                )
-                              }
-                            >
-                              <FormFieldRadioGroup
-                                legend={`Choose option from ${topic.title}`}
-                                legendHidden
-                                small
-                                showError={false}
-                                name="publicationId"
-                                disabled={form.isSubmitting}
-                                options={topic.publications.map(
-                                  publication => ({
-                                    label: publication.title,
-                                    value: publication.id,
-                                  }),
-                                )}
-                              />
-                            </DetailsMenu>
-                          ))}
-                        </DetailsMenu>
-                      ))
-                    ) : (
-                      <p>No publications found</p>
+                <p>or</p>
+
+                <div className={styles.optionsContainer}>
+                  <FormRadioGroup
+                    id={`${formId}-themes`}
+                    legend="Select a theme"
+                    legendSize="s"
+                    name="themeId"
+                    small
+                    options={themes.map(theme => {
+                      return {
+                        label: theme.title,
+                        value: theme.id,
+                      };
+                    })}
+                    value={selectedThemeId}
+                    onChange={e => {
+                      setSelectedThemeId(e.target.value);
+                      form.setFieldValue('publicationId', '');
+                      setSearchTerm('');
+                    }}
+                  />
+
+                  <div className={styles.publicationsList} id="publications">
+                    <FormFieldRadioGroup
+                      id={`${formId}-publications`}
+                      legend={
+                        <>
+                          Select a publication
+                          <span
+                            className="govuk-visually-hidden"
+                            aria-live="polite"
+                            aria-atomic="true"
+                          >
+                            {' '}
+                            {`${publications.length} ${
+                              publications.length === 1
+                                ? `publication`
+                                : `publications`
+                            } found`}
+                          </span>
+                        </>
+                      }
+                      legendSize="s"
+                      name="publicationId"
+                      small
+                      options={orderBy(publications, 'title').map(
+                        publication => {
+                          return {
+                            label: searchTerm
+                              ? `${publication.title} (${getThemeForPublication(
+                                  publication.id,
+                                )})`
+                              : publication.title,
+                            value: publication.id,
+                          };
+                        },
+                      )}
+                    />
+
+                    {!publications.length && (
+                      <>
+                        <p>Search or select a theme to view publications</p>
+                        {(searchTerm || selectedThemeId) && (
+                          <p>
+                            <em>No publications found</em>
+                          </p>
+                        )}
+                      </>
                     )}
-                  </div>
-                </FormGroup>
-              </FormFieldset>
 
-              <WizardStepFormActions {...stepProps} />
+                    <div className="govuk-!-margin-top-6">
+                      <WizardStepFormActions {...stepProps} />
+                    </div>
+                  </div>
+                </div>
+              </FormFieldset>
             </Form>
           );
         }
-
-        const publication = options
-          .flatMap(option => option.topics)
-          .flatMap(option => option.publications)
-          .find(option => option.id === form.values.publicationId);
 
         return (
           <WizardStepSummary {...stepProps} goToButtonText="Change publication">
@@ -213,7 +239,7 @@ const PublicationForm = ({
 
             <SummaryList noBorder>
               <SummaryListItem term="Publication">
-                {publication?.title}
+                {getSelectedPublication(form.values.publicationId)?.title}
               </SummaryListItem>
             </SummaryList>
           </WizardStepSummary>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -400,7 +400,7 @@ const TableToolWizard = ({
                     initialValues={{
                       publicationId: state.query.publicationId ?? '',
                     }}
-                    options={themeMeta}
+                    themes={themeMeta}
                     onSubmit={handlePublicationFormSubmit}
                   />
                 )}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationForm.test.tsx
@@ -4,27 +4,27 @@ import PublicationForm, {
 import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
 import { Theme } from '@common/services/themeService';
 import { waitFor } from '@testing-library/dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import noop from 'lodash/noop';
 import React from 'react';
 
 describe('PublicationForm', () => {
-  const testOptions: Theme[] = [
+  const testThemes: Theme[] = [
     {
       id: 'theme-1',
-      title: 'Further education',
+      title: 'Theme 1',
       summary: '',
       topics: [
         {
           id: 'topic-1',
-          title: 'Further education and skills',
+          title: 'Topic 1',
           summary: '',
           publications: [
             {
               id: 'publication-1',
-              title: 'Apprenticeships and traineeships',
-              slug: 'apprenticeships-and-traineeships',
+              title: 'Publication 1',
+              slug: 'publication-slug-1',
               type: 'NationalAndOfficial',
               isSuperseded: false,
             },
@@ -32,13 +32,13 @@ describe('PublicationForm', () => {
         },
         {
           id: 'topic-2',
-          title: 'National achievement rates tables',
+          title: 'Topic 2',
           summary: '',
           publications: [
             {
               id: 'publication-2',
-              title: 'National achievement rates tables',
-              slug: 'national-achievement-rates-tables',
+              title: 'Publication 2 find me',
+              slug: 'publication-slug-2',
               type: 'NationalAndOfficial',
               isSuperseded: false,
             },
@@ -48,18 +48,18 @@ describe('PublicationForm', () => {
     },
     {
       id: 'theme-2',
-      title: 'Children, early years and social care',
+      title: 'Theme 2',
       summary: '',
       topics: [
         {
           id: 'topic-3',
-          title: 'Early years foundation stage profile',
+          title: 'Topic 3',
           summary: '',
           publications: [
             {
               id: 'publication-3',
-              title: 'Early years foundation stage profile results',
-              slug: 'early-years-foundation-stage-profile-results',
+              title: 'Publication 3',
+              slug: 'publication-slug-3',
               type: 'NationalAndOfficial',
               isSuperseded: false,
             },
@@ -69,18 +69,18 @@ describe('PublicationForm', () => {
     },
     {
       id: 'theme-3',
-      title: 'Pupils and schools',
+      title: 'Theme 3',
       summary: '',
       topics: [
         {
           id: 'topic-4',
-          title: 'School applications',
+          title: 'Topic 4',
           summary: '',
           publications: [
             {
               id: 'publication-4',
-              title: 'Secondary and primary schools applications and offers',
-              slug: 'secondary-and-primary-schools-applications-and-offers',
+              title: 'Publication 4 find me',
+              slug: 'publication-slug-4',
               type: 'NationalAndOfficial',
               isSuperseded: false,
             },
@@ -88,13 +88,13 @@ describe('PublicationForm', () => {
         },
         {
           id: 'topic-5',
-          title: 'Pupil absence',
+          title: 'Topic 5',
           summary: '',
           publications: [
             {
               id: 'publication-5',
-              title: 'Pupil absence in schools in England',
-              slug: 'pupil-absence-in-schools-in-england',
+              title: 'Publication 5',
+              slug: 'publication-slug-5',
               type: 'NationalAndOfficial',
               isSuperseded: false,
             },
@@ -102,13 +102,13 @@ describe('PublicationForm', () => {
         },
         {
           id: 'topic-6',
-          title: 'Special educational needs (SEN)',
+          title: 'Topic 6',
           summary: '',
           publications: [
             {
               id: 'publication-6',
-              title: 'Statements of SEN and EHC plans',
-              slug: 'statements-of-sen-and-ehc-plans',
+              title: 'Publication 6',
+              slug: 'publication-slug-6',
               type: 'NationalAndOfficial',
               isSuperseded: false,
             },
@@ -116,13 +116,13 @@ describe('PublicationForm', () => {
         },
         {
           id: 'topic-7',
-          title: 'Exclusions',
+          title: 'Topic 7',
           summary: '',
           publications: [
             {
               id: 'publication-7',
-              title: 'Permanent and fixed-period exclusions in England',
-              slug: 'permanent-and-fixed-period-exclusions-in-england',
+              title: 'Publication 7',
+              slug: 'publication-slug-7',
               type: 'NationalAndOfficial',
               isSuperseded: false,
             },
@@ -132,18 +132,18 @@ describe('PublicationForm', () => {
     },
     {
       id: 'theme-4',
-      title: 'School and college outcomes and performance',
+      title: 'Theme 4',
       summary: '',
       topics: [
         {
           id: 'topic-8',
-          title: 'Key stage 2',
+          title: 'Topic 8',
           summary: '',
           publications: [
             {
               id: 'publication-8',
-              title: 'National curriculum assessments at key stage 2',
-              slug: 'national-curriculum-assessments-key-stage2',
+              title: 'Publication 8',
+              slug: 'publication-slug-8',
               type: 'NationalAndOfficial',
               isSuperseded: false,
             },
@@ -151,14 +151,13 @@ describe('PublicationForm', () => {
         },
         {
           id: 'topic-9',
-          title: 'GCSEs (key stage 4)',
+          title: 'Topic 9',
           summary: '',
           publications: [
             {
               id: 'publication-9',
-              title:
-                'GCSE and equivalent results, including pupil characteristics',
-              slug: 'gcse-results-including-pupil-characteristics',
+              title: 'Publication 9',
+              slug: 'publication-slug-9',
               type: 'NationalAndOfficial',
               isSuperseded: false,
             },
@@ -166,13 +165,13 @@ describe('PublicationForm', () => {
         },
         {
           id: 'topic-10',
-          title: '16 to 19 attainment',
+          title: 'Topic 10',
           summary: '',
           publications: [
             {
               id: 'publication-10',
-              title: 'Level 2 and 3 attainment by young people aged 19',
-              slug: 'Level 2 and 3 attainment by young people aged 19',
+              title: 'Publication 10',
+              slug: 'publication-slug-10',
               type: 'NationalAndOfficial',
               isSuperseded: false,
             },
@@ -194,67 +193,139 @@ describe('PublicationForm', () => {
     goToPreviousStep: task => task?.(),
   };
 
+  test('renders the form with the search form, themes list and empty publications list', () => {
+    render(
+      <PublicationForm {...wizardProps} themes={testThemes} onSubmit={noop} />,
+    );
+
+    expect(screen.getByLabelText('Search publications')).toBeInTheDocument();
+    const themeRadios = within(
+      screen.getByRole('group', { name: 'Select a theme' }),
+    ).getAllByRole('radio');
+    expect(themeRadios).toHaveLength(4);
+    expect(themeRadios[0]).toEqual(
+      screen.getByRole('radio', { name: 'Theme 1' }),
+    );
+    expect(themeRadios[1]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Theme 2',
+      }),
+    );
+    expect(themeRadios[2]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Theme 3',
+      }),
+    );
+    expect(themeRadios[3]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Theme 4',
+      }),
+    );
+
+    const publicationRadios = within(
+      screen.getByRole('group', {
+        name: /Select a publication/,
+      }),
+    ).queryAllByRole('radio');
+    expect(publicationRadios).toHaveLength(0);
+
+    expect(
+      screen.getByText('Search or select a theme to view publications'),
+    ).toBeInTheDocument();
+  });
+
   test('renders publication options filtered by title when using search field', async () => {
     jest.useFakeTimers();
 
     render(
-      <PublicationForm
-        {...wizardProps}
-        onSubmit={noop}
-        options={testOptions}
-      />,
+      <PublicationForm {...wizardProps} themes={testThemes} onSubmit={noop} />,
     );
-
-    expect(screen.getAllByRole('radio', { hidden: true })).toHaveLength(10);
 
     await userEvent.type(
       screen.getByLabelText('Search publications'),
-      'Early years',
+      'find me',
     );
 
     jest.runOnlyPendingTimers();
 
-    expect(screen.getAllByRole('radio')).toHaveLength(1);
-    expect(
-      screen.getByLabelText('Early years foundation stage profile results'),
-    ).toHaveAttribute('type', 'radio');
+    const publicationRadios = within(
+      screen.getByRole('group', {
+        name: /Select a publication/,
+      }),
+    ).queryAllByRole('radio');
+    expect(publicationRadios).toHaveLength(2);
+
+    expect(publicationRadios[0]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Publication 2 find me (Theme 1)',
+      }),
+    );
+    expect(publicationRadios[1]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Publication 4 find me (Theme 3)',
+      }),
+    );
   });
 
   test('renders publication options filtered by case-insensitive title', async () => {
     jest.useFakeTimers();
 
     render(
-      <PublicationForm
-        {...wizardProps}
-        onSubmit={noop}
-        options={testOptions}
-      />,
+      <PublicationForm {...wizardProps} themes={testThemes} onSubmit={noop} />,
     );
-
-    expect(screen.getAllByRole('radio', { hidden: true })).toHaveLength(10);
 
     await userEvent.type(
       screen.getByLabelText('Search publications'),
-      'early years',
+      'FiND Me',
     );
 
     jest.runOnlyPendingTimers();
 
-    expect(screen.getAllByRole('radio')).toHaveLength(1);
-    expect(
-      screen.getByLabelText('Early years foundation stage profile results'),
-    ).toHaveAttribute('type', 'radio');
+    const publicationRadios = within(
+      screen.getByRole('group', {
+        name: /Select a publication/,
+      }),
+    ).queryAllByRole('radio');
+    expect(publicationRadios).toHaveLength(2);
+
+    expect(publicationRadios[0]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Publication 2 find me (Theme 1)',
+      }),
+    );
+    expect(publicationRadios[1]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Publication 4 find me (Theme 3)',
+      }),
+    );
+  });
+
+  test('renders the `no publications found` message when there are no search results', async () => {
+    jest.useFakeTimers();
+
+    render(
+      <PublicationForm {...wizardProps} themes={testThemes} onSubmit={noop} />,
+    );
+
+    await userEvent.type(screen.getByLabelText('Search publications'), 'Nope');
+
+    jest.runOnlyPendingTimers();
+
+    const publicationRadios = within(
+      screen.getByRole('group', {
+        name: /Select a publication/,
+      }),
+    ).queryAllByRole('radio');
+    expect(publicationRadios).toHaveLength(0);
+
+    expect(screen.getByText('No publications found')).toBeInTheDocument();
   });
 
   test('does not throw error if regex sensitive search term is used', async () => {
     jest.useFakeTimers();
 
     render(
-      <PublicationForm
-        {...wizardProps}
-        onSubmit={noop}
-        options={testOptions}
-      />,
+      <PublicationForm {...wizardProps} themes={testThemes} onSubmit={noop} />,
     );
 
     await userEvent.type(screen.getByLabelText('Search publications'), '[');
@@ -264,90 +335,57 @@ describe('PublicationForm', () => {
     }).not.toThrow();
   });
 
-  test('renders empty message when there are no publication options', () => {
-    render(<PublicationForm {...wizardProps} onSubmit={noop} options={[]} />);
+  test('renders empty message when there are no themes', () => {
+    render(<PublicationForm {...wizardProps} onSubmit={noop} themes={[]} />);
 
-    expect(screen.queryAllByRole('radio')).toHaveLength(0);
-    expect(screen.queryByText('No publications found')).not.toBeNull();
-  });
+    expect(
+      screen.queryByRole('group', { name: 'Select a theme' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('group', { name: /Select a publication/ }),
+    ).not.toBeInTheDocument();
 
-  test('renders empty message when there are no filtered publication options', async () => {
-    jest.useFakeTimers();
-
-    render(
-      <PublicationForm
-        {...wizardProps}
-        onSubmit={noop}
-        options={testOptions}
-      />,
-    );
-
-    expect(screen.queryByText('No publications found')).not.toBeInTheDocument();
-    expect(screen.queryAllByRole('radio', { hidden: true })).toHaveLength(10);
-
-    await userEvent.type(
-      screen.getByLabelText('Search publications'),
-      'not a publication',
-    );
-
-    jest.runOnlyPendingTimers();
-
-    expect(screen.queryAllByRole('radio', { hidden: true })).toHaveLength(0);
     expect(screen.getByText('No publications found')).toBeInTheDocument();
   });
 
-  test('renders selected publication option even if it does not match search field', async () => {
-    jest.useFakeTimers();
-
+  test('renders the publication options when a theme is selected', async () => {
     render(
-      <PublicationForm
-        {...wizardProps}
-        onSubmit={noop}
-        options={testOptions}
-      />,
+      <PublicationForm {...wizardProps} themes={testThemes} onSubmit={noop} />,
     );
-
-    expect(screen.getAllByRole('radio', { hidden: true })).toHaveLength(10);
-    expect(screen.queryByText('No publications found')).not.toBeInTheDocument();
 
     userEvent.click(
-      screen.getByLabelText('Pupil absence in schools in England'),
+      screen.getByRole('radio', {
+        name: 'Theme 4',
+      }),
     );
 
-    await userEvent.type(
-      screen.getByLabelText('Search publications'),
-      'not a publication',
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Search or select a theme to view publications'),
+      ).not.toBeInTheDocument();
+    });
+
+    const publicationRadios = within(
+      screen.getByRole('group', {
+        name: /Select a publication/,
+      }),
+    ).queryAllByRole('radio');
+    expect(publicationRadios).toHaveLength(3);
+    expect(publicationRadios[0]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Publication 8',
+      }),
     );
-
-    jest.runOnlyPendingTimers();
-
-    expect(screen.getAllByRole('radio')).toHaveLength(1);
-    expect(
-      screen.getByLabelText('Pupil absence in schools in England'),
-    ).toBeInTheDocument();
-    expect(screen.queryByText('No publications found')).not.toBeInTheDocument();
-  });
-
-  test('renders dropdown for selected publication option as open', () => {
-    const { container } = render(
-      <PublicationForm
-        {...wizardProps}
-        onSubmit={noop}
-        options={testOptions}
-      />,
+    expect(publicationRadios[1]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Publication 9',
+      }),
     );
-
-    expect(container.querySelectorAll('details[open]')).toHaveLength(0);
-
-    userEvent.click(
-      screen.getByLabelText('Pupil absence in schools in England'),
+    expect(publicationRadios[2]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Publication 10',
+      }),
     );
-
-    const details = container.querySelectorAll('details[open]');
-
-    expect(details).toHaveLength(2);
-    expect(details[0]).toHaveTextContent('Pupils and schools');
-    expect(details[1]).toHaveTextContent('Pupil absence');
   });
 
   test('renders read-only view with initial `publicationId` when step is not active', () => {
@@ -355,45 +393,61 @@ describe('PublicationForm', () => {
       <PublicationForm
         {...wizardProps}
         initialValues={{
-          publicationId: 'publication-2',
+          publicationId: 'publication-3',
         }}
         isActive={false}
+        themes={testThemes}
         onSubmit={noop}
-        options={testOptions}
       />,
     );
 
-    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+    expect(
+      screen.queryByRole('group', { name: 'Select a theme' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('group', { name: /Select a publication/ }),
+    ).not.toBeInTheDocument();
+
     expect(screen.getByTestId('Publication')).toHaveTextContent(
-      'National achievement rates tables',
+      'Publication 3',
     );
   });
 
-  test('renders read-only view with selected publication when step is not active', () => {
+  test('renders read-only view with selected publication when step is not active', async () => {
     const { rerender } = render(
-      <PublicationForm
-        {...wizardProps}
-        onSubmit={noop}
-        options={testOptions}
-      />,
+      <PublicationForm {...wizardProps} themes={testThemes} onSubmit={noop} />,
     );
 
     userEvent.click(
-      screen.getByLabelText('Pupil absence in schools in England'),
+      screen.getByRole('radio', {
+        name: 'Theme 4',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Search or select a theme to view publications'),
+      ).not.toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('radio', {
+        name: 'Publication 9',
+      }),
     );
 
     rerender(
       <PublicationForm
         {...wizardProps}
         isActive={false}
+        themes={testThemes}
         onSubmit={noop}
-        options={testOptions}
       />,
     );
 
     expect(screen.queryAllByRole('radio')).toHaveLength(0);
     expect(screen.getByTestId('Publication')).toHaveTextContent(
-      'Pupil absence in schools in England',
+      'Publication 9',
     );
   });
 
@@ -403,18 +457,29 @@ describe('PublicationForm', () => {
     render(
       <PublicationForm
         {...wizardProps}
+        themes={testThemes}
         onSubmit={handleSubmit}
-        options={testOptions}
       />,
     );
 
-    expect(screen.queryByTestId('Publication')).not.toBeInTheDocument();
-
-    userEvent.click(screen.getByRole('button', { name: 'Pupils and schools' }));
-    userEvent.click(screen.getByRole('button', { name: 'Pupil absence' }));
     userEvent.click(
-      screen.getByLabelText('Pupil absence in schools in England'),
+      screen.getByRole('radio', {
+        name: 'Theme 4',
+      }),
     );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Search or select a theme to view publications'),
+      ).not.toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('radio', {
+        name: 'Publication 9',
+      }),
+    );
+
     userEvent.click(screen.getByRole('button', { name: 'Next step' }));
 
     await waitFor(() => {
@@ -423,9 +488,9 @@ describe('PublicationForm', () => {
         Parameters<PublicationFormSubmitHandler>
       >({
         publication: {
-          id: 'publication-5',
-          slug: 'pupil-absence-in-schools-in-england',
-          title: 'Pupil absence in schools in England',
+          id: 'publication-9',
+          slug: 'publication-slug-9',
+          title: 'Publication 9',
           type: 'NationalAndOfficial',
           isSuperseded: false,
         },

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
@@ -141,7 +141,7 @@ const DataCataloguePage: NextPage<Props> = ({
           publicationId: state.query.publication?.id ?? '',
         }}
         onSubmit={handlePublicationFormSubmit}
-        options={themes}
+        themes={themes}
       />
     );
   };

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
@@ -147,14 +147,41 @@ describe('DataCataloguePage', () => {
       'aria-current',
       'step',
     );
-    expect(screen.getByLabelText('Test publication')).not.toBeVisible();
 
-    userEvent.click(screen.getByRole('button', { name: 'Pupils and schools' }));
-    userEvent.click(screen.getByRole('button', { name: 'Admission appeals' }));
+    const themeRadios = within(
+      screen.getByRole('group', { name: 'Select a theme' }),
+    ).getAllByRole('radio');
+    expect(themeRadios).toHaveLength(1);
+    expect(themeRadios[0]).toEqual(
+      screen.getByRole('radio', { name: 'Pupils and schools' }),
+    );
+
+    expect(
+      screen.queryByRole('radio', {
+        name: 'Test publication',
+      }),
+    ).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByRole('radio', { name: 'Pupils and schools' }));
 
     // Check there is only one radio for the publication
-    expect(screen.getAllByRole('radio', { hidden: true })).toHaveLength(1);
-    expect(screen.getByLabelText('Test publication')).toBeVisible();
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Search or select a theme to view publications'),
+      ).not.toBeInTheDocument();
+    });
+
+    const publicationRadios = within(
+      screen.getByRole('group', {
+        name: /Select a publication/,
+      }),
+    ).queryAllByRole('radio');
+    expect(publicationRadios).toHaveLength(1);
+    expect(publicationRadios[0]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Test publication',
+      }),
+    );
   });
 
   test('can go through all the steps to download files', async () => {
@@ -174,8 +201,7 @@ describe('DataCataloguePage', () => {
 
     expect(step1.getByText('Choose a publication')).toBeInTheDocument();
 
-    userEvent.click(step1.getByRole('button', { name: 'Pupils and schools' }));
-    userEvent.click(step1.getByRole('button', { name: 'Admission appeals' }));
+    userEvent.click(step1.getByRole('radio', { name: 'Pupils and schools' }));
     userEvent.click(step1.getByRole('radio', { name: 'Test publication' }));
     userEvent.click(step1.getByRole('button', { name: 'Next step' }));
 
@@ -274,8 +300,7 @@ describe('DataCataloguePage', () => {
     // Step 1
 
     const step1 = within(screen.getByTestId('wizardStep-1'));
-    userEvent.click(step1.getByRole('button', { name: 'Pupils and schools' }));
-    userEvent.click(step1.getByRole('button', { name: 'Admission appeals' }));
+    userEvent.click(step1.getByRole('radio', { name: 'Pupils and schools' }));
     userEvent.click(step1.getByRole('radio', { name: 'Test publication' }));
     userEvent.click(step1.getByRole('button', { name: 'Next step' }));
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
@@ -5,7 +5,7 @@ import {
   SubjectMeta,
 } from '@common/services/tableBuilderService';
 import { Theme } from '@common/services/themeService';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import preloadAll from 'jest-next-dynamic';
 import TableToolPage from '@frontend/modules/table-tool/TableToolPage';
@@ -362,14 +362,34 @@ describe('TableToolPage', () => {
       'aria-current',
       'step',
     );
-    expect(screen.getByLabelText('Test publication')).not.toBeVisible();
+    const themeRadios = within(
+      screen.getByRole('group', { name: 'Select a theme' }),
+    ).getAllByRole('radio');
+    expect(themeRadios).toHaveLength(1);
+    expect(themeRadios[0]).toEqual(
+      screen.getByRole('radio', { name: 'Pupils and schools' }),
+    );
 
-    userEvent.click(screen.getByRole('button', { name: 'Pupils and schools' }));
-    userEvent.click(screen.getByRole('button', { name: 'Admission appeals' }));
+    expect(
+      screen.queryByRole('radio', {
+        name: 'Test publication',
+      }),
+    ).not.toBeInTheDocument();
 
-    // Check there is only one radio for the publication
-    expect(screen.getAllByRole('radio', { hidden: true })).toHaveLength(1);
-    expect(screen.getByLabelText('Test publication')).toBeVisible();
+    userEvent.click(screen.getByRole('radio', { name: 'Pupils and schools' }));
+
+    // Check there is only one radio for the publication;
+    const publicationRadios = within(
+      screen.getByRole('group', {
+        name: /Select a publication/,
+      }),
+    ).queryAllByRole('radio');
+    expect(publicationRadios).toHaveLength(1);
+    expect(publicationRadios[0]).toEqual(
+      screen.getByRole('radio', {
+        name: 'Test publication',
+      }),
+    );
   });
 
   test('renders the page correctly with pre-selected publication', async () => {

--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -9,7 +9,6 @@ Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 
-
 *** Variables ***
 ${PUBLICATION_NAME_ARCHIVE}=        UI tests - archived publication %{RUN_IDENTIFIER}
 ${RELEASE_NAME_ARCHIVE}=            Financial Year 3000-01
@@ -18,7 +17,6 @@ ${SUBJECT_NAME_ARCHIVE}=            Subject for archived publication
 ${PUBLICATION_NAME_SUPERSEDE}=      UI tests - superseding publication %{RUN_IDENTIFIER}
 ${RELEASE_NAME_SUPERSEDE}=          Financial Year 2000-01
 ${SUBJECT_NAME_SUPERSEDE}=          Subject for superseding publication
-
 
 *** Test Cases ***
 Create new publication to be archived and release via API
@@ -87,8 +85,7 @@ Validate that archive-publication appears correctly on Find stats page
 Check that archive-publication subject appears correctly on Data tables page
     user navigates to data tables page on public frontend
 
-    user opens details dropdown    %{TEST_THEME_NAME}
-    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user clicks radio    %{TEST_THEME_NAME}
 
     user checks page does not contain    ${PUBLICATION_NAME_SUPERSEDE}
 
@@ -137,8 +134,7 @@ Generate permalink for archive-publication
 Check that archive-publication subject appears correctly on Data catalogue page
     user navigates to data catalogue page on public frontend
 
-    user opens details dropdown    %{TEST_THEME_NAME}
-    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user clicks radio    %{TEST_THEME_NAME}
 
     user checks page contains    ${PUBLICATION_NAME_ARCHIVE}
     user checks page does not contain    ${PUBLICATION_NAME_SUPERSEDE}
@@ -202,8 +198,7 @@ Check public archive-publication release page displays correctly
 Check public data tables page contains superseding-publication's subject
     user navigates to data tables page on public frontend
 
-    user opens details dropdown    %{TEST_THEME_NAME}
-    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user clicks radio    %{TEST_THEME_NAME}
 
     user checks page does not contain    ${PUBLICATION_NAME_ARCHIVE}
 
@@ -217,8 +212,7 @@ Check public data tables page contains superseding-publication's subject
 Check data catalogue page contains archive and superseding publication subjects
     user navigates to data catalogue page on public frontend
 
-    user opens details dropdown    %{TEST_THEME_NAME}
-    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user clicks radio    %{TEST_THEME_NAME}
 
     user checks page contains    ${PUBLICATION_NAME_ARCHIVE}
     user checks page contains    ${PUBLICATION_NAME_SUPERSEDE}
@@ -239,8 +233,9 @@ Check data catalogue page contains archive and superseding publication subjects
     user checks page contains    This is not the latest data
 
     user clicks button    Change publication
-    user waits until page contains    ${PUBLICATION_NAME_SUPERSEDE}
+    user waits until page contains    Choose a publication
 
+    user clicks radio    %{TEST_THEME_NAME}
     user clicks radio    ${PUBLICATION_NAME_SUPERSEDE}
     user clicks button    Next step
     user waits until page contains    Choose a release
@@ -308,8 +303,7 @@ Check public archive-publication release page displays correctly after being una
 Check public data tables page is correct after archive-publication has been unarchived
     user navigates to data tables page on public frontend
 
-    user opens details dropdown    %{TEST_THEME_NAME}
-    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user clicks radio    %{TEST_THEME_NAME}
 
     user checks page contains    ${PUBLICATION_NAME_ARCHIVE}
 
@@ -323,8 +317,7 @@ Check public data tables page is correct after archive-publication has been unar
 Check data catalogue page is correct after archive-publication has been unarchived
     user navigates to data catalogue page on public frontend
 
-    user opens details dropdown    %{TEST_THEME_NAME}
-    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user clicks radio    %{TEST_THEME_NAME}
 
     user checks page contains    ${PUBLICATION_NAME_ARCHIVE}
     user checks page contains    ${PUBLICATION_NAME_SUPERSEDE}
@@ -345,8 +338,9 @@ Check data catalogue page is correct after archive-publication has been unarchiv
     user checks page does not contain    This is not the latest data
 
     user clicks button    Change publication
-    user waits until page contains    ${PUBLICATION_NAME_SUPERSEDE}
+    user waits until page contains    Choose a publication
 
+    user clicks radio    %{TEST_THEME_NAME}
     user clicks radio    ${PUBLICATION_NAME_SUPERSEDE}
     user clicks button    Next step
     user waits until page contains    Choose a release

--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -10,7 +10,6 @@ Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
-
 *** Variables ***
 ${PUBLICATION_NAME}=    UI tests - data catalogue %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Academic Year Q1
@@ -18,7 +17,6 @@ ${SUBJECT_NAME_1}=      UI test subject 1
 ${SUBJECT_NAME_2}=      UI test subject 2
 ${SUBJECT_NAME_3}=      UI test subject 3
 ${SUBJECT_NAME_4}=      UI test subject 4
-
 
 *** Test Cases ***
 Create publication
@@ -98,12 +96,11 @@ User navigates to /data-catalogue page
 
 User checks search filters publications properly
     user enters text into element    id:publicationForm-publicationIdSearch    Pupil
-    user waits until element is visible    testid:Expand Details Section Pupil absence    10
+    user waits until page contains    Pupil absence in schools in England (Pupils and schools)    10
     user clears element text    id:publicationForm-publicationIdSearch
 
-Choose publiction
-    user opens details dropdown    Test theme
-    user opens details dropdown    %{TEST_TOPIC_NAME}
+Choose publication
+    user clicks radio    Test theme
     user clicks radio    UI tests - data catalogue %{RUN_IDENTIFIER}
     user clicks button    Next step
 

--- a/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
@@ -9,16 +9,14 @@ Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
-
 *** Variables ***
 ${PUBLICATION_NAME}     UI tests - data reordering %{RUN_IDENTIFIER}
 ${RELEASE_NAME}         Calendar Year 2022
 ${SUBJECT_NAME}         UI test subject
 
-
 *** Test Cases ***
 Create new publication and release via API
-    ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
+    ${PUBLICATION_ID}    user creates test publication via api    ${PUBLICATION_NAME}
     user create test release via api    ${PUBLICATION_ID}    CY    2022
 
 Navigate to release
@@ -198,7 +196,7 @@ Cancel reordering indicators
 Replace subject data
     user clicks link    Data uploads
     user waits until h2 is visible    Uploaded data files
-    ${section}=    user gets accordion section content element    ${SUBJECT_NAME}
+    ${section}    user gets accordion section content element    ${SUBJECT_NAME}
     user clicks link    Replace data    ${section}
     user chooses file    id:dataFileUploadForm-dataFile    ${FILES_DIR}grouped-filters-and-indicators-replacement.csv
     user chooses file    id:dataFileUploadForm-metadataFile
@@ -364,8 +362,7 @@ Go to public table tool page
 Select "Test Topic" publication
     environment variable should be set    TEST_THEME_NAME
     environment variable should be set    TEST_TOPIC_NAME
-    user opens details dropdown    %{TEST_THEME_NAME}
-    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user clicks radio    %{TEST_THEME_NAME}
     user clicks radio    ${PUBLICATION_NAME}
     user clicks element    id:publicationForm-submit
     user waits until table tool wizard step is available    2    Choose a subject
@@ -602,11 +599,10 @@ Validate table cells again
     user checks results table cell contains    6    1    7,922,048
     user checks results table cell contains    7    1    6,759,498
 
-
 *** Keywords ***
 user moves item of draggable list down
     [Arguments]    ${locator}    ${item_num}
-    ${item}=    user gets list item element    ${locator}    ${item_num}
+    ${item}    user gets list item element    ${locator}    ${item_num}
     set focus to element    ${item}
     user presses keys    ${SPACE}
     user presses keys    ARROW_DOWN

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -9,7 +9,6 @@ Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 
-
 *** Variables ***
 ${TOPIC_NAME}=                          %{TEST_TOPIC_NAME}
 ${PUBLICATION_NAME}=                    UI tests - publish data %{RUN_IDENTIFIER}
@@ -27,7 +26,6 @@ ${FOOTNOTE_SUBJECT_1_FILTER}=           Footnote for subject 1 - filter
 ${FOOTNOTE_SUBJECT_1_FILTER_GROUP}=     Footnote for subject 1 - filter group
 ${FOOTNOTE_SUBJECT_1_FILTER_ITEM}=      Footnote for subject 1 - filter item
 ${FOOTNOTE_SUBJECT_1_MIXTURE}=          Footnote for subject 1 - mixture of all
-
 
 *** Test Cases ***
 Create new publication and release via API
@@ -438,8 +436,7 @@ Go to Table Tool page
     user navigates to data tables page on public frontend
 
 Select publication in table tool
-    user opens details dropdown    %{TEST_THEME_NAME}
-    user opens details dropdown    ${TOPIC_NAME}
+    user clicks radio    %{TEST_THEME_NAME}
     user clicks radio    ${PUBLICATION_NAME}
     user clicks element    id:publicationForm-submit
     user waits until table tool wizard step is available    2    Choose a subject

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -9,14 +9,12 @@ Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
-
 *** Variables ***
 ${RELEASE_NAME}         Academic Year Q1 2020/21
 ${PUBLICATION_NAME}     UI tests - publish release and amend 2 %{RUN_IDENTIFIER}
 ${SUBJECT_NAME}         Seven filters
 ${SECOND_SUBJECT}       upload file test
 ${THIRD_SUBJECT}        upload file test with filter subject
-
 
 *** Test Cases ***
 Create publication
@@ -112,8 +110,7 @@ Go to public Table Tool page
 Select "Test Topic" publication
     environment variable should be set    TEST_THEME_NAME
     environment variable should be set    TEST_TOPIC_NAME
-    user opens details dropdown    %{TEST_THEME_NAME}
-    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user clicks radio    %{TEST_THEME_NAME}
     user clicks radio    ${PUBLICATION_NAME}
     user clicks element    id:publicationForm-submit
     user waits until table tool wizard step is available    2    Choose a subject
@@ -373,8 +370,7 @@ Check the table has the same results as original table
 Check amended release doesn't contain deleted subject
     user navigates to public frontend    %{PUBLIC_URL}/data-tables
     user waits until h1 is visible    Create your own tables
-    user opens details dropdown    %{TEST_THEME_NAME}
-    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user clicks radio    %{TEST_THEME_NAME}
     user clicks radio    ${PUBLICATION_NAME}
     user clicks element    id:publicationForm-submit
     user waits until table tool wizard step is available    2    Choose a subject
@@ -434,8 +430,7 @@ Go to public Table Tool page for amendment
     user waits until h1 is visible    Create your own tables
 
 Select publication
-    user opens details dropdown    %{TEST_THEME_NAME}
-    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user clicks radio    %{TEST_THEME_NAME}
     user clicks radio    ${PUBLICATION_NAME}
     user clicks element    id:publicationForm-submit
     user waits until table tool wizard step is available    2    Choose a subject

--- a/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
@@ -7,14 +7,12 @@ Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Local    Dev    Preprod
 
-
 *** Test Cases ***
 Go to Table Tool page
     user navigates to data tables page on public frontend
 
 Select "Pupil absence" publication
-    user opens details dropdown    Pupils and schools
-    user opens details dropdown    Pupil absence
+    user clicks radio    Pupils and schools
     user clicks radio    Pupil absence in schools in England
     user clicks element    id:publicationForm-submit
     user waits until table tool wizard step is available    2    Choose a subject

--- a/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
@@ -7,14 +7,12 @@ Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Local    Dev    Preprod
 
-
 *** Test Cases ***
 Go to Table Tool page
     user navigates to data tables page on public frontend
 
 Select "Pupil absence" publication
-    user opens details dropdown    Pupils and schools
-    user opens details dropdown    Pupil absence
+    user clicks radio    Pupils and schools
     user clicks radio    Pupil absence in schools in England
     user clicks element    id:publicationForm-submit
     user waits until table tool wizard step is available    2    Choose a subject

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -7,14 +7,12 @@ Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Local    Dev
 
-
 *** Test Cases ***
 Go to Table Tool page
     user navigates to data tables page on public frontend
 
 Select Exclusions publication
-    user opens details dropdown    Pupils and schools
-    user opens details dropdown    Exclusions
+    user clicks radio    Pupils and schools
     user clicks radio    Permanent and fixed-period exclusions in England
     user clicks element    id:publicationForm-submit
     user waits until table tool wizard step is available    2    Choose a subject


### PR DESCRIPTION
The DAC report raised accessibility issues with the current 'Choose a publication' step of the table tool. To fix these we've changed the component to not use the Details component.

Instead:
- shows a list of themes as radio buttons
- on selecting a theme the list of publications for the theme is shown as radio buttons
- topics aren't shown
- searching populates the list of publications with those that match the search (a basic text match as currently)

This change also applies to the Data Catalogue.

![step1](https://user-images.githubusercontent.com/81572860/173567845-5452d98e-f07f-40e0-8c4b-f76822a94b68.PNG)
