### PR TITLE
EES-3454 Add 'Past releases' subheading to release page 'Supporting i…

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -231,6 +231,12 @@ const ReleaseContent = () => {
 
             {!!releaseCount && (
               <>
+                <h3
+                  className="govuk-heading-s govuk-!-margin-top-6"
+                  id="past-releases"
+                >
+                  Past releases
+                </h3>
                 <p className="govuk-!-margin-bottom-0">
                   {release.coverageTitle} <strong>{release.yearTitle}</strong>
                 </p>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -266,6 +266,12 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
             </ul>
             {!!releaseCount && (
               <>
+                <h3
+                  className="govuk-heading-s govuk-!-margin-top-6"
+                  id="past-releases"
+                >
+                  Past releases
+                </h3>
                 <p className="govuk-!-margin-bottom-0">
                   {release.coverageTitle} <strong>{release.yearTitle}</strong>
                 </p>


### PR DESCRIPTION
This PR adds a "Past releases" subheading to release pages' "Supporting information" section. This subheading only appears if there are past releases to display.

![image](https://user-images.githubusercontent.com/44812484/173852783-5397831e-3fd3-49fa-91f7-df44d8e4c8ab.png)
