### PR TITLE
EES-3437 Performance improvements to fetching subject metadata

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
@@ -220,7 +220,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var result = await controller.ClearPublicCacheTrees(
                 new ClearPublicCacheTreePathsViewModel
                 {
-                    Paths = SetOf("publication-tree-any-data.json"),
+                    Paths = SetOf("publication-tree.json")
                 }
             );
 
@@ -229,7 +229,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             MockUtils.VerifyAllMocks(publicBlobStorageService);
 
             Assert.Single(paths);
-            Assert.Equal("publication-tree-any-data.json", paths[0]);
+            Assert.Equal("publication-tree.json", paths[0]);
         }
 
         [Fact]
@@ -251,8 +251,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                     Paths = new HashSet<string>
                     {
                         "publication-tree.json",
-                        "publication-tree-any-data.json",
-                        "publication-tree-latest-data.json"
+                        "methodology-tree.json"
                     }
                 }
             );
@@ -261,10 +260,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             MockUtils.VerifyAllMocks(publicBlobStorageService);
 
-            Assert.Equal(3, paths.Count);
+            Assert.Equal(2, paths.Count);
             Assert.Equal("publication-tree.json", paths[0]);
-            Assert.Equal("publication-tree-any-data.json", paths[1]);
-            Assert.Equal("publication-tree-latest-data.json", paths[2]);
+            Assert.Equal("methodology-tree.json", paths[1]);
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
@@ -4,11 +4,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
-using GovUk.Education.ExploreEducationStatistics.Admin.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -435,7 +435,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 cacheService
                     .Setup(s =>
                         s.DeleteCacheFolder(
-                            ItIs.DeepEqualTo(new ReleaseContentFolderCacheKey(publicationId, releaseId))))
+                            ItIs.DeepEqualTo(new PrivateReleaseContentFolderCacheKey(releaseId))))
                     .Returns(Task.CompletedTask);
 
                 var result = await service.DeleteTopic(topicId);
@@ -589,7 +589,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         .InSequence(releaseCacheInvalidationSequence)
                         .Setup(s =>
                             s.DeleteCacheFolder(
-                                ItIs.DeepEqualTo(new ReleaseContentFolderCacheKey(publicationId, releaseId))))
+                                ItIs.DeepEqualTo(new PrivateReleaseContentFolderCacheKey(releaseId))))
                         .Returns(Task.CompletedTask));
 
                 publishingService.Setup(s => s.TaxonomyChanged())
@@ -877,7 +877,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 cacheService
                     .Setup(s =>
                         s.DeleteCacheFolder(
-                            ItIs.DeepEqualTo(new ReleaseContentFolderCacheKey(publicationId, releaseId))))
+                            ItIs.DeepEqualTo(new PrivateReleaseContentFolderCacheKey(releaseId))))
                     .Returns(Task.CompletedTask);
 
                 var result = await service.DeleteTopic(topicId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Cache/DataBlockTableResultCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Cache/DataBlockTableResultCacheKey.cs
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-#nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
@@ -11,7 +10,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Cache
 {
     public class DataBlockTableResultCacheKey : IBlobCacheKey
     {
-        private Guid PublicationId { get; }
         private Guid ReleaseId { get; }
         private Guid DataBlockId { get; }
 
@@ -25,7 +23,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Cache
             }
 
             var release = releaseContentBlock.Release;
-            PublicationId = release.PublicationId;
             ReleaseId = release.Id;
             DataBlockId = releaseContentBlock.ContentBlockId;
         }
@@ -33,7 +30,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Cache
         public IBlobContainer Container => PrivateContent;
 
         public string Key => PrivateContentDataBlockPath(
-            PublicationId,
             ReleaseId,
             DataBlockId
         );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderMetaController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderMetaController.cs
@@ -3,9 +3,11 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Cache;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
 using Microsoft.AspNetCore.Authorization;
@@ -26,6 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
         }
 
         [HttpGet("data/release/{releaseId:guid}/meta/subject/{subjectId:guid}")]
+        [BlobCache(typeof(PrivateSubjectMetaCacheKey))]
         public Task<ActionResult<SubjectMetaViewModel>> GetSubjectMeta(Guid releaseId, Guid subjectId)
         {
             return _subjectMetaService.GetSubjectMeta(releaseId: releaseId, subjectId: subjectId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
@@ -11,6 +11,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Metho
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -240,7 +241,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             return await _releaseDataFileService.DeleteAll(releaseId, forceDelete: true)
                 .OnSuccessDo(() => _releaseFileService.DeleteAll(releaseId, forceDelete: true))
-                .OnSuccessDo(() => DeleteCachedReleaseContent(releaseId, contentRelease.PublicationId))
+                .OnSuccessDo(() => DeleteCachedReleaseContent(releaseId))
                 .OnSuccessVoid(async () =>
                 {
                     _contentContext.Releases.Remove(contentRelease);
@@ -250,9 +251,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
-        private Task DeleteCachedReleaseContent(Guid releaseId, Guid publicationId)
+        private Task DeleteCachedReleaseContent(Guid releaseId)
         {
-            return _cacheService.DeleteCacheFolder(new ReleaseContentFolderCacheKey(publicationId, releaseId));
+            return _cacheService.DeleteCacheFolder(new PrivateReleaseContentFolderCacheKey(releaseId));
         }
 
         private async Task DeleteSoftDeletedContentDbRelease(Guid releaseId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -153,6 +153,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                     options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
                 });
 
+            // Adds Brotli and Gzip compressing
+            services.AddResponseCompression(options =>
+            {
+                options.EnableForHttps = true;
+            });
+
             // In production, the React files will be served from this directory
             services.AddSpaStaticFiles(configuration => { configuration.RootPath = "wwwroot"; });
             services.Configure<RouteOptions>(options => options.LowercaseUrls = true);
@@ -588,6 +594,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                     opts.Preload();
                 });
             }
+
+            app.UseResponseCompression();
 
             if (Configuration.GetValue<bool>("enableSwagger"))
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Converters/EnumToEnumValueConverterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Converters/EnumToEnumValueConverterTests.cs
@@ -1,0 +1,52 @@
+﻿#nullable enable
+using System;
+using System.Diagnostics.CodeAnalysis;
+using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Converters;
+
+public class EnumToEnumValueConverterTests
+{
+    [SuppressMessage("ReSharper", "UnusedMember.Local")]
+    private enum Numbers
+    {
+        [EnumLabelValue("1", "Value-1")] One,
+        [EnumLabelValue("2", "Value-2")] Two,
+        [EnumLabelValue("3", "Value-3")] Three
+    }
+
+    [Fact]
+    public void ConvertToProvider()
+    {
+        var converter = new EnumToEnumValueConverter<Numbers>();
+        var converted = converter.ConvertToProvider.Invoke(Numbers.Two);
+        Assert.IsType<string>(converted);
+        Assert.Equal("Value-2", converted);
+    }
+
+    [Fact]
+    public void ConvertFromProvider()
+    {
+        var converter = new EnumToEnumValueConverter<Numbers>();
+        var converted = converter.ConvertFromProvider.Invoke("Value-2");
+        Assert.IsType<Numbers>(converted);
+        Assert.Equal(Numbers.Two, converted);
+    }
+
+    [Fact]
+    public void ConvertFromProvider_StoredValueIsNull()
+    {
+        var converter = new EnumToEnumValueConverter<Numbers>();
+        var converted = converter.ConvertFromProvider.Invoke(null);
+        Assert.Null(converted);
+    }
+
+    [Fact]
+    public void ConvertFromProvider_StoredValueIsOutOfRange()
+    {
+        var converter = new EnumToEnumValueConverter<Numbers>();
+        Assert.Throws<ArgumentOutOfRangeException>(() => converter.ConvertFromProvider.Invoke("Value-4"));
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/PrivateReleaseContentFolderCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/PrivateReleaseContentFolderCacheKey.cs
@@ -15,7 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
             ReleaseId = releaseId;
         }
 
-        public string Key => PrivateContentReleaseParentPath(ReleaseId);
+        public string Key => $"{ReleasesDirectory}/{ReleaseId}";
 
         public IBlobContainer Container => PrivateContent;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/PrivateReleaseContentFolderCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/PrivateReleaseContentFolderCacheKey.cs
@@ -1,25 +1,21 @@
 #nullable enable
 using System;
-using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Cache
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
 {
-    public class ReleaseContentFolderCacheKey : IBlobCacheKey
+    public record PrivateReleaseContentFolderCacheKey : IBlobCacheKey
     {
-        private Guid PublicationId { get; }
-
         private Guid ReleaseId { get; }
 
-        public ReleaseContentFolderCacheKey(Guid publicationId, Guid releaseId)
+        public PrivateReleaseContentFolderCacheKey(Guid releaseId)
         {
-            PublicationId = publicationId;
             ReleaseId = releaseId;
         }
 
-        public string Key => PrivateContentReleaseParentPath(PublicationId, ReleaseId);
+        public string Key => PrivateContentReleaseParentPath(ReleaseId);
 
         public IBlobContainer Container => PrivateContent;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/EnumToEnumValueConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/EnumToEnumValueConverter.cs
@@ -1,28 +1,38 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Converters
+namespace GovUk.Education.ExploreEducationStatistics.Common.Converters;
+
+public class EnumToEnumValueConverter<TEnum> : ValueConverter<TEnum, string> where TEnum : Enum
 {
-    public class EnumToEnumValueConverter<TEnum> : ValueConverter<TEnum, string> where TEnum : Enum
+    private static readonly Dictionary<string, TEnum> Lookup =
+        EnumUtil.GetEnumValues<TEnum>().ToDictionary(value => value.GetEnumValue());
+
+    public EnumToEnumValueConverter(
+        ConverterMappingHints? mappingHints = null) :
+        base(value => ToProvider(value),
+            value => FromProvider(value),
+            mappingHints)
     {
-        public EnumToEnumValueConverter(ConverterMappingHints? mappingHints = null) :
-            base(x => ToProvider(x),
-                x => FromProvider(x),
-                mappingHints)
+    }
+
+    private static string ToProvider(TEnum value)
+    {
+        return value.GetEnumValue();
+    }
+
+    private static TEnum FromProvider(string value)
+    {
+        if (Lookup.TryGetValue(value, out var enumVal))
         {
+            return enumVal;
         }
 
-        private static string ToProvider(TEnum value)
-        {
-            return value.GetEnumValue();
-        }
-
-        private static TEnum FromProvider(string value)
-        {
-            return EnumUtil.GetFromString<TEnum>(value);
-        }
+        throw new ArgumentOutOfRangeException($"No enum value found for {value}");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -7,96 +8,83 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 {
     public static class FileStoragePathUtils
     {
-        public const string PublicContentDataBlocksDirectory = "data-blocks";
+        public const string DataBlocksDirectory = "data-blocks";
         [Obsolete("EES-2865 - Remove with other fast track code")]
-        public const string PublicContentFastTrackResultsDirectory = "fast-track-results";
-        public const string PublicContentSubjectMetaDirectory = "subject-meta";
+        public const string FastTrackResultsDirectory = "fast-track-results";
+        public const string SubjectMetaDirectory = "subject-meta";
 
         public static string PublicContentStagingPath()
         {
             return "staging";
         }
 
-        private static string PublicContentFastTrackPath(string prefix = null)
+        private static string PublicContentFastTrackPath(string? prefix = null)
         {
             return $"{AppendPathSeparator(prefix)}fast-track";
         }
 
-        private static string PrivateContentPublicationsPath(string prefix = null)
+        private static string PublicContentPublicationsPath(string? prefix = null)
         {
             return $"{AppendPathSeparator(prefix)}publications";
         }
 
-        private static string PublicContentPublicationsPath(string prefix = null)
-        {
-            return $"{AppendPathSeparator(prefix)}publications";
-        }
-
-        public static string PublicContentReleaseFastTrackPath(string releaseId, string prefix = null)
+        public static string PublicContentReleaseFastTrackPath(string releaseId, string? prefix = null)
         {
             return $"{PublicContentFastTrackPath(prefix)}/{releaseId}";
         }
 
-        public static string PublicContentFastTrackPath(string releaseId, string id, string prefix = null)
+        public static string PublicContentFastTrackPath(string releaseId, string id, string? prefix = null)
         {
             return $"{PublicContentReleaseFastTrackPath(releaseId, prefix)}/{id}.json";
         }
 
-        public static string PrivateContentPublicationParentPath(Guid publicationId, string prefix = null)
+        public static string PrivateContentReleaseParentPath(Guid releaseId)
         {
-            return $"{PrivateContentPublicationsPath(prefix)}/{publicationId}";
+            return $"releases/{releaseId}";
         }
 
-        public static string PublicContentPublicationParentPath(string slug, string prefix = null)
+        public static string PublicContentPublicationParentPath(string slug, string? prefix = null)
         {
             return $"{PublicContentPublicationsPath(prefix)}/{slug}";
         }
 
-        public static string PrivateContentReleaseParentPath(Guid publicationId, Guid releaseId, string prefix = null)
-        {
-            return $"{PrivateContentPublicationParentPath(publicationId, prefix)}/releases/{releaseId}";
-        }
-
-        public static string PublicContentReleaseParentPath(string publicationSlug, string releaseSlug, string prefix = null)
+        public static string PublicContentReleaseParentPath(string publicationSlug,
+            string releaseSlug,
+            string? prefix = null)
         {
             return $"{PublicContentPublicationParentPath(publicationSlug, prefix)}/releases/{releaseSlug}";
         }
 
-        public static string PublicContentPublicationPath(string slug, string prefix = null)
+        public static string PublicContentPublicationPath(string slug, string? prefix = null)
         {
             return $"{PublicContentPublicationParentPath(slug, prefix)}/publication.json";
         }
 
-        public static string PublicContentLatestReleasePath(string slug, string prefix = null)
+        public static string PublicContentLatestReleasePath(string slug, string? prefix = null)
         {
             return $"{PublicContentPublicationParentPath(slug, prefix)}/latest-release.json";
         }
 
-        public static string PublicContentReleasePath(string publicationSlug, string releaseSlug, string prefix = null)
+        public static string PublicContentReleasePath(string publicationSlug, string releaseSlug, string? prefix = null)
         {
             return $"{PublicContentPublicationParentPath(publicationSlug, prefix)}/releases/{releaseSlug}.json";
         }
 
-        public static string PrivateContentDataBlockParentPath(
-            Guid publicationId,
-            Guid releaseId)
+        public static string PublicContentDataBlockParentPath(string publicationSlug, string releaseSlug)
         {
-            return $"{PrivateContentReleaseParentPath(publicationId, releaseId)}/{PublicContentDataBlocksDirectory}";
+            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{DataBlocksDirectory}";
         }
 
-        public static string PublicContentDataBlockParentPath(
-            string publicationSlug,
-            string releaseSlug)
+        public static string PrivateContentDataBlockPath(Guid releaseId, Guid dataBlockId)
         {
-            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{PublicContentDataBlocksDirectory}";
+            return
+                $"{PrivateContentReleaseParentPath(releaseId)}/{DataBlocksDirectory}/{dataBlockId}.json";
         }
 
-        public static string PrivateContentDataBlockPath(
-            Guid publicationId,
-            Guid releaseId,
-            Guid dataBlockId)
+        public static string PrivateContentSubjectMetaPath(Guid releaseId, Guid subjectId)
         {
-            return $"{PrivateContentDataBlockParentPath(publicationId, releaseId)}/{dataBlockId}.json";
+            return
+                $"{PrivateContentReleaseParentPath(releaseId)}/{SubjectMetaDirectory}/{subjectId}.json";
         }
 
         public static string PublicContentDataBlockPath(
@@ -109,7 +97,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public static string PublicContentSubjectMetaParentPath(string publicationSlug, string releaseSlug)
         {
-            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{PublicContentSubjectMetaDirectory}";
+            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{SubjectMetaDirectory}";
         }
 
         public static string PublicContentSubjectMetaPath(string publicationSlug, string releaseSlug, Guid subjectId)
@@ -119,10 +107,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public static string PublicContentFastTrackResultsParentPath(string publicationSlug, string releaseSlug)
         {
-            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{PublicContentFastTrackResultsDirectory}";
+            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{FastTrackResultsDirectory}";
         }
 
-        public static string PublicContentFastTrackResultsPath(string publicationSlug, string releaseSlug, Guid fastTrackId)
+        public static string PublicContentFastTrackResultsPath(string publicationSlug, string releaseSlug,
+            Guid fastTrackId)
         {
             return $"{PublicContentFastTrackResultsParentPath(publicationSlug, releaseSlug)}/{fastTrackId}.json";
         }
@@ -138,7 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return $"{rootPath}/{typeFolder}/";
         }
 
-        private static string AppendPathSeparator(string segment = null)
+        private static string AppendPathSeparator(string? segment = null)
         {
             return segment == null ? "" : segment + "/";
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -11,6 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         public const string DataBlocksDirectory = "data-blocks";
         [Obsolete("EES-2865 - Remove with other fast track code")]
         public const string FastTrackResultsDirectory = "fast-track-results";
+        public const string ReleasesDirectory = "releases";
         public const string SubjectMetaDirectory = "subject-meta";
 
         public static string PublicContentStagingPath()
@@ -38,21 +39,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return $"{PublicContentReleaseFastTrackPath(releaseId, prefix)}/{id}.json";
         }
 
-        public static string PrivateContentReleaseParentPath(Guid releaseId)
-        {
-            return $"releases/{releaseId}";
-        }
-
-        public static string PublicContentPublicationParentPath(string slug, string? prefix = null)
+        private static string PublicContentPublicationParentPath(string slug, string? prefix = null)
         {
             return $"{PublicContentPublicationsPath(prefix)}/{slug}";
         }
 
-        public static string PublicContentReleaseParentPath(string publicationSlug,
+        private static string PublicContentReleaseParentPath(string publicationSlug,
             string releaseSlug,
             string? prefix = null)
         {
-            return $"{PublicContentPublicationParentPath(publicationSlug, prefix)}/releases/{releaseSlug}";
+            return $"{PublicContentPublicationParentPath(publicationSlug, prefix)}/{ReleasesDirectory}/{releaseSlug}";
         }
 
         public static string PublicContentPublicationPath(string slug, string? prefix = null)
@@ -67,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public static string PublicContentReleasePath(string publicationSlug, string releaseSlug, string? prefix = null)
         {
-            return $"{PublicContentPublicationParentPath(publicationSlug, prefix)}/releases/{releaseSlug}.json";
+            return $"{PublicContentPublicationParentPath(publicationSlug, prefix)}/{ReleasesDirectory}/{releaseSlug}.json";
         }
 
         public static string PublicContentDataBlockParentPath(string publicationSlug, string releaseSlug)
@@ -77,14 +73,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public static string PrivateContentDataBlockPath(Guid releaseId, Guid dataBlockId)
         {
-            return
-                $"{PrivateContentReleaseParentPath(releaseId)}/{DataBlocksDirectory}/{dataBlockId}.json";
+            return $"{ReleasesDirectory}/{releaseId}/{DataBlocksDirectory}/{dataBlockId}.json";
         }
 
         public static string PrivateContentSubjectMetaPath(Guid releaseId, Guid subjectId)
         {
-            return
-                $"{PrivateContentReleaseParentPath(releaseId)}/{SubjectMetaDirectory}/{subjectId}.json";
+            return $"{ReleasesDirectory}/{releaseId}/{SubjectMetaDirectory}/{subjectId}.json";
         }
 
         public static string PublicContentDataBlockPath(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -97,7 +97,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             );
 
             // Adds Brotli and Gzip compressing
-            services.AddResponseCompression();
+            services.AddResponseCompression(options =>
+            {
+                options.EnableForHttps = true;
+            });
 
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(swag =>
@@ -203,6 +206,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
 
             app.UseMvc();
             app.UseHealthChecks("/api/health");
+
+            app.UseResponseCompression();
         }
 
         /**

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -103,9 +103,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
                     .EnableSensitiveDataLogging(HostEnvironment.IsDevelopment())
             );
 
-            // ReSharper disable once CommentTypo
             // Adds Brotli and Gzip compressing
-            services.AddResponseCompression();
+            services.AddResponseCompression(options =>
+            {
+                options.EnableForHttps = true;
+            });
 
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
@@ -125,6 +125,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
         public DbSet<ReleaseFootnote> ReleaseFootnote { get; set; } = null!;
         public DbSet<MatchedObservation> MatchedObservations => this.TempTableSet<MatchedObservation>();
 
+        private readonly EnumToEnumValueConverter<GeographicLevel> _geographicLevelConverter = new();
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             ConfigureBoundaryLevel(modelBuilder);
@@ -151,20 +153,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
             ConfigureUnit(modelBuilder);
         }
 
-        private static void ConfigureBoundaryLevel(ModelBuilder modelBuilder)
+        private void ConfigureBoundaryLevel(ModelBuilder modelBuilder)
         {
-            var geographicLevelConverter = new EnumToEnumValueConverter<GeographicLevel>();
-
             modelBuilder.Entity<BoundaryLevel>()
                 .Property(boundaryLevel => boundaryLevel.Level)
-                .HasConversion(geographicLevelConverter);
-            
+                .HasConversion(_geographicLevelConverter);
+
             modelBuilder.Entity<BoundaryLevel>()
                 .Property(block => block.Created)
                 .HasConversion(
                     v => v,
                     v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
-            
+
             modelBuilder.Entity<BoundaryLevel>()
                 .Property(block => block.Published)
                 .HasConversion(
@@ -172,11 +172,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
                     v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
         }
 
-        private static void ConfigureLocation(ModelBuilder modelBuilder)
+        private void ConfigureLocation(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Location>()
                 .Property(location => location.GeographicLevel)
-                .HasConversion(new EnumToEnumValueConverter<GeographicLevel>())
+                .HasConversion(_geographicLevelConverter)
                 .HasMaxLength(6);
 
             modelBuilder.Entity<Location>()
@@ -360,11 +360,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
 
         private static void ConfigureTimePeriod(ModelBuilder modelBuilder)
         {
-            var timeIdentifierConverter = new EnumToEnumValueConverter<TimeIdentifier>();
-
             modelBuilder.Entity<Observation>()
                 .Property(observation => observation.TimeIdentifier)
-                .HasConversion(timeIdentifierConverter)
+                .HasConversion(new EnumToEnumValueConverter<TimeIdentifier>())
                 .HasMaxLength(6);
 
             modelBuilder.Entity<Observation>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServicePermissionTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -122,6 +123,7 @@ public class SubjectMetaServicePermissionTests
     private static SubjectMetaService SetupSubjectMetaService(
         StatisticsDbContext? statisticsDbContext = null,
         IPersistenceHelper<StatisticsDbContext>? statisticsPersistenceHelper = null,
+        IBlobCacheService? cacheService = null,
         IFilterRepository? filterRepository = null,
         IFilterItemRepository? filterItemRepository = null,
         IIndicatorGroupRepository? indicatorGroupRepository = null,
@@ -135,6 +137,7 @@ public class SubjectMetaServicePermissionTests
         return new(
             statisticsPersistenceHelper ?? DefaultPersistenceHelperMock().Object,
             statisticsDbContext ?? Mock.Of<StatisticsDbContext>(Strict),
+            cacheService ?? Mock.Of<IBlobCacheService>(Strict), 
             filterRepository ?? Mock.Of<IFilterRepository>(Strict),
             filterItemRepository ?? Mock.Of<IFilterItemRepository>(Strict),
             indicatorGroupRepository ?? Mock.Of<IIndicatorGroupRepository>(Strict),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Cache/PrivateSubjectMetaCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Cache/PrivateSubjectMetaCacheKey.cs
@@ -1,0 +1,27 @@
+﻿#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Cache;
+
+public record PrivateSubjectMetaCacheKey : IBlobCacheKey
+{
+    private Guid ReleaseId { get; }
+    private Guid SubjectId { get; }
+
+    public PrivateSubjectMetaCacheKey(Guid releaseId, Guid subjectId)
+    {
+        ReleaseId = releaseId;
+        SubjectId = subjectId;
+    }
+
+    public IBlobContainer Container => PrivateContent;
+
+    public string Key => PrivateContentSubjectMetaPath(
+        ReleaseId,
+        SubjectId
+    );
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/LocationViewModelBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/LocationViewModelBuilder.cs
@@ -79,35 +79,23 @@ public class LocationViewModelBuilder
         // Find duplicates by label which also have the same value.
         // They are unique by some other attribute of location and appending the value of this attribute won't deduplicate them.
         // TODO EES-2954 enhance the deduplication to append other attributes of the location
-        var notDistinctByLabelAndValue = locations
+        var nonDistinctByLabelAndValue = locations
             .GroupBy(model => (model.Value, model.Label))
             .Where(grouping => grouping.Count() > 1)
             .SelectMany(grouping => grouping)
             .ToList();
 
         // Excluding those, find duplicates due to having the same label
-        var notDistinctByLabel = locations
-            .Except(notDistinctByLabelAndValue)
+        var nonDistinctByLabel = locations
+            .Except(nonDistinctByLabelAndValue)
             .GroupBy(model => model.Label.ToLower())
             .Where(grouping => grouping.Count() > 1)
             .SelectMany(grouping => grouping)
             .ToList();
 
-        if (!notDistinctByLabel.Any())
-        {
-            return locations;
-        }
+        nonDistinctByLabel.ForEach(location => location.Label += $" ({location.Value})");
 
-        return locations.Select(location =>
-        {
-            if (notDistinctByLabel.Contains(location))
-            {
-                // Append the value to make them differentiable by label
-                location.Label += $" ({location.Value})";
-            }
-
-            return location;
-        }).ToList();
+        return locations;
     }
 
     private static string OrderingKey(LocationAttributeNode node)


### PR DESCRIPTION
The motivation behind this PR is that underlying datasets containing school level data are soon to be released in EES and 
the existing location wizard step in the table builder is going to be slow to use since it currently presents the full list of location options available. There could be 20k+ options.

We could implement a dedicated back-end location search and remove the dependency on all the locations being supplied upfront in the subject metadata response, but some rework would be required to restore data blocks and fast tracks in the table builder. See the notes of EES-3433 which has investigated this for more details.

Before we do this, we'd like to know if the existing client side location search would be sufficient if we can make the current subject meta data response more performant, and alter the front-end to not initially render any options until a search is performed.

Here's a current view of the client side search option:
![image](https://user-images.githubusercontent.com/4147126/173878663-bfbc5afe-dd08-4535-8653-253d88147ac4.png)

A separate PR will be raised for the front-end improvements, see EES-3452.

This PR has investigated ways of making the subject meta data response more performant and come up with four changes:

- Enable response compression
- Optimise the `EnumToEnumValueConverter` which provides a way of converting from `GeographicLevel` enum value strings in  to enum model values for each database location row returned.
- Optimise the way we deduplicate location view models.
- Add caching of unfiltered subject meta data requests to the Admin.

### Before and after

These changes were tested in my local development environment running in non-debug mode with an underlying dataset containing 22k schools and times averaged over a sample of requests.

#### Response size
Before: 2.3Mb
After: 776Kb

#### Response times
- Before with no changes: 2239ms
- Changing only `EnumToEnumValueConverter` only: 1425ms
- Changing only `DeduplicateLocationViewModels`:  1146ms
- Changing `EnumToEnumValueConverter` and `DeduplicateLocationViewModels`: 448ms
- Changing `EnumToEnumValueConverter` and `DeduplicateLocationViewModels` and enabling compression: 390ms
- Cached subject meta data and compression: 203ms

Enabling compression on it's own had very little or no effect in the local environment.

It's possible that the change to optimise the `EnumToEnumValueConverter` will also have had an positive impact on table result response times since the `TimeIdentifier` field of `Observation` also uses the same conversion.

### Other changes

- `ReleaseServiceTests` : Tidies up some of the mock verifications and fixes a few issues with missing or unnecessary setup of mock behaviour seen after enabling `strict` mode on all of the mocked services.
- Changes the layout of the private blob cache to no longer cache release content in a hierarchy by publication. The top level directory in the private cache changes now to be `releases` rather than `publications`. To cache subject meta data we were either going to need a lookup of the publication id or add it into the request, just for the purpose of creating a cache path containing the publication, which seems unnecessary.
- Adds more granularity to `BauCacheController.ClearPrivateCache` to provide the option of clearing data-blocks or subject meta data, or both. Previously we only cached data blocks so there was no option.
- Deletes cached data blocks and subject meta data from the private  storage container for the previous release version when publishing release amendments.