### PR TITLE
EES-3450 Enable a location hierarchy of school by Local Authority.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
@@ -38,6 +38,9 @@
       ],
       "LocalAuthorityDistrict": [
         "Region"
+      ],
+      "School": [
+        "LocalAuthority"
       ]
     }
   }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
@@ -19,6 +19,9 @@
       ],
       "LocalAuthorityDistrict": [
         "Region"
+      ],
+      "School": [
+        "LocalAuthority"
       ]
     }
   }


### PR DESCRIPTION
⚠️ This change requires clearing the public and private subject meta data caches using the `DELETE https://<admin-url>/api/bau/public-cache/releases` and the `DELETE https://<admin-url>/api/bau/private-cache` endpoints.

This PR adds the configuration to enable a location hierarchy for schools to group them by local authority in the table builder and in tables.

[Watch video of filtered results grouped into a hierarchy of LA's](https://www.loom.com/share/c78bddb8afaa445fac5a6729fba77d84)

and here's an underlying data set with a small set of schools where 2 schools are grouped into the 'Sunderland' LA:

**Table builder wizard step showing hierarchy of schools grouped by LA's**

![image](https://user-images.githubusercontent.com/4147126/174566877-f9d07b79-7bf5-431a-a770-ba73d83d2576.png)

**Table showing schools grouped by LA's**

![image](https://user-images.githubusercontent.com/4147126/174567875-ccb5b345-b94a-437a-9543-745804a14612.png)


