### PR TITLE
EES-3479 Allow chart reference lines to be unstyled

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
@@ -68,6 +68,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
     {
         public string Label = null!;
         public string Position = null!;
+        
+        [JsonConverter(typeof(StringEnumConverter))]
+        public AxisReferenceLineStyle? Style;
     }
 
     [SuppressMessage("ReSharper", "InconsistentNaming")]
@@ -76,5 +79,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
         [EnumMember(Value = "default")] Default,
         startEnd,
         custom
+    }
+
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public enum AxisReferenceLineStyle
+    {
+        dashed,
+        none
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
@@ -85,6 +85,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
     public enum AxisReferenceLineStyle
     {
         dashed,
+        solid,
         none
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -510,9 +510,8 @@ const ChartAxisConfiguration = ({
           {validationSchema.fields.referenceLines && (
             <ChartReferenceLinesConfiguration
               axisType={type}
-              configuration={configuration}
+              dataSetCategories={dataSetCategories}
               id={id}
-              meta={meta}
               lines={form.values.referenceLines ?? []}
               onAddLine={line => {
                 form.setFieldValue('referenceLines', [

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -511,6 +511,7 @@ const ChartAxisConfiguration = ({
             <ChartReferenceLinesConfiguration
               axisType={type}
               dataSetCategories={dataSetCategories}
+              definition={definition}
               id={id}
               lines={form.values.referenceLines ?? []}
               onAddLine={line => {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
@@ -4,27 +4,30 @@ import FormFieldSelect from '@common/components/form/FormFieldSelect';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import Tooltip from '@common/components/Tooltip';
 import {
-  AxisConfiguration,
   AxisType,
+  ChartDefinition,
   ReferenceLine,
+  ReferenceLineStyle,
 } from '@common/modules/charts/types/chart';
 import { DataSetCategory } from '@common/modules/charts/types/dataSet';
-import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import Yup from '@common/validation/yup';
 import FormSelect, {
   SelectOption,
 } from 'explore-education-statistics-common/src/components/form/FormSelect';
 import { Formik } from 'formik';
+import upperFirst from 'lodash/upperFirst';
 import React, { useMemo } from 'react';
 
 interface AddFormValues {
   label: string;
-  position: string;
+  position: string | number;
+  style: ReferenceLineStyle;
 }
 
 export interface ChartReferenceLinesConfigurationProps {
   axisType: AxisType;
   dataSetCategories: DataSetCategory[];
+  definition: ChartDefinition;
   id: string;
   lines: ReferenceLine[];
   onAddLine: (line: ReferenceLine) => void;
@@ -34,6 +37,7 @@ export interface ChartReferenceLinesConfigurationProps {
 export default function ChartReferenceLinesConfiguration({
   axisType,
   dataSetCategories,
+  definition,
   id,
   lines,
   onAddLine,
@@ -76,6 +80,8 @@ export default function ChartReferenceLinesConfiguration({
     return position;
   };
 
+  const axisDefinition = definition.axes[axisType];
+
   return (
     <table className="govuk-table">
       <caption className="govuk-heading-s">Reference lines</caption>
@@ -83,7 +89,8 @@ export default function ChartReferenceLinesConfiguration({
         <tr>
           <th>Position</th>
           <th>Label</th>
-          <th>Actions</th>
+          <th>Style</th>
+          <th className="dfe-align--right">Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -91,6 +98,7 @@ export default function ChartReferenceLinesConfiguration({
           <tr key={`${line.label}_${line.position}`}>
             <td>{getPositionLabel(line.position)}</td>
             <td>{line.label}</td>
+            <td>{upperFirst(line.style)}</td>
             <td>
               <Button
                 className="govuk-!-margin-bottom-0 dfe-float--right"
@@ -109,10 +117,15 @@ export default function ChartReferenceLinesConfiguration({
             initialValues={{
               label: '',
               position: '',
+              style: 'dashed',
+              ...(axisDefinition?.referenceLineDefaults ?? {}),
             }}
             validationSchema={Yup.object<AddFormValues>({
               label: Yup.string().required('Enter label'),
               position: Yup.string().required('Enter position'),
+              style: Yup.string()
+                .required('Enter style')
+                .oneOf<ReferenceLineStyle>(['dashed', 'none']),
             })}
             onSubmit={(values, helpers) => {
               onAddLine(values);
@@ -150,6 +163,19 @@ export default function ChartReferenceLinesConfiguration({
                     label="Label"
                     formGroup={false}
                     hideLabel
+                  />
+                </td>
+                <td className="dfe-vertical-align--bottom">
+                  <FormFieldSelect
+                    name="style"
+                    id={`${id}-referenceLines-style`}
+                    label="Style"
+                    formGroup={false}
+                    hideLabel
+                    options={[
+                      { label: 'Dashed', value: 'dashed' },
+                      { label: 'None', value: 'none' },
+                    ]}
                   />
                 </td>
                 <td className="dfe-vertical-align--bottom">

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
@@ -8,6 +8,7 @@ import {
   AxisType,
   ReferenceLine,
 } from '@common/modules/charts/types/chart';
+import { DataSetCategory } from '@common/modules/charts/types/dataSet';
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import Yup from '@common/validation/yup';
 import FormSelect, {
@@ -23,9 +24,8 @@ interface AddFormValues {
 
 export interface ChartReferenceLinesConfigurationProps {
   axisType: AxisType;
-  configuration: AxisConfiguration;
+  dataSetCategories: DataSetCategory[];
   id: string;
-  meta: FullTableMeta;
   lines: ReferenceLine[];
   onAddLine: (line: ReferenceLine) => void;
   onRemoveLine: (line: ReferenceLine) => void;
@@ -33,9 +33,8 @@ export interface ChartReferenceLinesConfigurationProps {
 
 export default function ChartReferenceLinesConfiguration({
   axisType,
-  configuration,
+  dataSetCategories,
   id,
-  meta,
   lines,
   onAddLine,
   onRemoveLine,
@@ -45,31 +44,11 @@ export default function ChartReferenceLinesConfiguration({
       return [];
     }
 
-    switch (configuration.groupBy) {
-      case 'filters':
-        return Object.values(meta.filters).flatMap(
-          filterGroup => filterGroup.options,
-        );
-      case 'indicators':
-        return meta.indicators;
-      case 'locations':
-        return meta.locations;
-      case 'timePeriod':
-        return meta.timePeriodRange.map(timePeriod => ({
-          value: `${timePeriod.year}_${timePeriod.code}`,
-          label: timePeriod.label,
-        }));
-      default:
-        return [];
-    }
-  }, [
-    axisType,
-    configuration.groupBy,
-    meta.filters,
-    meta.indicators,
-    meta.locations,
-    meta.timePeriodRange,
-  ]);
+    return dataSetCategories.map(({ filter }) => ({
+      label: filter.label,
+      value: filter.value,
+    }));
+  }, [axisType, dataSetCategories]);
 
   const filteredOptions = useMemo<SelectOption[]>(() => {
     return options.filter(option =>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
@@ -125,7 +125,7 @@ export default function ChartReferenceLinesConfiguration({
               position: Yup.string().required('Enter position'),
               style: Yup.string()
                 .required('Enter style')
-                .oneOf<ReferenceLineStyle>(['dashed', 'none']),
+                .oneOf<ReferenceLineStyle>(['dashed', 'solid', 'none']),
             })}
             onSubmit={(values, helpers) => {
               onAddLine(values);
@@ -172,8 +172,10 @@ export default function ChartReferenceLinesConfiguration({
                     label="Style"
                     formGroup={false}
                     hideLabel
+                    order={FormSelect.unordered}
                     options={[
                       { label: 'Dashed', value: 'dashed' },
+                      { label: 'Solid', value: 'solid' },
                       { label: 'None', value: 'none' },
                     ]}
                   />

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
@@ -183,6 +183,7 @@ describe('ChartAxisConfiguration', () => {
     expect(referenceLinesSection.getAllByRole('row')).toHaveLength(2);
     expect(referenceLinesSection.getByLabelText('Position')).toHaveValue('');
     expect(referenceLinesSection.getByLabelText('Label')).toHaveValue('');
+    expect(referenceLinesSection.getByLabelText('Style')).toHaveValue('none');
   });
 
   test('shows validation error if invalid custom tick spacing given', async () => {
@@ -597,6 +598,10 @@ describe('ChartAxisConfiguration', () => {
         'I am label',
       );
 
+      userEvent.selectOptions(referenceLinesSection.getByLabelText('Style'), [
+        'dashed',
+      ]);
+
       userEvent.click(screen.getByRole('button', { name: 'Add line' }));
 
       userEvent.click(
@@ -613,6 +618,7 @@ describe('ChartAxisConfiguration', () => {
             {
               label: 'I am label',
               position: '2014_AY',
+              style: 'dashed',
             },
           ],
           showGrid: true,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
@@ -35,7 +35,40 @@ describe('ChartAxisConfiguration', () => {
   };
 
   const testAxisConfiguration: AxisConfiguration = {
-    dataSets: [],
+    dataSets: [
+      {
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+      },
+      {
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-secondary'],
+      },
+      {
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-black-total', 'state-funded-primary'],
+      },
+      {
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-black-total', 'state-funded-secondary'],
+      },
+      {
+        indicator: 'overall-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+      },
+      {
+        indicator: 'overall-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-secondary'],
+      },
+      {
+        indicator: 'overall-absence-sessions',
+        filters: ['ethnicity-major-black-total', 'state-funded-primary'],
+      },
+      {
+        indicator: 'overall-absence-sessions',
+        filters: ['ethnicity-major-black-total', 'state-funded-secondary'],
+      },
+    ],
     groupBy: 'timePeriod',
     min: 0,
     referenceLines: [],
@@ -141,7 +174,7 @@ describe('ChartAxisConfiguration', () => {
     const axisSection = within(
       screen.getByRole('group', { name: 'Axis range' }),
     );
-    expect(axisSection.getByLabelText('Minimum')).toHaveValue('');
+    expect(axisSection.getByLabelText('Minimum')).toHaveValue('0');
     expect(axisSection.getByLabelText('Maximum')).toHaveValue('');
 
     const referenceLinesSection = within(
@@ -304,7 +337,7 @@ describe('ChartAxisConfiguration', () => {
 
     await waitFor(() => {
       const formValues: AxisConfiguration = {
-        dataSets: [],
+        dataSets: testAxisConfiguration.dataSets,
         groupBy: 'timePeriod',
         min: 0,
         max: undefined,
@@ -353,7 +386,7 @@ describe('ChartAxisConfiguration', () => {
 
       await waitFor(() => {
         const formValues: AxisConfiguration = {
-          dataSets: [],
+          dataSets: testAxisConfiguration.dataSets,
           groupBy: 'locations',
           groupByFilter: '',
           min: 0,
@@ -406,7 +439,7 @@ describe('ChartAxisConfiguration', () => {
 
       await waitFor(() => {
         const formValues: AxisConfiguration = {
-          dataSets: [],
+          dataSets: testAxisConfiguration.dataSets,
           groupBy: 'filters',
           groupByFilter: 'school_type',
           min: 0,
@@ -572,7 +605,7 @@ describe('ChartAxisConfiguration', () => {
 
       await waitFor(() => {
         const formValues: AxisConfiguration = {
-          dataSets: [],
+          dataSets: testAxisConfiguration.dataSets,
           groupBy: 'timePeriod',
           min: 0,
           max: undefined,
@@ -692,7 +725,7 @@ describe('ChartAxisConfiguration', () => {
 
       await waitFor(() => {
         const formValues: AxisConfiguration = {
-          dataSets: [],
+          dataSets: testAxisConfiguration.dataSets,
           groupBy: 'timePeriod',
           min: 0,
           max: undefined,
@@ -750,7 +783,7 @@ describe('ChartAxisConfiguration', () => {
 
       await waitFor(() => {
         const formValues: AxisConfiguration = {
-          dataSets: [],
+          dataSets: testAxisConfiguration.dataSets,
           groupBy: 'timePeriod',
           min: 0,
           max: undefined,
@@ -808,7 +841,7 @@ describe('ChartAxisConfiguration', () => {
 
       await waitFor(() => {
         const formValues: AxisConfiguration = {
-          dataSets: [],
+          dataSets: testAxisConfiguration.dataSets,
           groupBy: undefined,
           min: 0,
           max: undefined,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartReferenceLinesConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartReferenceLinesConfiguration.test.tsx
@@ -2,8 +2,12 @@ import { testTableData } from '@admin/pages/release/datablocks/components/chart/
 import ChartReferenceLinesConfiguration, {
   ChartReferenceLinesConfigurationProps,
 } from '@admin/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration';
-import { AxisConfiguration } from '@common/modules/charts/types/chart';
 import createDataSetCategories from '@common/modules/charts/util/createDataSetCategories';
+import { lineChartBlockDefinition } from '@common/modules/charts/components/LineChartBlock';
+import {
+  AxisConfiguration,
+  ChartDefinitionAxis,
+} from '@common/modules/charts/types/chart';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -78,6 +82,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       <ChartReferenceLinesConfiguration
         axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[{ position: '2014_AY', label: 'Test label 1' }]}
         onAddLine={noop}
@@ -116,6 +121,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[
           { position: 'ethnicity-major-chinese', label: 'Test label 1' },
@@ -166,6 +172,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[{ position: 'barnet', label: 'Test label 1' }]}
         onAddLine={noop}
@@ -205,6 +212,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[
           { position: 'overall-absence-sessions', label: 'Test label 1' },
@@ -243,6 +251,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       <ChartReferenceLinesConfiguration
         axisType="minor"
         dataSetCategories={[]}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[
           { position: 2000, label: 'Test label 1' },
@@ -271,6 +280,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       <ChartReferenceLinesConfiguration
         axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[]}
         onAddLine={noop}
@@ -299,6 +309,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       <ChartReferenceLinesConfiguration
         axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[]}
         onAddLine={noop}
@@ -325,6 +336,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       <ChartReferenceLinesConfiguration
         axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[]}
         onAddLine={noop}
@@ -353,6 +365,59 @@ describe('ChartReferenceLinesConfiguration', () => {
     ).toHaveTextContent('Cannot add invalid reference line');
   });
 
+  test('default value for `Style` field is dashed', async () => {
+    render(
+      <ChartReferenceLinesConfiguration
+        axisType="major"
+        dataSetCategories={testTimePeriodDataSetCategories}
+        definition={lineChartBlockDefinition}
+        id="test-form"
+        lines={[]}
+        onAddLine={noop}
+        onRemoveLine={noop}
+      />,
+    );
+
+    const referenceLines = within(
+      screen.getByRole('table', { name: 'Reference lines' }),
+    );
+    expect(referenceLines.getAllByRole('row')).toHaveLength(2);
+
+    expect(referenceLines.getByLabelText('Style')).toHaveValue('dashed');
+  });
+
+  test('can set default value for reference line `Style` field via chart definition', async () => {
+    render(
+      <ChartReferenceLinesConfiguration
+        axisType="major"
+        dataSetCategories={testTimePeriodDataSetCategories}
+        definition={{
+          ...lineChartBlockDefinition,
+          axes: {
+            major: {
+              ...lineChartBlockDefinition.axes?.major,
+              referenceLineDefaults: {
+                style: 'none',
+              },
+            } as ChartDefinitionAxis,
+            minor: lineChartBlockDefinition.axes.minor,
+          },
+        }}
+        id="test-form"
+        lines={[]}
+        onAddLine={noop}
+        onRemoveLine={noop}
+      />,
+    );
+
+    const referenceLines = within(
+      screen.getByRole('table', { name: 'Reference lines' }),
+    );
+    expect(referenceLines.getAllByRole('row')).toHaveLength(2);
+
+    expect(referenceLines.getByLabelText('Style')).toHaveValue('none');
+  });
+
   test('adding reference line when grouped by time periods', async () => {
     const handleAddLine = jest.fn();
 
@@ -360,6 +425,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       <ChartReferenceLinesConfiguration
         axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[]}
         onAddLine={handleAddLine}
@@ -389,6 +455,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       >({
         label: 'Test label',
         position: '2014_AY',
+        style: 'dashed',
       });
     });
   });
@@ -407,6 +474,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[]}
         onAddLine={handleAddLine}
@@ -434,6 +502,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       >({
         label: 'Test label',
         position: 'state-funded-primary',
+        style: 'dashed',
       });
     });
   });
@@ -452,6 +521,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[]}
         onAddLine={handleAddLine}
@@ -479,6 +549,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       >({
         label: 'Test label',
         position: 'barnsley',
+        style: 'dashed',
       });
     });
   });
@@ -497,6 +568,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[]}
         onAddLine={handleAddLine}
@@ -524,6 +596,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       >({
         label: 'Test label',
         position: 'authorised-absence-sessions',
+        style: 'dashed',
       });
     });
   });
@@ -535,6 +608,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       <ChartReferenceLinesConfiguration
         axisType="minor"
         dataSetCategories={[]}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[]}
         onAddLine={handleAddLine}
@@ -559,6 +633,52 @@ describe('ChartReferenceLinesConfiguration', () => {
       >({
         label: 'Test label',
         position: 3000,
+        style: 'dashed',
+      });
+    });
+  });
+
+  test('adding reference line with non-default style', async () => {
+    const handleAddLine = jest.fn();
+
+    render(
+      <ChartReferenceLinesConfiguration
+        axisType="major"
+        dataSetCategories={testTimePeriodDataSetCategories}
+        definition={lineChartBlockDefinition}
+        id="test-form"
+        lines={[]}
+        onAddLine={handleAddLine}
+        onRemoveLine={noop}
+      />,
+    );
+
+    const referenceLines = within(
+      screen.getByRole('table', { name: 'Reference lines' }),
+    );
+    expect(referenceLines.getAllByRole('row')).toHaveLength(2);
+
+    userEvent.selectOptions(referenceLines.getByLabelText('Position'), [
+      '2014_AY',
+    ]);
+    await userEvent.type(referenceLines.getByLabelText('Label'), 'Test label');
+
+    expect(referenceLines.getByLabelText('Style')).toHaveValue('dashed');
+
+    userEvent.selectOptions(referenceLines.getByLabelText('Style'), ['none']);
+
+    expect(handleAddLine).not.toHaveBeenCalled();
+
+    userEvent.click(screen.getByRole('button', { name: 'Add line' }));
+
+    await waitFor(() => {
+      expect(handleAddLine).toHaveBeenCalledTimes(1);
+      expect(handleAddLine).toHaveBeenCalledWith<
+        Parameters<ChartReferenceLinesConfigurationProps['onAddLine']>
+      >({
+        label: 'Test label',
+        position: '2014_AY',
+        style: 'none',
       });
     });
   });
@@ -570,6 +690,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       <ChartReferenceLinesConfiguration
         axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[
           { position: '2014_AY', label: 'Test label 1' },
@@ -599,6 +720,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       <ChartReferenceLinesConfiguration
         axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[
           { position: '2014_AY', label: 'Test label 1' },
@@ -644,6 +766,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[
           { position: 'state-funded-primary', label: 'Test label 1' },
@@ -690,6 +813,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[
           { position: 'barnet', label: 'Test label 1' },
@@ -735,6 +859,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[
           { position: 'authorised-absence-sessions', label: 'Test label 1' },
@@ -773,6 +898,7 @@ describe('ChartReferenceLinesConfiguration', () => {
       <ChartReferenceLinesConfiguration
         axisType="minor"
         dataSetCategories={[]}
+        definition={lineChartBlockDefinition}
         id="test-form"
         lines={[
           { position: 1000, label: 'Test label 1' },

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartReferenceLinesConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartReferenceLinesConfiguration.test.tsx
@@ -3,6 +3,7 @@ import ChartReferenceLinesConfiguration, {
   ChartReferenceLinesConfigurationProps,
 } from '@admin/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration';
 import { AxisConfiguration } from '@common/modules/charts/types/chart';
+import createDataSetCategories from '@common/modules/charts/util/createDataSetCategories';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -11,7 +12,40 @@ import React from 'react';
 
 describe('ChartReferenceLinesConfiguration', () => {
   const testAxisConfiguration: AxisConfiguration = {
-    dataSets: [],
+    dataSets: [
+      {
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+      },
+      {
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-secondary'],
+      },
+      {
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-black-total', 'state-funded-primary'],
+      },
+      {
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-black-total', 'state-funded-secondary'],
+      },
+      {
+        indicator: 'overall-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+      },
+      {
+        indicator: 'overall-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-secondary'],
+      },
+      {
+        indicator: 'overall-absence-sessions',
+        filters: ['ethnicity-major-black-total', 'state-funded-primary'],
+      },
+      {
+        indicator: 'overall-absence-sessions',
+        filters: ['ethnicity-major-black-total', 'state-funded-secondary'],
+      },
+    ],
     groupBy: 'timePeriod',
     min: 0,
     referenceLines: [],
@@ -30,14 +64,21 @@ describe('ChartReferenceLinesConfiguration', () => {
   };
 
   const testTable = mapFullTable(testTableData);
+  const testTimePeriodDataSetCategories = createDataSetCategories(
+    {
+      ...testAxisConfiguration,
+      groupBy: 'timePeriod',
+    },
+    testTable.results,
+    testTable.subjectMeta,
+  );
 
   test('renders correctly with existing lines when grouped by time periods', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={testAxisConfiguration}
+        dataSetCategories={testTimePeriodDataSetCategories}
         id="test-form"
-        meta={testTable.subjectMeta}
         lines={[{ position: '2014_AY', label: 'Test label 1' }]}
         onAddLine={noop}
         onRemoveLine={noop}
@@ -67,12 +108,15 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={{
-          ...testAxisConfiguration,
-          groupBy: 'filters',
-        }}
+        dataSetCategories={createDataSetCategories(
+          {
+            ...testAxisConfiguration,
+            groupBy: 'filters',
+          },
+          testTable.results,
+          testTable.subjectMeta,
+        )}
         id="test-form"
-        meta={testTable.subjectMeta}
         lines={[
           { position: 'ethnicity-major-chinese', label: 'Test label 1' },
           { position: 'state-funded-secondary', label: 'Test label 2' },
@@ -114,12 +158,15 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={{
-          ...testAxisConfiguration,
-          groupBy: 'locations',
-        }}
+        dataSetCategories={createDataSetCategories(
+          {
+            ...testAxisConfiguration,
+            groupBy: 'locations',
+          },
+          testTable.results,
+          testTable.subjectMeta,
+        )}
         id="test-form"
-        meta={testTable.subjectMeta}
         lines={[{ position: 'barnet', label: 'Test label 1' }]}
         onAddLine={noop}
         onRemoveLine={noop}
@@ -150,12 +197,15 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={{
-          ...testAxisConfiguration,
-          groupBy: 'indicators',
-        }}
+        dataSetCategories={createDataSetCategories(
+          {
+            ...testAxisConfiguration,
+            groupBy: 'indicators',
+          },
+          testTable.results,
+          testTable.subjectMeta,
+        )}
         id="test-form"
-        meta={testTable.subjectMeta}
         lines={[
           { position: 'overall-absence-sessions', label: 'Test label 1' },
         ]}
@@ -192,13 +242,8 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="minor"
-        configuration={{
-          ...testAxisConfiguration,
-          type: 'minor',
-          groupBy: undefined,
-        }}
+        dataSetCategories={[]}
         id="test-form"
-        meta={testTable.subjectMeta}
         lines={[
           { position: 2000, label: 'Test label 1' },
           { position: 4000, label: 'Test label 2' },
@@ -225,10 +270,9 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={testAxisConfiguration}
+        dataSetCategories={testTimePeriodDataSetCategories}
         id="test-form"
         lines={[]}
-        meta={testTable.subjectMeta}
         onAddLine={noop}
         onRemoveLine={noop}
       />,
@@ -254,10 +298,9 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={testAxisConfiguration}
+        dataSetCategories={testTimePeriodDataSetCategories}
         id="test-form"
         lines={[]}
-        meta={testTable.subjectMeta}
         onAddLine={noop}
         onRemoveLine={noop}
       />,
@@ -281,10 +324,9 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={testAxisConfiguration}
+        dataSetCategories={testTimePeriodDataSetCategories}
         id="test-form"
         lines={[]}
-        meta={testTable.subjectMeta}
         onAddLine={noop}
         onRemoveLine={noop}
       />,
@@ -317,10 +359,9 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={testAxisConfiguration}
+        dataSetCategories={testTimePeriodDataSetCategories}
         id="test-form"
         lines={[]}
-        meta={testTable.subjectMeta}
         onAddLine={handleAddLine}
         onRemoveLine={noop}
       />,
@@ -358,13 +399,16 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={{
-          ...testAxisConfiguration,
-          groupBy: 'filters',
-        }}
+        dataSetCategories={createDataSetCategories(
+          {
+            ...testAxisConfiguration,
+            groupBy: 'filters',
+          },
+          testTable.results,
+          testTable.subjectMeta,
+        )}
         id="test-form"
         lines={[]}
-        meta={testTable.subjectMeta}
         onAddLine={handleAddLine}
         onRemoveLine={noop}
       />,
@@ -400,13 +444,16 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={{
-          ...testAxisConfiguration,
-          groupBy: 'locations',
-        }}
+        dataSetCategories={createDataSetCategories(
+          {
+            ...testAxisConfiguration,
+            groupBy: 'locations',
+          },
+          testTable.results,
+          testTable.subjectMeta,
+        )}
         id="test-form"
         lines={[]}
-        meta={testTable.subjectMeta}
         onAddLine={handleAddLine}
         onRemoveLine={noop}
       />,
@@ -442,13 +489,16 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={{
-          ...testAxisConfiguration,
-          groupBy: 'indicators',
-        }}
+        dataSetCategories={createDataSetCategories(
+          {
+            ...testAxisConfiguration,
+            groupBy: 'indicators',
+          },
+          testTable.results,
+          testTable.subjectMeta,
+        )}
         id="test-form"
         lines={[]}
-        meta={testTable.subjectMeta}
         onAddLine={handleAddLine}
         onRemoveLine={noop}
       />,
@@ -484,14 +534,9 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="minor"
-        configuration={{
-          ...testAxisConfiguration,
-          type: 'minor',
-          groupBy: 'indicators',
-        }}
+        dataSetCategories={[]}
         id="test-form"
         lines={[]}
-        meta={testTable.subjectMeta}
         onAddLine={handleAddLine}
         onRemoveLine={noop}
       />,
@@ -524,13 +569,12 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={testAxisConfiguration}
+        dataSetCategories={testTimePeriodDataSetCategories}
         id="test-form"
         lines={[
           { position: '2014_AY', label: 'Test label 1' },
           { position: '2015_AY', label: 'Test label 1' },
         ]}
-        meta={testTable.subjectMeta}
         onAddLine={handleAddLine}
         onRemoveLine={noop}
       />,
@@ -554,16 +598,12 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={{
-          ...testAxisConfiguration,
-          groupBy: 'timePeriod',
-        }}
+        dataSetCategories={testTimePeriodDataSetCategories}
         id="test-form"
         lines={[
           { position: '2014_AY', label: 'Test label 1' },
           { position: '2015_AY', label: 'Test label 2' },
         ]}
-        meta={testTable.subjectMeta}
         onAddLine={noop}
         onRemoveLine={handleRemoveLine}
       />,
@@ -596,17 +636,20 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={{
-          ...testAxisConfiguration,
-          groupBy: 'filters',
-        }}
+        dataSetCategories={createDataSetCategories(
+          {
+            ...testAxisConfiguration,
+            groupBy: 'filters',
+          },
+          testTable.results,
+          testTable.subjectMeta,
+        )}
         id="test-form"
         lines={[
           { position: 'state-funded-primary', label: 'Test label 1' },
           { position: 'state-funded-secondary', label: 'Test label 2' },
           { position: 'ethnicity-major-chinese', label: 'Test label 3' },
         ]}
-        meta={testTable.subjectMeta}
         onAddLine={noop}
         onRemoveLine={handleRemoveLine}
       />,
@@ -639,16 +682,19 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={{
-          ...testAxisConfiguration,
-          groupBy: 'locations',
-        }}
+        dataSetCategories={createDataSetCategories(
+          {
+            ...testAxisConfiguration,
+            groupBy: 'locations',
+          },
+          testTable.results,
+          testTable.subjectMeta,
+        )}
         id="test-form"
         lines={[
           { position: 'barnet', label: 'Test label 1' },
           { position: 'barnsley', label: 'Test label 2' },
         ]}
-        meta={testTable.subjectMeta}
         onAddLine={noop}
         onRemoveLine={handleRemoveLine}
       />,
@@ -681,16 +727,19 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="major"
-        configuration={{
-          ...testAxisConfiguration,
-          groupBy: 'indicators',
-        }}
+        dataSetCategories={createDataSetCategories(
+          {
+            ...testAxisConfiguration,
+            groupBy: 'indicators',
+          },
+          testTable.results,
+          testTable.subjectMeta,
+        )}
         id="test-form"
         lines={[
           { position: 'authorised-absence-sessions', label: 'Test label 1' },
           { position: 'overall-absence-sessions', label: 'Test label 2' },
         ]}
-        meta={testTable.subjectMeta}
         onAddLine={noop}
         onRemoveLine={handleRemoveLine}
       />,
@@ -723,18 +772,13 @@ describe('ChartReferenceLinesConfiguration', () => {
     render(
       <ChartReferenceLinesConfiguration
         axisType="minor"
-        configuration={{
-          ...testAxisConfiguration,
-          type: 'minor',
-          groupBy: 'indicators',
-        }}
+        dataSetCategories={[]}
         id="test-form"
         lines={[
           { position: 1000, label: 'Test label 1' },
           { position: 2000, label: 'Test label 2' },
           { position: 3000, label: 'Test label 2' },
         ]}
-        meta={testTable.subjectMeta}
         onAddLine={noop}
         onRemoveLine={handleRemoveLine}
       />,

--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -171,6 +171,7 @@ const HorizontalBarBlock = ({
               chartData,
               label: referenceLine.label,
               position: referenceLine.position,
+              style: referenceLine.style,
               y: referenceLine.position,
             }),
           )}
@@ -180,6 +181,7 @@ const HorizontalBarBlock = ({
               chartData,
               label: referenceLine.label,
               position: referenceLine.position,
+              style: referenceLine.style,
               x: referenceLine.position,
             }),
           )}
@@ -233,6 +235,9 @@ export const horizontalBarBlockDefinition: ChartDefinition = {
         tickSpacing: 1,
         unit: '',
       },
+      referenceLineDefaults: {
+        style: 'none',
+      },
     },
     minor: {
       id: 'minor',
@@ -251,6 +256,9 @@ export const horizontalBarBlockDefinition: ChartDefinition = {
         label: {
           width: 100,
         },
+      },
+      referenceLineDefaults: {
+        style: 'none',
       },
     },
   },

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -207,6 +207,7 @@ const LineChartBlock = ({
               chartData,
               label: referenceLine.label,
               position: referenceLine.position,
+              style: referenceLine.style,
               x: referenceLine.position,
             }),
           )}
@@ -216,6 +217,7 @@ const LineChartBlock = ({
               chartData,
               label: referenceLine.label,
               position: referenceLine.position,
+              style: referenceLine.style,
               y: referenceLine.position,
             }),
           )}

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -172,6 +172,7 @@ const VerticalBarBlock = ({
               chartData,
               label: referenceLine.label,
               position: referenceLine.position,
+              style: referenceLine.style,
               x: referenceLine.position,
             }),
           )}
@@ -181,6 +182,7 @@ const VerticalBarBlock = ({
               chartData,
               label: referenceLine.label,
               position: referenceLine.position,
+              style: referenceLine.style,
               y: referenceLine.position,
             }),
           )}
@@ -234,6 +236,9 @@ export const verticalBarBlockDefinition: ChartDefinition = {
         tickSpacing: 1,
         unit: '',
       },
+      referenceLineDefaults: {
+        style: 'none',
+      },
     },
     minor: {
       id: 'minor',
@@ -251,6 +256,9 @@ export const verticalBarBlockDefinition: ChartDefinition = {
         label: {
           width: 100,
         },
+      },
+      referenceLineDefaults: {
+        style: 'none',
       },
     },
   },

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/createReferenceLine.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/createReferenceLine.tsx
@@ -32,6 +32,11 @@ export default function createReferenceLine({
           stroke: 'transparent',
           strokeWidth: 0,
         };
+      case 'solid':
+        return {
+          stroke: '#b1b4b6',
+          strokeWidth: 3,
+        };
       default:
         return {};
     }

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/createReferenceLine.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/createReferenceLine.tsx
@@ -1,27 +1,47 @@
 import CustomReferenceLineLabel from '@common/modules/charts/components/CustomReferenceLineLabel';
+import { ReferenceLineStyle } from '@common/modules/charts/types/chart';
 import { ChartData } from '@common/modules/charts/types/dataSet';
 import React, { ReactElement } from 'react';
 import { ReferenceLine, ReferenceLineProps } from 'recharts';
 
-interface Props extends Omit<ReferenceLineProps, 'label' | 'position'> {
+interface Props
+  extends Omit<ReferenceLineProps, 'label' | 'position' | 'style'> {
   chartData: ChartData[];
   label: string;
   position: string | number;
+  style?: ReferenceLineStyle;
 }
 
 export default function createReferenceLine({
   chartData,
   label,
   position,
+  style = 'dashed',
   ...props
 }: Props): ReactElement {
+  const styleProps = () => {
+    switch (style) {
+      case 'dashed':
+        return {
+          stroke: '#b1b4b6',
+          strokeDasharray: '8 4',
+          strokeWidth: 3,
+        };
+      case 'none':
+        return {
+          stroke: 'transparent',
+          strokeWidth: 0,
+        };
+      default:
+        return {};
+    }
+  };
+
   return (
     <ReferenceLine
-      key={`${position}_${label}`}
-      stroke="#b1b4b6"
-      strokeDasharray="8 4"
-      strokeWidth={3}
+      {...styleProps()}
       {...props}
+      key={`${position}_${label}`}
       label={(lineProps: ReferenceLineProps) => (
         <CustomReferenceLineLabel
           {...lineProps.viewBox}

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -31,7 +31,7 @@ export type LineStyle = 'solid' | 'dashed' | 'dotted';
 export type AxisGroupBy = 'timePeriod' | 'locations' | 'filters' | 'indicators';
 export type AxisType = 'major' | 'minor';
 export type TickConfig = 'default' | 'startEnd' | 'custom';
-export type ReferenceLineStyle = 'dashed' | 'none';
+export type ReferenceLineStyle = 'dashed' | 'solid' | 'none';
 
 export interface ReferenceLine {
   label: string;

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -31,10 +31,12 @@ export type LineStyle = 'solid' | 'dashed' | 'dotted';
 export type AxisGroupBy = 'timePeriod' | 'locations' | 'filters' | 'indicators';
 export type AxisType = 'major' | 'minor';
 export type TickConfig = 'default' | 'startEnd' | 'custom';
+export type ReferenceLineStyle = 'dashed' | 'none';
 
 export interface ReferenceLine {
   label: string;
   position: number | string;
+  style?: ReferenceLineStyle;
 }
 
 export interface Label {
@@ -137,6 +139,7 @@ export interface ChartDefinitionAxis {
   constants?: {
     groupBy?: AxisGroupBy;
   };
+  referenceLineDefaults?: Partial<ReferenceLine>;
 }
 
 export const chartDefinitions: ChartDefinition[] = [

--- a/src/explore-education-statistics-common/src/styles/utils/_position.scss
+++ b/src/explore-education-statistics-common/src/styles/utils/_position.scss
@@ -1,17 +1,17 @@
 .dfe-align--centre {
-  text-align: center;
+  text-align: center !important;
 }
 
 .dfe-align--left {
-  text-align: left;
+  text-align: left !important;
 }
 
 .dfe-align--right {
-  text-align: right;
+  text-align: right !important;
 }
 
 .dfe-float--right {
-  float: right;
+  float: right !important;
 }
 
 .dfe-vertical-align--bottom {


### PR DESCRIPTION
This PR adds the ability to configure chart reference line styling from one of three options:

- Dashed (the default for most charts)
- Solid (new option)
- None (new option and the default for bar charts)

## Related changes

- Fixed there potentially being excessive options for reference line positions due to the options previously being generated from the table meta. This would often lead to options that were not present in the rendered chart. 

  To reduce the options down, we now use the data set configurations (from `ChartAxisConfiguration`) to generate these options. Using data set configurations is advantageous as these should only generate position options for facets that actually exist on the chart.

## Screenshots

Chart reference line configuration:

![image](https://user-images.githubusercontent.com/9917868/175650249-57b3d8f8-d28a-4e8a-acb2-2b377ec8e393.png)

Rendered chart with different reference line styles:

![image](https://user-images.githubusercontent.com/9917868/175649984-eaf3e34b-92ae-49b8-adbf-99aee18511f2.png)