### PR TITLE
EES-3452 school search

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormCheckbox.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckbox.tsx
@@ -15,6 +15,7 @@ export interface FormCheckboxProps {
   conditional?: ReactNode;
   id: string;
   hint?: string | ReactNode;
+  hintSmall?: boolean;
   label: string;
   boldLabel?: boolean;
   name: string;
@@ -31,6 +32,7 @@ const FormCheckbox = ({
   conditional,
   id,
   hint,
+  hintSmall = false,
   label,
   boldLabel = false,
   name,
@@ -62,6 +64,7 @@ const FormCheckbox = ({
         <label
           className={classNames('govuk-label govuk-checkboxes__label', {
             'govuk-!-font-weight-bold': boldLabel,
+            'govuk-!-padding-bottom-1': hintSmall,
           })}
           htmlFor={id}
         >
@@ -70,7 +73,9 @@ const FormCheckbox = ({
         {hint && (
           <span
             id={`${id}-item-hint`}
-            className="govuk-hint govuk-checkboxes__hint"
+            className={classNames('govuk-hint govuk-checkboxes__hint', {
+              'govuk-!-font-size-14 govuk-!-margin-bottom-1': hintSmall,
+            })}
           >
             {hint}
           </span>

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.module.scss
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.module.scss
@@ -1,6 +1,6 @@
 @import '~govuk-frontend/govuk/base';
 
 .selectAll {
-  float: left;
+  display: block;
   margin-bottom: govuk-spacing(2);
 }

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -38,8 +38,11 @@ export type CheckboxGroupAllChangeEventHandler = (
 interface BaseFormCheckboxGroupProps {
   disabled?: boolean;
   id: string;
+  maxResults?: number;
   name: string;
   options: CheckboxOption[];
+  searchHelpText?: string;
+  searchOnly?: boolean;
   selectAll?: boolean;
   selectAllText?: (isAllChecked: boolean, options: CheckboxOption[]) => string;
   small?: boolean;
@@ -63,8 +66,11 @@ export const BaseFormCheckboxGroup = ({
   disabled,
   value = [],
   id,
+  maxResults = 500,
   name,
   options,
+  searchHelpText,
+  searchOnly = false,
   selectAll = false,
   selectAllText = getDefaultSelectAllText,
   small,
@@ -101,6 +107,34 @@ export const BaseFormCheckboxGroup = ({
     [isAllChecked, onAllChange, options],
   );
 
+  const showResults = !searchOnly || options.length <= maxResults;
+
+  const getResultsMessage = () => {
+    const numResults = options.length;
+    if (!searchOnly && numResults === 0) {
+      return <p>No options available.</p>;
+    }
+    if (searchOnly) {
+      if (numResults === 0) {
+        return (
+          <p>
+            {searchHelpText ||
+              'Search above and select at least one option before continuing to the next step.'}
+          </p>
+        );
+      }
+      if (numResults > maxResults) {
+        return (
+          <p>
+            {numResults} results found. Please refine your search to view
+            options.
+          </p>
+        );
+      }
+    }
+    return null;
+  };
+
   return (
     <div
       className={classNames('govuk-checkboxes', {
@@ -108,7 +142,7 @@ export const BaseFormCheckboxGroup = ({
       })}
       ref={ref}
     >
-      {options.length > 1 && selectAll && (
+      {options.length > 1 && selectAll && showResults && (
         <ButtonText
           id={`${id}-all`}
           onClick={handleAllChange}
@@ -118,25 +152,27 @@ export const BaseFormCheckboxGroup = ({
           {selectAllText(isAllChecked, options)}
         </ButtonText>
       )}
-
-      {naturalOrderBy(options, order, orderDirection).map(option => (
-        <FormCheckbox
-          disabled={disabled}
-          {...option}
-          id={
-            option.id
-              ? `${id}-${option.id}`
-              : `${id}-${option.value.replace(/\s/g, '-')}`
-          }
-          name={name}
-          key={option.value}
-          checked={value.indexOf(option.value) > -1}
-          onBlur={onBlur}
-          onChange={onChange}
-        />
-      ))}
-
-      {options.length === 0 && <p>No options available.</p>}
+      {showResults && (
+        <>
+          {naturalOrderBy(options, order, orderDirection).map(option => (
+            <FormCheckbox
+              disabled={disabled}
+              {...option}
+              id={
+                option.id
+                  ? `${id}-${option.id}`
+                  : `${id}-${option.value.replace(/\s/g, '-')}`
+              }
+              name={name}
+              key={option.value}
+              checked={value.indexOf(option.value) > -1}
+              onBlur={onBlur}
+              onChange={onChange}
+            />
+          ))}
+        </>
+      )}
+      {getResultsMessage()}
     </div>
   );
 };

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -5,6 +5,7 @@ import naturalOrderBy, {
   OrderDirection,
   OrderKeys,
 } from '@common/utils/array/naturalOrderBy';
+import numberWithCommas from '@common/utils/number/numberWithCommas';
 import classNames from 'classnames';
 import React, {
   FocusEventHandler,
@@ -126,8 +127,8 @@ export const BaseFormCheckboxGroup = ({
       if (numResults > maxResults) {
         return (
           <p>
-            {numResults} results found. Please refine your search to view
-            options.
+            {numberWithCommas(numResults)} results found. Please refine your
+            search to view options.
           </p>
         );
       }

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -96,7 +96,7 @@ export const BaseFormCheckboxGroup = ({
   });
 
   const isAllChecked = useMemo(() => {
-    return options.every(option => value.indexOf(option.value) > -1);
+    return options.every(option => value.includes(option.value));
   }, [options, value]);
 
   const handleAllChange: MouseEventHandler<HTMLButtonElement> = useCallback(
@@ -166,7 +166,7 @@ export const BaseFormCheckboxGroup = ({
               }
               name={name}
               key={option.value}
-              checked={value.indexOf(option.value) > -1}
+              checked={value.includes(option.value)}
               onBlur={onBlur}
               onChange={onChange}
             />

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.tsx
@@ -41,7 +41,7 @@ const FormCheckboxSearchGroup = ({
     ...groupProps
   } = props;
 
-  const minSearchCharacters = searchOnly ? 2 : 0;
+  const minSearchCharacters = searchOnly ? 3 : 0;
 
   const fieldsetProps: FormFieldsetProps = {
     id,
@@ -55,7 +55,7 @@ const FormCheckboxSearchGroup = ({
   };
 
   let filteredOptions = searchOnly
-    ? options.filter(option => value.indexOf(option.value) > -1)
+    ? options.filter(option => value.includes(option.value))
     : options;
 
   if (searchTerm) {
@@ -86,7 +86,7 @@ const FormCheckboxSearchGroup = ({
         width={20}
         onChange={event => {
           if (
-            event.target.value.length > minSearchCharacters ||
+            event.target.value.length >= minSearchCharacters ||
             !event.target.value.length
           ) {
             setSearchTerm(event.target.value);

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.tsx
@@ -64,7 +64,7 @@ const FormCheckboxSearchGroup = ({
       filteredOptions = options.filter(
         option =>
           option.hint?.toString().includes(searchTerm) ||
-          value.indexOf(option.value) > -1,
+          value.includes(option.value),
       );
     } else {
       filteredOptions = options.filter(
@@ -72,7 +72,7 @@ const FormCheckboxSearchGroup = ({
           option.label
             .toLowerCase()
             .includes(searchTerm.trim().toLowerCase()) ||
-          value.indexOf(option.value) > -1,
+          value.includes(option.value),
       );
     }
   }

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.tsx
@@ -36,9 +36,12 @@ const FormCheckboxSearchGroup = ({
     onFieldsetFocus,
     onFieldsetBlur,
     options = [],
+    searchOnly = false,
     value = [],
     ...groupProps
   } = props;
+
+  const minSearchCharacters = searchOnly ? 2 : 0;
 
   const fieldsetProps: FormFieldsetProps = {
     id,
@@ -51,14 +54,27 @@ const FormCheckboxSearchGroup = ({
     onBlur: onFieldsetBlur,
   };
 
-  let filteredOptions = options;
+  let filteredOptions = searchOnly
+    ? options.filter(option => value.indexOf(option.value) > -1)
+    : options;
 
   if (searchTerm) {
-    filteredOptions = options.filter(
-      option =>
-        option.label.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        value.indexOf(option.value) > -1,
-    );
+    // Search for URN in the hint field if search term is a number.
+    if (searchOnly && !Number.isNaN(Number(searchTerm))) {
+      filteredOptions = options.filter(
+        option =>
+          option.hint?.toString().includes(searchTerm) ||
+          value.indexOf(option.value) > -1,
+      );
+    } else {
+      filteredOptions = options.filter(
+        option =>
+          option.label
+            .toLowerCase()
+            .includes(searchTerm.trim().toLowerCase()) ||
+          value.indexOf(option.value) > -1,
+      );
+    }
   }
 
   return (
@@ -68,7 +84,14 @@ const FormCheckboxSearchGroup = ({
         name={`${name}-search`}
         label={searchLabel}
         width={20}
-        onChange={event => setSearchTerm(event.target.value)}
+        onChange={event => {
+          if (
+            event.target.value.length > minSearchCharacters ||
+            !event.target.value.length
+          ) {
+            setSearchTerm(event.target.value);
+          }
+        }}
         onKeyPress={event => {
           if (event.key === 'Enter') {
             event.preventDefault();
@@ -76,13 +99,25 @@ const FormCheckboxSearchGroup = ({
         }}
       />
 
-      <div aria-live="assertive" className={styles.optionsContainer}>
+      <div className={styles.optionsContainer}>
+        {filteredOptions.length > 0 && (
+          <span
+            aria-live="polite"
+            aria-atomic
+            className="govuk-visually-hidden"
+          >
+            {`${filteredOptions.length} option${
+              filteredOptions.length > 1 ? 's' : ''
+            } found`}
+          </span>
+        )}
         <BaseFormCheckboxGroup
           {...groupProps}
           id={`${id}-options`}
           value={value}
           name={name}
           options={filteredOptions}
+          searchOnly
           small
         />
       </div>

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxGroup.test.tsx
@@ -290,4 +290,62 @@ describe('FormCheckboxGroup', () => {
       'test-checkboxes-opt-4-is---here',
     );
   });
+
+  test('renders the no options message when there are no options', () => {
+    render(
+      <FormCheckboxGroup
+        value={[]}
+        id="test-checkboxes"
+        name="test-checkboxes"
+        legend="Test checkboxes"
+        selectAll
+        options={[]}
+      />,
+    );
+
+    expect(screen.getByText('No options available.')).toBeInTheDocument();
+  });
+
+  test('renders the search help text there are no options and searchOnly is true', () => {
+    render(
+      <FormCheckboxGroup
+        value={[]}
+        id="test-checkboxes"
+        name="test-checkboxes"
+        legend="Test checkboxes"
+        searchOnly
+        searchHelpText="This is the help text"
+        selectAll
+        options={[]}
+      />,
+    );
+
+    expect(screen.getByText('This is the help text')).toBeInTheDocument();
+  });
+
+  test('renders the too many results message when searchOnly is true and there are more than the maximum results', () => {
+    render(
+      <FormCheckboxGroup
+        value={[]}
+        id="test-checkboxes"
+        name="test-checkboxes"
+        legend="Test checkboxes"
+        maxResults={2}
+        searchOnly
+        searchHelpText="This is the help text"
+        selectAll
+        options={[
+          { id: 'checkbox-1', label: 'Test checkbox 1', value: '1' },
+          { id: 'checkbox-2', label: 'Test checkbox 2', value: '2' },
+          { id: 'checkbox-3', label: 'Test checkbox 3', value: '3' },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        '3 results found. Please refine your search to view options.',
+      ),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchGroup.test.tsx.snap
@@ -19,9 +19,13 @@ exports[`FormCheckboxSearchGroup renders list of checkboxes in correct order 1`]
            type="text"
            value
     >
-    <div aria-live="assertive"
-         class="optionsContainer"
-    >
+    <div class="optionsContainer">
+      <span aria-live="polite"
+            aria-atomic="true"
+            class="govuk-visually-hidden"
+      >
+        3 options found
+      </span>
       <div class="govuk-checkboxes govuk-checkboxes--small">
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input"

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -59,17 +59,30 @@ const LocationFiltersForm = ({
 
   // For school options flatten the location hierarchy and include the URN and LA as a hint.
   // If we use search only for other location types later then may need to change this.
-  const getFlattenedOptions = (opts: LocationOption[]) => {
+  const getSearchOnlyOptions = (
+    opts: LocationOption[],
+    hasSubGroups: boolean,
+  ) => {
+    if (!hasSubGroups) {
+      return opts.map(opt => ({
+        label: opt.label,
+        value: opt.id ?? '',
+        hint: `URN: ${opt.value}`,
+        hintSmall: true,
+      }));
+    }
     return opts.flatMap(group => {
+      const level =
+        group.level && group.label
+          ? `${locationLevelsMap[group.level].label}: ${group.label}`
+          : '';
       return (
-        group.options?.map(opt => {
-          return {
-            label: opt.label,
-            value: opt.id ?? '',
-            hint: `URN: ${opt.value}; Local authority: ${group.label}`,
-            hintSmall: true,
-          };
-        }) ?? []
+        group.options?.map(opt => ({
+          label: opt.label,
+          value: opt.id ?? '',
+          hint: `URN: ${opt.value}; ${level}`,
+          hintSmall: true,
+        })) ?? []
       );
     });
   };
@@ -187,7 +200,10 @@ const LocationFiltersForm = ({
                           order={searchOnly ? 'label' : []}
                           options={
                             searchOnly
-                              ? getFlattenedOptions(level.options)
+                              ? getSearchOnlyOptions(
+                                  level.options,
+                                  hasSubGroups,
+                                )
                               : level.options.map(option => ({
                                   label: option.label,
                                   value: option.id ?? '',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/LocationFiltersForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/LocationFiltersForm.test.tsx
@@ -346,7 +346,7 @@ describe('LocationFiltersForm', () => {
     expect(schoolCheckboxes[0]).toHaveAttribute('value', 'school-id-1');
     expect(schoolCheckboxes[0]).toEqual(schoolGroup.getByLabelText('School 1'));
     expect(
-      schoolGroup.getByText('URN: 000001; Local authority: LA 1'),
+      schoolGroup.getByText('URN: 000001; Local Authority: LA 1'),
     ).toHaveAttribute(
       'id',
       'locationFiltersForm-locations-school-options-school-id-1-item-hint',
@@ -356,7 +356,7 @@ describe('LocationFiltersForm', () => {
     expect(schoolCheckboxes[1]).toHaveAttribute('value', 'school-id-2');
     expect(schoolCheckboxes[1]).toEqual(schoolGroup.getByLabelText('School 2'));
     expect(
-      schoolGroup.getByText('URN: 000002; Local authority: LA 1'),
+      schoolGroup.getByText('URN: 000002; Local Authority: LA 1'),
     ).toHaveAttribute(
       'id',
       'locationFiltersForm-locations-school-options-school-id-2-item-hint',
@@ -366,7 +366,7 @@ describe('LocationFiltersForm', () => {
     expect(schoolCheckboxes[2]).toHaveAttribute('value', 'school-id-3');
     expect(schoolCheckboxes[2]).toEqual(schoolGroup.getByLabelText('School 3'));
     expect(
-      schoolGroup.getByText('URN: 000003; Local authority: LA 2'),
+      schoolGroup.getByText('URN: 000003; Local Authority: LA 2'),
     ).toHaveAttribute(
       'id',
       'locationFiltersForm-locations-school-options-school-id-3-item-hint',

--- a/src/explore-education-statistics-common/src/utils/number/numberWithCommas.ts
+++ b/src/explore-education-statistics-common/src/utils/number/numberWithCommas.ts
@@ -1,0 +1,6 @@
+/**
+ * Adds commas to large numbers as recommended by the GDS styleguide.
+ */
+export default function numberWithCommas(value: number): string {
+  return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}


### PR DESCRIPTION
Handles schools in the table tool locations step:
- as the data set is very large it doesn't show any schools initially, you have to search to get any results.
- there's a maximum limit on the number of results shown to prevent people searching for generic terms like 'school' and getting thousands of results. This is currently set to 500 which seems to render without problems.
- you can search by school name or URN. This uses the same basic text search as before.
- you have to type 3 characters or more to start a search.

This only applies to schools, all other location types function as before.

**Location hierarchy**
The backend provides the schools data with the location hierarchy (grouped by local authority). In the front end, instead of displaying the schools grouped by LA, as with other location types, we show a flat list and add the URN and LA to the hint field on the checkboxes.

This initially came about because of experimenting with virtualised lists for displaying larger numbers of items which wouldn't have worked with nested lists.  While it's not using a virtualised list any more I've stuck with the flat list as when you can only search the location grouping UI feels unnecessary and can add a lot of vertical space making it harder to find things, plus if we later want to improve the search by introducing relevance / ranking them the groupings wouldn't make sense.

![initial](https://user-images.githubusercontent.com/81572860/175961455-716c7d95-1663-46bd-9b03-9b10c0a3a421.PNG)
![toomany](https://user-images.githubusercontent.com/81572860/175961485-4ee733b5-c71c-4bfe-a8cf-75c882fac1b3.PNG)
![searchresults](https://user-images.githubusercontent.com/81572860/175961773-5c834f0f-d49d-462b-8cb0-acbbfd146b75.PNG)
