### PR TITLE
EES-3481 Update create_snaphots.py to interact with publications form after EES-3017

### DIFF
--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -3,6 +3,10 @@ import json
 import argparse
 import requests
 from bs4 import BeautifulSoup
+from get_webdriver import get_webdriver
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.options import Options
 
 """
 Script to check find statistics, table tool, methodologies and data catalogue snapshots.
@@ -72,29 +76,22 @@ def create_find_statistics_snapshot(public_url: str) -> str:
 
 def create_table_tool_snapshot(public_url: str) -> str:
     table_tool_url = f"{public_url.rstrip('/')}/data-tables"
-    parsed_html = _gets_parsed_html_from_page(table_tool_url)
+    driver.get(table_tool_url)
 
-    themes = parsed_html.select('[id^="theme-details-"]') or []
+    theme_labels = driver.find_elements(By.CSS_SELECTOR, 'label[for^="publicationForm-themes-"]')
 
     result = []
-    for theme_html in themes:
+    for theme_label in theme_labels:
+        theme_label.click()
         theme = {
-            'theme_heading': theme_html.select_one('[id^="theme-heading-"]').string,
-            'topics': [],
+            'theme_heading': theme_label.text,
+            'publications': [],
         }
 
-        topics = theme_html.select('[id^="topic-details-"]') or []
-        for topic_html in topics:
-            topic = {
-                'topic_heading': topic_html.select_one('[id^="topic-heading-"]').string,
-                'publications': [],
-            }
-
-            publications = topic_html.select('label') or []
-            for publication_label in publications:
-                topic['publications'].append(publication_label.string)
-
-            theme['topics'].append(topic)
+        publication_labels = driver.find_elements(By.CSS_SELECTOR,
+                                                  'label[for^="publicationForm-publicationForm-publications-"]')
+        for publication_label in publication_labels:
+            theme['publications'].append(publication_label.text)
 
         result.append(theme)
 
@@ -103,29 +100,22 @@ def create_table_tool_snapshot(public_url: str) -> str:
 
 def create_data_catalogue_snapshot(public_url: str) -> str:
     data_catalogue_url = f"{public_url.rstrip('/')}/data-catalogue"
-    parsed_html = _gets_parsed_html_from_page(data_catalogue_url)
+    driver.get(data_catalogue_url)
 
-    themes = parsed_html.select('[id^="theme-details-"]') or []
+    theme_labels = driver.find_elements(By.CSS_SELECTOR, 'label[for^="publicationForm-themes-"]')
 
     result = []
-    for theme_html in themes:
+    for theme_label in theme_labels:
+        theme_label.click()
         theme = {
-            'theme_heading': theme_html.select_one('[id^="theme-heading-"]').string,
-            'topics': [],
+            'theme_heading': theme_label.text,
+            'publications': [],
         }
 
-        topics = theme_html.select('[id^="topic-details-"]') or []
-        for topic_html in topics:
-            topic = {
-                'topic_heading': topic_html.select_one('[id^="topic-heading-"]').string,
-                'publications': [],
-            }
-
-            publications = topic_html.select('label') or []
-            for publication_label in publications:
-                topic['publications'].append(publication_label.string)
-
-            theme['topics'].append(topic)
+        publication_labels = driver.find_elements(By.CSS_SELECTOR,
+                                                  'label[for^="publicationForm-publicationForm-publications-"]')
+        for publication_label in publication_labels:
+            theme['publications'].append(publication_label.text)
 
         result.append(theme)
 
@@ -189,6 +179,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     assert os.path.basename(os.getcwd()) == 'robot-tests', 'Must run from the robot-tests directory!'
+
+    get_webdriver("latest")
+    chrome_options = Options()
+    chrome_options.add_argument("--headless")
+    driver = webdriver.Chrome(options=chrome_options)
 
     find_stats_snapshot = create_find_statistics_snapshot(args.public_url)
     _write_to_file('find_stats_snapshot.json', find_stats_snapshot)

--- a/tests/robot-tests/tests/snapshots/data_catalogue_snapshot.json
+++ b/tests/robot-tests/tests/snapshots/data_catalogue_snapshot.json
@@ -1,328 +1,128 @@
 [
   {
-    "theme_heading": "Children's social care",
-    "topics": [
-      {
-        "publications": [
-          "Characteristics of children in need"
-        ],
-        "topic_heading": "Children in need and child protection"
-      },
-      {
-        "publications": [
-          "Children looked after in England including adoptions"
-        ],
-        "topic_heading": "Children looked after"
-      },
-      {
-        "publications": [
-          "Children's social work workforce",
-          "Children's social work workforce: attrition, caseload, and agency workforce"
-        ],
-        "topic_heading": "Children's social work workforce"
-      },
-      {
-        "publications": [
-          "Outcomes for children in need, including children looked after by local authorities in England",
-          "Outcomes of children in need, including looked after children"
-        ],
-        "topic_heading": "Outcomes for children in social care"
-      },
-      {
-        "publications": [
-          "Children accommodated in secure children's homes"
-        ],
-        "topic_heading": "Secure children's homes"
-      },
-      {
-        "publications": [
-          "Serious incident notifications"
-        ],
-        "topic_heading": "Serious incident notifications"
-      }
-    ]
+    "publications": [
+      "Characteristics of children in need",
+      "Children accommodated in secure children's homes",
+      "Children looked after in England including adoptions",
+      "Children's social work workforce",
+      "Children's social work workforce: attrition, caseload, and agency workforce",
+      "Outcomes for children in need, including children looked after by local authorities in England",
+      "Outcomes of children in need, including looked after children",
+      "Serious incident notifications"
+    ],
+    "theme_heading": "Children's social care"
   },
   {
-    "theme_heading": "COVID-19",
-    "topics": [
-      {
-        "publications": [
-          "Attendance in education and early years settings during the coronavirus (COVID-19) pandemic"
-        ],
-        "topic_heading": "Attendance"
-      },
-      {
-        "publications": [
-          "CO2 monitors: cumulative delivery statistics"
-        ],
-        "topic_heading": "CO2 monitors"
-      },
-      {
-        "publications": [
-          "Coronavirus (COVID-19) Reporting in Higher Education Providers"
-        ],
-        "topic_heading": "Confirmed cases reported by Higher Education providers"
-      },
-      {
-        "publications": [
-          "Delivery of air cleaning units",
-          "Laptops and tablets data"
-        ],
-        "topic_heading": "Devices"
-      },
-      {
-        "publications": [
-          "COVID mass testing data in education"
-        ],
-        "topic_heading": "Testing"
-      }
-    ]
+    "publications": [
+      "Attendance in education and early years settings during the coronavirus (COVID-19) pandemic",
+      "CO2 monitors: cumulative delivery statistics",
+      "Coronavirus (COVID-19) Reporting in Higher Education Providers",
+      "COVID mass testing data in education",
+      "Delivery of air cleaning units",
+      "Laptops and tablets data"
+    ],
+    "theme_heading": "COVID-19"
   },
   {
-    "theme_heading": "Destination of pupils and students",
-    "topics": [
-      {
-        "publications": [
-          "16-18 destination measures",
-          "Key stage 4 destination measures",
-          "Longer term destinations",
-          "Progression to higher education or training"
-        ],
-        "topic_heading": "Destinations of key stage 4 and 16-18 pupils"
-      },
-      {
-        "publications": [
-          "NEET age 16 to 24",
-          "Participation in education, training and employment age 16 to 18"
-        ],
-        "topic_heading": "NEET and participation"
-      }
-    ]
+    "publications": [
+      "16-18 destination measures",
+      "Key stage 4 destination measures",
+      "Longer term destinations",
+      "NEET age 16 to 24",
+      "Participation in education, training and employment age 16 to 18",
+      "Progression to higher education or training"
+    ],
+    "theme_heading": "Destination of pupils and students"
   },
   {
-    "theme_heading": "Early years",
-    "topics": [
-      {
-        "publications": [
-          "Education provision: children under 5 years of age"
-        ],
-        "topic_heading": "Childcare and early years"
-      },
-      {
-        "publications": [
-          "Early years foundation stage profile results"
-        ],
-        "topic_heading": "Early years foundation stage profile"
-      }
-    ]
+    "publications": [
+      "Early years foundation stage profile results",
+      "Education provision: children under 5 years of age"
+    ],
+    "theme_heading": "Early years"
   },
   {
-    "theme_heading": "Finance and funding",
-    "topics": [
-      {
-        "publications": [
-          "LA and school expenditure",
-          "Planned LA and school expenditure",
-          "School funding statistics"
-        ],
-        "topic_heading": "Local authority and school finance"
-      },
-      {
-        "publications": [
-          "Student loan forecasts for England"
-        ],
-        "topic_heading": "Student loan forecasts"
-      }
-    ]
+    "publications": [
+      "LA and school expenditure",
+      "Planned LA and school expenditure",
+      "School funding statistics",
+      "Student loan forecasts for England"
+    ],
+    "theme_heading": "Finance and funding"
   },
   {
-    "theme_heading": "Further education",
-    "topics": [
-      {
-        "publications": [
-          "Apprenticeships and traineeships",
-          "Apprenticeships in England by industry characteristics ",
-          "Further education and skills",
-          "Skills Bootcamps outcomes"
-        ],
-        "topic_heading": "Further education and skills"
-      },
-      {
-        "publications": [
-          "Career pathways: post-16 qualifications held by employees",
-          "Detailed destinations of 16 to 18 year olds in Further Education",
-          "FE learners going into employment and learning destinations by local authority district",
-          "Further education: outcome-based success measures",
-          "Further education skills index"
-        ],
-        "topic_heading": "Further education outcomes"
-      }
-    ]
+    "publications": [
+      "Apprenticeships and traineeships",
+      "Apprenticeships in England by industry characteristics",
+      "Career pathways: post-16 qualifications held by employees",
+      "Detailed destinations of 16 to 18 year olds in Further Education",
+      "FE learners going into employment and learning destinations by local authority district",
+      "Further education and skills",
+      "Further education: outcome-based success measures",
+      "Further education skills index",
+      "Skills Bootcamps outcomes"
+    ],
+    "theme_heading": "Further education"
   },
   {
-    "theme_heading": "Higher education",
-    "topics": [
-      {
-        "publications": [
-          "UK revenue from education related exports and transnational education activity"
-        ],
-        "topic_heading": "Education exports"
-      },
-      {
-        "publications": [
-          "Graduate labour market statistics",
-          "Graduate outcomes (LEO)",
-          "Graduate outcomes (LEO): postgraduate outcomes",
-          "Graduate outcomes (LEO): Provider level data"
-        ],
-        "topic_heading": "Higher education graduate employment and earnings"
-      },
-      {
-        "publications": [
-          "Higher Level Learners in England"
-        ],
-        "topic_heading": "Higher level learners in England"
-      },
-      {
-        "publications": [
-          "Participation measures in higher education"
-        ],
-        "topic_heading": "Participation measures in higher education"
-      },
-      {
-        "publications": [
-          "Widening participation in higher education"
-        ],
-        "topic_heading": "Widening participation in higher education"
-      }
-    ]
+    "publications": [
+      "Graduate labour market statistics",
+      "Graduate outcomes (LEO)",
+      "Graduate outcomes (LEO): postgraduate outcomes",
+      "Graduate outcomes (LEO): Provider level data",
+      "Higher Level Learners in England",
+      "Participation measures in higher education",
+      "UK revenue from education related exports and transnational education activity",
+      "Widening participation in higher education"
+    ],
+    "theme_heading": "Higher education"
   },
   {
-    "theme_heading": "Pupils and schools",
-    "topics": [
-      {
-        "publications": [
-          "Academy transfers and funding"
-        ],
-        "topic_heading": "Academy transfers"
-      },
-      {
-        "publications": [
-          "Admission appeals in England"
-        ],
-        "topic_heading": "Admission appeals"
-      },
-      {
-        "publications": [
-          "Permanent exclusions and suspensions in England"
-        ],
-        "topic_heading": "Exclusions"
-      },
-      {
-        "publications": [
-          "Parental responsibility measures"
-        ],
-        "topic_heading": "Parental responsibility measures"
-      },
-      {
-        "publications": [
-          "Pupil absence in schools in England",
-          "Pupil absence in schools in England: autumn and spring terms",
-          "Pupil absence in schools in England: autumn term",
-          "The link between absence and attainment at KS2 and KS4"
-        ],
-        "topic_heading": "Pupil absence"
-      },
-      {
-        "publications": [
-          "National pupil projections"
-        ],
-        "topic_heading": "Pupil projections"
-      },
-      {
-        "publications": [
-          "Free school meals: Autumn term",
-          "National Tutoring Programme",
-          "Schools, pupils and their characteristics"
-        ],
-        "topic_heading": "School and pupil numbers"
-      },
-      {
-        "publications": [
-          "School placements for children from outside of the UK",
-          "Secondary and primary school applications and offers"
-        ],
-        "topic_heading": "School applications"
-      },
-      {
-        "publications": [
-          "Local authority school places scorecards",
-          "School capacity",
-          " School places sufficiency survey"
-        ],
-        "topic_heading": "School capacity"
-      },
-      {
-        "publications": [
-          "Education, health and care plans",
-          "Special educational needs in England"
-        ],
-        "topic_heading": "Special educational needs (SEN)"
-      }
-    ]
+    "publications": [
+      "Academy transfers and funding",
+      "Admission appeals in England",
+      "Education, health and care plans",
+      "Free school meals: Autumn term",
+      "Local authority school places scorecards",
+      "National pupil projections",
+      "National Tutoring Programme",
+      "Parental responsibility measures",
+      "Permanent exclusions and suspensions in England",
+      "Pupil absence in schools in England",
+      "Pupil absence in schools in England: autumn and spring terms",
+      "Pupil absence in schools in England: autumn term",
+      "School capacity",
+      "School placements for children from outside of the UK",
+      "School places sufficiency survey",
+      "Schools, pupils and their characteristics",
+      "Secondary and primary school applications and offers",
+      "Special educational needs in England",
+      "The link between absence and attainment at KS2 and KS4"
+    ],
+    "theme_heading": "Pupils and schools"
   },
   {
-    "theme_heading": "School and college outcomes and performance",
-    "topics": [
-      {
-        "publications": [
-          "A level and other 16 to 18 results",
-          "Level 2 and 3 attainment age 16 to 25"
-        ],
-        "topic_heading": "16 to 19 attainment"
-      },
-      {
-        "publications": [
-          "Key stage 4 performance"
-        ],
-        "topic_heading": "GCSEs (key stage 4)"
-      },
-      {
-        "publications": [
-          "Multi-academy trust performance measures at key stage 2"
-        ],
-        "topic_heading": "Key stage 2"
-      }
-    ]
+    "publications": [
+      "A level and other 16 to 18 results",
+      "Key stage 4 performance",
+      "Level 2 and 3 attainment age 16 to 25",
+      "Multi-academy trust performance measures at key stage 2"
+    ],
+    "theme_heading": "School and college outcomes and performance"
   },
   {
-    "theme_heading": "Teachers and school workforce",
-    "topics": [
-      {
-        "publications": [
-          "Initial Teacher Training Census",
-          "Initial teacher training performance profiles",
-          "Postgraduate initial teacher training targets"
-        ],
-        "topic_heading": "Initial teacher training (ITT)"
-      },
-      {
-        "publications": [
-          "School workforce in England"
-        ],
-        "topic_heading": "School workforce"
-      }
-    ]
+    "publications": [
+      "Initial Teacher Training Census",
+      "Initial teacher training performance profiles",
+      "Postgraduate initial teacher training targets",
+      "School workforce in England"
+    ],
+    "theme_heading": "Teachers and school workforce"
   },
   {
-    "theme_heading": "UK education and training statistics",
-    "topics": [
-      {
-        "publications": [
-          "Education and training statistics for the UK"
-        ],
-        "topic_heading": "UK education and training statistics"
-      }
-    ]
+    "publications": [
+      "Education and training statistics for the UK"
+    ],
+    "theme_heading": "UK education and training statistics"
   }
 ]

--- a/tests/robot-tests/tests/snapshots/table_tool_snapshot.json
+++ b/tests/robot-tests/tests/snapshots/table_tool_snapshot.json
@@ -1,328 +1,128 @@
 [
   {
-    "theme_heading": "Children's social care",
-    "topics": [
-      {
-        "publications": [
-          "Characteristics of children in need"
-        ],
-        "topic_heading": "Children in need and child protection"
-      },
-      {
-        "publications": [
-          "Children looked after in England including adoptions"
-        ],
-        "topic_heading": "Children looked after"
-      },
-      {
-        "publications": [
-          "Children's social work workforce",
-          "Children's social work workforce: attrition, caseload, and agency workforce"
-        ],
-        "topic_heading": "Children's social work workforce"
-      },
-      {
-        "publications": [
-          "Outcomes for children in need, including children looked after by local authorities in England",
-          "Outcomes of children in need, including looked after children"
-        ],
-        "topic_heading": "Outcomes for children in social care"
-      },
-      {
-        "publications": [
-          "Children accommodated in secure children's homes"
-        ],
-        "topic_heading": "Secure children's homes"
-      },
-      {
-        "publications": [
-          "Serious incident notifications"
-        ],
-        "topic_heading": "Serious incident notifications"
-      }
-    ]
+    "publications": [
+      "Characteristics of children in need",
+      "Children accommodated in secure children's homes",
+      "Children looked after in England including adoptions",
+      "Children's social work workforce",
+      "Children's social work workforce: attrition, caseload, and agency workforce",
+      "Outcomes for children in need, including children looked after by local authorities in England",
+      "Outcomes of children in need, including looked after children",
+      "Serious incident notifications"
+    ],
+    "theme_heading": "Children's social care"
   },
   {
-    "theme_heading": "COVID-19",
-    "topics": [
-      {
-        "publications": [
-          "Attendance in education and early years settings during the coronavirus (COVID-19) pandemic"
-        ],
-        "topic_heading": "Attendance"
-      },
-      {
-        "publications": [
-          "CO2 monitors: cumulative delivery statistics"
-        ],
-        "topic_heading": "CO2 monitors"
-      },
-      {
-        "publications": [
-          "Coronavirus (COVID-19) Reporting in Higher Education Providers"
-        ],
-        "topic_heading": "Confirmed cases reported by Higher Education providers"
-      },
-      {
-        "publications": [
-          "Delivery of air cleaning units",
-          "Laptops and tablets data"
-        ],
-        "topic_heading": "Devices"
-      },
-      {
-        "publications": [
-          "COVID mass testing data in education"
-        ],
-        "topic_heading": "Testing"
-      }
-    ]
+    "publications": [
+      "Attendance in education and early years settings during the coronavirus (COVID-19) pandemic",
+      "CO2 monitors: cumulative delivery statistics",
+      "Coronavirus (COVID-19) Reporting in Higher Education Providers",
+      "COVID mass testing data in education",
+      "Delivery of air cleaning units",
+      "Laptops and tablets data"
+    ],
+    "theme_heading": "COVID-19"
   },
   {
-    "theme_heading": "Destination of pupils and students",
-    "topics": [
-      {
-        "publications": [
-          "16-18 destination measures",
-          "Key stage 4 destination measures",
-          "Longer term destinations",
-          "Progression to higher education or training"
-        ],
-        "topic_heading": "Destinations of key stage 4 and 16-18 pupils"
-      },
-      {
-        "publications": [
-          "NEET age 16 to 24",
-          "Participation in education, training and employment age 16 to 18"
-        ],
-        "topic_heading": "NEET and participation"
-      }
-    ]
+    "publications": [
+      "16-18 destination measures",
+      "Key stage 4 destination measures",
+      "Longer term destinations",
+      "NEET age 16 to 24",
+      "Participation in education, training and employment age 16 to 18",
+      "Progression to higher education or training"
+    ],
+    "theme_heading": "Destination of pupils and students"
   },
   {
-    "theme_heading": "Early years",
-    "topics": [
-      {
-        "publications": [
-          "Education provision: children under 5 years of age"
-        ],
-        "topic_heading": "Childcare and early years"
-      },
-      {
-        "publications": [
-          "Early years foundation stage profile results"
-        ],
-        "topic_heading": "Early years foundation stage profile"
-      }
-    ]
+    "publications": [
+      "Early years foundation stage profile results",
+      "Education provision: children under 5 years of age"
+    ],
+    "theme_heading": "Early years"
   },
   {
-    "theme_heading": "Finance and funding",
-    "topics": [
-      {
-        "publications": [
-          "LA and school expenditure",
-          "Planned LA and school expenditure",
-          "School funding statistics"
-        ],
-        "topic_heading": "Local authority and school finance"
-      },
-      {
-        "publications": [
-          "Student loan forecasts for England"
-        ],
-        "topic_heading": "Student loan forecasts"
-      }
-    ]
+    "publications": [
+      "LA and school expenditure",
+      "Planned LA and school expenditure",
+      "School funding statistics",
+      "Student loan forecasts for England"
+    ],
+    "theme_heading": "Finance and funding"
   },
   {
-    "theme_heading": "Further education",
-    "topics": [
-      {
-        "publications": [
-          "Apprenticeships and traineeships",
-          "Apprenticeships in England by industry characteristics ",
-          "Further education and skills",
-          "Skills Bootcamps outcomes"
-        ],
-        "topic_heading": "Further education and skills"
-      },
-      {
-        "publications": [
-          "Career pathways: post-16 qualifications held by employees",
-          "Detailed destinations of 16 to 18 year olds in Further Education",
-          "FE learners going into employment and learning destinations by local authority district",
-          "Further education: outcome-based success measures",
-          "Further education skills index"
-        ],
-        "topic_heading": "Further education outcomes"
-      }
-    ]
+    "publications": [
+      "Apprenticeships and traineeships",
+      "Apprenticeships in England by industry characteristics",
+      "Career pathways: post-16 qualifications held by employees",
+      "Detailed destinations of 16 to 18 year olds in Further Education",
+      "FE learners going into employment and learning destinations by local authority district",
+      "Further education and skills",
+      "Further education: outcome-based success measures",
+      "Further education skills index",
+      "Skills Bootcamps outcomes"
+    ],
+    "theme_heading": "Further education"
   },
   {
-    "theme_heading": "Higher education",
-    "topics": [
-      {
-        "publications": [
-          "UK revenue from education related exports and transnational education activity"
-        ],
-        "topic_heading": "Education exports"
-      },
-      {
-        "publications": [
-          "Graduate labour market statistics",
-          "Graduate outcomes (LEO)",
-          "Graduate outcomes (LEO): postgraduate outcomes",
-          "Graduate outcomes (LEO): Provider level data"
-        ],
-        "topic_heading": "Higher education graduate employment and earnings"
-      },
-      {
-        "publications": [
-          "Higher Level Learners in England"
-        ],
-        "topic_heading": "Higher level learners in England"
-      },
-      {
-        "publications": [
-          "Participation measures in higher education"
-        ],
-        "topic_heading": "Participation measures in higher education"
-      },
-      {
-        "publications": [
-          "Widening participation in higher education"
-        ],
-        "topic_heading": "Widening participation in higher education"
-      }
-    ]
+    "publications": [
+      "Graduate labour market statistics",
+      "Graduate outcomes (LEO)",
+      "Graduate outcomes (LEO): postgraduate outcomes",
+      "Graduate outcomes (LEO): Provider level data",
+      "Higher Level Learners in England",
+      "Participation measures in higher education",
+      "UK revenue from education related exports and transnational education activity",
+      "Widening participation in higher education"
+    ],
+    "theme_heading": "Higher education"
   },
   {
-    "theme_heading": "Pupils and schools",
-    "topics": [
-      {
-        "publications": [
-          "Academy transfers and funding"
-        ],
-        "topic_heading": "Academy transfers"
-      },
-      {
-        "publications": [
-          "Admission appeals in England"
-        ],
-        "topic_heading": "Admission appeals"
-      },
-      {
-        "publications": [
-          "Permanent exclusions and suspensions in England"
-        ],
-        "topic_heading": "Exclusions"
-      },
-      {
-        "publications": [
-          "Parental responsibility measures"
-        ],
-        "topic_heading": "Parental responsibility measures"
-      },
-      {
-        "publications": [
-          "Pupil absence in schools in England",
-          "Pupil absence in schools in England: autumn and spring terms",
-          "Pupil absence in schools in England: autumn term",
-          "The link between absence and attainment at KS2 and KS4"
-        ],
-        "topic_heading": "Pupil absence"
-      },
-      {
-        "publications": [
-          "National pupil projections"
-        ],
-        "topic_heading": "Pupil projections"
-      },
-      {
-        "publications": [
-          "Free school meals: Autumn term",
-          "National Tutoring Programme",
-          "Schools, pupils and their characteristics"
-        ],
-        "topic_heading": "School and pupil numbers"
-      },
-      {
-        "publications": [
-          "School placements for children from outside of the UK",
-          "Secondary and primary school applications and offers"
-        ],
-        "topic_heading": "School applications"
-      },
-      {
-        "publications": [
-          "Local authority school places scorecards",
-          "School capacity",
-          " School places sufficiency survey"
-        ],
-        "topic_heading": "School capacity"
-      },
-      {
-        "publications": [
-          "Education, health and care plans",
-          "Special educational needs in England"
-        ],
-        "topic_heading": "Special educational needs (SEN)"
-      }
-    ]
+    "publications": [
+      "Academy transfers and funding",
+      "Admission appeals in England",
+      "Education, health and care plans",
+      "Free school meals: Autumn term",
+      "Local authority school places scorecards",
+      "National pupil projections",
+      "National Tutoring Programme",
+      "Parental responsibility measures",
+      "Permanent exclusions and suspensions in England",
+      "Pupil absence in schools in England",
+      "Pupil absence in schools in England: autumn and spring terms",
+      "Pupil absence in schools in England: autumn term",
+      "School capacity",
+      "School placements for children from outside of the UK",
+      "School places sufficiency survey",
+      "Schools, pupils and their characteristics",
+      "Secondary and primary school applications and offers",
+      "Special educational needs in England",
+      "The link between absence and attainment at KS2 and KS4"
+    ],
+    "theme_heading": "Pupils and schools"
   },
   {
-    "theme_heading": "School and college outcomes and performance",
-    "topics": [
-      {
-        "publications": [
-          "A level and other 16 to 18 results",
-          "Level 2 and 3 attainment age 16 to 25"
-        ],
-        "topic_heading": "16 to 19 attainment"
-      },
-      {
-        "publications": [
-          "Key stage 4 performance"
-        ],
-        "topic_heading": "GCSEs (key stage 4)"
-      },
-      {
-        "publications": [
-          "Multi-academy trust performance measures at key stage 2"
-        ],
-        "topic_heading": "Key stage 2"
-      }
-    ]
+    "publications": [
+      "A level and other 16 to 18 results",
+      "Key stage 4 performance",
+      "Level 2 and 3 attainment age 16 to 25",
+      "Multi-academy trust performance measures at key stage 2"
+    ],
+    "theme_heading": "School and college outcomes and performance"
   },
   {
-    "theme_heading": "Teachers and school workforce",
-    "topics": [
-      {
-        "publications": [
-          "Initial Teacher Training Census",
-          "Initial teacher training performance profiles",
-          "Postgraduate initial teacher training targets"
-        ],
-        "topic_heading": "Initial teacher training (ITT)"
-      },
-      {
-        "publications": [
-          "School workforce in England"
-        ],
-        "topic_heading": "School workforce"
-      }
-    ]
+    "publications": [
+      "Initial Teacher Training Census",
+      "Initial teacher training performance profiles",
+      "Postgraduate initial teacher training targets",
+      "School workforce in England"
+    ],
+    "theme_heading": "Teachers and school workforce"
   },
   {
-    "theme_heading": "UK education and training statistics",
-    "topics": [
-      {
-        "publications": [
-          "Education and training statistics for the UK"
-        ],
-        "topic_heading": "UK education and training statistics"
-      }
-    ]
+    "publications": [
+      "Education and training statistics for the UK"
+    ],
+    "theme_heading": "UK education and training statistics"
   }
 ]


### PR DESCRIPTION
https://github.com/dfe-analytical-services/explore-education-statistics/pull/3330 has changed the ‘Choose a Publication’ step on the Table Tool and the Data Catalogue pages to not use the Details component.

Instead of being able to gather the themes/topics/publications for these pages by scraping the HTML, the pages now include a form containing a list of themes as radio button inputs with labels. On selecting a theme the list of publications for the theme is shown as radio button inputs with labels.

Topics are no longer shown.

![image](https://user-images.githubusercontent.com/4147126/176115050-ac632904-4dee-4f84-b5b7-def163867c5f.png)

This PR updates the `create_snapshots.py` script to interact with the form using Selenium to build the collection of themes and publications as JSON.

It also contains a commit updating the snapshots to match the latest data from the Prod environment.