### PR TITLE
EES-3481 Alter snapshots.py to pass webdriver as argument

### DIFF
--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -3,7 +3,6 @@ import json
 import argparse
 import requests
 from bs4 import BeautifulSoup
-from get_webdriver import get_webdriver
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
@@ -74,7 +73,7 @@ def create_find_statistics_snapshot(public_url: str) -> str:
     return json.dumps(result, sort_keys=True, indent=2)
 
 
-def create_table_tool_snapshot(public_url: str) -> str:
+def create_table_tool_snapshot(public_url: str, driver: webdriver) -> str:
     table_tool_url = f"{public_url.rstrip('/')}/data-tables"
     driver.get(table_tool_url)
 
@@ -98,7 +97,7 @@ def create_table_tool_snapshot(public_url: str) -> str:
     return json.dumps(result, sort_keys=True, indent=2)
 
 
-def create_data_catalogue_snapshot(public_url: str) -> str:
+def create_data_catalogue_snapshot(public_url: str, driver: webdriver) -> str:
     data_catalogue_url = f"{public_url.rstrip('/')}/data-catalogue"
     driver.get(data_catalogue_url)
 
@@ -170,6 +169,8 @@ def _write_to_file(file_name: str, snapshot: str):
 
 
 if __name__ == "__main__":
+    from get_webdriver import get_webdriver
+
     parser = argparse.ArgumentParser(prog=f"python {os.path.basename(__file__)}",
                                      description="To create snapshots of specific public frontend pages")
     parser.add_argument(dest="public_url",
@@ -188,10 +189,10 @@ if __name__ == "__main__":
     find_stats_snapshot = create_find_statistics_snapshot(args.public_url)
     _write_to_file('find_stats_snapshot.json', find_stats_snapshot)
 
-    table_tool_snapshot = create_table_tool_snapshot(args.public_url)
+    table_tool_snapshot = create_table_tool_snapshot(args.public_url, driver)
     _write_to_file('table_tool_snapshot.json', table_tool_snapshot)
 
-    data_catalogue_snapshot = create_data_catalogue_snapshot(args.public_url)
+    data_catalogue_snapshot = create_data_catalogue_snapshot(args.public_url, driver)
     _write_to_file('data_catalogue_snapshot.json', data_catalogue_snapshot)
 
     all_methodologies_snapshot = create_all_methodologies_snapshot(args.public_url)

--- a/tests/robot-tests/tests/libs/snapshots.py
+++ b/tests/robot-tests/tests/libs/snapshots.py
@@ -3,6 +3,15 @@ from alerts import send_slack_alert
 from utilities import raise_assertion_error
 from scripts.create_snapshots \
     import create_find_statistics_snapshot, create_table_tool_snapshot, create_data_catalogue_snapshot, create_all_methodologies_snapshot
+from scripts.get_webdriver import get_webdriver
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.options import Options
+
+get_webdriver("latest")
+chrome_options = Options()
+chrome_options.add_argument("--headless")
+driver = webdriver.Chrome(options=chrome_options)
 
 
 def validate_find_stats_snapshot():
@@ -17,7 +26,7 @@ def validate_find_stats_snapshot():
 def validate_table_tool_snapshot():
     with open('tests/snapshots/table_tool_snapshot.json', 'r') as file:
         snapshot = file.read()
-    new_snapshot = create_table_tool_snapshot(os.getenv('PUBLIC_URL'))
+    new_snapshot = create_table_tool_snapshot(os.getenv('PUBLIC_URL'), driver)
     if snapshot != new_snapshot:
         send_slack_alert(f"Table tool page snapshot doesn't match current page on {os.getenv('PUBLIC_URL')}")
         raise_assertion_error(f"Table tool page snapshot doesn't match current page on {os.getenv('PUBLIC_URL')}")
@@ -27,7 +36,7 @@ def validate_table_tool_snapshot():
 def validate_data_catalogue_snapshot():
     with open('tests/snapshots/data_catalogue_snapshot.json', 'r') as file:
         snapshot = file.read()
-    new_snapshot = create_data_catalogue_snapshot(os.getenv('PUBLIC_URL'))
+    new_snapshot = create_data_catalogue_snapshot(os.getenv('PUBLIC_URL'), driver)
     if snapshot != new_snapshot:
         send_slack_alert(f"Data catalogue page snapshot doesn't match current page on {os.getenv('PUBLIC_URL')}")
         raise_assertion_error(f"Data catalogue page snapshot doesn't match current page on {os.getenv('PUBLIC_URL')}")


### PR DESCRIPTION
This PR alters `snapshots.py` to pass webdriver as an argument.

The process of creating the snapshots was failing in the DevOps pipeline where it runs via the robot test `tests/general_public/check_snapshots.robot` due to the missing webdriver.