### PR TITLE
EES-3453 Fix ReleaseDataAccordion styling issue

### DIFF
--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAccordion.module.scss
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAccordion.module.scss
@@ -8,11 +8,13 @@
     margin-top: 0;
   }
 
-  @include govuk-media-query($from: tablet) {
+  /* stylelint-disable max-nesting-depth */
+  :global(.govuk-accordion__section:is(:first-child)) {
     :global(.govuk-accordion__section-header) {
       border-top: 0;
     }
   }
+  /* stylelint-enable */
 }
 
 .section {


### PR DESCRIPTION
This fixes a styling issue in EES-3453 where a HR dividing line wasn't being displayed between the "Explore data and files" and "Related dashboard(s)" accordion sections

![image](https://user-images.githubusercontent.com/44812484/176456337-07a98440-691b-46b7-a373-b2f8e18bac3f.png)
