### PR TITLE
EES-3489 EES-3491 Changes to invites

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
@@ -51,21 +51,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
             Assert.Null(loginService.ErrorMessage);
             Assert.Empty(loginService.ModelState);
         }
-        
+
         [Fact]
         public async Task Login_ExistingUser_Failed()
         {
             var (result, loginService) = await DoExistingUserLogin(SignInResult.Failed);
             AssertRedirectedToLoginPageUponFailure(result, loginService);
         }
-        
+
         [Fact]
         public async Task Login_ExistingUser_NotAllowed()
         {
             var (result, loginService) = await DoExistingUserLogin(SignInResult.NotAllowed);
             AssertRedirectedToLoginPageUponFailure(result, loginService);
         }
-        
+
         [Fact]
         public async Task Login_ExistingUser_LockedOut()
         {
@@ -76,13 +76,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
             Assert.Equal(ExpectedLoginErrorMessage, loginService.ErrorMessage);
             Assert.Empty(loginService.ModelState);
         }
-        
+
         [Fact]
         public async Task Login_ExistingUser_NewProviderDetails_Success()
         {
             var (result, loginService) = await DoLoginExistingUserWithNewProviderKey(
                 ListOf(_providerDetails),
-                IdentityResult.Success, 
+                IdentityResult.Success,
                 SignInResult.Success);
 
             AssertSuccessfulLogin(result, loginService);
@@ -104,7 +104,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                         Code = "502",
                         Description = "Error 2"
                     }));
-            
+
             AssertRedirectedToLoginPageUponFailure(
                 result,
                 loginService,
@@ -116,7 +116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
         {
             var (result, loginService) = await DoLoginExistingUserWithNewProviderKey(
                 new List<IdentityUserLogin<string>>());
-            
+
             AssertRedirectedToLoginPageUponFailure(result, loginService);
         }
 
@@ -141,7 +141,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
 
             var result = await loginService.OnGetCallbackAsync(ReturnUrl);
             VerifyAllMocks(signInManager);
-            
+
             AssertRedirectedToLoginPageUponFailure(result, loginService);
         }
 
@@ -152,7 +152,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                 Guid.NewGuid(),
                 new Claim(ClaimTypes.GivenName, "FirstName"),
                 new Claim(ClaimTypes.Surname, "LastName"));
-            
+
             var signInManager = new Mock<ISignInManagerDelegate>(Strict);
 
             signInManager
@@ -165,7 +165,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
 
             await using var usersDbContext = InMemoryUserAndRolesDbContext();
             await using var contentDbContext = InMemoryApplicationDbContext();
-            
+
             var loginService = BuildService(
                 signInManager.Object,
                 usersDbContext: usersDbContext,
@@ -173,7 +173,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
 
             var result = await loginService.OnGetCallbackAsync(ReturnUrl);
             VerifyAllMocks(signInManager);
-            
+
             AssertRedirectedToLoginPageUponFailure(result, loginService);
         }
 
@@ -190,7 +190,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
 
             await using var usersDbContext = InMemoryUserAndRolesDbContext();
             await using var contentDbContext = InMemoryApplicationDbContext();
-            
+
             var loginService = BuildService(
                 signInManager.Object,
                 userManager.Object,
@@ -207,7 +207,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
 
             var result = await loginService.OnGetCallbackAsync(ReturnUrl);
             VerifyAllMocks(userManager, signInManager);
-                
+
             AssertRedirectedToLoginPageUponFailure(result, loginService);
         }
 
@@ -219,12 +219,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
             const string email = "inviteduser@example.com";
             const string firstName = "FirstName";
             const string lastName = "LastName";
-            
+
             var claimsPrincipal = CreateClaimsPrincipal(email, firstName, lastName);
 
             var userManager = new Mock<IUserManagerDelegate>(Strict);
             var signInManager = new Mock<ISignInManagerDelegate>(Strict);
-            
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
             {
                 await contentDbContext.UserReleaseInvites.AddRangeAsync(
@@ -311,16 +311,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                         It.Is<ApplicationUser>(u =>
                             u.Email == email &&
                             u.FirstName == firstName &&
-                            u.LastName == lastName), 
+                            u.LastName == lastName),
                         "Role A"))
                     .ReturnsAsync(IdentityResult.Success);
-                
+
                 userManager
                     .Setup(s => s.AddLoginAsync(
                         It.Is<ApplicationUser>(u =>
                             u.Email == email &&
                             u.FirstName == firstName &&
-                            u.LastName == lastName), 
+                            u.LastName == lastName),
                         It.Is<UserLoginInfo>(l =>
                             l.ProviderKey == ProviderKey
                             && l.LoginProvider == LoginProvider
@@ -333,7 +333,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
 
                 var result = await loginService.OnGetCallbackAsync(ReturnUrl);
                 VerifyAllMocks(userManager, signInManager);
-                
+
                 AssertSuccessfulLogin(result, loginService);
             }
 
@@ -347,6 +347,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                     .SingleAsync(invite => invite.Email == email);
                 Assert.True(newUsersInvite.Accepted);
 
+                // Assert that the other user's invites have all been left alone.
+                var otherUsersInvite = await usersDbContext
+                    .UserInvites
+                    .AsQueryable()
+                    .SingleAsync(invite => invite.Email != email);
+                Assert.False(otherUsersInvite.Accepted);
+
+                // Assert that the new user's release role invites have all been left alone.
+                var newUsersReleaseRoleInvites = await contentDbContext
+                    .UserReleaseInvites
+                    .AsQueryable()
+                    .Where(invite => invite.Email == email)
+                    .ToListAsync();
+                Assert.Equal(2, newUsersReleaseRoleInvites.Count);
+
                 // Assert that the other user's release role invites have all been left alone.
                 var otherUsersReleaseRoleInvites = await contentDbContext
                     .UserReleaseInvites
@@ -354,6 +369,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                     .Where(invite => invite.Email != email)
                     .ToListAsync();
                 Assert.Single(otherUsersReleaseRoleInvites);
+
+                // Assert that the new user's publication role invites have all been left alone.
+                var newUsersPublicationRoleInvites = await contentDbContext
+                    .UserPublicationInvites
+                    .AsQueryable()
+                    .Where(invite => invite.Email == email)
+                    .ToListAsync();
+                Assert.Equal(2, newUsersPublicationRoleInvites.Count);
+
+                // Assert that the other user's publication role invites have all been left alone.
+                var otherUsersPublicationRoleInvites = await contentDbContext
+                    .UserPublicationInvites
+                    .AsQueryable()
+                    .Where(invite => invite.Email != email)
+                    .ToListAsync();
+                Assert.Single(otherUsersPublicationRoleInvites);
 
                 // Assert that the user has been assigned the new release roles.
                 var newUsersReleaseRoles = await contentDbContext
@@ -423,7 +454,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
 
                 var result = await loginService.OnGetCallbackAsync(ReturnUrl);
                 VerifyAllMocks(userManager, signInManager);
-                
+
                 return (result, loginService);
             }
         }
@@ -459,7 +490,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                 {
                     await usersDbContext.UserLogins.AddRangeAsync(existingProviderKeys);
                 }
-                
+
                 await usersDbContext.SaveChangesAsync();
             }
 
@@ -555,8 +586,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                     .Errors
                     .Select(e => e.ErrorMessage))
                 .ToList());
-        }        
-        
+        }
+
         private static void AssertSuccessfulLogin(IActionResult? result, ExternalLoginModel loginService)
         {
             var redirectPage = Assert.IsType<LocalRedirectResult>(result);
@@ -567,9 +598,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
         }
 
         private static ExternalLoginModel BuildService(
-            ISignInManagerDelegate? signInManager = null, 
-            IUserManagerDelegate? userManager = null, 
-            ContentDbContext? contentDbContext = null, 
+            ISignInManagerDelegate? signInManager = null,
+            IUserManagerDelegate? userManager = null,
+            ContentDbContext? contentDbContext = null,
             UsersAndRolesDbContext? usersDbContext = null)
         {
             return new ExternalLoginModel(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
@@ -242,6 +242,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                     {
                         Email = "anotheruser@example.com",
                     });
+
+                await contentDbContext.UserPublicationInvites.AddRangeAsync(
+                    new UserPublicationInvite
+                    {
+                        Email = email,
+                        Role = PublicationRole.Owner
+                    },
+                    new UserPublicationInvite
+                    {
+                        Email = email,
+                        Role = PublicationRole.ReleaseApprover
+                    },
+                    new UserPublicationInvite
+                    {
+                        Email = "anotheruser@example.com"
+                    }
+                );
                 await contentDbContext.SaveChangesAsync();
             }
 
@@ -362,6 +379,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                 Assert.Equal(
                     ListOf(ReleaseRole.Approver, ReleaseRole.Lead),
                     newUsersReleaseRoles.Select(r => r.Role));
+
+                // Assert that the user has been assigned the new publication roles.
+                var newUserPublicationRoles = await contentDbContext
+                    .UserPublicationRoles
+                    .AsQueryable()
+                    .ToListAsync();
+                Assert.Equal(2, newUserPublicationRoles.Count);
+                Assert.Equal(
+                    ListOf(PublicationRole.Owner, PublicationRole.ReleaseApprover),
+                    newUserPublicationRoles.Select(r => r.Role));
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
@@ -346,21 +346,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
                     .AsQueryable()
                     .SingleAsync(invite => invite.Email == email);
                 Assert.True(newUsersInvite.Accepted);
-                
-                // Assert that the other user's invites have all been left alone.
-                var otherUsersInvite = await usersDbContext
-                    .UserInvites
-                    .AsQueryable()
-                    .SingleAsync(invite => invite.Email != email);
-                Assert.False(otherUsersInvite.Accepted);
-                
-                // Assert that the new user's release role invites have all been removed.
-                var newUsersReleaseRoleInvites = await contentDbContext
-                    .UserReleaseInvites
-                    .AsQueryable()
-                    .Where(invite => invite.Email == email)
-                    .ToListAsync();
-                Assert.Empty(newUsersReleaseRoleInvites);
 
                 // Assert that the other user's release role invites have all been left alone.
                 var otherUsersReleaseRoleInvites = await contentDbContext

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
@@ -555,10 +555,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(ReleaseRole.PrereleaseViewer, savedUserReleaseRole.Role);
                 Assert.Equal(user.Id, savedUserReleaseRole.UserId);
 
-                var userReleaseInvite = Assert.Single(context.UserReleaseInvites);
-                Assert.Equal("test@test.com", userReleaseInvite.Email);
-                Assert.Equal(release.Id, userReleaseInvite.ReleaseId);
-                Assert.Equal(ReleaseRole.PrereleaseViewer, userReleaseInvite.Role);
+                Assert.Empty(context.UserReleaseInvites);
             }
         }
 
@@ -692,12 +689,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(ReleaseRole.PrereleaseViewer, savedUserReleaseRole.Role);
                 Assert.Equal(user.Id, savedUserReleaseRole.UserId);
 
-                // Release invite isn't created for an existing user
+                // Release invite is created for an existing user if the release is not approved
                 var userReleaseInvite = Assert.Single(context.UserReleaseInvites);
                 Assert.Equal("test@test.com", userReleaseInvite.Email);
                 Assert.Equal(release.Id, userReleaseInvite.ReleaseId);
                 Assert.Equal(ReleaseRole.PrereleaseViewer, userReleaseInvite.Role);
-
+                Assert.False(userReleaseInvite.EmailSent); // Email not sent immediately for unapproved releases
             }
         }
 
@@ -1080,7 +1077,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var releaseInvites = await context.UserReleaseInvites.AsQueryable().ToListAsync();
-                Assert.Equal(6, releaseInvites.Count);
+                Assert.Equal(4, releaseInvites.Count);
 
                 Assert.True(releaseInvites.All(invite => invite.ReleaseId == release.Id));
                 Assert.True(releaseInvites.All(invite => invite.Role == ReleaseRole.PrereleaseViewer));
@@ -1092,9 +1089,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal("new.user.1@test.com", releaseInvites[2].Email);
                 Assert.Equal("new.user.2@test.com", releaseInvites[3].Email);
-
-                Assert.Equal("existing.user.1@test.com", releaseInvites[4].Email);
-                Assert.Equal("existing.user.2@test.com", releaseInvites[5].Email);
 
                 // Two new role assignments should have been created corresponding with the two accepted invites
                 var roles = await context.UserReleaseRoles.AsQueryable().ToListAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserInviteRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserInviteRepositoryTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 
-
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
     public class UserInviteRepositoryTests
@@ -17,13 +16,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         private static readonly Guid CreatedById = Guid.NewGuid();
 
         [Fact]
-        public async Task Create_RoleArgument()
+        public async Task CreateIfNotExists_RoleArgument()
         {
             var usersAndRolesDbContextId = Guid.NewGuid().ToString();
             await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
             {
                 var repository = new UserInviteRepository(usersAndRolesDbContext);
-                var userInvite = await repository.Create("test@test.com", Role.Analyst, CreatedById);
+                var userInvite = await repository.CreateIfNotExists("test@test.com", Role.Analyst, CreatedById);
 
                 Assert.Equal("test@test.com", userInvite.Email);
                 Assert.Equal(Role.Analyst.GetEnumValue(), userInvite.RoleId);
@@ -46,7 +45,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
 
         [Fact]
-        public async Task Create_RoleArgument_ExistingInvite()
+        public async Task CreateIfNotExists_RoleArgument_ExistingInvite()
         {
             var usersAndRolesDbContextId = Guid.NewGuid().ToString();
             await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
@@ -64,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
             {
                 var repository = new UserInviteRepository(usersAndRolesDbContext);
-                var userInvite = await repository.Create("test@test.com", Role.Analyst, CreatedById);
+                var userInvite = await repository.CreateIfNotExists("test@test.com", Role.Analyst, CreatedById);
 
                 Assert.Equal("test@test.com", userInvite.Email);
                 Assert.Equal(Role.BauUser.GetEnumValue(), userInvite.RoleId);
@@ -86,13 +85,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task Create_RoleIdStringArgument()
+        public async Task CreateIfNotExists_RoleIdStringArgument()
         {
             var usersAndRolesDbContextId = Guid.NewGuid().ToString();
             await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
             {
                 var repository = new UserInviteRepository(usersAndRolesDbContext);
-                var userInvite = await repository.Create("test@test.com", Role.Analyst.GetEnumValue(), CreatedById);
+                var userInvite =
+                    await repository.CreateIfNotExists("test@test.com", Role.Analyst.GetEnumValue(), CreatedById);
 
                 Assert.Equal("test@test.com", userInvite.Email);
                 Assert.Equal(Role.Analyst.GetEnumValue(), userInvite.RoleId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserInviteRepository.cs
@@ -8,8 +8,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IUserInviteRepository
     {
-        Task<UserInvite> Create(string email, Role role, Guid createdById);
+        Task<UserInvite> CreateIfNotExists(string email, Role role, Guid createdById);
 
-        Task<UserInvite> Create(string email, string roleId, Guid createdById);
+        Task<UserInvite> CreateIfNotExists(string email, string roleId, Guid createdById);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseUserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseUserService.cs
@@ -341,13 +341,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         return emailResult;
                     }
                 }
-
-                await _userReleaseInviteRepository.Create(
-                    releaseId: release.Id,
-                    email: email,
-                    releaseRole: PrereleaseViewer,
-                    emailSent: sendEmail,
-                    createdById: _userService.GetUserId());
+                else
+                {
+                    // Create an invite. The e-mail is sent if an invite exists when the release is approved
+                    await _userReleaseInviteRepository.Create(
+                        releaseId: release.Id,
+                        email: email,
+                        releaseRole: PrereleaseViewer,
+                        emailSent: false,
+                        createdById: _userService.GetUserId());
+                }
 
                 await _userReleaseRoleRepository.CreateIfNotExists(
                     userId: user.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseUserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseUserService.cs
@@ -290,7 +290,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             if (user == null)
             {
                 return await CreateUserReleaseInvite(release, email)
-                    .OnSuccessDo(() => _userInviteRepository.Create(
+                    .OnSuccessDo(() => _userInviteRepository.CreateIfNotExists(
                         email: email,
                         role: Role.PrereleaseUser,
                         createdById: _userService.GetUserId()))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseInviteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseInviteService.cs
@@ -120,10 +120,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 return emailResult;
             }
 
-            await _userInviteRepository.Create(
+            await _userInviteRepository.CreateIfNotExists(
                 email: email,
                 role: Role.Analyst,
                 createdById: _userService.GetUserId());
+
             await _userReleaseInviteRepository.CreateManyIfNotExists(
                 releaseIds: releaseIds,
                 email: email,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserInviteRepository.cs
@@ -19,12 +19,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _usersAndRolesDbContext = usersAndRolesDbContext;
         }
 
-        public async Task<UserInvite> Create(string email, Role role, Guid createdById)
+        public async Task<UserInvite> CreateIfNotExists(string email, Role role, Guid createdById)
         {
-            return await Create(email, role.GetEnumValue(), createdById);
+            return await CreateIfNotExists(email, role.GetEnumValue(), createdById);
         }
 
-        public async Task<UserInvite> Create(string email, string roleId, Guid createdById)
+        public async Task<UserInvite> CreateIfNotExists(string email, string roleId, Guid createdById)
         {
             var existingInvite = await _usersAndRolesDbContext
                 .UserInvites
@@ -43,7 +43,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 Created = DateTime.UtcNow,
                 CreatedById = createdById.ToString(),
             };
-            _usersAndRolesDbContext.Add(newInvite);
+            await _usersAndRolesDbContext.AddAsync(newInvite);
             await _usersAndRolesDbContext.SaveChangesAsync();
             return newInvite;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -288,7 +288,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         return ValidationActionResult(InvalidUserRole);
                     }
 
-                    var userInvite = await _userInviteRepository.Create(
+                    var userInvite = await _userInviteRepository.CreateIfNotExists(
                         email: sanitisedEmail,
                         roleId: roleId,
                         createdById: _userService.GetUserId());


### PR DESCRIPTION
This PR makes a couple of minor changes to invites:

1. When inviting an existing user to Pre-release, only create a `UserReleaseInvite` if the release is not approved, i.e. when the e-mail is not being sent immediately.

 An invite has to exist in order for the e-mail to be sent at a later date which is why we create it, but it's not necessary to create one if the release is already approved and the e-mail is being sent at the same time.

2. When a new user is logging in for the first time, don't delete their `UserReleaseInvite`'s and `UserPublicationInvite`'s.

The reason for removing the deletion of `UserReleaseInvites`'s is that there can be invites where e-mails haven't been sent yet, i.e. in the case of Pre-release invites where e-mails are not sent until a release is approved.

If _all_ invites  are deleted when the user first logs in it will include deleting invites which aren't yet 'active' yet like the Pre-release invites where e-mails haven't been sent yet. This results in e-mails potentially not being sent.

Here's an example of how sending an e-mail could be missed at present:

* Invite a new user by e-mail address to the service. This could be as a contributor to a release or pre-release user on a release, or some other means but do it in a way that they are sent an e-mail.
* Invite the same new user to the Pre-release of a **draft** release, so they are not sent an e-mail just yet.
* User follows the link in the e-mail from the initial invite and logs in to the service for the first time.
* UserReleaseInvite for the Pre-release role on the draft release is deleted when the login is processed.
* Approve the draft release. Pre-release e-mails would normally be sent out at this point, where invites exist.
* No e-mail gets sent to the user because the invite has been deleted.

This scenario seems most likely to occur where a new user is invited to the Pre-release of multiple draft releases being prepared for publishing at a similar time.

There's another benefit to keeping the invites as well which is an audit trail of when the user was invited and who by, which is why I've also made the same change to stop deleting `UserPublicationInvite`'s.

### Other changes
- Rename UserInviteRepository `Create` methods to `CreateIfNotExists` to reflect behaviour of that method.
- Add tests to `ExternalLoginTests` to make sure that `UserPublicationRole`'s are being created for invites.

### UI test report

![image](https://user-images.githubusercontent.com/4147126/176948951-ae9178fc-86ae-4a06-85a8-939861d80076.png)
