### PR TITLE
EES-3512 Limit number of 'CreateIfNotExists' calls to Azure Storage

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobStorageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobStorageServiceTests.cs
@@ -11,6 +11,7 @@ using Azure.Storage.Blobs.Models;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils.Interfaces;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
@@ -565,12 +566,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
                 .SetupGet(client => client.Name)
                 .Returns(containerName);
 
-            blobContainerClient
-                .Setup(s =>
-                    s.CreateIfNotExistsAsync(PublicAccessType.None, default, default,default))
-                .ReturnsAsync(Response.FromValue(
-                    BlobContainerInfo(ETag.All, DateTimeOffset.UtcNow), null!));
-
             foreach (var blobClient in blobClients)
             {
                 blobContainerClient.Setup(client => client.GetBlobClient(blobClient.Object.Name))
@@ -616,7 +611,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
                 connectionString: "",
                 blobServiceClient ?? new Mock<BlobServiceClient>().Object,
                 new Mock<ILogger<BlobStorageService>>().Object,
-                resetCreatedContainers: true
+                new Mock<IStorageInstanceCreationUtil>().Object
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobStorageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobStorageServiceTests.cs
@@ -615,7 +615,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             return new BlobStorageService(
                 connectionString: "",
                 blobServiceClient ?? new Mock<BlobServiceClient>().Object,
-                new Mock<ILogger<BlobStorageService>>().Object
+                new Mock<ILogger<BlobStorageService>>().Object,
+                resetCreatedContainers: true
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -40,6 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         private readonly string _connectionString;
         private readonly BlobServiceClient _client;
         private readonly ILogger<IBlobStorageService> _logger;
+        private static readonly HashSet<string> createdContainers = new();
 
         public BlobStorageService(string connectionString, BlobServiceClient client, ILogger<IBlobStorageService> logger)
         {
@@ -362,7 +363,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
             try
             {
-                await blob.CreateIfNotExistsAsync();
+                if (!createdContainers.Contains($"{containerName.Name}{_connectionString}"))
+                {
+                    await blob.CreateIfNotExistsAsync();
+                    createdContainers.Add($"{containerName.Name}{_connectionString}");
+                }
+
                 return true;
             }
             catch (StorageException e)
@@ -640,7 +646,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var container = blobClient.GetContainerReference(
                 IsDevelopmentStorageAccount(blobClient) ? containerName.EmulatedName : containerName.Name);
 
-            await container.CreateIfNotExistsAsync();
+            if (!createdContainers.Contains($"{containerName.Name}{_connectionString}"))
+            {
+                await container.CreateIfNotExistsAsync();
+                createdContainers.Add($"{containerName.Name}{_connectionString}");
+            }
 
             return container;
         }
@@ -650,7 +660,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var container = _client.GetBlobContainerClient(
                 IsDevelopmentStorageAccount(_client) ? containerName.EmulatedName : containerName.Name);
 
-            await container.CreateIfNotExistsAsync();
+            if (!createdContainers.Contains($"{containerName.Name}{_connectionString}"))
+            {
+                await container.CreateIfNotExistsAsync();
+                createdContainers.Add($"{containerName.Name}{_connectionString}");
+            }
+
 
             return container;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -42,8 +42,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         private readonly ILogger<IBlobStorageService> _logger;
         private static readonly HashSet<string> createdContainers = new();
 
-        public BlobStorageService(string connectionString, BlobServiceClient client, ILogger<IBlobStorageService> logger)
+        public BlobStorageService(string connectionString, BlobServiceClient client, ILogger<IBlobStorageService> logger, bool resetCreatedContainers = false)
         {
+            if (resetCreatedContainers)
+            {
+                createdContainers.Clear();
+            }
             _connectionString = connectionString;
             _client = client;
             _logger = logger;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ITableStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ITableStorageService.cs
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
         Task<IEnumerable<TElement>> ExecuteQueryAsync<TElement>(string tableName, TableQuery<TElement> query)
             where TElement : ITableEntity, new();
 
-        Task<CloudTable> GetTableAsync(string tableName, bool createIfNotExists = true);
+        Task<CloudTable> GetTableAsync(string tableName);
 
         Task<bool> DeleteEntityAsync(string tableName, ITableEntity entity);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/StorageQueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/StorageQueueService.cs
@@ -12,6 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
     public class StorageQueueService : IStorageQueueService
     {
         private readonly string _storageConnectionString;
+        private static readonly HashSet<string> createdQueues = new();
 
         public StorageQueueService(string storageConnectionString)
         {
@@ -56,7 +57,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var storageAccount = CloudStorageAccount.Parse(_storageConnectionString);
             var client = storageAccount.CreateCloudQueueClient();
             var queue = client.GetQueueReference(queueName);
-            queue.CreateIfNotExists();
+
+            if (!createdQueues.Contains($"{queueName}{_storageConnectionString}"))
+            {
+                queue.CreateIfNotExists();
+                createdQueues.Add($"{queueName}{_storageConnectionString}");
+            }
+
             return queue;
         }
 
@@ -65,7 +72,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var storageAccount = CloudStorageAccount.Parse(_storageConnectionString);
             var client = storageAccount.CreateCloudQueueClient();
             var queue = client.GetQueueReference(queueName);
-            await queue.CreateIfNotExistsAsync();
+
+            if (!createdQueues.Contains($"{queueName}{_storageConnectionString}"))
+            {
+                queue.CreateIfNotExists();
+                createdQueues.Add($"{queueName}{_storageConnectionString}");
+            }
+
             return queue;
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/StorageQueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/StorageQueueService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Queue;
 using Newtonsoft.Json;
@@ -12,7 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
     public class StorageQueueService : IStorageQueueService
     {
         private readonly string _storageConnectionString;
-        private static readonly HashSet<string> createdQueues = new();
+        private readonly StorageInstanceCreationUtil _storageInstanceCreationUtil = new ();
 
         public StorageQueueService(string storageConnectionString)
         {
@@ -58,11 +59,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var client = storageAccount.CreateCloudQueueClient();
             var queue = client.GetQueueReference(queueName);
 
-            if (!createdQueues.Contains($"{queueName}{_storageConnectionString}"))
-            {
-                queue.CreateIfNotExists();
-                createdQueues.Add($"{queueName}{_storageConnectionString}");
-            }
+            _storageInstanceCreationUtil.CreateInstanceIfNotExists(
+                _storageConnectionString,
+                AzureStorageType.Queue,
+                queueName,
+                () => queue.CreateIfNotExists());
 
             return queue;
         }
@@ -73,11 +74,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var client = storageAccount.CreateCloudQueueClient();
             var queue = client.GetQueueReference(queueName);
 
-            if (!createdQueues.Contains($"{queueName}{_storageConnectionString}"))
-            {
-                queue.CreateIfNotExists();
-                createdQueues.Add($"{queueName}{_storageConnectionString}");
-            }
+            await _storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
+                _storageConnectionString,
+                AzureStorageType.Queue,
+                queueName,
+                () => queue.CreateIfNotExistsAsync());
 
             return queue;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/TableStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/TableStorageService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Microsoft.Azure.Cosmos.Table;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Services
@@ -9,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
     public class TableStorageService : ITableStorageService
     {
         private readonly CloudTableClient _client;
-        private static readonly HashSet<string> createdTables = new();
+        private readonly StorageInstanceCreationUtil _storageInstanceCreationUtil = new StorageInstanceCreationUtil();
 
         public TableStorageService(string connectionString)
         {
@@ -27,11 +28,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         {
             var table = _client.GetTableReference(tableName);
 
-            if (!createdTables.Contains($"{tableName}{_client.StorageUri}"))
-            {
-                await table.CreateIfNotExistsAsync();
-                createdTables.Add($"{tableName}{_client.StorageUri}");
-            }
+            _storageInstanceCreationUtil.CreateInstanceIfNotExists(
+                _client.StorageUri.ToString(),
+                AzureStorageType.Table,
+                tableName,
+                () => table.CreateIfNotExists());
 
             return table;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/TableStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/TableStorageService.cs
@@ -9,6 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
     public class TableStorageService : ITableStorageService
     {
         private readonly CloudTableClient _client;
+        private static readonly HashSet<string> createdTables = new();
 
         public TableStorageService(string connectionString)
         {
@@ -22,13 +23,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         /// <param name="tableName">The name of the table to get.</param>
         /// <param name="createIfNotExists">Creates the table if it does not already exist, defaults to true.</param>
         /// <returns>The table</returns>
-        public async Task<CloudTable> GetTableAsync(string tableName, bool createIfNotExists = true)
+        public async Task<CloudTable> GetTableAsync(string tableName)
         {
             var table = _client.GetTableReference(tableName);
 
-            if (createIfNotExists)
+            if (!createdTables.Contains($"{tableName}{_client.StorageUri}"))
             {
                 await table.CreateIfNotExistsAsync();
+                createdTables.Add($"{tableName}{_client.StorageUri}");
             }
 
             return table;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Interfaces/IStorageInstanceCreationUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Interfaces/IStorageInstanceCreationUtil.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Interfaces;
+
+public interface IStorageInstanceCreationUtil
+{
+
+    Task CreateInstanceIfNotExistsAsync(
+        string connectionString,
+        AzureStorageType storageType,
+        string instance,
+        Func<Task> createIfNotExists);
+
+    void CreateInstanceIfNotExists(
+        string connectionString,
+        AzureStorageType storageType,
+        string instance,
+        Action createIfNotExists);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/StorageInstanceCreationUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/StorageInstanceCreationUtil.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils.Interfaces;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public class StorageInstanceCreationUtil : IStorageInstanceCreationUtil
+{
+    private static readonly ConcurrentDictionary<string, Unit> CreatedInstances = new();
+
+    public async Task CreateInstanceIfNotExistsAsync(
+        string connectionString,
+        AzureStorageType storageType,
+        string instance,
+        Func<Task> createIfNotExists)
+    {
+        var identifyingString = $"{instance}{storageType.ToString()}{connectionString}";
+        if (!CreatedInstances.ContainsKey(identifyingString))
+        {
+            await createIfNotExists.Invoke();
+            CreatedInstances[identifyingString] = Unit.Instance;
+        }
+    }
+
+    public void CreateInstanceIfNotExists(
+        string connectionString,
+        AzureStorageType storageType,
+        string instance,
+        Action createIfNotExists)
+    {
+        var identifyingString = $"{instance}{storageType.ToString()}{connectionString}";
+        if (!CreatedInstances.ContainsKey(identifyingString))
+        {
+            createIfNotExists.Invoke();
+            CreatedInstances[identifyingString] = Unit.Instance;
+        }
+    }
+}
+
+public enum AzureStorageType
+{
+    Blob,
+    Queue,
+    Table,
+}


### PR DESCRIPTION
This PR ensures that `CreateIfNotExists` calls to Azure Storage only happen once per container/queue/table each time a service is started. See EES-3512 for why I chose this method over creating all containers/queues/tables when services start.