### PR TITLE
EES-3534 Fix release page links 'Explore data and files' and 'View related dashboard(s)'

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -206,7 +206,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
               <ul className="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
                 <li>
                   <a
-                    href="#dataDownloads-1"
+                    href="#explore-data-and-files"
                     onClick={() => {
                       logEvent({
                         category: `${release.publication.title} release page`,

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -231,9 +231,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                 </li>
                 {!!release.relatedDashboardsSection?.content.length && (
                   <li>
-                    <a href="#related-dashboards-section">
-                      View related dashboard(s)
-                    </a>
+                    <a href="#related-dashboards">View related dashboard(s)</a>
                   </li>
                 )}
                 {showAllFilesButton && (

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
@@ -35,6 +35,96 @@ describe('PublicationReleasePage', () => {
     ).not.toBeInTheDocument();
   });
 
+  test('renders data downloads links', async () => {
+    render(
+      <PublicationReleasePage
+        release={{
+          ...testRelease,
+          relatedDashboardsSection: undefined,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole('navigation', { name: 'Data downloads' }),
+    ).toBeInTheDocument();
+
+    const dataDownloadsNav = screen.getByRole('navigation', {
+      name: 'Data downloads',
+    });
+
+    const dataDownloadsLinks = within(dataDownloadsNav).getAllByRole('link');
+
+    expect(dataDownloadsLinks).toHaveLength(2);
+
+    expect(dataDownloadsLinks[0]).toHaveTextContent('Explore data and files');
+    expect(dataDownloadsLinks[0]).toHaveAttribute(
+      'href',
+      '#explore-data-and-files',
+    );
+
+    expect(dataDownloadsLinks[1]).toHaveTextContent('View data guidance');
+    expect(dataDownloadsLinks[1]).toHaveAttribute(
+      'href',
+      '/find-statistics/pupil-absence-in-schools-in-england/data-guidance',
+    );
+  });
+
+  test(`renders data download link to view related dashboard(s) when section exists`, async () => {
+    render(
+      <PublicationReleasePage
+        release={{
+          ...testRelease,
+          relatedDashboardsSection: {
+            id: 'related-dashboards-id',
+            order: 0,
+            heading: '',
+            content: [
+              {
+                id: 'related-dashboards-content-block-id',
+                order: 0,
+                body: '',
+                type: 'HtmlBlock',
+              },
+            ],
+          },
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole('navigation', { name: 'Data downloads' }),
+    ).toBeInTheDocument();
+
+    const dataDownloadsNav = screen.getByRole('navigation', {
+      name: 'Data downloads',
+    });
+
+    const dataDownloadsLinks = within(dataDownloadsNav).getAllByRole('link');
+
+    expect(dataDownloadsLinks).toHaveLength(3);
+
+    expect(dataDownloadsLinks[0]).toHaveTextContent('Explore data and files');
+    expect(dataDownloadsLinks[0]).toHaveAttribute(
+      'href',
+      '#explore-data-and-files',
+    );
+
+    expect(dataDownloadsLinks[1]).toHaveTextContent('View data guidance');
+    expect(dataDownloadsLinks[1]).toHaveAttribute(
+      'href',
+      '/find-statistics/pupil-absence-in-schools-in-england/data-guidance',
+    );
+
+    expect(dataDownloadsLinks[2]).toHaveTextContent(
+      'View related dashboard(s)',
+    );
+    expect(dataDownloadsLinks[2]).toHaveAttribute(
+      'href',
+      '#related-dashboards',
+    );
+  });
+
   test('renders national statistics section', () => {
     render(<PublicationReleasePage release={testRelease} />);
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
@@ -84,11 +84,20 @@ Navigate to published release page
     user waits until page contains title caption    ${RELEASE_NAME}    %{WAIT_MEDIUM}
     user checks page contains    This is the latest data
 
-Check latest release contains related dashboards
-    user checks element contains link    testid:data-downloads    View data guidance
+Check latest release contains related dashboards section
     user checks there are x accordion sections    2    id:data-accordion
-    user opens accordion section    View related dashboard(s)    id:data-accordion
+    user checks accordion is in position    Explore data and files    1    id:data-accordion
+    user checks accordion is in position    View related dashboard(s)    2    id:data-accordion
     user checks element contains    id:related-dashboards-content    Related dashboards test text
+
+Check data downloads navigation contains link to related dashboards
+    user checks element contains link    testid:data-downloads    View related dashboard(s)
+
+Check related dashboard link opens accordion section
+    user verifies accordion is closed    View related dashboard(s)
+    user clicks link    View related dashboard(s)    testid:data-downloads
+    user verifies accordion is open    View related dashboard(s)
+    user closes accordion section    View related dashboard(s)    id:data-accordion
 
 Check latest release contains glossary info icon
     user opens accordion section    Test section    css:#content

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -63,8 +63,12 @@ Validate "About these statistics" -- "Last updated"
     user checks release update    2    22 March 2018    First published.
     user closes details dropdown    See all updates (2)
 
-Validate "Useful information"
-    user checks page contains element    link:Download all data
+Check data downloads navigation contains links
+    user checks element contains link    testid:data-downloads    Explore data and files
+    user checks element contains link    testid:data-downloads    View data guidance
+    user checks element contains link    testid:data-downloads    Download all data
+
+Check supporting information contains methodology link
     user checks page contains link with text and url    Pupil absence statistics: methodology
     ...    /methodology/pupil-absence-in-schools-in-england
 
@@ -196,6 +200,10 @@ Validate Key Statistics data block -- Data tables tab
     user checks row cell contains text    ${row}    5    4.7
 
 Validate accordion sections order
+    user checks accordion is in position    Explore data and files    1    id:data-accordion
+
+    user checks there are x accordion sections    1    id:data-accordion
+
     user checks accordion is in position    About these statistics    1    id:content
     user checks accordion is in position    Pupil absence rates    2    id:content
     user checks accordion is in position    Persistent absence    3    id:content
@@ -206,12 +214,19 @@ Validate accordion sections order
     user checks accordion is in position    Pupil referral unit absence    8    id:content
     user checks accordion is in position    Regional and local authority (LA) breakdown    9    id:content
 
-    user scrolls to element    id:help-and-support
+    user checks there are x accordion sections    9    id:content
+
     user checks accordion is in position    Methodology    1    id:help-and-support
     user checks accordion is in position    Official statistics    2    id:help-and-support
     user checks accordion is in position    Contact us    3    id:help-and-support
 
     user checks there are x accordion sections    3    id:help-and-support
+
+Check explore data and files link opens accordion section
+    user verifies accordion is closed    Explore data and files
+    user clicks link    Explore data and files    testid:data-downloads
+    user verifies accordion is open    Explore data and files
+    user closes accordion section    Explore data and files    id:data-accordion
 
 Validate Regional and local authority (LA) breakdown table
     [Documentation]    BAU-540


### PR DESCRIPTION
This PR fixes the Release content page links in the Data downloads section 'Explore data and files' and 'View related dashboard(s)' which were targeting the wrong accordion section id's.

### Other changes

- Add FE tests to check the Data Downloads links are rendered with the correct text and href attribute with and without a Related Dashboard section.
- Update Robot tests to check Data Downloads links and make sure they open the accordion sections when clicked.