### PR TITLE
EES-3534 Correct target of Explore data and files in the Admin release content page.

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -185,7 +185,7 @@ const ReleaseContent = () => {
             >
               <ul className="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
                 <li>
-                  <a href="#dataDownloads-1">Explore data and files</a>
+                  <a href="#explore-data-and-files">Explore data and files</a>
                 </li>
                 <li>
                   <Link


### PR DESCRIPTION
This PR makes a similar change to the Admin Release content page as  the change made to the public page in https://github.com/dfe-analytical-services/explore-education-statistics/pull/3373 to fix the 'Explore data and files' link which was broken.