### PR TITLE
Ees 3482 try fixing refresh tokens on dev

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Properties/launchSettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Properties/launchSettings.json
@@ -22,6 +22,15 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "GovUk.Education.ExploreStatistics.AdminKeycloak": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://0.0.0.0:5021;http://0.0.0.0:5020",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "IdpProviderConfiguration": "Keycloak"
+      }
     }
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -234,7 +234,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
 
                     var clientConfig = Configuration.GetSection("OpenIdConnectSpaClient");
 
-                    var allowRefreshTokens = clientConfig.GetValue<bool>("AllowOfflineAccess");
+                    if (clientConfig == null)
+                    {
+                        return;
+                    }
+                    
+                    var allowRefreshTokens = clientConfig.GetValue<bool>("AllowOfflineAccess", false);
 
                     if (allowRefreshTokens)
                     {
@@ -289,6 +294,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                         // https://localhost:5021, then the SPA will use https://localhost:5021 as a basis for
                         // negotiating with Identity Server, and thus Identity Server will issue its access tokens with
                         // the "Issuer" set to "https://localhost:5021".
+                        //
+                        // However, by default Identity Server will set its "TokenValidationParameters.ValidIssuer"
+                        // property to the "applicationUrl" value in "launchSettings.json" - locally for instance,
+                        // this would be "https://0.0.0.0:5021".  This complicates matters further as access tokens 
+                        // that it issues would otherwise be immediately invalidated by this setting, regardless of what 
+                        // URL the user was hitting the site on.  The answer is to manually let Identity Server know
+                        // which URLs are appropriate for each environment.
                         //
                         // As locally it's possible to access the service under an alternative URL like
                         // "https://ees.local:5021", then we need to ensure that both "https://localhost:5021" and

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -251,7 +251,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                             .Append(OpenIdConnectScope.OfflineAccess)
                             .ToList();
                         
-                        // spaClient.UpdateAccessTokenClaimsOnRefresh = true;
+                        spaClient.UpdateAccessTokenClaimsOnRefresh = true;
                         
                         var tokenUsage = clientConfig.GetValue<string>("RefreshTokenUsage");
                         

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
@@ -18,6 +18,11 @@
       "StoreLocation": "CurrentUser"
     }
   },
+  "OpenIdConnectSpaClient": {
+    "AllowOfflineAccess": false,
+    "RefreshTokenUsage": "OneTimeOnly",
+    "RefreshTokenExpiration": "Absolute"
+  },
   "OpenIdConnect": {
     "ClientId": "97d25f91-bd4b-4b82-843b-2583b8194800",
     "ClientSecret": "C@R3I_k42?3=15W5-KzV=Nbpg.eBq/:4",


### PR DESCRIPTION
This PR:
- adds some fallback support for cases where no OpenIdConnect additional configuration is available for a given environment
- switches to explicitly listing the ValidIssuers of access tokens for a given environment.  By default this will always be the environment-specific URL of the Admin service.  Locally, we can add more aliases like `ees.local` to the list. 