### PR TITLE
EES-3545, EES-3544 - Fix BS4 warning & fix UI tests

### DIFF
--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -52,6 +52,9 @@ Assert that test users are present in table
     user checks row cell contains text    ${ROW}    2    BAU User
     user checks row cell contains text    ${ROW}    3    Manage
 
+Assert prerelease users are present in table
+    [Tags]    NotAgainstDev
+    # Failing against dev because this user doesn't exist on dev. see https://dfedigital.atlassian.net/browse/EES-3546
     ${ROW}=    user gets table row with heading    Prerelease3 User3
     user checks row cell contains text    ${ROW}    1    ees-prerelease3@education.gov.uk
     user checks row cell contains text    ${ROW}    2    No role

--- a/tests/robot-tests/tests/libs/slack.py
+++ b/tests/robot-tests/tests/libs/slack.py
@@ -13,7 +13,7 @@ def _generate_slack_attachments(env: str, suite: str):
     with open(f'{PATH}{os.sep}output.xml', 'rb') as report:
         contents = report.read()
 
-    soup = BeautifulSoup(contents, 'lxml')
+    soup = BeautifulSoup(contents, features='xml')
     test = soup.find('total').find('stat')
 
     failed_tests = int(test['fail'])


### PR DESCRIPTION
This PR: 

- Fixes UI tests (disables an assertion from running to prevent false positives - see https://dfedigital.atlassian.net/browse/EES-3546 for context) 
- Fixes BS4 warning when sending test reports & test results via slack - see https://dfedigital.atlassian.net/browse/EES-3544