### PR TITLE
EES-3553 Remove zero length check getting cache items from blob storage which gets blob properties

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -449,12 +449,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
                 throw new FileNotFoundException($"Could not find file at {containerName}/{path}");
             }
 
-            var properties = await blob.GetPropertiesAsync();
-            if (properties.Value.ContentLength == 0)
-            {
-                return string.Empty;
-            }
-
             await using var stream = await blob.OpenReadAsync();
 
             var streamReader = new StreamReader(stream);


### PR DESCRIPTION
This PR makes a quick change to remove a zero length check on a blob in `BlobStorageService#DownloadBlobText` before streaming it. This is used by `BlobCacheService#GetItem` every time a cached call looks up the cache key in the storage container to return the deserialised JSON if the blob exists.

This code was a shortcut to avoid opening a content stream if the content is empty.

This change is being made as it seems unlikely that an empty blob will exist and this check was adding additional overhead to every call since checking the content length required retrieving the blob properties.

Retrieving blob properties is an additional HTTP call to the storage container meaning a lot of unnecessary outgoing HTTP traffic get blob properties were occurring for cached method calls.

After this change, the result for a blob with empty content is still the same, i.e. the return value of the method is an empty string.