### PR TITLE
EES-3547 Migrate blob Size and ContentType from blobs to database to avoid calls to GetBlob

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileMigrationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileMigrationServicePermissionTests.cs
@@ -1,0 +1,51 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+public class FileMigrationServicePermissionTests
+{
+    [Fact]
+    public async Task MigrateAll()
+    {
+        await PolicyCheckBuilder()
+            .SetupCheck(CanRunReleaseMigrations, false)
+            .AssertForbidden(
+                async userService =>
+                {
+                    await using var contentDbContext = ContentDbUtils.InMemoryContentDbContext();
+
+                    var service = SetupService(
+                        contentDbContext: contentDbContext,
+                        userService: userService.Object
+                    );
+
+                    return await service.MigrateAll();
+                }
+            );
+    }
+
+    private static FileMigrationService SetupService(
+        ContentDbContext contentDbContext,
+        IStorageQueueService? storageQueueService = null,
+        IUserService? userService = null)
+    {
+        return new FileMigrationService(
+            contentDbContext,
+            storageQueueService ?? Mock.Of<IStorageQueueService>(Strict),
+            userService ?? Mock.Of<IUserService>(Strict),
+            Mock.Of<ILogger<FileMigrationService>>()
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileMigrationServiceTests.cs
@@ -1,0 +1,188 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+public class FileMigrationServiceTests
+{
+    [Fact]
+    public async Task MigrateAll_FailsWithNullMessageCount()
+    {
+        var storageQueueService = MockStorageQueueService(messageCount: null);
+
+        var service = SetupService(
+            contentDbContext: InMemoryContentDbContext(),
+            storageQueueService: storageQueueService.Object);
+
+        var result = await service.MigrateAll();
+
+        VerifyAllMocks(storageQueueService);
+
+        var left = result.AssertLeft();
+        Assert.IsAssignableFrom<BadRequestObjectResult>(left);
+    }
+
+    [Fact]
+    public async Task MigrateAll_FailsWithNonZeroMessageCount()
+    {
+        var storageQueueService = MockStorageQueueService(messageCount: 1);
+
+        var service = SetupService(
+            contentDbContext: InMemoryContentDbContext(),
+            storageQueueService: storageQueueService.Object);
+
+        var result = await service.MigrateAll();
+
+        VerifyAllMocks(storageQueueService);
+
+        var left = result.AssertLeft();
+        Assert.IsAssignableFrom<BadRequestObjectResult>(left);
+    }
+
+    [Fact]
+    public async Task MigrateAll_IgnoresFilesWithContentTypeOrSize()
+    {
+        // Set up files that have content type, size, or both content type and size
+        var files = new List<File>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                ContentType = "application/pdf",
+                Size = null
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                ContentType = null,
+                Size = 1024
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                ContentType = "application/pdf",
+                Size = 1024
+            }
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Files.AddRangeAsync(files);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var storageQueueService = MockStorageQueueService(messageCount: 0);
+
+        storageQueueService.Setup(mock =>
+                mock.GetApproximateMessageCount(MigrateFilesQueue))
+            .ReturnsAsync(0);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var service = SetupService(
+                contentDbContext: contentDbContext,
+                storageQueueService: storageQueueService.Object);
+
+            var result = await service.MigrateAll();
+
+            // There should be no other interactions with the storage queue service
+
+            VerifyAllMocks(storageQueueService);
+
+            result.AssertRight();
+        }
+    }
+
+    [Fact]
+    public async Task MigrateAll()
+    {
+        var files = new List<File>
+        {
+            new()
+            {
+                Id = Guid.NewGuid()
+            },
+            // Ignored as already migrated
+            new()
+            {
+                Id = Guid.NewGuid(),
+                ContentType = "application/pdf",
+                Size = 1024
+            },
+            new()
+            {
+                Id = Guid.NewGuid()
+            }
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Files.AddRangeAsync(files);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var storageQueueService = MockStorageQueueService(messageCount: 0);
+
+        storageQueueService.Setup(mock =>
+                mock.AddMessages(MigrateFilesQueue, new List<MigrateFileMessage>
+                {
+                    new(files[0].Id),
+                    new(files[2].Id)
+                }))
+            .Returns(Task.CompletedTask);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var service = SetupService(
+                contentDbContext: contentDbContext,
+                storageQueueService: storageQueueService.Object);
+
+            var result = await service.MigrateAll();
+
+            VerifyAllMocks(storageQueueService);
+
+            result.AssertRight();
+        }
+    }
+
+    private static Mock<IStorageQueueService> MockStorageQueueService(int? messageCount)
+    {
+        var service = new Mock<IStorageQueueService>(MockBehavior.Strict);
+        service.Setup(s => s.GetApproximateMessageCount(MigrateFilesQueue))
+            .ReturnsAsync(messageCount);
+        return service;
+    }
+
+    private static FileMigrationService SetupService(
+        ContentDbContext contentDbContext,
+        IStorageQueueService? storageQueueService = null,
+        IUserService? userService = null)
+    {
+        return new FileMigrationService(
+            contentDbContext,
+            storageQueueService ?? Mock.Of<IStorageQueueService>(MockBehavior.Strict),
+            userService ?? AlwaysTrueUserService().Object,
+            Mock.Of<ILogger<FileMigrationService>>()
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/FileMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/FileMigrationController.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+/**
+ * Controller used to migrate files in EES-3547
+ * TODO Remove in EES-3552
+ */
+[Route("api")]
+[ApiController]
+[Authorize(Roles = GlobalRoles.RoleNames.BauUser)]
+public class FileMigrationController : ControllerBase
+{
+    private readonly IFileMigrationService _fileMigrationService;
+
+    public FileMigrationController(IFileMigrationService fileMigrationService)
+    {
+        _fileMigrationService = fileMigrationService;
+    }
+
+    [HttpPatch("bau/migrate-files")]
+    public async Task<ActionResult<Unit>> MigrateFiles()
+    {
+        return await _fileMigrationService
+            .MigrateAll()
+            .HandleFailuresOrOk();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220713144101_EES3529_AddFileContentTypeAndSize.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220713144101_EES3529_AddFileContentTypeAndSize.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220713144101_EES3529_AddFileContentTypeAndSize")]
+    partial class EES3529_AddFileContentTypeAndSize
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220713144101_EES3529_AddFileContentTypeAndSize.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220713144101_EES3529_AddFileContentTypeAndSize.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES3529_AddFileContentTypeAndSize : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Filename",
+                table: "Files",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ContentType",
+                table: "Files",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "Size",
+                table: "Files",
+                type: "bigint",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ContentType",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "Size",
+                table: "Files");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Filename",
+                table: "Files",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileMigrationService.cs
@@ -1,0 +1,80 @@
+﻿#nullable enable
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+/**
+ *  Service used to migrate files in EES-3547
+ *  TODO Remove in EES-3552
+ */
+public class FileMigrationService : IFileMigrationService
+{
+    private readonly ContentDbContext _contentDbContext;
+    private readonly IStorageQueueService _storageQueueService;
+    private readonly IUserService _userService;
+    private readonly ILogger<FileMigrationService> _logger;
+
+    public FileMigrationService(ContentDbContext contentDbContext,
+        IStorageQueueService storageQueueService,
+        IUserService userService,
+        ILogger<FileMigrationService> logger)
+    {
+        _contentDbContext = contentDbContext;
+        _storageQueueService = storageQueueService;
+        _userService = userService;
+        _logger = logger;
+    }
+
+    public async Task<Either<ActionResult, Unit>> MigrateAll()
+    {
+        return await _userService.CheckCanRunMigrations()
+            .OnSuccessVoid<ActionResult, Unit, Unit>(async () =>
+            {
+                var messageCount = await _storageQueueService.GetApproximateMessageCount(MigrateFilesQueue);
+
+                switch (messageCount)
+                {
+                    case null:
+                        return new BadRequestObjectResult(
+                            $"Unexpected null message count for queue {MigrateFilesQueue}");
+                    case > 0:
+                        return new BadRequestObjectResult(
+                            $"Found non-empty queue {MigrateFilesQueue}. Message count: {messageCount}");
+                }
+
+                // Queue one message per file for all files that don't have the new content type and size values
+                var files = await _contentDbContext.Files
+                    .AsNoTracking()
+                    .Where(file => file.ContentType == null && file.Size == null)
+                    .Select(file => new MigrateFileMessage(file.Id))
+                    .ToListAsync();
+
+                if (files.Any())
+                {
+                    _logger.LogInformation("Adding {count} messages to the '{queue}' queue",
+                        files.Count,
+                        MigrateFilesQueue);
+
+                    await _storageQueueService.AddMessages(MigrateFilesQueue, files);
+                }
+                else
+                {
+                    _logger.LogInformation("Found no files that require migrating");
+                }
+
+                return Unit.Instance;
+            });
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileMigrationService.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+
+/**
+ * Interface used to migrate files in EES-3547
+ * TODO Remove in EES-3552
+ */
+public interface IFileMigrationService
+{
+    Task<Either<ActionResult, Unit>> MigrateAll();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -569,6 +569,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IStorageQueueService, StorageQueueService>(s =>
                 new StorageQueueService(Configuration.GetValue<string>("CoreStorage")));
             services.AddTransient<IDataBlockMigrationService, DataBlockMigrationService>();
+            services.AddTransient<IFileMigrationService, FileMigrationService>(provider =>
+                new FileMigrationService(
+                    contentDbContext: provider.GetRequiredService<ContentDbContext>(),
+                    storageQueueService: new StorageQueueService(Configuration.GetValue<string>("PublisherStorage")),
+                    userService: provider.GetRequiredService<IUserService>(),
+                    logger: provider.GetRequiredService<ILogger<FileMigrationService>>()));
             services.AddSingleton<IGuidGenerator, SequentialGuidGenerator>();
             AddPersistenceHelper<ContentDbContext>(services);
             AddPersistenceHelper<StatisticsDbContext>(services);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -8,6 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
     {
         public Guid Id { get; set; }
 
+        // TODO EES-3552 Remove nullable and migrate db column to be not-null
         public string? ContentType { get; set; }
 
         public Guid RootPath { get; set; }
@@ -30,6 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public File? Source { get; set; }
 
+        // TODO EES-3552 Remove nullable and migrate db column to be not-null
         public long? Size { get; set; }
 
         public DateTime? Created { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -1,35 +1,40 @@
+#nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
-    public class File
+    public class File : ICreatedTimestamp<DateTime?>
     {
         public Guid Id { get; set; }
+
+        public string? ContentType { get; set; }
 
         public Guid RootPath { get; set; }
 
         public Guid? SubjectId { get; set; }
 
-        public string Filename { get; set; }
+        public string Filename { get; set; } = string.Empty;
 
         public FileType Type { get; set; }
 
         public Guid? ReplacedById { get; set; }
 
-        public File ReplacedBy { get; set; }
+        public File? ReplacedBy { get; set; }
 
         public Guid? ReplacingId { get; set; }
 
-        public File Replacing { get; set; }
+        public File? Replacing { get; set; }
 
         public Guid? SourceId { get; set; }
 
         public File? Source { get; set; }
 
+        public long? Size { get; set; }
+
         public DateTime? Created { get; set; }
 
-        public User CreatedBy { get; set; }
+        public User? CreatedBy { get; set; }
 
         public Guid? CreatedById { get; set; }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/MigrateFileMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/MigrateFileMessage.cs
@@ -1,0 +1,16 @@
+﻿#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+
+/// <summary>
+/// Temporary message class used to migrate a file in EES-3547
+/// TODO Remove in EES-3552
+/// </summary>
+public record MigrateFileMessage(Guid Id)
+{
+    public override string ToString()
+    {
+        return $"{nameof(Id)}: {Id}";
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
@@ -1,4 +1,5 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
+﻿#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
 {
     public static class PublisherQueues
     {
@@ -11,5 +12,11 @@
         public const string PublishTaxonomyQueue = "publish-taxonomy";
         public const string RetryStageQueue = "retry";
         public const string NotifyChangeQueue = "notify";
+
+        /**
+         * Temporary queue used to migrate files in EES-3547
+         * TODO Remove in EES-3552
+         */
+        public const string MigrateFilesQueue = "migrate-files";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/FileMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/FileMigrationServiceTests.cs
@@ -1,0 +1,285 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services;
+
+public class FileMigrationServiceTests
+{
+    [Fact]
+    public async Task MigrateFile_FileNotFound()
+    {
+        var service = BuildService(contentDbContext: InMemoryContentDbContext());
+
+        var result = await service.MigrateFile(Guid.NewGuid());
+
+        result.AssertNotFound();
+    }
+
+    [Fact]
+    public async Task MigrateFile_BlobNotFound()
+    {
+        var file = new File
+        {
+            Id = Guid.NewGuid(),
+            RootPath = Guid.NewGuid(),
+            ContentType = null,
+            Size = null,
+            Type = FileType.Ancillary
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Files.AddAsync(file);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var blobStorageService = new Mock<IBlobStorageService>(Strict);
+
+        blobStorageService.SetupFindBlob(BlobContainers.PrivateReleaseFiles,
+            file.Path(),
+            blob: null);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var service = BuildService(contentDbContext: contentDbContext,
+                blobStorageService.Object);
+
+            var result = await service.MigrateFile(file.Id);
+
+            MockUtils.VerifyAllMocks(blobStorageService);
+
+            result.AssertNotFound();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var after = await contentDbContext.Files.SingleAsync(f => f.Id == file.Id);
+
+            Assert.Null(after.ContentType);
+            Assert.Null(after.Size);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateFile_ImageFileHasNoLink()
+    {
+        var file = new File
+        {
+            Id = Guid.NewGuid(),
+            RootPath = Guid.NewGuid(),
+            ContentType = null,
+            Size = null,
+            Type = FileType.Image
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Files.AddAsync(file);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var service = BuildService(contentDbContext: contentDbContext);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.MigrateFile(file.Id));
+            Assert.Equal($"No release or methodology link found for image file '{file.Id}'.", exception.Message);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var after = await contentDbContext.Files.SingleAsync(f => f.Id == file.Id);
+
+            Assert.Null(after.ContentType);
+            Assert.Null(after.Size);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateFile()
+    {
+        var file = new File
+        {
+            Id = Guid.NewGuid(),
+            RootPath = Guid.NewGuid(),
+            ContentType = null,
+            Size = null,
+            Type = FileType.Ancillary
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Files.AddAsync(file);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var blobStorageService = new Mock<IBlobStorageService>(Strict);
+
+        blobStorageService.SetupFindBlob(BlobContainers.PrivateReleaseFiles,
+            file.Path(),
+            new BlobInfo(path: "not used",
+                size: "not used",
+                contentType: "application/pdf",
+                contentLength: 1024));
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var service = BuildService(contentDbContext: contentDbContext,
+                blobStorageService.Object);
+
+            var result = await service.MigrateFile(file.Id);
+
+            MockUtils.VerifyAllMocks(blobStorageService);
+
+            result.AssertRight();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var after = await contentDbContext.Files.SingleAsync(f => f.Id == file.Id);
+
+            Assert.Equal("application/pdf", after.ContentType);
+            Assert.Equal(1024, after.Size);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateFile_MigratesReleaseImageFile()
+    {
+        var releaseFile = new ReleaseFile
+        {
+            Release = new Release(),
+            File = new File
+            {
+                Id = Guid.NewGuid(),
+                RootPath = Guid.NewGuid(),
+                ContentType = null,
+                Size = null,
+                Type = FileType.Image
+            }
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var blobStorageService = new Mock<IBlobStorageService>(Strict);
+
+        blobStorageService.SetupFindBlob(BlobContainers.PrivateReleaseFiles,
+            releaseFile.Path(),
+            new BlobInfo(path: "not used",
+                size: "not used",
+                contentType: "image/png",
+                contentLength: 1024));
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var service = BuildService(contentDbContext: contentDbContext,
+                blobStorageService.Object);
+
+            var result = await service.MigrateFile(releaseFile.File.Id);
+
+            MockUtils.VerifyAllMocks(blobStorageService);
+
+            result.AssertRight();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var after = await contentDbContext.Files.SingleAsync(f => f.Id == releaseFile.File.Id);
+
+            Assert.Equal("image/png", after.ContentType);
+            Assert.Equal(1024, after.Size);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateFile_MigratesMethodologyImageFile()
+    {
+        var methodologyFile = new MethodologyFile
+        {
+            MethodologyVersion = new MethodologyVersion(),
+            File = new File
+            {
+                Id = Guid.NewGuid(),
+                RootPath = Guid.NewGuid(),
+                ContentType = null,
+                Size = null,
+                Type = FileType.Image
+            }
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.MethodologyFiles.AddAsync(methodologyFile);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var blobStorageService = new Mock<IBlobStorageService>(Strict);
+
+        blobStorageService.SetupFindBlob(BlobContainers.PrivateMethodologyFiles,
+            methodologyFile.Path(),
+            new BlobInfo(path: "not used",
+                size: "not used",
+                contentType: "image/png",
+                contentLength: 1024));
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var service = BuildService(contentDbContext: contentDbContext,
+                blobStorageService.Object);
+
+            var result = await service.MigrateFile(methodologyFile.File.Id);
+
+            MockUtils.VerifyAllMocks(blobStorageService);
+
+            result.AssertRight();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var after = await contentDbContext.Files.SingleAsync(f => f.Id == methodologyFile.File.Id);
+
+            Assert.Equal("image/png", after.ContentType);
+            Assert.Equal(1024, after.Size);
+        }
+    }
+
+    private static FileMigrationService BuildService(
+        ContentDbContext contentDbContext,
+        IBlobStorageService? blobStorageService = null)
+    {
+        return new FileMigrationService(
+            contentDbContext,
+            new PersistenceHelper<ContentDbContext>(contentDbContext),
+            blobStorageService ?? Mock.Of<IBlobStorageService>(Strict));
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/MigrateFileFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/MigrateFileFunction.cs
@@ -1,0 +1,60 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using Microsoft.Azure.WebJobs;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions;
+
+/**
+ * Function used to migrate files in EES-3547
+ * TODO Remove in EES-3552
+ */
+public class MigrateFileFunction
+{
+    private readonly IFileMigrationService _fileMigrationService;
+
+    public MigrateFileFunction(
+        IFileMigrationService fileMigrationService)
+    {
+        _fileMigrationService = fileMigrationService;
+    }
+
+    /// <summary>
+    /// Azure Function which copies content type and size properties from a blob to a file
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="executionContext"></param>
+    /// <param name="logger"></param>
+    [FunctionName("MigrateFile")]
+    public async Task MigrateFile(
+        [QueueTrigger(MigrateFilesQueue)] MigrateFileMessage message,
+        ExecutionContext executionContext,
+        ILogger logger)
+    {
+        logger.LogInformation("{functionName} triggered: {message}",
+            executionContext.FunctionName,
+            message);
+
+        try
+        {
+            var result = await _fileMigrationService.MigrateFile(message.Id);
+            if (result.IsLeft)
+            {
+                var failure = result.Left;
+                logger.LogError(
+                    "Failed to migrate file {id}. Service returned {type}.",
+                    message.Id,
+                    failure.GetType().ShortDisplayName());
+            }
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to migrate file {id}", message.Id);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileMigrationService.cs
@@ -1,0 +1,103 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+
+/**
+ * Service used to migrate files in EES-3547
+ * TODO Remove in EES-3552
+ */
+public class FileMigrationService : IFileMigrationService
+{
+    private readonly ContentDbContext _contentDbContext;
+    private readonly IPersistenceHelper<ContentDbContext> _contentPersistenceHelper;
+    private readonly IBlobStorageService _privateBlobStorageService;
+
+    public FileMigrationService(
+        ContentDbContext contentDbContext,
+        IPersistenceHelper<ContentDbContext> contentPersistenceHelper,
+        IBlobStorageService privateBlobStorageService)
+    {
+        _contentDbContext = contentDbContext;
+        _contentPersistenceHelper = contentPersistenceHelper;
+        _privateBlobStorageService = privateBlobStorageService;
+    }
+
+    public async Task<Either<ActionResult, Unit>> MigrateFile(Guid id)
+    {
+        return await _contentPersistenceHelper
+            .CheckEntityExists<File>(id)
+            .OnSuccess(async file =>
+            {
+                // Assume we can find all files within private blob containers
+                // and therefore we can use file.Path and ignore file.PublicPath
+                var privatePath = file.Path();
+
+                var privateContainer = await GetPrivateContainer(file);
+
+                var blob = await _privateBlobStorageService.FindBlob(privateContainer, privatePath);
+
+                if (blob == null)
+                {
+                    return new NotFoundResult();
+                }
+
+                _contentDbContext.Files.Update(file);
+                file.ContentType = blob.ContentType;
+                file.Size = blob.ContentLength;
+                await _contentDbContext.SaveChangesAsync();
+
+                return new Either<ActionResult, Unit>(Unit.Instance);
+            });
+    }
+
+    private async Task<IBlobContainer> GetPrivateContainer(File file)
+    {
+        return file.Type switch
+        {
+            FileType.Ancillary => BlobContainers.PrivateReleaseFiles,
+            FileType.Chart => BlobContainers.PrivateReleaseFiles,
+            FileType.Data => BlobContainers.PrivateReleaseFiles,
+            FileType.DataGuidance => BlobContainers.PrivateReleaseFiles,
+            FileType.DataZip => BlobContainers.PrivateReleaseFiles,
+            FileType.Image => await GetPrivateImageFileContainer(file),
+            FileType.Metadata => BlobContainers.PrivateReleaseFiles,
+            _ => throw new ArgumentOutOfRangeException(nameof(file), $"Unexpected file type '{file.Type}'.")
+        };
+    }
+
+    private async Task<IBlobContainer> GetPrivateImageFileContainer(File file)
+    {
+        if (file.Type != FileType.Image)
+        {
+            throw new ArgumentException("Expecting image file", nameof(file));
+        }
+
+        // Determine if it's a release or a methodology image based on what type of links to the file exist
+
+        var existsReleaseFile = await _contentDbContext.ReleaseFiles.AnyAsync(rf => rf.FileId == file.Id);
+        if (existsReleaseFile)
+        {
+            return BlobContainers.PrivateReleaseFiles;
+        }
+
+        var existsMethodologyFile = await _contentDbContext.MethodologyFiles.AnyAsync(mf => mf.FileId == file.Id);
+        if (existsMethodologyFile)
+        {
+            return BlobContainers.PrivateMethodologyFiles;
+        }
+
+        throw new InvalidOperationException($"No release or methodology link found for image file '{file.Id}'.");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFileMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFileMigrationService.cs
@@ -1,0 +1,16 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+
+/**
+ * Interface used to migrate files in EES-3547
+ * TODO Remove in EES-3552
+ */
+public interface IFileMigrationService
+{
+    Task<Either<ActionResult, Unit>> MigrateFile(Guid id);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -5,6 +5,7 @@ using Azure.Storage.Blobs;
 using GovUk.Education.ExploreEducationStatistics.Common.Functions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
@@ -109,7 +110,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                     ))
                 .AddScoped<IFilterRepository, FilterRepository>()
                 .AddScoped<IFootnoteRepository, FootnoteRepository>()
-                .AddScoped<IIndicatorRepository, IndicatorRepository>();
+                .AddScoped<IIndicatorRepository, IndicatorRepository>()
+
+                // Service temporarily added to migrate files in EES-3547
+                // TODO Remove in EES-3552
+                .AddScoped<IFileMigrationService, FileMigrationService>(provider =>
+                    new FileMigrationService(
+                        contentDbContext: provider.GetService<ContentDbContext>(),
+                        provider.GetService<IPersistenceHelper<ContentDbContext>>(),
+                        privateBlobStorageService: GetBlobStorageService(provider, "CoreStorage")
+                    ));
 
             AddPersistenceHelper<ContentDbContext>(builder.Services);
             AddPersistenceHelper<StatisticsDbContext>(builder.Services);


### PR DESCRIPTION
This PR is a placeholder for the migration that will eventually be required to migrate blob Size and ContentType from blob properties to Files in order to remove multiple calls to `GetBlob` which returns information about a blob.

### Other changes

- Alters Content database File table column Filename to be not-null.