### PR TITLE
EES-3557 Ensure all Releases have non-null RelatedInformation

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220721114241_EES-3557_ReleaseRelatedInformationNotNull.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220721114241_EES-3557_ReleaseRelatedInformationNotNull.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220721114241_EES-3557_ReleaseRelatedInformationNotNull")]
+    partial class EES3557_ReleaseRelatedInformationNotNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220721114241_EES-3557_ReleaseRelatedInformationNotNull.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220721114241_EES-3557_ReleaseRelatedInformationNotNull.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES3557_ReleaseRelatedInformationNotNull : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Update all Releases with null RelatedInformation to have an empty array instead to match expectations in code
+            // accessing the RelatedInformation property which expect a non-null List<Link> value.
+            migrationBuilder.Sql("UPDATE dbo.Releases SET RelatedInformation = '[]' WHERE RelatedInformation IS NULL");
+
+            // Make the RelatedInformation column not nullable now that every Release should have a value
+            migrationBuilder.AlterColumn<string>(
+                name: "RelatedInformation",
+                table: "Releases",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "RelatedInformation",
+                table: "Releases",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -233,6 +233,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
 
             modelBuilder.Entity<Release>()
                 .Property<List<Link>>("RelatedInformation")
+                .IsRequired()
                 .HasConversion(
                     v => JsonConvert.SerializeObject(v),
                     v => JsonConvert.DeserializeObject<List<Link>>(v));


### PR DESCRIPTION
This PR makes an update to `Release.RelatedInformation`, updating all Releases with a null value in the database to have an empty array. This then matches expectations in code accessing the `RelatedInformation` property which expect a non-null `List<Link>` value.

After this change we also make the `Release.RelatedInformation` column not nullable now that every Release should have a value.

This fixes a bug seen where users were unable to create Release amendments where the current version has a null RelatedInformation value, failing in `ReleaseAmendmentExtensions.CreateAmendment:58` projecting the list which is expected to be non-null.