### PR TITLE
EES-3562 - updated slow query with multiple joins and lots of duplica…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
@@ -37,18 +37,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     Slug = "methodology-slug",
                     OwningPublicationTitle = "Owning Publication Title"
                 },
-                Content = new List<ContentSection>
-                {
-                    new()
+                MethodologyContent = new MethodologyVersionContent {
+                    Content = new List<ContentSection>
                     {
-                        Content = new List<ContentBlock>
+                        new()
                         {
-                            new HtmlBlock
+                            Content = new List<ContentBlock>
                             {
-                                Body = "Content!"
+                                new HtmlBlock
+                                {
+                                    Body = "Content!"
+                                }
                             }
                         }
-                    }
+                    },
                 },
                 Notes = new List<MethodologyNote>
                 {
@@ -99,11 +101,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var amendment = await context.MethodologyVersions
                     .Include(m => m.Notes)
+                    .Include(m => m.MethodologyContent)
                     .SingleAsync(m => m.Id == amendmentId);
 
                 Assert.Equal(originalVersion.Id, amendment.PreviousVersionId);
 
-                var contentSection = Assert.Single(amendment.Content);
+                var contentSection = Assert.Single(amendment.MethodologyContent.Content);
                 Assert.NotNull(contentSection);
 
                 var contentBlock = Assert.Single(contentSection.Content) as HtmlBlock;
@@ -129,13 +132,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     Slug = "methodology-slug",
                     OwningPublicationTitle = "Owning Publication Title"
                 },
-                Content = AsList(new ContentSection
-                {
-                    Content = AsList<ContentBlock>(new HtmlBlock
+                MethodologyContent = new MethodologyVersionContent {
+                    Content = AsList(new ContentSection
                     {
-                        Body = "Content!"
+                        Content = AsList<ContentBlock>(new HtmlBlock
+                        {
+                            Body = "Content!"
+                        })
                     })
-                })
+                }
             };
 
             var originalMethodologyFile1 = new MethodologyFile

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyContentServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyContentServicePermissionTests.cs
@@ -81,9 +81,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var methodologyVersion = new MethodologyVersion
             {
-                Content = new List<ContentSection>
-                {
-                    new ContentSection()
+                MethodologyContent = new MethodologyVersionContent {
+                    Content = new List<ContentSection>
+                    {
+                        new()
+                    }
                 }
             };
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -104,7 +106,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                             var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
 
                             return methodologyContentService.GetContentSection(methodologyVersion.Id,
-                                methodologyVersion.Content.First().Id);
+                                methodologyVersion.MethodologyContent.Content.First().Id);
                         });
             }
         }
@@ -170,11 +172,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var methodologyVersion = new MethodologyVersion
             {
-                Content = new List<ContentSection>
-                {
-                    new()
+                MethodologyContent = new MethodologyVersionContent {
+                    Content = new List<ContentSection>
+                    {
+                        new()
+                    }
                 }
-
             };
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -195,7 +198,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                             return methodologyContentService.UpdateContentSectionHeading(
                                 methodologyVersion.Id,
-                                methodologyVersion.Content.First().Id,
+                                methodologyVersion.MethodologyContent.Content.First().Id,
                                 "New heading");
                         });
             }
@@ -206,11 +209,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var methodologyVersion = new MethodologyVersion
             {
-                Content = new List<ContentSection>
-                {
-                    new()
+                MethodologyContent = new MethodologyVersionContent {
+                    Content = new List<ContentSection>
+                    {
+                        new()
+                    }
                 }
-
             };
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -231,7 +235,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                             return methodologyContentService.RemoveContentSection(
                                 methodologyVersion.Id,
-                                methodologyVersion.Content.First().Id);
+                                methodologyVersion.MethodologyContent.Content.First().Id);
                         });
             }
         }
@@ -241,11 +245,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var methodologyVersion = new MethodologyVersion
             {
-                Content = new List<ContentSection>
-                {
-                    new()
+                MethodologyContent = new MethodologyVersionContent {
+                    Content = new List<ContentSection>
+                    {
+                        new()
+                    }
                 }
-
             };
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -266,7 +271,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                             return methodologyContentService.ReorderContentBlocks(
                                 methodologyVersion.Id,
-                                methodologyVersion.Content.First().Id,
+                                methodologyVersion.MethodologyContent.Content.First().Id,
                                 new Dictionary<Guid, int>()
                             );
                         });
@@ -278,14 +283,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var methodologyVersion = new MethodologyVersion
             {
-                Content = new List<ContentSection>
-                {
-                    new()
+                MethodologyContent = new MethodologyVersionContent {
+                    Content = new List<ContentSection>
                     {
-                        Id = Guid.NewGuid()
+                        new()
+                        {
+                            Id = Guid.NewGuid()
+                        }
                     }
-                }
-
+                }   
             };
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -306,7 +312,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                             return methodologyContentService.AddContentBlock(
                                 methodologyVersion.Id,
-                                methodologyVersion.Content.First().Id,
+                                methodologyVersion.MethodologyContent.Content.First().Id,
                                 new ContentBlockAddRequest()
                             );
                         });
@@ -318,17 +324,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var methodologyVersion = new MethodologyVersion
             {
-                Content = new List<ContentSection>
-                {
-                    new()
+                MethodologyContent = new MethodologyVersionContent {
+                    Content = new List<ContentSection>
                     {
-                        Content = new List<ContentBlock>
+                        new()
                         {
-                            new HtmlBlock()
+                            Content = new List<ContentBlock>
+                            {
+                                new HtmlBlock()
+                            }
                         }
                     }
                 }
-
             };
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -349,8 +356,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                             return methodologyContentService.RemoveContentBlock(
                                 methodologyVersion.Id,
-                                methodologyVersion.Content.First().Id,
-                                methodologyVersion.Content.First().Content.First().Id
+                                methodologyVersion.MethodologyContent.Content.First().Id,
+                                methodologyVersion.MethodologyContent.Content.First().Content.First().Id
                             );
                         });
             }
@@ -361,17 +368,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var methodologyVersion = new MethodologyVersion
             {
-                Content = new List<ContentSection>
-                {
-                    new()
+                MethodologyContent = new MethodologyVersionContent {
+                    Content = new List<ContentSection>
                     {
-                        Content = new List<ContentBlock>
+                        new()
                         {
-                            new HtmlBlock()
+                            Content = new List<ContentBlock>
+                            {
+                                new HtmlBlock()
+                            }
                         }
                     }
                 }
-
             };
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -392,8 +400,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                             return methodologyContentService.UpdateTextBasedContentBlock(
                                 methodologyVersion.Id,
-                                methodologyVersion.Content.First().Id,
-                                methodologyVersion.Content.First().Content.First().Id,
+                                methodologyVersion.MethodologyContent.Content.First().Id,
+                                methodologyVersion.MethodologyContent.Content.First().Content.First().Id,
                                 new ContentBlockUpdateRequest()
                             );
                         });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyContentServiceTests.cs
@@ -83,53 +83,55 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     new()
                     {
                         Id = Guid.NewGuid(),
-                        Annexes = new List<ContentSection>
-                        {
-                            new()
+                        MethodologyContent = new MethodologyVersionContent {
+                            Annexes = new List<ContentSection>
                             {
-                                Id = Guid.NewGuid(),
-                                Order = 2,
-                                Heading = "Annex 3 heading",
-                                Caption = "Annex 3 caption"
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 2,
+                                    Heading = "Annex 3 heading",
+                                    Caption = "Annex 3 caption"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 0,
+                                    Heading = "Annex 1 heading",
+                                    Caption = "Annex 1 caption"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 1,
+                                    Heading = "Annex 2 heading",
+                                    Caption = "Annex 2 caption"
+                                }
                             },
-                            new()
+                            Content = new List<ContentSection>
                             {
-                                Id = Guid.NewGuid(),
-                                Order = 0,
-                                Heading = "Annex 1 heading",
-                                Caption = "Annex 1 caption"
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 2,
+                                    Heading = "Section 3 heading",
+                                    Caption = "Section 3 caption"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 0,
+                                    Heading = "Section 1 heading",
+                                    Caption = "Section 1 caption"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 1,
+                                    Heading = "Section 2 heading",
+                                    Caption = "Section 2 caption"
+                                }
                             },
-                            new()
-                            {
-                                Id = Guid.NewGuid(),
-                                Order = 1,
-                                Heading = "Annex 2 heading",
-                                Caption = "Annex 2 caption"
-                            }
-                        },
-                        Content = new List<ContentSection>
-                        {
-                            new()
-                            {
-                                Id = Guid.NewGuid(),
-                                Order = 2,
-                                Heading = "Section 3 heading",
-                                Caption = "Section 3 caption"
-                            },
-                            new()
-                            {
-                                Id = Guid.NewGuid(),
-                                Order = 0,
-                                Heading = "Section 1 heading",
-                                Caption = "Section 1 caption"
-                            },
-                            new()
-                            {
-                                Id = Guid.NewGuid(),
-                                Order = 1,
-                                Heading = "Section 2 heading",
-                                Caption = "Section 2 caption"
-                            }
                         },
                         PreviousVersionId = null,
                         PublishingStrategy = Immediately,
@@ -157,17 +159,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(3, result.Annexes.Count);
                 Assert.Equal(3, result.Content.Count);
 
-                var expectedAnnex1 = methodologyVersion.Annexes.Single(section => section.Order == 0);
-                var expectedAnnex2 = methodologyVersion.Annexes.Single(section => section.Order == 1);
-                var expectedAnnex3 = methodologyVersion.Annexes.Single(section => section.Order == 2);
+                var expectedAnnex1 = methodologyVersion.MethodologyContent.Annexes.Single(section => section.Order == 0);
+                var expectedAnnex2 = methodologyVersion.MethodologyContent.Annexes.Single(section => section.Order == 1);
+                var expectedAnnex3 = methodologyVersion.MethodologyContent.Annexes.Single(section => section.Order == 2);
 
                 AssertContentSectionAndViewModelEqual(expectedAnnex1, result.Annexes[0]);
                 AssertContentSectionAndViewModelEqual(expectedAnnex2, result.Annexes[1]);
                 AssertContentSectionAndViewModelEqual(expectedAnnex3, result.Annexes[2]);
 
-                var expectedContent1 = methodologyVersion.Content.Single(section => section.Order == 0);
-                var expectedContent2 = methodologyVersion.Content.Single(section => section.Order == 1);
-                var expectedContent3 = methodologyVersion.Content.Single(section => section.Order == 2);
+                var expectedContent1 = methodologyVersion.MethodologyContent.Content.Single(section => section.Order == 0);
+                var expectedContent2 = methodologyVersion.MethodologyContent.Content.Single(section => section.Order == 1);
+                var expectedContent3 = methodologyVersion.MethodologyContent.Content.Single(section => section.Order == 2);
 
                 AssertContentSectionAndViewModelEqual(expectedContent1, result.Content[0]);
                 AssertContentSectionAndViewModelEqual(expectedContent2, result.Content[1]);
@@ -301,22 +303,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var methodologyVersion = new MethodologyVersion
             {
-                Annexes = new List<ContentSection>
-                {
-                    new()
+                MethodologyContent = new MethodologyVersionContent {
+                    Annexes = new List<ContentSection>
                     {
-                        Id = Guid.NewGuid(),
-                        Heading = "New section",
-                        Order = 1
-                    }
-                },
-                Content = new List<ContentSection>
-                {
-                    new()
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Heading = "New section",
+                            Order = 1
+                        }
+                    },
+                    Content = new List<ContentSection>
                     {
-                        Id = Guid.NewGuid(),
-                        Heading = "New section",
-                        Order = 2
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Heading = "New section",
+                            Order = 2
+                        }
                     }
                 }
             };
@@ -366,64 +370,66 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             var methodologyVersion = new MethodologyVersion
             {
-                Annexes = new List<ContentSection>
-                {
-                    new()
+                MethodologyContent = new MethodologyVersionContent {
+                    Annexes = new List<ContentSection>
                     {
-                        Id = Guid.NewGuid(),
-                        Heading = "New section",
-                        Order = 1,
-                        Content = new List<ContentBlock>
+                        new()
                         {
-                            annexHtmlBlock1,
-                            new DataBlock
+                            Id = Guid.NewGuid(),
+                            Heading = "New section",
+                            Order = 1,
+                            Content = new List<ContentBlock>
                             {
-                                Id = Guid.NewGuid()
+                                annexHtmlBlock1,
+                                new DataBlock
+                                {
+                                    Id = Guid.NewGuid()
+                                }
+                            }
+                        },
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Heading = "New section",
+                            Order = 2,
+                            Content = new List<ContentBlock>
+                            {
+                                annexHtmlBlock2,
+                                new DataBlock
+                                {
+                                    Id = Guid.NewGuid()
+                                }
                             }
                         }
                     },
-                    new()
+                    Content = new List<ContentSection>
                     {
-                        Id = Guid.NewGuid(),
-                        Heading = "New section",
-                        Order = 2,
-                        Content = new List<ContentBlock>
+                        new()
                         {
-                            annexHtmlBlock2,
-                            new DataBlock
+                            Id = Guid.NewGuid(),
+                            Heading = "New section",
+                            Order = 1,
+                            Content = new List<ContentBlock>
                             {
-                                Id = Guid.NewGuid()
+                                contentHtmlBlock1,
+                                new DataBlock
+                                {
+                                    Id = Guid.NewGuid()
+                                }
                             }
-                        }
-                    }
-                },
-                Content = new List<ContentSection>
-                {
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Heading = "New section",
-                        Order = 1,
-                        Content = new List<ContentBlock>
+                        },
+                        new()
                         {
-                            contentHtmlBlock1,
-                            new DataBlock
+                            Id = Guid.NewGuid(),
+                            Heading = "New section",
+                            Order = 2,
+                            Content = new List<ContentBlock>
                             {
-                                Id = Guid.NewGuid()
-                            }
-                        }
-                    },
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Heading = "New section",
-                        Order = 2,
-                        Content = new List<ContentBlock>
-                        {
-                            contentHtmlBlock2,
-                            new DataBlock
-                            {
-                                Id = Guid.NewGuid()
+                                contentHtmlBlock2,
+                                new DataBlock
+                                {
+                                    Id = Guid.NewGuid()
+                                }
                             }
                         }
                     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -229,10 +229,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
             CreateMap<MethodologyVersion, ManageMethodologyContentViewModel>()
                 .ForMember(dest => dest.Content,
                     m => m.MapFrom(methodologyVersion =>
-                        methodologyVersion.Content.OrderBy(contentSection => contentSection.Order)))
+                        methodologyVersion.MethodologyContent.Content.OrderBy(contentSection => contentSection.Order)))
                 .ForMember(dest => dest.Annexes,
                     m => m.MapFrom(methodologyVersion =>
-                        methodologyVersion.Annexes.OrderBy(annexSection => annexSection.Order)))
+                        methodologyVersion.MethodologyContent.Annexes.OrderBy(annexSection => annexSection.Order)))
                 .ForMember(dest => dest.Notes,
                     m => m.MapFrom(methodologyVersion =>
                         methodologyVersion.Notes.OrderByDescending(note => note.DisplayDate)));

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
@@ -439,14 +439,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<string>("AlternativeTitle")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Annexes")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Content")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
                     b.Property<DateTime?>("Created")
                         .HasColumnType("datetime2");
 
@@ -493,6 +485,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasIndex("ScheduledWithReleaseId");
 
                     b.ToTable("MethodologyVersions");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersionContent", b =>
+                {
+                    b.Property<Guid>("MethodologyVersionId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Annexes")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Content")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("MethodologyVersionId");
+
+                    b.ToTable("MethodologyVersions", (string)null);
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", b =>
@@ -1255,6 +1265,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Navigation("ScheduledWithRelease");
                 });
 
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersionContent", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", null)
+                        .WithOne("MethodologyContent")
+                        .HasForeignKey("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersionContent", "MethodologyVersionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Contact", "Contact")
@@ -1576,6 +1595,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", b =>
                 {
+                    b.Navigation("MethodologyContent")
+                        .IsRequired();
+
                     b.Navigation("Notes");
                 });
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyAmendmentService.cs
@@ -88,6 +88,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 .Reference(m => m.Methodology)
                 .LoadAsync();
 
+            await _context
+                .Entry(methodologyVersion)
+                .Reference(m => m.MethodologyContent)
+                .LoadAsync();
+
             return methodologyVersion;
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -346,7 +346,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public static IQueryable<Publication> HydratePublicationForPublicationViewModel(IQueryable<Publication> values)
         {
-            return values.Include(p => p.Contact)
+            return values
+                .AsSplitQuery()
+                .Include(p => p.Contact)
                 .Include(p => p.Releases)
                 .ThenInclude(r => r.ReleaseStatuses)
                 .Include(p => p.LegacyReleases)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
@@ -249,36 +249,38 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
             var originalVersion = new MethodologyVersion
             {
                 Id = Guid.NewGuid(),
-                Annexes = new List<ContentSection>
-                {
-                    new()
+                MethodologyContent = new MethodologyVersionContent {
+                    Annexes = new List<ContentSection>
                     {
-                        Id = Guid.NewGuid(),
-                        Caption = "Annex caption",
-                        Heading = "Annex heading",
-                        Order = 2,
-                        Type = ContentSectionType.Generic,
-                        Content = ListOf<ContentBlock>(new HtmlBlock
+                        new()
                         {
                             Id = Guid.NewGuid(),
-                            Body = "Annex body",
-                            Created = DateTime.Today.AddDays(-13),
-                            Order = 5,
-                            ContentSection = new ContentSection(),
-                            ContentSectionId = Guid.NewGuid(),
-                            Comments = new List<Comment>
+                            Caption = "Annex caption",
+                            Heading = "Annex heading",
+                            Order = 2,
+                            Type = ContentSectionType.Generic,
+                            Content = ListOf<ContentBlock>(new HtmlBlock
                             {
-                                new()
+                                Id = Guid.NewGuid(),
+                                Body = "Annex body",
+                                Created = DateTime.Today.AddDays(-13),
+                                Order = 5,
+                                ContentSection = new ContentSection(),
+                                ContentSectionId = Guid.NewGuid(),
+                                Comments = new List<Comment>
                                 {
-                                    Id = Guid.NewGuid(),
-                                    Content = "Annex comment",
-                                    Created = DateTime.Today.AddDays(-4),
-                                    CreatedById = Guid.NewGuid(),
-                                    Updated = DateTime.Today.AddDays(-3),
-                                    CreatedBy = new User()
+                                    new()
+                                    {
+                                        Id = Guid.NewGuid(),
+                                        Content = "Annex comment",
+                                        Created = DateTime.Today.AddDays(-4),
+                                        CreatedById = Guid.NewGuid(),
+                                        Updated = DateTime.Today.AddDays(-3),
+                                        CreatedBy = new User()
+                                    }
                                 }
-                            }
-                        })
+                            })
+                        }
                     }
                 }
             };
@@ -286,7 +288,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
 
             var createdDate = DateTime.Today.AddMinutes(-2);
             var amendment = originalVersion.CreateMethodologyAmendment(createdDate, Guid.NewGuid());
-            AssertContentSectionAmendedCorrectly(amendment.Annexes[0], originalVersion.Annexes[0], createdDate);
+            AssertContentSectionAmendedCorrectly(
+                amendment.MethodologyContent.Annexes[0], 
+                originalVersion.MethodologyContent.Annexes[0], 
+                createdDate);
         }
 
         [Fact]
@@ -295,32 +300,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
             var originalVersion = new MethodologyVersion
             {
                 Id = Guid.NewGuid(),
-                Content = new List<ContentSection>
-                {
-                    new()
+                MethodologyContent = new MethodologyVersionContent {
+                    Content = new List<ContentSection>
                     {
-                        Id = Guid.NewGuid(),
-                        Caption = "Content caption",
-                        Heading = "Content heading",
-                        Order = 2,
-                        Type = ContentSectionType.Generic,
-                        Content = ListOf<ContentBlock>(new HtmlBlock
+                        new()
                         {
                             Id = Guid.NewGuid(),
-                            Body = "Content body",
-                            Comments = new List<Comment>
+                            Caption = "Content caption",
+                            Heading = "Content heading",
+                            Order = 2,
+                            Type = ContentSectionType.Generic,
+                            Content = ListOf<ContentBlock>(new HtmlBlock
                             {
-                                new()
+                                Id = Guid.NewGuid(),
+                                Body = "Content body",
+                                Comments = new List<Comment>
                                 {
-                                    Id = Guid.NewGuid(),
-                                    Content = "Content comment",
-                                    Created = DateTime.Today.AddDays(-4),
-                                    CreatedById = Guid.NewGuid(),
-                                    Updated = DateTime.Today.AddDays(-3),
-                                    CreatedBy = new User()
+                                    new()
+                                    {
+                                        Id = Guid.NewGuid(),
+                                        Content = "Content comment",
+                                        Created = DateTime.Today.AddDays(-4),
+                                        CreatedById = Guid.NewGuid(),
+                                        Updated = DateTime.Today.AddDays(-3),
+                                        CreatedBy = new User()
+                                    }
                                 }
-                            }
-                        })
+                            })
+                        }
                     }
                 }
             };
@@ -328,7 +335,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
 
             var createdDate = DateTime.Today.AddMinutes(-2);
             var amendment = originalVersion.CreateMethodologyAmendment(createdDate, Guid.NewGuid());
-            AssertContentSectionAmendedCorrectly(amendment.Content[0], originalVersion.Content[0], createdDate);
+            AssertContentSectionAmendedCorrectly(
+                amendment.MethodologyContent.Content[0], 
+                originalVersion.MethodologyContent.Content[0], 
+                createdDate);
         }
 
         private static void AssertContentSectionAmendedCorrectly(ContentSection amendmentContentSection,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -44,6 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
 
         public DbSet<Methodology> Methodologies { get; set; }
         public DbSet<MethodologyVersion> MethodologyVersions { get; set; }
+        public DbSet<MethodologyVersionContent> MethodologyContent { get; set; }
         public DbSet<PublicationMethodology> PublicationMethodologies { get; set; }
         public DbSet<MethodologyFile> MethodologyFiles { get; set; }
         public DbSet<Theme> Themes { get; set; }
@@ -119,17 +120,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     v => v,
                     v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
 
-            modelBuilder.Entity<MethodologyVersion>()
+            modelBuilder.Entity<MethodologyVersionContent>().ToTable("MethodologyVersions");
+            modelBuilder.Entity<MethodologyVersionContent>().Property<Guid>("MethodologyVersionId");
+            modelBuilder.Entity<MethodologyVersionContent>().HasKey("MethodologyVersionId");
+            
+            modelBuilder.Entity<MethodologyVersionContent>()
                 .Property(m => m.Content)
                 .HasConversion(
                     v => JsonConvert.SerializeObject(v),
                     v => JsonConvert.DeserializeObject<List<ContentSection>>(v));
 
-            modelBuilder.Entity<MethodologyVersion>()
+            modelBuilder.Entity<MethodologyVersionContent>()
                 .Property(m => m.Annexes)
                 .HasConversion(
                     v => JsonConvert.SerializeObject(v),
                     v => JsonConvert.DeserializeObject<List<ContentSection>>(v));
+
+            modelBuilder.Entity<MethodologyVersion>()
+                .HasOne(m => m.MethodologyContent)
+                .WithOne()
+                .HasForeignKey<MethodologyVersionContent>(m => m.MethodologyVersionId);
 
             modelBuilder.Entity<MethodologyVersion>()
                 .Property(m => m.Status)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyVersion.cs
@@ -36,9 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public DateTime? Updated { get; set; }
 
-        public List<ContentSection> Content { get; set; } = new();
-
-        public List<ContentSection> Annexes { get; set; } = new();
+        public MethodologyVersionContent MethodologyContent { get; set; } = new();
 
         public List<MethodologyNote> Notes { get; set; } = new();
 
@@ -112,13 +110,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             copy.Methodology = null!;
             copy.InternalReleaseNote = null;
 
-            copy.Annexes = Annexes
-                .Select(c => c.Clone(createdDate))
-                .ToList();
-
-            copy.Content = Content
-                .Select(c => c.Clone(createdDate))
-                .ToList();
+            copy.MethodologyContent = MethodologyContent.Clone(createdDate);
 
             copy.Notes = copy
                 .Notes
@@ -128,4 +120,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             return copy;
         }
     }
+
+    public class MethodologyVersionContent
+    {
+        public Guid MethodologyVersionId { get; set; }
+            
+        public List<ContentSection> Content { get; set; } = new();
+
+        public List<ContentSection> Annexes { get; set; } = new();
+
+        public MethodologyVersionContent Clone(DateTime createdDate)
+        {
+            return new MethodologyVersionContent
+            {
+                Annexes = Annexes
+                    .Select(c => c.Clone(createdDate))
+                    .ToList(),
+
+                Content = Content
+                    .Select(c => c.Clone(createdDate))
+                    .ToList()
+            };
+        }
+    }
 }
+
+

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceCachingTests.cs
@@ -318,8 +318,10 @@ public class MethodologyServiceCachingTests : BlobCacheServiceTestFixture
             new MethodologyVersion
             {
                 Id = Guid.NewGuid(),
-                Annexes = new List<ContentSection>(),
-                Content = new List<ContentSection>(),
+                MethodologyContent = new MethodologyVersionContent {
+                    Annexes = new List<ContentSection>(),
+                    Content = new List<ContentSection>(),
+                },
                 PreviousVersionId = null,
                 PublishingStrategy = Immediately,
                 Status = Approved,
@@ -333,8 +335,10 @@ public class MethodologyServiceCachingTests : BlobCacheServiceTestFixture
             new MethodologyVersion
             {
                 Id = Guid.NewGuid(),
-                Annexes = new List<ContentSection>(),
-                Content = new List<ContentSection>(),
+                MethodologyContent = new MethodologyVersionContent {
+                    Annexes = new List<ContentSection>(),
+                    Content = new List<ContentSection>(),
+                },
                 PreviousVersionId = null,
                 PublishingStrategy = Immediately,
                 Status = Approved,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
@@ -249,53 +249,55 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     new()
                     {
                         Id = Guid.NewGuid(),
-                        Annexes = new List<ContentSection>
-                        {
-                            new()
+                        MethodologyContent = new MethodologyVersionContent {
+                            Annexes = new List<ContentSection>
                             {
-                                Id = Guid.NewGuid(),
-                                Order = 2,
-                                Heading = "Annex 3 heading",
-                                Caption = "Annex 3 caption"
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 2,
+                                    Heading = "Annex 3 heading",
+                                    Caption = "Annex 3 caption"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 0,
+                                    Heading = "Annex 1 heading",
+                                    Caption = "Annex 1 caption"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 1,
+                                    Heading = "Annex 2 heading",
+                                    Caption = "Annex 2 caption"
+                                }
                             },
-                            new()
+                            Content = new List<ContentSection>
                             {
-                                Id = Guid.NewGuid(),
-                                Order = 0,
-                                Heading = "Annex 1 heading",
-                                Caption = "Annex 1 caption"
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 2,
+                                    Heading = "Section 3 heading",
+                                    Caption = "Section 3 caption"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 0,
+                                    Heading = "Section 1 heading",
+                                    Caption = "Section 1 caption"
+                                },
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Order = 1,
+                                    Heading = "Section 2 heading",
+                                    Caption = "Section 2 caption"
+                                }
                             },
-                            new()
-                            {
-                                Id = Guid.NewGuid(),
-                                Order = 1,
-                                Heading = "Annex 2 heading",
-                                Caption = "Annex 2 caption"
-                            }
-                        },
-                        Content = new List<ContentSection>
-                        {
-                            new()
-                            {
-                                Id = Guid.NewGuid(),
-                                Order = 2,
-                                Heading = "Section 3 heading",
-                                Caption = "Section 3 caption"
-                            },
-                            new()
-                            {
-                                Id = Guid.NewGuid(),
-                                Order = 0,
-                                Heading = "Section 1 heading",
-                                Caption = "Section 1 caption"
-                            },
-                            new()
-                            {
-                                Id = Guid.NewGuid(),
-                                Order = 1,
-                                Heading = "Section 2 heading",
-                                Caption = "Section 2 caption"
-                            }
                         },
                         PublishingStrategy = Immediately,
                         Status = Approved,
@@ -332,17 +334,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 Assert.Equal(3, result.Annexes.Count);
                 Assert.Equal(3, result.Content.Count);
 
-                var expectedAnnex1 = methodologyVersion.Annexes.Single(section => section.Order == 0);
-                var expectedAnnex2 = methodologyVersion.Annexes.Single(section => section.Order == 1);
-                var expectedAnnex3 = methodologyVersion.Annexes.Single(section => section.Order == 2);
+                var expectedAnnex1 = methodologyVersion.MethodologyContent.Annexes.Single(section => section.Order == 0);
+                var expectedAnnex2 = methodologyVersion.MethodologyContent.Annexes.Single(section => section.Order == 1);
+                var expectedAnnex3 = methodologyVersion.MethodologyContent.Annexes.Single(section => section.Order == 2);
 
                 AssertContentSectionAndViewModelEqual(expectedAnnex1, result.Annexes[0]);
                 AssertContentSectionAndViewModelEqual(expectedAnnex2, result.Annexes[1]);
                 AssertContentSectionAndViewModelEqual(expectedAnnex3, result.Annexes[2]);
 
-                var expectedContent1 = methodologyVersion.Content.Single(section => section.Order == 0);
-                var expectedContent2 = methodologyVersion.Content.Single(section => section.Order == 1);
-                var expectedContent3 = methodologyVersion.Content.Single(section => section.Order == 2);
+                var expectedContent1 = methodologyVersion.MethodologyContent.Content.Single(section => section.Order == 0);
+                var expectedContent2 = methodologyVersion.MethodologyContent.Content.Single(section => section.Order == 1);
+                var expectedContent3 = methodologyVersion.MethodologyContent.Content.Single(section => section.Order == 2);
 
                 AssertContentSectionAndViewModelEqual(expectedContent1, result.Content[0]);
                 AssertContentSectionAndViewModelEqual(expectedContent2, result.Content[1]);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
@@ -29,10 +29,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Mappings
             CreateMap<MethodologyVersion, MethodologyVersionViewModel>()
                 .ForMember(dest => dest.Annexes,
                     m => m.MapFrom(methodologyVersion =>
-                        methodologyVersion.Annexes.OrderBy(annexSection => annexSection.Order)))
+                        methodologyVersion.MethodologyContent.Annexes.OrderBy(annexSection => annexSection.Order)))
                 .ForMember(dest => dest.Content,
                     m => m.MapFrom(methodologyVersion =>
-                        methodologyVersion.Content.OrderBy(contentSection => contentSection.Order)))
+                        methodologyVersion.MethodologyContent.Content.OrderBy(contentSection => contentSection.Order)))
                 .ForMember(dest => dest.Notes,
                     m => m.MapFrom(methodologyVersion =>
                         methodologyVersion.Notes.OrderByDescending(note => note.DisplayDate)));

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
@@ -46,16 +46,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                 {
                     var latestPublishedVersion =
                         await _methodologyVersionRepository.GetLatestPublishedVersion(methodology.Id);
+                    
                     if (latestPublishedVersion == null)
                     {
                         return new NotFoundResult();
                     }
 
-                    await _contentDbContext.Entry(latestPublishedVersion)
+                    await _contentDbContext
+                        .Entry(latestPublishedVersion)
                         .Collection(m => m.Notes)
+                        .LoadAsync();
+                    
+                    await _contentDbContext
+                        .Entry(latestPublishedVersion)
+                        .Reference(m => m.MethodologyContent)
                         .LoadAsync();
 
                     var viewModel = _mapper.Map<MethodologyVersionViewModel>(latestPublishedVersion);
+                    
                     viewModel.Publications =
                         await GetPublishedPublicationsForMethodology(latestPublishedVersion.MethodologyId);
 


### PR DESCRIPTION
## This PR
- addresses the slow queries as reported on tickets https://dfedigital.atlassian.net/browse/EES-3562 and https://dfedigital.atlassian.net/browse/EES-3561

Both of these queries pulled large quantities of data from the DB (350 - 450 MB responses) in part due to pulling large Methodology Content (and Annexes) back when not necessary, but also compounded by the fact that the query had several joins that led to large amounts of content in the table rows being duplicated in the various different JOIN combinations ("cartesian explosion").
   
## Reducing size of DB responses
The biggest benefit to this is to initiate a Split Query, thereby avoiding the excessive duplication found in the query response rows due to all the JOIN combinations.  A single Split Query in `PublicationService#HydratePublicationForPublicationViewModel` addresses this for both slow queries mentioned in this PR.

## Including MethodologyVersion content only when required
Another change was to move `Content` and `Annex` content lists from MethodologyVersion to a new "entity" called `MethodologyVersionContent`, using [Table Splitting](https://docs.microsoft.com/en-us/ef/core/modeling/table-splitting), which then means that EF will only pull in their columns into queries when explicitly "Included".

Unfortunately it transpired that OOTB (or at least in the way that I'd wired it up with their limited instructions), when you make changes to the MethodologyContent and then save the MethodologyVersion that they belong to, these changes are not updated in the DB.  It required an explicit `context.MethodologyVersionContent.Add(methodology.MethodologyContent)` to get EF to save the changes on the `context.SaveChangesAsync()`.

This was a shame, so I tried switching to owned entities, but they do not support lazy fetching / Including.  So I decided it was worth the explicit adding of the MethodologyContent itself to the db context before a save and went with Table Splitting.

## AsSplitQuery not 100% efficient
The queries spit out by AsSplitQuery are far from optimal, but probably dot he job of avoiding the worst of the cartesian explosion issue.  This is conjunction with avoiding pulling back the really big Methodology content fields will solve the live issue, I'm sure.  But it's worth taking a look at the queries spit out to know what to potentially expect from `AsSplitQuery` in the future and to consider if we wanna hand-crank via `LoadAsync()` over and above `AsSplitQuery()` in the near future.

Here's the broken down query into 4 queries.  Note the fetching of `Contacts`, `Topics` and `ExternalMethodology` in each query.  It's not a biggie here because they're all small entities in their own right, but there is some duplication so we know it's not 100% optimal.  In this case though as I say, I think it's fine:

```
exec sp_executesql N'SELECT [p].[Id], [p].[ContactId], [p].[LegacyPublicationUrl], [p].[Published], [p].[Slug], [p].[SupersededById], [p].[Title], [p].[TopicId], [p].[Updated], [e].[PublicationId], [e].[Title], [e].[Url], [c].[Id], [c].[ContactName], [c].[ContactTelNo], [c].[TeamEmail], [c].[TeamName], [t].[Id], [t].[Slug], [t].[ThemeId], [t].[Title]
FROM [Publications] AS [p]
LEFT JOIN [Contacts] AS [c] ON [p].[ContactId] = [c].[Id]
INNER JOIN [Topics] AS [t] ON [p].[TopicId] = [t].[Id]
LEFT JOIN [ExternalMethodology] AS [e] ON [p].[Id] = [e].[PublicationId]
WHERE [p].[TopicId] = @__topicId_0
ORDER BY [p].[Id], [c].[Id], [t].[Id], [e].[PublicationId]',N'@__topicId_0 uniqueidentifier',@__topicId_0='1003FA5C-B60A-4036-A178-E3A69A81B852'
```

```
exec sp_executesql N'SELECT [t0].[Id], [t0].[ApprovalStatus], [t0].[Created], [t0].[CreatedById], [t0].[DataGuidance], [t0].[DataLastPublished], [t0].[NextReleaseDate], [t0].[PreReleaseAccessList], [t0].[PreviousVersionId], [t0].[PublicationId], [t0].[PublishScheduled], [t0].[Published], [t0].[RelatedInformation], [t0].[ReleaseName], [t0].[Slug], [t0].[SoftDeleted], [t0].[TimePeriodCoverage], [t0].[Type], [t0].[Version], [p].[Id], [c].[Id], [t].[Id], [e].[PublicationId]
FROM [Publications] AS [p]
LEFT JOIN [Contacts] AS [c] ON [p].[ContactId] = [c].[Id]
INNER JOIN [Topics] AS [t] ON [p].[TopicId] = [t].[Id]
LEFT JOIN [ExternalMethodology] AS [e] ON [p].[Id] = [e].[PublicationId]
INNER JOIN (
    SELECT [r].[Id], [r].[ApprovalStatus], [r].[Created], [r].[CreatedById], [r].[DataGuidance], [r].[DataLastPublished], [r].[NextReleaseDate], [r].[PreReleaseAccessList], [r].[PreviousVersionId], [r].[PublicationId], [r].[PublishScheduled], [r].[Published], [r].[RelatedInformation], [r].[ReleaseName], [r].[Slug], [r].[SoftDeleted], [r].[TimePeriodCoverage], [r].[Type], [r].[Version]
    FROM [Releases] AS [r]
    WHERE [r].[SoftDeleted] = CAST(0 AS bit)
) AS [t0] ON [p].[Id] = [t0].[PublicationId]
WHERE [p].[TopicId] = @__topicId_0
ORDER BY [p].[Id], [c].[Id], [t].[Id], [e].[PublicationId], [t0].[Id]',N'@__topicId_0 uniqueidentifier',@__topicId_0='1003FA5C-B60A-4036-A178-E3A69A81B852'
```

```
exec sp_executesql N'SELECT [l].[Id], [l].[Description], [l].[Order], [l].[PublicationId], [l].[Url], [p].[Id], [c].[Id], [t].[Id], [e].[PublicationId]
FROM [Publications] AS [p]
LEFT JOIN [Contacts] AS [c] ON [p].[ContactId] = [c].[Id]
INNER JOIN [Topics] AS [t] ON [p].[TopicId] = [t].[Id]
LEFT JOIN [ExternalMethodology] AS [e] ON [p].[Id] = [e].[PublicationId]
INNER JOIN [LegacyReleases] AS [l] ON [p].[Id] = [l].[PublicationId]
WHERE [p].[TopicId] = @__topicId_0
ORDER BY [p].[Id], [c].[Id], [t].[Id], [e].[PublicationId]',N'@__topicId_0 uniqueidentifier',@__topicId_0='1003FA5C-B60A-4036-A178-E3A69A81B852'
```

```
exec sp_executesql N'SELECT [t0].[PublicationId], [t0].[MethodologyId], [t0].[Owner], [t0].[Id], [t0].[OwningPublicationTitle], [t0].[Slug], [p].[Id], [c].[Id], [t].[Id], [e].[PublicationId]
FROM [Publications] AS [p]
LEFT JOIN [Contacts] AS [c] ON [p].[ContactId] = [c].[Id]
INNER JOIN [Topics] AS [t] ON [p].[TopicId] = [t].[Id]
LEFT JOIN [ExternalMethodology] AS [e] ON [p].[Id] = [e].[PublicationId]
INNER JOIN (
    SELECT [p0].[PublicationId], [p0].[MethodologyId], [p0].[Owner], [m].[Id], [m].[OwningPublicationTitle], [m].[Slug]
    FROM [PublicationMethodologies] AS [p0]
    INNER JOIN [Methodologies] AS [m] ON [p0].[MethodologyId] = [m].[Id]
) AS [t0] ON [p].[Id] = [t0].[PublicationId]
WHERE [p].[TopicId] = @__topicId_0
ORDER BY [p].[Id], [c].[Id], [t].[Id], [e].[PublicationId], [t0].[PublicationId], [t0].[MethodologyId], [t0].[Id]',N'@__topicId_0 uniqueidentifier',@__topicId_0='1003FA5C-B60A-4036-A178-E3A69A81B852'
```

## Future work?
It might be worth moving to the same DB tables model that Releases have with the ContentSections and ContentBlocks tables, but I think this'll do for a hotfix!

We could think of enabling SplitQueries globally, and falling back to `AsSingleQuery()` if we notice areas of degradation.  There's also a [health warning](https://docs.microsoft.com/en-us/ef/core/querying/single-split-queries) where in certain scenarios you might end up with duplicate results which we'd have to be on the lookout for.  

![image](https://user-images.githubusercontent.com/12444316/180326884-3b416021-4e69-49bf-8c72-29ec545799c7.png)
