### PR TITLE
EES-3548 Secure methodology images with methodology version permission check

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/AuthorizationHandlersTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/AuthorizationHandlersTestUtil.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlerContextFactory;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils
@@ -113,9 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             HandlerTestScenario scenario)
             where TRequirement : IAuthorizationRequirement
         {
-            var authContext = new AuthorizationHandlerContext(
-                new IAuthorizationRequirement[] { Activator.CreateInstance<TRequirement>() },
-                scenario.User, scenario.Entity);
+            var authContext = CreateAuthContext<TRequirement>(scenario.User, scenario.Entity);
 
             await handler.HandleAsync(authContext);
 
@@ -158,9 +157,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         public static AuthorizationHandlerContext CreateAuthorizationHandlerContext<TRequirement, TEntity>(
             ClaimsPrincipal user, TEntity entity) where TRequirement : IAuthorizationRequirement
         {
-            return new AuthorizationHandlerContext(
-                new IAuthorizationRequirement[] { Activator.CreateInstance<TRequirement>() },
-                user, entity);
+            return CreateAuthContext<TRequirement, TEntity>(user, entity);
         }
 
         public class HandlerTestScenario

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Security/AuthorizationHandlerContextFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Security/AuthorizationHandlerContextFactory.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+using System;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Security;
+
+public static class AuthorizationHandlerContextFactory
+{
+    public static AuthorizationHandlerContext CreateAnonymousAuthContext<TRequirement, TResource>(TResource resource)
+        where TRequirement : IAuthorizationRequirement
+    {
+        var requirements = new IAuthorizationRequirement[] {Activator.CreateInstance<TRequirement>()};
+        ClaimsPrincipal user = null!;
+        return new AuthorizationHandlerContext(requirements, user, resource);
+    }
+
+    public static AuthorizationHandlerContext CreateAuthContext<TRequirement, TResource>(ClaimsPrincipal user,
+        TResource resource) where TRequirement : IAuthorizationRequirement
+    {
+        var requirements = new IAuthorizationRequirement[] {Activator.CreateInstance<TRequirement>()};
+        return new AuthorizationHandlerContext(requirements, user, resource);
+    }
+
+    public static AuthorizationHandlerContext CreateAuthContext<TRequirement>(ClaimsPrincipal user,
+        object? resource) where TRequirement : IAuthorizationRequirement
+    {
+        var requirements = new IAuthorizationRequirement[] {Activator.CreateInstance<TRequirement>()};
+        return new AuthorizationHandlerContext(requirements, user, resource);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MethodologyImageController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MethodologyImageController.cs
@@ -17,14 +17,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
             _methodologyImageService = methodologyImageService;
         }
 
-        [HttpGet("methodologies/{methodologyId}/images/{fileId}")]
-        public async Task<ActionResult> Stream(string methodologyId, string fileId)
+        [HttpGet("methodologies/{methodologyVersionId}/images/{fileId}")]
+        public async Task<ActionResult> Stream(string methodologyVersionId, string fileId)
         {
-            if (Guid.TryParse(methodologyId, out var methodologyIdAsGuid) &&
+            if (Guid.TryParse(methodologyVersionId, out var methodologyVersionIdAsGuid) &&
                 Guid.TryParse(fileId, out var fileIdAsGuid))
             {
                 return await _methodologyImageService
-                    .Stream(methodologyId: methodologyIdAsGuid, fileId: fileIdAsGuid)
+                    .Stream(methodologyVersionId: methodologyVersionIdAsGuid, fileId: fileIdAsGuid)
                     .HandleFailures();
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -8,14 +8,10 @@ using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Content.Security;
-using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Content.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -24,7 +20,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interface
 using GovUk.Education.ExploreEducationStatistics.Data.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -141,22 +136,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             services.AddTransient<IReleaseFileService, ReleaseFileService>();
             services.AddTransient<IReleaseDataFileRepository, ReleaseDataFileRepository>();
             services.AddTransient<IDataGuidanceFileWriter, DataGuidanceFileWriter>();
-            services.AddTransient<IUserService, UserService>();
             services.AddTransient<IGlossaryService, GlossaryService>();
 
-            services.AddAuthorization(options =>
-            {
-                // does this use have permission to view a specific Publication?
-                options.AddPolicy(ContentSecurityPolicies.CanViewSpecificPublication.ToString(), policy =>
-                    policy.Requirements.Add(new ViewPublicationRequirement()));
-
-                // does this use have permission to view a specific Release?
-                options.AddPolicy(ContentSecurityPolicies.CanViewSpecificRelease.ToString(), policy =>
-                    policy.Requirements.Add(new ViewReleaseRequirement()));
-            });
-
-            services.AddTransient<IAuthorizationHandler, ViewPublicationAuthorizationHandler>();
-            services.AddTransient<IAuthorizationHandler, ViewReleaseAuthorizationHandler>();
+            StartupSecurityConfiguration.ConfigureAuthorizationPolicies(services);
+            StartupSecurityConfiguration.ConfigureResourceBasedAuthorization(services);
 
             AddPersistenceHelper<ContentDbContext>(services);
             AddPersistenceHelper<StatisticsDbContext>(services);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/StartupSecurityConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/StartupSecurityConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
@@ -17,6 +18,10 @@ public static class StartupSecurityConfiguration
     {
         services.AddAuthorization(options =>
         {
+            // does this use have permission to view a specific MethodologyVersion?
+            options.AddPolicy(ContentSecurityPolicies.CanViewSpecificMethodologyVersion.ToString(), policy =>
+                policy.Requirements.Add(new ViewMethodologyVersionRequirement()));
+
             // does this use have permission to view a specific Publication?
             options.AddPolicy(ContentSecurityPolicies.CanViewSpecificPublication.ToString(), policy =>
                 policy.Requirements.Add(new ViewPublicationRequirement()));
@@ -35,6 +40,7 @@ public static class StartupSecurityConfiguration
     {
         services.AddTransient<IUserService, UserService>();
 
+        services.AddTransient<IAuthorizationHandler, ViewMethodologyVersionAuthorizationHandler>();
         services.AddTransient<IAuthorizationHandler, ViewPublicationAuthorizationHandler>();
         services.AddTransient<IAuthorizationHandler, ViewReleaseAuthorizationHandler>();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/StartupSecurityConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/StartupSecurityConfiguration.cs
@@ -1,0 +1,41 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api;
+
+public static class StartupSecurityConfiguration
+{
+    /// <summary>
+    /// Configure security policies
+    /// </summary>
+    /// <param name="services"></param>
+    public static void ConfigureAuthorizationPolicies(IServiceCollection services)
+    {
+        services.AddAuthorization(options =>
+        {
+            // does this use have permission to view a specific Publication?
+            options.AddPolicy(ContentSecurityPolicies.CanViewSpecificPublication.ToString(), policy =>
+                policy.Requirements.Add(new ViewPublicationRequirement()));
+
+            // does this use have permission to view a specific Release?
+            options.AddPolicy(ContentSecurityPolicies.CanViewSpecificRelease.ToString(), policy =>
+                policy.Requirements.Add(new ViewReleaseRequirement()));
+        });
+    }
+
+    /// <summary>
+    /// Set up our Resource-based Authorization Handlers and supporting services in DI
+    /// </summary>
+    /// <param name="services"></param>
+    public static void ConfigureResourceBasedAuthorization(IServiceCollection services)
+    {
+        services.AddTransient<IUserService, UserService>();
+
+        services.AddTransient<IAuthorizationHandler, ViewPublicationAuthorizationHandler>();
+        services.AddTransient<IAuthorizationHandler, ViewReleaseAuthorizationHandler>();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandlerTests.cs
@@ -1,0 +1,81 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlerContextFactory;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.AuthorizationHandlers;
+
+public class ViewMethodologyVersionAuthorizationHandlerTests
+{
+    private readonly MethodologyVersion _methodologyVersion = new()
+    {
+        Id = Guid.NewGuid()
+    };
+
+    [Fact]
+    public async Task MethodologyVersionIsPubliclyAccessible()
+    {
+        var (
+            handler,
+            methodologyVersionRepository
+            ) = CreateHandlerAndDependencies();
+
+        methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(_methodologyVersion.Id))
+            .ReturnsAsync(true);
+
+        var authContext =
+            CreateAnonymousAuthContext<ViewMethodologyVersionRequirement, MethodologyVersion>(_methodologyVersion);
+
+        await handler.HandleAsync(authContext);
+
+        VerifyAllMocks(methodologyVersionRepository);
+
+        Assert.True(authContext.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task MethodologyVersionIsNotPubliclyAccessible()
+    {
+        var (
+            handler,
+            methodologyVersionRepository
+            ) = CreateHandlerAndDependencies();
+
+        methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(_methodologyVersion.Id))
+            .ReturnsAsync(false);
+
+        var authContext =
+            CreateAnonymousAuthContext<ViewMethodologyVersionRequirement, MethodologyVersion>(_methodologyVersion);
+
+        await handler.HandleAsync(authContext);
+
+        VerifyAllMocks(methodologyVersionRepository);
+
+        Assert.False(authContext.HasSucceeded);
+    }
+
+    private static
+        (ViewMethodologyVersionAuthorizationHandler,
+        Mock<IMethodologyVersionRepository>
+        )
+        CreateHandlerAndDependencies()
+    {
+        var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(Strict);
+
+        var handler = new ViewMethodologyVersionAuthorizationHandler(
+            methodologyVersionRepository.Object
+        );
+
+        return (
+            handler,
+            methodologyVersionRepository
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewPublicationAuthorizationHandlerTests.cs
@@ -4,8 +4,8 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
-using Microsoft.AspNetCore.Authorization;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlerContextFactory;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
 
@@ -39,11 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
             {
                 var handler = new ViewPublicationAuthorizationHandler(contentDbContext);
 
-                var authContext = new AuthorizationHandlerContext(
-                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewPublicationRequirement>() },
-                    null,
-                    publication
-                );
+                var authContext = CreateAnonymousAuthContext<ViewPublicationRequirement, Publication>(publication);
 
                 await handler.HandleAsync(authContext);
 
@@ -84,11 +80,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
             {
                 var handler = new ViewPublicationAuthorizationHandler(contentDbContext);
 
-                var authContext = new AuthorizationHandlerContext(
-                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewPublicationRequirement>() },
-                    null,
-                    publication
-                );
+                var authContext = CreateAnonymousAuthContext<ViewPublicationRequirement, Publication>(publication);
 
                 await handler.HandleAsync(authContext);
 
@@ -128,11 +120,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
             {
                 var handler = new ViewPublicationAuthorizationHandler(contentDbContext);
 
-                var authContext = new AuthorizationHandlerContext(
-                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewPublicationRequirement>() },
-                    null,
-                    publication
-                );
+                var authContext = CreateAnonymousAuthContext<ViewPublicationRequirement, Publication>(publication);
 
                 await handler.HandleAsync(authContext);
 
@@ -166,11 +154,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
             {
                 var handler = new ViewPublicationAuthorizationHandler(contentDbContext);
 
-                var authContext = new AuthorizationHandlerContext(
-                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewPublicationRequirement>() },
-                    null,
-                    publication
-                );
+                var authContext = CreateAnonymousAuthContext<ViewPublicationRequirement, Publication>(publication);
 
                 await handler.HandleAsync(authContext);
 
@@ -196,11 +180,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
 
             var handler = new ViewPublicationAuthorizationHandler(contentDbContext);
 
-            var authContext = new AuthorizationHandlerContext(
-                new IAuthorizationRequirement[] { Activator.CreateInstance<ViewPublicationRequirement>() },
-                null,
-                publication
-            );
+            var authContext = CreateAnonymousAuthContext<ViewPublicationRequirement, Publication>(publication);
 
             await handler.HandleAsync(authContext);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewReleaseAuthorizationHandlerTests.cs
@@ -3,8 +3,8 @@ using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
-using Microsoft.AspNetCore.Authorization;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlerContextFactory;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
 
@@ -37,11 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
             {
                 var handler = new ViewReleaseAuthorizationHandler(contentDbContext);
 
-                var authContext = new AuthorizationHandlerContext(
-                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewReleaseRequirement>() },
-                    null,
-                    release
-                );
+                var authContext = CreateAnonymousAuthContext<ViewReleaseRequirement, Release>(release);
 
                 await handler.HandleAsync(authContext);
 
@@ -79,11 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
             {
                 var handler = new ViewReleaseAuthorizationHandler(contentDbContext);
 
-                var authContext = new AuthorizationHandlerContext(
-                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewReleaseRequirement>() },
-                    null,
-                    amendedRelease
-                );
+                var authContext = CreateAnonymousAuthContext<ViewReleaseRequirement, Release>(amendedRelease);
 
                 await handler.HandleAsync(authContext);
 
@@ -113,11 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
             {
                 var handler = new ViewReleaseAuthorizationHandler(contentDbContext);
 
-                var authContext = new AuthorizationHandlerContext(
-                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewReleaseRequirement>() },
-                    null,
-                    release
-                );
+                var authContext = CreateAnonymousAuthContext<ViewReleaseRequirement, Release>(release);
 
                 await handler.HandleAsync(authContext);
 
@@ -156,11 +144,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
             {
                 var handler = new ViewReleaseAuthorizationHandler(contentDbContext);
 
-                var authContext = new AuthorizationHandlerContext(
-                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewReleaseRequirement>() },
-                    null,
-                    originalRelease
-                );
+                var authContext = CreateAnonymousAuthContext<ViewReleaseRequirement, Release>(originalRelease);
 
                 await handler.HandleAsync(authContext);
 
@@ -175,14 +159,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
 
             var handler = new ViewReleaseAuthorizationHandler(contentDbContext);
 
-            var authContext = new AuthorizationHandlerContext(
-                new IAuthorizationRequirement[] { Activator.CreateInstance<ViewReleaseRequirement>() },
-                null,
-                new Release
-                {
-                    Id = Guid.NewGuid()
-                }
-            );
+            var authContext = CreateAnonymousAuthContext<ViewReleaseRequirement, Release>(new Release
+            {
+                Id = Guid.NewGuid()
+            });
 
             await handler.HandleAsync(authContext);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandler.cs
@@ -1,0 +1,32 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
+
+public class ViewMethodologyVersionRequirement : IAuthorizationRequirement
+{
+}
+
+public class ViewMethodologyVersionAuthorizationHandler :
+    AuthorizationHandler<ViewMethodologyVersionRequirement, MethodologyVersion>
+{
+    private readonly IMethodologyVersionRepository _methodologyVersionRepository;
+
+    public ViewMethodologyVersionAuthorizationHandler(IMethodologyVersionRepository methodologyVersionRepository)
+    {
+        _methodologyVersionRepository = methodologyVersionRepository;
+    }
+
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
+        ViewMethodologyVersionRequirement requirement,
+        MethodologyVersion methodologyVersion)
+    {
+        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion.Id))
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/ContentSecurityPolicies.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/ContentSecurityPolicies.cs
@@ -3,6 +3,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security
 {
     public enum ContentSecurityPolicies
     {
+        CanViewSpecificMethodologyVersion,
         CanViewSpecificPublication,
         CanViewSpecificRelease
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/Extensions/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/Extensions/UserServiceExtensions.cs
@@ -4,23 +4,31 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Mvc;
+using static GovUk.Education.ExploreEducationStatistics.Content.Security.ContentSecurityPolicies;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions
 {
     public static class UserServiceExtensions
     {
+        public static Task<Either<ActionResult, MethodologyVersion>> CheckCanViewMethodologyVersion(
+            this IUserService userService,
+            MethodologyVersion methodologyVersion)
+        {
+            return userService.CheckPolicy(methodologyVersion, CanViewSpecificMethodologyVersion);
+        }
+
         public static Task<Either<ActionResult, Publication>> CheckCanViewPublication(
             this IUserService userService,
             Publication publication)
         {
-            return userService.CheckPolicy(publication, ContentSecurityPolicies.CanViewSpecificPublication);
+            return userService.CheckPolicy(publication, CanViewSpecificPublication);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanViewRelease(
             this IUserService userService,
             Release release)
         {
-            return userService.CheckPolicy(release, ContentSecurityPolicies.CanViewSpecificRelease);
+            return userService.CheckPolicy(release, CanViewSpecificRelease);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyImageServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyImageServicePermissionTests.cs
@@ -1,0 +1,72 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Security.ContentSecurityPolicies;
+using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests;
+
+public class MethodologyImageServicePermissionTests
+{
+    private static readonly MethodologyVersion MethodologyVersion = new()
+    {
+        Id = Guid.NewGuid()
+    };
+
+    private static readonly File File = new()
+    {
+        Id = Guid.NewGuid()
+    };
+
+    private static readonly MethodologyFile MethodologyFile = new()
+    {
+        MethodologyVersion = MethodologyVersion,
+        File = File
+    };
+
+    [Fact]
+    public async Task StreamFile()
+    {
+        await PolicyCheckBuilder<ContentSecurityPolicies>()
+            .SetupResourceCheckToFail(MethodologyVersion, CanViewSpecificMethodologyVersion)
+            .AssertForbidden(
+                userService =>
+                {
+                    var persistenceHelper = MockPersistenceHelper<ContentDbContext, MethodologyFile>(MethodologyFile);
+
+                    var service = BuildService(
+                        userService: userService.Object,
+                        persistenceHelper: persistenceHelper.Object
+                    );
+                    return service.Stream(MethodologyVersion.Id, File.Id);
+                }
+            );
+    }
+
+    private MethodologyImageService BuildService(
+        IPersistenceHelper<ContentDbContext>? persistenceHelper = null,
+        IBlobStorageService? blobStorageService = null,
+        IUserService? userService = null)
+    {
+        return new(
+            persistenceHelper ?? DefaultPersistenceHelperMock().Object,
+            blobStorageService ?? Mock.Of<IBlobStorageService>(),
+            userService ?? Mock.Of<IUserService>()
+        );
+    }
+
+    private Mock<IPersistenceHelper<ContentDbContext>> DefaultPersistenceHelperMock()
+    {
+        return MockPersistenceHelper<ContentDbContext, MethodologyVersion>(MethodologyVersion.Id, MethodologyVersion);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyImageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyImageServiceTests.cs
@@ -222,7 +222,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         {
             return new MethodologyImageService(
                 contentPersistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
-                blobStorageService ?? new Mock<IBlobStorageService>().Object
+                blobStorageService ?? new Mock<IBlobStorageService>().Object,
+                MockUtils.AlwaysTrueUserService().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyImageService.cs
@@ -8,6 +8,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces
 {
     public interface IMethodologyImageService
     {
-        Task<Either<ActionResult, FileStreamResult>> Stream(Guid methodologyId, Guid fileId);
+        Task<Either<ActionResult, FileStreamResult>> Stream(Guid methodologyVersionId, Guid fileId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyImageService.cs
@@ -28,12 +28,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             _blobStorageService = blobStorageService;
         }
 
-        public async Task<Either<ActionResult, FileStreamResult>> Stream(Guid methodologyId, Guid fileId)
+        public async Task<Either<ActionResult, FileStreamResult>> Stream(Guid methodologyVersionId, Guid fileId)
         {
             return await _persistenceHelper
                 .CheckEntityExists<MethodologyFile>(q => q
                     .Include(mf => mf.File)
-                    .Where(mf => mf.MethodologyVersionId == methodologyId && mf.FileId == fileId))
+                    .Where(mf => mf.MethodologyVersionId == methodologyVersionId && mf.FileId == fileId))
                 .OnSuccess(async mf =>
                 {
                     return await GetBlob(mf.Path())

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyImageService.cs
@@ -1,14 +1,17 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -20,12 +23,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
     {
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
         private readonly IBlobStorageService _blobStorageService;
+        private readonly IUserService _userService;
 
         public MethodologyImageService(IPersistenceHelper<ContentDbContext> persistenceHelper,
-            IBlobStorageService blobStorageService)
+            IBlobStorageService blobStorageService,
+            IUserService userService)
         {
             _persistenceHelper = persistenceHelper;
             _blobStorageService = blobStorageService;
+            _userService = userService;
         }
 
         public async Task<Either<ActionResult, FileStreamResult>> Stream(Guid methodologyVersionId, Guid fileId)
@@ -33,7 +39,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             return await _persistenceHelper
                 .CheckEntityExists<MethodologyFile>(q => q
                     .Include(mf => mf.File)
+                    .Include(mf => mf.MethodologyVersion)
                     .Where(mf => mf.MethodologyVersionId == methodologyVersionId && mf.FileId == fileId))
+                .OnSuccessDo(mf => _userService.CheckCanViewMethodologyVersion(mf.MethodologyVersion))
                 .OnSuccess(async mf =>
                 {
                     return await GetBlob(mf.Path())


### PR DESCRIPTION
Methodology images are currently secured by comparing a special `releasedatetime` property on the image blob containing the date/time that the file was published with the current date/time of the request.

This relies on the blob property being set during publishing when blobs are copied from private to public storage. Only images which have been published are publicly accessible, and only when their published date/time has passed.

To find the `releasedatetime` value we use `BlobStorageService#GetBlob` to get the blob properties and custom metadata. Internally this relies on `BaseBlobClient.GetPropertiesAsync` which makes an additional HTTP call to the storage account.

Making additional calls to get check a blob exists and then get the blob properties before streaming a blob (which already checks the blob exists) is being removed by  https://github.com/dfe-analytical-services/explore-education-statistics/pull/3387.

This PR secures methodology image requests with a permission check on the `MethodologyVersion` related to the image. This uses the standard claims based authorization which evaluates if the `MethodologyVersion` is publicly accessible.

### UI Test report

![image](https://user-images.githubusercontent.com/4147126/181056494-fbdd5f6e-0ce6-4fe1-957e-552fa9df3a9f.png)
