### PR TITLE
EES-3223 publication contact details

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
@@ -63,9 +63,11 @@ const PublicationContactPage = () => {
               {contact?.contactTelNo}
             </SummaryListItem>
           </SummaryList>
-          <Button variant="secondary" onClick={toggleReadOnly.off}>
-            Edit contact details
-          </Button>
+          {publication.permissions.canUpdatePublication && (
+            <Button variant="secondary" onClick={toggleReadOnly.off}>
+              Edit contact details
+            </Button>
+          )}
         </>
       ) : (
         <PublicationContactForm

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
@@ -36,17 +36,17 @@ const PublicationContactPage = () => {
 
   return (
     <>
+      <h2>Contact for this publication</h2>
+      <div className="govuk-grid-row  govuk-!-margin-bottom-6">
+        <div className="govuk-grid-column-three-quarters">
+          <p>
+            They will be the main point of contact for data and methodology
+            enquiries for this publication and its releases.
+          </p>
+        </div>
+      </div>
       {readOnly ? (
         <>
-          <h2>Contact for this publication</h2>
-          <div className="govuk-grid-row  govuk-!-margin-bottom-6">
-            <div className="govuk-grid-column-three-quarters">
-              <p>
-                They will be the main point of contact for data and methodology
-                enquiries for this publication and its releases.
-              </p>
-            </div>
-          </div>
           <SummaryList>
             <SummaryListItem term="Team name">
               {contact?.teamName}

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
@@ -1,0 +1,86 @@
+import Button from '@common/components/Button';
+import PublicationContactForm, {
+  FormValues,
+} from '@admin/pages/publication/components/PublicationContactForm';
+import usePublicationContext from '@admin/pages/publication/contexts/PublicationContext';
+import publicationService from '@admin/services/publicationService';
+import SummaryList from '@common/components/SummaryList';
+import SummaryListItem from '@common/components/SummaryListItem';
+import useToggle from '@common/hooks/useToggle';
+import React from 'react';
+
+const PublicationContactPage = () => {
+  const { publication, onReload } = usePublicationContext();
+  const { contact } = publication;
+  const [readOnly, toggleReadOnly] = useToggle(true);
+
+  const handleSubmit = async ({
+    teamName,
+    teamEmail,
+    contactName,
+    contactTelNo,
+  }: FormValues) => {
+    await publicationService.updatePublication(publication.id, {
+      contact: {
+        teamName,
+        teamEmail,
+        contactName,
+        contactTelNo,
+      },
+      title: publication.title,
+      topicId: publication.topicId,
+    });
+
+    onReload();
+  };
+
+  return (
+    <>
+      {readOnly ? (
+        <>
+          <h2>Contact for this publication</h2>
+          <div className="govuk-grid-row  govuk-!-margin-bottom-6">
+            <div className="govuk-grid-column-three-quarters">
+              <p>
+                They will be the main point of contact for data and methodology
+                enquiries for this publication and its releases.
+              </p>
+            </div>
+          </div>
+          <SummaryList>
+            <SummaryListItem term="Team name">
+              {contact?.teamName}
+            </SummaryListItem>
+            <SummaryListItem term="Team email">
+              {contact?.teamEmail && (
+                <a href={`mailto:${contact.teamEmail}`}>{contact.teamEmail}</a>
+              )}
+            </SummaryListItem>
+            <SummaryListItem term="Contact name">
+              {contact?.contactName}
+            </SummaryListItem>
+            <SummaryListItem term="Contact telephone">
+              {contact?.contactTelNo}
+            </SummaryListItem>
+          </SummaryList>
+          <Button variant="secondary" onClick={toggleReadOnly.off}>
+            Edit contact details
+          </Button>
+        </>
+      ) : (
+        <PublicationContactForm
+          initialValues={{
+            teamName: contact?.teamName ?? '',
+            teamEmail: contact?.teamEmail ?? '',
+            contactName: contact?.contactName ?? '',
+            contactTelNo: contact?.contactTelNo ?? '',
+          }}
+          onCancel={toggleReadOnly.on}
+          onSubmit={handleSubmit}
+        />
+      )}
+    </>
+  );
+};
+
+export default PublicationContactPage;

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
@@ -4,6 +4,7 @@ import Page from '@admin/components/Page';
 import PageTitle from '@admin/components/PageTitle';
 import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
 import {
+  publicationContactRoute,
   publicationDetailsRoute,
   publicationReleasesRoute,
   PublicationRouteParams,
@@ -16,7 +17,11 @@ import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React from 'react';
 import { generatePath, Route, RouteComponentProps, Switch } from 'react-router';
 
-const navRoutes = [publicationReleasesRoute, publicationDetailsRoute];
+const navRoutes = [
+  publicationReleasesRoute,
+  publicationDetailsRoute,
+  publicationContactRoute,
+];
 
 const routes = [...navRoutes];
 

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
@@ -51,32 +51,14 @@ describe('PublicationContactPage', () => {
       screen.getByText('Contact for this publication'),
     ).toBeInTheDocument();
 
-    expect(screen.getByTestId('Team name-key')).toHaveTextContent('Team name');
-    expect(screen.getByTestId('Team name-value')).toHaveTextContent(
-      'Team Smith',
-    );
-
-    expect(screen.getByTestId('Team email-key')).toHaveTextContent(
-      'Team email',
-    );
-    expect(screen.getByTestId('Team email-value')).toHaveTextContent(
+    expect(screen.getByTestId('Team name')).toHaveTextContent('Team Smith');
+    expect(screen.getByTestId('Team email')).toHaveTextContent(
       'john.smith@test.com',
     );
-
-    expect(screen.getByTestId('Contact name-key')).toHaveTextContent(
-      'Contact name',
-    );
-    expect(screen.getByTestId('Contact name-value')).toHaveTextContent(
-      'John Smith',
-    );
-
-    expect(screen.getByTestId('Contact telephone-key')).toHaveTextContent(
-      'Contact telephone',
-    );
-    expect(screen.getByTestId('Contact telephone-value')).toHaveTextContent(
+    expect(screen.getByTestId('Contact name')).toHaveTextContent('John Smith');
+    expect(screen.getByTestId('Contact telephone')).toHaveTextContent(
       '0777777777',
     );
-
     expect(
       screen.getByRole('button', { name: 'Edit contact details' }),
     ).toBeInTheDocument();
@@ -114,7 +96,20 @@ describe('PublicationContactPage', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-    expect(screen.getByTestId('Team name-key')).toHaveTextContent('Team name');
+    expect(screen.getByTestId('Team name')).toHaveTextContent('Team Smith');
+
+    expect(screen.queryByLabelText('Team name')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Team email')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Contact name')).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Contact telephone'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Update contact details' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' }),
+    ).not.toBeInTheDocument();
   });
 
   test('shows validation errors when there are no contact details', async () => {

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
@@ -47,9 +47,11 @@ describe('PublicationContactPage', () => {
   test('renders the contact page correctly', async () => {
     renderPage(testPublication);
 
-    expect(
-      screen.getByText('Contact for this publication'),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText('Contact for this publication'),
+      ).toBeInTheDocument();
+    });
 
     expect(screen.getByTestId('Team name')).toHaveTextContent('Team Smith');
     expect(screen.getByTestId('Team email')).toHaveTextContent(
@@ -64,7 +66,7 @@ describe('PublicationContactPage', () => {
     ).toBeInTheDocument();
   });
 
-  test('does not show the edit button if do not have permission', () => {
+  test('does not show the edit button if do not have permission', async () => {
     renderPage({
       ...testPublication,
       permissions: {
@@ -73,13 +75,25 @@ describe('PublicationContactPage', () => {
       },
     });
 
+    await waitFor(() => {
+      expect(
+        screen.getByText('Contact for this publication'),
+      ).toBeInTheDocument();
+    });
+
     expect(
       screen.queryByRole('button', { name: 'Edit contact details' }),
     ).not.toBeInTheDocument();
   });
 
-  test('clicking the edit button shows the edit form', () => {
+  test('clicking the edit button shows the edit form', async () => {
     renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Contact for this publication'),
+      ).toBeInTheDocument();
+    });
 
     userEvent.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
@@ -99,8 +113,14 @@ describe('PublicationContactPage', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 
-  test('clicking the cancel button switches back to readOnly view', () => {
+  test('clicking the cancel button switches back to readOnly view', async () => {
     renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Contact for this publication'),
+      ).toBeInTheDocument();
+    });
 
     userEvent.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
@@ -128,6 +148,12 @@ describe('PublicationContactPage', () => {
 
   test('shows validation errors when there are no contact details', async () => {
     renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Contact for this publication'),
+      ).toBeInTheDocument();
+    });
 
     userEvent.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
@@ -175,6 +201,12 @@ describe('PublicationContactPage', () => {
   test('show validation error when contact email is not valid', async () => {
     renderPage(testPublication);
 
+    await waitFor(() => {
+      expect(
+        screen.getByText('Contact for this publication'),
+      ).toBeInTheDocument();
+    });
+
     userEvent.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
     );
@@ -197,6 +229,12 @@ describe('PublicationContactPage', () => {
   test('shows a confirmation modal on submit', async () => {
     renderPage(testPublication);
 
+    await waitFor(() => {
+      expect(
+        screen.getByText('Contact for this publication'),
+      ).toBeInTheDocument();
+    });
+
     userEvent.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
     );
@@ -217,6 +255,12 @@ describe('PublicationContactPage', () => {
   test('clicking confirm calls the publication service', async () => {
     renderPage(testPublication);
 
+    await waitFor(() => {
+      expect(
+        screen.getByText('Contact for this publication'),
+      ).toBeInTheDocument();
+    });
+
     userEvent.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
     );
@@ -231,14 +275,13 @@ describe('PublicationContactPage', () => {
       expect(publicationService.updatePublication).toHaveBeenCalledWith(
         testPublication.id,
         {
+          ...testPublication,
           contact: {
             contactName: 'John Smith',
             contactTelNo: '0777777777',
             teamEmail: 'john.smith@test.com',
             teamName: 'Team Smith',
           },
-          title: testPublication.title,
-          topicId: testPublication.topicId,
         },
       );
     });

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
@@ -64,6 +64,20 @@ describe('PublicationContactPage', () => {
     ).toBeInTheDocument();
   });
 
+  test('does not show the edit button if do not have permission', () => {
+    renderPage({
+      ...testPublication,
+      permissions: {
+        ...testPublication.permissions,
+        canUpdatePublication: false,
+      },
+    });
+
+    expect(
+      screen.queryByRole('button', { name: 'Edit contact details' }),
+    ).not.toBeInTheDocument();
+  });
+
   test('clicking the edit button shows the edit form', () => {
     renderPage(testPublication);
 

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
@@ -1,0 +1,251 @@
+import PublicationContactPage from '@admin/pages/publication/PublicationContactPage';
+import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
+import _publicationService, {
+  MyPublication,
+  PublicationContactDetails,
+} from '@admin/services/publicationService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import noop from 'lodash/noop';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@admin/services/publicationService');
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+
+describe('PublicationContactPage', () => {
+  const testContact: PublicationContactDetails = {
+    id: 'contact-1',
+    contactName: 'John Smith',
+    contactTelNo: '0777777777',
+    teamEmail: 'john.smith@test.com',
+    teamName: 'Team Smith',
+  };
+
+  const testPublication: MyPublication = {
+    id: 'publication-1',
+    title: 'Publication 1',
+    contact: testContact,
+    releases: [],
+    legacyReleases: [],
+    methodologies: [],
+    themeId: 'theme-1',
+    topicId: 'topic-1',
+    permissions: {
+      canAdoptMethodologies: true,
+      canCreateReleases: true,
+      canUpdatePublication: true,
+      canUpdatePublicationTitle: true,
+      canUpdatePublicationSupersededBy: true,
+      canCreateMethodologies: true,
+      canManageExternalMethodology: true,
+    },
+  };
+
+  test('renders the contact page correctly', async () => {
+    renderPage(testPublication);
+
+    expect(
+      screen.getByText('Contact for this publication'),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('Team name-key')).toHaveTextContent('Team name');
+    expect(screen.getByTestId('Team name-value')).toHaveTextContent(
+      'Team Smith',
+    );
+
+    expect(screen.getByTestId('Team email-key')).toHaveTextContent(
+      'Team email',
+    );
+    expect(screen.getByTestId('Team email-value')).toHaveTextContent(
+      'john.smith@test.com',
+    );
+
+    expect(screen.getByTestId('Contact name-key')).toHaveTextContent(
+      'Contact name',
+    );
+    expect(screen.getByTestId('Contact name-value')).toHaveTextContent(
+      'John Smith',
+    );
+
+    expect(screen.getByTestId('Contact telephone-key')).toHaveTextContent(
+      'Contact telephone',
+    );
+    expect(screen.getByTestId('Contact telephone-value')).toHaveTextContent(
+      '0777777777',
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Edit contact details' }),
+    ).toBeInTheDocument();
+  });
+
+  test('clicking the edit button shows the edit form', () => {
+    renderPage(testPublication);
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit contact details' }),
+    );
+
+    expect(screen.getByLabelText('Team name')).toHaveValue('Team Smith');
+    expect(screen.getByLabelText('Team email')).toHaveValue(
+      'john.smith@test.com',
+    );
+    expect(screen.getByLabelText('Contact name')).toHaveValue('John Smith');
+    expect(screen.getByLabelText('Contact telephone')).toHaveValue(
+      '0777777777',
+    );
+    expect(
+      screen.getByRole('button', { name: 'Update contact details' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  test('clicking the cancel button switches back to readOnly view', () => {
+    renderPage(testPublication);
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit contact details' }),
+    );
+
+    expect(screen.getByLabelText('Team name')).toHaveValue('Team Smith');
+
+    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByTestId('Team name-key')).toHaveTextContent('Team name');
+  });
+
+  test('shows validation errors when there are no contact details', async () => {
+    renderPage(testPublication);
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit contact details' }),
+    );
+
+    userEvent.clear(screen.getByLabelText('Team name'));
+    userEvent.tab();
+
+    userEvent.clear(screen.getByLabelText('Team email'));
+    userEvent.tab();
+
+    userEvent.clear(screen.getByLabelText('Contact name'));
+    userEvent.tab();
+
+    userEvent.clear(screen.getByLabelText('Contact telephone'));
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Enter a team name', {
+          selector: '#publicationContactForm-teamName-error',
+        }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByText('Enter a team email', {
+          selector: '#publicationContactForm-teamEmail-error',
+        }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByText('Enter a contact name', {
+          selector: '#publicationContactForm-contactName-error',
+        }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByText('Enter a contact telephone', {
+          selector: '#publicationContactForm-contactTelNo-error',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('show validation error when contact email is not valid', async () => {
+    renderPage(testPublication);
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit contact details' }),
+    );
+
+    userEvent.clear(screen.getByLabelText('Team email'));
+
+    userEvent.type(screen.getByLabelText('Team email'), 'not a valid email');
+
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Enter a valid team email', {
+          selector: '#publicationContactForm-teamEmail-error',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows a confirmation modal on submit', async () => {
+    renderPage(testPublication);
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit contact details' }),
+    );
+
+    expect(publicationService.updatePublication).not.toHaveBeenCalled();
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Update contact details' }),
+    );
+
+    const modal = within(screen.getByRole('dialog'));
+    expect(modal.getByRole('heading')).toHaveTextContent(
+      'Confirm contact changes',
+    );
+    userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+  });
+
+  test('clicking confirm calls the publication service', async () => {
+    renderPage(testPublication);
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit contact details' }),
+    );
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Update contact details' }),
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(publicationService.updatePublication).toHaveBeenCalledWith(
+        testPublication.id,
+        {
+          contact: {
+            contactName: 'John Smith',
+            contactTelNo: '0777777777',
+            teamEmail: 'john.smith@test.com',
+            teamName: 'Team Smith',
+          },
+          title: testPublication.title,
+          topicId: testPublication.topicId,
+        },
+      );
+    });
+  });
+});
+
+function renderPage(publication: MyPublication) {
+  render(
+    <MemoryRouter>
+      <PublicationContextProvider
+        publication={publication}
+        onPublicationChange={noop}
+        onReload={noop}
+      >
+        <PublicationContactPage />
+      </PublicationContextProvider>
+    </MemoryRouter>,
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
@@ -65,11 +65,13 @@ describe('PublicationPageContainer', () => {
         name: 'Publication',
       }),
     ).getAllByRole('link');
-    expect(navLinks).toHaveLength(2);
+    expect(navLinks).toHaveLength(3);
     expect(navLinks[0]).toHaveTextContent('Releases');
     expect(navLinks[0].getAttribute('aria-current')).toBe('page');
     expect(navLinks[1]).toHaveTextContent('Details');
     expect(navLinks[1]).not.toHaveAttribute('aria-current');
+    expect(navLinks[2]).toHaveTextContent('Contact');
+    expect(navLinks[2]).not.toHaveAttribute('aria-current');
 
     expect(screen.getByText('Manage releases')).toBeInTheDocument();
   });

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
@@ -1,0 +1,133 @@
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import ButtonText from '@common/components/ButtonText';
+import { FormFieldset } from '@common/components/form';
+import Form from '@common/components/form/Form';
+import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
+import ModalConfirm from '@common/components/ModalConfirm';
+import useFormSubmit from '@common/hooks/useFormSubmit';
+import useToggle from '@common/hooks/useToggle';
+import Yup from '@common/validation/yup';
+import { Formik } from 'formik';
+import React from 'react';
+
+export interface FormValues {
+  teamName: string;
+  teamEmail: string;
+  contactName: string;
+  contactTelNo: string;
+}
+
+interface Props {
+  initialValues: FormValues;
+  onCancel: () => void;
+  onSubmit: (values: FormValues) => void;
+}
+
+const PublicationContactForm = ({
+  initialValues,
+  onCancel,
+  onSubmit,
+}: Props) => {
+  const [showConfirmSubmitModal, toggleShowConfirmSubmitModal] = useToggle(
+    false,
+  );
+
+  const validationSchema = Yup.object<FormValues>({
+    teamName: Yup.string().required('Enter a team name'),
+    teamEmail: Yup.string()
+      .required('Enter a team email')
+      .email('Enter a valid team email'),
+    contactName: Yup.string().required('Enter a contact name'),
+    contactTelNo: Yup.string().required('Enter a contact telephone'),
+  });
+
+  return (
+    <Formik<FormValues>
+      enableReinitialize
+      initialValues={{
+        ...(initialValues ?? {
+          teamName: '',
+          teamEmail: '',
+          contactName: '',
+          contactTelNo: '',
+        }),
+      }}
+      validationSchema={validationSchema}
+      onSubmit={useFormSubmit((values: FormValues) => {
+        onSubmit(values);
+      })}
+    >
+      {form => (
+        <>
+          <Form id="publicationContactForm">
+            <FormFieldset
+              id="contact"
+              legend="Contact for this publication"
+              legendSize="m"
+              hint="They will be the main point of contact for data and methodology enquiries for this publication and its releases."
+            >
+              <FormFieldTextInput<FormValues>
+                name="teamName"
+                label="Team name"
+                className="govuk-!-width-one-half"
+              />
+
+              <FormFieldTextInput<FormValues>
+                name="teamEmail"
+                label="Team email"
+                className="govuk-!-width-one-half"
+              />
+
+              <FormFieldTextInput<FormValues>
+                name="contactName"
+                label="Contact name"
+                className="govuk-!-width-one-half"
+              />
+
+              <FormFieldTextInput<FormValues>
+                name="contactTelNo"
+                label="Contact telephone"
+                className="govuk-!-width-one-half"
+              />
+            </FormFieldset>
+
+            <ButtonGroup>
+              <Button
+                type="submit"
+                onClick={async e => {
+                  e.preventDefault();
+                  if (form.isValid) {
+                    toggleShowConfirmSubmitModal.on();
+                  } else {
+                    await form.submitForm();
+                  }
+                }}
+              >
+                Update contact details
+              </Button>
+              <ButtonText onClick={onCancel}>Cancel</ButtonText>
+            </ButtonGroup>
+          </Form>
+
+          <ModalConfirm
+            title="Confirm contact changes"
+            onConfirm={async () => {
+              await form.submitForm();
+            }}
+            onExit={toggleShowConfirmSubmitModal.off}
+            onCancel={toggleShowConfirmSubmitModal.off}
+            open={showConfirmSubmitModal}
+          >
+            <p>
+              Any changes made here will appear on the public site immediately.
+            </p>
+            <p>Are you sure you want to save the changes?</p>
+          </ModalConfirm>
+        </>
+      )}
+    </Formik>
+  );
+};
+
+export default PublicationContactForm;

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
@@ -1,7 +1,6 @@
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
-import { FormFieldset } from '@common/components/form';
 import Form from '@common/components/form/Form';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import ModalConfirm from '@common/components/ModalConfirm';
@@ -11,7 +10,7 @@ import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
 import React from 'react';
 
-export interface FormValues {
+export interface PublicationContactFormValues {
   teamName: string;
   teamEmail: string;
   contactName: string;
@@ -19,9 +18,9 @@ export interface FormValues {
 }
 
 interface Props {
-  initialValues: FormValues;
+  initialValues: PublicationContactFormValues;
   onCancel: () => void;
-  onSubmit: (values: FormValues) => void;
+  onSubmit: (values: PublicationContactFormValues) => void;
 }
 
 const PublicationContactForm = ({
@@ -31,7 +30,7 @@ const PublicationContactForm = ({
 }: Props) => {
   const [showConfirmModal, toggleConfirmModal] = useToggle(false);
 
-  const validationSchema = Yup.object<FormValues>({
+  const validationSchema = Yup.object<PublicationContactFormValues>({
     teamName: Yup.string().required('Enter a team name'),
     teamEmail: Yup.string()
       .required('Enter a team email')
@@ -41,41 +40,34 @@ const PublicationContactForm = ({
   });
 
   return (
-    <Formik<FormValues>
+    <Formik<PublicationContactFormValues>
       enableReinitialize
-      initialValues={{
-        ...(initialValues ?? {
-          teamName: '',
-          teamEmail: '',
-          contactName: '',
-          contactTelNo: '',
-        }),
-      }}
+      initialValues={initialValues}
       validationSchema={validationSchema}
       onSubmit={useFormSubmit(onSubmit)}
     >
       {form => (
         <>
           <Form id="publicationContactForm">
-            <FormFieldTextInput<FormValues>
+            <FormFieldTextInput<PublicationContactFormValues>
               name="teamName"
               label="Team name"
               className="govuk-!-width-one-half"
             />
 
-            <FormFieldTextInput<FormValues>
+            <FormFieldTextInput<PublicationContactFormValues>
               name="teamEmail"
               label="Team email"
               className="govuk-!-width-one-half"
             />
 
-            <FormFieldTextInput<FormValues>
+            <FormFieldTextInput<PublicationContactFormValues>
               name="contactName"
               label="Contact name"
               className="govuk-!-width-one-half"
             />
 
-            <FormFieldTextInput<FormValues>
+            <FormFieldTextInput<PublicationContactFormValues>
               name="contactTelNo"
               label="Contact telephone"
               className="govuk-!-width-one-half"

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
@@ -29,9 +29,7 @@ const PublicationContactForm = ({
   onCancel,
   onSubmit,
 }: Props) => {
-  const [showConfirmSubmitModal, toggleShowConfirmSubmitModal] = useToggle(
-    false,
-  );
+  const [showConfirmModal, toggleConfirmModal] = useToggle(false);
 
   const validationSchema = Yup.object<FormValues>({
     teamName: Yup.string().required('Enter a team name'),
@@ -54,43 +52,34 @@ const PublicationContactForm = ({
         }),
       }}
       validationSchema={validationSchema}
-      onSubmit={useFormSubmit((values: FormValues) => {
-        onSubmit(values);
-      })}
+      onSubmit={useFormSubmit(onSubmit)}
     >
       {form => (
         <>
           <Form id="publicationContactForm">
-            <FormFieldset
-              id="contact"
-              legend="Contact for this publication"
-              legendSize="m"
-              hint="They will be the main point of contact for data and methodology enquiries for this publication and its releases."
-            >
-              <FormFieldTextInput<FormValues>
-                name="teamName"
-                label="Team name"
-                className="govuk-!-width-one-half"
-              />
+            <FormFieldTextInput<FormValues>
+              name="teamName"
+              label="Team name"
+              className="govuk-!-width-one-half"
+            />
 
-              <FormFieldTextInput<FormValues>
-                name="teamEmail"
-                label="Team email"
-                className="govuk-!-width-one-half"
-              />
+            <FormFieldTextInput<FormValues>
+              name="teamEmail"
+              label="Team email"
+              className="govuk-!-width-one-half"
+            />
 
-              <FormFieldTextInput<FormValues>
-                name="contactName"
-                label="Contact name"
-                className="govuk-!-width-one-half"
-              />
+            <FormFieldTextInput<FormValues>
+              name="contactName"
+              label="Contact name"
+              className="govuk-!-width-one-half"
+            />
 
-              <FormFieldTextInput<FormValues>
-                name="contactTelNo"
-                label="Contact telephone"
-                className="govuk-!-width-one-half"
-              />
-            </FormFieldset>
+            <FormFieldTextInput<FormValues>
+              name="contactTelNo"
+              label="Contact telephone"
+              className="govuk-!-width-one-half"
+            />
 
             <ButtonGroup>
               <Button
@@ -98,7 +87,7 @@ const PublicationContactForm = ({
                 onClick={async e => {
                   e.preventDefault();
                   if (form.isValid) {
-                    toggleShowConfirmSubmitModal.on();
+                    toggleConfirmModal.on();
                   } else {
                     await form.submitForm();
                   }
@@ -115,9 +104,9 @@ const PublicationContactForm = ({
             onConfirm={async () => {
               await form.submitForm();
             }}
-            onExit={toggleShowConfirmSubmitModal.off}
-            onCancel={toggleShowConfirmSubmitModal.off}
-            open={showConfirmSubmitModal}
+            onExit={toggleConfirmModal.off}
+            onCancel={toggleConfirmModal.off}
+            open={showConfirmModal}
           >
             <p>
               Any changes made here will appear on the public site immediately.

--- a/src/explore-education-statistics-admin/src/routes/publicationRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/publicationRoutes.ts
@@ -1,3 +1,4 @@
+import PublicationContactPage from '@admin/pages/publication/PublicationContactPage';
 import PublicationDetailsPage from '@admin/pages/publication/PublicationDetailsPage';
 import PublicationReleasesPage from '@admin/pages/publication/PublicationReleasesPage';
 import { RouteProps } from 'react-router';
@@ -21,4 +22,10 @@ export const publicationDetailsRoute: PublicationRouteProps = {
   path: '/publication/:publicationId/details',
   title: 'Details',
   component: PublicationDetailsPage,
+};
+
+export const publicationContactRoute: PublicationRouteProps = {
+  path: '/publication/:publicationId/contact',
+  title: 'Contact',
+  component: PublicationContactPage,
 };


### PR DESCRIPTION
Adds the Contact page to the new Manage Publication section.

This work will be hidden to users until it's all ready, so for this you can only access the new page directly, at /publication//contact, there are no links to it yet.

This PR and https://github.com/dfe-analytical-services/explore-education-statistics/pull/3391 both make changes to PublicationPageContainer and publicationRoutes, when one is merged I'll rebase the other so all changes are kept.

![contact1](https://user-images.githubusercontent.com/81572860/180810754-29c6db34-8016-4eda-9859-62231564645c.PNG)
![contact2](https://user-images.githubusercontent.com/81572860/180810791-220aa586-62e7-48e9-b8f9-64ee75fd962f.PNG)

