### PR TITLE
EES-3569 Rename DataImport TotalRows to ImportedRows and Rows to TotalRows

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ImportStatusBauServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ImportStatusBauServiceTests.cs
@@ -77,7 +77,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 File = releaseFile1.File,
                 NumBatches = 1,
-                Rows = 100,
+                TotalRows = 100,
                 StagePercentageComplete = 99,
                 Status = FAILED,
                 SubjectId = Guid.NewGuid(),
@@ -88,7 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 File = releaseFile2.File,
                 NumBatches = 2,
-                Rows = 200,
+                TotalRows = 200,
                 StagePercentageComplete = 54,
                 Status = STAGE_1,
                 SubjectId = Guid.NewGuid(),
@@ -99,7 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 File = releaseFile3.File,
                 NumBatches = 3,
-                Rows = 300,
+                TotalRows = 300,
                 StagePercentageComplete = 76,
                 Status = STAGE_4,
                 SubjectId = Guid.NewGuid(),
@@ -136,7 +136,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release.Id, imports[0].ReleaseId);
                 Assert.Equal(release.Title, imports[0].ReleaseTitle);
                 Assert.Equal(import2.File.Filename, imports[0].DataFileName);
-                Assert.Equal(import2.Rows, imports[0].Rows);
+                Assert.Equal(import2.TotalRows, imports[0].TotalRows);
                 Assert.Equal(import2.NumBatches, imports[0].Batches);
                 Assert.Equal(import2.Status, imports[0].Status);
                 Assert.Equal(import2.StagePercentageComplete, imports[0].StagePercentageComplete);
@@ -150,7 +150,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release.Id, imports[1].ReleaseId);
                 Assert.Equal(release.Title, imports[1].ReleaseTitle);
                 Assert.Equal(import1.File.Filename, imports[1].DataFileName);
-                Assert.Equal(import1.Rows, imports[1].Rows);
+                Assert.Equal(import1.TotalRows, imports[1].TotalRows);
                 Assert.Equal(import1.NumBatches, imports[1].Batches);
                 Assert.Equal(import1.Status, imports[1].Status);
                 Assert.Equal(import1.StagePercentageComplete, imports[1].StagePercentageComplete);
@@ -164,7 +164,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release.Id, imports[2].ReleaseId);
                 Assert.Equal(release.Title, imports[2].ReleaseTitle);
                 Assert.Equal(import3.File.Filename, imports[2].DataFileName);
-                Assert.Equal(import3.Rows, imports[2].Rows);
+                Assert.Equal(import3.TotalRows, imports[2].TotalRows);
                 Assert.Equal(import3.NumBatches, imports[2].Batches);
                 Assert.Equal(import3.StagePercentageComplete, imports[2].StagePercentageComplete);
                 Assert.Equal(import3.PercentageComplete(), imports[2].PercentageComplete);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220725145526_EES3569_RenamingTotalRows.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220725145526_EES3569_RenamingTotalRows.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220725145526_EES3569_RenamingTotalRows")]
+    partial class EES3569_RenamingTotalRows
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220725145526_EES3569_RenamingTotalRows.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220725145526_EES3569_RenamingTotalRows.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES3569_RenamingTotalRows : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1. Rename TotalRows -> ImportedRows
+            migrationBuilder.RenameColumn(
+                name: "TotalRows",
+                table: "DataImports",
+                newName: "ImportedRows");
+
+            // 2. Rename Rows -> TotalRows
+            migrationBuilder.RenameColumn(
+                name: "Rows",
+                table: "DataImports",
+                newName: "TotalRows");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // 1. Rename TotalRows -> Rows
+            migrationBuilder.RenameColumn(
+                name: "TotalRows",
+                table: "DataImports",
+                newName: "Rows");
+
+            // 2. Rename ImportedRows -> TotalRows
+            migrationBuilder.RenameColumn(
+                name: "ImportedRows",
+                table: "DataImports",
+                newName: "TotalRows");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataImportService.cs
@@ -88,7 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 Errors = import.Errors.Select(error => error.Message).ToList(),
                 PercentageComplete = import.PercentageComplete(),
                 StagePercentageComplete = import.StagePercentageComplete,
-                NumberOfRows = import.Rows,
+                TotalRows = import.TotalRows,
                 Status = import.Status
             };
         }
@@ -101,7 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 FileId = dataFile.Id,
                 MetaFileId = metaFile.Id,
                 SubjectId = subjectId,
-                Rows = CalculateNumberOfRows(formFile.OpenReadStream()),
+                TotalRows = CalculateNumberOfRows(formFile.OpenReadStream()),
                 Status = DataImportStatus.QUEUED
             });
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ImportStatusBauService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ImportStatusBauService.cs
@@ -67,7 +67,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 ReleaseTitle = release.Title,
                 FileId = file.Id,
                 DataFileName = file.Filename,
-                Rows = dataImport.Rows,
+                TotalRows = dataImport.TotalRows,
                 Batches = dataImport.NumBatches,
                 Status = dataImport.Status,
                 StagePercentageComplete = dataImport.StagePercentageComplete,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataImportViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataImportViewModel.cs
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public List<string> Errors { get; set; }
         public int PercentageComplete { get; set; }
         public int StagePercentageComplete { get; set; }
-        public int NumberOfRows { get; set; }
+        public int TotalRows { get; set; }
         [JsonConverter(typeof(StringEnumConverter))]
         public DataImportStatus Status { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ImportStatusBauViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ImportStatusBauViewModel.cs
@@ -15,7 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public string ReleaseTitle { get; set; }
         public Guid FileId { get; set; }
         public string DataFileName { get; set; }
-        public int Rows { get; set; }
+        public int TotalRows { get; set; }
         public int Batches { get; set; }
         [JsonConverter(typeof(StringEnumConverter))]
         public DataImportStatus Status { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataImport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataImport.cs
@@ -45,13 +45,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Guid? ZipFileId { get; set; }
 
-        public int Rows { get; set; }
+        public int TotalRows { get; set; }
 
         public int NumBatches { get; set; }
 
         public int RowsPerBatch { get; set; }
 
-        public int TotalRows { get; set; }
+        public int ImportedRows { get; set; }
 
         public HashSet<GeographicLevel> GeographicLevels { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
@@ -119,7 +119,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             var import = new DataImport
             {
                 RowsPerBatch = 1,
-                TotalRows = 1,
+                ImportedRows = 1,
                 NumBatches = 1
             };
 
@@ -135,7 +135,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
 
             await service.Update(import.Id,
                 rowsPerBatch: 1000,
-                totalRows: 10000,
+                importedRows: 10000,
                 numBatches: 10,
                 geographicLevels: new HashSet<GeographicLevel>
                 {
@@ -148,7 +148,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 var updated = await contentDbContext.DataImports.FindAsync(import.Id);
                 Assert.NotNull(updated);
                 Assert.Equal(1000, updated.RowsPerBatch);
-                Assert.Equal(10000, updated.TotalRows);
+                Assert.Equal(10000, updated.ImportedRows);
                 Assert.Equal(10, updated.NumBatches);
 
                 Assert.Equal(2, updated.GeographicLevels.Count);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
@@ -49,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 SubjectId = Guid.NewGuid(),
                 Status = STAGE_4,
                 NumBatches = 1,
-                TotalRows = 2
+                ImportedRows = 2
             };
 
             var dataImportService = new Mock<IDataImportService>(Strict);
@@ -117,7 +117,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 SubjectId = Guid.NewGuid(),
                 Status = STAGE_4,
                 NumBatches = 2,
-                TotalRows = 2
+                ImportedRows = 2
             };
 
             var batchService = new Mock<IBatchService>(Strict);
@@ -187,7 +187,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 SubjectId = Guid.NewGuid(),
                 Status = STAGE_4,
                 NumBatches = 2,
-                TotalRows = 2
+                ImportedRows = 2
             };
 
             var batchService = new Mock<IBatchService>(Strict);
@@ -245,7 +245,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 SubjectId = Guid.NewGuid(),
                 Status = STAGE_4,
                 NumBatches = 1,
-                TotalRows = 2
+                ImportedRows = 2
             };
 
             var dataImportService = new Mock<IDataImportService>(Strict);
@@ -309,7 +309,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 SubjectId = Guid.NewGuid(),
                 Status = STAGE_4,
                 NumBatches = 1,
-                TotalRows = 3
+                ImportedRows = 3
             };
 
             var dataImportService = new Mock<IDataImportService>(Strict);
@@ -320,7 +320,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
 
             dataImportService
                 .Setup(s => s.FailImport(import.Id, 
-                    $"Number of observations inserted (2) does not equal that expected ({import.TotalRows}) : Please delete & retry"))
+                    $"Number of observations inserted (2) does not equal that expected ({import.ImportedRows}) : Please delete & retry"))
                 .Returns(Task.CompletedTask);
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -376,7 +376,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 SubjectId = Guid.NewGuid(),
                 Status = STAGE_4,
                 NumBatches = 2,
-                TotalRows = 2
+                ImportedRows = 2
             };
             
             var batchService = new Mock<IBatchService>(Strict);
@@ -446,7 +446,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 SubjectId = Guid.NewGuid(),
                 Status = STAGE_4,
                 NumBatches = 2,
-                TotalRows = 3
+                ImportedRows = 3
             };
             
             var batchService = new Mock<IBatchService>(Strict);
@@ -462,7 +462,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
 
             dataImportService
                 .Setup(s => s.FailImport(import.Id,
-                    $"Number of observations inserted (2) does not equal that expected ({import.TotalRows}) : Please delete & retry"))
+                    $"Number of observations inserted (2) does not equal that expected ({import.ImportedRows}) : Please delete & retry"))
                 .Returns(Task.CompletedTask);
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -520,7 +520,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                         SubjectId = Guid.NewGuid(),
                         Status = finishedStatus,
                         NumBatches = 1,
-                        TotalRows = 2
+                        ImportedRows = 2
                     };
 
                     var dataImportService = new Mock<IDataImportService>(Strict);
@@ -569,7 +569,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                         SubjectId = Guid.NewGuid(),
                         Status = finishedStatus,
                         NumBatches = 2,
-                        TotalRows = 2
+                        ImportedRows = 2
                     };
 
                     var dataImportService = new Mock<IDataImportService>(Strict);
@@ -618,7 +618,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                         SubjectId = Guid.NewGuid(),
                         Status = abortingStatus,
                         NumBatches = 1,
-                        TotalRows = 2
+                        ImportedRows = 2
                     };
 
                     var dataImportService = new Mock<IDataImportService>(Strict);
@@ -672,7 +672,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                         SubjectId = Guid.NewGuid(),
                         Status = abortingStatus,
                         NumBatches = 2,
-                        TotalRows = 2
+                        ImportedRows = 2
                     };
 
                     var dataImportService = new Mock<IDataImportService>(Strict);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -76,7 +76,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             return import.Status;
         }
 
-        public async Task Update(Guid id, int rowsPerBatch, int totalRows, int numBatches,
+        public async Task Update(Guid id,
+            int rowsPerBatch,
+            int importedRows,
+            int numBatches,
             HashSet<GeographicLevel> geographicLevels)
         {
             await using var contentDbContext = new ContentDbContext(_contentDbContextOptions);
@@ -84,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             contentDbContext.Update(import);
 
             import.RowsPerBatch = rowsPerBatch;
-            import.TotalRows = totalRows;
+            import.ImportedRows = importedRows;
             import.NumBatches = numBatches;
             import.GeographicLevels = geographicLevels;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -139,11 +139,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             {
                 var observationCount = context.Observation.Count(o => o.SubjectId.Equals(import.SubjectId));
 
-                if (!observationCount.Equals(import.TotalRows))
+                if (!observationCount.Equals(import.ImportedRows))
                 {
                     await _dataImportService.FailImport(message.Id,
                         $"Number of observations inserted ({observationCount}) " +
-                                $"does not equal that expected ({import.TotalRows}) : Please delete & retry");
+                                $"does not equal that expected ({import.ImportedRows}) : Please delete & retry");
                 }
                 else
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
@@ -18,7 +18,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Int
 
         Task UpdateStatus(Guid id, DataImportStatus newStatus, double percentageComplete);
 
-        Task Update(Guid id, int rowsPerBatch, int totalRows, int numBatches,
+        Task Update(Guid id,
+            int rowsPerBatch,
+            int importedRows,
+            int numBatches,
             HashSet<GeographicLevel> geographicLevels);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
@@ -56,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 {
                     await _dataImportService.Update(importId, 
                         rowsPerBatch: result.RowsPerBatch,
-                        totalRows: result.ImportableRowCount,
+                        importedRows: result.ImportableRowCount,
                         numBatches: result.NumBatches,
                         geographicLevels: result.GeographicLevels);
                 })

--- a/src/explore-education-statistics-admin/src/pages/bau/BauImportsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauImportsPage.tsx
@@ -49,7 +49,7 @@ const BauImportsPage = () => {
                   <td>{subject.status}</td>
                   <td>{subject.subjectId}</td>
                   <td>{subject.dataFileName}</td>
-                  <td>{subject.rows}</td>
+                  <td>{subject.totalRows}</td>
                   <td>{subject.batches}</td>
                   <td>{subject.stagePercentageComplete}%</td>
                   <td>{subject.percentageComplete}%</td>

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
@@ -88,7 +88,7 @@ describe('ReleaseDataFileReplacePage', () => {
       status: 'COMPLETE',
       percentageComplete: 100,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
 
     render(
@@ -137,7 +137,7 @@ describe('ReleaseDataFileReplacePage', () => {
       status: 'COMPLETE',
       percentageComplete: 100,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
     dataReplacementService.getReplacementPlan.mockResolvedValue(
       testValidReplacementPlan,
@@ -188,7 +188,7 @@ describe('ReleaseDataFileReplacePage', () => {
       status: 'COMPLETE',
       percentageComplete: 100,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
     dataReplacementService.getReplacementPlan.mockResolvedValue(
       testValidReplacementPlan,
@@ -275,7 +275,7 @@ describe('ReleaseDataFileReplacePage', () => {
       status: 'COMPLETE',
       percentageComplete: 100,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
 
     render(
@@ -348,7 +348,7 @@ describe('ReleaseDataFileReplacePage', () => {
       status: 'COMPLETE',
       percentageComplete: 100,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
     dataReplacementService.getReplacementPlan.mockResolvedValue(
       testValidReplacementPlan,
@@ -402,13 +402,13 @@ describe('ReleaseDataFileReplacePage', () => {
       status: 'COMPLETE',
       percentageComplete: 100,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
     releaseDataFileService.getDataFileImportStatus.mockResolvedValueOnce({
       status: 'STAGE_1',
       percentageComplete: 10,
       stagePercentageComplete: 100,
-      numberOfRows: 110,
+      totalRows: 110,
     });
 
     render(
@@ -457,7 +457,7 @@ describe('ReleaseDataFileReplacePage', () => {
       status: 'COMPLETE',
       percentageComplete: 100,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
     dataReplacementService.getReplacementPlan.mockRejectedValue(
       new Error('Something went wrong'),
@@ -581,7 +581,7 @@ describe('ReleaseDataFileReplacePage', () => {
       status: 'FAILED',
       percentageComplete: 0,
       stagePercentageComplete: 0,
-      numberOfRows: 0,
+      totalRows: 0,
     });
 
     render(

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
@@ -46,7 +46,7 @@ describe('ImporterStatus', () => {
       status: 'COMPLETE',
       percentageComplete: 100,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
 
     render(<ImporterStatus releaseId="release-1" dataFile={testDataFile} />);
@@ -61,7 +61,7 @@ describe('ImporterStatus', () => {
       status: 'STAGE_1',
       percentageComplete: 100,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
 
     render(
@@ -92,7 +92,7 @@ describe('ImporterStatus', () => {
       status: 'STAGE_1',
       percentageComplete: 10,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
 
     render(
@@ -124,7 +124,7 @@ describe('ImporterStatus', () => {
       status: 'STAGE_2',
       percentageComplete: 50,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
 
     jest.advanceTimersByTime(5000);
@@ -146,7 +146,7 @@ describe('ImporterStatus', () => {
       status: 'COMPLETE',
       percentageComplete: 100,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
     });
 
     jest.advanceTimersByTime(5000);
@@ -169,7 +169,7 @@ describe('ImporterStatus', () => {
       status: 'FAILED',
       percentageComplete: 0,
       stagePercentageComplete: 100,
-      numberOfRows: 100,
+      totalRows: 100,
       errors: ['Some error 1', 'Some error 2'],
     });
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -105,21 +105,21 @@ describe('ReleaseDataUploadsSection', () => {
     status: 'QUEUED',
     percentageComplete: 0,
     stagePercentageComplete: 0,
-    numberOfRows: 0,
+    totalRows: 0,
   };
 
   const testImportingImportStatus: DataFileImportStatus = {
     status: 'STAGE_1',
     percentageComplete: 0,
     stagePercentageComplete: 0,
-    numberOfRows: 0,
+    totalRows: 0,
   };
 
   const testCompleteImportStatus: DataFileImportStatus = {
     status: 'COMPLETE',
     percentageComplete: 100,
     stagePercentageComplete: 100,
-    numberOfRows: 100,
+    totalRows: 100,
   };
 
   test('renders list of uploaded data files', async () => {

--- a/src/explore-education-statistics-admin/src/services/importStatusService.ts
+++ b/src/explore-education-statistics-admin/src/services/importStatusService.ts
@@ -8,7 +8,7 @@ export interface ImportStatus {
   releaseId: string;
   releaseTitle: string;
   dataFileName: string;
-  rows: number;
+  totalRows: number;
   batches: number;
   status: number;
   stagePercentageComplete: number;

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -88,7 +88,7 @@ export interface DataFileImportStatus {
   percentageComplete: number;
   stagePercentageComplete: number;
   errors?: string[];
-  numberOfRows: number;
+  totalRows: number;
 }
 
 function mapFile({ name, ...file }: DataFileInfo): DataFile {


### PR DESCRIPTION
`DataImport` stores information about a data import. It holds transient data while an import is in progress but is also retained to display information such as the number of rows a file has.

In future it might be better if we split data files out from the `File` model to have their own table type and keep all information about a data file that needs retained together in one entity.

If the importer needs to use the database for transient data then it could continue to use `DataImport` but this would remove the need for the import data to be retained long term.

For now, this PR addresses a problem with the naming of the `DataImport` rows columns `Rows` and `TotalRows`.

It seems `Rows` is the total number of rows and `TotalRows` is the number of rows that are importable (i.e. matching allowed geographic levels) and used for validating that the import is complete.

In the majority of cases, `Rows` is one greater than `TotalRows` since it's actually the count of all lines including the header row. 

This naming has led to lots of confusion so to avoid it we do the following renaming:

1. `TotalRows` -> `ImportedRows`
2. `Rows` -> `TotalRows`

It doesn't make any other changes apart from renaming, and `ImportedRows` continues to be a field that's only used in the context of validating the import.

Even though we might expect `ImportedRows` to be shown in the UI over `TotalRows` or alongside it, this wasn't the case before and is left for a future improvement if it's required.