### PR TITLE
EES-3571 Update all DataImports without TotalRows set

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileMigrationServiceTests.cs
@@ -164,7 +164,7 @@ public class FileMigrationServiceTests
     {
         var dataFiles = new List<DataImport>
         {
-            // Files have ContentLength and ContentType and TotalRows is 0 so all should be ignored
+            // Files have ContentLength and ContentType and TotalRows is positive so all should be ignored
             new()
             {
                 File = new File
@@ -310,7 +310,7 @@ public class FileMigrationServiceTests
             },
             new()
             {
-                // Ignored as ContentLength, ContentType already migrated and TotalRows is set
+                // Ignored as ContentLength, ContentType already migrated and TotalRows is positive
                 File = new File
                 {
                     Id = Guid.NewGuid(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileMigrationServiceTests.cs
@@ -160,24 +160,203 @@ public class FileMigrationServiceTests
     }
 
     [Fact]
+    public async Task MigrateAll_MigratesDataFilesWithoutTotalRows()
+    {
+        var dataFiles = new List<DataImport>
+        {
+            // Files have ContentLength and ContentType and TotalRows is 0 so all should be ignored
+            new()
+            {
+                File = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "text/csv",
+                    ContentLength = 1024
+                },
+                MetaFile = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "text/csv",
+                    ContentLength = 1024
+                },
+                ZipFile = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "application/x-zip-compressed",
+                    ContentLength = 1024
+                },
+                TotalRows = 100
+            },
+            // Files have no ContentLength or ContentType and TotalRows is 0 so all files should be migrated
+            new()
+            {
+                File = new File
+                {
+                    Id = Guid.NewGuid()
+                },
+                MetaFile = new File
+                {
+                    Id = Guid.NewGuid()
+                },
+                ZipFile = new File
+                {
+                    Id = Guid.NewGuid()
+                },
+                TotalRows = 0
+            },
+            // Files have ContentLength and ContentType but TotalRows is 0 so the *data* file should be migrated
+            new()
+            {
+                File = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "text/csv",
+                    ContentLength = 1024
+                },
+                MetaFile = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "text/csv",
+                    ContentLength = 1024
+                },
+                ZipFile = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "application/x-zip-compressed",
+                    ContentLength = 1024
+                },
+                TotalRows = 0
+            }
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.DataImports.AddRangeAsync(dataFiles);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var storageQueueService = MockStorageQueueService(messageCount: 0);
+
+        storageQueueService.Setup(mock =>
+                mock.AddMessages(MigrateFilesQueue, new List<MigrateFileMessage>
+                {
+                    new(dataFiles[1].File.Id),
+                    new(dataFiles[1].MetaFile.Id),
+                    new(dataFiles[1].ZipFile.Id),
+                    new(dataFiles[2].File.Id)
+                }))
+            .Returns(Task.CompletedTask);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var service = SetupService(
+                contentDbContext: contentDbContext,
+                storageQueueService: storageQueueService.Object);
+
+            var result = await service.MigrateAll();
+
+            VerifyAllMocks(storageQueueService);
+
+            result.AssertRight();
+        }
+    }
+
+    [Fact]
     public async Task MigrateAll()
     {
         var files = new List<File>
         {
+            // Should be migrated
             new()
             {
-                Id = Guid.NewGuid()
+                Id = Guid.NewGuid(),
             },
-            // Ignored as already migrated
+            // Ignored as ContentLength, ContentType already migrated
             new()
             {
                 Id = Guid.NewGuid(),
                 ContentType = "application/pdf",
                 ContentLength = 1024
             },
+            // Should be migrated
             new()
             {
                 Id = Guid.NewGuid()
+            }
+        };
+
+        var dataFiles = new List<DataImport>
+        {
+            new()
+            {
+                // Should be migrated
+                File = new File
+                {
+                    Id = Guid.NewGuid()
+                },
+                // Should be migrated
+                MetaFile = new File
+                {
+                    Id = Guid.NewGuid()
+                },
+                // Should be migrated
+                ZipFile = new File
+                {
+                    Id = Guid.NewGuid()
+                },
+                TotalRows = 100
+            },
+            new()
+            {
+                // Ignored as ContentLength, ContentType already migrated and TotalRows is set
+                File = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "text/csv",
+                    ContentLength = 1024
+                },
+                // Ignored as ContentLength, ContentType already migrated
+                MetaFile = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "text/csv",
+                    ContentLength = 1024
+                },
+                // Ignored as ContentLength, ContentType already migrated
+                ZipFile = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "application/x-zip-compressed",
+                    ContentLength = 1024
+                },
+                TotalRows = 100
+            },
+            new()
+            { 
+                // Should be migrated as TotalRows is 0
+                File = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "text/csv",
+                    ContentLength = 1024
+                },
+                // Ignored as ContentLength, ContentType already migrated
+                MetaFile = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "text/csv",
+                    ContentLength = 1024
+                },
+                // Ignored as ContentLength, ContentType already migrated
+                ZipFile = new File
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "application/x-zip-compressed",
+                    ContentLength = 1024
+                },
+                TotalRows = 0
             }
         };
 
@@ -186,6 +365,7 @@ public class FileMigrationServiceTests
         await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
         {
             await contentDbContext.Files.AddRangeAsync(files);
+            await contentDbContext.DataImports.AddRangeAsync(dataFiles);
             await contentDbContext.SaveChangesAsync();
         }
 
@@ -195,7 +375,11 @@ public class FileMigrationServiceTests
                 mock.AddMessages(MigrateFilesQueue, new List<MigrateFileMessage>
                 {
                     new(files[0].Id),
-                    new(files[2].Id)
+                    new(files[2].Id),
+                    new(dataFiles[0].File.Id),
+                    new(dataFiles[0].MetaFile.Id),
+                    new(dataFiles[0].ZipFile.Id),
+                    new(dataFiles[2].File.Id)
                 }))
             .Returns(Task.CompletedTask);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -123,7 +123,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                     new FileMigrationService(
                         contentDbContext: provider.GetService<ContentDbContext>(),
                         provider.GetService<IPersistenceHelper<ContentDbContext>>(),
-                        privateBlobStorageService: GetBlobStorageService(provider, "CoreStorage")
+                        privateBlobStorageService: GetBlobStorageService(provider, "CoreStorage"),
+                        logger: provider.GetRequiredService<ILogger<FileMigrationService>>()
                     ));
 
             AddPersistenceHelper<ContentDbContext>(builder.Services);


### PR DESCRIPTION
⚠️ Has deploy task EES-3549

This PR makes an update to the files migration introduced by EES-3547 in https://github.com/dfe-analytical-services/explore-education-statistics/pull/3389 which will be run by EES-3549.

It's already been run but is re-runnable so it can be used at any time to 'catch-up' with new files that don't yet have `ContentLength` or `ContentType` values.

This PR updates it so that it will also queue messages for data file id's if the `DataImport` doesn't have a positive value for `TotalRows`. When processing each data file it will now retrieve the `DataImport` and set `TotalRows` if necessary.

This update seems to be necessary for all data files that were originally uploaded as zip files. The value was not being set when creating the `DataImport` and wasn't updated even after the data file was extracted and processed. This issue is fixed in future by EES-3529  in https://github.com/dfe-analytical-services/explore-education-statistics/pull/3387.