### PR TITLE
EES-3224 publication details page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -180,7 +180,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "Test theme",
                 Slug = "test-theme",
-                Summary = "Test summary"
+                Summary = "Test summary",
+                Topics = new List<Topic>
+                {
+                    new()
+                    {
+                        Title = "Test topic 1",
+                        Slug = "test-topic-1"
+                    },
+                    new()
+                    {
+                        Title = "Test topic 2",
+                        Slug = "test-topic-2",
+                    }
+                }
+            };
+
+            // This topic should not be included with
+            // the theme as it is unrelated.
+            var unrelatedTopic = new Topic
+            {
+                Title = "Unrelated topic",
+                Slug = "unrelated-topic"
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -188,6 +209,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 context.Add(theme);
+                context.Add(unrelatedTopic);
 
                 await context.SaveChangesAsync();
             }
@@ -197,11 +219,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var service = SetupThemeService(context);
                 var result = await service.GetTheme(theme.Id);
 
-                result.AssertRight();
-                Assert.Equal(theme.Id, result.Right.Id);
-                Assert.Equal("Test theme", result.Right.Title);
-                Assert.Equal("test-theme", result.Right.Slug);
-                Assert.Equal("Test summary", result.Right.Summary);
+                var viewModel = result.AssertRight();
+                Assert.Equal(theme.Id, viewModel.Id);
+                Assert.Equal("Test theme", viewModel.Title);
+                Assert.Equal("test-theme", viewModel.Slug);
+                Assert.Equal("Test summary", viewModel.Summary);
+                
+                Assert.Equal(2, theme.Topics.Count);
+                Assert.Equal("Test topic 1", theme.Topics[0].Title);
+                Assert.Equal("test-topic-1", theme.Topics[0].Slug);
+                
+                Assert.Equal("Test topic 2", theme.Topics[1].Title);
+                Assert.Equal("test-topic-2", theme.Topics[1].Slug);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -109,7 +109,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, ThemeViewModel>> GetTheme(Guid id)
         {
             return await _persistenceHelper
-                .CheckEntityExists<Theme>(id)
+                .CheckEntityExists<Theme>(id, q => 
+                    q.Include(t => t.Topics))
                 .OnSuccessDo(_userService.CheckCanManageAllTaxonomy)
                 .OnSuccess(_mapper.Map<ThemeViewModel>);
         }

--- a/src/explore-education-statistics-admin/src/components/form/FormThemeTopicSelect.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/FormThemeTopicSelect.tsx
@@ -10,6 +10,7 @@ export interface FormThemeTopicSelectProps {
   error?: string;
   id: string;
   hint?: string;
+  inline?: boolean;
   legend: string;
   legendHidden?: FormFieldsetProps['legendHidden'];
   legendSize?: FormFieldsetProps['legendSize'];
@@ -22,8 +23,9 @@ export interface FormThemeTopicSelectProps {
 
 const FormThemeTopicSelect = ({
   error,
-  id,
   hint,
+  id,
+  inline = true,
   legend,
   legendHidden,
   legendSize,
@@ -50,13 +52,17 @@ const FormThemeTopicSelect = ({
       legendHidden={legendHidden}
       legendSize={legendSize}
     >
-      <div className="dfe-flex dfe-flex-wrap">
-        <div className="govuk-!-margin-right-4">
+      <div className={inline ? 'dfe-flex dfe-flex-wrap' : ''}>
+        <div
+          className={
+            inline ? 'govuk-!-margin-right-4' : 'govuk-!-margin-bottom-6'
+          }
+        >
           <FormSelect
             id={`${id}-themeId`}
             label="Select theme"
             name={themeInputName}
-            className={styles.select}
+            className={inline ? styles.select : 'govuk-!-width-one-half'}
             value={selectedTheme?.id}
             options={themes.map(theme => ({
               label: theme.title,
@@ -91,7 +97,7 @@ const FormThemeTopicSelect = ({
             id={`${id}-topicId`}
             label="Select topic"
             name={topicInputName}
-            className={styles.select}
+            className={inline ? styles.select : 'govuk-!-width-one-half'}
             value={topicId}
             options={
               selectedTheme?.topics.map(topic => ({

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -62,12 +62,7 @@ const MethodologySummary = ({
   const handleRemoveExternalMethodology = async () => {
     const updatedPublication = {
       title,
-      contact: {
-        contactName: contact?.contactName ?? '',
-        contactTelNo: contact?.contactTelNo ?? '',
-        teamEmail: contact?.teamEmail ?? '',
-        teamName: contact?.teamName ?? '',
-      },
+      contact,
       topicId,
     };
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -905,12 +905,7 @@ describe('MethodologySummary', () => {
 
       const updatedPublication: UpdatePublicationRequest = {
         title: testPublicationWithExternalMethodology.title,
-        contact: {
-          contactName: testContact.contactName,
-          contactTelNo: testContact.contactTelNo,
-          teamEmail: testContact.teamEmail,
-          teamName: testContact.teamName,
-        },
+        contact: testContact,
         topicId: testTopicId,
       };
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
@@ -40,7 +40,7 @@ describe('PublicationSummary', () => {
   const testPublication: MyPublication = {
     id: 'publication-1',
     title: 'Publication 1',
-    contact: undefined,
+    contact: testContact,
     releases: [],
     legacyReleases: [],
     methodologies: [],
@@ -143,7 +143,7 @@ describe('PublicationSummary', () => {
     releaseService.getReleaseStatus.mockResolvedValue(completeReleaseStatus);
   });
 
-  test('renders correctly with a publication with no releases, methodologies, contact details or permissions', async () => {
+  test('renders correctly with a publication with no releases, methodologies or permissions', async () => {
     render(
       <MemoryRouter>
         <PublicationSummary
@@ -153,9 +153,6 @@ describe('PublicationSummary', () => {
         />
       </MemoryRouter>,
     );
-
-    expect(screen.getByText('No team name')).toBeInTheDocument();
-    expect(screen.getByText('No contact name')).toBeInTheDocument();
 
     expect(screen.getByText('No releases created')).toBeInTheDocument();
 
@@ -186,7 +183,7 @@ describe('PublicationSummary', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('renders correctly with team and contact details', async () => {
+  test('renders contact details correctly', async () => {
     render(
       <MemoryRouter>
         <PublicationSummary

--- a/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/ExternalMethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/ExternalMethodologyPage.tsx
@@ -30,12 +30,7 @@ const ExternalMethodologyPage = ({
     }
     const updatedPublication: UpdatePublicationRequest = {
       title: publication.title,
-      contact: {
-        contactName: publication.contact?.contactName ?? '',
-        contactTelNo: publication.contact?.contactTelNo ?? '',
-        teamEmail: publication.contact?.teamEmail ?? '',
-        teamName: publication.contact?.teamName ?? '',
-      },
+      contact: publication.contact,
       topicId: publication.topicId,
       externalMethodology: {
         title: values.title,

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
@@ -1,0 +1,108 @@
+import PublicationDetailsForm, {
+  FormValues,
+} from '@admin/pages/publication/components/PublicationDetailsForm';
+import usePublicationContext from '@admin/pages/publication/contexts/PublicationContext';
+import publicationService from '@admin/services/publicationService';
+import themeService from '@admin/services/themeService';
+import Button from '@common/components/Button';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import SummaryList from '@common/components/SummaryList';
+import SummaryListItem from '@common/components/SummaryListItem';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import useToggle from '@common/hooks/useToggle';
+import React from 'react';
+
+const PublicationDetailsPage = () => {
+  const { publication, onReload } = usePublicationContext();
+  const {
+    contact,
+    id,
+    permissions,
+    supersededById,
+    themeId,
+    title,
+    topicId,
+  } = publication;
+  const [readOnly, toggleReadOnly] = useToggle(true);
+
+  const { value, isLoading } = useAsyncHandledRetry(async () => {
+    const themes = await themeService.getThemes();
+    if (!supersededById && !permissions.canUpdatePublicationSupersededBy) {
+      return { themes };
+    }
+
+    const allPublications = await publicationService.getPublicationSummaries();
+    const publications = allPublications.filter(pub => pub.id !== id);
+
+    return {
+      themes,
+      publications,
+    };
+  });
+
+  const { themes, publications } = value ?? {};
+
+  const currentTheme = themes?.find(theme => theme.id === themeId);
+  const currentTopic = currentTheme?.topics.find(topic => topic.id === topicId);
+  const currentSupersededByPublication = publications?.find(
+    pub => pub.id === supersededById,
+  );
+
+  const handleSubmit = async (values: FormValues) => {
+    await publicationService.updatePublication(publication.id, {
+      ...values,
+      contact: {
+        teamName: contact?.teamName ?? '',
+        teamEmail: contact?.teamEmail ?? '',
+        contactName: contact?.contactName ?? '',
+        contactTelNo: contact?.contactTelNo ?? '',
+      },
+    });
+    onReload();
+  };
+
+  return (
+    <LoadingSpinner loading={isLoading}>
+      {readOnly ? (
+        <>
+          <h2>Publication details</h2>
+          <SummaryList>
+            <SummaryListItem term="Publication title">{title}</SummaryListItem>
+            <SummaryListItem term="Theme">
+              {currentTheme?.title}
+            </SummaryListItem>
+            <SummaryListItem term="Topic">
+              {currentTopic?.title}
+            </SummaryListItem>
+            <SummaryListItem term="Superseding publication">
+              {supersededById
+                ? currentSupersededByPublication?.title
+                : 'This publication is not archived'}
+            </SummaryListItem>
+          </SummaryList>
+          <Button variant="secondary" onClick={toggleReadOnly.off}>
+            Edit publication details
+          </Button>
+        </>
+      ) : (
+        <PublicationDetailsForm
+          canUpdatePublicationSupersededBy={
+            permissions.canUpdatePublicationSupersededBy
+          }
+          canUpdatePublicationTitle={permissions.canUpdatePublicationTitle}
+          initialValues={{
+            supersededById,
+            title,
+            topicId,
+          }}
+          publications={publications}
+          themes={themes}
+          onCancel={toggleReadOnly.on}
+          onSubmit={handleSubmit}
+        />
+      )}
+    </LoadingSpinner>
+  );
+};
+
+export default PublicationDetailsPage;

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
@@ -1,5 +1,5 @@
 import PublicationDetailsForm, {
-  FormValues,
+  PublicationDetailsFormValues,
 } from '@admin/pages/publication/components/PublicationDetailsForm';
 import usePublicationContext from '@admin/pages/publication/contexts/PublicationContext';
 import publicationService from '@admin/services/publicationService';
@@ -27,23 +27,23 @@ const PublicationDetailsPage = () => {
 
   const { value, isLoading } = useAsyncHandledRetry(async () => {
     const theme = await themeService.getTheme(themeId);
+    const topic = theme?.topics.find(themeTopic => themeTopic.id === topicId);
     if (!supersededById) {
-      return { theme };
+      return { theme, topic };
     }
 
     const supersedingPublication = await publicationService.getPublication(id);
 
     return {
       theme,
+      topic,
       supersedingPublication,
     };
   });
 
-  const { theme, supersedingPublication } = value ?? {};
+  const { theme, topic, supersedingPublication } = value ?? {};
 
-  const topic = theme?.topics.find(themeTopic => themeTopic.id === topicId);
-
-  const handleSubmit = async (values: FormValues) => {
+  const handleSubmit = async (values: PublicationDetailsFormValues) => {
     await publicationService.updatePublication(publication.id, {
       ...values,
       contact,

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationEditPage.tsx
@@ -73,10 +73,10 @@ const PublicationEditPage = ({
             initialValues={{
               title: publication.title,
               topicId: publication.topicId,
-              teamName: contact?.teamName ?? '',
-              teamEmail: contact?.teamEmail ?? '',
-              contactName: contact?.contactName ?? '',
-              contactTelNo: contact?.contactTelNo ?? '',
+              teamName: contact.teamName,
+              teamEmail: contact.teamEmail,
+              contactName: contact.contactName,
+              contactTelNo: contact.contactTelNo,
               supersededById: publication.supersededById,
             }}
             onSubmit={async ({

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
@@ -76,7 +76,7 @@ const PublicationPageContainer = ({
                 publicationId,
               }),
             }))}
-            label="Release"
+            label="Publication"
           />
 
           <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
@@ -4,17 +4,19 @@ import Page from '@admin/components/Page';
 import PageTitle from '@admin/components/PageTitle';
 import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
 import {
+  publicationDetailsRoute,
   publicationReleasesRoute,
   PublicationRouteParams,
 } from '@admin/routes/publicationRoutes';
 import publicationService from '@admin/services/publicationService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import RelatedInformation from '@common/components/RelatedInformation';
+import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React from 'react';
 import { generatePath, Route, RouteComponentProps, Switch } from 'react-router';
 
-const navRoutes = [publicationReleasesRoute];
+const navRoutes = [publicationReleasesRoute, publicationDetailsRoute];
 
 const routes = [...navRoutes];
 
@@ -41,6 +43,17 @@ const PublicationPageContainer = ({
                 title={publication.title}
                 caption="Manage publication"
               />
+              {publication.isSuperseded && (
+                <WarningMessage className="govuk-!-margin-bottom-0">
+                  This publication is archived.
+                </WarningMessage>
+              )}
+              {publication.supersededById && !publication.isSuperseded && (
+                <WarningMessage className="govuk-!-margin-bottom-0">
+                  This publication will be archived when its superseding
+                  publication has a live release published.
+                </WarningMessage>
+              )}
             </div>
 
             <div className="govuk-grid-column-one-third">

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
@@ -154,241 +154,250 @@ describe('PublicationDetailsPage', () => {
     );
   });
 
-  test('shows the form when the edit button is clicked', async () => {
-    renderPage(testPublication);
+  describe('details form', () => {
+    test('shows the form when the edit button is clicked', async () => {
+      renderPage(testPublication);
 
-    await waitFor(() => {
-      expect(screen.getByText('Publication details')).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(screen.getByText('Publication details')).toBeInTheDocument();
+      });
 
-    userEvent.click(
-      screen.getByRole('button', { name: 'Edit publication details' }),
-    );
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit publication details' }),
+      );
 
-    await waitFor(() => {
-      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+      });
 
-    expect(screen.getByLabelText('Publication title')).toHaveValue(
-      'Publication 1',
-    );
+      expect(screen.getByLabelText('Publication title')).toHaveValue(
+        'Publication 1',
+      );
 
-    const themeSelect = screen.getByLabelText('Select theme');
-    expect(themeSelect).toHaveValue('theme-1');
-    const themes = within(themeSelect).getAllByRole('option');
-    expect(themes).toHaveLength(2);
-    expect(themes[0]).toHaveTextContent('Theme 1');
-    expect(themes[0]).toHaveValue('theme-1');
-    expect(themes[1]).toHaveTextContent('Theme 2');
-    expect(themes[1]).toHaveValue('theme-2');
+      const themeSelect = screen.getByLabelText('Select theme');
+      expect(themeSelect).toHaveValue('theme-1');
+      const themes = within(themeSelect).getAllByRole('option');
+      expect(themes).toHaveLength(2);
+      expect(themes[0]).toHaveTextContent('Theme 1');
+      expect(themes[0]).toHaveValue('theme-1');
+      expect(themes[1]).toHaveTextContent('Theme 2');
+      expect(themes[1]).toHaveValue('theme-2');
 
-    const topicSelect = screen.getByLabelText('Select topic');
-    expect(topicSelect).toHaveValue('theme-1-topic-2');
-    const topics = within(topicSelect).getAllByRole('option');
-    expect(topics).toHaveLength(2);
-    expect(topics[0]).toHaveTextContent('Theme 1 Topic 1');
-    expect(topics[0]).toHaveValue('theme-1-topic-1');
-    expect(topics[1]).toHaveTextContent('Theme 1 Topic 2');
-    expect(topics[1]).toHaveValue('theme-1-topic-2');
+      const topicSelect = screen.getByLabelText('Select topic');
+      expect(topicSelect).toHaveValue('theme-1-topic-2');
+      const topics = within(topicSelect).getAllByRole('option');
+      expect(topics).toHaveLength(2);
+      expect(topics[0]).toHaveTextContent('Theme 1 Topic 1');
+      expect(topics[0]).toHaveValue('theme-1-topic-1');
+      expect(topics[1]).toHaveTextContent('Theme 1 Topic 2');
+      expect(topics[1]).toHaveValue('theme-1-topic-2');
 
-    const supersedingPublicationSelect = screen.getByLabelText(
-      'Superseding publication',
-    );
-    expect(supersedingPublicationSelect).toHaveValue('');
-    const supersedingPublications = within(
-      supersedingPublicationSelect,
-    ).getAllByRole('option');
-    expect(supersedingPublications).toHaveLength(3);
-    expect(supersedingPublications[0]).toHaveTextContent('None selected');
-    expect(supersedingPublications[0]).toHaveValue('');
-    expect(supersedingPublications[1]).toHaveTextContent('Publication 2');
-    expect(supersedingPublications[1]).toHaveValue('publication-2');
-    expect(supersedingPublications[2]).toHaveTextContent('Publication 3');
-    expect(supersedingPublications[2]).toHaveValue('publication-3');
+      const supersedingPublicationSelect = screen.getByLabelText(
+        'Superseding publication',
+      );
+      expect(supersedingPublicationSelect).toHaveValue('');
+      const supersedingPublications = within(
+        supersedingPublicationSelect,
+      ).getAllByRole('option');
+      expect(supersedingPublications).toHaveLength(3);
+      expect(supersedingPublications[0]).toHaveTextContent('None selected');
+      expect(supersedingPublications[0]).toHaveValue('');
+      expect(supersedingPublications[1]).toHaveTextContent('Publication 2');
+      expect(supersedingPublications[1]).toHaveValue('publication-2');
+      expect(supersedingPublications[2]).toHaveTextContent('Publication 3');
+      expect(supersedingPublications[2]).toHaveValue('publication-3');
 
-    expect(
-      screen.getByRole('button', { name: 'Update publication details' }),
-    ).toBeInTheDocument();
-
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-  });
-
-  test('updates the topics dropdown when change the theme', async () => {
-    renderPage(testPublication);
-
-    await waitFor(() => {
-      expect(screen.getByText('Publication details')).toBeInTheDocument();
-    });
-
-    userEvent.click(
-      screen.getByRole('button', { name: 'Edit publication details' }),
-    );
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
-    });
-
-    const topics = within(screen.getByLabelText('Select topic')).getAllByRole(
-      'option',
-    );
-    expect(topics).toHaveLength(2);
-
-    expect(topics[0]).toHaveTextContent('Theme 1 Topic 1');
-    expect(topics[0]).toHaveValue('theme-1-topic-1');
-    expect(topics[1]).toHaveTextContent('Theme 1 Topic 2');
-    expect(topics[1]).toHaveValue('theme-1-topic-2');
-
-    userEvent.selectOptions(screen.getByLabelText('Select theme'), ['theme-2']);
-
-    const updatedTopics = within(
-      screen.getByLabelText('Select topic'),
-    ).getAllByRole('option');
-
-    expect(updatedTopics[0]).toHaveTextContent('Theme 2 Topic 1');
-    expect(updatedTopics[0]).toHaveValue('theme-2-topic-1');
-    expect(updatedTopics[1]).toHaveTextContent('Theme 2 Topic 2');
-    expect(updatedTopics[1]).toHaveValue('theme-2-topic-2');
-  });
-
-  test('clicking the cancel button switches back to readOnly view', async () => {
-    renderPage(testPublication);
-
-    await waitFor(() => {
-      expect(screen.getByText('Publication details')).toBeInTheDocument();
-    });
-
-    userEvent.click(
-      screen.getByRole('button', { name: 'Edit publication details' }),
-    );
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
-    });
-
-    expect(screen.getByLabelText('Publication title')).toHaveValue(
-      'Publication 1',
-    );
-
-    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-
-    expect(screen.getByTestId('Publication title')).toHaveTextContent(
-      'Publication 1',
-    );
-
-    expect(
-      screen.queryByLabelText('Publication title'),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Theme')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Topic')).not.toBeInTheDocument();
-    expect(
-      screen.queryByLabelText('Superseding publication'),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Update publication details' }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Cancel' }),
-    ).not.toBeInTheDocument();
-  });
-
-  test('shows validation errors when there is no title', async () => {
-    renderPage(testPublication);
-
-    await waitFor(() => {
-      expect(screen.getByText('Publication details')).toBeInTheDocument();
-    });
-
-    userEvent.click(
-      screen.getByRole('button', { name: 'Edit publication details' }),
-    );
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
-    });
-
-    userEvent.clear(screen.getByLabelText('Publication title'));
-    userEvent.tab();
-
-    await waitFor(() => {
       expect(
-        screen.getByText('Enter a title', {
-          selector: '#publicationDetailsForm-title-error',
-        }),
+        screen.getByRole('button', { name: 'Update publication details' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', { name: 'Cancel' }),
       ).toBeInTheDocument();
     });
-  });
 
-  test('shows a confirmation modal on submit', async () => {
-    renderPage(testPublication);
+    test('updates the topics dropdown when change the theme', async () => {
+      renderPage(testPublication);
 
-    await waitFor(() => {
-      expect(screen.getByText('Publication details')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('Publication details')).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit publication details' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+      });
+
+      const topics = within(screen.getByLabelText('Select topic')).getAllByRole(
+        'option',
+      );
+      expect(topics).toHaveLength(2);
+
+      expect(topics[0]).toHaveTextContent('Theme 1 Topic 1');
+      expect(topics[0]).toHaveValue('theme-1-topic-1');
+      expect(topics[1]).toHaveTextContent('Theme 1 Topic 2');
+      expect(topics[1]).toHaveValue('theme-1-topic-2');
+
+      userEvent.selectOptions(screen.getByLabelText('Select theme'), [
+        'theme-2',
+      ]);
+
+      const updatedTopics = within(
+        screen.getByLabelText('Select topic'),
+      ).getAllByRole('option');
+      expect(updatedTopics).toHaveLength(2);
+
+      expect(updatedTopics[0]).toHaveTextContent('Theme 2 Topic 1');
+      expect(updatedTopics[0]).toHaveValue('theme-2-topic-1');
+      expect(updatedTopics[1]).toHaveTextContent('Theme 2 Topic 2');
+      expect(updatedTopics[1]).toHaveValue('theme-2-topic-2');
     });
 
-    userEvent.click(
-      screen.getByRole('button', { name: 'Edit publication details' }),
-    );
+    test('clicking the cancel button switches back to readOnly view', async () => {
+      renderPage(testPublication);
 
-    await waitFor(() => {
-      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('Publication details')).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit publication details' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText('Publication title')).toHaveValue(
+        'Publication 1',
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(screen.getByTestId('Publication title')).toHaveTextContent(
+        'Publication 1',
+      );
+
+      expect(
+        screen.queryByLabelText('Publication title'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Theme')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Topic')).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText('Superseding publication'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Update publication details' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Cancel' }),
+      ).not.toBeInTheDocument();
     });
 
-    expect(publicationService.updatePublication).not.toHaveBeenCalled();
+    test('shows validation errors when there is no title', async () => {
+      renderPage(testPublication);
 
-    userEvent.click(
-      screen.getByRole('button', { name: 'Update publication details' }),
-    );
+      await waitFor(() => {
+        expect(screen.getByText('Publication details')).toBeInTheDocument();
+      });
 
-    const modal = within(screen.getByRole('dialog'));
-    expect(modal.getByRole('heading')).toHaveTextContent(
-      'Confirm publication changes',
-    );
-    userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-  });
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit publication details' }),
+      );
 
-  test('successfullly submits with updated values', async () => {
-    renderPage(testPublication);
+      await waitFor(() => {
+        expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+      });
 
-    await waitFor(() => {
-      expect(screen.getByText('Publication details')).toBeInTheDocument();
+      userEvent.clear(screen.getByLabelText('Publication title'));
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Enter a title', {
+            selector: '#publicationDetailsForm-title-error',
+          }),
+        ).toBeInTheDocument();
+      });
     });
 
-    userEvent.click(
-      screen.getByRole('button', { name: 'Edit publication details' }),
-    );
+    test('shows a confirmation modal on submit', async () => {
+      renderPage(testPublication);
 
-    await waitFor(() => {
-      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('Publication details')).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit publication details' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+      });
+
+      expect(publicationService.updatePublication).not.toHaveBeenCalled();
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Update publication details' }),
+      );
+
+      const modal = within(screen.getByRole('dialog'));
+      expect(modal.getByRole('heading')).toHaveTextContent(
+        'Confirm publication changes',
+      );
+      userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
     });
 
-    userEvent.type(screen.getByLabelText('Publication title'), ' updated');
+    test('successfullly submits with updated values', async () => {
+      renderPage(testPublication);
 
-    userEvent.selectOptions(screen.getByLabelText('Select theme'), ['theme-2']);
+      await waitFor(() => {
+        expect(screen.getByText('Publication details')).toBeInTheDocument();
+      });
 
-    userEvent.selectOptions(screen.getByLabelText('Select topic'), [
-      'theme-2-topic-2',
-    ]);
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit publication details' }),
+      );
 
-    userEvent.selectOptions(screen.getByLabelText('Superseding publication'), [
-      'publication-2',
-    ]);
+      await waitFor(() => {
+        expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+      });
 
-    userEvent.click(
-      screen.getByRole('button', { name: 'Update publication details' }),
-    );
+      userEvent.type(screen.getByLabelText('Publication title'), ' updated');
 
-    userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+      userEvent.selectOptions(screen.getByLabelText('Select theme'), [
+        'theme-2',
+      ]);
 
-    await waitFor(() => {
-      expect(publicationService.updatePublication).toHaveBeenCalledWith(
-        testPublication.id,
-        {
+      userEvent.selectOptions(screen.getByLabelText('Select topic'), [
+        'theme-2-topic-2',
+      ]);
+
+      userEvent.selectOptions(
+        screen.getByLabelText('Superseding publication'),
+        ['publication-2'],
+      );
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Update publication details' }),
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => {
+        expect(publicationService.updatePublication).toHaveBeenCalledWith<
+          Parameters<typeof publicationService.updatePublication>
+        >(testPublication.id, {
           contact: testContact,
           supersededById: 'publication-2',
           title: 'Publication 1 updated',
           topicId: 'theme-2-topic-2',
-        },
-      );
+        });
+      });
     });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
@@ -1,0 +1,384 @@
+import PublicationDetailsPage from '@admin/pages/publication/PublicationDetailsPage';
+import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
+import _publicationService, {
+  MyPublication,
+  PublicationContactDetails,
+} from '@admin/services/publicationService';
+import _themeService, { Theme } from '@admin/services/themeService';
+import { PublicationSummary } from '@common/services/publicationService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import noop from 'lodash/noop';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@admin/services/themeService');
+const themeService = _themeService as jest.Mocked<typeof _themeService>;
+
+jest.mock('@admin/services/publicationService');
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+
+describe('PublicationDetailsPage', () => {
+  const testContact: PublicationContactDetails = {
+    contactName: 'John Smith',
+    contactTelNo: '0777777777',
+    id: 'contact-id-1',
+    teamEmail: 'john.smith@test.com',
+    teamName: 'Team Smith',
+  };
+
+  const testPublication: MyPublication = {
+    id: 'publication-1',
+    title: 'Publication 1',
+    contact: testContact,
+    releases: [],
+    legacyReleases: [],
+    methodologies: [],
+    themeId: 'theme-1',
+    topicId: 'theme-1-topic-2',
+    permissions: {
+      canAdoptMethodologies: true,
+      canCreateReleases: true,
+      canUpdatePublication: true,
+      canUpdatePublicationTitle: true,
+      canUpdatePublicationSupersededBy: true,
+      canCreateMethodologies: true,
+      canManageExternalMethodology: true,
+    },
+  };
+
+  const testThemes: Theme[] = [
+    {
+      id: 'theme-1',
+      slug: 'theme-1-slug',
+      summary: '',
+      title: 'Theme 1',
+      topics: [
+        {
+          id: 'theme-1-topic-1',
+          slug: 'theme-1-topic-1-slug',
+          themeId: 'theme-1',
+          title: 'Theme 1 Topic 1',
+        },
+        {
+          id: 'theme-1-topic-2',
+          slug: 'theme-1-topic-2-slug',
+          themeId: 'theme-1',
+          title: 'Theme 1 Topic 2',
+        },
+      ],
+    },
+    {
+      id: 'theme-2',
+      slug: 'theme-2-slug',
+      summary: '',
+      title: 'Theme 2',
+      topics: [
+        {
+          id: 'theme-2-topic-1',
+          slug: 'theme-2-topic-1-slug',
+          themeId: 'theme-2',
+          title: 'Theme 2 Topic 1',
+        },
+        {
+          id: 'theme-2-topic-2',
+          slug: 'theme-2-topic-2-slug',
+          themeId: 'theme-2',
+          title: 'Theme 2 Topic 2',
+        },
+      ],
+    },
+  ];
+
+  const testPublicationSummaries: PublicationSummary[] = [
+    {
+      id: 'publication-1',
+      slug: 'publication-1-slug',
+      title: 'Publication 1',
+    },
+    {
+      id: 'publication-2',
+      slug: 'publication-2-slug',
+      title: 'Publication 2',
+    },
+    {
+      id: 'publication-3',
+      slug: 'publication-3-slug',
+      title: 'Publication 3',
+    },
+  ];
+
+  beforeEach(() => {
+    themeService.getThemes.mockResolvedValue(testThemes);
+    publicationService.getPublicationSummaries.mockResolvedValue(
+      testPublicationSummaries,
+    );
+  });
+
+  test('renders the read only page correctly', async () => {
+    renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(screen.getByText('Publication details')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('Publication title')).toHaveTextContent(
+      'Publication 1',
+    );
+    expect(screen.getByTestId('Theme')).toHaveTextContent('Theme 1');
+    expect(screen.getByTestId('Topic')).toHaveTextContent('Theme 1 Topic 2');
+    expect(screen.getByTestId('Superseding publication')).toHaveTextContent(
+      'This publication is not archived',
+    );
+    expect(
+      screen.getByRole('button', { name: 'Edit publication details' }),
+    ).toBeInTheDocument();
+  });
+
+  test('shows the superseding publication if the publication is archived', async () => {
+    renderPage({ ...testPublication, supersededById: 'publication-2' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Publication details')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('Superseding publication')).toHaveTextContent(
+      'Publication 2',
+    );
+  });
+
+  test('shows the form when the edit button is clicked', async () => {
+    renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(screen.getByText('Publication details')).toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit publication details' }),
+    );
+
+    expect(screen.getByLabelText('Publication title')).toHaveValue(
+      'Publication 1',
+    );
+
+    const themeSelect = screen.getByLabelText('Select theme');
+    expect(themeSelect).toHaveValue('theme-1');
+    const themes = within(themeSelect).getAllByRole('option');
+    expect(themes).toHaveLength(2);
+    expect(themes[0]).toHaveTextContent('Theme 1');
+    expect(themes[0]).toHaveValue('theme-1');
+    expect(themes[1]).toHaveTextContent('Theme 2');
+    expect(themes[1]).toHaveValue('theme-2');
+
+    const topicSelect = screen.getByLabelText('Select topic');
+    expect(topicSelect).toHaveValue('theme-1-topic-2');
+    const topics = within(topicSelect).getAllByRole('option');
+    expect(topics).toHaveLength(2);
+    expect(topics[0]).toHaveTextContent('Theme 1 Topic 1');
+    expect(topics[0]).toHaveValue('theme-1-topic-1');
+    expect(topics[1]).toHaveTextContent('Theme 1 Topic 2');
+    expect(topics[1]).toHaveValue('theme-1-topic-2');
+
+    const supersedingPublicationSelect = screen.getByLabelText(
+      'Superseding publication',
+    );
+    expect(supersedingPublicationSelect).toHaveValue('');
+    const supersedingPublications = within(
+      supersedingPublicationSelect,
+    ).getAllByRole('option');
+    expect(supersedingPublications).toHaveLength(3);
+    expect(supersedingPublications[0]).toHaveTextContent('None selected');
+    expect(supersedingPublications[0]).toHaveValue('');
+    expect(supersedingPublications[1]).toHaveTextContent('Publication 2');
+    expect(supersedingPublications[1]).toHaveValue('publication-2');
+    expect(supersedingPublications[2]).toHaveTextContent('Publication 3');
+    expect(supersedingPublications[2]).toHaveValue('publication-3');
+
+    expect(
+      screen.getByRole('button', { name: 'Update publication details' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  test('updates the topics dropdown when change the theme', async () => {
+    renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(screen.getByText('Publication details')).toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit publication details' }),
+    );
+
+    const topics = within(screen.getByLabelText('Select topic')).getAllByRole(
+      'option',
+    );
+    expect(topics).toHaveLength(2);
+
+    expect(topics[0]).toHaveTextContent('Theme 1 Topic 1');
+    expect(topics[0]).toHaveValue('theme-1-topic-1');
+    expect(topics[1]).toHaveTextContent('Theme 1 Topic 2');
+    expect(topics[1]).toHaveValue('theme-1-topic-2');
+
+    userEvent.selectOptions(screen.getByLabelText('Select theme'), ['theme-2']);
+
+    const updatedTopics = within(
+      screen.getByLabelText('Select topic'),
+    ).getAllByRole('option');
+
+    expect(updatedTopics[0]).toHaveTextContent('Theme 2 Topic 1');
+    expect(updatedTopics[0]).toHaveValue('theme-2-topic-1');
+    expect(updatedTopics[1]).toHaveTextContent('Theme 2 Topic 2');
+    expect(updatedTopics[1]).toHaveValue('theme-2-topic-2');
+  });
+
+  test('clicking the cancel button switches back to readOnly view', async () => {
+    renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(screen.getByText('Publication details')).toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit publication details' }),
+    );
+
+    expect(screen.getByLabelText('Publication title')).toHaveValue(
+      'Publication 1',
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByTestId('Publication title')).toHaveTextContent(
+      'Publication 1',
+    );
+
+    expect(
+      screen.queryByLabelText('Publication title'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Theme')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Topic')).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Superseding publication'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Update publication details' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows validation errors when there is no title', async () => {
+    renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(screen.getByText('Publication details')).toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit publication details' }),
+    );
+
+    userEvent.clear(screen.getByLabelText('Publication title'));
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Enter a title', {
+          selector: '#publicationDetailsForm-title-error',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows a confirmation modal on submit', async () => {
+    renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(screen.getByText('Publication details')).toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit publication details' }),
+    );
+
+    expect(publicationService.updatePublication).not.toHaveBeenCalled();
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Update publication details' }),
+    );
+
+    const modal = within(screen.getByRole('dialog'));
+    expect(modal.getByRole('heading')).toHaveTextContent(
+      'Confirm publication changes',
+    );
+    userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+  });
+
+  test('successfullly submits with updated values', async () => {
+    renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(screen.getByText('Publication details')).toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit publication details' }),
+    );
+
+    userEvent.type(screen.getByLabelText('Publication title'), ' updated');
+
+    userEvent.selectOptions(screen.getByLabelText('Select theme'), ['theme-2']);
+
+    userEvent.selectOptions(screen.getByLabelText('Select topic'), [
+      'theme-2-topic-2',
+    ]);
+
+    userEvent.selectOptions(screen.getByLabelText('Superseding publication'), [
+      'publication-2',
+    ]);
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Update publication details' }),
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(publicationService.updatePublication).toHaveBeenCalledWith(
+        testPublication.id,
+        {
+          contact: {
+            contactName: 'John Smith',
+            contactTelNo: '0777777777',
+            teamEmail: 'john.smith@test.com',
+            teamName: 'Team Smith',
+          },
+          supersededById: 'publication-2',
+          title: 'Publication 1 updated',
+          topicId: 'theme-2-topic-2',
+        },
+      );
+    });
+  });
+});
+
+function renderPage(publication: MyPublication) {
+  render(
+    <MemoryRouter>
+      <PublicationContextProvider
+        publication={publication}
+        onPublicationChange={noop}
+        onReload={noop}
+      >
+        <PublicationDetailsPage />
+      </PublicationContextProvider>
+    </MemoryRouter>,
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
@@ -1,6 +1,7 @@
 import PublicationDetailsPage from '@admin/pages/publication/PublicationDetailsPage';
 import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
 import _publicationService, {
+  BasicPublicationDetails,
   MyPublication,
   PublicationContactDetails,
 } from '@admin/services/publicationService';
@@ -111,7 +112,11 @@ describe('PublicationDetailsPage', () => {
   ];
 
   beforeEach(() => {
+    themeService.getTheme.mockResolvedValue(testThemes[0]);
     themeService.getThemes.mockResolvedValue(testThemes);
+    publicationService.getPublication.mockResolvedValue(
+      testPublicationSummaries[1] as BasicPublicationDetails,
+    );
     publicationService.getPublicationSummaries.mockResolvedValue(
       testPublicationSummaries,
     );
@@ -159,6 +164,10 @@ describe('PublicationDetailsPage', () => {
     userEvent.click(
       screen.getByRole('button', { name: 'Edit publication details' }),
     );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
 
     expect(screen.getByLabelText('Publication title')).toHaveValue(
       'Publication 1',
@@ -215,6 +224,10 @@ describe('PublicationDetailsPage', () => {
       screen.getByRole('button', { name: 'Edit publication details' }),
     );
 
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
+
     const topics = within(screen.getByLabelText('Select topic')).getAllByRole(
       'option',
     );
@@ -247,6 +260,10 @@ describe('PublicationDetailsPage', () => {
     userEvent.click(
       screen.getByRole('button', { name: 'Edit publication details' }),
     );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
 
     expect(screen.getByLabelText('Publication title')).toHaveValue(
       'Publication 1',
@@ -285,6 +302,10 @@ describe('PublicationDetailsPage', () => {
       screen.getByRole('button', { name: 'Edit publication details' }),
     );
 
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
+
     userEvent.clear(screen.getByLabelText('Publication title'));
     userEvent.tab();
 
@@ -307,6 +328,10 @@ describe('PublicationDetailsPage', () => {
     userEvent.click(
       screen.getByRole('button', { name: 'Edit publication details' }),
     );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
 
     expect(publicationService.updatePublication).not.toHaveBeenCalled();
 
@@ -332,6 +357,10 @@ describe('PublicationDetailsPage', () => {
       screen.getByRole('button', { name: 'Edit publication details' }),
     );
 
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
+
     userEvent.type(screen.getByLabelText('Publication title'), ' updated');
 
     userEvent.selectOptions(screen.getByLabelText('Select theme'), ['theme-2']);
@@ -354,12 +383,7 @@ describe('PublicationDetailsPage', () => {
       expect(publicationService.updatePublication).toHaveBeenCalledWith(
         testPublication.id,
         {
-          contact: {
-            contactName: 'John Smith',
-            contactTelNo: '0777777777',
-            teamEmail: 'john.smith@test.com',
-            teamName: 'Team Smith',
-          },
+          contact: testContact,
           supersededById: 'publication-2',
           title: 'Publication 1 updated',
           topicId: 'theme-2-topic-2',

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
@@ -1,0 +1,132 @@
+import PublicationPageContainer from '@admin/pages/publication/PublicationPageContainer';
+import {
+  publicationReleasesRoute,
+  PublicationRouteParams,
+} from '@admin/routes/publicationRoutes';
+import { publicationRoute } from '@admin/routes/routes';
+import _publicationService, {
+  MyPublication,
+  PublicationContactDetails,
+} from '@admin/services/publicationService';
+import { generatePath, MemoryRouter } from 'react-router';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { Route } from 'react-router-dom';
+
+jest.mock('@admin/services/publicationService');
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+
+describe('PublicationPageContainer', () => {
+  const testContact: PublicationContactDetails = {
+    contactName: 'John Smith',
+    contactTelNo: '0777777777',
+    id: 'contact-id-1',
+    teamEmail: 'john.smith@test.com',
+    teamName: 'Team Smith',
+  };
+
+  const testPublication: MyPublication = {
+    id: 'publication-1',
+    title: 'Publication 1',
+    contact: testContact,
+    releases: [],
+    legacyReleases: [],
+    methodologies: [],
+    themeId: 'theme-1',
+    topicId: 'theme-1-topic-2',
+    permissions: {
+      canAdoptMethodologies: true,
+      canCreateReleases: true,
+      canUpdatePublication: true,
+      canUpdatePublicationTitle: true,
+      canUpdatePublicationSupersededBy: true,
+      canCreateMethodologies: true,
+      canManageExternalMethodology: true,
+    },
+  };
+
+  test('renders the page with the releases tab', async () => {
+    publicationService.getMyPublication.mockResolvedValue(testPublication);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Publication 1')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('page-title-caption')).toHaveTextContent(
+      'Manage publication',
+    );
+
+    const navLinks = within(
+      screen.getByRole('navigation', {
+        name: 'Publication',
+      }),
+    ).getAllByRole('link');
+    expect(navLinks).toHaveLength(2);
+    expect(navLinks[0]).toHaveTextContent('Releases');
+    expect(navLinks[0].getAttribute('aria-current')).toBe('page');
+    expect(navLinks[1]).toHaveTextContent('Details');
+    expect(navLinks[1]).not.toHaveAttribute('aria-current');
+
+    expect(screen.getByText('Manage releases')).toBeInTheDocument();
+  });
+
+  test('shows a message when the publication is archived', async () => {
+    publicationService.getMyPublication.mockResolvedValue({
+      ...testPublication,
+      isSuperseded: true,
+      supersededById: 'publication-2',
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Publication 1')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText('This publication is archived.'),
+    ).toBeInTheDocument();
+  });
+
+  test('shows a message when the publication is superseded but not yet archived', async () => {
+    publicationService.getMyPublication.mockResolvedValue({
+      ...testPublication,
+      isSuperseded: false,
+      supersededById: 'publication-2',
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Publication 1')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(
+        'This publication will be archived when its superseding publication has a live release published.',
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+function renderPage() {
+  const path = generatePath<PublicationRouteParams>(
+    publicationReleasesRoute.path,
+    {
+      publicationId: 'publication-1',
+    },
+  );
+
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Route
+        component={PublicationPageContainer}
+        path={publicationRoute.path}
+      />
+    </MemoryRouter>,
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
@@ -1,0 +1,157 @@
+import FormFieldThemeTopicSelect from '@admin/components/form/FormFieldThemeTopicSelect';
+import { Theme } from '@admin/services/themeService';
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import ButtonText from '@common/components/ButtonText';
+import { FormFieldset, FormFieldSelect } from '@common/components/form';
+import Form from '@common/components/form/Form';
+import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
+import ModalConfirm from '@common/components/ModalConfirm';
+import useFormSubmit from '@common/hooks/useFormSubmit';
+import useToggle from '@common/hooks/useToggle';
+import { PublicationSummary } from '@common/services/publicationService';
+import { mapFieldErrors } from '@common/validation/serverValidations';
+import Yup from '@common/validation/yup';
+import { Formik } from 'formik';
+import React from 'react';
+
+export interface FormValues {
+  supersededById?: string;
+  title: string;
+  topicId: string;
+}
+
+interface Props {
+  canUpdatePublicationSupersededBy?: boolean;
+  canUpdatePublicationTitle?: boolean;
+  initialValues: FormValues;
+  publications?: PublicationSummary[];
+  themes?: Theme[];
+  onCancel: () => void;
+  onSubmit: (values: FormValues) => void;
+}
+
+const PublicationDetailsForm = ({
+  canUpdatePublicationSupersededBy = false,
+  canUpdatePublicationTitle = false,
+  initialValues,
+  publications,
+  themes,
+  onCancel,
+  onSubmit,
+}: Props) => {
+  const [showConfirmModal, toggleConfirmModal] = useToggle(false);
+
+  const errorMappings = [
+    mapFieldErrors<FormValues>({
+      target: 'title',
+      messages: {
+        SlugNotUnique: 'Choose a unique title',
+      },
+    }),
+  ];
+
+  const validationSchema = Yup.object<FormValues>({
+    title: Yup.string().required('Enter a title'),
+    topicId: Yup.string().required('Choose a topic'),
+  });
+
+  const handleSubmit = useFormSubmit((values: FormValues) => {
+    onSubmit(values);
+  }, errorMappings);
+
+  const id = 'publicationDetailsForm';
+
+  return (
+    <Formik<FormValues>
+      enableReinitialize
+      initialValues={{
+        ...(initialValues ?? {
+          theme: '',
+          title: '',
+          topicId: '',
+        }),
+      }}
+      validationSchema={validationSchema}
+      onSubmit={handleSubmit}
+    >
+      {form => (
+        <>
+          <Form id={id}>
+            <FormFieldset id="details" legend="Publication details">
+              {canUpdatePublicationTitle && (
+                <FormFieldTextInput<FormValues>
+                  name="title"
+                  label="Publication title"
+                  className="govuk-!-width-one-half"
+                />
+              )}
+
+              {themes && initialValues?.topicId && (
+                <FormFieldThemeTopicSelect<FormValues>
+                  id={id}
+                  inline={false}
+                  legend="Choose a topic for this publication"
+                  legendHidden
+                  name="topicId"
+                  themes={themes}
+                />
+              )}
+            </FormFieldset>
+            {canUpdatePublicationSupersededBy && (
+              <FormFieldset
+                id="supersede"
+                legend="Archive this publication"
+                legendSize="s"
+              >
+                <FormFieldSelect<FormValues>
+                  className="govuk-!-width-one-half"
+                  hint="If superseded by a publication with a live release, this will archive the current publication immediately"
+                  label="Superseding publication"
+                  name="supersededById"
+                  options={publications?.map(publication => ({
+                    label: publication.title,
+                    value: publication.id,
+                  }))}
+                  placeholder="None selected"
+                />
+              </FormFieldset>
+            )}
+
+            <ButtonGroup>
+              <Button
+                type="submit"
+                onClick={e => {
+                  e.preventDefault();
+                  if (form.isValid) {
+                    toggleConfirmModal.on();
+                  } else {
+                    form.submitForm();
+                  }
+                }}
+              >
+                Update publication details
+              </Button>
+              <ButtonText onClick={onCancel}>Cancel</ButtonText>
+            </ButtonGroup>
+          </Form>
+
+          <ModalConfirm
+            title="Confirm publication changes"
+            onConfirm={form.submitForm}
+            onExit={toggleConfirmModal.off}
+            onCancel={toggleConfirmModal.off}
+            open={showConfirmModal}
+          >
+            <p>
+              Any changes made here will appear on the public site immediately.
+            </p>
+            <p>Are you sure you want to save the changes?</p>
+          </ModalConfirm>
+        </>
+      )}
+    </Formik>
+  );
+};
+
+export default PublicationDetailsForm;

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
@@ -1,19 +1,30 @@
 import FormFieldThemeTopicSelect from '@admin/components/form/FormFieldThemeTopicSelect';
-import { Theme } from '@admin/services/themeService';
+import publicationService from '@admin/services/publicationService';
+import themeService from '@admin/services/themeService';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
 import { FormFieldset, FormFieldSelect } from '@common/components/form';
 import Form from '@common/components/form/Form';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 import ModalConfirm from '@common/components/ModalConfirm';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import useFormSubmit from '@common/hooks/useFormSubmit';
 import useToggle from '@common/hooks/useToggle';
-import { PublicationSummary } from '@common/services/publicationService';
 import { mapFieldErrors } from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
 import React from 'react';
+
+const errorMappings = [
+  mapFieldErrors<FormValues>({
+    target: 'title',
+    messages: {
+      SlugNotUnique: 'Choose a unique title',
+    },
+  }),
+];
 
 export interface FormValues {
   supersededById?: string;
@@ -25,8 +36,7 @@ interface Props {
   canUpdatePublicationSupersededBy?: boolean;
   canUpdatePublicationTitle?: boolean;
   initialValues: FormValues;
-  publications?: PublicationSummary[];
-  themes?: Theme[];
+  publicationId: string;
   onCancel: () => void;
   onSubmit: (values: FormValues) => void;
 }
@@ -35,122 +45,127 @@ const PublicationDetailsForm = ({
   canUpdatePublicationSupersededBy = false,
   canUpdatePublicationTitle = false,
   initialValues,
-  publications,
-  themes,
+  publicationId,
   onCancel,
   onSubmit,
 }: Props) => {
   const [showConfirmModal, toggleConfirmModal] = useToggle(false);
 
-  const errorMappings = [
-    mapFieldErrors<FormValues>({
-      target: 'title',
-      messages: {
-        SlugNotUnique: 'Choose a unique title',
-      },
-    }),
-  ];
+  const { value, isLoading } = useAsyncHandledRetry(async () => {
+    const themes = await themeService.getThemes();
+    if (!canUpdatePublicationSupersededBy) {
+      return { themes };
+    }
 
-  const validationSchema = Yup.object<FormValues>({
-    title: Yup.string().required('Enter a title'),
-    topicId: Yup.string().required('Choose a topic'),
+    const allPublications = await publicationService.getPublicationSummaries();
+    const publications = allPublications.filter(
+      publication => publication.id !== publicationId,
+    );
+
+    return {
+      themes,
+      publications,
+    };
   });
 
-  const handleSubmit = useFormSubmit((values: FormValues) => {
-    onSubmit(values);
-  }, errorMappings);
+  const { themes, publications } = value ?? {};
 
   const id = 'publicationDetailsForm';
 
   return (
-    <Formik<FormValues>
-      enableReinitialize
-      initialValues={{
-        ...(initialValues ?? {
-          theme: '',
-          title: '',
-          topicId: '',
-        }),
-      }}
-      validationSchema={validationSchema}
-      onSubmit={handleSubmit}
-    >
-      {form => (
-        <>
-          <Form id={id}>
-            <FormFieldset id="details" legend="Publication details">
+    <LoadingSpinner loading={isLoading}>
+      <Formik<FormValues>
+        enableReinitialize
+        initialValues={{
+          ...(initialValues ?? {
+            theme: '',
+            title: '',
+            topicId: '',
+          }),
+        }}
+        validationSchema={Yup.object<FormValues>({
+          title: Yup.string().required('Enter a title'),
+          topicId: Yup.string().required('Choose a topic'),
+        })}
+        onSubmit={useFormSubmit(onSubmit, errorMappings)}
+      >
+        {form => (
+          <>
+            <Form id={id}>
               {canUpdatePublicationTitle && (
-                <FormFieldTextInput<FormValues>
-                  name="title"
-                  label="Publication title"
-                  className="govuk-!-width-one-half"
-                />
+                <FormFieldset id="details" legend="Publication details">
+                  <FormFieldTextInput<FormValues>
+                    name="title"
+                    label="Publication title"
+                    className="govuk-!-width-one-half"
+                  />
+                  {themes && initialValues?.topicId && (
+                    <FormFieldThemeTopicSelect<FormValues>
+                      id={id}
+                      inline={false}
+                      legend="Choose a topic for this publication"
+                      legendHidden
+                      name="topicId"
+                      themes={themes}
+                    />
+                  )}
+                </FormFieldset>
+              )}
+              {canUpdatePublicationSupersededBy && (
+                <FormFieldset
+                  id="supersede"
+                  legend="Archive this publication"
+                  legendSize="s"
+                >
+                  <FormFieldSelect<FormValues>
+                    className="govuk-!-width-one-half"
+                    hint="If superseded by a publication with a live release, this will archive the current publication immediately"
+                    label="Superseding publication"
+                    name="supersededById"
+                    options={publications?.map(publication => ({
+                      label: publication.title,
+                      value: publication.id,
+                    }))}
+                    placeholder="None selected"
+                  />
+                </FormFieldset>
               )}
 
-              {themes && initialValues?.topicId && (
-                <FormFieldThemeTopicSelect<FormValues>
-                  id={id}
-                  inline={false}
-                  legend="Choose a topic for this publication"
-                  legendHidden
-                  name="topicId"
-                  themes={themes}
-                />
-              )}
-            </FormFieldset>
-            {canUpdatePublicationSupersededBy && (
-              <FormFieldset
-                id="supersede"
-                legend="Archive this publication"
-                legendSize="s"
-              >
-                <FormFieldSelect<FormValues>
-                  className="govuk-!-width-one-half"
-                  hint="If superseded by a publication with a live release, this will archive the current publication immediately"
-                  label="Superseding publication"
-                  name="supersededById"
-                  options={publications?.map(publication => ({
-                    label: publication.title,
-                    value: publication.id,
-                  }))}
-                  placeholder="None selected"
-                />
-              </FormFieldset>
-            )}
+              <ButtonGroup>
+                <Button
+                  type="submit"
+                  onClick={e => {
+                    e.preventDefault();
+                    if (form.isValid) {
+                      toggleConfirmModal.on();
+                    } else {
+                      form.submitForm();
+                    }
+                  }}
+                >
+                  Update publication details
+                </Button>
+                <ButtonText onClick={onCancel}>Cancel</ButtonText>
+              </ButtonGroup>
+            </Form>
 
-            <ButtonGroup>
-              <Button
-                type="submit"
-                onClick={e => {
-                  e.preventDefault();
-                  if (form.isValid) {
-                    toggleConfirmModal.on();
-                  } else {
-                    form.submitForm();
-                  }
-                }}
-              >
-                Update publication details
-              </Button>
-              <ButtonText onClick={onCancel}>Cancel</ButtonText>
-            </ButtonGroup>
-          </Form>
-
-          <ModalConfirm
-            title="Confirm publication changes"
-            onConfirm={form.submitForm}
-            onExit={toggleConfirmModal.off}
-            onCancel={toggleConfirmModal.off}
-            open={showConfirmModal}
-          >
-            <p>
-              Any changes made here will appear on the public site immediately.
-            </p>
-            <p>Are you sure you want to save the changes?</p>
-          </ModalConfirm>
-        </>
-      )}
-    </Formik>
+            <ModalConfirm
+              title="Confirm publication changes"
+              onConfirm={form.submitForm}
+              onExit={toggleConfirmModal.off}
+              onCancel={toggleConfirmModal.off}
+              open={showConfirmModal}
+            >
+              <p>
+                Any changes made here will appear on the public site
+                immediately.
+              </p>
+              <p>Are you sure you want to save the changes?</p>
+            </ModalConfirm>
+          </>
+        )}
+      </Formik>
+    </LoadingSpinner>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
@@ -18,7 +18,7 @@ import { Formik } from 'formik';
 import React from 'react';
 
 const errorMappings = [
-  mapFieldErrors<FormValues>({
+  mapFieldErrors<PublicationDetailsFormValues>({
     target: 'title',
     messages: {
       SlugNotUnique: 'Choose a unique title',
@@ -26,7 +26,9 @@ const errorMappings = [
   }),
 ];
 
-export interface FormValues {
+const id = 'publicationDetailsForm';
+
+export interface PublicationDetailsFormValues {
   supersededById?: string;
   title: string;
   topicId: string;
@@ -35,10 +37,10 @@ export interface FormValues {
 interface Props {
   canUpdatePublicationSupersededBy?: boolean;
   canUpdatePublicationTitle?: boolean;
-  initialValues: FormValues;
+  initialValues: PublicationDetailsFormValues;
   publicationId: string;
   onCancel: () => void;
-  onSubmit: (values: FormValues) => void;
+  onSubmit: (values: PublicationDetailsFormValues) => void;
 }
 
 const PublicationDetailsForm = ({
@@ -70,11 +72,9 @@ const PublicationDetailsForm = ({
 
   const { themes, publications } = value ?? {};
 
-  const id = 'publicationDetailsForm';
-
   return (
     <LoadingSpinner loading={isLoading}>
-      <Formik<FormValues>
+      <Formik<PublicationDetailsFormValues>
         enableReinitialize
         initialValues={{
           ...(initialValues ?? {
@@ -83,7 +83,7 @@ const PublicationDetailsForm = ({
             topicId: '',
           }),
         }}
-        validationSchema={Yup.object<FormValues>({
+        validationSchema={Yup.object<PublicationDetailsFormValues>({
           title: Yup.string().required('Enter a title'),
           topicId: Yup.string().required('Choose a topic'),
         })}
@@ -94,13 +94,13 @@ const PublicationDetailsForm = ({
             <Form id={id}>
               {canUpdatePublicationTitle && (
                 <FormFieldset id="details" legend="Publication details">
-                  <FormFieldTextInput<FormValues>
+                  <FormFieldTextInput<PublicationDetailsFormValues>
                     name="title"
                     label="Publication title"
                     className="govuk-!-width-one-half"
                   />
                   {themes && initialValues?.topicId && (
-                    <FormFieldThemeTopicSelect<FormValues>
+                    <FormFieldThemeTopicSelect<PublicationDetailsFormValues>
                       id={id}
                       inline={false}
                       legend="Choose a topic for this publication"
@@ -117,7 +117,7 @@ const PublicationDetailsForm = ({
                   legend="Archive this publication"
                   legendSize="s"
                 >
-                  <FormFieldSelect<FormValues>
+                  <FormFieldSelect<PublicationDetailsFormValues>
                     className="govuk-!-width-one-half"
                     hint="If superseded by a publication with a live release, this will archive the current publication immediately"
                     label="Superseding publication"

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/LegacyReleasesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/LegacyReleasesTable.test.tsx
@@ -1,6 +1,9 @@
 import LegacyReleasesTable from '@admin/pages/publication/components/LegacyReleasesTable';
 import _legacyReleaseService from '@admin/services/legacyReleaseService';
-import { MyPublication } from '@admin/services/publicationService';
+import {
+  MyPublication,
+  PublicationContactDetails,
+} from '@admin/services/publicationService';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { Router } from 'react-router';
 import userEvent from '@testing-library/user-event';
@@ -13,7 +16,16 @@ const legacyReleaseService = _legacyReleaseService as jest.Mocked<
 >;
 
 describe('LegacyReleasesTable', () => {
+  const testContact: PublicationContactDetails = {
+    id: 'contact-1',
+    contactName: 'John Smith',
+    contactTelNo: '0777777777',
+    teamEmail: 'john.smith@test.com',
+    teamName: 'Team Smith',
+  };
+
   const testPublication: MyPublication = {
+    contact: testContact,
     id: 'publication-id-1',
     title: 'Publication 1',
     releases: [],

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationInviteNewUsersTab.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationInviteNewUsersTab.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { BasicPublicationDetails } from '@admin/services/publicationService';
+import {
+  BasicPublicationDetails,
+  PublicationContactDetails,
+} from '@admin/services/publicationService';
 import { ReleaseSummary } from '@admin/services/releaseService';
 import userEvent from '@testing-library/user-event';
 import userService from '@admin/services/userService';
@@ -8,7 +11,16 @@ import PublicationInviteNewUsersTab from '../PublicationInviteNewUsersTab';
 
 jest.mock('@admin/services/userService');
 
+const testContact: PublicationContactDetails = {
+  id: 'contact-1',
+  contactName: 'John Smith',
+  contactTelNo: '0777777777',
+  teamEmail: 'john.smith@test.com',
+  teamName: 'Team Smith',
+};
+
 const publication: BasicPublicationDetails = {
+  contact: testContact,
   id: 'publication-id',
   title: 'Publication title',
   slug: 'publication-slug',

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -5,6 +5,7 @@ import {
 } from '@admin/routes/releaseRoutes';
 import _publicationService, {
   BasicPublicationDetails,
+  PublicationContactDetails,
 } from '@admin/services/publicationService';
 import _tableBuilderService from '@common/services/tableBuilderService';
 import { render, screen, waitFor, within } from '@testing-library/react';
@@ -23,7 +24,16 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
   typeof _tableBuilderService
 >;
 
+const testContact: PublicationContactDetails = {
+  id: 'contact-1',
+  contactName: 'John Smith',
+  contactTelNo: '0777777777',
+  teamEmail: 'john.smith@test.com',
+  teamName: 'Team Smith',
+};
+
 const testPublication: BasicPublicationDetails = {
+  contact: testContact,
   id: 'publication-1',
   title: 'Pupil absence',
   slug: 'pupil-absence',

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
@@ -3,6 +3,7 @@ import { preReleaseMethodologiesRoute } from '@admin/routes/preReleaseRoutes';
 import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
 import _publicationService, {
   MyPublication,
+  PublicationContactDetails,
 } from '@admin/services/publicationService';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
@@ -15,7 +16,16 @@ const publicationService = _publicationService as jest.Mocked<
 >;
 
 describe('PreReleaseMethodologiesPage', () => {
+  const testContact: PublicationContactDetails = {
+    id: 'contact-1',
+    contactName: 'John Smith',
+    contactTelNo: '0777777777',
+    teamEmail: 'john.smith@test.com',
+    teamName: 'Team Smith',
+  };
+
   const testPublicationNoMethodologies: MyPublication = {
+    contact: testContact,
     id: 'pub-1-id',
     title: 'Publication 1',
     releases: [],

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -284,29 +284,26 @@ describe('PreReleaseTableToolPage', () => {
         'aria-current',
         'step',
       );
-
-      const step1 = within(screen.getByTestId('wizardStep-1'));
-      const tabs = step1.getAllByRole('tabpanel', { hidden: true });
-
-      expect(tabs).toHaveLength(2);
-
-      expect(
-        within(tabs[0]).getByRole('heading', { name: 'Choose a table' }),
-      ).toBeInTheDocument();
-      expect(
-        within(tabs[0]).getByRole('link', { name: 'Test highlight' }),
-      ).toHaveAttribute(
-        'href',
-        '/publication/publication-1/release/release-1/prerelease/table-tool/block-1',
-      );
-
-      expect(
-        within(tabs[1]).getByLabelText('Test subject'),
-      ).toBeInTheDocument();
-
-      expect(screen.queryByTestId('dataTableCaption')).not.toBeInTheDocument();
-      expect(screen.queryByRole('table')).not.toBeInTheDocument();
     });
+    const step1 = within(screen.getByTestId('wizardStep-1'));
+    const tabs = step1.getAllByRole('tabpanel', { hidden: true });
+
+    expect(tabs).toHaveLength(2);
+
+    expect(
+      within(tabs[0]).getByRole('heading', { name: 'Choose a table' }),
+    ).toBeInTheDocument();
+    expect(
+      within(tabs[0]).getByRole('link', { name: 'Test highlight' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/prerelease/table-tool/block-1',
+    );
+
+    expect(within(tabs[1]).getByLabelText('Test subject')).toBeInTheDocument();
+
+    expect(screen.queryByTestId('dataTableCaption')).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 
   test('renders correctly on step 1 without featured tables', async () => {
@@ -321,17 +318,17 @@ describe('PreReleaseTableToolPage', () => {
         'aria-current',
         'step',
       );
-
-      const step1 = within(screen.getByTestId('wizardStep-1'));
-
-      expect(step1.getByLabelText('Test subject')).toBeInTheDocument();
-      expect(
-        step1.queryByRole('heading', { name: 'Choose a table' }),
-      ).not.toBeInTheDocument();
-
-      expect(screen.queryByTestId('dataTableCaption')).not.toBeInTheDocument();
-      expect(screen.queryByRole('table')).not.toBeInTheDocument();
     });
+
+    const step1 = within(screen.getByTestId('wizardStep-1'));
+
+    expect(step1.getByLabelText('Test subject')).toBeInTheDocument();
+    expect(
+      step1.queryByRole('heading', { name: 'Choose a table' }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByTestId('dataTableCaption')).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 
   test('renders correctly on step 5 with `dataBlockId` route param', async () => {
@@ -362,31 +359,31 @@ describe('PreReleaseTableToolPage', () => {
         'aria-current',
         'step',
       );
-
-      expect(screen.getByTestId('dataTableCaption')).toHaveTextContent(
-        /Number of authorised absence sessions for 'Absence by characteristic'/,
-      );
-
-      expect(screen.getByRole('table')).toBeInTheDocument();
-      expect(screen.getAllByRole('row')).toHaveLength(3);
-      expect(screen.getAllByRole('cell')).toHaveLength(5);
-
-      expect(
-        screen.queryByRole('radio', {
-          name: 'Table in ODS format (spreadsheet, with title and footnotes)',
-        }),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole('radio', {
-          name: 'Table in CSV format (flat file, with location codes)',
-        }),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole('button', {
-          name: 'Download table',
-        }),
-      ).toBeInTheDocument();
     });
+
+    expect(screen.getByTestId('dataTableCaption')).toHaveTextContent(
+      /Number of authorised absence sessions for 'Absence by characteristic'/,
+    );
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getAllByRole('row')).toHaveLength(3);
+    expect(screen.getAllByRole('cell')).toHaveLength(5);
+
+    expect(
+      screen.queryByRole('radio', {
+        name: 'Table in ODS format (spreadsheet, with title and footnotes)',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('radio', {
+        name: 'Table in CSV format (flat file, with location codes)',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'Download table',
+      }),
+    ).toBeInTheDocument();
   });
 
   const renderPage = (

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -8,6 +8,7 @@ import _dataBlockService, {
 } from '@admin/services/dataBlockService';
 import _publicationService, {
   BasicPublicationDetails,
+  PublicationContactDetails,
 } from '@admin/services/publicationService';
 import _tableBuilderService, {
   SubjectMeta,
@@ -183,7 +184,16 @@ describe('PreReleaseTableToolPage', () => {
     ],
   };
 
+  const testContact: PublicationContactDetails = {
+    id: 'contact-1',
+    contactName: 'John Smith',
+    contactTelNo: '0777777777',
+    teamEmail: 'john.smith@test.com',
+    teamName: 'Team Smith',
+  };
+
   const testPublication: BasicPublicationDetails = {
+    contact: testContact,
     id: 'publication-1',
     title: 'Pupil absence',
     slug: 'pupil-absence',

--- a/src/explore-education-statistics-admin/src/routes/publicationRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/publicationRoutes.ts
@@ -1,3 +1,4 @@
+import PublicationDetailsPage from '@admin/pages/publication/PublicationDetailsPage';
 import PublicationReleasesPage from '@admin/pages/publication/PublicationReleasesPage';
 import { RouteProps } from 'react-router';
 
@@ -14,4 +15,10 @@ export const publicationReleasesRoute: PublicationRouteProps = {
   path: '/publication/:publicationId/releases',
   title: 'Releases',
   component: PublicationReleasesPage,
+};
+
+export const publicationDetailsRoute: PublicationRouteProps = {
+  path: '/publication/:publicationId/details',
+  title: 'Details',
+  component: PublicationDetailsPage,
 };

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -21,14 +21,14 @@ export interface PublicationContactDetails {
   contactName: string;
   contactTelNo: string;
   teamEmail: string;
-  teamName?: string;
+  teamName: string;
 }
 
 export interface SavePublicationContact {
   contactName: string;
   contactTelNo: string;
   teamEmail: string;
-  teamName?: string;
+  teamName: string;
 }
 
 export interface ExternalMethodology {
@@ -45,7 +45,7 @@ export interface MyPublication {
   legacyReleases: LegacyRelease[];
   topicId: string;
   themeId: string;
-  contact?: PublicationContactDetails;
+  contact: PublicationContactDetails;
   permissions: {
     canAdoptMethodologies: boolean;
     canCreateReleases: boolean;
@@ -71,7 +71,7 @@ export interface BasicPublicationDetails {
   id: string;
   title: string;
   slug: string;
-  contact?: PublicationContactDetails;
+  contact: PublicationContactDetails;
   releases?: Release[];
   methodologies?: BasicMethodologyVersion[];
   externalMethodology?: ExternalMethodology;


### PR DESCRIPTION
Adds the Details page to the new Manage Publication section.

This work will be hidden to users until it's all ready, so for this you can only access the new page directly, at /publication/details, there are no links to it yet.

This PR, https://github.com/dfe-analytical-services/explore-education-statistics/pull/3391 and https://github.com/dfe-analytical-services/explore-education-statistics/pull/3404 all make changes to PublicationPageContainer and publicationRoutes, when one is merged I'll rebase the others so all changes are kept.

Other things to note:
- archive publication is included in this section (it's not in the designs but I checked with Marv that it should go here)
- added the message when a publication is archived to the header of the Manage Publication section so it'll appear on all tabs
- added an `inline` option to `FormThemeTopicSelect` to control the style differences when it's used on this new page and the existing create/edit publication page

<img width="994" alt="details1" src="https://user-images.githubusercontent.com/81572860/181197639-dc715753-36ae-4dba-a590-f87ce6d441aa.PNG">
<img width="989" alt="details2" src="https://user-images.githubusercontent.com/81572860/181197668-dc27ce73-62d2-4b8d-a9c3-8f372989cb43.PNG">

