### PR TITLE
EES-3580 Roll SQL Server back to 2019 in docker-compose.yml

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - data-storage-data:/data
   db:
     container_name: ees-mssql
-    image: "mcr.microsoft.com/mssql/server:2022-latest"
+    image: "mcr.microsoft.com/mssql/server:2019-latest"
     ports:
       - "1433:1433"
     volumes:


### PR DESCRIPTION
This PR rolls back the SQL Server version specified in `docker-compose.yml` from 2022 to 2019. Currently, 2022 is only in public preview and is consequently not safe to use.

We should only bump this up when it goes generally available and check that there wouldn't be any problems with compatibility with Azure SQL Database.