### PR TITLE
EES-3550, EES-3589 - review UI tests for TODOs, failing tags & other tags

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -145,7 +145,7 @@ const ReleaseStatusPage = () => {
             loading={!releaseStatuses}
             text="Loading release status history"
           >
-            <table>
+            <table data-testid="release-status-history">
               <thead>
                 <tr>
                   <th scope="col">Date</th>

--- a/tests/robot-tests/scripts/get_auth_tokens.py
+++ b/tests/robot-tests/scripts/get_auth_tokens.py
@@ -7,7 +7,7 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 from typing import Union
 from .get_webdriver import get_webdriver
-from pathlib import Path
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 
 def wait_until_page_contains_xpath(context, selector):
@@ -130,14 +130,26 @@ def get_identity_info(identity_provider, url, email, password, first_name="Bau1"
     if not driver:
         get_webdriver("latest")
 
+    # TODO: investigate whether this is necessary for data-guidance assertions
+    # when downloading files, place them by default in ~/tests/robot-tests directory
+    # this is useful when testing data-guidance downloads (without this it
+    # would be placed in your user's download directory)
+
+    # preferences = {
+    #     "download.default_directory": f'{Path().absolute()}/downloads',
+    #     "download.prompt_for_download": False,
+    #     "download.directory_upgrade": True
+    # }
+
     chrome_options = webdriver.ChromeOptions()
+    # chrome_options.add_experimental_option('prefs', preferences)
     chrome_options.add_argument('--no-sandbox')
     chrome_options.add_argument('--headless')
     chrome_options.add_argument('--disable-gpu')
     chrome_options.add_argument('--ignore-certificate-errors')
     chrome_options.add_argument('--disable-logging')
     chrome_options.add_argument('--log-level=\3')
-    driver = webdriver.Chrome(options=chrome_options)
+    driver = webdriver.Chrome(options=chrome_options, desired_capabilities=DesiredCapabilities.CHROME)
 
     if identity_provider == 'KEYCLOAK':
         try:

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -188,6 +188,14 @@ Invite users to the prerelease
     user checks results table cell contains    1    1    simulate-delivered@notifications.service.gov.uk
     user checks results table cell contains    2    1    EES-test.ANALYST1@education.gov.uk
 
+Refresh page and check prerelease user list isn't duplicated
+    [Documentation]    EES-3535
+    user reloads page
+    user waits until table is visible
+    user checks table body has x rows    2
+    user checks table cell in offset row contains    1    0    1    ees-test.analyst1@education.gov.uk
+    user checks table cell in offset row contains    2    0    1    simulate-delivered@notifications.service.gov.uk
+
 Validate the invite emails field is invalid for addresses that are all already invited or accepted
     ${emails}=    Catenate    SEPARATOR=\n
     ...    simulate-delivered@notifications.service.gov.uk
@@ -209,6 +217,7 @@ Invite a further list of new users but mixed with existing invitees and accepted
     user waits until element contains    ${modal}    Email notifications will be sent immediately
 
     user checks list has x items    testid:invitableList    2    ${modal}
+
     user checks list item contains    testid:invitableList    1    simulate-delivered-2@notifications.service.gov.uk
     ...    ${modal}
     user checks list item contains    testid:invitableList    2    simulate-delivered-3@notifications.service.gov.uk
@@ -221,10 +230,13 @@ Invite a further list of new users but mixed with existing invitees and accepted
     user checks list item contains    testid:invitedList    1    simulate-delivered@notifications.service.gov.uk
     ...    ${modal}
 
+    user waits until button is enabled    Confirm    10
     user clicks button    Confirm
+    user waits until table is visible    css:body    %{WAIT_SMALL}
     user checks table column heading contains    1    1    User email
-    user checks results table cell contains    1    1    simulate-delivered@notifications.service.gov.uk
-    user checks results table cell contains    2    1    EES-test.ANALYST1@education.gov.uk
+
+    user checks results table cell contains    1    1    ees-test.analyst1@education.gov.uk
+    user checks results table cell contains    2    1    simulate-delivered@notifications.service.gov.uk
     user checks results table cell contains    3    1    simulate-delivered-2@notifications.service.gov.uk
     user checks results table cell contains    4    1    simulate-delivered-3@notifications.service.gov.uk
 

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -61,8 +61,6 @@ Add summary content to release
     user adds summary text block
     user adds content to summary text block    Test intro text for ${PUBLICATION_NAME}
 
-# TODO: Add comment to summary content
-
 Add release note to release
     user clicks button    Add note
     user enters text into element    id:createReleaseNoteForm-reason    Test release note one

--- a/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
@@ -212,7 +212,7 @@ Replace subject data
     user checks headed table body row cell contains    Subject title    1    ${SUBJECT_NAME}
     user checks headed table body row cell contains    Data file    1    grouped-filters-and-indicators.csv
     user checks headed table body row cell contains    Metadata file    1    grouped-filters-and-indicators.meta.csv
-    user checks headed table body row cell contains    Number of rows    1    100
+    user checks headed table body row cell contains    Number of rows    1    100    wait=%{WAIT_SMALL}
     user checks headed table body row cell contains    Data file size    1    13 Kb
     user checks headed table body row cell contains    Status    1    Data replacement in progress    wait=%{WAIT_LONG}
 
@@ -220,8 +220,8 @@ Replace subject data
     user checks headed table body row cell contains    Data file    2    grouped-filters-and-indicators-replacement.csv
     user checks headed table body row cell contains    Metadata file    2
     ...    grouped-filters-and-indicators-replacement.meta.csv
-    user checks headed table body row cell contains    Number of rows    2    140
-    user checks headed table body row cell contains    Data file size    2    19 Kb
+    user checks headed table body row cell contains    Number of rows    2    140    wait=%{WAIT_SMALL}
+    user checks headed table body row cell contains    Data file size    2    19 Kb    wait=%{WAIT_SMALL}
     user checks headed table body row cell contains    Status    2    Complete    wait=%{WAIT_LONG}
 
 Confirm data replacement
@@ -530,8 +530,6 @@ Validate table cells
     user checks results table cell contains    10    2    39,761,905
 
 Go back to locations step
-    # TODO not sure why button with test Id isn't found? Using label instead
-    # user clicks button    testid:wizardStep-3-goToButton
     user clicks button    Edit locations
     user waits until page contains element    xpath://h2[text()="Go back to previous step"]
     user clicks button    Confirm

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -76,7 +76,6 @@ Go to "Sign off" page
     user waits until page contains button    Edit release status    %{WAIT_SMALL}
 
 Approve release and wait for it to be Scheduled
-    [Tags]    NotAgainstDev
     ${day}=    get current datetime    %-d    2
     ${month}=    get current datetime    %-m    2
     ${month_word}=    get current datetime    %B    2

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -455,10 +455,6 @@ Select subject "${SUBJECT_2_NAME}" in table tool
     user checks previous table tool step contains    2    Subject    ${SUBJECT_2_NAME}
 
 Select locations in table tool
-    # LH: Not using the 'user opens details dropdown' keyword here as
-    # it opens the 'Local Authority District' dropdown instead
-    # due to using 'contains'
-    # TODO: LH - fix this
     user clicks element    testid:Expand Details Section Local Authority
     user clicks checkbox    Barnsley
     user clicks checkbox    Birmingham

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -315,8 +315,8 @@ Navigate to data replacement page
     user checks headed table body row contains    Subject title    Dates test subject
     user checks headed table body row contains    Data file    dates.csv
     user checks headed table body row contains    Metadata file    dates.meta.csv
-    user checks headed table body row contains    Number of rows    118
-    user checks headed table body row contains    Data file size    17 Kb
+    user checks headed table body row contains    Number of rows    118    wait=%{WAIT_SMALL}
+    user checks headed table body row contains    Data file size    17 Kb    wait=%{WAIT_SMALL}
     user checks headed table body row contains    Status    Complete    wait=%{WAIT_LONG}
 
 Upload replacement data
@@ -332,15 +332,15 @@ Upload replacement data
     user checks headed table body row cell contains    Subject title    1    Dates test subject
     user checks headed table body row cell contains    Data file    1    dates.csv
     user checks headed table body row cell contains    Metadata file    1    dates.meta.csv
-    user checks headed table body row cell contains    Number of rows    1    118
-    user checks headed table body row cell contains    Data file size    1    17 Kb
+    user checks headed table body row cell contains    Number of rows    1    118    wait=%{WAIT_SMALL}
+    user checks headed table body row cell contains    Data file size    1    17 Kb    wait=%{WAIT_SMALL}
     user checks headed table body row cell contains    Status    1    Data replacement in progress    wait=%{WAIT_LONG}
 
     user checks headed table body row cell contains    Subject title    2    Dates test subject
     user checks headed table body row cell contains    Data file    2    dates-replacement.csv
     user checks headed table body row cell contains    Metadata file    2    dates-replacement.meta.csv
-    user checks headed table body row cell contains    Number of rows    2    118
-    user checks headed table body row cell contains    Data file size    2    17 Kb
+    user checks headed table body row cell contains    Number of rows    2    118    wait=%{WAIT_SMALL}
+    user checks headed table body row cell contains    Data file size    2    17 Kb    wait=%{WAIT_SMALL}
     user checks headed table body row cell contains    Status    2    Complete    wait=%{WAIT_LONG}
 
 Confirm data replacement
@@ -372,7 +372,23 @@ Update existing data guidance for amendment
 
     user clicks button    Save guidance
 
-# TODO luke: Add footnotes
+Navigate to 'Footnotes' section
+    user clicks link    Footnotes
+    user waits until h2 is visible    Footnotes
+
+Add a Footnote
+    user waits until page contains link    Create footnote
+    user clicks link    Create footnote
+    user waits until h2 is visible    Create footnote
+    user clicks footnote subject radio    Dates test subject    Applies to all data
+    user clicks element    id:footnoteForm-content
+    user enters text into element    id:footnoteForm-content
+    ...    A footnote
+    user clicks button    Save footnote
+    user waits until h2 is visible    Footnotes
+
+Check footnote has been added
+    user checks element is visible    testid:Footnote - A footnote
 
 Add ancillary file to amendment
     user clicks link    Data and files
@@ -438,11 +454,11 @@ Save data block for amendment
     user waits until page contains button    Delete this data block
 
 Update data block chart for amendment
-    user waits until page contains link    Chart
+    user waits until page contains link    Chart    %{WAIT_SMALL}
     user waits until page does not contain loading spinner
     user clicks link    Chart
 
-    user waits until page contains element    id:chartConfigurationForm-title
+    user waits until page contains element    id:chartConfigurationForm-title    %{WAIT_SMALL}
 
     user checks radio is checked    Use table title
     user clicks radio    Set an alternative title
@@ -502,15 +518,13 @@ Navigate to amendment release page
     user checks nth breadcrumb contains    3    ${PUBLICATION_NAME}
 
 Verify amendment is displayed as the latest release
-    [Documentation]    EES-1301
-    [Tags]    Failing
     user checks page does not contain    View latest data:
     user checks page does not contain    See other releases (1)
 
 Verify amendment is published
     user checks summary list contains    Published
     ...    ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}
-    user checks summary list contains    Next update    December 3001    # TODO: Check Next update date can be updated
+    user checks summary list contains    Next update    December 3001
 
 Verify amendment files
     user opens accordion section    Explore data and files
@@ -527,7 +541,6 @@ Verify amendment files
     user opens details dropdown    More details    ${other_files_1}
     ${other_files_1_details}=    user gets details content element    More details    ${other_files_1}
     user checks element should contain    ${other_files_1_details}    Test ancillary file 1 summary
-
     download file    link:Test ancillary file 1    test_ancillary_file_1.txt
     downloaded file should have first line    test_ancillary_file_1.txt    Test file 1
 
@@ -630,3 +643,34 @@ Verify amendment Test text accordion section contains correct text
     user opens accordion section    Test text    id:content
     ${section}=    user gets accordion section content element    Test text    id:content
     user closes accordion section    Test text    id:content
+
+Check next release date can be updated
+    user navigates to admin dashboard    Bau1
+    user creates amendment for release    ${PUBLICATION_NAME}    ${RELEASE_NAME}    (Live - Latest release)
+    user clicks link    Sign off
+    user clicks button    Edit release status
+    user waits until h2 is visible    Edit release status    %{WAIT_SMALL}
+    user enters text into element    releaseStatusForm-nextReleaseDate-month    08
+    user enters text into element    id:releaseStatusForm-nextReleaseDate-year    4001
+    user clicks button    Update status
+
+Leave release note for amendment
+    user clicks link    Content
+    user clicks button    Add note
+    user enters text into element    testid:comment-textarea    updated amendment
+    user clicks button    Save note
+
+Approve release amendment for immedate publication
+    user approves amended release for immediate publication
+
+Save public release link for later use
+    user waits until page contains element    testid:public-release-url
+    ${PUBLIC_RELEASE_LINK}=    Get Value    xpath://*[@data-testid="public-release-url"]
+    check that variable is not empty    PUBLIC_RELEASE_LINK    ${PUBLIC_RELEASE_LINK}
+    Set Suite Variable    ${PUBLIC_RELEASE_LINK}
+
+Navigate to amended public release
+    user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
+
+Validate Next update date
+    user checks summary list contains    Next update    August 4001

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -9,12 +9,14 @@ Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
+
 *** Variables ***
 ${RELEASE_NAME}         Academic Year Q1 2020/21
 ${PUBLICATION_NAME}     UI tests - publish release and amend 2 %{RUN_IDENTIFIER}
 ${SUBJECT_NAME}         Seven filters
 ${SECOND_SUBJECT}       upload file test
 ${THIRD_SUBJECT}        upload file test with filter subject
+
 
 *** Test Cases ***
 Create publication
@@ -306,6 +308,10 @@ Validate Release status table row is correct
 
 Approve release amendment
     user approves amended release for immediate publication
+
+Check new release status history entry is present
+    user waits until h3 is visible    Release status history    10
+    table cell should contain    testid:release-status-history    2    4    2    # Release version 2
 
 Go to permalink page & check for error element to be present
     user navigates to public frontend    ${PERMA_LOCATION_URL}

--- a/tests/robot-tests/tests/general_public/methodology_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/methodology_page_absence.robot
@@ -28,7 +28,6 @@ Go to Pupil absence methodology page
     user waits until page contains title caption    Methodology
 
 Validate Published date
-    [Tags]    NotAgainstDev
     user checks summary list contains    Published    22 March 2018
 
 Validate Last updated is not visible

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -82,6 +82,13 @@ Validate subject files file type and file unit style
 Validate absence_in_prus.csv file can be downloaded
     [Documentation]    DFE-958    DFE-562
     [Tags]    NotAgainstLocal    Failing
+
+    # TODO: This needs new file utils to be added to (related to EES-3241):
+    # * unzip the directory once download
+    # * navigate to the 'data' directory
+    # * find 'absence_in_prus.csv' in the directory
+    #    * run 'downloaded file should have first line' keyword
+
     user opens details dropdown    Download data files
 
     download file    link:Absence in PRUs    absence_in_prus.csv

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -629,7 +629,7 @@ user clears element text
     [Arguments]    ${selector}
     user clicks element    ${selector}
     press keys    ${selector}    CTRL+a+BACKSPACE
-    sleep    0.1
+    sleep    0.3
 
 user presses keys
     [Arguments]    @{keys}
@@ -642,7 +642,7 @@ user enters text into element
     user waits until element is visible    ${selector}    %{WAIT_SMALL}
     user clears element text    ${selector}
     press keys    ${selector}    ${text}
-    sleep    0.1
+    sleep    0.3
 
 user checks element count is x
     [Arguments]    ${locator}    ${count}


### PR DESCRIPTION
This PR: 
- fixes a few TODOs and removes either unnecessary or failing tags from the tests. 

Relevant changes:
* Starts to scaffold out possibilities of how to validate data-guidance directory structure/files 
* Adds assertion to check new release status history entries get created on amendments
* Introduces a data-guidance related TODO in `release_page_absence.robot`
* Increases the timeout for `user clears element text` & `user presses keys` due to periodic failures I noticed when running the tests locally
* Adds `desired_capabilities=DesiredCapabilities.CHROME` parameter when creating a new instance of chrome driver. This seems to silence the various logging some people get on other consoles 
* Adds assertions to check for regressions of [EES-3535](https://dfedigital.atlassian.net/browse/EES-3535)
* Adds `%{WAIT_SMALL}` in various tests that check table rows due to changes made to how table sizes/rows are fetched which seems to have introduced flakiness in these areas (fixes https://dfedigital.atlassian.net/browse/EES-3589)
Local run: 
![image](https://user-images.githubusercontent.com/55030296/182028479-0d6ffe1c-c055-4dc7-915d-cc41e5b83927.png)