### PR TITLE
EES-3535 Prevent duplicates in PRA invite list

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PreReleaseUserViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PreReleaseUserViewModels.cs
@@ -4,29 +4,21 @@ using System.ComponentModel.DataAnnotations;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
-    public class PreReleaseUserViewModel
-    {
-        public PreReleaseUserViewModel(string email)
-        {
-            Email = email;
-        }
-
-        [EmailAddress] public string Email { get; }
-    }
+    public record PreReleaseUserViewModel(string Email);
 
     public class PreReleaseUserInvitePlan
     {
-        public List<string> AlreadyInvited { get; } = new List<string>();
+        public List<string> AlreadyInvited { get; } = new();
 
-        public List<string> AlreadyAccepted { get; } = new List<string>();
+        public List<string> AlreadyAccepted { get; } = new();
 
-        public List<string> Invitable { get; } = new List<string>();
+        public List<string> Invitable { get; } = new();
     }
 
     public class PreReleaseUserInviteViewModel
     {
         [MinLength(1, ErrorMessage = "Must have at least one email.")]
-        public List<string> Emails { get; set; } = new List<string>();
+        public List<string> Emails { get; set; } = new();
     }
 
     public class PreReleaseUserRemoveRequest


### PR DESCRIPTION
This PR fixes a bug in the PRA invite list where duplicates can appear in the UI and console errors occur due to list elements not using unique keys. Users are likely to attempt removing the duplicate rows which then removes the invited email address completely leaving them not invited.

Prior to https://github.com/dfe-analytical-services/explore-education-statistics/commit/348e85ffdba1d9426e368d296e76df29358181d4#diff-cd8f55ba5c572b8c2ff29a81a0e9dbbd60cfa9d1592d7b7d73d2bfe07564e064 producing the email addresses for this list combined active users who already had the Prerelease role with the list of UserReleaseInvites for Prerelease not yet accepted. 

Despite there being a `.Distinct()` on the list of `PreReleaseUserViewModel` prior to returning it there was no definition of equality on the view model class which included `Email`, so no duplicates were removed.

Duplicates were unlikely but with the removal of the accepted flag duplicates now begin occurring.

If inviting a new user they get a `UserReleaseInvite` (responsible for one entry) and then get a `UserReleaseRole` (responsible for second entry) at the point of first log in. At login the `UserReleaseInvite` would previously have been changed to accepted and filtered out.

If inviting an existing user they get the `UserReleaseRole` (responsible for one entry) but if the release is not approved they also get a `UserReleaseInvite` (responsible for second entry). This is created since emails are sent on approval based on the existence of invites. Previously this invite was created as accepted and filtered out.

The work to remove the accepted flag was made in combination with other changes such as deleting invites during first login, and not creating invites for existing users, but these led to other bugs with emails not being sent [https://dfedigital.atlassian.net/browse/EES-3483](https://dfedigital.atlassian.net/browse/EES-3483) and [https://dfedigital.atlassian.net/browse/EES-3491](https://dfedigital.atlassian.net/browse/EES-3491) fixed in https://github.com/dfe-analytical-services/explore-education-statistics/pull/3357 and https://github.com/dfe-analytical-services/explore-education-statistics/pull/3365 which reverted these changes.

An easy way to fix the duplicates in the list is to either convert the `PreReleaseUserViewModel` to be a record type which has built in equality of values, or get the distinct list of emails prior to building the view models. This PR does both.

Long term it seems we need to improve the way we invite users and track which emails need to be sent which doesn't rely on invites existing unnecessarily. As it currently stands there is still a bug [https://dfedigital.atlassian.net/browse/EES-2959](https://dfedigital.atlassian.net/browse/EES-2959) where removing the Prerelease role from a user using the BAU Platform administration pages doesn't delete the invite, so they still appear in the PRA invite list and can't be reinvited. 
