### PR TITLE
EES-3075 - add 'zip' to download all data button

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -219,7 +219,7 @@ const ReleaseContent = () => {
                         releaseFileService.downloadAllFilesZip(release.id)
                       }
                     >
-                      Download all data
+                      Download all data (zip)
                     </Button>
                   </li>
                 )}
@@ -332,7 +332,7 @@ const ReleaseContent = () => {
               variant="secondary"
               onClick={() => releaseFileService.downloadAllFilesZip(release.id)}
             >
-              Download all data
+              Download all data (zip)
             </Button>
           }
           renderDownloadLink={file => (

--- a/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseDataAccordion.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseDataAccordion.test.tsx
@@ -56,7 +56,7 @@ describe('ReleaseDataAccordion', () => {
     slug: 'release-1',
   } as Release;
 
-  const mockAllFilesButton = <a href="#">Mock download all data</a>;
+  const mockAllFilesButton = <a href="#">Mock download all data (zip)</a>;
   const mockCreateTablesButton = <a href="#">Mock create tables button</a>;
   const mockDataCatalogueLink = <a href="#">Mock data catalogue link</a>;
   const mockDownloadLink = (file: FileInfo) => <a href="/">{file.name}</a>;
@@ -81,7 +81,7 @@ describe('ReleaseDataAccordion', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('link', { name: 'Mock download all data' }),
+      screen.getByRole('link', { name: 'Mock download all data (zip)' }),
     ).toBeInTheDocument();
   });
 

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -247,7 +247,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                         });
                       }}
                     >
-                      Download all data
+                      Download all data (zip)
                     </ButtonLink>
                   </li>
                 )}
@@ -408,7 +408,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                 });
               }}
             >
-              Download all data
+              Download all data (zip)
             </ButtonLink>
           }
           renderCreateTablesButton={<CreateTablesButton release={release} />}

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -134,7 +134,7 @@ Validate 'Explore data and files' accordion
     ${section}=    user gets accordion section content element    Explore data and files
 
     # All files zip
-    user checks element contains button    ${section}    Download all data
+    user checks element contains button    ${section}    Download all data (zip)
 
     # Data files
     user waits until h3 is visible    Open data

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -163,7 +163,7 @@ Verify release associated files
     ${downloads}=    user gets accordion section content element    Explore data and files
     user waits until page contains element    ${downloads}    %{WAIT_SMALL}
 
-    user checks element should contain    ${downloads}    Download all data
+    user checks element should contain    ${downloads}    Download all data (zip)
     ...    %{WAIT_SMALL}
     user checks element should contain    ${downloads}
     ...    All data used in this release is available as open data for download
@@ -515,7 +515,7 @@ Verify amendment is published
 Verify amendment files
     user opens accordion section    Explore data and files
     ${downloads}=    user gets accordion section content element    Explore data and files
-    user checks element should contain    ${downloads}    Download all data
+    user checks element should contain    ${downloads}    Download all data (zip)
     ...    %{WAIT_SMALL}
 
     user opens details dropdown    List of all supporting files

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -66,7 +66,7 @@ Validate "About these statistics" -- "Last updated"
 Check data downloads navigation contains links
     user checks element contains link    testid:data-downloads    Explore data and files
     user checks element contains link    testid:data-downloads    View data guidance
-    user checks element contains link    testid:data-downloads    Download all data
+    user checks element contains link    testid:data-downloads    Download all data (zip)
 
 Check supporting information contains methodology link
     user checks page contains link with text and url    Pupil absence statistics: methodology


### PR DESCRIPTION
This PR: 

 * adds `(zip)` to the end of the download all data button.

Other notes:
* Not sure what `downloads.title` is but there seems to be a reference to it in one of the GA logEvents. I've removed the stray curly bracket but potentially it can be removed all together

```typescript 
           onClick={() => {
                logEvent({
                  category: 'Downloads',
                  action: `Release page all files downloads.title, Release: ${release.title}, File: All files`,
                });
              }}
```