### PR TITLE
EES-3218 EES-3219 EES-3220 admin dashboard

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
@@ -105,7 +105,7 @@ const AdminDashboardPage = () => {
       </div>
 
       <Tabs
-        id="publicationTabs"
+        id="dashboardTabs"
         onToggle={section => {
           if (showNewDashboard && section.id === 'draft-releases') {
             reloadDraftReleases();
@@ -113,7 +113,7 @@ const AdminDashboardPage = () => {
         }}
       >
         <TabsSection
-          id="publicationsReleases"
+          id={showNewDashboard ? 'publications' : 'publicationsReleases'}
           title={
             showNewDashboard
               ? 'Your publications'

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
@@ -1,45 +1,42 @@
-import ButtonLink from '@admin/components/ButtonLink';
+import useQueryParams from '@admin/hooks/useQueryParams';
+import { ThemeTopicParams } from '@admin/routes/routes';
 import Link from '@admin/components/Link';
 import Page from '@admin/components/Page';
 import PageTitle from '@admin/components/PageTitle';
 import { useAuthContext } from '@admin/contexts/AuthContext';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import DraftReleasesTab from '@admin/pages/admin-dashboard/components/DraftReleasesTab';
-import ReleasesTab from '@admin/pages/admin-dashboard/components/ReleasesByStatusTab';
-import ReleaseSummary from '@admin/pages/admin-dashboard/components/ReleaseSummary';
-import {
-  ReleaseRouteParams,
-  releaseSummaryRoute,
-} from '@admin/routes/releaseRoutes';
+import PublicationsTab from '@admin/pages/admin-dashboard/components/PublicationsTab';
+import ScheduledReleasesTab from '@admin/pages/admin-dashboard/components/ScheduledReleasesTab';
 import loginService from '@admin/services/loginService';
 import releaseService from '@admin/services/releaseService';
-import LoadingSpinner from '@common/components/LoadingSpinner';
 import RelatedInformation from '@common/components/RelatedInformation';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
-import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import React from 'react';
-import { generatePath } from 'react-router';
+import React, { useState } from 'react';
 import ManagePublicationsAndReleasesTab from './components/ManagePublicationsAndReleasesTab';
 
 const AdminDashboardPage = () => {
+  const { showNewDashboard } = useQueryParams<ThemeTopicParams>(); // TODO EES-3217 - remove when ready to go live
   const { user } = useAuthContext();
+  const isBauUser = user?.permissions.canAccessUserAdministrationPages ?? false;
+
+  const [totalDraftReleases, setTotalDraftReleases] = useState<number>(0);
+
   const {
-    value,
-    isLoading: loadingReleases,
-    retry: reloadDashboard,
-  } = useAsyncRetry(async () => {
-    const [draftReleases, scheduledReleases] = await Promise.all([
-      releaseService.getDraftReleases(),
-      releaseService.getScheduledReleases(),
-    ]);
-
-    return {
-      draftReleases,
-      scheduledReleases,
-    };
-  }, []);
-
-  const { draftReleases = [], scheduledReleases = [] } = value ?? {};
+    value: draftReleases = [],
+    isLoading: isLoadingDraftReleases,
+    retry: reloadDraftReleases,
+  } = useAsyncHandledRetry(async () => {
+    const releases = await releaseService.getDraftReleases();
+    // Store the total so it doesn't flicker in the tab while reloading.
+    setTotalDraftReleases(releases.length);
+    return releases;
+  });
+  const {
+    value: scheduledReleases = [],
+    isLoading: isLoadingScheduledReleases,
+  } = useAsyncHandledRetry(releaseService.getScheduledReleases);
 
   return (
     <Page wide breadcrumbs={[{ name: 'Administrator dashboard' }]}>
@@ -62,34 +59,41 @@ const AdminDashboardPage = () => {
             </Link>
           </p>
 
-          <p>This is your administration dashboard - here you can:</p>
+          {showNewDashboard ? (
+            <>
+              <p>
+                This is your administration dashboard, here you can manage
+                publications, releases and methodologies.
+              </p>
+              {isBauUser && (
+                <ul className="govuk-!-margin-bottom-6">
+                  <li>
+                    <Link to="/themes">manage themes and topics</Link>
+                  </li>
+                </ul>
+              )}
+            </>
+          ) : (
+            <>
+              <p>This is your administration dashboard - here you can:</p>
 
-          <ul className="govuk-!-margin-bottom-6">
-            <li>
-              <Link to="/dashboard">manage publications and releases</Link>
-            </li>
-            {user?.permissions.canManageAllTaxonomy && (
-              <li>
-                <Link to="/themes">manage themes and topics</Link>
-              </li>
-            )}
-          </ul>
+              <ul className="govuk-!-margin-bottom-6">
+                <li>
+                  <Link to="/dashboard">manage publications and releases</Link>
+                </li>
+                {user?.permissions.canManageAllTaxonomy && (
+                  <li>
+                    <Link to="/themes">manage themes and topics</Link>
+                  </li>
+                )}
+              </ul>
+            </>
+          )}
         </div>
 
         <div className="govuk-grid-column-one-third">
           <RelatedInformation heading="Help and guidance">
             <ul className="govuk-list">
-              {/* EES-2464
-              <li>
-                <Link to="/documentation/using-dashboard" target="_blank">
-                  Using your administration dashboard{' '}
-                </Link>
-              </li>
-              <li>
-                <Link to="/documentation/create-new-release" target="_blank">
-                  Creating a new release{' '}
-                </Link>
-              </li> */}
               <li>
                 <Link to="/contact-us" target="_blank">
                   Contact us
@@ -100,56 +104,61 @@ const AdminDashboardPage = () => {
         </div>
       </div>
 
-      <LoadingSpinner loading={loadingReleases}>
-        <Tabs id="publicationTabs">
-          <TabsSection
-            id="publicationsReleases"
-            title="Manage publications and releases"
-          >
+      <Tabs
+        id="publicationTabs"
+        onToggle={section => {
+          if (showNewDashboard && section.id === 'draft-releases') {
+            reloadDraftReleases();
+          }
+        }}
+      >
+        <TabsSection
+          id="publicationsReleases"
+          title={
+            showNewDashboard
+              ? 'Your publications'
+              : 'Manage publications and releases'
+          }
+        >
+          {showNewDashboard ? (
+            <PublicationsTab isBauUser={isBauUser} />
+          ) : (
             <ManagePublicationsAndReleasesTab />
-          </TabsSection>
-          <TabsSection
-            lazy
-            id="draft-releases"
-            title={`View draft releases (${draftReleases.length})`}
-          >
-            <DraftReleasesTab
-              releases={draftReleases}
-              onChangeRelease={reloadDashboard}
-            />
-          </TabsSection>
-          <TabsSection
-            lazy
-            id="scheduled-releases"
-            title={`View scheduled releases (${scheduledReleases.length})`}
-          >
-            <ReleasesTab
-              releases={scheduledReleases}
-              noReleasesMessage="There are currently no scheduled releases"
-              releaseSummaryRenderer={release => (
-                <ReleaseSummary
-                  key={release.id}
-                  release={release}
-                  actions={
-                    <ButtonLink
-                      to={generatePath<ReleaseRouteParams>(
-                        releaseSummaryRoute.path,
-                        {
-                          publicationId: release.publicationId,
-                          releaseId: release.id,
-                        },
-                      )}
-                      variant="secondary"
-                    >
-                      View release
-                    </ButtonLink>
-                  }
-                />
-              )}
-            />
-          </TabsSection>
-        </Tabs>
-      </LoadingSpinner>
+          )}
+        </TabsSection>
+        <TabsSection
+          lazy
+          id="draft-releases"
+          title={
+            showNewDashboard
+              ? `Draft releases (${totalDraftReleases})`
+              : `View draft releases (${totalDraftReleases})`
+          }
+        >
+          <DraftReleasesTab
+            isBauUser={isBauUser}
+            isLoading={isLoadingDraftReleases}
+            releases={draftReleases}
+            showNewDashboard={!!showNewDashboard}
+            onChangeRelease={reloadDraftReleases}
+          />
+        </TabsSection>
+        <TabsSection
+          lazy
+          id="scheduled-releases"
+          title={
+            showNewDashboard
+              ? `Approved scheduled releases (${scheduledReleases?.length})`
+              : `View scheduled releases (${scheduledReleases?.length})`
+          }
+        >
+          <ScheduledReleasesTab
+            isLoading={isLoadingScheduledReleases}
+            releases={scheduledReleases}
+            showNewDashboard={!!showNewDashboard}
+          />
+        </TabsSection>
+      </Tabs>
     </Page>
   );
 };

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
@@ -1,19 +1,16 @@
 import Link from '@admin/components/Link';
+import DraftReleaseRowIssues from '@admin/pages/admin-dashboard/components/DraftReleaseRowIssues';
 import { getReleaseApprovalStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
-import releaseService, { MyRelease } from '@admin/services/releaseService';
+import { MyRelease } from '@admin/services/releaseService';
 import {
   ReleaseRouteParams,
   releaseSummaryRoute,
 } from '@admin/routes/releaseRoutes';
 import ButtonText from '@common/components/ButtonText';
-import Details from '@common/components/Details';
-import LoadingSpinner from '@common/components/LoadingSpinner';
 import Tag from '@common/components/Tag';
 import VisuallyHidden from '@common/components/VisuallyHidden';
-import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React from 'react';
 import { generatePath } from 'react-router';
-import TagGroup from '@common/components/TagGroup';
 
 interface Props {
   isBauUser: boolean;
@@ -22,17 +19,6 @@ interface Props {
 }
 
 const DraftReleaseRow = ({ isBauUser, release, onDelete }: Props) => {
-  const {
-    value: checklist,
-    isLoading: isLoadingChecklist,
-  } = useAsyncHandledRetry(() =>
-    releaseService.getReleaseChecklist(release.id),
-  );
-
-  const totalIssues = checklist
-    ? checklist?.errors?.length + checklist?.warnings.length
-    : 0;
-
   return (
     <tr>
       <td>{release.title}</td>
@@ -43,25 +29,7 @@ const DraftReleaseRow = ({ isBauUser, release, onDelete }: Props) => {
           }`}
         </Tag>
       </td>
-      {!isBauUser && (
-        <td>
-          <LoadingSpinner inline loading={isLoadingChecklist} size="sm">
-            {totalIssues === 0 ? (
-              'No issues'
-            ) : (
-              <Details
-                className="govuk-!-margin-bottom-0"
-                summary={`View issues (${totalIssues})`}
-              >
-                <TagGroup>
-                  <Tag colour="red">{`${checklist?.errors.length} errors`}</Tag>
-                  <Tag colour="yellow">{`${checklist?.warnings.length} warnings`}</Tag>
-                </TagGroup>
-              </Details>
-            )}
-          </LoadingSpinner>
-        </td>
-      )}
+      {!isBauUser && <DraftReleaseRowIssues releaseId={release.id} />}
       <td>
         <Link
           to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
@@ -1,0 +1,99 @@
+import Link from '@admin/components/Link';
+import { getReleaseApprovalStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
+import releaseService, { MyRelease } from '@admin/services/releaseService';
+import {
+  ReleaseRouteParams,
+  releaseSummaryRoute,
+} from '@admin/routes/releaseRoutes';
+import ButtonText from '@common/components/ButtonText';
+import Details from '@common/components/Details';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import Tag from '@common/components/Tag';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import React from 'react';
+import { generatePath } from 'react-router';
+import TagGroup from '@common/components/TagGroup';
+
+interface Props {
+  isBauUser: boolean;
+  release: MyRelease;
+  onDelete: () => void;
+}
+
+const DraftReleaseRow = ({ isBauUser, release, onDelete }: Props) => {
+  const {
+    value: checklist,
+    isLoading: isLoadingChecklist,
+  } = useAsyncHandledRetry(() =>
+    releaseService.getReleaseChecklist(release.id),
+  );
+
+  const totalIssues = checklist
+    ? checklist?.errors?.length + checklist?.warnings.length
+    : 0;
+
+  return (
+    <tr>
+      <td>{release.title}</td>
+      <td>
+        <Tag>
+          {`${getReleaseApprovalStatusLabel(release.approvalStatus)}${
+            release.amendment ? ' Amendment' : ''
+          }`}
+        </Tag>
+      </td>
+      {!isBauUser && (
+        <td>
+          <LoadingSpinner inline loading={isLoadingChecklist} size="sm">
+            {totalIssues === 0 ? (
+              'No issues'
+            ) : (
+              <Details
+                className="govuk-!-margin-bottom-0"
+                summary={`View issues (${totalIssues})`}
+              >
+                <TagGroup>
+                  <Tag colour="red">{`${checklist?.errors.length} errors`}</Tag>
+                  <Tag colour="yellow">{`${checklist?.warnings.length} warnings`}</Tag>
+                </TagGroup>
+              </Details>
+            )}
+          </LoadingSpinner>
+        </td>
+      )}
+      <td>
+        <Link
+          to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
+            publicationId: release.publicationId,
+            releaseId: release.id,
+          })}
+        >
+          {release.permissions.canUpdateRelease ? 'Edit' : 'View'}
+          <VisuallyHidden> {release.title}</VisuallyHidden>
+        </Link>
+        {release.permissions.canDeleteRelease && release.amendment && (
+          <ButtonText className="govuk-!-margin-left-4" onClick={onDelete}>
+            Cancel amendment
+            <VisuallyHidden> for {release.title}</VisuallyHidden>
+          </ButtonText>
+        )}
+
+        {release.amendment && (
+          <Link
+            className="govuk-!-margin-left-4"
+            to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
+              publicationId: release.publicationId,
+              releaseId: release.previousVersionId,
+            })}
+          >
+            View original
+            <VisuallyHidden> for {release.title}</VisuallyHidden>
+          </Link>
+        )}
+      </td>
+    </tr>
+  );
+};
+
+export default DraftReleaseRow;

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRowIssues.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRowIssues.tsx
@@ -1,0 +1,44 @@
+import releaseService from '@admin/services/releaseService';
+import Details from '@common/components/Details';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import Tag from '@common/components/Tag';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import React from 'react';
+import TagGroup from '@common/components/TagGroup';
+
+interface Props {
+  releaseId: string;
+}
+
+const DraftReleaseRowIssues = ({ releaseId }: Props) => {
+  const {
+    value: checklist,
+    isLoading: isLoadingChecklist,
+  } = useAsyncHandledRetry(() => releaseService.getReleaseChecklist(releaseId));
+
+  const totalIssues = checklist
+    ? checklist?.errors?.length + checklist?.warnings.length
+    : 0;
+
+  return (
+    <td>
+      <LoadingSpinner inline loading={isLoadingChecklist} size="sm">
+        {totalIssues === 0 ? (
+          'No issues'
+        ) : (
+          <Details
+            className="govuk-!-margin-bottom-0"
+            summary={`View issues (${totalIssues})`}
+          >
+            <TagGroup>
+              <Tag colour="red">{`${checklist?.errors.length} errors`}</Tag>
+              <Tag colour="yellow">{`${checklist?.warnings.length} warnings`}</Tag>
+            </TagGroup>
+          </Details>
+        )}
+      </LoadingSpinner>
+    </td>
+  );
+};
+
+export default DraftReleaseRowIssues;

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
@@ -34,22 +34,26 @@ const DraftReleasesTab = ({
             </p>
           </div>
         </div>
-
-        <DraftReleasesTable
-          isBauUser={isBauUser}
-          isLoading={isLoading}
-          releases={releases}
-          onChangeRelease={onChangeRelease}
-        />
+        <LoadingSpinner
+          hideText
+          loading={isLoading}
+          text="Loading draft releases"
+        >
+          <DraftReleasesTable
+            isBauUser={isBauUser}
+            releases={releases}
+            onChangeRelease={onChangeRelease}
+          />
+        </LoadingSpinner>
       </>
     );
   }
   return (
-    <LoadingSpinner loading={isLoading}>
+    <LoadingSpinner hideText loading={isLoading} text="Loading draft releases">
       <ReleasesTab
         releases={releases}
         noReleasesMessage="There are currently no draft releases"
-        releaseSummaryRenderer={release => (
+        renderReleaseSummary={release => (
           <NonScheduledReleaseSummary
             key={release.id}
             release={release}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
@@ -1,26 +1,63 @@
+import DraftReleasesTable from '@admin/pages/admin-dashboard/components/DraftReleasesTable';
 import NonScheduledReleaseSummary from '@admin/pages/admin-dashboard/components/NonScheduledReleaseSummary';
 import ReleasesTab from '@admin/pages/admin-dashboard/components/ReleasesByStatusTab';
 import { MyRelease } from '@admin/services/releaseService';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 import React from 'react';
 
 interface Props {
+  isBauUser: boolean;
+  isLoading: boolean;
   releases: MyRelease[];
+  showNewDashboard?: boolean; // TODO EES-3217 remove when ready to go live
   onChangeRelease: () => void;
 }
 
-const DraftReleasesTab = ({ releases, onChangeRelease }: Props) => {
-  return (
-    <ReleasesTab
-      releases={releases}
-      noReleasesMessage="There are currently no draft releases"
-      releaseSummaryRenderer={release => (
-        <NonScheduledReleaseSummary
-          key={release.id}
-          release={release}
-          onAmendmentCancelled={onChangeRelease}
+const DraftReleasesTab = ({
+  isBauUser,
+  isLoading,
+  releases,
+  showNewDashboard = false,
+  onChangeRelease,
+}: Props) => {
+  if (showNewDashboard) {
+    return (
+      <>
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-two-thirds">
+            <h2>Draft releases</h2>
+            <p>
+              Here you can view and edit any of your releases that are currently
+              in 'Draft' or 'In review' and also 'Amendments' that are being
+              made to a published release. You can also view a summary of any
+              outstanding issues that may need to be resolved.
+            </p>
+          </div>
+        </div>
+
+        <DraftReleasesTable
+          isBauUser={isBauUser}
+          isLoading={isLoading}
+          releases={releases}
+          onChangeRelease={onChangeRelease}
         />
-      )}
-    />
+      </>
+    );
+  }
+  return (
+    <LoadingSpinner loading={isLoading}>
+      <ReleasesTab
+        releases={releases}
+        noReleasesMessage="There are currently no draft releases"
+        releaseSummaryRenderer={release => (
+          <NonScheduledReleaseSummary
+            key={release.id}
+            release={release}
+            onAmendmentCancelled={onChangeRelease}
+          />
+        )}
+      />
+    </LoadingSpinner>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTable.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTable.module.scss
@@ -1,0 +1,3 @@
+.issuesColumn {
+  width: 300px;
+}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTable.tsx
@@ -1,0 +1,170 @@
+import CancelAmendmentModal from '@admin/pages/admin-dashboard/components/CancelAmendmentModal';
+import DraftReleaseRow from '@admin/pages/admin-dashboard/components/DraftReleaseRow';
+import styles from '@admin/pages/admin-dashboard/components/DraftReleasesTable.module.scss';
+import {
+  DraftStatusGuidanceModal,
+  IssuesGuidanceModal,
+} from '@admin/pages/publication/components/PublicationGuidance';
+import releaseService, {
+  DeleteReleasePlan,
+  MyRelease,
+} from '@admin/services/releaseService';
+import ButtonText from '@common/components/ButtonText';
+import InfoIcon from '@common/components/InfoIcon';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import useToggle from '@common/hooks/useToggle';
+import { Dictionary } from '@common/types';
+import orderBy from 'lodash/orderBy';
+import React, { useMemo, useState } from 'react';
+
+interface PublicationRowProps {
+  isBauUser: boolean;
+  publication: string;
+  releases: MyRelease[];
+  onDelete: (releaseId: string) => void;
+}
+const PublicationRow = ({
+  isBauUser,
+  publication,
+  releases,
+  onDelete,
+}: PublicationRowProps) => {
+  return (
+    <>
+      <tr key={publication}>
+        <th className="govuk-!-padding-top-6" colSpan={isBauUser ? 3 : 4}>
+          {publication}
+        </th>
+      </tr>
+      {releases.map(release => (
+        <DraftReleaseRow
+          key={release.id}
+          isBauUser={isBauUser}
+          release={release}
+          onDelete={() => onDelete(release.id)}
+        />
+      ))}
+    </>
+  );
+};
+
+interface Props {
+  isBauUser: boolean;
+  isLoading: boolean;
+  releases: MyRelease[];
+  onChangeRelease: () => void;
+}
+
+const DraftReleasesTable = ({
+  isBauUser,
+  isLoading,
+  releases,
+  onChangeRelease,
+}: Props) => {
+  const [deleteReleasePlan, setDeleteReleasePlan] = useState<
+    DeleteReleasePlan & {
+      releaseId: string;
+    }
+  >();
+
+  const [showDraftStatusGuidance, toggleDraftStatusGuidance] = useToggle(false);
+  const [showIssuesGuidance, toggleIssuesGuidance] = useToggle(false);
+
+  const releasesByPublication: Dictionary<MyRelease[]> = useMemo(() => {
+    const groupedReleases: Dictionary<MyRelease[]> = {};
+    releases.forEach(release => {
+      if (groupedReleases[release.publicationTitle]) {
+        groupedReleases[release.publicationTitle].push(release);
+      } else {
+        groupedReleases[release.publicationTitle] = [release];
+      }
+    });
+    return groupedReleases;
+  }, [releases]);
+
+  return (
+    <>
+      <LoadingSpinner loading={isLoading}>
+        <>
+          {releases.length === 0 ? (
+            <p>There are currently no draft releases</p>
+          ) : (
+            <>
+              {releasesByPublication &&
+                Object.keys(releasesByPublication).length > 0 && (
+                  <table>
+                    <thead>
+                      <tr>
+                        <th
+                          className={isBauUser ? 'govuk-!-width-one-half' : ''}
+                        >
+                          Publication / Release period
+                        </th>
+                        <th>
+                          Status{' '}
+                          <ButtonText onClick={toggleDraftStatusGuidance.on}>
+                            <InfoIcon description="Guidance on draft states" />
+                          </ButtonText>
+                        </th>
+                        {/* Don't render the issues for BAU users to prevent performance problems. */}
+                        {!isBauUser && (
+                          <th className={styles.issuesColumn}>
+                            Issues{' '}
+                            <ButtonText onClick={toggleIssuesGuidance.on}>
+                              <InfoIcon description="Guidance on draft release issues" />
+                            </ButtonText>
+                          </th>
+                        )}
+                        <th>Actions</th>
+                      </tr>
+                      {orderBy(Object.keys(releasesByPublication)).map(
+                        publication => (
+                          <PublicationRow
+                            key={publication}
+                            isBauUser={isBauUser}
+                            publication={publication}
+                            releases={releasesByPublication[publication]}
+                            onDelete={async releaseId => {
+                              setDeleteReleasePlan({
+                                ...(await releaseService.getDeleteReleasePlan(
+                                  releaseId,
+                                )),
+                                releaseId,
+                              });
+                            }}
+                          />
+                        ),
+                      )}
+                    </thead>
+                  </table>
+                )}
+            </>
+          )}
+        </>
+      </LoadingSpinner>
+
+      {deleteReleasePlan && (
+        <CancelAmendmentModal
+          scheduledMethodologies={deleteReleasePlan.scheduledMethodologies}
+          onConfirm={async () => {
+            await releaseService.deleteRelease(deleteReleasePlan.releaseId);
+            setDeleteReleasePlan(undefined);
+            onChangeRelease();
+          }}
+          onCancel={() => setDeleteReleasePlan(undefined)}
+        />
+      )}
+
+      <DraftStatusGuidanceModal
+        open={showDraftStatusGuidance}
+        onClose={toggleDraftStatusGuidance.off}
+      />
+      <IssuesGuidanceModal
+        open={showIssuesGuidance}
+        onClose={toggleIssuesGuidance.off}
+      />
+    </>
+  );
+};
+
+export default DraftReleasesTable;

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationsTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationsTab.tsx
@@ -1,0 +1,198 @@
+import FormThemeTopicSelect from '@admin/components/form/FormThemeTopicSelect';
+import useQueryParams from '@admin/hooks/useQueryParams';
+import TopicPublications from '@admin/pages/admin-dashboard/components/TopicPublications';
+import { ThemeTopicParams, dashboardRoute } from '@admin/routes/routes';
+import themeService, { Theme } from '@admin/services/themeService';
+import { Topic } from '@admin/services/topicService';
+import appendQuery from '@admin/utils/url/appendQuery';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import useStorageItem from '@common/hooks/useStorageItem';
+import orderBy from 'lodash/orderBy';
+import React, { useEffect, useMemo } from 'react';
+import { useHistory, useLocation } from 'react-router';
+
+interface Props {
+  isBauUser: boolean;
+}
+
+const PublicationsTab = ({ isBauUser }: Props) => {
+  const { showNewDashboard, themeId, topicId } = useQueryParams<
+    ThemeTopicParams
+  >();
+  const location = useLocation();
+  const history = useHistory();
+
+  const [savedThemeTopic, setSavedThemeTopic] = useStorageItem<
+    ThemeTopicParams
+  >('dashboardThemeTopic', undefined);
+
+  const { value: themes, isLoading: loadingThemes } = useAsyncHandledRetry(
+    themeService.getThemes,
+  );
+
+  const selectedTheme = useMemo<Theme | undefined>(() => {
+    // Only select a theme for BAU users.
+    // Analysts see all their publications for all themes.
+    if (!isBauUser) {
+      return undefined;
+    }
+    const selectedThemeId = themeId || savedThemeTopic?.themeId;
+
+    return (
+      themes?.find(t => t.id === selectedThemeId) ??
+      orderBy(themes, t => t.title)[0]
+    );
+  }, [isBauUser, savedThemeTopic, themeId, themes]);
+
+  const selectedTopic = useMemo<Topic | undefined>(() => {
+    if (!selectedTheme) {
+      return undefined;
+    }
+
+    const selectedTopicId = topicId || savedThemeTopic?.topicId;
+
+    return (
+      selectedTheme.topics.find(t => t.id === selectedTopicId) ??
+      orderBy(selectedTheme.topics, t => t.title)[0]
+    );
+  }, [savedThemeTopic, selectedTheme, topicId]);
+
+  useEffect(() => {
+    if (savedThemeTopic) {
+      return;
+    }
+
+    // Set default theme/topic in storage if it hasn't been set yet (e.g. first time
+    // visiting dashboard).
+    if (selectedTheme && selectedTopic) {
+      setSavedThemeTopic({
+        themeId: selectedTheme.id,
+        topicId: selectedTopic.id,
+      });
+    }
+  }, [
+    isBauUser,
+    savedThemeTopic,
+    selectedTheme,
+    selectedTopic,
+    setSavedThemeTopic,
+  ]);
+
+  useEffect(() => {
+    if (!selectedTheme || !selectedTopic) {
+      return;
+    }
+
+    // Update query params to reflect the chosen
+    // theme/topic if they haven't already been set.
+    if (selectedTheme?.id !== themeId || selectedTopic?.id !== topicId) {
+      history.replace(
+        appendQuery<ThemeTopicParams>(location.pathname, {
+          themeId: selectedTheme?.id,
+          topicId: selectedTopic?.id,
+        }),
+      );
+    }
+  }, [
+    isBauUser,
+    history,
+    location.pathname,
+    savedThemeTopic,
+    selectedTheme,
+    selectedTopic,
+    themeId,
+    topicId,
+  ]);
+
+  if (loadingThemes) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <>
+      <h2>View and manage your publications</h2>
+      <p>Select a publication to:</p>
+
+      <ul>
+        <li>create new releases and methodologies</li>
+        <li>edit exiting releases and methodologies</li>
+        <li>view and sign-off releases and methodologies</li>
+      </ul>
+
+      {isBauUser && (
+        <>
+          {themes && themes.length > 0 && (
+            <FormThemeTopicSelect
+              id="publicationsReleases-themeTopic"
+              legend="Choose a theme and topic to view publications for"
+              legendHidden
+              themes={themes}
+              topicId={topicId}
+              onChange={(nextTopicId, nextThemeId) => {
+                setSavedThemeTopic({
+                  themeId: nextThemeId,
+                  topicId: nextTopicId,
+                });
+
+                history.replace(
+                  appendQuery<ThemeTopicParams>(dashboardRoute.path, {
+                    themeId: nextThemeId,
+                    topicId: nextTopicId,
+                    showNewDashboard,
+                  }),
+                );
+              }}
+            />
+          )}
+        </>
+      )}
+
+      <hr />
+
+      {themes?.length === 0 ? (
+        <>
+          <h3
+            className="govuk-heading-s"
+            data-testid="no-permission-to-access-releases"
+          >
+            You do not currently have permission to edit any releases within the
+            service. To view a prerelease, please use the link provided to you
+            by email.
+          </h3>
+          <p>
+            To request access to a release, contact your team leader or the
+            Explore education statistics team at{' '}
+            <a href="mailto:explore.statistics@education.gov.uk">
+              explore.statistics@education.gov.uk
+            </a>
+          </p>
+        </>
+      ) : (
+        <>
+          {selectedTheme && selectedTopic ? (
+            <TopicPublications
+              key={selectedTopic.id}
+              themeTitle={selectedTheme.title}
+              topic={selectedTopic}
+            />
+          ) : (
+            <>
+              {themes?.map(theme => {
+                return theme.topics.map(topic => (
+                  <TopicPublications
+                    key={topic.id}
+                    themeTitle={theme.title}
+                    topic={topic}
+                  />
+                ));
+              })}
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+
+export default PublicationsTab;

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationsTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationsTab.tsx
@@ -105,12 +105,12 @@ const PublicationsTab = ({ isBauUser }: Props) => {
     topicId,
   ]);
 
-  if (loadingThemes) {
-    return <LoadingSpinner />;
-  }
-
   return (
-    <>
+    <LoadingSpinner
+      hideText
+      loading={loadingThemes}
+      text="Loading your publications"
+    >
       <h2>View and manage your publications</h2>
       <p>Select a publication to:</p>
 
@@ -148,7 +148,7 @@ const PublicationsTab = ({ isBauUser }: Props) => {
         </>
       )}
 
-      <hr />
+      <hr className="govuk-!-margin-bottom-0" />
 
       {themes?.length === 0 ? (
         <>
@@ -191,7 +191,7 @@ const PublicationsTab = ({ isBauUser }: Props) => {
           )}
         </>
       )}
-    </>
+    </LoadingSpinner>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleasesByStatusTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleasesByStatusTab.tsx
@@ -5,13 +5,13 @@ import React, { ReactNode } from 'react';
 interface Props {
   noReleasesMessage: string;
   releases: MyRelease[];
-  releaseSummaryRenderer: (release: MyRelease) => ReactNode;
+  renderReleaseSummary: (release: MyRelease) => ReactNode;
 }
 
 const ReleasesByStatusTab = ({
   releases,
   noReleasesMessage,
-  releaseSummaryRenderer,
+  renderReleaseSummary,
 }: Props) => {
   const releasesByPublication: Dictionary<MyRelease[]> = {};
 
@@ -35,7 +35,7 @@ const ReleasesByStatusTab = ({
               <hr />
               <h3>{publication}</h3>
               {releasesByPublication[publication].map(release =>
-                releaseSummaryRenderer(release),
+                renderReleaseSummary(release),
               )}
             </div>
           ))}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTab.tsx
@@ -35,16 +35,26 @@ const ScheduledReleasesTab = ({
             </p>
           </div>
         </div>
-        <ScheduledReleasesTable isLoading={isLoading} releases={releases} />
+        <LoadingSpinner
+          hideText
+          loading={isLoading}
+          text="Loading scheduled releases"
+        >
+          <ScheduledReleasesTable releases={releases} />
+        </LoadingSpinner>
       </>
     );
   }
   return (
-    <LoadingSpinner loading={isLoading}>
+    <LoadingSpinner
+      hideText
+      loading={isLoading}
+      text="Loading scheduled releases"
+    >
       <ReleasesTab
         releases={releases}
         noReleasesMessage="There are currently no scheduled releases"
-        releaseSummaryRenderer={release => (
+        renderReleaseSummary={release => (
           <ReleaseSummary
             key={release.id}
             release={release}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTab.tsx
@@ -1,0 +1,69 @@
+import ButtonLink from '@admin/components/ButtonLink';
+import ScheduledReleasesTable from '@admin/pages/admin-dashboard/components/ScheduledReleasesTable';
+import ReleasesTab from '@admin/pages/admin-dashboard/components/ReleasesByStatusTab';
+import ReleaseSummary from '@admin/pages/admin-dashboard/components/ReleaseSummary';
+import {
+  ReleaseRouteParams,
+  releaseSummaryRoute,
+} from '@admin/routes/releaseRoutes';
+import { MyRelease } from '@admin/services/releaseService';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import React from 'react';
+import { generatePath } from 'react-router';
+
+interface Props {
+  isLoading: boolean;
+  releases: MyRelease[];
+  showNewDashboard?: boolean; // TODO EES-3217 remove when ready to go live
+}
+
+const ScheduledReleasesTab = ({
+  isLoading,
+  releases,
+  showNewDashboard = false,
+}: Props) => {
+  if (showNewDashboard) {
+    return (
+      <>
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-two-thirds">
+            <h2>Approved scheduled releases</h2>
+            <p>
+              Here you can view releases that have been approved and are now
+              scheduled for publication. You can also check the progress of any
+              releases that are currently being published to live.
+            </p>
+          </div>
+        </div>
+        <ScheduledReleasesTable isLoading={isLoading} releases={releases} />
+      </>
+    );
+  }
+  return (
+    <LoadingSpinner loading={isLoading}>
+      <ReleasesTab
+        releases={releases}
+        noReleasesMessage="There are currently no scheduled releases"
+        releaseSummaryRenderer={release => (
+          <ReleaseSummary
+            key={release.id}
+            release={release}
+            actions={
+              <ButtonLink
+                to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
+                  publicationId: release.publicationId,
+                  releaseId: release.id,
+                })}
+                variant="secondary"
+              >
+                View release
+              </ButtonLink>
+            }
+          />
+        )}
+      />
+    </LoadingSpinner>
+  );
+};
+
+export default ScheduledReleasesTab;

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
@@ -1,0 +1,116 @@
+import ScheduledReleaseRow from '@admin/pages/publication/components/ScheduledReleaseRow';
+import {
+  ScheduledStagesGuidanceModal,
+  ScheduledStatusGuidanceModal,
+} from '@admin/pages/publication/components/PublicationGuidance';
+import { MyRelease } from '@admin/services/releaseService';
+import ButtonText from '@common/components/ButtonText';
+import InfoIcon from '@common/components/InfoIcon';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import useToggle from '@common/hooks/useToggle';
+import { Dictionary } from '@common/types';
+import orderBy from 'lodash/orderBy';
+import React, { useMemo } from 'react';
+
+interface PublicationRowProps {
+  publication: string;
+  releases: MyRelease[];
+}
+const PublicationRow = ({ publication, releases }: PublicationRowProps) => {
+  return (
+    <>
+      <tr key={publication}>
+        <th className="govuk-!-padding-top-6" colSpan={5}>
+          {publication}
+        </th>
+      </tr>
+      {releases.map(release => (
+        <ScheduledReleaseRow key={release.id} release={release} />
+      ))}
+    </>
+  );
+};
+
+interface Props {
+  isLoading: boolean;
+  releases: MyRelease[];
+}
+
+const ScheduledReleasesTable = ({ isLoading, releases }: Props) => {
+  const [
+    showScheduledStatusGuidance,
+    toggleScheduledStatusGuidance,
+  ] = useToggle(false);
+  const [
+    showScheduledStagesGuidance,
+    toggleScheduledStagesGuidance,
+  ] = useToggle(false);
+
+  const releasesByPublication: Dictionary<MyRelease[]> = useMemo(() => {
+    const groupedReleases: Dictionary<MyRelease[]> = {};
+    releases.forEach(release => {
+      if (groupedReleases[release.publicationTitle]) {
+        groupedReleases[release.publicationTitle].push(release);
+      } else {
+        groupedReleases[release.publicationTitle] = [release];
+      }
+    });
+    return groupedReleases;
+  }, [releases]);
+
+  return (
+    <>
+      <LoadingSpinner loading={isLoading}>
+        {releases.length === 0 ? (
+          <p>There are currently no scheduled releases</p>
+        ) : (
+          <>
+            {releasesByPublication &&
+              Object.keys(releasesByPublication).length > 0 && (
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Publication / Release period</th>
+                      <th>
+                        Status{' '}
+                        <ButtonText onClick={toggleScheduledStatusGuidance.on}>
+                          <InfoIcon description="Guidance on scheduled states" />
+                        </ButtonText>
+                      </th>
+                      <th className="govuk-!-width-one-quarter">
+                        Stages checklist{' '}
+                        <ButtonText onClick={toggleScheduledStagesGuidance.on}>
+                          <InfoIcon description="Guidance on publication stages" />
+                        </ButtonText>
+                      </th>
+                      <th>Scheduled publish date</th>
+                      <th>Actions</th>
+                    </tr>
+                    {orderBy(Object.keys(releasesByPublication)).map(
+                      publication => (
+                        <PublicationRow
+                          key={publication}
+                          publication={publication}
+                          releases={releasesByPublication[publication]}
+                        />
+                      ),
+                    )}
+                  </thead>
+                </table>
+              )}
+          </>
+        )}
+      </LoadingSpinner>
+      <ScheduledStagesGuidanceModal
+        open={showScheduledStagesGuidance}
+        onClose={toggleScheduledStagesGuidance.off}
+      />
+      <ScheduledStatusGuidanceModal
+        open={showScheduledStatusGuidance}
+        onClose={toggleScheduledStatusGuidance.off}
+      />
+    </>
+  );
+};
+
+export default ScheduledReleasesTable;

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
@@ -6,7 +6,6 @@ import {
 import { MyRelease } from '@admin/services/releaseService';
 import ButtonText from '@common/components/ButtonText';
 import InfoIcon from '@common/components/InfoIcon';
-import LoadingSpinner from '@common/components/LoadingSpinner';
 import useToggle from '@common/hooks/useToggle';
 import { Dictionary } from '@common/types';
 import orderBy from 'lodash/orderBy';
@@ -31,12 +30,11 @@ const PublicationRow = ({ publication, releases }: PublicationRowProps) => {
   );
 };
 
-interface Props {
-  isLoading: boolean;
+interface ScheduledReleasesTableProps {
   releases: MyRelease[];
 }
 
-const ScheduledReleasesTable = ({ isLoading, releases }: Props) => {
+const ScheduledReleasesTable = ({ releases }: ScheduledReleasesTableProps) => {
   const [
     showScheduledStatusGuidance,
     toggleScheduledStatusGuidance,
@@ -47,60 +45,57 @@ const ScheduledReleasesTable = ({ isLoading, releases }: Props) => {
   ] = useToggle(false);
 
   const releasesByPublication: Dictionary<MyRelease[]> = useMemo(() => {
-    const groupedReleases: Dictionary<MyRelease[]> = {};
-    releases.forEach(release => {
-      if (groupedReleases[release.publicationTitle]) {
-        groupedReleases[release.publicationTitle].push(release);
+    return releases.reduce<Dictionary<MyRelease[]>>((acc, release) => {
+      if (acc[release.publicationTitle]) {
+        acc[release.publicationTitle].push(release);
       } else {
-        groupedReleases[release.publicationTitle] = [release];
+        acc[release.publicationTitle] = [release];
       }
-    });
-    return groupedReleases;
-  }, [releases]);
 
+      return acc;
+    }, {});
+  }, [releases]);
   return (
     <>
-      <LoadingSpinner loading={isLoading}>
-        {releases.length === 0 ? (
-          <p>There are currently no scheduled releases</p>
-        ) : (
-          <>
-            {releasesByPublication &&
-              Object.keys(releasesByPublication).length > 0 && (
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Publication / Release period</th>
-                      <th>
-                        Status{' '}
-                        <ButtonText onClick={toggleScheduledStatusGuidance.on}>
-                          <InfoIcon description="Guidance on scheduled states" />
-                        </ButtonText>
-                      </th>
-                      <th className="govuk-!-width-one-quarter">
-                        Stages checklist{' '}
-                        <ButtonText onClick={toggleScheduledStagesGuidance.on}>
-                          <InfoIcon description="Guidance on publication stages" />
-                        </ButtonText>
-                      </th>
-                      <th>Scheduled publish date</th>
-                      <th>Actions</th>
-                    </tr>
-                    {orderBy(Object.keys(releasesByPublication)).map(
-                      publication => (
-                        <PublicationRow
-                          key={publication}
-                          publication={publication}
-                          releases={releasesByPublication[publication]}
-                        />
-                      ),
-                    )}
-                  </thead>
-                </table>
-              )}
-          </>
-        )}
-      </LoadingSpinner>
+      {releases.length === 0 ? (
+        <p>There are currently no scheduled releases</p>
+      ) : (
+        <>
+          {releasesByPublication &&
+            Object.keys(releasesByPublication).length > 0 && (
+              <table>
+                <thead>
+                  <tr>
+                    <th>Publication / Release period</th>
+                    <th>
+                      Status{' '}
+                      <ButtonText onClick={toggleScheduledStatusGuidance.on}>
+                        <InfoIcon description="Guidance on scheduled states" />
+                      </ButtonText>
+                    </th>
+                    <th className="govuk-!-width-one-quarter">
+                      Stages checklist{' '}
+                      <ButtonText onClick={toggleScheduledStagesGuidance.on}>
+                        <InfoIcon description="Guidance on publication stages" />
+                      </ButtonText>
+                    </th>
+                    <th>Scheduled publish date</th>
+                    <th>Actions</th>
+                  </tr>
+                  {orderBy(Object.keys(releasesByPublication)).map(
+                    publication => (
+                      <PublicationRow
+                        key={publication}
+                        publication={publication}
+                        releases={releasesByPublication[publication]}
+                      />
+                    ),
+                  )}
+                </thead>
+              </table>
+            )}
+        </>
+      )}
       <ScheduledStagesGuidanceModal
         open={showScheduledStagesGuidance}
         onClose={toggleScheduledStagesGuidance.off}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/TopicPublications.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/TopicPublications.module.scss
@@ -1,0 +1,9 @@
+@import '~govuk-frontend/govuk/base';
+
+.publication {
+  align-items: flex-start;
+  border-bottom: 1px solid $govuk-border-colour;
+  display: flex;
+  justify-content: space-between;
+  padding: govuk-spacing(3) 0;
+}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/TopicPublications.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/TopicPublications.tsx
@@ -1,0 +1,77 @@
+import ButtonLink from '@admin/components/ButtonLink';
+import { publicationCreateRoute, TopicParams } from '@admin/routes/routes';
+import Link from '@admin/components/Link';
+import {
+  publicationReleasesRoute,
+  PublicationRouteParams,
+} from '@admin/routes/publicationRoutes';
+import permissionService from '@admin/services/permissionService';
+import publicationService from '@admin/services/publicationService';
+import { Topic } from '@admin/services/topicService';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import React from 'react';
+import { generatePath } from 'react-router';
+
+interface Props {
+  themeTitle: string;
+  topic: Topic;
+}
+
+const TopicPublications = ({ topic, themeTitle }: Props) => {
+  const { value, isLoading } = useAsyncHandledRetry(async () => {
+    const [publications, canCreatePublication] = await Promise.all([
+      publicationService.getMyPublicationsByTopic(topic.id),
+      permissionService.canCreatePublicationForTopic(topic.id),
+    ]);
+    return { publications, canCreatePublication };
+  });
+
+  const { publications, canCreatePublication } = value ?? {};
+
+  return (
+    <div
+      className="dfe-flex dfe-justify-content--space-between dfe-align-items-start"
+      data-testid="topic-publications"
+    >
+      <div>
+        <h3>
+          {themeTitle} / {topic.title}
+        </h3>
+        <LoadingSpinner loading={isLoading} size="sm">
+          {publications?.length !== 0 ? (
+            <ul className="govuk-list">
+              {publications?.map(publication => (
+                <li key={publication.id}>
+                  <Link
+                    to={generatePath<PublicationRouteParams>(
+                      publicationReleasesRoute.path,
+                      {
+                        publicationId: publication.id,
+                      },
+                    )}
+                  >
+                    {publication.title}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>No publications available</p>
+          )}
+        </LoadingSpinner>
+      </div>
+      {canCreatePublication && (
+        <ButtonLink
+          to={generatePath<TopicParams>(publicationCreateRoute.path, {
+            topicId: topic.id,
+          })}
+        >
+          Create new publication
+        </ButtonLink>
+      )}
+    </div>
+  );
+};
+
+export default TopicPublications;

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/TopicPublications.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/TopicPublications.tsx
@@ -1,4 +1,5 @@
 import ButtonLink from '@admin/components/ButtonLink';
+import styles from '@admin/pages/admin-dashboard/components/TopicPublications.module.scss';
 import { publicationCreateRoute, TopicParams } from '@admin/routes/routes';
 import Link from '@admin/components/Link';
 import {
@@ -10,6 +11,7 @@ import publicationService from '@admin/services/publicationService';
 import { Topic } from '@admin/services/topicService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import orderBy from 'lodash/orderBy';
 import React from 'react';
 import { generatePath } from 'react-router';
 
@@ -30,18 +32,21 @@ const TopicPublications = ({ topic, themeTitle }: Props) => {
   const { publications, canCreatePublication } = value ?? {};
 
   return (
-    <div
-      className="dfe-flex dfe-justify-content--space-between dfe-align-items-start"
-      data-testid="topic-publications"
-    >
+    <div className={styles.publication} data-testid="topic-publications">
       <div>
         <h3>
           {themeTitle} / {topic.title}
         </h3>
-        <LoadingSpinner loading={isLoading} size="sm">
+        <LoadingSpinner
+          hideText
+          inline
+          loading={isLoading}
+          text="Loading publications"
+          size="md"
+        >
           {publications?.length !== 0 ? (
             <ul className="govuk-list">
-              {publications?.map(publication => (
+              {orderBy(publications, 'title')?.map(publication => (
                 <li key={publication.id}>
                   <Link
                     to={generatePath<PublicationRouteParams>(

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/DraftReleasesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/DraftReleasesTable.test.tsx
@@ -1,0 +1,521 @@
+import DraftReleasesTable from '@admin/pages/admin-dashboard/components/DraftReleasesTable';
+import _releaseService, { MyRelease } from '@admin/services/releaseService';
+import { waitFor, within } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+jest.mock('@admin/services/releaseService');
+const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
+
+describe('DraftReleasesTable', () => {
+  const testReleases: MyRelease[] = [
+    {
+      id: 'release-1',
+      latestRelease: true,
+      slug: 'release-1-slug',
+      title: 'Release 1',
+      publicationId: 'publication-1',
+      publicationTitle: 'Publication 1',
+      permissions: {
+        canUpdateRelease: true,
+      },
+      approvalStatus: 'Draft',
+    } as MyRelease,
+    {
+      id: 'release-2',
+      latestRelease: true,
+      slug: 'release-2-slug',
+      title: 'Release 2',
+      publicationId: 'publication-2',
+      publicationTitle: 'Publication 2',
+      permissions: {
+        canDeleteRelease: true,
+        canUpdateRelease: true,
+      },
+      approvalStatus: 'Draft',
+      amendment: true,
+      previousVersionId: 'previous-version-id',
+    } as MyRelease,
+    {
+      id: 'release-3',
+      latestRelease: false,
+      slug: 'release-3-slug',
+      title: 'Release 3',
+      publicationId: 'publication-1',
+      publicationTitle: 'Publication 1',
+      permissions: {
+        canUpdateRelease: true,
+        canDeleteRelease: true,
+      },
+      approvalStatus: 'HigherLevelReview',
+    } as MyRelease,
+
+    {
+      id: 'release-4',
+      latestRelease: true,
+      slug: 'release-4-slug',
+      title: 'Release 4',
+      publicationId: 'publication-3',
+      publicationTitle: 'Publication 3',
+      permissions: {
+        canUpdateRelease: true,
+      },
+      approvalStatus: 'Draft',
+    } as MyRelease,
+  ];
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  beforeEach(() => {
+    releaseService.getReleaseChecklist.mockResolvedValue({
+      errors: [
+        {
+          code: 'DataFileImportsMustBeCompleted',
+        },
+        {
+          code: 'EmptyContentSectionExists',
+        },
+      ],
+      valid: false,
+      warnings: [{ code: 'NoMethodology' }],
+    });
+  });
+
+  test('renders the table correctly for BAU users', async () => {
+    render(
+      <MemoryRouter>
+        <DraftReleasesTable
+          isBauUser
+          isLoading={false}
+          releases={testReleases}
+          onChangeRelease={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Publication / Release period'),
+      ).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(8);
+
+    expect(within(rows[1]).getByRole('columnheader')).toHaveTextContent(
+      'Publication 1',
+    );
+
+    // Draft
+    const row3cells = within(rows[2]).getAllByRole('cell');
+    expect(within(row3cells[0]).getByText('Release 1')).toBeInTheDocument();
+    expect(within(row3cells[1]).getByText('Draft')).toBeInTheDocument();
+    expect(
+      within(row3cells[2]).getByRole('link', { name: 'Edit Release 1' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/summary',
+    );
+    expect(
+      within(row3cells[2]).queryByRole('button', { name: /View issues/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row3cells[2]).queryByRole('button', {
+        name: 'Cancel amendment for Release 1',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row3cells[2]).queryByRole('link', {
+        name: 'View original for Release 1',
+      }),
+    ).not.toBeInTheDocument();
+
+    // In review
+    const row4cells = within(rows[3]).getAllByRole('cell');
+    expect(within(row4cells[0]).getByText('Release 3')).toBeInTheDocument();
+    expect(within(row4cells[1]).getByText('In Review')).toBeInTheDocument();
+    expect(
+      within(row4cells[2]).getByRole('link', { name: 'Edit Release 3' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-3/summary',
+    );
+    expect(
+      within(row4cells[2]).queryByRole('button', { name: /View issues/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row4cells[2]).queryByRole('button', {
+        name: 'Cancel amendment for Release 3',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row4cells[2]).queryByRole('link', {
+        name: 'View original for Release 3',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(within(rows[4]).getByRole('columnheader')).toHaveTextContent(
+      'Publication 2',
+    );
+
+    // Amendment
+    const row6cells = within(rows[5]).getAllByRole('cell');
+    expect(row6cells[0]).toHaveTextContent('Release 2');
+    expect(within(row6cells[0]).getByText('Release 2')).toBeInTheDocument();
+    expect(
+      within(row6cells[1]).getByText('Draft Amendment'),
+    ).toBeInTheDocument();
+    expect(
+      within(row6cells[2]).getByRole('link', { name: 'Edit Release 2' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-2/release/release-2/summary',
+    );
+    expect(
+      within(row6cells[2]).getByRole('button', {
+        name: 'Cancel amendment for Release 2',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(row6cells[2]).getByRole('link', {
+        name: 'View original for Release 2',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(row6cells[2]).queryByRole('button', { name: /View issues/ }),
+    ).not.toBeInTheDocument();
+
+    expect(within(rows[6]).getByRole('columnheader')).toHaveTextContent(
+      'Publication 3',
+    );
+
+    // Draft
+    const row8cells = within(rows[7]).getAllByRole('cell');
+    expect(within(row8cells[0]).getByText('Release 4')).toBeInTheDocument();
+    expect(within(row8cells[1]).getByText('Draft')).toBeInTheDocument();
+    expect(
+      within(row8cells[2]).getByRole('link', { name: 'Edit Release 4' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-3/release/release-4/summary',
+    );
+    expect(
+      within(row8cells[2]).queryByRole('button', { name: /View issues/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row8cells[2]).queryByRole('button', {
+        name: 'Cancel amendment for Release 4',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row8cells[2]).queryByRole('link', {
+        name: 'View original for Release 4',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders the table correctly for non-BAU users ', async () => {
+    render(
+      <MemoryRouter>
+        <DraftReleasesTable
+          isBauUser={false}
+          isLoading={false}
+          releases={testReleases}
+          onChangeRelease={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Publication / Release period'),
+      ).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(8);
+
+    expect(within(rows[1]).getByRole('columnheader')).toHaveTextContent(
+      'Publication 1',
+    );
+
+    // Draft
+    const row3cells = within(rows[2]).getAllByRole('cell');
+    expect(within(row3cells[0]).getByText('Release 1')).toBeInTheDocument();
+    expect(within(row3cells[1]).getByText('Draft')).toBeInTheDocument();
+    expect(
+      within(row3cells[2]).getByRole('button', { name: 'View issues (3)' }),
+    ).toBeInTheDocument();
+    expect(
+      within(row3cells[3]).getByRole('link', { name: 'Edit Release 1' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/summary',
+    );
+    expect(
+      within(row3cells[3]).queryByRole('button', {
+        name: 'Cancel amendment for Release 1',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row3cells[3]).queryByRole('link', {
+        name: 'View original for Release 1',
+      }),
+    ).not.toBeInTheDocument();
+
+    // In review
+    const row4cells = within(rows[3]).getAllByRole('cell');
+    expect(within(row4cells[0]).getByText('Release 3')).toBeInTheDocument();
+    expect(within(row4cells[1]).getByText('In Review')).toBeInTheDocument();
+    expect(
+      within(row4cells[2]).getByRole('button', { name: 'View issues (3)' }),
+    ).toBeInTheDocument();
+    expect(
+      within(row4cells[3]).getByRole('link', { name: 'Edit Release 3' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-3/summary',
+    );
+    expect(
+      within(row4cells[3]).queryByRole('button', {
+        name: 'Cancel amendment for Release 3',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row4cells[3]).queryByRole('link', {
+        name: 'View original for Release 3',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(within(rows[4]).getByRole('columnheader')).toHaveTextContent(
+      'Publication 2',
+    );
+
+    // Amendment
+    const row6cells = within(rows[5]).getAllByRole('cell');
+    expect(row6cells[0]).toHaveTextContent('Release 2');
+    expect(within(row6cells[0]).getByText('Release 2')).toBeInTheDocument();
+    expect(
+      within(row6cells[1]).getByText('Draft Amendment'),
+    ).toBeInTheDocument();
+    expect(
+      within(row6cells[2]).getByRole('button', { name: 'View issues (3)' }),
+    ).toBeInTheDocument();
+    expect(
+      within(row6cells[3]).getByRole('link', { name: 'Edit Release 2' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-2/release/release-2/summary',
+    );
+    expect(
+      within(row6cells[3]).getByRole('button', {
+        name: 'Cancel amendment for Release 2',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(row6cells[3]).getByRole('link', {
+        name: 'View original for Release 2',
+      }),
+    ).toBeInTheDocument();
+
+    expect(within(rows[6]).getByRole('columnheader')).toHaveTextContent(
+      'Publication 3',
+    );
+
+    // Draft
+    const row8cells = within(rows[7]).getAllByRole('cell');
+    expect(within(row8cells[0]).getByText('Release 4')).toBeInTheDocument();
+    expect(within(row8cells[1]).getByText('Draft')).toBeInTheDocument();
+    expect(
+      within(row8cells[2]).getByRole('button', { name: 'View issues (3)' }),
+    ).toBeInTheDocument();
+    expect(
+      within(row8cells[3]).getByRole('link', { name: 'Edit Release 4' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-3/release/release-4/summary',
+    );
+    expect(
+      within(row8cells[3]).queryByRole('button', {
+        name: 'Cancel amendment for Release 4',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row8cells[3]).queryByRole('link', {
+        name: 'View original for Release 4',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows a view instead of edit link if you do not have permission to edit the release', async () => {
+    render(
+      <MemoryRouter>
+        <DraftReleasesTable
+          isBauUser
+          isLoading={false}
+          releases={[
+            {
+              ...testReleases[0],
+              permissions: {
+                ...testReleases[0].permissions,
+                canUpdateRelease: false,
+              },
+            },
+          ]}
+          onChangeRelease={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Publication / Release period'),
+      ).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByRole('row');
+    const row3cells = within(rows[2]).getAllByRole('cell');
+
+    expect(
+      within(row3cells[2]).getByRole('link', { name: 'View Release 1' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/summary',
+    );
+  });
+
+  test('does not show the cancel button if you do not have permission to cancel the amendment', async () => {
+    render(
+      <MemoryRouter>
+        <DraftReleasesTable
+          isBauUser
+          isLoading={false}
+          releases={[
+            {
+              ...testReleases[2],
+              permissions: {
+                ...testReleases[2].permissions,
+                canDeleteRelease: false,
+              },
+            },
+          ]}
+          onChangeRelease={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Publication / Release period'),
+      ).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByRole('row');
+    const row3cells = within(rows[2]).getAllByRole('cell');
+    expect(
+      within(row3cells[2]).queryByRole('button', {
+        name: 'Cancel amendment for Release 2',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('handles cancelling an amendment correctly', async () => {
+    const handleOnChange = jest.fn();
+    releaseService.getDeleteReleasePlan.mockResolvedValue({
+      scheduledMethodologies: [
+        {
+          id: 'methodology-1',
+          title: 'Methodology 1',
+        },
+        {
+          id: 'methodology-2',
+          title: 'Methodology 2',
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <DraftReleasesTable
+          isBauUser
+          isLoading={false}
+          releases={testReleases}
+          onChangeRelease={handleOnChange}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Publication / Release period'),
+      ).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByRole('row');
+    const row6cells = within(rows[5]).getAllByRole('cell');
+
+    userEvent.click(
+      within(row6cells[2]).getByRole('button', {
+        name: 'Cancel amendment for Release 2',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(releaseService.getDeleteReleasePlan).toHaveBeenCalledWith(
+        'release-2',
+      );
+    });
+
+    const modal = within(screen.getByRole('dialog'));
+
+    expect(
+      modal.getByText('Confirm you want to cancel this amended release'),
+    ).toBeInTheDocument();
+    expect(modal.getByText('Methodology 1')).toBeInTheDocument();
+    expect(modal.getByText('Methodology 2')).toBeInTheDocument();
+
+    userEvent.click(
+      modal.getByRole('button', {
+        name: 'Confirm',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(releaseService.deleteRelease).toHaveBeenCalledWith('release-2');
+    });
+
+    expect(handleOnChange).toHaveBeenCalled();
+
+    expect(
+      screen.queryByText('Confirm you want to cancel this amended release'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly when no releases are available', async () => {
+    render(
+      <MemoryRouter>
+        <DraftReleasesTable
+          isBauUser
+          isLoading={false}
+          releases={[]}
+          onChangeRelease={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('There are currently no draft releases'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/DraftReleasesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/DraftReleasesTable.test.tsx
@@ -61,9 +61,12 @@ describe('DraftReleasesTable', () => {
       publicationId: 'publication-3',
       publicationTitle: 'Publication 3',
       permissions: {
+        canDeleteRelease: true,
         canUpdateRelease: true,
       },
-      approvalStatus: 'Draft',
+      approvalStatus: 'HigherLevelReview',
+      amendment: true,
+      previousVersionId: 'previous-version-id',
     } as MyRelease,
   ];
 
@@ -95,7 +98,6 @@ describe('DraftReleasesTable', () => {
       <MemoryRouter>
         <DraftReleasesTable
           isBauUser
-          isLoading={false}
           releases={testReleases}
           onChangeRelease={noop}
         />
@@ -198,10 +200,12 @@ describe('DraftReleasesTable', () => {
       'Publication 3',
     );
 
-    // Draft
+    // In review amendment
     const row8cells = within(rows[7]).getAllByRole('cell');
     expect(within(row8cells[0]).getByText('Release 4')).toBeInTheDocument();
-    expect(within(row8cells[1]).getByText('Draft')).toBeInTheDocument();
+    expect(
+      within(row8cells[1]).getByText('In Review Amendment'),
+    ).toBeInTheDocument();
     expect(
       within(row8cells[2]).getByRole('link', { name: 'Edit Release 4' }),
     ).toHaveAttribute(
@@ -215,20 +219,19 @@ describe('DraftReleasesTable', () => {
       within(row8cells[2]).queryByRole('button', {
         name: 'Cancel amendment for Release 4',
       }),
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
     expect(
       within(row8cells[2]).queryByRole('link', {
         name: 'View original for Release 4',
       }),
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
   });
 
-  test('renders the table correctly for non-BAU users ', async () => {
+  test('renders the table correctly for non-BAU users', async () => {
     render(
       <MemoryRouter>
         <DraftReleasesTable
           isBauUser={false}
-          isLoading={false}
           releases={testReleases}
           onChangeRelease={noop}
         />
@@ -331,10 +334,12 @@ describe('DraftReleasesTable', () => {
       'Publication 3',
     );
 
-    // Draft
+    // In review amendment
     const row8cells = within(rows[7]).getAllByRole('cell');
     expect(within(row8cells[0]).getByText('Release 4')).toBeInTheDocument();
-    expect(within(row8cells[1]).getByText('Draft')).toBeInTheDocument();
+    expect(
+      within(row8cells[1]).getByText('In Review Amendment'),
+    ).toBeInTheDocument();
     expect(
       within(row8cells[2]).getByRole('button', { name: 'View issues (3)' }),
     ).toBeInTheDocument();
@@ -348,12 +353,12 @@ describe('DraftReleasesTable', () => {
       within(row8cells[3]).queryByRole('button', {
         name: 'Cancel amendment for Release 4',
       }),
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
     expect(
       within(row8cells[3]).queryByRole('link', {
         name: 'View original for Release 4',
       }),
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
   });
 
   test('shows a view instead of edit link if you do not have permission to edit the release', async () => {
@@ -361,7 +366,6 @@ describe('DraftReleasesTable', () => {
       <MemoryRouter>
         <DraftReleasesTable
           isBauUser
-          isLoading={false}
           releases={[
             {
               ...testReleases[0],
@@ -398,7 +402,6 @@ describe('DraftReleasesTable', () => {
       <MemoryRouter>
         <DraftReleasesTable
           isBauUser
-          isLoading={false}
           releases={[
             {
               ...testReleases[2],
@@ -447,7 +450,6 @@ describe('DraftReleasesTable', () => {
       <MemoryRouter>
         <DraftReleasesTable
           isBauUser
-          isLoading={false}
           releases={testReleases}
           onChangeRelease={handleOnChange}
         />
@@ -503,12 +505,7 @@ describe('DraftReleasesTable', () => {
   test('renders correctly when no releases are available', async () => {
     render(
       <MemoryRouter>
-        <DraftReleasesTable
-          isBauUser
-          isLoading={false}
-          releases={[]}
-          onChangeRelease={noop}
-        />
+        <DraftReleasesTable isBauUser releases={[]} onChangeRelease={noop} />
       </MemoryRouter>,
     );
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationsTab.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationsTab.test.tsx
@@ -120,7 +120,7 @@ describe('PublicationsTab', () => {
     },
   ];
 
-  const testTopic2Publications = [
+  const testTopic2Publications: MyPublication[] = [
     {
       id: 'publication-3',
       title: 'Publication 3',
@@ -142,7 +142,7 @@ describe('PublicationsTab', () => {
     },
   ];
 
-  const testTopic3Publications = [
+  const testTopic3Publications: MyPublication[] = [
     {
       id: 'publication-4',
       title: 'Publication 4',
@@ -164,7 +164,7 @@ describe('PublicationsTab', () => {
     },
   ];
 
-  const testTopic4Publications = [
+  const testTopic4Publications: MyPublication[] = [
     {
       id: 'publication-5',
       title: 'Publication 5',

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationsTab.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationsTab.test.tsx
@@ -1,0 +1,758 @@
+import PublicationsTab from '@admin/pages/admin-dashboard/components/PublicationsTab';
+import _permissionService from '@admin/services/permissionService';
+import _publicationService, {
+  MyPublication,
+  PublicationContactDetails,
+} from '@admin/services/publicationService';
+import _themeService, { Theme } from '@admin/services/themeService';
+import _storageService from '@common/services/storageService';
+import { waitFor } from '@testing-library/dom';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { MemoryRouter, Router } from 'react-router';
+
+jest.mock('@admin/services/permissionService');
+jest.mock('@admin/services/publicationService');
+jest.mock('@admin/services/themeService');
+jest.mock('@common/services/storageService');
+
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+const permissionService = _permissionService as jest.Mocked<
+  typeof _permissionService
+>;
+const themeService = _themeService as jest.Mocked<typeof _themeService>;
+const storageService = _storageService as jest.Mocked<typeof _storageService>;
+
+describe('PublicationsTab', () => {
+  const testThemeTopics: Theme[] = [
+    {
+      id: 'theme-1',
+      title: 'Theme 1',
+      slug: 'theme-1',
+      summary: '',
+      topics: [
+        {
+          id: 'topic-1',
+          title: 'Topic 1',
+          slug: 'topic-1',
+          themeId: 'theme-1',
+        },
+        {
+          id: 'topic-2',
+          title: 'Topic 2',
+          slug: 'topic-2',
+          themeId: 'theme-1',
+        },
+      ],
+    },
+    {
+      id: 'theme-2',
+      title: 'Theme 2',
+      slug: 'theme-2',
+      summary: '',
+      topics: [
+        {
+          id: 'topic-3',
+          title: 'Topic 3',
+          slug: 'topic-3',
+          themeId: 'theme-1',
+        },
+        {
+          id: 'topic-4',
+          title: 'Topic 4',
+          slug: 'topic-4',
+          themeId: 'theme-1',
+        },
+      ],
+    },
+  ];
+
+  const testContact: PublicationContactDetails = {
+    id: 'contact-1',
+    contactName: 'John Smith',
+    contactTelNo: '0777777777',
+    teamEmail: 'john.smith@test.com',
+    teamName: 'Team Smith',
+  };
+
+  const testTopic1Publications: MyPublication[] = [
+    {
+      id: 'publication-1',
+      title: 'Publication 1',
+      contact: testContact,
+      releases: [],
+      legacyReleases: [],
+      methodologies: [],
+      themeId: 'theme-1',
+      topicId: 'topic-1',
+      permissions: {
+        canAdoptMethodologies: true,
+        canCreateReleases: true,
+        canUpdatePublication: true,
+        canUpdatePublicationTitle: true,
+        canUpdatePublicationSupersededBy: true,
+        canCreateMethodologies: true,
+        canManageExternalMethodology: true,
+      },
+    },
+    {
+      id: 'publication-2',
+      title: 'Publication 2',
+      contact: testContact,
+      releases: [],
+      legacyReleases: [],
+      methodologies: [],
+      themeId: 'theme-1',
+      topicId: 'topic-1',
+      permissions: {
+        canAdoptMethodologies: true,
+        canCreateReleases: true,
+        canUpdatePublication: true,
+        canUpdatePublicationTitle: true,
+        canUpdatePublicationSupersededBy: true,
+        canCreateMethodologies: true,
+        canManageExternalMethodology: true,
+      },
+    },
+  ];
+
+  const testTopic2Publications = [
+    {
+      id: 'publication-3',
+      title: 'Publication 3',
+      contact: testContact,
+      releases: [],
+      legacyReleases: [],
+      methodologies: [],
+      themeId: 'theme-1',
+      topicId: 'topic-2',
+      permissions: {
+        canAdoptMethodologies: true,
+        canCreateReleases: true,
+        canUpdatePublication: true,
+        canUpdatePublicationTitle: true,
+        canUpdatePublicationSupersededBy: true,
+        canCreateMethodologies: true,
+        canManageExternalMethodology: true,
+      },
+    },
+  ];
+
+  const testTopic3Publications = [
+    {
+      id: 'publication-4',
+      title: 'Publication 4',
+      contact: testContact,
+      releases: [],
+      legacyReleases: [],
+      methodologies: [],
+      themeId: 'theme-3',
+      topicId: 'topic-3',
+      permissions: {
+        canAdoptMethodologies: true,
+        canCreateReleases: true,
+        canUpdatePublication: true,
+        canUpdatePublicationTitle: true,
+        canUpdatePublicationSupersededBy: true,
+        canCreateMethodologies: true,
+        canManageExternalMethodology: true,
+      },
+    },
+  ];
+
+  const testTopic4Publications = [
+    {
+      id: 'publication-5',
+      title: 'Publication 5',
+      contact: testContact,
+      releases: [],
+      legacyReleases: [],
+      methodologies: [],
+      themeId: 'theme-3',
+      topicId: 'topic-4',
+      permissions: {
+        canAdoptMethodologies: true,
+        canCreateReleases: true,
+        canUpdatePublication: true,
+        canUpdatePublicationTitle: true,
+        canUpdatePublicationSupersededBy: true,
+        canCreateMethodologies: true,
+        canManageExternalMethodology: true,
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+  });
+
+  describe('BAU user', () => {
+    test('renders with first theme and topic selected by default', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic1Publications,
+      );
+
+      render(
+        <MemoryRouter>
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText('Select theme')).toHaveValue('theme-1');
+      expect(screen.getByLabelText('Select topic')).toHaveValue('topic-1');
+      expect(screen.getByRole('heading', { name: 'Theme 1 / Topic 1' }));
+    });
+
+    test('adds `themeId` and `topicId` query params from initial theme/topic', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic1Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      const history = createMemoryHistory();
+
+      render(
+        <Router history={history}>
+          <PublicationsTab isBauUser />
+        </Router>,
+      );
+
+      await waitFor(() => {
+        expect(history.location.search).toBe(
+          '?themeId=theme-1&topicId=topic-1',
+        );
+      });
+    });
+
+    test('renders with saved theme and topic', async () => {
+      storageService.getSync.mockReturnValue({
+        themeId: 'theme-2',
+        topicId: 'topic-4',
+      });
+
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic1Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter>
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText('Select theme')).toHaveValue('theme-2');
+      expect(screen.getByLabelText('Select topic')).toHaveValue('topic-4');
+      expect(screen.getByRole('heading', { name: 'Theme 2 / Topic 4' }));
+    });
+
+    test('renders with first theme/topic if saved theme and topic are invalid', async () => {
+      storageService.getSync.mockReturnValue({
+        themeId: 'not a theme',
+        topicId: 'not a topic',
+      });
+
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic1Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter>
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText('Select theme')).toHaveValue('theme-1');
+      expect(screen.getByLabelText('Select topic')).toHaveValue('topic-1');
+      expect(screen.getByRole('heading', { name: 'Theme 1 / Topic 1' }));
+    });
+
+    test('adds `themeId` and `topicId` query params from saved theme and topic', async () => {
+      storageService.getSync.mockReturnValue({
+        themeId: 'theme-2',
+        topicId: 'topic-4',
+      });
+
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic4Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      const history = createMemoryHistory();
+
+      render(
+        <Router history={history}>
+          <PublicationsTab isBauUser />
+        </Router>,
+      );
+
+      await waitFor(() => {
+        expect(history.location.search).toBe(
+          '?themeId=theme-2&topicId=topic-4',
+        );
+      });
+    });
+
+    test('renders theme/topic selected from query params instead of saved theme/topic', async () => {
+      storageService.getSync.mockReturnValue({
+        themeId: 'theme-1',
+        topicId: 'topic-2',
+      });
+
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic2Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter
+          initialEntries={[{ search: '?themeId=theme-2&topicId=topic-4' }]}
+        >
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText('Select theme')).toHaveValue('theme-2');
+      expect(screen.getByLabelText('Select topic')).toHaveValue('topic-4');
+      expect(screen.getByRole('heading', { name: 'Theme 2 / Topic 4' }));
+    });
+
+    test('renders with first theme selected if `themeId` query param does not match any theme', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic1Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter initialEntries={[{ search: '?themeId=not-a-theme' }]}>
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText('Select theme')).toHaveValue('theme-1');
+      expect(screen.getByLabelText('Select topic')).toHaveValue('topic-1');
+      expect(screen.getByRole('heading', { name: 'Theme 1 / Topic 1' }));
+    });
+
+    test('renders with saved theme selected if `topicId` query param is missing', async () => {
+      storageService.getSync.mockReturnValue({
+        themeId: 'theme-2',
+        topicId: 'topic-3',
+      });
+
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic3Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter initialEntries={[{ search: '?topicId=topic-4' }]}>
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText('Select theme')).toHaveValue('theme-2');
+      expect(screen.getByLabelText('Select topic')).toHaveValue('topic-4');
+      expect(screen.getByRole('heading', { name: 'Theme 2 / Topic 4' }));
+    });
+
+    test('renders with first topic selected if `topicId` query param is missing', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic3Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter initialEntries={[{ search: '?themeId=theme-2' }]}>
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText('Select theme')).toHaveValue('theme-2');
+      expect(screen.getByLabelText('Select topic')).toHaveValue('topic-3');
+      expect(screen.getByRole('heading', { name: 'Theme 2 / Topic 3' }));
+    });
+
+    test('renders with first topic selected if `topicId` query param does not match any topic', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic3Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter
+          initialEntries={[{ search: '?themeId=theme-2&topicId=not-a-topic' }]}
+        >
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText('Select theme')).toHaveValue('theme-2');
+      expect(screen.getByLabelText('Select topic')).toHaveValue('topic-3');
+      expect(screen.getByRole('heading', { name: 'Theme 2 / Topic 3' }));
+    });
+
+    test('renders with saved topic selected if `topicId` query param is missing', async () => {
+      storageService.getSync.mockReturnValue({
+        themeId: 'theme-2',
+        topicId: 'topic-4',
+      });
+
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic4Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter initialEntries={[{ search: '?themeId=theme-2' }]}>
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText('Select theme')).toHaveValue('theme-2');
+      expect(screen.getByLabelText('Select topic')).toHaveValue('topic-4');
+      expect(screen.getByRole('heading', { name: 'Theme 2 / Topic 4' }));
+    });
+
+    test('selecting new theme selects first topic automatically', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic3Publications,
+      );
+
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter>
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.selectOptions(screen.getByLabelText('Select theme'), 'theme-2');
+
+      await waitFor(() => {
+        expect(screen.getByText('Theme 2 / Topic 3'));
+      });
+
+      expect(screen.getByLabelText('Select theme')).toHaveValue('theme-2');
+      expect(screen.getByLabelText('Select topic')).toHaveValue('topic-3');
+
+      expect(
+        screen.getByRole('link', { name: 'Publication 4' }),
+      ).toBeInTheDocument();
+    });
+
+    test('selecting new theme and topic renders correctly', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic4Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter>
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.selectOptions(screen.getByLabelText('Select theme'), 'theme-2');
+
+      await waitFor(() => {
+        expect(screen.getByText('Topic 4', { selector: 'option' })).toHaveValue(
+          'topic-4',
+        );
+      });
+
+      userEvent.selectOptions(screen.getByLabelText('Select topic'), 'topic-4');
+
+      await waitFor(() => {
+        expect(screen.getByText('Theme 2 / Topic 4'));
+      });
+
+      expect(screen.getByLabelText('Select theme')).toHaveValue('theme-2');
+      expect(screen.getByLabelText('Select topic')).toHaveValue('topic-4');
+      expect(
+        screen.getByRole('link', { name: 'Publication 5' }),
+      ).toBeInTheDocument();
+    });
+
+    test('selecting new theme and topic updates query params correctly', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic4Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      const history = createMemoryHistory();
+
+      render(
+        <Router history={history}>
+          <PublicationsTab isBauUser />
+        </Router>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.selectOptions(screen.getByLabelText('Select theme'), 'theme-2');
+
+      await waitFor(() => {
+        expect(screen.getByText('Topic 4', { selector: 'option' })).toHaveValue(
+          'topic-4',
+        );
+      });
+
+      userEvent.selectOptions(screen.getByLabelText('Select topic'), 'topic-4');
+
+      await waitFor(() => {
+        expect(history.location.search).toBe(
+          '?themeId=theme-2&topicId=topic-4&showNewDashboard=',
+        );
+      });
+    });
+
+    test('renders correctly when no themes are available', async () => {
+      themeService.getThemes.mockResolvedValue([]);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue([]);
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter>
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.queryByLabelText('Select theme')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Select ')).not.toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /do not currently have permission to edit any releases/,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    test('renders list of publications for the selected topic', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic1Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter>
+          <PublicationsTab isBauUser />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('heading', { name: 'Theme 1 / Topic 1' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('link', { name: 'Publication 1' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('non-BAU user', () => {
+    test('does not render the theme and topic dropdowns', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic1Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter>
+          <PublicationsTab isBauUser={false} />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.queryByLabelText('Select theme')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Select topic')).not.toBeInTheDocument();
+    });
+
+    test('does not add `themeId` and `topicId` query params', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic.mockResolvedValue(
+        testTopic1Publications,
+      );
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      const history = createMemoryHistory();
+
+      render(
+        <Router history={history}>
+          <PublicationsTab isBauUser={false} />
+        </Router>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      expect(history.location.search).toBe('');
+    });
+
+    test('renders a list of all publications grouped by theme and topic', async () => {
+      themeService.getThemes.mockResolvedValue(testThemeTopics);
+      publicationService.getMyPublicationsByTopic
+        .mockResolvedValueOnce(testTopic1Publications)
+        .mockResolvedValueOnce(testTopic2Publications)
+        .mockResolvedValueOnce(testTopic3Publications)
+        .mockResolvedValueOnce(testTopic4Publications);
+      permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+      render(
+        <MemoryRouter>
+          <PublicationsTab isBauUser={false} />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('View and manage your publications'),
+        ).toBeInTheDocument();
+      });
+
+      const groups = screen.getAllByTestId('topic-publications');
+      expect(groups).toHaveLength(4);
+
+      expect(
+        within(groups[0]).getByRole('heading', { name: 'Theme 1 / Topic 1' }),
+      ).toBeInTheDocument();
+      expect(
+        within(groups[0]).getByRole('link', { name: 'Publication 1' }),
+      ).toBeInTheDocument();
+      expect(
+        within(groups[0]).getByRole('link', { name: 'Publication 2' }),
+      ).toBeInTheDocument();
+
+      expect(
+        within(groups[1]).getByRole('heading', { name: 'Theme 1 / Topic 2' }),
+      ).toBeInTheDocument();
+      expect(
+        within(groups[1]).getByRole('link', { name: 'Publication 3' }),
+      ).toBeInTheDocument();
+
+      expect(
+        within(groups[2]).getByRole('heading', { name: 'Theme 2 / Topic 3' }),
+      ).toBeInTheDocument();
+      expect(
+        within(groups[2]).getByRole('link', { name: 'Publication 4' }),
+      ).toBeInTheDocument();
+
+      expect(
+        within(groups[3]).getByRole('heading', { name: 'Theme 2 / Topic 4' }),
+      ).toBeInTheDocument();
+      expect(
+        within(groups[3]).getByRole('link', { name: 'Publication 5' }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ScheduledReleasesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ScheduledReleasesTable.test.tsx
@@ -75,7 +75,7 @@ describe('ScheduledReleasesTable', () => {
   test('renders the table of releases grouped by publication ', async () => {
     render(
       <MemoryRouter>
-        <ScheduledReleasesTable isLoading={false} releases={testReleases} />
+        <ScheduledReleasesTable releases={testReleases} />
       </MemoryRouter>,
     );
 
@@ -141,7 +141,6 @@ describe('ScheduledReleasesTable', () => {
     render(
       <MemoryRouter>
         <ScheduledReleasesTable
-          isLoading={false}
           releases={[
             {
               ...testReleases[0],
@@ -175,7 +174,7 @@ describe('ScheduledReleasesTable', () => {
   test('renders correctly when no releases are available', async () => {
     render(
       <MemoryRouter>
-        <ScheduledReleasesTable isLoading={false} releases={[]} />
+        <ScheduledReleasesTable releases={[]} />
       </MemoryRouter>,
     );
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ScheduledReleasesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ScheduledReleasesTable.test.tsx
@@ -1,0 +1,188 @@
+import ScheduledReleasesTable from '@admin/pages/admin-dashboard/components/ScheduledReleasesTable';
+import _releaseService, { MyRelease } from '@admin/services/releaseService';
+import { waitFor, within } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+jest.mock('@admin/services/releaseService');
+const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
+
+describe('ScheduledReleasesTable', () => {
+  const testReleases: MyRelease[] = [
+    {
+      id: 'release-1',
+      latestRelease: true,
+      publishScheduled: '2021-06-30T00:00:00',
+      slug: 'release-1-slug',
+      title: 'Release 1',
+      publicationId: 'publication-1',
+      publicationTitle: 'Publication 1',
+      permissions: {
+        canUpdateRelease: true,
+      },
+      approvalStatus: 'Approved',
+    } as MyRelease,
+    {
+      id: 'release-2',
+      latestRelease: true,
+      publishScheduled: '2021-05-30T00:00:00',
+      slug: 'release-2-slug',
+      title: 'Release 2',
+      publicationId: 'publication-2',
+      publicationTitle: 'Publication 2',
+      permissions: {
+        canUpdateRelease: true,
+      },
+      approvalStatus: 'Approved',
+    } as MyRelease,
+    {
+      id: 'release-3',
+      latestRelease: false,
+      publishScheduled: '2021-01-01T00:00:00',
+      slug: 'release-3-slug',
+      title: 'Release 3',
+      publicationId: 'publication-1',
+      publicationTitle: 'Publication 1',
+      permissions: {
+        canUpdateRelease: true,
+        canDeleteRelease: true,
+      },
+      approvalStatus: 'Approved',
+    } as MyRelease,
+
+    {
+      id: 'release-4',
+      latestRelease: true,
+      publishScheduled: '2021-05-30T00:00:00',
+      slug: 'release-4-slug',
+      title: 'Release 4',
+      publicationId: 'publication-3',
+      publicationTitle: 'Publication 3',
+      permissions: {
+        canUpdateRelease: true,
+      },
+      approvalStatus: 'Approved',
+    } as MyRelease,
+  ];
+
+  beforeEach(() => {
+    releaseService.getReleaseStatus.mockResolvedValue({
+      overallStage: 'Scheduled',
+    });
+  });
+
+  test('renders the table of releases grouped by publication ', async () => {
+    render(
+      <MemoryRouter>
+        <ScheduledReleasesTable isLoading={false} releases={testReleases} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Publication / Release period'),
+      ).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(8);
+
+    expect(within(rows[1]).getByRole('columnheader')).toHaveTextContent(
+      'Publication 1',
+    );
+
+    const row3cells = within(rows[2]).getAllByRole('cell');
+    expect(row3cells[0]).toHaveTextContent('Release 1');
+    expect(row3cells[1]).toHaveTextContent('Scheduled');
+    expect(row3cells[2]).toHaveTextContent('View stages');
+    expect(row3cells[3]).toHaveTextContent('30 June 2021');
+    expect(
+      within(row3cells[4]).getByRole('link', { name: 'Edit Release 1' }),
+    ).toBeInTheDocument();
+
+    const row4cells = within(rows[3]).getAllByRole('cell');
+    expect(row4cells[0]).toHaveTextContent('Release 3');
+    expect(row4cells[1]).toHaveTextContent('Scheduled');
+    expect(row4cells[2]).toHaveTextContent('View stages');
+    expect(row4cells[3]).toHaveTextContent('1 January 2021');
+    expect(
+      within(row4cells[4]).getByRole('link', { name: 'Edit Release 3' }),
+    ).toBeInTheDocument();
+
+    expect(within(rows[4]).getByRole('columnheader')).toHaveTextContent(
+      'Publication 2',
+    );
+
+    const row6cells = within(rows[5]).getAllByRole('cell');
+    expect(row6cells[0]).toHaveTextContent('Release 2');
+    expect(row6cells[1]).toHaveTextContent('Scheduled');
+    expect(row6cells[2]).toHaveTextContent('View stages');
+    expect(row6cells[3]).toHaveTextContent('30 May 2021');
+    expect(
+      within(row6cells[4]).getByRole('link', { name: 'Edit Release 2' }),
+    ).toBeInTheDocument();
+
+    expect(within(rows[6]).getByRole('columnheader')).toHaveTextContent(
+      'Publication 3',
+    );
+
+    const row8cells = within(rows[7]).getAllByRole('cell');
+    expect(row8cells[0]).toHaveTextContent('Release 4');
+    expect(row8cells[1]).toHaveTextContent('Scheduled');
+    expect(row8cells[2]).toHaveTextContent('View stages');
+    expect(row8cells[3]).toHaveTextContent('30 May 2021');
+    expect(
+      within(row8cells[4]).getByRole('link', { name: 'Edit Release 4' }),
+    ).toBeInTheDocument();
+  });
+
+  test('shows a view instead of edit link if you do not have permission to edit the release', async () => {
+    render(
+      <MemoryRouter>
+        <ScheduledReleasesTable
+          isLoading={false}
+          releases={[
+            {
+              ...testReleases[0],
+              permissions: {
+                ...testReleases[0].permissions,
+                canUpdateRelease: false,
+              },
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Publication / Release period'),
+      ).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByRole('row');
+    const row3cells = within(rows[2]).getAllByRole('cell');
+
+    expect(
+      within(row3cells[4]).getByRole('link', { name: 'View Release 1' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/summary',
+    );
+  });
+
+  test('renders correctly when no releases are available', async () => {
+    render(
+      <MemoryRouter>
+        <ScheduledReleasesTable isLoading={false} releases={[]} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('There are currently no scheduled releases'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/TopicPublications.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/TopicPublications.test.tsx
@@ -1,0 +1,120 @@
+import TopicPublications from '@admin/pages/admin-dashboard/components/TopicPublications';
+import { testPublication } from '@admin/pages/publication/__data__/testPublication';
+import _permissionService from '@admin/services/permissionService';
+import _publicationService, {
+  MyPublication,
+} from '@admin/services/publicationService';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+jest.mock('@admin/services/permissionService');
+jest.mock('@admin/services/publicationService');
+jest.mock('@admin/services/themeService');
+jest.mock('@common/services/storageService');
+
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+const permissionService = _permissionService as jest.Mocked<
+  typeof _permissionService
+>;
+
+describe('TopicPublications', () => {
+  const testTopic = {
+    id: 'topic-1',
+    title: 'Topic 1',
+    slug: 'topic-1',
+    themeId: 'theme-1',
+  };
+  const testThemeTitle = 'Theme 1';
+
+  const testPublications: MyPublication[] = [
+    testPublication,
+    { ...testPublication, id: 'publication-2', title: 'Publication 2' },
+  ];
+
+  test('renders correctly with list of publications', async () => {
+    publicationService.getMyPublicationsByTopic.mockResolvedValue(
+      testPublications,
+    );
+    permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+    render(
+      <MemoryRouter>
+        <TopicPublications themeTitle={testThemeTitle} topic={testTopic} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Theme 1 / Topic 1')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('link', { name: 'Publication 1' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Publication 2' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders correctly when no publications are available', async () => {
+    publicationService.getMyPublicationsByTopic.mockResolvedValue([]);
+    permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+    render(
+      <MemoryRouter>
+        <TopicPublications themeTitle={testThemeTitle} topic={testTopic} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Theme 1 / Topic 1')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('No publications available')).toBeInTheDocument();
+  });
+
+  test("renders 'Create new publication' button if authorised", async () => {
+    publicationService.getMyPublicationsByTopic.mockResolvedValue(
+      testPublications,
+    );
+    permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
+
+    render(
+      <MemoryRouter>
+        <TopicPublications themeTitle={testThemeTitle} topic={testTopic} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Theme 1 / Topic 1')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('link', { name: 'Create new publication' }),
+    ).toBeInTheDocument();
+  });
+
+  test("does not render 'Create new publication' button if unauthorised", async () => {
+    publicationService.getMyPublicationsByTopic.mockResolvedValue(
+      testPublications,
+    );
+    permissionService.canCreatePublicationForTopic.mockResolvedValue(false);
+
+    render(
+      <MemoryRouter>
+        <TopicPublications themeTitle={testThemeTitle} topic={testTopic} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Theme 1 / Topic 1')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('link', { name: 'Create new publication' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/TopicPublications.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/TopicPublications.test.tsx
@@ -51,12 +51,14 @@ describe('TopicPublications', () => {
       expect(screen.getByText('Theme 1 / Topic 1')).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByRole('link', { name: 'Publication 1' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: 'Publication 2' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Publication 1' })).toHaveAttribute(
+      'href',
+      '/publication/publication-1/releases',
+    );
+    expect(screen.getByRole('link', { name: 'Publication 2' })).toHaveAttribute(
+      'href',
+      '/publication/publication-2/releases',
+    );
   });
 
   test('renders correctly when no publications are available', async () => {
@@ -94,7 +96,7 @@ describe('TopicPublications', () => {
 
     expect(
       screen.getByRole('link', { name: 'Create new publication' }),
-    ).toBeInTheDocument();
+    ).toHaveAttribute('href', '/topics/topic-1/publications/create');
   });
 
   test("does not render 'Create new publication' button if unauthorised", async () => {

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStages.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStages.tsx
@@ -64,6 +64,19 @@ const ReleasePublishingStages = ({
           );
         })}
       </ul>
+      {checklistStyle && currentStatus.overallStage === 'Failed' && (
+        <>
+          <p className="govuk-!-margin-bottom-0 govuk-!-font-size-16">
+            <strong>Help and guidance</strong>
+          </p>
+          <p className=" govuk-!-font-size-16">
+            For extra help and guidance to help rectify this issue please email:{' '}
+            <a href="mailto:explore.statistics@education.gov.uk">
+              explore.statistics@education.gov.uk
+            </a>
+          </p>
+        </>
+      )}
     </Details>
   );
 };

--- a/src/explore-education-statistics-admin/src/routes/routes.ts
+++ b/src/explore-education-statistics-admin/src/routes/routes.ts
@@ -39,7 +39,12 @@ export type TopicParams = {
   topicId: string;
 };
 
-export type ThemeTopicParams = ThemeParams & TopicParams;
+// TODO EES-3217 - feature flag to show new dashboard, remove when ready to go live
+export type NewDashBoardParams = {
+  showNewDashboard?: string;
+};
+
+export type ThemeTopicParams = ThemeParams & TopicParams & NewDashBoardParams;
 
 export const homeRoute: ProtectedRouteProps = {
   path: '/',


### PR DESCRIPTION
Adds the new admin dashboard under a feature flag, add &showNewDashboard=true to the url to see it:

EES-3218 - Publications tab
- only the publication name is shown, which links to the new Manage Publication section
- BAU users still get the theme and topic dropdowns
- non-BAU users see all their publications at once (this is quite inefficient currently but will be updated when the API work is done) 
- loading draft and scheduled releases no longer blocks loading the publications

EES-3219 - Draft releases tab
- new style table of releases
- BAU users don't see the Issues as there are potential performance problems loading the checklist for lots of releases
- the draft releases are refreshed when you go to the tab

EES-3220 - Scheduled releases tab
- new style table of releases
- this tab isn't refreshed when you go to it as the endpoint is known to be slow

I ran out of time so haven't checked this for silly mistakes, so apologies if there are some!

![dashboard-non-bau](https://user-images.githubusercontent.com/81572860/182906548-6865a299-c24b-4e68-89b8-492cb2a0f744.PNG)
![dashboard-bau](https://user-images.githubusercontent.com/81572860/182906550-e9270691-e597-4cda-99ac-f0e73f71d842.PNG)
![scheduled](https://user-images.githubusercontent.com/81572860/182906530-aebffb1f-0938-4242-a7b3-ca5b5bff9207.PNG)
![drafts](https://user-images.githubusercontent.com/81572860/182906537-4e2e5549-e74b-4187-9d96-fffabc9b5846.PNG)


