### PR TITLE
EES-3544 - fix bs4 warning when parsing xml documents

### DIFF
--- a/tests/robot-tests/tests/libs/slack.py
+++ b/tests/robot-tests/tests/libs/slack.py
@@ -5,7 +5,6 @@ import shutil
 import json
 import requests
 from bs4 import BeautifulSoup
-
 PATH = f'{os.getcwd()}{os.sep}test-results'
 
 
@@ -14,6 +13,7 @@ def _generate_slack_attachments(env: str, suite: str):
         contents = report.read()
 
     soup = BeautifulSoup(contents, features='xml')
+
     test = soup.find('total').find('stat')
 
     failed_tests = int(test['fail'])
@@ -57,7 +57,7 @@ def _tests_failed():
     with open(f'{PATH}{os.sep}output.xml', 'rb') as report:
         contents = report.read()
 
-        soup = BeautifulSoup(contents, 'lxml')
+        soup = BeautifulSoup(contents, features='xml')
         test = soup.find('total').find('stat')
 
         failed_tests = int(test['fail'])


### PR DESCRIPTION
This PR: 
Fixes a bs4 warning when parsing XML documents. This is something that was missed when upgrading BeautifulSoup to the latest version.

Warning: 
```python 
 XMLParsedAsHTMLWarning: It looks like you're parsing an XML document using an HTML parser. If this really is an HTML document (maybe it's XHTML?), you can ignore or filter this warning. If it's XML, you should know that using an XML parser will be more reliable. To parse this document as XML, make sure you have the lxml package installed, and pass the keyword argument `features="xml"` into the BeautifulSoup constructor.

```