### PR TITLE
EES-3581 Reduce number of footnotes in collapsible list before collapsing from 5 to 2

### DIFF
--- a/src/explore-education-statistics-common/src/components/FigureFootnotes.tsx
+++ b/src/explore-education-statistics-common/src/components/FigureFootnotes.tsx
@@ -13,7 +13,7 @@ const FigureFootnotes = ({ footnotes }: Props) => {
     <>
       <h3 className="govuk-heading-m">Footnotes</h3>
 
-      <CollapsibleList listStyle="number" testId="footnotes">
+      <CollapsibleList listStyle="number" collapseAfter={2} testId="footnotes">
         {footnotes.map(footnote => (
           <li key={footnote.id}>{footnote.label}</li>
         ))}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -357,6 +357,9 @@ Check created table has footnotes
     user checks list item contains    testid:footnotes    2    ${FOOTNOTE_ALL_INDICATOR}
     user checks list item contains    testid:footnotes    3    ${FOOTNOTE_ALL_FILTER}
 
+    user checks page contains button    Show 1 more item
+    user checks list item is visually hidden    testid:footnotes    3
+
 Save data block as a featured table
     user enters text into element    id:dataBlockDetailsForm-name    UI Test data block name
     user enters text into element    id:dataBlockDetailsForm-heading    UI Test table title
@@ -396,6 +399,9 @@ Check footnote was updated on data block
     user checks list item contains    testid:footnotes    1    ${FOOTNOTE_ALL}
     user checks list item contains    testid:footnotes    2    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
     user checks list item contains    testid:footnotes    3    ${FOOTNOTE_ALL_FILTER}
+
+    user checks page contains button    Show 1 more item
+    user checks list item is visually hidden    testid:footnotes    3
 
 Add public prerelease access list for release
     user clicks link    Pre-release access
@@ -506,6 +512,9 @@ Validate table has footnotes
     user checks list item contains    testid:footnotes    2    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
     user checks list item contains    testid:footnotes    3    ${FOOTNOTE_ALL_FILTER}
 
+    user checks page contains button    Show 1 more item
+    user checks list item is visually hidden    testid:footnotes    3
+
 Select table featured table from subjects step
     user clicks element    testid:wizardStep-2-goToButton
     user waits until h2 is visible    Go back to previous step
@@ -577,6 +586,9 @@ Validate featured table has footnotes
     user checks list item contains    testid:footnotes    1    ${FOOTNOTE_ALL}
     user checks list item contains    testid:footnotes    2    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
     user checks list item contains    testid:footnotes    3    ${FOOTNOTE_ALL_FILTER}
+
+    user checks page contains button    Show 1 more item
+    user checks list item is visually hidden    testid:footnotes    3
 
 Go to release page
     user opens accordion section    Related information

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -72,6 +72,34 @@ Add ancillary file
 
     user checks there are x accordion sections    1    id:file-uploads
 
+Navigate to 'Footnotes' section
+    user clicks link    Footnotes
+    user waits until h2 is visible    Footnotes
+
+Add a footnote
+    user clicks link    Create footnote
+    user waits until h2 is visible    Create footnote
+    user clicks footnote subject radio    Dates test subject    Applies to all data
+    user clicks element    id:footnoteForm-content
+    user enters text into element    id:footnoteForm-content
+    ...    Applies to all data 1
+    user clicks button    Save footnote
+    user waits until h2 is visible    Footnotes
+
+Add a second footnote
+    user clicks link    Create footnote
+    user waits until h2 is visible    Create footnote
+    user clicks footnote subject radio    Dates test subject    Applies to all data
+    user clicks element    id:footnoteForm-content
+    user enters text into element    id:footnoteForm-content
+    ...    Applies to all data 2
+    user clicks button    Save footnote
+    user waits until h2 is visible    Footnotes
+
+Confirm created footnotes
+    user waits until page contains element    testid:Footnote - Applies to all data 1
+    user waits until page contains element    testid:Footnote - Applies to all data 2
+
 Create data block table
     user creates data block for dates csv    Dates test subject    ${DATABLOCK_NAME}    Dates table title
 
@@ -111,6 +139,18 @@ Add data block to first accordion section
     user waits until element contains infographic chart    ${datablock}
     user checks chart title contains    ${datablock}    Dates table title
     user checks infographic chart contains alt    ${datablock}    Sample alt text
+
+Verify data block table has footnotes
+    ${accordion}=    user opens accordion section    Dates data block    css:#releaseMainContent
+    ${data_block_table}=    user gets data block table from parent    ${DATABLOCK_NAME}    ${accordion}
+
+    user checks list has x items    testid:footnotes    2    ${data_block_table}
+    user checks list item contains    testid:footnotes    1
+    ...    Applies to all data 1
+    ...    ${data_block_table}
+    user checks list item contains    testid:footnotes    2
+    ...    Applies to all data 2
+    ...    ${data_block_table}
 
 Add test text to second accordion section
     user adds text block to editable accordion section    Test text    css:#releaseMainContent
@@ -281,6 +321,18 @@ Verify Dates data block accordion section
 
     user closes accordion section    Dates data block    id:content
 
+Verify Dates data block table has footnotes
+    ${accordion}=    user opens accordion section    Dates data block    id:content
+    ${data_block_table}=    user gets data block table from parent    ${DATABLOCK_NAME}    ${accordion}
+
+    user checks list has x items    testid:footnotes    2    ${data_block_table}
+    user checks list item contains    testid:footnotes    1
+    ...    Applies to all data 1
+    ...    ${data_block_table}
+    user checks list item contains    testid:footnotes    2
+    ...    Applies to all data 2
+    ...    ${data_block_table}
+
 Verify Test text accordion section contains correct text
     user opens accordion section    Test text    id:content
     ${section}=    user gets accordion section content element    Test text    id:content
@@ -372,23 +424,26 @@ Update existing data guidance for amendment
 
     user clicks button    Save guidance
 
-Navigate to 'Footnotes' section
+Navigate to 'Footnotes' section for amendment
     user clicks link    Footnotes
     user waits until h2 is visible    Footnotes
 
-Add a Footnote
+Add a footnote to amendment
     user waits until page contains link    Create footnote
     user clicks link    Create footnote
     user waits until h2 is visible    Create footnote
     user clicks footnote subject radio    Dates test subject    Applies to all data
     user clicks element    id:footnoteForm-content
     user enters text into element    id:footnoteForm-content
-    ...    A footnote
+    ...    Applies to all data 3
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
-Check footnote has been added
-    user checks element is visible    testid:Footnote - A footnote
+Confirm amendment has footnotes
+    user waits until h2 is visible    Footnotes
+    user waits until page contains element    testid:Footnote - Applies to all data 1
+    user waits until page contains element    testid:Footnote - Applies to all data 2
+    user waits until page contains element    testid:Footnote - Applies to all data 3
 
 Add ancillary file to amendment
     user clicks link    Data and files
@@ -476,6 +531,24 @@ Navigate to 'Content' page for amendment
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user waits until page contains button    Add a summary text block
+
+Verify amended Dates data block table has footnotes
+    ${accordion}=    user opens accordion section    Dates data block    css:#releaseMainContent
+    ${data_block_table}=    user gets data block table from parent    ${DATABLOCK_NAME}    ${accordion}
+
+    user checks list has x items    testid:footnotes    3    ${data_block_table}
+    user checks list item contains    testid:footnotes    1
+    ...    Applies to all data 1
+    ...    ${data_block_table}
+    user checks list item contains    testid:footnotes    2
+    ...    Applies to all data 2
+    ...    ${data_block_table}
+    user checks list item contains    testid:footnotes    3
+    ...    Applies to all data 3
+    ...    ${data_block_table}
+
+    user checks element contains button    ${data_block_table}    Show 1 more item
+    user checks list item is visually hidden    testid:footnotes    3    ${data_block_table}
 
 Update second accordion section text for amendment
     user opens accordion section    Test text    css:#releaseMainContent
@@ -638,6 +711,24 @@ Verify amendment Dates data block accordion section
     user checks headed table body row cell contains    Number of open settings    1    23,600    ${section}
     user checks headed table body row cell contains    Proportion of settings open    1    1%    ${section}
     user closes accordion section    Dates data block    id:content
+
+Verify amendment Dates data block table has footnotes
+    ${accordion}=    user opens accordion section    Dates data block    id:content
+    ${data_block_table}=    user gets data block table from parent    ${DATABLOCK_NAME}    ${accordion}
+
+    user checks list has x items    testid:footnotes    3    ${data_block_table}
+    user checks list item contains    testid:footnotes    1
+    ...    Applies to all data 1
+    ...    ${data_block_table}
+    user checks list item contains    testid:footnotes    2
+    ...    Applies to all data 2
+    ...    ${data_block_table}
+    user checks list item contains    testid:footnotes    3
+    ...    Applies to all data 3
+    ...    ${data_block_table}
+
+    user checks element contains button    ${data_block_table}    Show 1 more item
+    user checks list item is visually hidden    testid:footnotes    3    ${data_block_table}
 
 Verify amendment Test text accordion section contains correct text
     user opens accordion section    Test text    id:content

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -161,12 +161,16 @@ Validate Key Statistics data block -- Charts tab
     user checks chart tooltip item contains    ${headline_chart}    2    Authorised absence rate (England): 3.4%
     user checks chart tooltip item contains    ${headline_chart}    3    Unauthorised absence rate (England): 1.3%
 
-    user waits until element contains    ${headline_chart} [data-testid="footnotes"] li:nth-of-type(1)
-    ...    Absence rates are the number of absence sessions expressed
-    user waits until element contains    ${headline_chart} [data-testid="footnotes"] li:nth-of-type(2)
-    ...    There may be discrepancies between totals and the sum of constituent parts
-    user waits until element contains    ${headline_chart} [data-testid="footnotes"] li:nth-of-type(3)
-    ...    x - 1 or 2 enrolments, or a percentage based on 1 or 2 enrolments.
+    user checks list has x items    testid:footnotes    3    ${headline_chart}
+    user checks list item contains    testid:footnotes    1
+    ...    Absence rates are the number of absence sessions expressed    ${headline_chart}
+    user checks list item contains    testid:footnotes    2
+    ...    There may be discrepancies between totals and the sum of constituent parts    ${headline_chart}
+    user checks list item contains    testid:footnotes    3
+    ...    x - 1 or 2 enrolments, or a percentage based on 1 or 2 enrolments.    ${headline_chart}
+
+    user checks element contains button    ${headline_chart}    Show 1 more item
+    user checks list item is visually hidden    testid:footnotes    3    ${headline_chart}
 
 Validate Key Statistics data block -- Data tables tab
     user clicks element    id:releaseHeadlines-tables-tab
@@ -205,6 +209,17 @@ Validate Key Statistics data block -- Data tables tab
     user checks row cell contains text    ${row}    3    4.6
     user checks row cell contains text    ${row}    4    4.6
     user checks row cell contains text    ${row}    5    4.7
+
+    user checks list has x items    testid:footnotes    3    id:releaseHeadlines-tables
+    user checks list item contains    testid:footnotes    1
+    ...    Absence rates are the number of absence sessions expressed    id:releaseHeadlines-tables
+    user checks list item contains    testid:footnotes    2
+    ...    There may be discrepancies between totals and the sum of constituent parts    id:releaseHeadlines-tables
+    user checks list item contains    testid:footnotes    3
+    ...    x - 1 or 2 enrolments, or a percentage based on 1 or 2 enrolments.    id:releaseHeadlines-tables
+
+    user checks element contains button    id:releaseHeadlines-tables    Show 1 more item
+    user checks list item is visually hidden    testid:footnotes    3    id:releaseHeadlines-tables
 
 Validate accordion sections order
     user checks accordion is in position    Explore data and files    1    id:data-accordion
@@ -283,6 +298,24 @@ Validate Regional and local authority (LA) breakdown table
     user checks row contains heading    ${row}    Unauthorised absence rate
     user checks row cell contains text    ${row}    1    1.7%
 
+Check Regional and local authority (LA) breakdown table has footnotes
+    ${accordion}=    user opens accordion section    Regional and local authority (LA) breakdown    id:content
+    ${data_block_table}=    user gets data block table from parent    LAD map    ${accordion}
+
+    user checks list has x items    testid:footnotes    3    ${data_block_table}
+    user checks list item contains    testid:footnotes    1
+    ...    Absence rates are the number of absence sessions expressed as a percentage of the total number of possible sessions.
+    ...    ${data_block_table}
+    user checks list item contains    testid:footnotes    2
+    ...    There may be discrepancies between totals and the sum of constituent parts as national and regional totals and totals across school types have been rounded to the nearest 5.
+    ...    ${data_block_table}
+    user checks list item contains    testid:footnotes    3
+    ...    x - 1 or 2 enrolments, or a percentage based on 1 or 2 enrolments.
+    ...    ${data_block_table}
+
+    user checks element contains button    ${data_block_table}    Show 1 more item
+    user checks list item is visually hidden    testid:footnotes    3    ${data_block_table}
+
 Validate Regional and local authority (LA) breakdown chart
     [Tags]    Failing
     user opens accordion section    Regional and local authority (LA) breakdown    id:content
@@ -319,6 +352,28 @@ Validate Regional and local authority (LA) breakdown chart
     user checks chart tooltip item contains    ${datablock}    Unauthorised absence rate: 1.7%
 
     user checks map chart indicator tile contains    ${datablock}    Unauthorised absence rate    1.7%
+
+Check Regional and local authority (LA) breakdown chart has footnotes
+    ${accordion}=    user opens accordion section    Regional and local authority (LA) breakdown    id:content
+    ${data_block_chart}=    user gets data block chart from parent    LAD map    ${accordion}
+
+    user checks list has x items    testid:footnotes    4    ${data_block_chart}
+    user checks list item contains    testid:footnotes    1
+    ...    Absence rates are the number of absence sessions expressed as a percentage of the total number of possible sessions.
+    ...    ${data_block_chart}
+    user checks list item contains    testid:footnotes    2
+    ...    There may be discrepancies between totals and the sum of constituent parts as national and regional totals and totals across school types have been rounded to the nearest 5.
+    ...    ${data_block_chart}
+    user checks list item contains    testid:footnotes    3
+    ...    x - 1 or 2 enrolments, or a percentage based on 1 or 2 enrolments.
+    ...    ${data_block_chart}
+    user checks list item contains    testid:footnotes    4
+    ...    This map uses the boundary data Local Authority Districts December 2017 Ultra Generalised Clipped Boundaries in United Kingdom WGS84
+    ...    ${data_block_chart}
+
+    user checks element contains button    ${data_block_chart}    Show 2 more items
+    user checks list item is visually hidden    testid:footnotes    3    ${data_block_chart}
+    user checks list item is visually hidden    testid:footnotes    4    ${data_block_chart}
 
 Clicking "Create tables" takes user to Table Tool page with absence publication selected
     [Documentation]    DFE-898

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -423,6 +423,19 @@ user checks element is not visible
     [Arguments]    ${element}    ${wait}=${timeout}
     element should not be visible    ${element}    ${wait}
 
+user checks element is visually hidden
+    [Arguments]    ${selector}    ${parent}=css:body
+    user checks element has class
+    ...    ${selector}
+    ...    govuk-visually-hidden
+    ...    ${parent}
+
+user checks element has class
+    [Arguments]    ${selector}    ${class}    ${parent}=css:body
+    ${element}=    lookup or return webelement    ${selector}    ${parent}
+    ${classes}=    get element attribute    ${element}    class
+    should contain    ${classes}    ${class}
+
 user waits until element is enabled
     [Arguments]    ${element}    ${wait}=${timeout}
     wait until element is enabled    ${element}    ${wait}
@@ -800,6 +813,11 @@ user checks list item contains
     ${item}=    user gets list item element    ${locator}    ${item_num}    ${parent}
     user checks element should contain    ${item}    ${content}
 
+user checks list item is visually hidden
+    [Arguments]    ${locator}    ${item_num}    ${parent}=css:body
+    ${item}=    user gets list item element    ${locator}    ${item_num}    ${parent}
+    user checks element is visually hidden    ${item}
+
 user checks list contains exact items in order
     [Arguments]    ${locator}    ${expected_items}    ${parent}=css:body
     user waits until parent contains element    ${parent}    ${locator}
@@ -880,6 +898,29 @@ user waits until table tool wizard step is available
     user waits until element is visible    xpath://h2|h3//*[contains(text(),"${table_tool_step_title}")]
     ...    %{WAIT_SMALL}
     user waits until page does not contain loading spinner
+
+user gets data block from parent
+    [Arguments]    ${data_block_name}    ${parent}
+    ${data_block_test_id}=    set variable    testid:Data block - ${data_block_name}
+    user waits until parent contains element    ${parent}    ${data_block_test_id}
+    ${data_block}=    get child element    ${parent}    ${data_block_test_id}
+    [Return]    ${data_block}
+
+user gets data block table from parent
+    [Arguments]    ${data_block_name}    ${parent}
+    ${data_block}=    user gets data block from parent    ${data_block_name}    ${parent}
+    user clicks link by visible text    Table    ${data_block}
+    ${data_block_id}=    get element attribute    ${data_block}    id
+    ${data_block_table}=    get child element    ${data_block}    id:${data_block_id}-tables
+    [Return]    ${data_block_table}
+
+user gets data block chart from parent
+    [Arguments]    ${data_block_name}    ${parent}
+    ${data_block}=    user gets data block from parent    ${data_block_name}    ${parent}
+    user clicks link by visible text    Chart    ${data_block}
+    ${data_block_id}=    get element attribute    ${data_block}    id
+    ${data_block_chart}=    get child element    ${data_block}    id:${data_block_id}-chart
+    [Return]    ${data_block_chart}
 
 lookup or return webelement
     [Arguments]


### PR DESCRIPTION
This PR reduces the number of footnotes shown in the collapsible list below data blocks before collapsing them from 5 to 2.