### PR TITLE
EES-3600 Fix methodology content and annexe content section reordering

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
@@ -99,7 +99,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             Dictionary<Guid, int> newSectionOrder)
         {
             return _persistenceHelper
-                .CheckEntityExists<MethodologyVersion>(methodologyVersionId)
+                .CheckEntityExists<MethodologyVersion>(methodologyVersionId, q => 
+                    q.Include(version => version.MethodologyContent))
                 .OnSuccess(CheckCanUpdateMethodologyContent)
                 .OnSuccess(methodology => FindContentList(methodology, newSectionOrder.Keys.ToList()))
                 .OnSuccess(async tuple =>
@@ -427,6 +428,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             if (methodologyVersion.Status != MethodologyStatus.Draft)
             {
                 return ValidationActionResult(ValidationErrorMessages.MethodologyMustBeDraft);
+            }
+
+            if (methodologyVersion.MethodologyContent == null)
+            {
+                throw new ArgumentException("MethodologyContent must be hydrated");
             }
 
             return await _userService

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
 {
@@ -133,6 +134,42 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
         {
             var list = new List<string> {"foo", "bar"};
             Assert.False(list.IsNullOrEmpty());
+        }
+
+        [Fact]
+        public void IsSameAsIgnoringOrder_ListsAreEmpty()
+        {
+            Assert.True(new List<string>().IsSameAsIgnoringOrder(new List<string>()));
+        }
+
+        [Fact]
+        public void IsSameAsIgnoringOrder_ListsAreSame()
+        {
+            Assert.True(ListOf("a", "b").IsSameAsIgnoringOrder(ListOf("a", "b")));
+        }
+
+        [Fact]
+        public void IsSameAsIgnoringOrder_ListsAreSameIgnoringOrder()
+        {
+            Assert.True(ListOf("a", "b").IsSameAsIgnoringOrder(ListOf("b", "a")));
+        }
+
+        [Fact]
+        public void IsSameAsIgnoringOrder_FirstHasElementNotInSecond()
+        {
+            var first = ListOf("a", "b", "c");
+            var second = ListOf("b", "a");
+
+            Assert.False(first.IsSameAsIgnoringOrder(second));
+        }
+
+        [Fact]
+        public void IsSameAsIgnoringOrder_SecondHasElementNotInFirst()
+        {
+            var first = ListOf("a", "b");
+            var second = ListOf("c", "b", "a");
+
+            Assert.False(first.IsSameAsIgnoringOrder(second));
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -246,5 +246,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
         {
             return source.Distinct(ComparerUtils.CreateComparerByProperty(propertyGetter));
         }
+
+        public static bool IsSameAsIgnoringOrder<T>(this IEnumerable<T> first, IEnumerable<T> second)
+        {
+            var firstList = first.ToList();
+            var secondList = second.ToList();
+
+            var firstNotInSecond = firstList.Except(secondList);
+            var secondNotInFirst = secondList.Except(firstList);
+
+            return !(firstNotInSecond.Any() || secondNotInFirst.Any());
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -384,23 +384,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             IEnumerable<T> second,
             ValidationErrorMessages error)
         {
-            if (CollectionsAreSameIgnoringOrder(first, second))
+            if (first.IsSameAsIgnoringOrder(second))
             {
                 return Unit.Instance;
             }
 
             return ValidationResult(error);
-        }
-
-        private static bool CollectionsAreSameIgnoringOrder<T>(IEnumerable<T> first, IEnumerable<T> second)
-        {
-            var firstList = first.ToList();
-            var secondList = second.ToList();
-
-            var firstNotInSecond = firstList.Except(secondList);
-            var secondNotInFirst = secondList.Except(firstList);
-
-            return !(firstNotInSecond.Any() || secondNotInFirst.Any());
         }
     }
 }

--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
@@ -95,6 +95,7 @@ const EditableAccordion = (props: EditableAccordionProps) => {
             <Button
               variant="secondary"
               className="govuk-!-font-size-16 govuk-!-margin-bottom-0"
+              id={`${id}-reorder`}
               onClick={toggleReordering.on}
             >
               Reorder<span className="govuk-visually-hidden"> sections</span>

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -22,16 +22,42 @@ Create a draft release
     ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
     user create test release via api    ${PUBLICATION_ID}    AY    2021
 
-Approve a methodology for publishing immediately
+Create a methodology
     user creates methodology for publication    ${PUBLICATION_NAME}
 
+Add content to methodology
     user clicks link    Manage content
-    user creates new content section    1    Methodology content section 1    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+
+    user creates new content section    1    Methodology content section 1
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
     user adds text block to editable accordion section    Methodology content section 1
     ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
     user adds content to accordion section text block    Methodology content section 1    1
-    ...    Adding Methodology content    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    ...    Content 1    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
 
+    user creates new content section    2    Methodology content section 2
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user adds text block to editable accordion section    Methodology content section 2
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user adds content to accordion section text block    Methodology content section 2    1
+    ...    Content 2    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+
+Add annexe content to methodology
+    user creates new content section    1    Methodology annexe section 1
+    ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
+    user adds text block to editable accordion section    Methodology annexe section 1
+    ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
+    user adds content to accordion section text block    Methodology annexe section 1    1
+    ...    Annexe 1    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
+
+    user creates new content section    2    Methodology annexe section 2
+    ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
+    user adds text block to editable accordion section    Methodology annexe section 2
+    ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
+    user adds content to accordion section text block    Methodology annexe section 2    1
+    ...    Annexe 2    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
+
+Approve the methodology for publishing immediately
     user approves methodology for publication    ${PUBLICATION_NAME}
 
 Verify the expected public URL of the methodology on the Sign off tab
@@ -115,10 +141,34 @@ Verify that the methodology displays a link to the publication
 Verify that the methodology content is correct
     ${date}=    get current datetime    %-d %B %Y
     user checks summary list contains    Published    ${date}
-    user waits until page contains accordion section    Methodology content section 1
+
+    user checks accordion is in position    Methodology content section 1    1    id:content
+    user checks accordion is in position    Methodology content section 2    2    id:content
+
+    user checks there are x accordion sections    2    id:content
+
     user opens accordion section    Methodology content section 1
-    ${content}=    user gets accordion section content element    Methodology content section 1
-    user checks element contains    ${content}    Adding Methodology content
+    ${content_section_1}=    user gets accordion section content element    Methodology content section 1
+    user checks element contains    ${content_section_1}    Content 1
+
+    user opens accordion section    Methodology content section 2
+    ${content_section_2}=    user gets accordion section content element    Methodology content section 2
+    user checks element contains    ${content_section_2}    Content 2
+
+    user checks accordion is in position    Methodology annexe section 1    1    id:annexes
+    user checks accordion is in position    Methodology annexe section 2    2    id:annexes
+
+    user checks there are x accordion sections    2    id:annexes
+
+    user opens accordion section    Methodology annexe section 1    id:annexes
+    ${annexe_section_1}=    user gets accordion section content element    Methodology annexe section 1
+    ...    id:annexes
+    user checks element contains    ${annexe_section_1}    Annexe 1
+
+    user opens accordion section    Methodology annexe section 2    id:annexes
+    ${annexe_section_2}=    user gets accordion section content element    Methodology annexe section 2
+    ...    id:annexes
+    user checks element contains    ${annexe_section_2}    Annexe 2
 
 Amend the methodology in preparation to test publishing immediately
     user creates methodology amendment for publication    ${PUBLICATION_NAME}
@@ -134,9 +184,51 @@ Update the methodology amendment's content
     ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
     user adds text block to editable accordion section    Methodology content section 1
     ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
-    user adds content to accordion section text block    Methodology content section 1    2    New & Updated content
+    user checks accordion section contains x blocks    Methodology content section 1    2
     ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
-    user changes accordion section title    1    New and Updated Title    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user adds content to accordion section text block    Methodology content section 1    2
+    ...    New amendment content
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user changes accordion section title    1    Methodology content section 1 updated
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+
+Reorder amendment content sections
+    user clicks element    id:methodologyAccordion-content-reorder
+
+    user sets focus to element
+    ...    xpath:(.//*[@data-testid="editableAccordionSection"])[1]
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+
+    user presses keys    ${SPACE}
+    user presses keys    ARROW_DOWN
+    user presses keys    ${SPACE}
+
+    user clicks button    Save order
+
+Check the new order of amendment content sections
+    user checks accordion is in position    Methodology content section 2    1
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user checks accordion is in position    Methodology content section 1 updated    2
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+
+Reorder amendment annexe sections
+    user clicks element    id:methodologyAccordion-annexes-reorder
+
+    user sets focus to element
+    ...    xpath:(.//*[@data-testid="editableAccordionSection"])[1]
+    ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
+
+    user presses keys    ${SPACE}
+    user presses keys    ARROW_DOWN
+    user presses keys    ${SPACE}
+
+    user clicks button    Save order
+
+Check the new order of amendment annexe sections
+    user checks accordion is in position    Methodology annexe section 2    1
+    ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
+    user checks accordion is in position    Methodology annexe section 1    2
+    ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
 
 Add a note describing the amendment
     user adds note to methodology
@@ -187,11 +279,35 @@ Verify that the amended methodology content is correct
     ${date}=    get current datetime    %-d %B %Y
     user checks summary list contains    Published    ${date}
     user checks summary list contains    Last updated    ${date}
-    user waits until page contains accordion section    New and Updated Title
-    user opens accordion section    New and Updated Title
-    ${content}=    user gets accordion section content element    New and Updated Title
-    user checks element contains    ${content}    Adding Methodology content
-    user checks element contains    ${content}    New & Updated content
+
+    user checks accordion is in position    Methodology content section 2    1    id:content
+    user checks accordion is in position    Methodology content section 1 updated    2    id:content
+
+    user checks there are x accordion sections    2    id:content
+
+    user opens accordion section    Methodology content section 2
+    ${content_section_2}=    user gets accordion section content element    Methodology content section 2
+    user checks element contains    ${content_section_2}    Content 2
+
+    user opens accordion section    Methodology content section 1 updated
+    ${content_section_1}=    user gets accordion section content element    Methodology content section 1 updated
+    user checks element contains    ${content_section_1}    Content 1
+    user checks element contains    ${content_section_1}    New amendment content
+
+    user checks accordion is in position    Methodology annexe section 2    1    id:annexes
+    user checks accordion is in position    Methodology annexe section 1    2    id:annexes
+
+    user checks there are x accordion sections    2    id:annexes
+
+    user opens accordion section    Methodology annexe section 2    id:annexes
+    ${annexe_section_2}=    user gets accordion section content element    Methodology annexe section 2
+    ...    id:annexes
+    user checks element contains    ${annexe_section_2}    Annexe 2
+
+    user opens accordion section    Methodology annexe section 1    id:annexes
+    ${annexe_section_1}=    user gets accordion section content element    Methodology annexe section 1
+    ...    id:annexes
+    user checks element contains    ${annexe_section_1}    Annexe 1
 
 Verify the list of notes
     ${date}=    get current datetime    %-d %B %Y


### PR DESCRIPTION
This PR fixes a bug in the Admin where content sections and annexe content sections could not be reordered on the methodology content page.

This was due to the `MethodologyVersionContent` related to the `MethodologyVersion` not being loaded when processing the request to reorder the sections.

It might be preferable that in future we change the `MethodologyContent` property to not be initialised by default.

Currently in `MethodologyVersion.cs`:

`public MethodologyVersionContent MethodologyContent { get; set; } = new();`

This could change to using the null-forgiving operator:

`public MethodologyVersionContent MethodologyContent { get; set; } = null!;`

This way we should observe a null `MethodologyVersionContent` if it hasn't been set due a bug where loading the related entity was missed, rather than being  initialised as an empty `MethodologyVersionContent` which was the case here.

Combined with changes like throwing an exception where the related entity is null would make it easier to spot a bug.

```
            if (methodologyVersion.MethodologyContent == null)
            {
                throw new ArgumentException("MethodologyContent must be hydrated");
            }
```

## Other changes

* Add missing unit tests for `MethodologyContentService.ReorderContentSections`.
* Fix a bug where the ordering request could be missing section one or more section id's but still be a valid.
* Enhance the UI tests to add multiple content sections and annexes when creating a methodology. This checks the public order of the sections once the methodology is published.

The UI test reorders them on an amendment and again checks the order once the amendment is published.

# UI test report

![image](https://user-images.githubusercontent.com/4147126/184410682-3bd8af34-9686-4a8c-9042-ccd0a6af96e1.png)
