### PR TITLE
EES-3153 Zip files replacement uploads are valid if the data file entry has the same name as the file it's replacing

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
@@ -12,7 +12,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;
@@ -31,7 +30,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task ValidateFileForUpload_FileCannotBeEmpty()
         {
             var file = CreateFormFile("test.csv", "test.csv");
-            
+
             var (service, _) = BuildService();
             var result = await service.ValidateFileForUpload(file, Ancillary);
             result.AssertBadRequest(FileCannotBeEmpty);
@@ -51,14 +50,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var file = CreateSingleLineFormFile("test.csv", "test.csv");
 
-            var (service, mocks) = BuildService();
-            
-            mocks.fileTypeService
+            var (service, fileTypeService) = BuildService();
+
+            fileTypeService
                 .Setup(s => s.HasMatchingMimeType(file, It.IsAny<IEnumerable<Regex>>()))
                 .ReturnsAsync(() => true);
-            
+
             var result = await service.ValidateFileForUpload(file, Ancillary);
-            VerifyAllMocks(mocks);
+            VerifyAllMocks(fileTypeService);
 
             result.AssertRight();
         }
@@ -67,29 +66,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task ValidateFileForUpload_FileTypeIsInvalid()
         {
             var file = CreateSingleLineFormFile("test.csv", "test.csv");
-        
-            var (service, mocks) = BuildService();
-        
-            mocks.fileTypeService
+
+            var (service, fileTypeService) = BuildService();
+
+            fileTypeService
                 .Setup(s => s.HasMatchingMimeType(file, It.IsAny<IEnumerable<Regex>>()))
                 .ReturnsAsync(() => false);
-            
+
             var result = await service.ValidateFileForUpload(file, Ancillary);
-            VerifyAllMocks(mocks);
-        
+            VerifyAllMocks(fileTypeService);
+
             result.AssertBadRequest(FileTypeInvalid);
         }
-        
+
         [Fact]
         public async Task ValidateSubjectName_SubjectNameContainsSpecialCharacters()
         {
             var (service, _) = BuildService();
-            
+
             var result = await service.ValidateSubjectName(Guid.NewGuid(), "Subject & Title");
-            
+
             result.AssertBadRequest(SubjectTitleCannotContainSpecialCharacters);
         }
-        
+
         [Fact]
         public async Task ValidateSubjectName_SubjectNameNotUnique()
         {
@@ -110,63 +109,63 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await contentDbContext.AddAsync(dataReleaseFile);
                 await contentDbContext.SaveChangesAsync();
             }
-        
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var (service, _) = BuildService(contentDbContext);
-        
-                var result = await service.ValidateSubjectName(release.Id,  "Subject Title");
-                
+
+                var result = await service.ValidateSubjectName(release.Id, "Subject Title");
+
                 result.AssertBadRequest(SubjectTitleMustBeUnique);
             }
         }
-        
+
         [Fact]
         public async Task UploadedDatafilesAreValid()
         {
             await using (var context = InMemoryApplicationDbContext())
             {
-                var (service, mocks) = BuildService(context);
-        
+                var (service, fileTypeService) = BuildService(context);
+
                 var dataFile = CreateSingleLineFormFile("test.csv", "test.csv");
                 var metaFile = CreateSingleLineFormFile("test.meta.csv", "test.meta.csv");
-        
-                mocks.fileTypeService
+
+                fileTypeService
                     .Setup(s => s.HasMatchingMimeType(dataFile, It.IsAny<IEnumerable<Regex>>()))
                     .ReturnsAsync(() => true);
-                mocks.fileTypeService
+                fileTypeService
                     .Setup(s => s.HasMatchingMimeType(metaFile, It.IsAny<IEnumerable<Regex>>()))
                     .ReturnsAsync(() => true);
-                mocks.fileTypeService
+                fileTypeService
                     .Setup(s => s.HasMatchingEncodingType(dataFile, It.IsAny<IEnumerable<string>>()))
                     .Returns(() => true);
-                mocks.fileTypeService
+                fileTypeService
                     .Setup(s => s.HasMatchingEncodingType(metaFile, It.IsAny<IEnumerable<string>>()))
                     .Returns(() => true);
-        
+
                 var result = await service.ValidateDataFilesForUpload(Guid.NewGuid(), dataFile, metaFile);
-                VerifyAllMocks(mocks);
-        
+                VerifyAllMocks(fileTypeService);
+
                 Assert.True(result.IsRight);
             }
         }
-        
+
         [Fact]
         public async Task ValidateDataFilesForUpload_DataFileIsEmpty()
         {
             await using (var context = InMemoryApplicationDbContext())
             {
                 var (service, _) = BuildService(context);
-        
+
                 var dataFile = CreateFormFile("test.csv", "test.csv");
                 var metaFile = CreateSingleLineFormFile("test.meta.csv", "test.meta.csv");
-        
+
                 var result = await service.ValidateDataFilesForUpload(Guid.NewGuid(), dataFile, metaFile);
-        
+
                 result.AssertBadRequest(DataFileCannotBeEmpty);
             }
         }
-        
+
         [Fact]
         public async Task ValidateDataFilesForUpload_MetadataFileIsEmpty()
         {
@@ -176,68 +175,68 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var dataFile = CreateSingleLineFormFile("test.csv", "test.csv");
                 var metaFile = CreateFormFile("test.meta.csv", "test.meta.csv");
-        
+
                 var result = await service.ValidateDataFilesForUpload(Guid.NewGuid(), dataFile, metaFile);
-        
+
                 result.AssertBadRequest(MetadataFileCannotBeEmpty);
             }
         }
-        
+
         [Fact]
         public async Task ValidateDataFilesForUpload_DataFileNotCsv()
         {
             await using (var context = InMemoryApplicationDbContext())
             {
-                var (service, mocks) = BuildService(context);
+                var (service, fileTypeService) = BuildService(context);
 
                 var dataFile = CreateSingleLineFormFile("test.csv", "test.csv");
                 var metaFile = CreateSingleLineFormFile("test.meta.csv", "test.meta.csv");
-        
-                mocks.fileTypeService
+
+                fileTypeService
                     .Setup(s => s.HasMatchingMimeType(dataFile, It.IsAny<IEnumerable<Regex>>()))
                     .ReturnsAsync(() => false);
-        
+
                 var result = await service.ValidateDataFilesForUpload(Guid.NewGuid(), dataFile, metaFile);
-                VerifyAllMocks(mocks);
-        
+                VerifyAllMocks(fileTypeService);
+
                 result.AssertBadRequest(DataFileMustBeCsvFile);
             }
         }
-        
+
         [Fact]
         public async Task ValidateDataFilesForUpload_MetadataFileNotCsv()
         {
             await using (var context = InMemoryApplicationDbContext())
             {
-                var (service, mocks) = BuildService(context);
+                var (service, fileTypeService) = BuildService(context);
 
                 var dataFile = CreateSingleLineFormFile("test.csv", "test.csv");
                 var metaFile = CreateSingleLineFormFile("test.meta.csv", "test.meta.csv");
-        
-                mocks.fileTypeService
+
+                fileTypeService
                     .Setup(s => s.HasMatchingMimeType(dataFile, It.IsAny<IEnumerable<Regex>>()))
                     .ReturnsAsync(() => true);
-                mocks.fileTypeService
+                fileTypeService
                     .Setup(s => s.HasMatchingEncodingType(dataFile, It.IsAny<IEnumerable<string>>()))
                     .Returns(() => true);
-                mocks.fileTypeService
+                fileTypeService
                     .Setup(s => s.HasMatchingMimeType(metaFile, It.IsAny<IEnumerable<Regex>>()))
                     .ReturnsAsync(() => false);
-        
+
                 var result = await service.ValidateDataFilesForUpload(Guid.NewGuid(), dataFile, metaFile);
-                VerifyAllMocks(mocks);
-        
+                VerifyAllMocks(fileTypeService);
+
                 result.AssertBadRequest(MetaFileMustBeCsvFile);
             }
         }
-        
+
         [Fact]
         public async Task ValidateDataFilesForUpload_DuplicateDataFile()
         {
             var releaseId = Guid.NewGuid();
-        
+
             var contextId = Guid.NewGuid().ToString();
-            
+
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 context.ReleaseFiles.Add(new ReleaseFile
@@ -249,23 +248,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Filename = "test.csv"
                     }
                 });
-        
+
                 await context.SaveChangesAsync();
             }
-            
+
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var (service, _) = BuildService(context);
-        
+
                 var dataFile = CreateSingleLineFormFile("test.csv", "test.csv");
                 var metaFile = CreateSingleLineFormFile("test.meta.csv", "test.meta.csv");
-        
+
                 var result = await service.ValidateDataFilesForUpload(releaseId, dataFile, metaFile);
-        
+
                 result.AssertBadRequest(DataFilenameNotUnique);
             }
         }
-        
+
         [Fact]
         public async Task UploadedZippedDatafileIsValid()
         {
@@ -274,21 +273,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var (service, _) = BuildService(context);
 
                 var archiveFile = GetArchiveFile("data-zip-valid.zip");
-        
+
                 var result = await service.ValidateDataArchiveEntriesForUpload(Guid.NewGuid(),
                     archiveFile);
-        
+
                 result.AssertRight();
             }
         }
-        
+
         [Fact]
         public async Task ValidateDataFilesForUpload_ReplacingDataFileWithFileOfSameName()
         {
             var releaseId = Guid.NewGuid();
-        
+
             var contextId = Guid.NewGuid().ToString();
-            
+
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 context.ReleaseFiles.Add(new ReleaseFile
@@ -300,52 +299,52 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Filename = "test.csv"
                     }
                 });
-        
+
                 await context.SaveChangesAsync();
             }
-            
+
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                var (service, mocks) = BuildService(context);
+                var (service, fileTypeService) = BuildService(context);
 
                 // The replacement file here has the same name as the one it is replacing, so this should be ok.
                 var dataFile = CreateSingleLineFormFile("test.csv", "test.csv");
                 var metaFile = CreateSingleLineFormFile("test.meta.csv", "test.meta.csv");
-        
+
                 // The file being replaced here has the same name as the one being uploaded, but that's ok.
                 var fileBeingReplaced = new File
                 {
                     Filename = "test.csv"
                 };
-                
-                mocks.fileTypeService
+
+                fileTypeService
                     .Setup(s => s.HasMatchingMimeType(dataFile, It.IsAny<IEnumerable<Regex>>()))
                     .ReturnsAsync(() => true);
-                mocks.fileTypeService
+                fileTypeService
                     .Setup(s => s.HasMatchingMimeType(metaFile, It.IsAny<IEnumerable<Regex>>()))
                     .ReturnsAsync(() => true);
-                mocks.fileTypeService
+                fileTypeService
                     .Setup(s => s.HasMatchingEncodingType(dataFile, It.IsAny<IEnumerable<string>>()))
                     .Returns(() => true);
-                mocks.fileTypeService
+                fileTypeService
                     .Setup(s => s.HasMatchingEncodingType(metaFile, It.IsAny<IEnumerable<string>>()))
                     .Returns(() => true);
-        
+
                 var result = await service.ValidateDataFilesForUpload(
                     releaseId, dataFile, metaFile, fileBeingReplaced);
-                VerifyAllMocks(mocks);
-                
+                VerifyAllMocks(fileTypeService);
+
                 result.AssertRight();
             }
         }
-        
+
         [Fact]
         public async Task ValidateDataFilesForUpload_ReplacingDataFileWithFileOfDifferentNameButClashesWithAnother()
         {
             var releaseId = Guid.NewGuid();
-        
+
             var contextId = Guid.NewGuid().ToString();
-            
+
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 context.ReleaseFiles.AddRange(new ReleaseFile
@@ -365,10 +364,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Filename = "another.csv"
                     }
                 });
-        
+
                 await context.SaveChangesAsync();
             }
-            
+
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var (service, _) = BuildService(context);
@@ -378,28 +377,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 // in this Release after the replacement is complete.
                 var dataFile = CreateSingleLineFormFile("another.csv", "test.csv");
                 var metaFile = CreateSingleLineFormFile("test.meta.csv", "test.meta.csv");
-        
+
                 var fileBeingReplaced = new File
                 {
                     Filename = "test.csv"
                 };
-        
+
                 var result = await service.ValidateDataFilesForUpload(
                     releaseId, dataFile, metaFile, fileBeingReplaced);
-                
+
                 result.AssertBadRequest(DataFilenameNotUnique);
             }
         }
-        
+
         [Fact]
         public async Task ValidateFileForUpload_MetadataFileNamesCanBeDuplicated()
         {
             var releaseId = Guid.NewGuid();
-        
+
             var file = CreateSingleLineFormFile("test.csv", "test.csv");
-        
+
             var contextId = Guid.NewGuid().ToString();
-            
+
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 context.ReleaseFiles.AddRange(new ReleaseFile
@@ -419,40 +418,40 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Filename = "test.meta.csv"
                     }
                 });
-        
+
                 await context.SaveChangesAsync();
             }
-            
+
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                var (service, mocks) = BuildService(context);
+                var (service, fileTypeService) = BuildService(context);
 
                 var dataFile = CreateSingleLineFormFile("another.csv", "another.csv");
-                
+
                 // This metafile has the same name as an existing metafile, but it shouldn't matter for metadata files
                 // as they don't appear anywhere where the filenames have to be unique (e.g. in zip files).
                 var metaFile = CreateSingleLineFormFile("test.meta.csv", "test.meta.csv");
-        
-                mocks.fileTypeService
+
+                fileTypeService
                     .Setup(s => s.HasMatchingMimeType(dataFile, It.IsAny<IEnumerable<Regex>>()))
                     .ReturnsAsync(() => true);
-                mocks.fileTypeService
+                fileTypeService
                     .Setup(s => s.HasMatchingMimeType(metaFile, It.IsAny<IEnumerable<Regex>>()))
                     .ReturnsAsync(() => true);
-                mocks.fileTypeService
+                fileTypeService
                     .Setup(s => s.HasMatchingEncodingType(dataFile, It.IsAny<IEnumerable<string>>()))
                     .Returns(() => true);
-                mocks.fileTypeService
+                fileTypeService
                     .Setup(s => s.HasMatchingEncodingType(metaFile, It.IsAny<IEnumerable<string>>()))
                     .Returns(() => true);
-        
+
                 var result = await service.ValidateDataFilesForUpload(releaseId, dataFile, metaFile);
-                VerifyAllMocks(mocks);
-                
+                VerifyAllMocks(fileTypeService);
+
                 result.AssertRight();
             }
         }
-        
+
         [Fact]
         public async Task UploadedZippedDatafileIsInvalid()
         {
@@ -461,15 +460,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var (service, _) = BuildService();
 
                 var archiveFile = GetArchiveFile("data-zip-invalid.zip");
-        
+
                 var result = await service.ValidateDataArchiveEntriesForUpload(Guid.NewGuid(),
                     archiveFile);
-        
+
                 result.AssertBadRequest(DataFileMustBeCsvFile);
             }
         }
 
-        private static IFormFile CreateSingleLineFormFile( string fileName, string name)
+        private static IFormFile CreateSingleLineFormFile(string fileName, string name)
         {
             return CreateFormFile(fileName, name, "line1");
         }
@@ -521,27 +520,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Returns(() => System.IO.File.OpenRead(filePath));
             return formFile.Object;
         }
-        
+
         private static (
-            FileUploadsValidatorService, 
-            (
-                Mock<ISubjectRepository> subjectRepository, 
-                Mock<IFileTypeService> fileTypeService
-            ))
+            FileUploadsValidatorService,
+            Mock<IFileTypeService> fileTypeService
+            )
             BuildService(
                 ContentDbContext? contentDbContext = null,
-                ISubjectRepository? subjectRepository = null,
                 IFileTypeService? fileTypeService = null)
         {
-            var subjectRepositoryMock = new Mock<ISubjectRepository>(Strict);
             var fileTypeServiceMock = new Mock<IFileTypeService>(Strict);
 
             var service = new FileUploadsValidatorService(
-                subjectRepository ?? subjectRepositoryMock.Object,
                 fileTypeService ?? fileTypeServiceMock.Object,
                 contentDbContext!);
 
-            return (service, (subjectRepositoryMock, fileTypeServiceMock));
+            return (service, fileTypeServiceMock);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
@@ -262,7 +262,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         
                 var result = await service.ValidateDataFilesForUpload(releaseId, dataFile, metaFile);
         
-                result.AssertBadRequest(CannotOverwriteDataFile);
+                result.AssertBadRequest(DataFilenameNotUnique);
             }
         }
         
@@ -387,7 +387,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.ValidateDataFilesForUpload(
                     releaseId, dataFile, metaFile, fileBeingReplaced);
                 
-                result.AssertBadRequest(CannotOverwriteDataFile);
+                result.AssertBadRequest(DataFilenameNotUnique);
             }
         }
         

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
@@ -196,7 +196,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var dbReleaseFile4 = contentDbContext.ReleaseFiles.Single(rf => rf.Id == releaseFile4.Id);
                 Assert.Equal(3, dbReleaseFile4.Order);
 
-                var dbReleaseFile4Replacement = contentDbContext.ReleaseFiles.Single(rf => rf.Id == releaseFile4Replacement.Id);
+                var dbReleaseFile4Replacement =
+                    contentDbContext.ReleaseFiles.Single(rf => rf.Id == releaseFile4Replacement.Id);
                 Assert.Equal(3, dbReleaseFile4Replacement.Order);
             }
         }
@@ -315,7 +316,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             blobStorageService
                 .Setup(mock => mock.DeleteBlobs(
                     PrivateReleaseFiles,
-                    replacementDataFile.BatchesPath(), 
+                    replacementDataFile.BatchesPath(),
                     null))
                 .Returns(Task.CompletedTask);
 
@@ -703,7 +704,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             blobStorageService.Setup(mock => mock.DeleteBlobs(
                     PrivateReleaseFiles,
-                    dataFile.BatchesPath(), 
+                    dataFile.BatchesPath(),
                     null))
                 .Returns(Task.CompletedTask);
 
@@ -1167,7 +1168,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await contentDbContext.ReleaseFiles.AddRangeAsync(
                     releaseDataFile1, releaseDataFile2, releaseDataFile3, releaseDataFile4, releaseDataFile5,
                     releaseMetaFile1, releaseMetaFile2, releaseMetaFile3, releaseMetaFile4, releaseMetaFile5
-                    );
+                );
                 await contentDbContext.DataImports.AddRangeAsync(dataImports);
                 await contentDbContext.SaveChangesAsync();
             }
@@ -1685,7 +1686,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 blobStorageService.Setup(mock =>
                     mock.UploadFile(PrivateReleaseFiles,
-                        It.Is<string>(path => 
+                        It.Is<string>(path =>
                             path.Contains(FilesPath(release.Id, FileType.Data))),
                         dataFormFile
                     )).Returns(Task.CompletedTask);
@@ -1914,7 +1915,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         rs.SubjectId == replacementSubject!.Id
                         && rs.ReleaseId == release.Id);
             }
-            
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var files = contentDbContext.Files.ToList();
@@ -2008,7 +2009,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Release = release,
                     File = new File { Type = FileType.Data },
                     Order = 3,
-
                 },
                 new () // Ancillary files should be ignored
                 {
@@ -2175,7 +2175,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(Unit.Instance);
 
                 fileUploadsValidatorService
-                    .Setup(s => s.ValidateDataArchiveEntriesForUpload(release.Id, archiveFile))
+                    .Setup(s => s.ValidateDataArchiveEntriesForUpload(release.Id, archiveFile, null))
                     .ReturnsAsync(Unit.Instance);
 
                 dataArchiveValidationService
@@ -2317,7 +2317,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Release = release,
                     File = new File { Type = FileType.Data },
                     Order = 3,
-
                 },
                 new () // Ancillary files should be ignored
                 {
@@ -2353,7 +2352,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(Unit.Instance);
 
                 fileUploadsValidatorService
-                    .Setup(s => s.ValidateDataArchiveEntriesForUpload(release.Id, archiveFile))
+                    .Setup(s => s.ValidateDataArchiveEntriesForUpload(release.Id, archiveFile, null))
                     .ReturnsAsync(Unit.Instance);
 
                 dataArchiveValidationService
@@ -2475,7 +2474,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     SubjectId = originalSubject.Id
                 }
             };
-            
+
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -2489,7 +2488,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 ReleaseId = release.Id,
                 SubjectId = originalSubject.Id
             };
-            
+
             var statisticsDbContextId = Guid.NewGuid().ToString();
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
@@ -2509,7 +2508,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 fileUploadsValidatorService
-                    .Setup(s => s.ValidateDataArchiveEntriesForUpload(release.Id, archiveFile))
+                    .Setup(s => s.ValidateDataArchiveEntriesForUpload(release.Id,
+                        archiveFile,
+                        It.Is<File>(file => file.Id == originalDataReleaseFile.File.Id)))
                     .ReturnsAsync(Unit.Instance);
 
                 dataArchiveValidationService
@@ -2631,31 +2632,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.NotNull(releaseFiles.SingleOrDefault(rf =>
                     rf.ReleaseId == release.Id && rf.FileId == metaFile.Id));
             }
-        }
-
-        private static Mock<IDataArchiveFile> CreateDataArchiveFileMock(
-            string dataFileName,
-            string metaFileName)
-        {
-            var dataArchiveFile = new Mock<IDataArchiveFile>();
-
-            dataArchiveFile
-                .SetupGet(f => f.DataFileName)
-                .Returns(dataFileName);
-
-            dataArchiveFile
-                .SetupGet(f => f.DataFileSize)
-                .Returns(1048576);
-
-            dataArchiveFile
-                .SetupGet(f => f.MetaFileName)
-                .Returns(metaFileName);
-
-            dataArchiveFile
-                .SetupGet(f => f.MetaFileSize)
-                .Returns(1024);
-
-            return dataArchiveFile;
         }
 
         private ReleaseDataFileService SetupReleaseDataFileService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataArchiveValidationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataArchiveValidationService.cs
@@ -34,7 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             if (!await IsZipFile(zipFile))
             {
-                return ValidationActionResult(DataFileMustBeZipFile);
+                return ValidationActionResult(DataZipMustBeZipFile);
             }
 
             await using var stream = zipFile.OpenReadStream();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
@@ -4,11 +4,9 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -23,13 +21,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 {
     public class FileUploadsValidatorService : IFileUploadsValidatorService
     {
-        private readonly ISubjectRepository _subjectRepository;
         private readonly IFileTypeService _fileTypeService;
         private readonly ContentDbContext _context;
 
-        public FileUploadsValidatorService(ISubjectRepository subjectRepository, IFileTypeService fileTypeService, ContentDbContext context)
+        public FileUploadsValidatorService(IFileTypeService fileTypeService,
+            ContentDbContext context)
         {
-            _subjectRepository = subjectRepository;
             _fileTypeService = fileTypeService;
             _context = context;
         }
@@ -66,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             {
                 return ValidationActionResult(FileCannotBeEmpty);
             }
-            
+
             if (!await _fileTypeService.HasMatchingMimeType(file, AllowedMimeTypesByFileType[type]))
             {
                 return ValidationActionResult(FileTypeInvalid);
@@ -127,12 +124,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .Where(rf => rf.ReleaseId == releaseId)
                 .ToList()
                 .Any(rf => String.Equals(rf.File.Filename, name, CurrentCultureIgnoreCase)
-                && rf.File.Type == type);
+                           && rf.File.Type == type);
         }
 
         private async Task<Either<ActionResult, Unit>> ValidateDataFileNames(
-            Guid releaseId, 
-            string dataFileName, 
+            Guid releaseId,
+            string dataFileName,
             string metaFileName,
             File? replacingFile)
         {
@@ -166,7 +163,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 return ValidationActionResult(MetaFileMustBeCsvFile);
             }
 
-            if (IsFileExisting(releaseId, FileType.Data, dataFileName) && 
+            if (IsFileExisting(releaseId, FileType.Data, dataFileName) &&
                 (replacingFile == null || replacingFile.Filename != dataFileName))
             {
                 return ValidationActionResult(DataFilenameNotUnique);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
@@ -169,7 +169,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             if (IsFileExisting(releaseId, FileType.Data, dataFileName) && 
                 (replacingFile == null || replacingFile.Filename != dataFileName))
             {
-                return ValidationActionResult(CannotOverwriteDataFile);
+                return ValidationActionResult(DataFilenameNotUnique);
             }
 
             return Unit.Instance;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
@@ -38,17 +38,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IFormFile metaFile,
             File? replacingFile = null)
         {
-            return await ValidateDataFileNames(releaseId, dataFile.FileName, metaFile.FileName, replacingFile)
+            return await ValidateDataFileNames(releaseId,
+                    dataFileName: dataFile.FileName,
+                    metaFileName: metaFile.FileName,
+                    replacingFile)
                 .OnSuccess(async _ => await ValidateDataFileSizes(dataFile.Length, metaFile.Length))
                 .OnSuccess(async _ => await ValidateDataFileTypes(dataFile, metaFile));
         }
 
         public async Task<Either<ActionResult, Unit>> ValidateDataArchiveEntriesForUpload(
             Guid releaseId,
-            IDataArchiveFile archiveFile)
+            IDataArchiveFile archiveFile,
+            File? replacingFile = null)
         {
-            return await ValidateDataFileNames(releaseId, archiveFile.DataFileName, archiveFile.MetaFileName, null)
-                .OnSuccess(async _ => await ValidateDataFileSizes(archiveFile.DataFileSize, archiveFile.MetaFileSize));
+            return await ValidateDataFileSizes(archiveFile.DataFileSize, archiveFile.MetaFileSize)
+                .OnSuccess(async _ => await ValidateDataFileNames(releaseId,
+                    dataFileName: archiveFile.DataFileName,
+                    metaFileName: archiveFile.MetaFileName,
+                    replacingFile));
         }
 
         public async Task<Either<ActionResult, Unit>> ValidateFileForUpload(IFormFile file, FileType type)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileUploadsValidatorService.cs
@@ -18,7 +18,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             IFormFile metaFile,
             File? replacingFile = null);
 
-        Task<Either<ActionResult, Unit>> ValidateDataArchiveEntriesForUpload(Guid releaseId, IDataArchiveFile archiveFile);
+        Task<Either<ActionResult, Unit>> ValidateDataArchiveEntriesForUpload(Guid releaseId,
+            IDataArchiveFile archiveFile,
+            File? replacingFile = null);
 
         Task<Either<ActionResult, Unit>> ValidateSubjectName(Guid releaseId, string name);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileUploadsValidatorService.cs
@@ -13,9 +13,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, Unit>> ValidateFileForUpload(IFormFile file, FileType type);
 
         Task<Either<ActionResult, Unit>> ValidateDataFilesForUpload(
-            Guid releaseId, 
+            Guid releaseId,
             IFormFile dataFile,
-            IFormFile metaFile, 
+            IFormFile metaFile,
             File? replacingFile = null);
 
         Task<Either<ActionResult, Unit>> ValidateDataArchiveEntriesForUpload(Guid releaseId, IDataArchiveFile archiveFile);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
@@ -322,7 +322,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                         .OnSuccess(async archiveFile =>
                                         {
                                             return await _fileUploadsValidatorService
-                                                .ValidateDataArchiveEntriesForUpload(releaseId, archiveFile)
+                                                .ValidateDataArchiveEntriesForUpload(releaseId,
+                                                    archiveFile,
+                                                    replacingFile)
                                                 .OnSuccess(async () =>
                                                 {
                                                     var subjectId = await _releaseRepository
@@ -478,7 +480,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             return await _fileUploadsValidatorService.ValidateSubjectName(releaseId, subjectName)
                 .OnSuccess(async () => await Task.FromResult(subjectName));
-
         }
 
         private async Task UploadFileToStorage(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -54,7 +54,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         SubjectTitleCannotBeEmpty,
         SubjectTitleCannotContainSpecialCharacters,
         SubjectTitleMustBeUnique,
-        CannotOverwriteDataFile,
+        DataFilenameNotUnique,
         DataAndMetadataFilesCannotHaveTheSameName,
         DataFileCannotBeEmpty,
         DataFileMustBeCsvFile,
@@ -66,12 +66,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         IncorrectNumberOfFileIds,
 
         // Data zip file
-        DataFileMustBeZipFile,
+        DataZipMustBeZipFile,
         DataZipFileCanOnlyContainTwoFiles,
         DataZipFileDoesNotContainCsvFiles,
-
-        ReplacementFileTypesMustBeData,
-        ReplacementMustBeValid,
 
         // Meta file
         MetadataFileCannotBeEmpty,
@@ -79,6 +76,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         UnableToFindMetadataFileToDelete,
         MetaFilenameCannotContainSpacesOrSpecialCharacters,
         MetaFileIsIncorrectlyNamed,
+
+        // Data replacement
+        ReplacementFileTypesMustBeData,
+        ReplacementMustBeValid,
 
         // Release
         ReleaseNotApproved,

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockFormTestUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockFormTestUtils.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Http;
 using Moq;
 
@@ -33,6 +34,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
                 .Returns(size);
 
             return formFile;
+        }
+
+        public static Mock<IDataArchiveFile> CreateDataArchiveFileMock(
+            string dataFileName,
+            string metaFileName,
+            long dataFileSize = 1048576,
+            long metaFileSize = 1024)
+        {
+            var dataArchiveFile = new Mock<IDataArchiveFile>();
+
+            dataArchiveFile
+                .SetupGet(f => f.DataFileName)
+                .Returns(dataFileName);
+
+            dataArchiveFile
+                .SetupGet(f => f.DataFileSize)
+                .Returns(dataFileSize);
+
+            dataArchiveFile
+                .SetupGet(f => f.MetaFileName)
+                .Returns(metaFileName);
+
+            dataArchiveFile
+                .SetupGet(f => f.MetaFileSize)
+                .Returns(metaFileSize);
+
+            return dataArchiveFile;
         }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -30,13 +30,12 @@ const baseErrorMappings = (
       mapFieldErrors<DataFileUploadFormValues>({
         target: 'zipFile',
         messages: {
-          DataFileMustBeZipFile: 'Choose a valid ZIP file',
+          DataZipMustBeZipFile: 'Choose a valid ZIP file',
           DataZipFileCanOnlyContainTwoFiles:
             'ZIP file can only contain two CSV files',
           DataZipFileDoesNotContainCsvFiles:
             'ZIP file does not contain any CSV files',
-          DataZipFileAlreadyExists: 'ZIP file already exists',
-          CannotOverwriteDataFile: 'Choose a unique ZIP data file name',
+          DataFilenameNotUnique: 'Choose a unique ZIP data file name',
           DataAndMetadataFilesCannotHaveTheSameName:
             'ZIP data and metadata filenames cannot be the same',
           DataFileCannotBeEmpty: 'Choose a ZIP data file that is not empty',
@@ -57,14 +56,13 @@ const baseErrorMappings = (
     mapFieldErrors<DataFileUploadFormValues>({
       target: 'dataFile',
       messages: {
-        CannotOverwriteDataFile: 'Choose a unique data file name',
+        DataFilenameNotUnique: 'Choose a unique data file name',
         DataAndMetadataFilesCannotHaveTheSameName:
           'Choose a different file name for data and metadata files',
         DataFileCannotBeEmpty: 'Choose a data file that is not empty',
         DataFileMustBeCsvFile: 'Data file must be a CSV with UTF-8 encoding',
         DataFilenameCannotContainSpacesOrSpecialCharacters:
           'Data filename cannot contain spaces or special characters',
-        DataFileAlreadyUploaded: 'Data file has already been uploaded',
       },
     }),
     mapFieldErrors<DataFileUploadFormValues>({


### PR DESCRIPTION
Normally a data filename is invalid if it already exists on the Release so that there's no ambiguity in the presentation of multiple files with the same name. If a data file is uploaded with the same name then a validation error is returned.

The only exception to this is in the case of data replacements where the same filename as the file being replaced is allowed.

`ValidateDataFileNames` method is parameterised with `replacingFile` so that the filename can be compared with the file being replaced, if any.

In the case of zip file upload validation, the value of `replacingFile` was missing, causing a bug where a validation error occurred uploading a replacement zip file containing a data file entry with the same name as the file being replaced.

This PR alters the `FileUploadsValidatorService` to make it aware of any file being replaced when uploading a zip file.

### Rules

Just in case there's any confusion about what's allowed, in general:

* Data filename has to be unique on the Release.
* Meta filenames (ending .meta.csv) don't have to be unique.
* Zip filenames (ending .zip) don't have to be unique.
* Zip file must contain data file with filename unique on the Release.

and specific to replacements:

* Replacement data filename has to be unique on the Release but can be the same as the file being replaced.
* Replacement zip file must contain data file with filename unique on the Release but can be the same as the file being replaced.

### Other changes

* Tidy up file upload error messages including renaming `CannotOverwriteDataFile -> DataFilenameNotUnique` and removing unused keys `DataZipFileAlreadyExists` and `DataFileAlreadyUploaded` from `DataFileUploadForm.tsx`.
* Tidy up FileUploadsValidatorService and unit tests. Remove unused ISubjectRepository property.
* Move `CreateDataArchiveFileMock` from `ReleaseDataFileServiceTest` to `MockFormTestUtils`.
* Use `MockFormTestUtils` to simplify the tests in `FileUploadsValidatorServiceTests`.