### PR TITLE
EES-3655 - check 'WAIT_MEMORY_CACHE_EXPIRY' exists in UI tests

### DIFF
--- a/tests/robot-tests/.env.example
+++ b/tests/robot-tests/.env.example
@@ -17,3 +17,4 @@ TIMEOUT=30 # Variable used throughout tests (in seconds)
 IMPLICIT_WAIT=15 # Variable used throughout tests (in seconds)
 FAIL_TEST_SUITES_FAST=1 # ("0" or "1") Fails entire test suite after any failure
 IDENTITY_PROVIDER= # ("AZURE" or "KEYCLOAK") opt into using either a Keycloak or Azure based identity provider
+WAIT_MEMORY_CACHE_EXPIRY= # Time to wait for the memory cache to expire (in minutes. Local = 2, Dev = 10)

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -164,6 +164,8 @@ assert os.getenv('WAIT_LONG') is not None
 assert os.getenv('WAIT_SMALL') is not None
 assert os.getenv('FAIL_TEST_SUITES_FAST') is not None
 assert os.getenv('IDENTITY_PROVIDER') is not None
+assert os.getenv('WAIT_MEMORY_CACHE_EXPIRY') is not None
+
 
 if args.slack_webhook_url:
     os.environ['SLACK_WEBHOOK_URL'] = args.slack_webhook_url


### PR DESCRIPTION
This PR: 
- adds an assertion to `run_tests.py` to check that the required environment variable `WAIT_MEMORY_CACHE_EXPIRY` exists

Other changes:
* changes assertion error messages to be a bit more helpful if environment variables are missing
* Updates `.env.example`