### PR TITLE
EES-3050, EES-3051 - add more context to 'More details' + 'help' buttons for accessibility

### DIFF
--- a/src/explore-education-statistics-common/src/components/Details.tsx
+++ b/src/explore-education-statistics-common/src/components/Details.tsx
@@ -11,6 +11,7 @@ import React, {
   useState,
 } from 'react';
 import styles from './Details.module.scss';
+import VisuallyHidden from './VisuallyHidden';
 
 let hasNativeDetails: boolean;
 let idCounter = 0;
@@ -41,6 +42,7 @@ export interface DetailsProps {
   open?: boolean;
   summary: string;
   summaryAfter?: ReactNode;
+  visuallyHiddenText?: string;
 }
 
 const Details = ({
@@ -53,6 +55,7 @@ const Details = ({
   onToggle,
   summary,
   summaryAfter,
+  visuallyHiddenText,
 }: DetailsProps) => {
   const [id] = useState(propId);
   const ref = useRef<HTMLElement>(null);
@@ -138,8 +141,10 @@ const Details = ({
           data-testid={formatTestId(`Expand Details Section ${summary}`)}
         >
           {summary}
+          {visuallyHiddenText && (
+            <VisuallyHidden> {visuallyHiddenText}</VisuallyHidden>
+          )}
         </span>
-
         {summaryAfter}
       </summary>
       <div

--- a/src/explore-education-statistics-common/src/components/__tests__/Details.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Details.test.tsx
@@ -200,4 +200,20 @@ describe('Details', () => {
       expect.objectContaining({ target: summary }),
     );
   });
+
+  test('passing a visuallyHiddenText prop displays visually hidden text', () => {
+    const { container } = render(
+      <Details
+        summary="Test summary"
+        id="test-details"
+        visuallyHiddenText="publication 1"
+      >
+        Key stats
+      </Details>,
+    );
+
+    expect(container.querySelector('.govuk-visually-hidden')).toHaveTextContent(
+      'publication 1',
+    );
+  });
 });

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
@@ -73,6 +73,11 @@ const KeyStat = ({
               <Details
                 summary={summary?.dataDefinitionTitle[0] || 'Help'}
                 className={styles.definition}
+                visuallyHiddenText={
+                  !summary?.dataDefinitionTitle[0]
+                    ? `for ${keyStat.title}`
+                    : undefined
+                }
               >
                 <div data-testid={`${testId}-definition`}>
                   {summary.dataDefinition.map(data => (

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAccordion.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAccordion.tsx
@@ -173,6 +173,7 @@ const ReleaseDataAccordion = ({
                           <Details
                             summary="More details"
                             className="govuk-!-margin-top-2"
+                            visuallyHiddenText={` for file ${file.name}`}
                           >
                             <div className="dfe-white-space--pre-wrap">
                               {file.summary}


### PR DESCRIPTION
This PR:
- addresses an accessibility issue whereby the 'More details; and 'help' buttons don't give enough context about the 'More details' and 'help' buttons
