### PR TITLE
EES-3669 - change publication summary to be textarea

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
@@ -60,7 +60,7 @@ const PublicationDetailsPage = () => {
           <SummaryList>
             <SummaryListItem term="Publication title">{title}</SummaryListItem>
             <SummaryListItem term="Publication summary">
-              {summary}
+              {summary ?? 'Not set'}
             </SummaryListItem>
             <SummaryListItem term="Theme">{theme?.title}</SummaryListItem>
             <SummaryListItem term="Topic">{topic?.title}</SummaryListItem>

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
@@ -4,7 +4,11 @@ import themeService from '@admin/services/themeService';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
-import { FormFieldset, FormFieldSelect } from '@common/components/form';
+import {
+  FormFieldset,
+  FormFieldSelect,
+  FormFieldTextArea,
+} from '@common/components/form';
 import Form from '@common/components/form/Form';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -105,10 +109,11 @@ const PublicationDetailsForm = ({
                     className="govuk-!-width-one-half"
                   />
 
-                  <FormFieldTextInput<PublicationDetailsFormValues>
+                  <FormFieldTextArea<PublicationDetailsFormValues>
                     name="summary"
                     label="Publication summary"
                     className="govuk-!-width-one-half"
+                    maxLength={160}
                   />
                   {themes && initialValues?.topicId && (
                     <FormFieldThemeTopicSelect<PublicationDetailsFormValues>

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
@@ -3,7 +3,11 @@ import publicationService from '@admin/services/publicationService';
 import themeService from '@admin/services/themeService';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
-import { FormFieldSelect, FormFieldset } from '@common/components/form';
+import {
+  FormFieldSelect,
+  FormFieldset,
+  FormFieldTextArea,
+} from '@common/components/form';
 import Form from '@common/components/form/Form';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -139,10 +143,11 @@ const PublicationForm = ({
               />
             )}
 
-            <FormFieldTextInput<FormValues>
+            <FormFieldTextArea<FormValues>
               label="Publication summary"
               name="summary"
               className="govuk-!-width-one-half"
+              maxLength={160}
             />
 
             {themes && initialValues?.topicId && (


### PR DESCRIPTION
This PR: 
- changes publication summary field from an input to text area
- fixes `PublicationDetailsPage.tsx` table formatting if no publication summary is set


![image](https://user-images.githubusercontent.com/55030296/186669316-8dcf9b2c-b5b1-48a9-a4ee-d0ffc7ff357b.png)
