### PR TITLE
EES-3671 - fix user resets user roles keyword

### DIFF
--- a/tests/robot-tests/tests/libs/admin_api.py
+++ b/tests/robot-tests/tests/libs/admin_api.py
@@ -186,15 +186,15 @@ def user_resets_user_roles_via_api_if_required(user_emails: list) -> None:
             user_ids = [get_prerelease_user_details_via_api(user_email)['id']]
             _ = [user_removes_all_release_and_publication_roles_from_user(user_id) for user_id in user_ids]
             BuiltIn().log(f'All userReleaseRoles & userPublicationRoles reset for user: {user_email}')
-        except IndexError:
-            BuiltIn().log(f'User with email {user_email} does not exist in pre-release user list')
+        except TypeError or IndexError:
+            BuiltIn().log(f'User with email {user_email} does not exist in pre-release user list', 'WARN')
 
             try:
                 user_ids = [get_user_details_via_api(user_email)['id']]
                 _ = [user_removes_all_release_and_publication_roles_from_user(user_id) for user_id in user_ids]
                 BuiltIn().log(f'All userReleaseRoles & userPublicationRoles reset for user: {user_email}')
-            except IndexError:
-                BuiltIn().log(f'User with email {user_email} does not exist in user list')
+            except TypeError or IndexError:
+                BuiltIn().log(f'User with email {user_email} does not exist in user list', 'WARN')
 
 
 def user_create_test_release_via_api(

--- a/tests/robot-tests/tests/libs/admin_api.py
+++ b/tests/robot-tests/tests/libs/admin_api.py
@@ -183,17 +183,18 @@ def user_resets_user_roles_via_api_if_required(user_emails: list) -> None:
         if user_email not in allowed_users:
             raise AssertionError(f'`User emails` must contain only allowed users: {allowed_users}')
         try:
-            user_ids = [get_user_details_via_api(user_email)['id']]
-        except IndexError:
-            BuiltIn().log(f'User with email {user_email} does not exist')
-
-        try:
-            result = [user_removes_all_release_and_publication_roles_from_user(user_id) for user_id in user_ids]
-            assert(all(result))
+            user_ids = [get_prerelease_user_details_via_api(user_email)['id']]
+            _ = [user_removes_all_release_and_publication_roles_from_user(user_id) for user_id in user_ids]
             BuiltIn().log(f'All userReleaseRoles & userPublicationRoles reset for user: {user_email}')
+        except IndexError:
+            BuiltIn().log(f'User with email {user_email} does not exist in pre-release user list')
 
-        except AssertionError:
-            BuiltIn().log(f'Failed to remove roles from user {user_email}')
+            try:
+                user_ids = [get_user_details_via_api(user_email)['id']]
+                _ = [user_removes_all_release_and_publication_roles_from_user(user_id) for user_id in user_ids]
+                BuiltIn().log(f'All userReleaseRoles & userPublicationRoles reset for user: {user_email}')
+            except IndexError:
+                BuiltIn().log(f'User with email {user_email} does not exist in user list')
 
 
 def user_create_test_release_via_api(
@@ -222,5 +223,13 @@ def get_user_details_via_api(
         user_email: str):
 
     users = admin_client.get('/api/user-management/users').json()
+
+    return list(filter(lambda user: user['email'] == user_email, users))[0]
+
+
+def get_prerelease_user_details_via_api(
+        user_email: str):
+
+    users = admin_client.get('/api/user-management/pre-release').json()
 
     return list(filter(lambda user: user['email'] == user_email, users))[0]


### PR DESCRIPTION
This PR fixes the 'user resets user roles' keyword

I tested this by: 
* changing prelease user2 to a user to pre-release viewer
* changing prerelease user1 to an analyst user 
* running `manage_users_page.robot` and checked these users were reset to 'no role' & the test passed


![image](https://user-images.githubusercontent.com/55030296/186714820-6ad84782-bbba-4e40-9e5a-ea156e13fc1d.png)


full run: 
![image](https://user-images.githubusercontent.com/55030296/186723986-c707bb53-c7b0-48de-a782-ddf129d798cd.png)
