### PR TITLE
EES-3058 - accordion accessibility fixes

### DIFF
--- a/src/explore-education-statistics-common/src/components/Accordion.tsx
+++ b/src/explore-education-statistics-common/src/components/Accordion.tsx
@@ -17,6 +17,7 @@ import {
   accordionSectionClasses,
   AccordionSectionProps,
 } from './AccordionSection';
+import VisuallyHidden from './VisuallyHidden';
 
 export interface AccordionProps {
   children: ReactNode;
@@ -25,6 +26,7 @@ export interface AccordionProps {
   showOpenAll?: boolean;
   onToggleAll?: (open: boolean) => void;
   onSectionOpen?: (accordionSection: { id: string; title: string }) => void;
+  toggleAllHiddenText?: string;
 }
 
 const Accordion = ({
@@ -34,6 +36,7 @@ const Accordion = ({
   showOpenAll = true,
   onToggleAll,
   onSectionOpen,
+  toggleAllHiddenText,
 }: AccordionProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -177,7 +180,11 @@ const Accordion = ({
             }}
           >
             {isAllOpen ? 'Close all ' : 'Open all '}
-            <span className="govuk-visually-hidden">sections</span>
+            <VisuallyHidden>
+              {!toggleAllHiddenText
+                ? ' sections'
+                : `${' '}${toggleAllHiddenText}`}
+            </VisuallyHidden>
           </button>
         </div>
       )}

--- a/src/explore-education-statistics-common/src/components/__tests__/Accordion.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Accordion.test.tsx
@@ -314,4 +314,22 @@ describe('Accordion', () => {
 
     expect(toggleAll).toHaveBeenCalledWith(false);
   });
+
+  test('it renders visually hidden text', () => {
+    const { container } = render(
+      <Accordion
+        id="test-sections"
+        toggleAllHiddenText="Academic Year 2016/17 sections"
+      >
+        <AccordionSection heading="Test heading">Test content</AccordionSection>
+      </Accordion>,
+    );
+
+    expect(container.querySelectorAll('.govuk-visually-hidden')).toHaveLength(
+      1,
+    );
+    expect(container.querySelector('.govuk-visually-hidden')).toHaveTextContent(
+      'Academic Year 2016/17 sections',
+    );
+  });
 });

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
@@ -129,6 +129,7 @@ const AccordionComponent = ({
 }: AccordionComponentProps) => {
   return includeAnalytics ? (
     <Accordion
+      toggleAllHiddenText="help and support sections"
       id={accordionId}
       onSectionOpen={accordionSection => {
         logEvent({
@@ -141,7 +142,9 @@ const AccordionComponent = ({
       {children}
     </Accordion>
   ) : (
-    <Accordion id={accordionId}>{children}</Accordion>
+    <Accordion id={accordionId} toggleAllHiddenText="help and support sections">
+      {children}
+    </Accordion>
   );
 };
 


### PR DESCRIPTION
This PR:
- adds visually hidden text to 'Open all' & 'Close all' accordion section buttons to address accesibility issues around 'Open all' & 'Close all' buttons not having enough context/repeating throughout a release page