### PR TITLE
EES-3062 - explore data button accesibility fixes

### DIFF
--- a/src/explore-education-statistics-common/src/components/Details.tsx
+++ b/src/explore-education-statistics-common/src/components/Details.tsx
@@ -42,7 +42,7 @@ export interface DetailsProps {
   open?: boolean;
   summary: string;
   summaryAfter?: ReactNode;
-  visuallyHiddenText?: string;
+  hiddenText?: string;
 }
 
 const Details = ({
@@ -55,7 +55,7 @@ const Details = ({
   onToggle,
   summary,
   summaryAfter,
-  visuallyHiddenText,
+  hiddenText,
 }: DetailsProps) => {
   const [id] = useState(propId);
   const ref = useRef<HTMLElement>(null);
@@ -141,9 +141,7 @@ const Details = ({
           data-testid={formatTestId(`Expand Details Section ${summary}`)}
         >
           {summary}
-          {visuallyHiddenText && (
-            <VisuallyHidden> {visuallyHiddenText}</VisuallyHidden>
-          )}
+          {hiddenText && <VisuallyHidden> {hiddenText}</VisuallyHidden>}
         </span>
         {summaryAfter}
       </summary>

--- a/src/explore-education-statistics-common/src/components/__tests__/Details.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Details.test.tsx
@@ -201,12 +201,12 @@ describe('Details', () => {
     );
   });
 
-  test('passing a visuallyHiddenText prop displays visually hidden text', () => {
+  test('passing a hiddenText prop displays visually hidden text', () => {
     const { container } = render(
       <Details
         summary="Test summary"
         id="test-details"
-        visuallyHiddenText="publication 1"
+        hiddenText="publication 1"
       >
         Key stats
       </Details>,

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -54,7 +54,7 @@ interface BaseFormCheckboxGroupProps {
   onAllChange?: CheckboxGroupAllChangeEventHandler;
   onBlur?: FocusEventHandler<HTMLInputElement>;
   onChange?: CheckboxChangeEventHandler;
-  visuallyHiddenText?: string;
+  hiddenText?: string;
 }
 
 const getDefaultSelectAllText = (
@@ -82,7 +82,7 @@ export const BaseFormCheckboxGroup = ({
   onBlur,
   onChange,
   onAllChange,
-  visuallyHiddenText,
+  hiddenText,
 }: BaseFormCheckboxGroupProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -154,9 +154,7 @@ export const BaseFormCheckboxGroup = ({
           underline={false}
         >
           {selectAllText(isAllChecked, options)}
-          {visuallyHiddenText && (
-            <VisuallyHidden> {visuallyHiddenText}</VisuallyHidden>
-          )}
+          {hiddenText && <VisuallyHidden> {hiddenText}</VisuallyHidden>}
         </ButtonText>
       )}
       {showResults && (

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
@@ -197,7 +197,7 @@ const FormCheckboxSearchSubGroups = ({
                     onSubGroupAllChange(event, checked, optionGroup.options);
                   }
                 }}
-                visuallyHiddenText={`for ${optionGroup.legend}`}
+                hiddenText={`for ${optionGroup.legend}`}
               />
             ))}
           </>

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
@@ -73,7 +73,7 @@ const KeyStat = ({
               <Details
                 summary={summary?.dataDefinitionTitle[0] || 'Help'}
                 className={styles.definition}
-                visuallyHiddenText={
+                hiddenText={
                   !summary?.dataDefinitionTitle[0]
                     ? `for ${keyStat.title}`
                     : undefined

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAccordion.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAccordion.tsx
@@ -173,7 +173,7 @@ const ReleaseDataAccordion = ({
                           <Details
                             summary="More details"
                             className="govuk-!-margin-top-2"
-                            visuallyHiddenText={` for file ${file.name}`}
+                            hiddenText={` for file ${file.name}`}
                           >
                             <div className="dfe-white-space--pre-wrap">
                               {file.summary}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/ExploreDataButton.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/ExploreDataButton.tsx
@@ -4,14 +4,15 @@ import ButtonLink from '@frontend/components/ButtonLink';
 import { DataBlock } from '@common/services/types/blocks';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
 import React from 'react';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 
 interface Props {
   block: DataBlock;
+  hiddenText?: string;
 }
 
-const ExploreDataButton = ({ block }: Props) => {
+const ExploreDataButton = ({ block, hiddenText }: Props) => {
   const [buttonClicked, toggleButtonClicked] = useToggle(false);
-
   return (
     <>
       <ButtonLink
@@ -27,6 +28,7 @@ const ExploreDataButton = ({ block }: Props) => {
         }}
       >
         Explore data
+        {hiddenText && <VisuallyHidden>{` ${hiddenText}`}</VisuallyHidden>}
       </ButtonLink>
       <LoadingSpinner
         alert

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
@@ -56,7 +56,10 @@ const PublicationSectionBlocks = ({
                     </h3>
 
                     <p>Use our table tool to explore this data.</p>
-                    <ExploreDataButton block={block} />
+                    <ExploreDataButton
+                      block={block}
+                      hiddenText={`for ${block.heading}`}
+                    />
                   </div>
                 }
               />


### PR DESCRIPTION
This PR: 
- fixes an accessibility issue whereby the 'explore data' button is repeated without additional context. For now, I've added visually hidden text inside the `ExploreDataButton` component and used `block.name` to provide additional context. Not too sure about whether the block is the right thing to use here as it just contains: ` Generic data block - National`. This potentially needs revisiting to decide whether something such as the datablock name would be a more appropriate text