### PR TITLE
EES-3648 Update cached publications rather than deleting them from the cache

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/LegacyReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/LegacyReleaseServicePermissionTests.cs
@@ -3,11 +3,11 @@ using System;
 using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
@@ -61,7 +61,7 @@ public class LegacyReleaseServicePermissionTests
     private LegacyReleaseService SetupService(
         ContentDbContext? contentDbContext = null,
         PersistenceHelper<ContentDbContext>? persistenceHelper = null,
-        IBlobCacheService? publicBlobCacheService = null,
+        IPublicationCacheService? publicationCacheService = null,
         IUserService? userService = null,
         IMapper? mapper = null)
     {
@@ -70,7 +70,7 @@ public class LegacyReleaseServicePermissionTests
             mapper ?? AdminMapper(),
             userService ?? Mock.Of<IUserService>(Strict),
             persistenceHelper ?? DefaultPersistenceHelperMock().Object,
-            publicBlobCacheService ?? Mock.Of<IBlobCacheService>(Strict)
+            publicationCacheService ?? Mock.Of<IPublicationCacheService>(Strict)
         );
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -6,7 +6,6 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
@@ -15,7 +14,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
-using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
@@ -40,7 +38,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         };
 
         [Fact]
-        public void GetMyPublicationsAndReleasesByTopic_NoAccessOfSystem()
+        public async Task GetMyPublicationsAndReleasesByTopic_NoAccessOfSystem()
         {
             var userService = AlwaysTrueUserService();
             var publicationRepository = new Mock<IPublicationRepository>(Strict);
@@ -63,14 +61,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             publicationRepository.Setup(s => s.GetAllPublicationsForTopic(topicId)).ReturnsAsync(list);
 
-            var result = publicationService.GetMyPublicationsAndReleasesByTopic(topicId).Result.Left;
-            Assert.IsAssignableFrom<ForbidResult>(result);
+            var result = await publicationService.GetMyPublicationsAndReleasesByTopic(topicId);
 
-            userService.Verify(s => s.GetUserId());
-            userService.Verify(s => s.MatchesPolicy(SecurityPolicies.CanAccessSystem));
-            userService.VerifyNoOtherCalls();
+            VerifyAllMocks(userService, publicationRepository);
 
-            publicationRepository.VerifyNoOtherCalls();
+            result.AssertForbidden();
         }
 
         [Fact]
@@ -337,11 +332,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                var publicBlobCacheService = new Mock<IBlobCacheService>(Strict);
-
                 var publicationService = BuildPublicationService(context,
-                    userService: userService.Object,
-                    publicBlobCacheService: publicBlobCacheService.Object);
+                    userService: userService.Object);
 
                 var result = await publicationService.UpdatePublication(
                     publication.Id,
@@ -351,8 +343,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 );
 
-                var actionResult = result.AssertLeft();
-                Assert.IsType<ForbidResult>(actionResult);
+                VerifyAllMocks(userService);
+
+                result.AssertForbidden();
             }
         }
 
@@ -388,11 +381,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                var publicBlobCacheService = new Mock<IBlobCacheService>(Strict);
-
                 var publicationService = BuildPublicationService(context,
-                    userService: userService.Object,
-                    publicBlobCacheService: publicBlobCacheService.Object);
+                    userService: userService.Object);
 
                 var result = await publicationService.UpdatePublication(
                     publication.Id,
@@ -404,8 +394,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 );
 
-                var actionResult = result.AssertLeft();
-                Assert.IsType<ForbidResult>(actionResult);
+                VerifyAllMocks(userService);
+
+                result.AssertForbidden();
             }
         }
 
@@ -448,11 +439,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                var publicBlobCacheService = new Mock<IBlobCacheService>(Strict);
-
                 var publicationService = BuildPublicationService(context,
-                    userService: userService.Object,
-                    publicBlobCacheService: publicBlobCacheService.Object);
+                    userService: userService.Object);
 
                 var result = await publicationService.UpdatePublication(
                     publication.Id,
@@ -463,8 +451,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 );
 
-                var actionResult = result.AssertLeft();
-                Assert.IsType<ForbidResult>(actionResult);
+                result.AssertForbidden();
             }
         }
 
@@ -505,7 +492,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IUserService? userService = null,
             IPublicationRepository? publicationRepository = null,
             IMethodologyVersionRepository? methodologyVersionRepository = null,
-            IBlobCacheService? publicBlobCacheService = null,
+            IPublicationCacheService? publicationCacheService = null,
             IMethodologyCacheService? methodologyCacheService = null,
             IThemeCacheService? themeCacheService = null)
         {
@@ -516,7 +503,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 userService ?? AlwaysTrueUserService().Object,
                 publicationRepository ?? Mock.Of<IPublicationRepository>(Strict),
                 methodologyVersionRepository ?? Mock.Of<IMethodologyVersionRepository>(Strict),
-                publicBlobCacheService ?? Mock.Of<IBlobCacheService>(Strict),
+                publicationCacheService ?? Mock.Of<IPublicationCacheService>(Strict),
                 methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
                 themeCacheService ?? Mock.Of<IThemeCacheService>(Strict));
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -385,8 +385,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(true);
             userService.Setup(s => s.MatchesPolicy(CanViewAllReleases))
                 .ReturnsAsync(true);
-            userService.Setup(s => s.GetUserId())
-                .Returns(Guid.NewGuid());
             userService
                 .Setup(s => s.MatchesPolicy(
                     It.IsAny<Release>(), CanUpdateSpecificRelease))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/LegacyReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/LegacyReleaseService.cs
@@ -7,13 +7,12 @@ using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -25,20 +24,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IMapper _mapper;
         private readonly IUserService _userService;
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
-        private readonly IBlobCacheService _publicBlobCacheService;
+        private readonly IPublicationCacheService _publicationCacheService;
 
-        public LegacyReleaseService(
-            ContentDbContext context,
+        public LegacyReleaseService(ContentDbContext context,
             IMapper mapper,
             IUserService userService,
             IPersistenceHelper<ContentDbContext> persistenceHelper,
-            IBlobCacheService publicBlobCacheService)
+            IPublicationCacheService publicationCacheService)
         {
             _context = context;
             _mapper = mapper;
             _userService = userService;
             _persistenceHelper = persistenceHelper;
-            _publicBlobCacheService = publicBlobCacheService;
+            _publicationCacheService = publicationCacheService;
         }
 
         public async Task<Either<ActionResult, LegacyReleaseViewModel>> GetLegacyRelease(Guid id)
@@ -94,7 +92,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     await _context.SaveChangesAsync();
 
-                    await _publicBlobCacheService.DeleteItem(new PublicationCacheKey(publication.Slug));
+                    await _publicationCacheService.UpdatePublication(publication.Slug);
 
                     return _mapper.Map<LegacyReleaseViewModel>(saved.Entity);
                 });
@@ -148,7 +146,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     await _context.SaveChangesAsync();
 
-                    await _publicBlobCacheService.DeleteItem(new PublicationCacheKey(publication.Slug));
+                    await _publicationCacheService.UpdatePublication(publication.Slug);
 
                     return _mapper.Map<LegacyReleaseViewModel>(legacyRelease);
                 });
@@ -181,7 +179,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     await _context.SaveChangesAsync();
 
-                    await _publicBlobCacheService.DeleteItem(new PublicationCacheKey(publication.Slug));
+                    await _publicationCacheService.UpdatePublication(publication.Slug);
 
                     return true;
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -65,13 +65,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, List<MyPublicationViewModel>>> GetMyPublicationsAndReleasesByTopic(
             Guid topicId)
         {
-            var userId = _userService.GetUserId();
-
             return await _userService
                 .CheckCanAccessSystem()
                 .OnSuccess(_ => _userService.CheckCanViewAllReleases()
                     .OnSuccess(() => _publicationRepository.GetAllPublicationsForTopic(topicId))
-                    .OrElse(() => _publicationRepository.GetPublicationsForTopicRelatedToUser(topicId, userId))
+                    .OrElse(() =>
+                        _publicationRepository.GetPublicationsForTopicRelatedToUser(topicId, _userService.GetUserId()))
                 )
                 .OnSuccess(async publicationViewModels =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -80,6 +80,8 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Services.Collecti
 using static GovUk.Education.ExploreEducationStatistics.Common.Utils.StartupUtils;
 using IContentMethodologyService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IMethodologyService;
 using ContentMethodologyService = GovUk.Education.ExploreEducationStatistics.Content.Services.MethodologyService;
+using ContentPublicationService = GovUk.Education.ExploreEducationStatistics.Content.Services.PublicationService;
+using IContentPublicationService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IPublicationService;
 using IContentThemeService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IThemeService;
 using ContentThemeService = GovUk.Education.ExploreEducationStatistics.Content.Services.ThemeService;
 using DataGuidanceService = GovUk.Education.ExploreEducationStatistics.Admin.Services.DataGuidanceService;
@@ -406,8 +408,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             // being done from Admin directly, and so these DI dependencies should eventually be removed.
             services.AddTransient<IContentThemeService, ContentThemeService>();
             services.AddTransient<IContentMethodologyService, ContentMethodologyService>();
+            services.AddTransient<IContentPublicationService, ContentPublicationService>();
             services.AddTransient<IMethodologyCacheService, MethodologyCacheService>();
             services.AddTransient<IThemeCacheService, ThemeCacheService>();
+            services.AddTransient<IPublicationCacheService, PublicationCacheService>();
 
             services.AddTransient<IMyPublicationPermissionsResolver,
                 MyPublicationPermissionsResolver>();
@@ -458,10 +462,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                     userService: provider.GetRequiredService<IUserService>(),
                     publicationRepository: provider.GetRequiredService<IPublicationRepository>(),
                     methodologyVersionRepository: provider.GetRequiredService<IMethodologyVersionRepository>(),
-                    publicBlobCacheService: new BlobCacheService(
-                        GetBlobStorageService(provider, "PublicStorage"),
-                        provider.GetRequiredService<ILogger<BlobCacheService>>()),
                     methodologyCacheService: provider.GetRequiredService<IMethodologyCacheService>(),
+                    publicationCacheService: provider.GetRequiredService<IPublicationCacheService>(),
                     themeCacheService: provider.GetRequiredService<IThemeCacheService>()
                 )
             );
@@ -473,11 +475,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                     mapper: provider.GetService<IMapper>(),
                     userService: provider.GetService<IUserService>(),
                     persistenceHelper: provider.GetService<IPersistenceHelper<ContentDbContext>>(),
-                    publicBlobCacheService: new BlobCacheService(
-                        GetBlobStorageService(provider, "PublicStorage"),
-                        provider.GetRequiredService<ILogger<BlobCacheService>>())
-                )
-            );
+                    publicationCacheService: provider.GetRequiredService<IPublicationCacheService>())
+                );
             services.AddTransient<IReleaseService, ReleaseService>();
             services.AddTransient<IReleaseApprovalService, ReleaseApprovalService>();
             services.AddTransient<ReleaseSubjectRepository.SubjectDeleter, ReleaseSubjectRepository.SubjectDeleter>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/CacheServiceTestFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/CacheServiceTestFixture.cs
@@ -15,12 +15,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures
         protected const string CacheServiceTests = "Cache service tests";
 
         protected static readonly Mock<IBlobCacheService> BlobCacheService = new(MockBehavior.Strict);
+        protected static readonly Mock<IBlobCacheService> PublicBlobCacheService = new(MockBehavior.Strict);
         protected static readonly Mock<IMemoryCacheService> MemoryCacheService = new(MockBehavior.Strict);
 
         protected CacheServiceTestFixture()
         {
             CacheAspect.Enabled = true;
             BlobCacheAttribute.AddService("default", BlobCacheService.Object);
+            BlobCacheAttribute.AddService("public", PublicBlobCacheService.Object);
             MemoryCacheAttribute.AddService("default", MemoryCacheService.Object);
         }
 
@@ -30,6 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures
 
             BlobCacheAttribute.ClearServices();
             BlobCacheService.Reset();
+            PublicBlobCacheService.Reset();
 
             MemoryCacheAttribute.ClearServices();
             MemoryCacheService.Reset();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/CacheServiceTestFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/CacheServiceTestFixture.cs
@@ -2,10 +2,7 @@
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
-using Microsoft.Extensions.Configuration;
 using Moq;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
-using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures
 {
@@ -19,7 +16,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures
 
         protected static readonly Mock<IBlobCacheService> BlobCacheService = new(MockBehavior.Strict);
         protected static readonly Mock<IMemoryCacheService> MemoryCacheService = new(MockBehavior.Strict);
-        protected static readonly Mock<IConfigurationSection> MemoryCacheConfig = new(MockBehavior.Strict);
 
         protected CacheServiceTestFixture()
         {
@@ -31,10 +27,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures
         public void Dispose()
         {
             CacheAspect.Enabled = false;
-            
+
             BlobCacheAttribute.ClearServices();
             BlobCacheService.Reset();
-            
+
             MemoryCacheAttribute.ClearServices();
             MemoryCacheService.Reset();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PreReleaseAccessListController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PreReleaseAccessListController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 
@@ -12,13 +13,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
     [Route("api")]
     public class PreReleaseAccessListController : ControllerBase
     {
+        private readonly IPublicationCacheService _publicationCacheService;
         private readonly IPublicationService _publicationService;
         private readonly IReleaseService _releaseService;
 
-        public PreReleaseAccessListController(
+        public PreReleaseAccessListController(IPublicationCacheService publicationCacheService,
             IPublicationService publicationService,
             IReleaseService releaseService)
         {
+            _publicationCacheService = publicationCacheService;
             _publicationService = publicationService;
             _releaseService = releaseService;
         }
@@ -46,8 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
             string publicationSlug,
             string? releaseSlug = null)
         {
-
-            return await _publicationService.Get(publicationSlug)
+            return await _publicationCacheService.GetPublication(publicationSlug)
                 .OnSuccessCombineWith(_ => _releaseService.GetCachedRelease(publicationSlug, releaseSlug))
                 .OnSuccess(publicationAndRelease =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
@@ -3,7 +3,7 @@ using System.Net.Mime;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 
@@ -13,17 +13,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
     [Produces(MediaTypeNames.Application.Json)]
     public class PublicationController : ControllerBase
     {
-        private readonly IPublicationService _publicationService;
+        private readonly IPublicationCacheService _publicationCacheService;
 
-        public PublicationController(IPublicationService publicationService)
+        public PublicationController(IPublicationCacheService publicationCacheService)
         {
-            _publicationService = publicationService;
+            _publicationCacheService = publicationCacheService;
         }
 
         [HttpGet("publications/{slug}/title")]
         public async Task<ActionResult<PublicationTitleViewModel>> GetPublicationTitle(string slug)
         {
-            return await _publicationService.Get(slug)
+            return await _publicationCacheService.GetPublication(slug)
                 .OnSuccess(p => new PublicationTitleViewModel
                 {
                     Id = p.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -36,6 +36,7 @@ using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
 using static GovUk.Education.ExploreEducationStatistics.Common.Utils.StartupUtils;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+using IPublicationService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IPublicationService;
 using IReleaseService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IReleaseService;
 using IThemeService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IThemeService;
 using ThemeService = GovUk.Education.ExploreEducationStatistics.Content.Services.ThemeService;
@@ -139,7 +140,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             services.AddTransient<IFilterRepository, FilterRepository>();
             services.AddTransient<IIndicatorRepository, IndicatorRepository>();
             services.AddTransient<IDataGuidanceService, DataGuidanceService>();
-            services.AddTransient<Services.Interfaces.IPublicationService, Services.PublicationService>();
+            services.AddTransient<IPublicationCacheService, PublicationCacheService>();
+            services.AddTransient<IPublicationService, Services.PublicationService>();
             services.AddTransient<ITimePeriodService, TimePeriodService>();
             services.AddTransient<IDataGuidanceSubjectService, DataGuidanceSubjectService>();
             services.AddTransient<IFootnoteRepository, FootnoteRepository>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/MethodologyCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/MethodologyCacheServiceTests.cs
@@ -22,11 +22,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cach
 [Collection(CacheServiceTests)]
 public class MethodologyCacheServiceTests : CacheServiceTestFixture
 {
-    public MethodologyCacheServiceTests()
-    {
-        BlobCacheAttribute.AddService("public", BlobCacheService.Object);
-    }
-
     private readonly List<AllMethodologiesThemeViewModel> _methodologyTree = ListOf(
         new AllMethodologiesThemeViewModel
         {
@@ -66,7 +61,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
     [Fact]
     public async Task GetSummariesTree_NoCachedTreeExists()
     {
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.GetItem(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
             .ReturnsAsync(null);
 
@@ -76,7 +71,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
             .Setup(s => s.GetSummariesTree())
             .ReturnsAsync(new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(_methodologyTree));
 
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.SetItem<object>(new AllMethodologiesCacheKey(), _methodologyTree))
             .Returns(Task.CompletedTask);
 
@@ -84,7 +79,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.GetSummariesTree();
 
-        VerifyAllMocks(methodologyService, BlobCacheService);
+        VerifyAllMocks(methodologyService, PublicBlobCacheService);
 
         result.AssertRight(_methodologyTree);
     }
@@ -92,7 +87,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
     [Fact]
     public async Task GetSummariesTree_CachedTreeExists()
     {
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.GetItem(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
             .ReturnsAsync(_methodologyTree);
 
@@ -100,7 +95,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.GetSummariesTree();
 
-        VerifyAllMocks(BlobCacheService);
+        VerifyAllMocks(PublicBlobCacheService);
 
         result.AssertRight(_methodologyTree);
     }
@@ -110,7 +105,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
     {
         var publicationId = _methodologyTree[1].Topics[0].Publications[0].Id;
 
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.GetItem(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
             .ReturnsAsync(null);
 
@@ -120,7 +115,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
             .Setup(s => s.GetSummariesTree())
             .ReturnsAsync(new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(_methodologyTree));
 
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.SetItem<object>(new AllMethodologiesCacheKey(), _methodologyTree))
             .Returns(Task.CompletedTask);
 
@@ -128,7 +123,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.GetSummariesByPublication(publicationId);
 
-        VerifyAllMocks(methodologyService, BlobCacheService);
+        VerifyAllMocks(methodologyService, PublicBlobCacheService);
 
         var expectedMethodologiesByPublication =
             _methodologyTree[1].Topics[0].Publications[0].Methodologies;
@@ -147,7 +142,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
 
         // We should not see any attempt to "get" the cached tree, but rather only see a fresh fetching
         // of the latest tree and then it being cached.
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.SetItem<object>(new AllMethodologiesCacheKey(), _methodologyTree))
             .Returns(Task.CompletedTask);
 
@@ -155,7 +150,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.UpdateSummariesTree();
 
-        VerifyAllMocks(methodologyService, BlobCacheService);
+        VerifyAllMocks(methodologyService, PublicBlobCacheService);
 
         result.AssertRight(_methodologyTree);
     }
@@ -165,7 +160,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
     {
         var publicationId = _methodologyTree[1].Topics[0].Publications[0].Id;
 
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.GetItem(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
             .ReturnsAsync(_methodologyTree);
 
@@ -173,7 +168,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.GetSummariesByPublication(publicationId);
 
-        VerifyAllMocks(BlobCacheService);
+        VerifyAllMocks(PublicBlobCacheService);
 
         var expectedMethodologiesByPublication =
             _methodologyTree[1].Topics[0].Publications[0].Methodologies;
@@ -186,7 +181,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
     {
         var publicationId = Guid.NewGuid();
 
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.GetItem(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
             .ReturnsAsync(_methodologyTree);
 
@@ -194,7 +189,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.GetSummariesByPublication(publicationId);
 
-        VerifyAllMocks(BlobCacheService);
+        VerifyAllMocks(PublicBlobCacheService);
 
         result.AssertRight(new List<MethodologyVersionSummaryViewModel>());
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -17,11 +17,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cach
 [Collection(CacheServiceTests)]
 public class PublicationCacheServiceTests : CacheServiceTestFixture
 {
-    public PublicationCacheServiceTests()
-    {
-        BlobCacheAttribute.AddService("public", BlobCacheService.Object);
-    }
-
     private const string PublicationSlug = "publication-slug";
 
     private readonly PublicationViewModel _publicationViewModel = new()
@@ -34,11 +29,11 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
     {
         var cacheKey = new PublicationCacheKey(PublicationSlug);
 
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.GetItem(cacheKey, typeof(PublicationViewModel)))
             .ReturnsAsync(null);
 
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.SetItem<object>(cacheKey, _publicationViewModel))
             .Returns(Task.CompletedTask);
 
@@ -52,7 +47,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.GetPublication(PublicationSlug);
 
-        VerifyAllMocks(publicationService, BlobCacheService);
+        VerifyAllMocks(publicationService, PublicBlobCacheService);
 
         result.AssertRight(_publicationViewModel);
     }
@@ -62,7 +57,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
     {
         var cacheKey = new PublicationCacheKey(PublicationSlug);
 
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.GetItem(cacheKey, typeof(PublicationViewModel)))
             .ReturnsAsync(_publicationViewModel);
 
@@ -70,7 +65,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.GetPublication(PublicationSlug);
 
-        VerifyAllMocks(BlobCacheService);
+        VerifyAllMocks(PublicBlobCacheService);
 
         result.AssertRight(_publicationViewModel);
     }
@@ -86,7 +81,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
             .Setup(s => s.Get(PublicationSlug))
             .ReturnsAsync(_publicationViewModel);
 
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.SetItem<object>(cacheKey, _publicationViewModel))
             .Returns(Task.CompletedTask);
 
@@ -96,7 +91,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
 
         // There should be no attempt on the cache service to get the cached resource
 
-        VerifyAllMocks(publicationService, BlobCacheService);
+        VerifyAllMocks(publicationService, PublicBlobCacheService);
 
         result.AssertRight(_publicationViewModel);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -1,0 +1,81 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cache;
+
+[Collection(CacheServiceTests)]
+public class PublicationCacheServiceTests : CacheServiceTestFixture
+{
+    private const string PublicationSlug = "publication-slug";
+
+    private readonly PublicationViewModel _publicationViewModel = new()
+    {
+        Id = Guid.NewGuid()
+    };
+
+    [Fact]
+    public async Task GetPublication_NoCachedPublication()
+    {
+        var cacheKey = new PublicationCacheKey(PublicationSlug);
+
+        BlobCacheService
+            .Setup(s => s.GetItem(cacheKey, typeof(PublicationViewModel)))
+            .ReturnsAsync(null);
+
+        BlobCacheService
+            .Setup(s => s.SetItem<object>(cacheKey, _publicationViewModel))
+            .Returns(Task.CompletedTask);
+
+        var publicationService = new Mock<IPublicationService>(Strict);
+
+        publicationService
+            .Setup(s => s.Get(PublicationSlug))
+            .ReturnsAsync(_publicationViewModel);
+
+        var service = BuildService(publicationService: publicationService.Object);
+
+        var result = await service.GetPublication(PublicationSlug);
+
+        VerifyAllMocks(publicationService, BlobCacheService);
+
+        result.AssertRight(_publicationViewModel);
+    }
+
+    [Fact]
+    public async Task GetPublication_CachedPublication()
+    {
+        var cacheKey = new PublicationCacheKey(PublicationSlug);
+
+        BlobCacheService
+            .Setup(s => s.GetItem(cacheKey, typeof(PublicationViewModel)))
+            .ReturnsAsync(_publicationViewModel);
+
+        var service = BuildService();
+
+        var result = await service.GetPublication(PublicationSlug);
+
+        VerifyAllMocks(BlobCacheService);
+
+        result.AssertRight(_publicationViewModel);
+    }
+
+    private static PublicationCacheService BuildService(
+        IPublicationService? publicationService = null
+    )
+    {
+        return new PublicationCacheService(
+            publicationService: publicationService ?? Mock.Of<IPublicationService>(Strict)
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -70,6 +70,32 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
         result.AssertRight(_publicationViewModel);
     }
 
+    [Fact]
+    public async Task UpdatePublication()
+    {
+        var cacheKey = new PublicationCacheKey(PublicationSlug);
+
+        var publicationService = new Mock<IPublicationService>(Strict);
+
+        publicationService
+            .Setup(s => s.Get(PublicationSlug))
+            .ReturnsAsync(_publicationViewModel);
+
+        BlobCacheService
+            .Setup(s => s.SetItem<object>(cacheKey, _publicationViewModel))
+            .Returns(Task.CompletedTask);
+
+        var service = BuildService(publicationService: publicationService.Object);
+
+        var result = await service.UpdatePublication(PublicationSlug);
+
+        // There should be no attempt on the cache service to get the cached resource
+
+        VerifyAllMocks(publicationService, BlobCacheService);
+
+        result.AssertRight(_publicationViewModel);
+    }
+
     private static PublicationCacheService BuildService(
         IPublicationService? publicationService = null
     )

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -17,6 +17,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cach
 [Collection(CacheServiceTests)]
 public class PublicationCacheServiceTests : CacheServiceTestFixture
 {
+    public PublicationCacheServiceTests()
+    {
+        BlobCacheAttribute.AddService("public", BlobCacheService.Object);
+    }
+
     private const string PublicationSlug = "publication-slug";
 
     private readonly PublicationViewModel _publicationViewModel = new()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/ThemeCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/ThemeCacheServiceTests.cs
@@ -20,11 +20,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cach
 [Collection(CacheServiceTests)]
 public class ThemeCacheServiceTests : CacheServiceTestFixture
 {
-    public ThemeCacheServiceTests()
-    {
-        BlobCacheAttribute.AddService("public", BlobCacheService.Object);
-    }
-
     [Fact]
     public async Task GetPublicationTree_NoCachedTreeExists()
     {
@@ -46,7 +41,7 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
             }
         });
         
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.GetItem(
                 new PublicationTreeCacheKey(), typeof(IList<ThemeTree<PublicationTreeNode>>)))
             .ReturnsAsync(null);
@@ -57,7 +52,7 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
             .Setup(s => s.GetPublicationTree())
             .ReturnsAsync(publicationTree);
         
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.SetItem<object>(
                 new PublicationTreeCacheKey(), publicationTree))
             .Returns(Task.CompletedTask);
@@ -66,7 +61,7 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.GetPublicationTree(PublicationTreeFilter.FindStatistics);
 
-        VerifyAllMocks(BlobCacheService);
+        VerifyAllMocks(PublicBlobCacheService);
 
         var filteredTree = result.AssertRight();
         filteredTree.AssertDeepEqualTo(publicationTree);
@@ -93,7 +88,7 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
             }
         };
         
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.GetItem(
                 new PublicationTreeCacheKey(), typeof(IList<ThemeTree<PublicationTreeNode>>)))
             .ReturnsAsync(ListOf(publicationTree));
@@ -102,7 +97,7 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.GetPublicationTree(PublicationTreeFilter.FindStatistics);
 
-        VerifyAllMocks(BlobCacheService);   
+        VerifyAllMocks(PublicBlobCacheService);   
 
         var filteredTree = result.AssertRight();
         filteredTree.AssertDeepEqualTo(ListOf(publicationTree));
@@ -388,7 +383,7 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
         
         // We should not see any attempt to "get" the cached tree, but rather only see a fresh fetching
         // of the latest tree and then it being cached.
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.SetItem<object>(
                 new PublicationTreeCacheKey(), publicationTree))
             .Returns(Task.CompletedTask);
@@ -397,7 +392,7 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
 
         var filteredTree = await service.UpdatePublicationTree();
 
-        VerifyAllMocks(BlobCacheService);
+        VerifyAllMocks(PublicBlobCacheService);
         
         publicationTree.AssertDeepEqualTo(filteredTree);
     }
@@ -406,7 +401,7 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
         ThemeTree<PublicationTreeNode> publicationTree,
         PublicationTreeFilter filter)
     {
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.GetItem(
                 new PublicationTreeCacheKey(), typeof(IList<ThemeTree<PublicationTreeNode>>)))
             .ReturnsAsync(ListOf(publicationTree));
@@ -415,7 +410,7 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.GetPublicationTree(filter);
 
-        VerifyAllMocks(BlobCacheService);
+        VerifyAllMocks(PublicBlobCacheService);
 
         var filteredTree = result.AssertRight();
         filteredTree.AssertDeepEqualTo(ListOf(publicationTree));
@@ -425,7 +420,7 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
         ThemeTree<PublicationTreeNode> publicationTree,
         PublicationTreeFilter filter)
     {
-        BlobCacheService
+        PublicBlobCacheService
             .Setup(s => s.GetItem(
                 new PublicationTreeCacheKey(), typeof(IList<ThemeTree<PublicationTreeNode>>)))
             .ReturnsAsync(ListOf(publicationTree));
@@ -434,7 +429,7 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
 
         var result = await service.GetPublicationTree(filter);
 
-        VerifyAllMocks(BlobCacheService);
+        VerifyAllMocks(PublicBlobCacheService);
 
         var filteredTree = result.AssertRight();
         Assert.Empty(filteredTree);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -3,40 +3,21 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
-using GovUk.Education.ExploreEducationStatistics.Common.Tests.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Mappings;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 {
-    [Collection(CacheServiceTests)]
-    public class PublicationServiceTests : CacheServiceTestFixture
+    public class PublicationServiceTests
     {
-        public PublicationServiceTests()
-        {
-            BlobCacheService
-                .Setup(s => s.GetItem(
-                    It.IsAny<PublicationCacheKey>(), typeof(PublicationViewModel)))
-                .ReturnsAsync(null);
-
-            BlobCacheService
-                .Setup(s => s.SetItem<object>(
-                    It.IsAny<PublicationCacheKey>(), It.IsAny<PublicationViewModel>()))
-                .Returns(Task.CompletedTask);
-        }
-        
         [Fact]
         public async Task Get()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -4,12 +4,10 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.Mappings;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
@@ -201,6 +199,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                         Slug = "test-theme",
                     }
                 },
+                Contact = new Contact
+                {
+                    TeamName = "Team name",
+                    TeamEmail = "team@email.com",
+                    ContactName = "Contact name",
+                    ContactTelNo = "1234",
+                },
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -288,8 +293,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 contentDbContext ?? Mock.Of<ContentDbContext>(),
                 contentDbContext is null
                     ? Mock.Of<IPersistenceHelper<ContentDbContext>>()
-                    : new PersistenceHelper<ContentDbContext>(contentDbContext),
-                mapper ?? MapperUtils.MapperForProfile<MappingProfiles>()
+                    : new PersistenceHelper<ContentDbContext>(contentDbContext)
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -19,8 +19,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task Get()
         {
-            BlobCacheAttribute.AddService("public", BlobCacheService.Object);
-
             var release2000Version0Id = Guid.NewGuid();
             var supersedingPublication = new Publication
             {
@@ -159,8 +157,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task Get_IsSuperseded()
         {
-            BlobCacheAttribute.AddService("public", BlobCacheService.Object);
-
             var release2000Version0Id = Guid.NewGuid();
             var supersedingPublication = new Publication
             {
@@ -234,8 +230,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task Get_NoPublication()
         {
-            BlobCacheAttribute.AddService("public", BlobCacheService.Object);
-
             var contentDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
@@ -251,8 +245,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task Get_PublicationHasNoLiveLatestRelease()
         {
-            BlobCacheAttribute.AddService("public", BlobCacheService.Object);
-
             const string publicationSlug = "publication-slug";
 
             var contentDbContextId = Guid.NewGuid().ToString();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseServiceTests.cs
@@ -44,11 +44,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 Title = "Methodology"
             };
 
-            var publicationService = new Mock<IPublicationService>(Strict);
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
             var fileStorageService = new Mock<IFileStorageService>(Strict);
             var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
 
-            publicationService.Setup(mock => mock.Get(publicationSlug))
+            publicationCacheService.Setup(mock => mock.GetPublication(publicationSlug))
                 .ReturnsAsync(
                     new PublicationViewModel
                     {
@@ -91,13 +91,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupReleaseService(
                     contentDbContext: contentDbContext,
-                    publicationService: publicationService.Object,
+                    publicationCacheService: publicationCacheService.Object,
                     methodologyCacheService: methodologyCacheService.Object,
                     fileStorageService: fileStorageService.Object);
 
                 var result = await service.GetCachedViewModel(publicationSlug, releaseSlug);
 
-                VerifyAllMocks(methodologyCacheService, publicationService, fileStorageService);
+                VerifyAllMocks(methodologyCacheService, publicationCacheService, fileStorageService);
 
                 var releaseViewModel = result.AssertRight();
 
@@ -120,16 +120,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var contentDbContextId = Guid.NewGuid().ToString();
             await using var contentDbContext = InMemoryContentDbContext(contentDbContextId);
 
-            var publicationService = new Mock<IPublicationService>(Strict);
-            publicationService.Setup(mock => mock.Get(publicationSlug))
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(mock => mock.GetPublication(publicationSlug))
                 .ReturnsAsync(new NotFoundResult());
 
             var service = SetupReleaseService(contentDbContext,
-                publicationService: publicationService.Object);
+                publicationCacheService: publicationCacheService.Object);
 
             var result = await service.GetCachedViewModel(publicationSlug, releaseSlug);
 
-            VerifyAllMocks(publicationService);
+            VerifyAllMocks(publicationCacheService);
 
             result.AssertNotFound();
         }
@@ -143,11 +143,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             const string publicationSlug = "publication-a";
             const string releaseSlug = "2016";
 
-            var publicationService = new Mock<IPublicationService>(Strict);
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
             var fileStorageService = new Mock<IFileStorageService>(Strict);
             var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
 
-            publicationService.Setup(mock => mock.Get(publicationSlug))
+            publicationCacheService.Setup(mock => mock.GetPublication(publicationSlug))
                 .ReturnsAsync(
                     new PublicationViewModel
                     {
@@ -181,13 +181,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupReleaseService(
                     contentDbContext: contentDbContext,
-                    publicationService: publicationService.Object,
+                    publicationCacheService: publicationCacheService.Object,
                     fileStorageService: fileStorageService.Object,
                     methodologyCacheService: methodologyCacheService.Object);
 
                 var result = await service.GetCachedViewModel(publicationSlug, releaseSlug);
 
-                VerifyAllMocks(publicationService, fileStorageService, methodologyCacheService);
+                VerifyAllMocks(publicationCacheService, fileStorageService, methodologyCacheService);
 
                 result.AssertNotFound();
             }
@@ -202,10 +202,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             const string publicationSlug = "publication-a";
             const string releaseSlug = "2016";
 
-            var publicationService = new Mock<IPublicationService>(Strict);
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
             var fileStorageService = new Mock<IFileStorageService>(Strict);
 
-            publicationService.Setup(mock => mock.Get(publicationSlug))
+            publicationCacheService.Setup(mock => mock.GetPublication(publicationSlug))
                 .ReturnsAsync(
                     new PublicationViewModel
                     {
@@ -245,13 +245,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupReleaseService(
                     contentDbContext: contentDbContext,
-                    publicationService: publicationService.Object,
+                    publicationCacheService: publicationCacheService.Object,
                     fileStorageService: fileStorageService.Object
                 );
 
                 var result = await service.GetSummary(publicationSlug, releaseSlug);
 
-                VerifyAllMocks(publicationService, fileStorageService);
+                VerifyAllMocks(publicationCacheService, fileStorageService);
 
                 var releaseSummaryViewModel = result.AssertRight();
 
@@ -272,12 +272,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var contentDbContextId = Guid.NewGuid().ToString();
             await using var contentDbContext = InMemoryContentDbContext(contentDbContextId);
 
-           var publicationService = new Mock<IPublicationService>(Strict);
-           publicationService.Setup(mock => mock.Get(publicationSlug))
+           var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+           publicationCacheService.Setup(mock => mock.GetPublication(publicationSlug))
                .ReturnsAsync(new NotFoundResult());
 
            var service = SetupReleaseService(contentDbContext,
-               publicationService: publicationService.Object);
+               publicationCacheService: publicationCacheService.Object);
 
            var result = await service.GetSummary(publicationSlug, releaseSlug);
 
@@ -293,10 +293,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             const string publicationSlug = "publication-a";
             const string releaseSlug = "2016";
 
-            var publicationService = new Mock<IPublicationService>(Strict);
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
             var fileStorageService = new Mock<IFileStorageService>(Strict);
 
-            publicationService.Setup(mock => mock.Get(publicationSlug))
+            publicationCacheService.Setup(mock => mock.GetPublication(publicationSlug))
                 .ReturnsAsync(
                     new PublicationViewModel
                     {
@@ -327,12 +327,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupReleaseService(
                     contentDbContext: contentDbContext,
-                    publicationService: publicationService.Object,
+                    publicationCacheService: publicationCacheService.Object,
                     fileStorageService: fileStorageService.Object);
 
                 var result = await service.GetSummary(publicationSlug, releaseSlug);
 
-                VerifyAllMocks(publicationService, fileStorageService);
+                VerifyAllMocks(publicationCacheService, fileStorageService);
 
                 result.AssertNotFound();
             }
@@ -527,19 +527,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         private static ReleaseService SetupReleaseService(
             ContentDbContext? contentDbContext = null,
             IFileStorageService? fileStorageService = null,
-            IUserService? userService = null,
-            IPublicationService? publicationService = null,
             IMethodologyCacheService? methodologyCacheService = null,
+            IPublicationCacheService? publicationCacheService = null,
+            IUserService? userService = null,
             IMapper? mapper = null)
         {
             return new(
                 contentDbContext is null
                     ? Mock.Of<IPersistenceHelper<ContentDbContext>>()
                     : new PersistenceHelper<ContentDbContext>(contentDbContext),
-                fileStorageService ?? Mock.Of<IFileStorageService>(),
-                methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(),
+                fileStorageService ?? Mock.Of<IFileStorageService>(Strict),
+                methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
+                publicationCacheService ?? Mock.Of<IPublicationCacheService>(Strict),
                 userService ?? AlwaysTrueUserService().Object,
-                publicationService ?? Mock.Of<IPublicationService>(),
                 mapper ?? MapperUtils.MapperForProfile<MappingProfiles>()
             );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseServiceTests.cs
@@ -2,10 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -13,7 +11,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.Mappings;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -529,8 +526,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             IFileStorageService? fileStorageService = null,
             IMethodologyCacheService? methodologyCacheService = null,
             IPublicationCacheService? publicationCacheService = null,
-            IUserService? userService = null,
-            IMapper? mapper = null)
+            IUserService? userService = null)
         {
             return new(
                 contentDbContext is null
@@ -539,8 +535,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 fileStorageService ?? Mock.Of<IFileStorageService>(Strict),
                 methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
                 publicationCacheService ?? Mock.Of<IPublicationCacheService>(Strict),
-                userService ?? AlwaysTrueUserService().Object,
-                mapper ?? MapperUtils.MapperForProfile<MappingProfiles>()
+                userService ?? AlwaysTrueUserService().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
@@ -23,4 +23,10 @@ public class PublicationCacheService : IPublicationCacheService
     {
         return _publicationService.Get(publicationSlug);
     }
+
+    [BlobCache(typeof(PublicationCacheKey), forceUpdate: true)]
+    public Task<Either<ActionResult, PublicationViewModel>> UpdatePublication(string publicationSlug)
+    {
+        return _publicationService.Get(publicationSlug);
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
@@ -1,0 +1,26 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
+
+public class PublicationCacheService : IPublicationCacheService
+{
+    private readonly IPublicationService _publicationService;
+
+    public PublicationCacheService(IPublicationService publicationService)
+    {
+        _publicationService = publicationService;
+    }
+
+    [BlobCache(typeof(PublicationCacheKey))]
+    public Task<Either<ActionResult, PublicationViewModel>> GetPublication(string publicationSlug)
+    {
+        return _publicationService.Get(publicationSlug);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
@@ -18,13 +18,13 @@ public class PublicationCacheService : IPublicationCacheService
         _publicationService = publicationService;
     }
 
-    [BlobCache(typeof(PublicationCacheKey))]
+    [BlobCache(typeof(PublicationCacheKey), ServiceName = "public")]
     public Task<Either<ActionResult, PublicationViewModel>> GetPublication(string publicationSlug)
     {
         return _publicationService.Get(publicationSlug);
     }
 
-    [BlobCache(typeof(PublicationCacheKey), forceUpdate: true)]
+    [BlobCache(typeof(PublicationCacheKey), forceUpdate: true, ServiceName = "public")]
     public Task<Either<ActionResult, PublicationViewModel>> UpdatePublication(string publicationSlug)
     {
         return _publicationService.Get(publicationSlug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceService.cs
@@ -3,31 +3,33 @@ using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using IReleaseService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IReleaseService;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services
 {
     public class DataGuidanceService : IDataGuidanceService
     {
         private readonly IDataGuidanceSubjectService _dataGuidanceSubjectService;
-        private readonly Interfaces.IPublicationService _publicationService;
-        private readonly Interfaces.IReleaseService _releaseService;
+        private readonly IPublicationCacheService _publicationCacheService;
+        private readonly IReleaseService _releaseService;
 
-        public DataGuidanceService(
-            IDataGuidanceSubjectService dataGuidanceSubjectService,
-            Interfaces.IPublicationService publicationService,
-            Interfaces.IReleaseService releaseService)
+        public DataGuidanceService(IDataGuidanceSubjectService dataGuidanceSubjectService,
+            IPublicationCacheService publicationCacheService,
+            IReleaseService releaseService)
         {
             _dataGuidanceSubjectService = dataGuidanceSubjectService;
-            _publicationService = publicationService;
+            _publicationCacheService = publicationCacheService;
             _releaseService = releaseService;
         }
 
-        public async Task<Either<ActionResult, DataGuidanceViewModel>> Get(string publicationSlug, string? releaseSlug = null)
+        public async Task<Either<ActionResult, DataGuidanceViewModel>> Get(string publicationSlug,
+            string? releaseSlug = null)
         {
-            return await _publicationService.Get(publicationSlug)
+            return await _publicationCacheService.GetPublication(publicationSlug)
                 .OnSuccessCombineWith(_ => _releaseService.GetCachedRelease(publicationSlug, releaseSlug))
                 .OnSuccess(publicationAndRelease =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IPublicationCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IPublicationCacheService.cs
@@ -1,0 +1,12 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
+
+public interface IPublicationCacheService
+{
+    Task<Either<ActionResult, PublicationViewModel>> GetPublication(string publicationSlug);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IPublicationCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IPublicationCacheService.cs
@@ -9,4 +9,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces
 public interface IPublicationCacheService
 {
     Task<Either<ActionResult, PublicationViewModel>> GetPublication(string publicationSlug);
+
+    Task<Either<ActionResult, PublicationViewModel>> UpdatePublication(string publicationSlug);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
@@ -39,11 +39,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Mappings
 
             CreateMap<Publication, PublicationSummaryViewModel>();
 
-            CreateMap<Publication, PublicationViewModel>()
-                .ForMember(dest => dest.LegacyReleases,
-                    m => m.MapFrom(p => p.LegacyReleases.OrderByDescending(l => l.Order)))
-                .ForMember(dest => dest.Releases, m => m.Ignore());
-
             CreateMap<Release, CachedReleaseViewModel>()
                 .ForMember(dest => dest.CoverageTitle,
                     m => m.MapFrom(release => release.TimePeriodCoverage.GetEnumLabel()))
@@ -58,18 +53,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Mappings
                 .ForMember(
                     dest => dest.Content,
                     m => m.MapFrom(r => r.GenericContent.OrderBy(s => s.Order)));
-
-            CreateMap<Topic, TopicViewModel>();
-
-            CreateMap<Theme, ThemeViewModel>();
-
-            CreateMap<Contact, ContactViewModel>();
-
-            CreateMap<Release, ReleaseTitleViewModel>();
-
-            CreateMap<LegacyRelease, LegacyReleaseViewModel>();
-
-            CreateMap<ExternalMethodology, ExternalMethodologyViewModel>();
         }
 
         private void CreateContentBlockMap()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -32,7 +31,6 @@ public class PublicationService : IPublicationService
         _mapper = mapper;
     }
 
-    [BlobCache(typeof(PublicationCacheKey), ServiceName = "public")]
     public async Task<Either<ActionResult, PublicationViewModel>> Get(string publicationSlug)
     {
         return await _contentPersistenceHelper
@@ -43,7 +41,6 @@ public class PublicationService : IPublicationService
                 .Include(p => p.Topic)
                 .ThenInclude(topic => topic.Theme)
                 .Where(p => p.Slug == publicationSlug))
-            // NOTE: BlobCache won't cache result if GetLatestRelease returns an Either.IsLeft - i.e. if there is no latestRelease
             .OnSuccessCombineWith(GetLatestRelease)
             .OnSuccess(tuple =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -19,16 +18,13 @@ public class PublicationService : IPublicationService
 {
     private readonly ContentDbContext _contentDbContext;
     private readonly IPersistenceHelper<ContentDbContext> _contentPersistenceHelper;
-    private readonly IMapper _mapper;
 
     public PublicationService(
         ContentDbContext contentDbContext,
-        IPersistenceHelper<ContentDbContext> contentPersistenceHelper,
-        IMapper mapper)
+        IPersistenceHelper<ContentDbContext> contentPersistenceHelper)
     {
         _contentDbContext = contentDbContext;
         _contentPersistenceHelper = contentPersistenceHelper;
-        _mapper = mapper;
     }
 
     public async Task<Either<ActionResult, PublicationViewModel>> Get(string publicationSlug)
@@ -42,14 +38,10 @@ public class PublicationService : IPublicationService
                 .ThenInclude(topic => topic.Theme)
                 .Where(p => p.Slug == publicationSlug))
             .OnSuccessCombineWith(GetLatestRelease)
-            .OnSuccess(tuple =>
+            .OnSuccess(async tuple =>
             {
                 var (publication, latestRelease) = tuple;
-                var publicationViewModel = _mapper.Map<PublicationViewModel>(publication);
-                publicationViewModel.LatestReleaseId = latestRelease.Id;
-                publicationViewModel.IsSuperseded = IsSuperseded(publication);
-                publicationViewModel.Releases = ListPublishedReleases(publication);
-                return publicationViewModel;
+                return await BuildPublicationViewModel(publication, latestRelease);
             });
     }
 
@@ -58,21 +50,48 @@ public class PublicationService : IPublicationService
         return publication.LatestPublishedRelease() ?? new Either<ActionResult, Release>(new NotFoundResult());
     }
 
-    private List<ReleaseTitleViewModel> ListPublishedReleases(Publication publication)
+    private async Task<PublicationViewModel> BuildPublicationViewModel(Publication publication, Release latestRelease)
     {
-        var releases = publication.GetPublishedReleases()
-            .OrderByDescending(release => release.Year)
-            .ThenByDescending(release => release.TimePeriodCoverage)
-            .ToList();
-        return _mapper.Map<List<ReleaseTitleViewModel>>(releases);
+        return new PublicationViewModel
+        {
+            Id = publication.Id,
+            Title = publication.Title,
+            Slug = publication.Slug,
+            LegacyReleases = publication.LegacyReleases
+                .OrderByDescending(legacyRelease => legacyRelease.Order)
+                .Select(legacyRelease => new LegacyReleaseViewModel(legacyRelease))
+                .ToList(),
+            Topic = new TopicViewModel(new ThemeViewModel(publication.Topic.Theme.Title)),
+            Contact = new ContactViewModel(publication.Contact),
+            ExternalMethodology = publication.ExternalMethodology != null
+                ? new ExternalMethodologyViewModel(publication.ExternalMethodology)
+                : null,
+            LatestReleaseId = latestRelease.Id,
+            IsSuperseded = await IsSuperseded(publication),
+            Releases = ListPublishedReleases(publication)
+        };
     }
 
-    private bool IsSuperseded(Publication publication)
+    private static List<ReleaseTitleViewModel> ListPublishedReleases(Publication publication)
+    {
+        return publication.GetPublishedReleases()
+            .OrderByDescending(release => release.Year)
+            .ThenByDescending(release => release.TimePeriodCoverage)
+            .Select(release => new ReleaseTitleViewModel
+            {
+                Id = release.Id,
+                Slug = release.Slug,
+                Title = release.Title
+            })
+            .ToList();
+    }
+
+    private async Task<bool> IsSuperseded(Publication publication)
     {
         return publication.SupersededById != null
                // To be superseded, superseding publication must have Live release
-               && _contentDbContext.Releases
-                   .Any(r => r.PublicationId == publication.SupersededById
-                             && r.Published.HasValue && DateTime.UtcNow >= r.Published.Value);
+               && await _contentDbContext.Releases
+                   .AnyAsync(r => r.PublicationId == publication.SupersededById
+                                  && r.Published.HasValue && DateTime.UtcNow >= r.Published.Value);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
@@ -26,31 +26,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
         private readonly IFileStorageService _fileStorageService;
         private readonly IMethodologyCacheService _methodologyCacheService;
+        private readonly IPublicationCacheService _publicationCacheService;
         private readonly IUserService _userService;
-        private readonly IPublicationService _publicationService;
         private readonly IMapper _mapper;
 
-        public ReleaseService(
-            IPersistenceHelper<ContentDbContext> persistenceHelper,
+        public ReleaseService(IPersistenceHelper<ContentDbContext> persistenceHelper,
             IFileStorageService fileStorageService,
             IMethodologyCacheService methodologyCacheService,
+            IPublicationCacheService publicationCacheService,
             IUserService userService,
-            IPublicationService publicationService,
             IMapper mapper)
-
         {
             _persistenceHelper = persistenceHelper;
             _fileStorageService = fileStorageService;
             _methodologyCacheService = methodologyCacheService;
+            _publicationCacheService = publicationCacheService;
             _userService = userService;
-            _publicationService = publicationService;
             _mapper = mapper;
         }
 
         // TODO EES-3643 - move into a ReleaseCacheService?
         public async Task<Either<ActionResult, ReleaseViewModel>> GetCachedViewModel(string publicationSlug, string? releaseSlug = null)
         {
-            return await _publicationService.Get(publicationSlug)
+            return await _publicationCacheService.GetPublication(publicationSlug)
                 .OnSuccessCombineWith(publication => _methodologyCacheService.GetSummariesByPublication(publication.Id))
                 .OnSuccess(async tuple =>
                 {
@@ -77,7 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
         public async Task<Either<ActionResult, ReleaseSummaryViewModel>> GetSummary(string publicationSlug,
             string? releaseSlug)
         {
-            return await _publicationService.Get(publicationSlug)
+            return await _publicationCacheService.GetPublication(publicationSlug)
                 .OnSuccessCombineWith(_ => GetCachedRelease(publicationSlug, releaseSlug))
                 .OnSuccess(publicationAndRelease =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -28,21 +27,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
         private readonly IMethodologyCacheService _methodologyCacheService;
         private readonly IPublicationCacheService _publicationCacheService;
         private readonly IUserService _userService;
-        private readonly IMapper _mapper;
 
         public ReleaseService(IPersistenceHelper<ContentDbContext> persistenceHelper,
             IFileStorageService fileStorageService,
             IMethodologyCacheService methodologyCacheService,
             IPublicationCacheService publicationCacheService,
-            IUserService userService,
-            IMapper mapper)
+            IUserService userService)
         {
             _persistenceHelper = persistenceHelper;
             _fileStorageService = fileStorageService;
             _methodologyCacheService = methodologyCacheService;
             _publicationCacheService = publicationCacheService;
             _userService = userService;
-            _mapper = mapper;
         }
 
         // TODO EES-3643 - move into a ReleaseCacheService?
@@ -81,8 +77,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                 {
                     var (publication, release) = publicationAndRelease;
                     return new ReleaseSummaryViewModel(
-                        _mapper.Map<CachedReleaseViewModel>(release),
-                        _mapper.Map<PublicationViewModel>(publication)
+                        release!,
+                        publication
                     );
                 });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ContactViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ContactViewModel.cs
@@ -1,13 +1,20 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+
+public record ContactViewModel(
+    string TeamName,
+    string TeamEmail,
+    string ContactName,
+    string ContactTelNo)
 {
-    public class ContactViewModel
+    public ContactViewModel(Contact contact) : this(
+        TeamName: contact.TeamName,
+        TeamEmail: contact.TeamEmail,
+        ContactName: contact.ContactName,
+        ContactTelNo: contact.ContactTelNo
+    )
     {
-        public string TeamName { get; set; }
-
-        public string TeamEmail { get; set; }
-
-        public string ContactName { get; set; }
-
-        public string ContactTelNo { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ExternalMethodologyViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ExternalMethodologyViewModel.cs
@@ -1,8 +1,17 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
+﻿#nullable enable
+
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+
+public record ExternalMethodologyViewModel(
+    string Title,
+    string Url)
 {
-    public class ExternalMethodologyViewModel
+    public ExternalMethodologyViewModel(ExternalMethodology externalMethodology) : this(
+        Title: externalMethodology.Title,
+        Url: externalMethodology.Url
+    )
     {
-        public string Title { get; set; }
-        public string Url { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/LegacyReleaseViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/LegacyReleaseViewModel.cs
@@ -1,13 +1,16 @@
-﻿using System;
+﻿#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+
+public record LegacyReleaseViewModel(Guid Id, string Description, string Url)
 {
-    public class LegacyReleaseViewModel
+    public LegacyReleaseViewModel(LegacyRelease legacyRelease) : this(
+        Id: legacyRelease.Id,
+        Description: legacyRelease.Description,
+        Url: legacyRelease.Url
+    )
     {
-        public Guid Id { get; set; }
-
-        public string Description { get; set; }
-
-        public string Url { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ThemeViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ThemeViewModel.cs
@@ -1,9 +1,5 @@
 ﻿#nullable enable
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
-{
-    public class ThemeViewModel
-    {
-        public string Title { get; set; } = null!;
-    }
-}
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+
+public record ThemeViewModel(string Title);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/TopicViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/TopicViewModel.cs
@@ -1,9 +1,5 @@
 ﻿#nullable enable
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
-{
-    public class TopicViewModel
-    {
-        public ThemeViewModel Theme { get; set; } = null!;
-    }
-}
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+
+public record TopicViewModel(ThemeViewModel Theme);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/BlobCacheStartup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/BlobCacheStartup.cs
@@ -1,0 +1,36 @@
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Publisher;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Config;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Hosting;
+
+[assembly: WebJobsStartup(typeof(BlobCacheStartup))]
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher;
+
+/// <summary>
+/// <p>
+/// Registering a BlobCacheService with BlobCacheAttribute can't take place in the default FunctionsStartup
+/// Configure method as part of its own factory initialisation because that won't happen until the service is
+/// required for dependency injection. A cached method could be invoked before it's been required by some other
+/// component in which case it won't be initialised and it won't be registered with BlobCacheAttribute. If no
+/// component requires a IBlobCacheService to be injected, it would never be initialised and registered.
+/// </p>
+///  <p>
+/// It's also not possible in the FunctionsStartup Configure method to create a BlobCacheService or eagerly retrieve
+/// one by getting it from the IServiceProvider because of its dependency on ILogger.
+/// You can't request an ILogger during service initialisation because it's not set up yet.
+/// See https://github.com/Azure/azure-functions-host/issues/7322
+/// </p>
+/// <p>
+/// For these reasons, create and register any caching services using an extension. Their creation is independent of
+/// whether they are required by DI and done at a stage during startup where logging is set up.
+/// </p>
+/// </summary>
+public class BlobCacheStartup : IWebJobsStartup
+{
+    public void Configure(IWebJobsBuilder builder)
+    {
+        builder.AddExtension<BlobCacheConfigProvider>();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Config/BlobCacheConfigProvider.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Config/BlobCacheConfigProvider.cs
@@ -1,0 +1,60 @@
+﻿#nullable enable
+using System;
+using Azure.Storage.Blobs;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Config;
+
+[Extension("BlobCache")]
+// ReSharper disable once ClassNeverInstantiated.Global
+public class BlobCacheConfigProvider : IExtensionConfigProvider
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public BlobCacheConfigProvider(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public void Initialize(ExtensionConfigContext context)
+    {
+        // Enable caching and register any caching services.
+        CacheAspect.Enabled = true;
+
+        using var scope = _scopeFactory.CreateScope();
+
+        var publicBlobCacheService = GetBlobCacheService(scope.ServiceProvider, "PublicStorage");
+        BlobCacheAttribute.AddService("public", publicBlobCacheService);
+    }
+
+    private static IBlobCacheService GetBlobCacheService(IServiceProvider provider, string connectionStringKey)
+    {
+        return new BlobCacheService(
+            blobStorageService: GetBlobStorageService(provider, connectionStringKey),
+            logger: provider.GetRequiredService<ILogger<BlobCacheService>>());
+    }
+
+    private static IBlobStorageService GetBlobStorageService(IServiceProvider provider, string connectionStringKey)
+    {
+        var connectionString = GetConfigurationValue(provider, connectionStringKey);
+        return new BlobStorageService(
+            connectionString,
+            new BlobServiceClient(connectionString),
+            provider.GetRequiredService<ILogger<BlobStorageService>>(),
+            new StorageInstanceCreationUtil());
+    }
+
+    private static string GetConfigurationValue(IServiceProvider provider, string key)
+    {
+        var configuration = provider.GetService<IConfiguration>();
+        return configuration.GetValue<string>(key);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
@@ -20,9 +19,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
     public class PublishReleaseContentFunction
     {
         private readonly ContentDbContext _contentDbContext;
-        // TODO EES-3648 IBlobCacheService is not used but still needed to force it's initialisation from DI
-        // where it's registered with the BlobCacheAttribute
-        private readonly IBlobCacheService _blobCacheService;
         private readonly IContentService _contentService;
         private readonly INotificationsService _notificationsService;
         private readonly IPublicationCacheService _publicationCacheService;
@@ -31,7 +27,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
         public PublishReleaseContentFunction(
             ContentDbContext contentDbContext,
-            IBlobCacheService blobCacheService,
             IContentService contentService,
             INotificationsService notificationsService,
             IPublicationCacheService publicationCacheService,
@@ -39,7 +34,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             IReleasePublishingStatusService releasePublishingStatusService)
         {
             _contentDbContext = contentDbContext;
-            _blobCacheService = blobCacheService;
             _contentService = contentService;
             _notificationsService = notificationsService;
             _publicationCacheService = publicationCacheService;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
@@ -19,6 +20,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
     public class PublishReleaseContentFunction
     {
         private readonly ContentDbContext _contentDbContext;
+        // TODO EES-3648 IBlobCacheService is not used but still needed to force it's initialisation from DI
+        // where it's registered with the BlobCacheAttribute
+        private readonly IBlobCacheService _blobCacheService;
         private readonly IContentService _contentService;
         private readonly INotificationsService _notificationsService;
         private readonly IPublicationCacheService _publicationCacheService;
@@ -27,6 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
         public PublishReleaseContentFunction(
             ContentDbContext contentDbContext,
+            IBlobCacheService blobCacheService,
             IContentService contentService,
             INotificationsService notificationsService,
             IPublicationCacheService publicationCacheService,
@@ -34,6 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             IReleasePublishingStatusService releasePublishingStatusService)
         {
             _contentDbContext = contentDbContext;
+            _blobCacheService = blobCacheService;
             _contentService = contentService;
             _notificationsService = notificationsService;
             _publicationCacheService = publicationCacheService;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/MappingProfiles.cs
@@ -16,8 +16,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
         {
             CreateMap<Link, LinkViewModel>();
 
-            CreateMap<Contact, ContactViewModel>();
-
             CreateContentBlockMap();
 
             CreateMap<ContentSection, ContentSectionViewModel>().ForMember(dest => dest.Content,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -26,6 +26,8 @@ using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Common.Utils.StartupUtils;
 using IContentMethodologyService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IMethodologyService;
 using ContentMethodologyService = GovUk.Education.ExploreEducationStatistics.Content.Services.MethodologyService;
+using IContentPublicationService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IPublicationService;
+using ContentPublicationService = GovUk.Education.ExploreEducationStatistics.Content.Services.PublicationService;
 using IContentThemeService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IThemeService;
 using ContentThemeService = GovUk.Education.ExploreEducationStatistics.Content.Services.ThemeService;
 using FileStorageService = GovUk.Education.ExploreEducationStatistics.Publisher.Services.FileStorageService;
@@ -69,6 +71,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                 // being done from Publisher directly, and so these DI dependencies should eventually be removed.
                 .AddScoped<IContentMethodologyService, ContentMethodologyService>()
                 .AddScoped<IMethodologyCacheService, MethodologyCacheService>()
+                .AddScoped<IContentPublicationService, ContentPublicationService>()
+                .AddScoped<IPublicationCacheService, PublicationCacheService>()
                 .AddScoped<IThemeCacheService, ThemeCacheService>()
                 .AddScoped<IContentThemeService, ContentThemeService>()
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -2,7 +2,6 @@
 using System;
 using AutoMapper;
 using Azure.Storage.Blobs;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Functions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -47,8 +46,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            CacheAspect.Enabled = true;
-
             builder.Services
                 .AddAutoMapper(typeof(Startup).Assembly)
                 .AddMemoryCache()
@@ -60,18 +57,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                     options.UseSqlServer(ConnectionUtils.GetAzureSqlConnectionString("PublicStatisticsDb")))
                 .AddSingleton<IFileStorageService, FileStorageService>(provider =>
                     new FileStorageService(GetConfigurationValue(provider, "PublisherStorage")))
-
-                // TODO EES-3648 A component needs to depend on IBlobCacheService in order for the service to be be
-                // created from this factory method.
-                // If not, the factory method won't be run and the registration with BlobCacheAttribute
-                // won't happen. We should separate the DI configuration and the configuration required for caching.
-                // Remove this service and also IBlobCacheService from PublishReleaseContentFunction when this is fixed.
-                .AddScoped(provider =>
-                {
-                    var publicBlobCacheService = GetBlobCacheService(provider, "PublicStorage");
-                    BlobCacheAttribute.AddService("public", publicBlobCacheService);
-                    return publicBlobCacheService;
-                })
 
                 // TODO EES-3510 These services from the Content.Services namespace are used to update cached resources.
                 // EES-3528 plans to send a request to the Content API to update its cached resources instead of this


### PR DESCRIPTION
This PR builds on https://github.com/dfe-analytical-services/explore-education-statistics/pull/3463, adding a new `Content.Services.PublicationCacheService` with methods to get and update a cached publication.

Prior to this change, when publishing a release immediately the Publisher function would delete the cached publication, including any superseded publications where the superseding is now potentially in effect.

Rather than deleting the cached publication, we now update it to ensure that there's never a window where a cached publication doesn't exist.

Additionally, all cases in the Admin where cached publications were deleted from blob storage (including superseded publications) are now swapped to update the cached publication instead.

### Other changes

* In order to avoid needing to configure the Admin app service and Publisher function projects with the AutoMapper configuration to map a publication to a public `Content.Services.ViewModels.PublicationViewModel`, and in turn map the entire object graph, AutoMapper is no longer used. View models constructors are used to make the code a little less verbose. 

* Registering a `BlobCacheService` with `BlobCacheAttribute` can't take place in the default `FunctionsStartup.Configure` method as part of its own factory initialisation because that won't happen until the service is required for dependency injection. A cached method could be invoked before it's been required by some other component in which case it won't be initialised and it won't be registered with `BlobCacheAttribute`. If no component requires an `IBlobCacheService` to be injected, it would never be initialised and registered.
It's also not possible in the `FunctionsStartup.Configure` method to create a `BlobCacheService` or eagerly retrieve one by getting it from the `IServiceProvider` because of its dependency on `ILogger`. You can't request an `ILogger` during service initialisation because it's not set up yet.

For these reasons, this PR creates and registers the public `BlobCacheService` using an extension. Its creation is now independent of whether its required by DI and done at a stage during startup where logging is already set up.

### Alternative approach without separate cache services

As part of this work I looked at how different this approach to caching could work if we don't create separate cache services, instead in-lining the cached methods alongside the `Get`  un-cached resource method in the service, adding in `GetCached{Resource}` and `UpdateCached{Resourced}`.

[V2 of this PR](https://github.com/dfe-analytical-services/explore-education-statistics/pull/3479) has no `PublicationCacheService` and so no additional test class for it either. However it adds an extra complication when it comes to setting up tests for `GetCachedPublication` and `UpdateCachedPublication` in `PublicationServiceTests`.

To avoid repeating all the set-up of data required to support their internal call to `Get` for the un-cached publication, it creates a stub of `Get` in a `PublicationServiceStub` and uses this as the class under test rather than `PublicationService`.

```
        private class PublicationServiceStub : PublicationService
        {
            public PublicationServiceStub(ContentDbContext contentDbContext,
                IPersistenceHelper<ContentDbContext> contentPersistenceHelper) : base(
                contentDbContext,
                contentPersistenceHelper)
            {
            }

            public override Task<Either<ActionResult, PublicationViewModel>> Get(string publicationSlug)
            {
                // Stub a response value to allow testing cached methods which use this
                return Task.FromResult(new Either<ActionResult, PublicationViewModel>(PublicationViewModel));
            }
        }
```

With separate cache services, the un-cached service call only requires standard setup to mock behaviour of that method. Also if there are any additional operations that happen post retrieval of the cached resource before returning the response, such is the case in `ThemeCacheService` where the cached result is filtered, the cache service provides a clearer separation in the tests between testing the cached and un-cached methods.

After discussing with the team, we felt the benefit of having less classes doesn't warrant going with the [V2 approach](https://github.com/dfe-analytical-services/explore-education-statistics/pull/3479).

### UI Test Report

![image](https://user-images.githubusercontent.com/4147126/188697464-dd3d757a-2594-4ff7-92b7-a3614c94e044.png)
