### PR TITLE
EES-3677 - disable re-order controls when release is published

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />
         <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-        <PackageReference Include="Mime" Version="3.1.0" />
+        <PackageReference Include="Mime" Version="3.4.0" />
         <PackageReference Include="Mime-Detective" Version="0.0.6-beta5" />
         <PackageReference Include="Thinktecture.EntityFrameworkCore.BulkOperations" Version="4.1.0" />
     </ItemGroup>

--- a/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordion.tsx
@@ -1,5 +1,6 @@
 import Accordion, { AccordionProps } from '@common/components/Accordion';
 import Button from '@common/components/Button';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 import useToggle from '@common/hooks/useToggle';
 import { OmitStrict } from '@common/types';
 import reorder from '@common/utils/reorder';
@@ -24,10 +25,11 @@ export interface ReorderableAccordionProps
   extends OmitStrict<AccordionProps, 'openAll'> {
   heading?: string;
   onReorder: (sectionIds: string[]) => void;
+  canUpdateRelease: boolean;
 }
 
 const ReorderableAccordion = (props: ReorderableAccordionProps) => {
-  const { children, id, heading, onReorder } = props;
+  const { children, id, heading, onReorder, canUpdateRelease } = props;
 
   const [isReordering, toggleReordering] = useToggle(false);
 
@@ -45,7 +47,7 @@ const ReorderableAccordion = (props: ReorderableAccordionProps) => {
 
   const saveOrder = useCallback(async () => {
     if (onReorder) {
-      await onReorder(sections.map(section => section.props.id));
+      onReorder(sections.map(section => section.props.id));
       toggleReordering.off();
     }
   }, [onReorder, sections, toggleReordering]);
@@ -61,7 +63,7 @@ const ReorderableAccordion = (props: ReorderableAccordionProps) => {
 
   const accordion = useMemo(() => {
     return (
-      <Accordion {...props} openAll={isReordering ? false : undefined}>
+      <Accordion {...props} openAll={isReordering ?? false}>
         {sections.map((child, index) => {
           const section = child as ReactElement<
             ReorderableAccordionSectionProps & DraggableAccordionSectionProps
@@ -82,21 +84,24 @@ const ReorderableAccordion = (props: ReorderableAccordionProps) => {
         <h2 className="govuk-heading-l govuk-!-margin-bottom-0">{heading}</h2>
 
         {sections.length > 1 &&
+          canUpdateRelease &&
           (!isReordering ? (
             <Button
               variant="secondary"
               className="govuk-!-font-size-16 govuk-!-margin-bottom-0"
               onClick={toggleReordering.on}
             >
-              Reorder<span className="govuk-visually-hidden"> data files</span>
+              Reorder<VisuallyHidden> data files</VisuallyHidden>
             </Button>
           ) : (
-            <Button
-              className="govuk-!-font-size-16 govuk-!-margin-bottom-0"
-              onClick={saveOrder}
-            >
-              Save order
-            </Button>
+            <>
+              <Button
+                className="govuk-!-font-size-16 govuk-!-margin-bottom-0"
+                onClick={saveOrder}
+              >
+                Save order
+              </Button>
+            </>
           ))}
       </div>
 

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/ReorderableAccordion.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/ReorderableAccordion.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import noop from 'lodash/noop';
+import ReorderableAccordion from '../ReorderableAccordion';
+
+describe('ReorderableAccordion', () => {
+  test("it doesn't show controls if `canUpdateRelease` is false", () => {
+    render(
+      <ReorderableAccordion
+        canUpdateRelease={false}
+        id="test"
+        onReorder={() => noop}
+        heading="test"
+        onSectionOpen={() => noop}
+        onToggleAll={() => noop}
+      >
+        reorder secton
+      </ReorderableAccordion>,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Reorder sections' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('it shows controls if `canUpdateRelease` is true', () => {
+    render(
+      <ReorderableAccordion
+        canUpdateRelease
+        id="test"
+        onReorder={() => noop}
+        heading="test"
+        onSectionOpen={() => noop}
+        onToggleAll={() => noop}
+      >
+        reorder secton
+      </ReorderableAccordion>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Reorder sections' }),
+    ).toBeInTheDocument();
+  });
+
+  test('it reorders sections', () => {
+    const onReorder = jest.fn();
+    render(
+      <ReorderableAccordion
+        canUpdateRelease
+        id="test"
+        onReorder={onReorder}
+        heading="test"
+        onSectionOpen={() => noop}
+        onToggleAll={() => noop}
+      >
+        reorder secton
+      </ReorderableAccordion>,
+    );
+
+    const reorderButton = screen.getByRole('button', { name: 'Reorder' });
+    reorderButton.click();
+
+    expect(
+      screen.getByRole('button', { name: 'Save order' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId('reorderableAccordionSection'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -231,6 +231,7 @@ const ReleaseDataUploadsSection = ({
       <LoadingSpinner loading={isLoading}>
         {dataFiles.length > 0 ? (
           <ReorderableAccordion
+            canUpdateRelease={canUpdateRelease}
             id="uploadedDataFiles"
             heading="Uploaded data files"
             onReorder={async (fileIds: string[]) => {

--- a/tests/robot-tests/tests/admin_and_public/bau/subject_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/subject_reordering.robot
@@ -182,6 +182,17 @@ Add data guidance for all subjects
 Publish release
     user approves original release for immediate publication
 
+Check subjects can no longer be re-ordered after release has been published
+    user clicks link    Data and files
+    user waits until page contains element    id:uploadedDataFiles
+
+    user checks accordion is in position    One    1    id:uploadedDataFiles
+    user checks accordion is in position    Two    2    id:uploadedDataFiles
+    user checks accordion is in position    Three    3    id:uploadedDataFiles
+    user checks accordion is in position    Four    4    id:uploadedDataFiles
+
+    user checks element is not visible    //*[button[text()="Reorder"]]    %{WAIT_SMALL}
+
 Check subject order in data tables
     user navigates to data tables page on public frontend
 


### PR DESCRIPTION
This PR: 
* disables re-order controls if a user can't update a release (such as when it's being published/approved). Previously, the re-order data-files still showed up even when a release was in the process of publishing or had the status of approved
