### PR TITLE
EES-3554 Part 2 - Integrate publication releases endpoint with Manage publication > Releases page

### DIFF
--- a/src/explore-education-statistics-admin/package-lock.json
+++ b/src/explore-education-statistics-admin/package-lock.json
@@ -17,6 +17,7 @@
 				"@microsoft/signalr": "^6.0.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
 				"@svgr/webpack": "^6.1.0",
+				"@tanstack/react-query": "^4.2.1",
 				"@testing-library/dom": "^7.24.4",
 				"@testing-library/jest-dom": "^5.11.4",
 				"@testing-library/react": "^11.0.4",
@@ -6768,6 +6769,42 @@
 				"url": "https://github.com/sponsors/gregberge"
 			}
 		},
+		"node_modules/@tanstack/query-core": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.2.1.tgz",
+			"integrity": "sha512-UOyOhHKLS/5i9qG2iUnZNVV3R9riJJmG9eG+hnMFIPT/oRh5UzAfjxCtBneNgPQZLDuP8y6YtRYs/n4qVAD5Ng==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/react-query": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.2.1.tgz",
+			"integrity": "sha512-w02oTOYpoxoBzD/onAGRQNeLAvggLn7WZjS811cT05WAE/4Q3br0PTp388M7tnmyYGbgOOhFq0MkhH0wIfAKqA==",
+			"dependencies": {
+				"@tanstack/query-core": "^4.0.0-beta.1",
+				"@types/use-sync-external-store": "^0.0.3",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react-native": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-dom": {
+					"optional": true
+				},
+				"react-native": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@testing-library/dom": {
 			"version": "7.24.4",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.4.tgz",
@@ -7535,6 +7572,11 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
+		},
+		"node_modules/@types/use-sync-external-store": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+			"integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
 		},
 		"node_modules/@types/yargs": {
 			"version": "15.0.7",
@@ -29449,6 +29491,14 @@
 				"react": "^16.8.0"
 			}
 		},
+		"node_modules/use-sync-external-store": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -35482,6 +35532,21 @@
 				"@svgr/plugin-svgo": "^6.1.0"
 			}
 		},
+		"@tanstack/query-core": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.2.1.tgz",
+			"integrity": "sha512-UOyOhHKLS/5i9qG2iUnZNVV3R9riJJmG9eG+hnMFIPT/oRh5UzAfjxCtBneNgPQZLDuP8y6YtRYs/n4qVAD5Ng=="
+		},
+		"@tanstack/react-query": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.2.1.tgz",
+			"integrity": "sha512-w02oTOYpoxoBzD/onAGRQNeLAvggLn7WZjS811cT05WAE/4Q3br0PTp388M7tnmyYGbgOOhFq0MkhH0wIfAKqA==",
+			"requires": {
+				"@tanstack/query-core": "^4.0.0-beta.1",
+				"@types/use-sync-external-store": "^0.0.3",
+				"use-sync-external-store": "^1.2.0"
+			}
+		},
 		"@testing-library/dom": {
 			"version": "7.24.4",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.4.tgz",
@@ -36148,6 +36213,11 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
+		},
+		"@types/use-sync-external-store": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+			"integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
 		},
 		"@types/yargs": {
 			"version": "15.0.7",
@@ -52623,6 +52693,12 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.1.tgz",
 			"integrity": "sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==",
+			"requires": {}
+		},
+		"use-sync-external-store": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
 			"requires": {}
 		},
 		"util-deprecate": {

--- a/src/explore-education-statistics-admin/package.json
+++ b/src/explore-education-statistics-admin/package.json
@@ -12,6 +12,7 @@
     "@microsoft/signalr": "^6.0.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
     "@svgr/webpack": "^6.1.0",
+    "@tanstack/react-query": "^4.2.1",
     "@testing-library/dom": "^7.24.4",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",

--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -13,11 +13,14 @@ import {
   useApplicationInsights,
 } from '@common/contexts/ApplicationInsightsContext';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React, { lazy, Suspense, useEffect } from 'react';
 import { Route, Switch, useHistory } from 'react-router';
 import { BrowserRouter } from 'react-router-dom';
 import PageNotFoundPage from './pages/errors/PageNotFoundPage';
 import { LastLocationContextProvider } from './contexts/LastLocationContext';
+
+const queryClient = new QueryClient();
 
 const PrototypeIndexPage = lazy(
   () => import('@admin/prototypes/PrototypeIndexPage'),
@@ -71,37 +74,39 @@ function App() {
           <BrowserRouter>
             <ApplicationInsightsTracking />
 
-            <AuthContextProvider>
-              <LastLocationContextProvider>
-                <PageErrorBoundary>
-                  <Switch>
-                    {Object.entries(apiAuthorizationRouteList).map(
-                      ([key, authRoute]) => (
-                        <Route exact key={key} {...authRoute} />
-                      ),
-                    )}
+            <QueryClientProvider client={queryClient}>
+              <AuthContextProvider>
+                <LastLocationContextProvider>
+                  <PageErrorBoundary>
+                    <Switch>
+                      {Object.entries(apiAuthorizationRouteList).map(
+                        ([key, authRoute]) => (
+                          <Route exact key={key} {...authRoute} />
+                        ),
+                      )}
 
-                    {Object.entries(routes).map(([key, route]) => (
-                      <ProtectedRoute key={key} {...route} />
-                    ))}
+                      {Object.entries(routes).map(([key, route]) => (
+                        <ProtectedRoute key={key} {...route} />
+                      ))}
 
-                    <ProtectedRoute
-                      path="/prototypes"
-                      protectionAction={user =>
-                        user.permissions.canAccessUserAdministrationPages
-                      }
-                      component={PrototypesEntry}
-                    />
+                      <ProtectedRoute
+                        path="/prototypes"
+                        protectionAction={user =>
+                          user.permissions.canAccessUserAdministrationPages
+                        }
+                        component={PrototypesEntry}
+                      />
 
-                    <ProtectedRoute
-                      path="*"
-                      allowAnonymousUsers
-                      component={PageNotFoundPage}
-                    />
-                  </Switch>
-                </PageErrorBoundary>
-              </LastLocationContextProvider>
-            </AuthContextProvider>
+                      <ProtectedRoute
+                        path="*"
+                        allowAnonymousUsers
+                        component={PageNotFoundPage}
+                      />
+                    </Switch>
+                  </PageErrorBoundary>
+                </LastLocationContextProvider>
+              </AuthContextProvider>
+            </QueryClientProvider>
           </BrowserRouter>
         </ApplicationInsightsContextProvider>
       )}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
@@ -15,6 +15,7 @@ interface PublicationRowProps {
   publication: string;
   releases: Release[];
 }
+
 const PublicationRow = ({ publication, releases }: PublicationRowProps) => {
   return (
     <>
@@ -24,7 +25,11 @@ const PublicationRow = ({ publication, releases }: PublicationRowProps) => {
         </th>
       </tr>
       {releases.map(release => (
-        <ScheduledReleaseRow key={release.id} release={release} />
+        <ScheduledReleaseRow
+          key={release.id}
+          publicationId={release.publicationId}
+          release={release}
+        />
       ))}
     </>
   );

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationReleasesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationReleasesPage.tsx
@@ -1,53 +1,17 @@
 import ButtonLink from '@admin/components/ButtonLink';
-import PublicationDraftReleases from '@admin/pages/publication/components/PublicationDraftReleases';
 import PublicationPublishedReleases from '@admin/pages/publication/components/PublicationPublishedReleases';
-import PublicationScheduledReleases from '@admin/pages/publication/components/PublicationScheduledReleases';
+import PublicationUnpublishedReleases from '@admin/pages/publication/components/PublicationUnpublishedReleases';
 import usePublicationContext from '@admin/pages/publication/contexts/PublicationContext';
 import { PublicationRouteParams } from '@admin/routes/publicationRoutes';
 import { releaseCreateRoute } from '@admin/routes/routes';
-import publicationService from '@admin/services/publicationService';
-import LoadingSpinner from '@common/components/LoadingSpinner';
-import WarningMessage from '@common/components/WarningMessage';
-import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
-import React, { useMemo } from 'react';
+import noop from 'lodash/noop';
+import React, { useRef } from 'react';
 import { generatePath } from 'react-router';
 
 const PublicationReleasesPage = () => {
-  const { publicationId } = usePublicationContext();
+  const { publicationId, publication } = usePublicationContext();
 
-  // To ensure the releases are up to date when you switch to this tab
-  // we're re-fetching the publication here instead of using it from the context.
-  // This is not ideal and will be replaced by a call to just get the publication
-  // releases when an endpoint for this is ready - EES-3554 .
-  const {
-    value: publication,
-    isLoading: loadingPublication,
-    retry: reloadPublication,
-  } = useAsyncHandledRetry(() =>
-    publicationService.getMyPublication(publicationId),
-  );
-
-  const draftReleases = useMemo(() => {
-    return (
-      publication?.releases.filter(
-        release =>
-          release.approvalStatus === 'Draft' ||
-          release.approvalStatus === 'HigherLevelReview',
-      ) ?? []
-    );
-  }, [publication?.releases]);
-
-  const publishedReleases = useMemo(() => {
-    return publication?.releases.filter(release => release.live) ?? [];
-  }, [publication?.releases]);
-
-  const scheduledReleases = useMemo(() => {
-    return (
-      publication?.releases.filter(
-        release => !release.live && release.approvalStatus === 'Approved',
-      ) ?? []
-    );
-  }, [publication?.releases]);
+  const publishedReleasesRefetchRef = useRef<() => void>(noop);
 
   return (
     <>
@@ -64,39 +28,18 @@ const PublicationReleasesPage = () => {
           Create new release
         </ButtonLink>
       )}
-      <LoadingSpinner loading={loadingPublication}>
-        {publication ? (
-          <>
-            {publication.releases.length > 0 ? (
-              <>
-                {scheduledReleases.length > 0 && (
-                  <PublicationScheduledReleases releases={scheduledReleases} />
-                )}
 
-                {draftReleases.length > 0 && (
-                  <PublicationDraftReleases
-                    releases={draftReleases}
-                    onChange={reloadPublication}
-                  />
-                )}
+      <PublicationUnpublishedReleases
+        publicationId={publicationId}
+        onAmendmentDelete={() => {
+          publishedReleasesRefetchRef.current();
+        }}
+      />
 
-                {publishedReleases.length > 0 && (
-                  <PublicationPublishedReleases
-                    publicationId={publicationId}
-                    releases={publishedReleases}
-                  />
-                )}
-              </>
-            ) : (
-              <p>There are no releases for this publication yet.</p>
-            )}
-          </>
-        ) : (
-          <WarningMessage>
-            There was a problem loading this publication.
-          </WarningMessage>
-        )}
-      </LoadingSpinner>
+      <PublicationPublishedReleases
+        publicationId={publicationId}
+        refetchRef={publishedReleasesRefetchRef}
+      />
     </>
   );
 };

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
@@ -1,14 +1,17 @@
-import PublicationPageContainer from '@admin/pages/publication/PublicationPageContainer';
+import render from '@admin-test/render';
 import { testPublication } from '@admin/pages/publication/__data__/testPublication';
+import PublicationPageContainer from '@admin/pages/publication/PublicationPageContainer';
 import {
   publicationReleasesRoute,
   PublicationRouteParams,
 } from '@admin/routes/publicationRoutes';
 import { publicationRoute } from '@admin/routes/routes';
 import _publicationService from '@admin/services/publicationService';
-import { generatePath, MemoryRouter } from 'react-router';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { ReleaseSummaryWithPermissions } from '@admin/services/releaseService';
+import { PaginatedList } from '@common/services/types/pagination';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
+import { generatePath, MemoryRouter } from 'react-router';
 import { Route } from 'react-router-dom';
 
 jest.mock('@admin/services/publicationService');
@@ -17,8 +20,19 @@ const publicationService = _publicationService as jest.Mocked<
 >;
 
 describe('PublicationPageContainer', () => {
+  const testEmptyReleases: PaginatedList<ReleaseSummaryWithPermissions> = {
+    paging: {
+      page: 1,
+      pageSize: 5,
+      totalPages: 1,
+      totalResults: 0,
+    },
+    results: [],
+  };
+
   test('renders the page with the releases tab', async () => {
     publicationService.getMyPublication.mockResolvedValue(testPublication);
+    publicationService.listReleases.mockResolvedValue(testEmptyReleases);
 
     renderPage();
 
@@ -58,6 +72,7 @@ describe('PublicationPageContainer', () => {
       isSuperseded: true,
       supersededById: 'publication-2',
     });
+    publicationService.listReleases.mockResolvedValue(testEmptyReleases);
 
     renderPage();
 
@@ -76,6 +91,7 @@ describe('PublicationPageContainer', () => {
       isSuperseded: false,
       supersededById: 'publication-2',
     });
+    publicationService.listReleases.mockResolvedValue(testEmptyReleases);
 
     renderPage();
 

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationReleasesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationReleasesPage.test.tsx
@@ -1,17 +1,15 @@
-import PublicationReleasesPage from '@admin/pages/publication/PublicationReleasesPage';
+import render from '@admin-test/render';
+import { testPublication } from '@admin/pages/publication/__data__/testPublication';
 import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
-import {
-  testContact,
-  testPublication as baseTestPublication,
-} from '@admin/pages/publication/__data__/testPublication';
+import PublicationReleasesPage from '@admin/pages/publication/PublicationReleasesPage';
 import _publicationService, {
   MyPublication,
 } from '@admin/services/publicationService';
-import _releaseService, { Release } from '@admin/services/releaseService';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import _releaseService from '@admin/services/releaseService';
+import { screen, waitFor } from '@testing-library/react';
+import noop from 'lodash/noop';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import noop from 'lodash/noop';
 
 jest.mock('@admin/services/releaseService');
 const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
@@ -22,80 +20,6 @@ const publicationService = _publicationService as jest.Mocked<
 >;
 
 describe('PublicationReleasesPage', () => {
-  const testRelease1: Release = {
-    amendment: false,
-    approvalStatus: 'Approved',
-    id: 'release-1',
-    latestRelease: false,
-    live: false,
-    permissions: {
-      canAddPrereleaseUsers: false,
-      canUpdateRelease: true,
-      canDeleteRelease: false,
-      canMakeAmendmentOfRelease: true,
-    },
-    previousVersionId: 'release-previous-id',
-    publicationId: 'publication-1',
-    publicationTitle: 'Publication 1',
-    publicationSummary: 'Publication 1 summary',
-    publicationSlug: 'publication-slug-1',
-    published: '2022-01-01T00:00:00',
-    publishScheduled: '2022-01-01T00:00:00',
-    slug: 'release-1-slug',
-    title: 'Release 1',
-    timePeriodCoverage: {
-      label: 'Academic year',
-      value: 'AY',
-    },
-    type: 'AdHocStatistics',
-    contact: testContact,
-    preReleaseAccessList: '',
-    year: 2022,
-    yearTitle: '2022/23',
-  };
-
-  const testRelease2: Release = {
-    ...testRelease1,
-    approvalStatus: 'Draft',
-    id: 'release-2',
-    published: '2022-01-02T00:00:00',
-    slug: 'release-2-slug',
-    title: 'Release 2',
-  };
-
-  const testRelease3: Release = {
-    ...testRelease1,
-    approvalStatus: 'Approved',
-    id: 'release-3',
-    live: true,
-    published: '2022-01-03T00:00:00',
-    slug: 'release-3-slug',
-    title: 'Release 3',
-  };
-
-  const testRelease4: Release = {
-    ...testRelease1,
-    approvalStatus: 'Approved',
-    id: 'release-4',
-    live: true,
-    published: '2022-01-04T00:00:00',
-    slug: 'release-4-slug',
-    title: 'Release 4',
-  };
-
-  const testPublication: MyPublication = {
-    ...baseTestPublication,
-    releases: [testRelease1, testRelease2, testRelease3, testRelease4],
-  };
-
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-  });
-
   beforeEach(() => {
     releaseService.getReleaseStatus.mockResolvedValue({
       overallStage: 'Complete',
@@ -107,51 +31,22 @@ describe('PublicationReleasesPage', () => {
     });
   });
 
-  test('renders the releases page correctly', async () => {
+  test('shows the create release button if you have permission', async () => {
     publicationService.getMyPublication.mockResolvedValue(testPublication);
+
     renderPage(testPublication);
 
-    expect(screen.getByText('Manage releases')).toBeInTheDocument();
-
     await waitFor(() => {
-      expect(screen.getByText('Scheduled releases')).toBeInTheDocument();
+      expect(screen.getByText('Manage releases')).toBeInTheDocument();
     });
+
     expect(
       screen.getByRole('link', { name: 'Create new release' }),
-    ).toBeInTheDocument();
-    const scheduledTable = screen.getByTestId('publication-scheduled-releases');
-    const scheduledRows = within(scheduledTable).getAllByRole('row');
-    expect(scheduledRows).toHaveLength(2);
-    const scheduledRow1cells = within(scheduledRows[1]).getAllByRole('cell');
-    expect(
-      within(scheduledRow1cells[0]).getByText('Release 1'),
-    ).toBeInTheDocument();
-
-    expect(screen.getByText('Draft releases')).toBeInTheDocument();
-    const draftTable = screen.getByTestId('publication-draft-releases');
-    const draftRows = within(draftTable).getAllByRole('row');
-    expect(draftRows).toHaveLength(2);
-    const draftRow1cells = within(draftRows[1]).getAllByRole('cell');
-    expect(
-      within(draftRow1cells[0]).getByText('Release 2'),
-    ).toBeInTheDocument();
-
-    expect(screen.getByText('Published releases (2 of 2)')).toBeInTheDocument();
-    const publishedTable = screen.getByTestId('publication-published-releases');
-    const publishedRows = within(publishedTable).getAllByRole('row');
-    expect(publishedRows).toHaveLength(3);
-    const publishedRow1cells = within(publishedRows[1]).getAllByRole('cell');
-    const publishedRow2cells = within(publishedRows[2]).getAllByRole('cell');
-    expect(
-      within(publishedRow1cells[0]).getByText('Release 3'),
-    ).toBeInTheDocument();
-    expect(
-      within(publishedRow2cells[0]).getByText('Release 4'),
     ).toBeInTheDocument();
   });
 
   test('does not show the create release button if you do not have permission', async () => {
-    const publication = {
+    const publication: MyPublication = {
       ...testPublication,
       permissions: {
         ...testPublication.permissions,
@@ -168,31 +63,6 @@ describe('PublicationReleasesPage', () => {
 
     expect(
       screen.queryByRole('link', { name: 'Create new release' }),
-    ).not.toBeInTheDocument();
-  });
-
-  test('show a message if there are no releases', async () => {
-    const publication = {
-      ...testPublication,
-      releases: [],
-    };
-    publicationService.getMyPublication.mockResolvedValue(publication);
-    renderPage(publication);
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('There are no releases for this publication yet.'),
-      );
-    });
-
-    expect(
-      screen.queryByTestId('publication-scheduled-releases'),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId('publication-draft-releases'),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId('publication-published-releases'),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/publication/components/DraftReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/DraftReleaseRow.tsx
@@ -1,6 +1,8 @@
 import Link from '@admin/components/Link';
 import { getReleaseApprovalStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
-import releaseService, { Release } from '@admin/services/releaseService';
+import releaseService, {
+  ReleaseSummaryWithPermissions,
+} from '@admin/services/releaseService';
 import {
   ReleaseRouteParams,
   releaseSummaryRoute,
@@ -14,11 +16,12 @@ import React from 'react';
 import { generatePath } from 'react-router';
 
 interface Props {
-  release: Release;
+  publicationId: string;
+  release: ReleaseSummaryWithPermissions;
   onDelete: () => void;
 }
 
-const DraftReleaseRow = ({ release, onDelete }: Props) => {
+const DraftReleaseRow = ({ publicationId, release, onDelete }: Props) => {
   const {
     value: checklist,
     isLoading: isLoadingChecklist,
@@ -49,7 +52,7 @@ const DraftReleaseRow = ({ release, onDelete }: Props) => {
       <td>
         <Link
           to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
-            publicationId: release.publicationId,
+            publicationId,
             releaseId: release.id,
           })}
         >
@@ -63,11 +66,11 @@ const DraftReleaseRow = ({ release, onDelete }: Props) => {
           </ButtonText>
         )}
 
-        {release.amendment && (
+        {release.amendment && release.previousVersionId && (
           <Link
             className="govuk-!-margin-left-4"
             to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
-              publicationId: release.publicationId,
+              publicationId,
               releaseId: release.previousVersionId,
             })}
           >

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDraftReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDraftReleases.tsx
@@ -6,19 +6,25 @@ import {
 } from '@admin/pages/publication/components/PublicationGuidance';
 import releaseService, {
   DeleteReleasePlan,
-  Release,
+  ReleaseSummaryWithPermissions,
 } from '@admin/services/releaseService';
 import ButtonText from '@common/components/ButtonText';
 import InfoIcon from '@common/components/InfoIcon';
+import InsetText from '@common/components/InsetText';
 import useToggle from '@common/hooks/useToggle';
 import React, { useState } from 'react';
 
 interface Props {
-  releases: Release[];
-  onChange: () => void;
+  publicationId: string;
+  releases: ReleaseSummaryWithPermissions[];
+  onAmendmentDelete?: () => void;
 }
 
-const PublicationDraftReleases = ({ releases, onChange }: Props) => {
+const PublicationDraftReleases = ({
+  publicationId,
+  releases,
+  onAmendmentDelete,
+}: Props) => {
   const [deleteReleasePlan, setDeleteReleasePlan] = useState<
     DeleteReleasePlan & {
       releaseId: string;
@@ -28,13 +34,16 @@ const PublicationDraftReleases = ({ releases, onChange }: Props) => {
   const [showDraftStatusGuidance, toggleDraftStatusGuidance] = useToggle(false);
   const [showIssuesGuidance, toggleIssuesGuidance] = useToggle(false);
 
+  if (releases.length === 0) {
+    return <InsetText>There are no draft releases.</InsetText>;
+  }
+
   return (
     <>
       <table
-        className="dfe-hide-empty-cells govuk-!-margin-bottom-9"
+        className="dfe-hide-empty-cells"
         data-testid="publication-draft-releases"
       >
-        <caption className="govuk-table__caption--m">Draft releases</caption>
         <thead>
           <tr>
             <th className="govuk-!-width-one-third">Release period</th>
@@ -63,6 +72,7 @@ const PublicationDraftReleases = ({ releases, onChange }: Props) => {
           {releases.map(release => (
             <DraftReleaseRow
               key={release.id}
+              publicationId={publicationId}
               release={release}
               onDelete={async () => {
                 setDeleteReleasePlan({
@@ -81,7 +91,7 @@ const PublicationDraftReleases = ({ releases, onChange }: Props) => {
           onConfirm={async () => {
             await releaseService.deleteRelease(deleteReleasePlan.releaseId);
             setDeleteReleasePlan(undefined);
-            onChange();
+            onAmendmentDelete?.();
           }}
           onCancel={() => setDeleteReleasePlan(undefined)}
         />

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
@@ -1,0 +1,107 @@
+import Link from '@admin/components/Link';
+import styles from '@admin/pages/publication/PublicationReleasesPage.module.scss';
+import {
+  ReleaseRouteParams,
+  releaseSummaryRoute,
+} from '@admin/routes/releaseRoutes';
+import { ReleaseSummaryWithPermissions } from '@admin/services/releaseService';
+import ButtonText from '@common/components/ButtonText';
+import FormattedDate from '@common/components/FormattedDate';
+import InfoIcon from '@common/components/InfoIcon';
+import InsetText from '@common/components/InsetText';
+import Tag from '@common/components/Tag';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import React, { MouseEventHandler, useEffect, useRef } from 'react';
+import { generatePath } from 'react-router';
+
+interface PublishedReleasesTableProps {
+  focusReleaseId?: string;
+  publicationId: string;
+  releases: ReleaseSummaryWithPermissions[];
+  onAmend: (releaseId: string) => void;
+  onGuidanceClick: MouseEventHandler<HTMLButtonElement>;
+}
+
+export default function PublicationPublishedReleasesTable({
+  focusReleaseId,
+  publicationId,
+  releases,
+  onAmend,
+  onGuidanceClick,
+}: PublishedReleasesTableProps) {
+  const rowRef = useRef<HTMLTableRowElement>(null);
+
+  useEffect(() => {
+    rowRef.current?.focus();
+  }, [focusReleaseId]);
+
+  if (releases.length === 0) {
+    return <InsetText>There are no published releases.</InsetText>;
+  }
+
+  return (
+    <table
+      className="dfe-hide-empty-cells"
+      data-testid="publication-published-releases"
+    >
+      <thead>
+        <tr>
+          <th className="govuk-!-width-one-third">Release period</th>
+          <th className={styles.statusColumn}>
+            State{' '}
+            <ButtonText onClick={onGuidanceClick}>
+              <InfoIcon description="Guidance on states" />
+            </ButtonText>
+          </th>
+          <th>Published date</th>
+          <th className={styles.actionsColumn}>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {releases.map(release => {
+          const isFocused = focusReleaseId === release.id;
+
+          return (
+            <tr
+              className={styles.row}
+              key={release.id}
+              ref={isFocused ? rowRef : undefined}
+              tabIndex={isFocused ? -1 : undefined}
+            >
+              <td>{release.title}</td>
+              <td>
+                <Tag colour="green">Published</Tag>
+              </td>
+              <td>
+                {release.published && (
+                  <FormattedDate>{release.published}</FormattedDate>
+                )}
+              </td>
+              <td>
+                <Link
+                  to={generatePath<ReleaseRouteParams>(
+                    releaseSummaryRoute.path,
+                    {
+                      publicationId,
+                      releaseId: release.id,
+                    },
+                  )}
+                >
+                  View<VisuallyHidden> {release.title}</VisuallyHidden>
+                </Link>
+                {release.permissions.canMakeAmendmentOfRelease && (
+                  <ButtonText
+                    className="govuk-!-margin-left-4"
+                    onClick={() => onAmend(release.id)}
+                  >
+                    Amend<VisuallyHidden> {release.title}</VisuallyHidden>
+                  </ButtonText>
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationScheduledReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationScheduledReleases.tsx
@@ -4,17 +4,19 @@ import {
   ScheduledStagesGuidanceModal,
   ScheduledStatusGuidanceModal,
 } from '@admin/pages/publication/components/PublicationGuidance';
-import { Release } from '@admin/services/releaseService';
+import { ReleaseSummaryWithPermissions } from '@admin/services/releaseService';
 import ButtonText from '@common/components/ButtonText';
 import InfoIcon from '@common/components/InfoIcon';
+import InsetText from '@common/components/InsetText';
 import useToggle from '@common/hooks/useToggle';
 import React from 'react';
 
 interface Props {
-  releases: Release[];
+  publicationId: string;
+  releases: ReleaseSummaryWithPermissions[];
 }
 
-const PublicationScheduledReleases = ({ releases }: Props) => {
+const PublicationScheduledReleases = ({ publicationId, releases }: Props) => {
   const [
     showScheduledStatusGuidance,
     toggleScheduledStatusGuidance,
@@ -24,15 +26,13 @@ const PublicationScheduledReleases = ({ releases }: Props) => {
     toggleScheduledStagesGuidance,
   ] = useToggle(false);
 
+  if (releases.length === 0) {
+    return <InsetText>There are no scheduled releases.</InsetText>;
+  }
+
   return (
     <>
-      <table
-        className="govuk-!-margin-bottom-9"
-        data-testid="publication-scheduled-releases"
-      >
-        <caption className="govuk-table__caption--m">
-          Scheduled releases
-        </caption>
+      <table data-testid="publication-scheduled-releases">
         <thead>
           <tr>
             <th className="govuk-!-width-one-third">Release period</th>
@@ -53,9 +53,13 @@ const PublicationScheduledReleases = ({ releases }: Props) => {
           </tr>
         </thead>
         <tbody>
-          {releases.map(release => {
-            return <ScheduledReleaseRow key={release.id} release={release} />;
-          })}
+          {releases.map(release => (
+            <ScheduledReleaseRow
+              key={release.id}
+              publicationId={publicationId}
+              release={release}
+            />
+          ))}
         </tbody>
       </table>
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationUnpublishedReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationUnpublishedReleases.tsx
@@ -1,0 +1,99 @@
+import PublicationDraftReleases from '@admin/pages/publication/components/PublicationDraftReleases';
+import PublicationScheduledReleases from '@admin/pages/publication/components/PublicationScheduledReleases';
+import publicationService from '@admin/services/publicationService';
+import { ReleaseSummaryWithPermissions } from '@admin/services/releaseService';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import WarningMessage from '@common/components/WarningMessage';
+import { useQuery } from '@tanstack/react-query';
+import React, { useMemo } from 'react';
+
+interface Props {
+  publicationId: string;
+  onAmendmentDelete?: () => void;
+}
+
+export default function PublicationUnpublishedReleases({
+  publicationId,
+  onAmendmentDelete,
+}: Props) {
+  const { data: releases, isLoading, isSuccess, refetch } = useQuery(
+    ['publicationUnpublishedReleases', publicationId],
+    () =>
+      publicationService.listReleases<ReleaseSummaryWithPermissions>(
+        publicationId,
+        {
+          live: false,
+          pageSize: 100,
+          permissions: true,
+        },
+      ),
+  );
+
+  const draftReleases = useMemo(() => {
+    return (
+      releases?.results.filter(
+        release =>
+          release.approvalStatus === 'Draft' ||
+          release.approvalStatus === 'HigherLevelReview',
+      ) ?? []
+    );
+  }, [releases?.results]);
+
+  const scheduledReleases = useMemo(() => {
+    return (
+      releases?.results.filter(
+        release => release.approvalStatus === 'Approved',
+      ) ?? []
+    );
+  }, [releases?.results]);
+
+  return (
+    <>
+      <h3>Scheduled releases</h3>
+
+      <LoadingSpinner
+        loading={isLoading}
+        text="Loading scheduled releases"
+        hideText
+      >
+        <section className="govuk-!-margin-bottom-8">
+          {isSuccess ? (
+            <PublicationScheduledReleases
+              publicationId={publicationId}
+              releases={scheduledReleases}
+            />
+          ) : (
+            <WarningMessage>
+              There was a problem loading the scheduled releases.
+            </WarningMessage>
+          )}
+        </section>
+      </LoadingSpinner>
+
+      <h3>Draft releases</h3>
+
+      <LoadingSpinner
+        loading={isLoading}
+        text="Loading draft releases"
+        hideText
+      >
+        <section className="govuk-!-margin-bottom-8">
+          {isSuccess ? (
+            <PublicationDraftReleases
+              publicationId={publicationId}
+              releases={draftReleases}
+              onAmendmentDelete={async () => {
+                await refetch();
+                onAmendmentDelete?.();
+              }}
+            />
+          ) : (
+            <WarningMessage>
+              There was a problem loading the draft releases.
+            </WarningMessage>
+          )}
+        </section>
+      </LoadingSpinner>
+    </>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/publication/components/ScheduledReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/ScheduledReleaseRow.tsx
@@ -1,22 +1,23 @@
 import Link from '@admin/components/Link';
-import ReleasePublishingStatusTag from '@admin/pages/release/components/ReleasePublishingStatusTag';
 import ReleasePublishingStages from '@admin/pages/release/components/ReleasePublishingStages';
+import ReleasePublishingStatusTag from '@admin/pages/release/components/ReleasePublishingStatusTag';
 import useReleasePublishingStatus from '@admin/pages/release/hooks/useReleasePublishingStatus';
 import {
   ReleaseRouteParams,
   releaseSummaryRoute,
 } from '@admin/routes/releaseRoutes';
-import { Release } from '@admin/services/releaseService';
+import { ReleaseSummary } from '@admin/services/releaseService';
 import FormattedDate from '@common/components/FormattedDate';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import React from 'react';
 import { generatePath } from 'react-router';
 
 interface Props {
-  release: Release;
+  publicationId: string;
+  release: ReleaseSummary;
 }
 
-const ScheduledReleaseRow = ({ release }: Props) => {
+const ScheduledReleaseRow = ({ publicationId, release }: Props) => {
   const { currentStatus, currentStatusDetail } = useReleasePublishingStatus({
     releaseId: release.id,
   });
@@ -45,7 +46,7 @@ const ScheduledReleaseRow = ({ release }: Props) => {
       <td>
         <Link
           to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
-            publicationId: release.publicationId,
+            publicationId,
             releaseId: release.id,
           })}
         >

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationPublishedReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationPublishedReleases.test.tsx
@@ -1,32 +1,33 @@
 import PublicationPublishedReleases from '@admin/pages/publication/components/PublicationPublishedReleases';
-import { testContact } from '@admin/pages/publication/__data__/testPublication';
 import _releaseService, {
   Release,
-  ReleaseSummary,
-  ReleaseWithPermissions,
+  ReleaseSummaryWithPermissions,
 } from '@admin/services/releaseService';
-import {
-  render as baseRender,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react';
+import _publicationService from '@admin/services/publicationService';
+import baseRender from '@admin-test/render';
+import { PaginatedList } from '@common/services/types/pagination';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
+import produce from 'immer';
 import React, { ReactElement } from 'react';
 import { MemoryRouter, Router } from 'react-router-dom';
 
 jest.mock('@admin/services/releaseService');
 const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 
+jest.mock('@admin/services/publicationService');
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+
 describe('PublicationPublishedReleases', () => {
   const testPublicationId = 'publication-1';
 
-  const testRelease1: ReleaseWithPermissions = {
+  const testRelease1: ReleaseSummaryWithPermissions = {
     amendment: false,
     approvalStatus: 'Approved',
     id: 'release-1',
-    latestRelease: false,
     live: true,
     permissions: {
       canAddPrereleaseUsers: false,
@@ -34,11 +35,6 @@ describe('PublicationPublishedReleases', () => {
       canDeleteRelease: false,
       canMakeAmendmentOfRelease: true,
     },
-    previousVersionId: '',
-    publicationId: 'publication-1',
-    publicationTitle: 'Publication 1',
-    publicationSummary: 'Publication 1 summary',
-    publicationSlug: 'publication-slug-1',
     published: '2022-01-01T00:00:00',
     slug: 'release-1-slug',
     title: 'Release 1',
@@ -47,61 +43,71 @@ describe('PublicationPublishedReleases', () => {
       value: 'AY',
     },
     type: 'AdHocStatistics',
-    contact: testContact,
-    preReleaseAccessList: '',
     year: 2021,
     yearTitle: '2021/22',
   };
 
-  const testRelease2: Release = {
+  const testRelease2: ReleaseSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-2',
     published: '2022-01-02T00:00:00',
     slug: 'release-2-slug',
     title: 'Release 2',
+    year: 2020,
+    yearTitle: '2020/21',
   };
 
-  const testRelease3: Release = {
+  const testRelease3: ReleaseSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-3',
     published: '2022-01-03T00:00:00',
     slug: 'release-3-slug',
     title: 'Release 3',
+    year: 2019,
+    yearTitle: '2019/20',
   };
 
-  const testRelease4: Release = {
+  const testRelease4: ReleaseSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-4',
     published: '2022-01-04T00:00:00',
     slug: 'release-4-slug',
     title: 'Release 4',
+    year: 2018,
+    yearTitle: '2018/19',
   };
 
-  const testRelease5: Release = {
+  const testRelease5: ReleaseSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-5',
     published: '2022-01-05T00:00:00',
     slug: 'release-5-slug',
     title: 'Release 5',
+    year: 2017,
+    yearTitle: '2017/18',
   };
 
-  const testRelease6: Release = {
+  const testRelease6: ReleaseSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-6',
     published: '2022-01-06T00:00:00',
     slug: 'release-6-slug',
     title: 'Release 6',
+    year: 2016,
+    yearTitle: '2016/17',
   };
 
-  const testRelease7: Release = {
+  const testRelease7: ReleaseSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-7',
     published: '2022-01-07T00:00:00',
     slug: 'release-7-slug',
     title: 'Release 7',
+    year: 2015,
+    yearTitle: '2015/16',
   };
 
-  const testReleases = [
+  const testReleases: ReleaseSummaryWithPermissions[] = [
     testRelease1,
     testRelease2,
     testRelease3,
@@ -111,13 +117,35 @@ describe('PublicationPublishedReleases', () => {
     testRelease7,
   ];
 
-  test('renders the published releases table correctly', () => {
-    render(
-      <PublicationPublishedReleases
-        publicationId={testPublicationId}
-        releases={testReleases}
-      />,
-    );
+  const testReleasesPage1: PaginatedList<ReleaseSummaryWithPermissions> = {
+    paging: {
+      page: 1,
+      pageSize: 5,
+      totalPages: 2,
+      totalResults: 7,
+    },
+    results: testReleases.slice(0, 5),
+  };
+  const testReleasesPage2: PaginatedList<ReleaseSummaryWithPermissions> = {
+    paging: {
+      page: 2,
+      pageSize: 5,
+      totalPages: 2,
+      totalResults: 7,
+    },
+    results: testReleases.slice(5),
+  };
+
+  test('renders the published releases table once loaded', async () => {
+    publicationService.listReleases.mockResolvedValue(testReleasesPage1);
+
+    render(<PublicationPublishedReleases publicationId={testPublicationId} />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Loading published releases'),
+      ).not.toBeInTheDocument();
+    });
 
     expect(screen.getByText('Published releases (5 of 7)')).toBeInTheDocument();
     expect(
@@ -127,131 +155,165 @@ describe('PublicationPublishedReleases', () => {
     const rows = screen.getAllByRole('row');
     expect(rows).toHaveLength(6);
 
-    const row1cells = within(rows[1]).getAllByRole('cell');
-    expect(within(row1cells[0]).getByText('Release 1')).toBeInTheDocument();
-    expect(within(row1cells[1]).getByText('Published')).toBeInTheDocument();
+    const row1Cells = within(rows[1]).getAllByRole('cell');
+    expect(within(row1Cells[0]).getByText('Release 1')).toBeInTheDocument();
+    expect(within(row1Cells[1]).getByText('Published')).toBeInTheDocument();
     expect(
-      within(row1cells[2]).getByText('1 January 2022'),
+      within(row1Cells[2]).getByText('1 January 2022'),
     ).toBeInTheDocument();
     expect(
-      within(row1cells[3]).getByRole('button', { name: 'Amend Release 1' }),
+      within(row1Cells[3]).getByRole('button', { name: 'Amend Release 1' }),
     ).toBeInTheDocument();
     expect(
-      within(row1cells[3]).getByRole('link', { name: 'View Release 1' }),
+      within(row1Cells[3]).getByRole('link', { name: 'View Release 1' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-1/summary',
     );
 
-    const row2cells = within(rows[2]).getAllByRole('cell');
-    expect(within(row2cells[0]).getByText('Release 2')).toBeInTheDocument();
-    expect(within(row2cells[1]).getByText('Published')).toBeInTheDocument();
+    const row2Cells = within(rows[2]).getAllByRole('cell');
+    expect(within(row2Cells[0]).getByText('Release 2')).toBeInTheDocument();
+    expect(within(row2Cells[1]).getByText('Published')).toBeInTheDocument();
     expect(
-      within(row2cells[2]).getByText('2 January 2022'),
+      within(row2Cells[2]).getByText('2 January 2022'),
     ).toBeInTheDocument();
     expect(
-      within(row2cells[3]).getByRole('button', { name: 'Amend Release 2' }),
+      within(row2Cells[3]).getByRole('button', { name: 'Amend Release 2' }),
     ).toBeInTheDocument();
     expect(
-      within(row2cells[3]).getByRole('link', { name: 'View Release 2' }),
+      within(row2Cells[3]).getByRole('link', { name: 'View Release 2' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-2/summary',
     );
 
-    const row3cells = within(rows[3]).getAllByRole('cell');
-    expect(within(row3cells[0]).getByText('Release 3')).toBeInTheDocument();
-    expect(within(row3cells[1]).getByText('Published')).toBeInTheDocument();
+    const row3Cells = within(rows[3]).getAllByRole('cell');
+    expect(within(row3Cells[0]).getByText('Release 3')).toBeInTheDocument();
+    expect(within(row3Cells[1]).getByText('Published')).toBeInTheDocument();
     expect(
-      within(row3cells[2]).getByText('3 January 2022'),
+      within(row3Cells[2]).getByText('3 January 2022'),
     ).toBeInTheDocument();
     expect(
-      within(row3cells[3]).getByRole('button', { name: 'Amend Release 3' }),
+      within(row3Cells[3]).getByRole('button', { name: 'Amend Release 3' }),
     ).toBeInTheDocument();
     expect(
-      within(row3cells[3]).getByRole('link', { name: 'View Release 3' }),
+      within(row3Cells[3]).getByRole('link', { name: 'View Release 3' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-3/summary',
     );
 
-    const row4cells = within(rows[4]).getAllByRole('cell');
-    expect(within(row4cells[0]).getByText('Release 4')).toBeInTheDocument();
-    expect(within(row4cells[1]).getByText('Published')).toBeInTheDocument();
+    const row4Cells = within(rows[4]).getAllByRole('cell');
+    expect(within(row4Cells[0]).getByText('Release 4')).toBeInTheDocument();
+    expect(within(row4Cells[1]).getByText('Published')).toBeInTheDocument();
     expect(
-      within(row4cells[2]).getByText('4 January 2022'),
+      within(row4Cells[2]).getByText('4 January 2022'),
     ).toBeInTheDocument();
     expect(
-      within(row4cells[3]).getByRole('button', { name: 'Amend Release 4' }),
+      within(row4Cells[3]).getByRole('button', { name: 'Amend Release 4' }),
     ).toBeInTheDocument();
     expect(
-      within(row4cells[3]).getByRole('link', { name: 'View Release 4' }),
+      within(row4Cells[3]).getByRole('link', { name: 'View Release 4' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-4/summary',
     );
 
-    const row5cells = within(rows[5]).getAllByRole('cell');
-    expect(within(row5cells[0]).getByText('Release 5')).toBeInTheDocument();
-    expect(within(row5cells[1]).getByText('Published')).toBeInTheDocument();
+    const row5Cells = within(rows[5]).getAllByRole('cell');
+    expect(within(row5Cells[0]).getByText('Release 5')).toBeInTheDocument();
+    expect(within(row5Cells[1]).getByText('Published')).toBeInTheDocument();
     expect(
-      within(row5cells[2]).getByText('5 January 2022'),
+      within(row5Cells[2]).getByText('5 January 2022'),
     ).toBeInTheDocument();
     expect(
-      within(row5cells[3]).getByRole('button', { name: 'Amend Release 5' }),
+      within(row5Cells[3]).getByRole('button', { name: 'Amend Release 5' }),
     ).toBeInTheDocument();
     expect(
-      within(row5cells[3]).getByRole('link', { name: 'View Release 5' }),
+      within(row5Cells[3]).getByRole('link', { name: 'View Release 5' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-5/summary',
     );
   });
 
-  test('displays more releases when the show more button is clicked', () => {
-    render(
-      <PublicationPublishedReleases
-        publicationId={testPublicationId}
-        releases={testReleases}
-      />,
+  test('renders show more button with a maximum of the default `pageSize`', async () => {
+    publicationService.listReleases.mockResolvedValue(
+      produce(testReleasesPage1, draft => {
+        draft.paging.totalPages = 3;
+        draft.paging.totalResults = 12;
+      }),
     );
 
+    render(<PublicationPublishedReleases publicationId={testPublicationId} />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Loading published releases'),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Show 5 more published releases' }),
+    ).toBeInTheDocument();
+  });
+
+  test('displays more releases when the show more button is clicked', async () => {
+    publicationService.listReleases
+      .mockResolvedValueOnce(testReleasesPage1)
+      .mockResolvedValueOnce(testReleasesPage2);
+
+    render(<PublicationPublishedReleases publicationId={testPublicationId} />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Loading published releases'),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Published releases (5 of 7)'));
     expect(screen.getAllByRole('row')).toHaveLength(6);
 
     userEvent.click(
       screen.getByRole('button', { name: 'Show 2 more published releases' }),
     );
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Show 2 more published releases'),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Published releases (7 of 7)'));
 
     const rows = screen.getAllByRole('row');
     expect(rows).toHaveLength(8);
 
-    const row6cells = within(rows[6]).getAllByRole('cell');
-    expect(within(row6cells[0]).getByText('Release 6')).toBeInTheDocument();
-    expect(within(row6cells[1]).getByText('Published')).toBeInTheDocument();
+    const row6Cells = within(rows[6]).getAllByRole('cell');
+    expect(within(row6Cells[0]).getByText('Release 6')).toBeInTheDocument();
+    expect(within(row6Cells[1]).getByText('Published')).toBeInTheDocument();
     expect(
-      within(row6cells[2]).getByText('6 January 2022'),
+      within(row6Cells[2]).getByText('6 January 2022'),
     ).toBeInTheDocument();
     expect(
-      within(row6cells[3]).getByRole('button', { name: 'Amend Release 6' }),
+      within(row6Cells[3]).getByRole('button', { name: 'Amend Release 6' }),
     ).toBeInTheDocument();
     expect(
-      within(row6cells[3]).getByRole('link', { name: 'View Release 6' }),
+      within(row6Cells[3]).getByRole('link', { name: 'View Release 6' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-6/summary',
     );
 
-    const row7cells = within(rows[7]).getAllByRole('cell');
-    expect(within(row7cells[0]).getByText('Release 7')).toBeInTheDocument();
-    expect(within(row7cells[1]).getByText('Published')).toBeInTheDocument();
+    const row7Cells = within(rows[7]).getAllByRole('cell');
+    expect(within(row7Cells[0]).getByText('Release 7')).toBeInTheDocument();
+    expect(within(row7Cells[1]).getByText('Published')).toBeInTheDocument();
     expect(
-      within(row7cells[2]).getByText('7 January 2022'),
+      within(row7Cells[2]).getByText('7 January 2022'),
     ).toBeInTheDocument();
     expect(
-      within(row7cells[3]).getByRole('button', { name: 'Amend Release 7' }),
+      within(row7Cells[3]).getByRole('button', { name: 'Amend Release 7' }),
     ).toBeInTheDocument();
     expect(
-      within(row7cells[3]).getByRole('link', { name: 'View Release 7' }),
+      within(row7Cells[3]).getByRole('link', { name: 'View Release 7' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-7/summary',
@@ -263,6 +325,8 @@ describe('PublicationPublishedReleases', () => {
   });
 
   test('creating an amendment works correctly', async () => {
+    publicationService.listReleases.mockResolvedValue(testReleasesPage1);
+
     const history = createMemoryHistory();
 
     releaseService.createReleaseAmendment.mockResolvedValue({
@@ -271,13 +335,15 @@ describe('PublicationPublishedReleases', () => {
 
     baseRender(
       <Router history={history}>
-        <PublicationPublishedReleases
-          publicationId={testPublicationId}
-          releases={testReleases}
-        />
-        ,
+        <PublicationPublishedReleases publicationId={testPublicationId} />,
       </Router>,
     );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Loading published releases'),
+      ).not.toBeInTheDocument();
+    });
 
     const rows = screen.getAllByRole('row');
     expect(rows).toHaveLength(6);
@@ -313,27 +379,20 @@ describe('PublicationPublishedReleases', () => {
     );
   });
 
-  test('does not show the amendment button if you do not have the correct permissions', () => {
-    render(
-      <PublicationPublishedReleases
-        publicationId={testPublicationId}
-        releases={[
-          {
-            ...testRelease1,
-            permissions: {
-              ...testRelease1.permissions,
-              canMakeAmendmentOfRelease: false,
-            },
-          },
-          testRelease2,
-          testRelease3,
-          testRelease4,
-          testRelease5,
-          testRelease6,
-          testRelease7,
-        ]}
-      />,
+  test('does not show the amendment button if you do not have the correct permissions', async () => {
+    publicationService.listReleases.mockResolvedValue(
+      produce(testReleasesPage1, draft => {
+        draft.results[0].permissions.canMakeAmendmentOfRelease = false;
+      }),
     );
+
+    render(<PublicationPublishedReleases publicationId={testPublicationId} />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Loading published releases'),
+      ).not.toBeInTheDocument();
+    });
 
     const rows = screen.getAllByRole('row');
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationScheduledReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationScheduledReleases.test.tsx
@@ -1,8 +1,6 @@
 import PublicationScheduledReleases from '@admin/pages/publication/components/PublicationScheduledReleases';
-import { testContact } from '@admin/pages/publication/__data__/testPublication';
 import _releaseService, {
-  Release,
-  ReleaseWithPermissions,
+  ReleaseSummaryWithPermissions,
 } from '@admin/services/releaseService';
 import {
   render as baseRender,
@@ -17,11 +15,12 @@ jest.mock('@admin/services/releaseService');
 const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 
 describe('PublicationScheduledReleases', () => {
-  const testRelease1: ReleaseWithPermissions = {
+  const testPublicationId = 'publication-1';
+
+  const testRelease1: ReleaseSummaryWithPermissions = {
     amendment: false,
     approvalStatus: 'Approved',
     id: 'release-1',
-    latestRelease: false,
     live: false,
     permissions: {
       canAddPrereleaseUsers: false,
@@ -30,11 +29,6 @@ describe('PublicationScheduledReleases', () => {
       canMakeAmendmentOfRelease: true,
     },
     previousVersionId: 'release-previous-id',
-    publicationId: 'publication-1',
-    publicationSlug: 'publication-slug-1',
-    publicationTitle: 'Publication 1',
-    publicationSummary: 'Publication 1 summary',
-    published: '2022-01-01T00:00:00',
     publishScheduled: '2022-01-01T00:00:00',
     year: 2021,
     yearTitle: '2021/22',
@@ -45,15 +39,12 @@ describe('PublicationScheduledReleases', () => {
       value: 'AY',
     },
     type: 'AdHocStatistics',
-    contact: testContact,
-    preReleaseAccessList: '',
   };
 
-  const testRelease2: Release = {
+  const testRelease2: ReleaseSummaryWithPermissions = {
     ...testRelease1,
     approvalStatus: 'Approved',
     id: 'release-2',
-    published: '2022-01-02T00:00:00',
     publishScheduled: '2022-01-02T00:00:00',
     slug: 'release-2-slug',
     title: 'Release 2',
@@ -68,53 +59,70 @@ describe('PublicationScheduledReleases', () => {
   });
 
   test('renders the scheduled releases table correctly', async () => {
-    render(<PublicationScheduledReleases releases={testReleases} />);
-
-    expect(screen.getByText('Scheduled releases')).toBeInTheDocument();
+    render(
+      <PublicationScheduledReleases
+        publicationId={testPublicationId}
+        releases={testReleases}
+      />,
+    );
 
     const rows = screen.getAllByRole('row');
     expect(rows).toHaveLength(3);
 
-    const row1cells = within(rows[1]).getAllByRole('cell');
-    expect(within(row1cells[0]).getByText('Release 1')).toBeInTheDocument();
+    const row1Cells = within(rows[1]).getAllByRole('cell');
+    expect(within(row1Cells[0]).getByText('Release 1')).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(within(row1cells[1]).getByText('Scheduled')).toBeInTheDocument();
+      expect(within(row1Cells[1]).getByText('Scheduled')).toBeInTheDocument();
     });
 
     expect(
-      within(row1cells[2]).getByRole('button', { name: 'View stages' }),
+      within(row1Cells[2]).getByRole('button', { name: 'View stages' }),
     ).toBeInTheDocument();
     expect(
-      within(row1cells[3]).getByText('1 January 2022'),
+      within(row1Cells[3]).getByText('1 January 2022'),
     ).toBeInTheDocument();
     expect(
-      within(row1cells[4]).getByRole('link', { name: 'Edit Release 1' }),
+      within(row1Cells[4]).getByRole('link', { name: 'Edit Release 1' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-1/summary',
     );
 
-    const row2cells = within(rows[2]).getAllByRole('cell');
-    expect(within(row2cells[0]).getByText('Release 2')).toBeInTheDocument();
-    expect(within(row2cells[1]).getByText('Scheduled')).toBeInTheDocument();
+    const row2Cells = within(rows[2]).getAllByRole('cell');
+    expect(within(row2Cells[0]).getByText('Release 2')).toBeInTheDocument();
+    expect(within(row2Cells[1]).getByText('Scheduled')).toBeInTheDocument();
     expect(
-      within(row2cells[2]).getByRole('button', { name: 'View stages' }),
+      within(row2Cells[2]).getByRole('button', { name: 'View stages' }),
     ).toBeInTheDocument();
     expect(
-      within(row2cells[3]).getByText('2 January 2022'),
+      within(row2Cells[3]).getByText('2 January 2022'),
     ).toBeInTheDocument();
     expect(
-      within(row2cells[4]).getByRole('link', { name: 'Edit Release 2' }),
+      within(row2Cells[4]).getByRole('link', { name: 'Edit Release 2' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-2/summary',
     );
   });
 
+  test('shows an empty message when there are no scheduled releases', () => {
+    render(
+      <PublicationScheduledReleases
+        publicationId={testPublicationId}
+        releases={[]}
+      />,
+    );
+
+    expect(
+      screen.getByText('There are no scheduled releases.'),
+    ).toBeInTheDocument();
+  });
+
   test('shows a view instead of edit link if you do not have permission to edit the release', () => {
     render(
       <PublicationScheduledReleases
+        publicationId={testPublicationId}
         releases={[
           {
             ...testRelease1,
@@ -129,12 +137,12 @@ describe('PublicationScheduledReleases', () => {
     );
 
     const rows = screen.getAllByRole('row');
-    const row1cells = within(rows[1]).getAllByRole('cell');
+    const row1Cells = within(rows[1]).getAllByRole('cell');
 
-    expect(within(row1cells[0]).getByText('Release 1')).toBeInTheDocument();
+    expect(within(row1Cells[0]).getByText('Release 1')).toBeInTheDocument();
 
     expect(
-      within(row1cells[4]).getByRole('link', { name: 'View Release 1' }),
+      within(row1Cells[4]).getByRole('link', { name: 'View Release 1' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-1/summary',

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationUnpublishedReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationUnpublishedReleases.test.tsx
@@ -1,0 +1,243 @@
+import baseRender from '@admin-test/render';
+import PublicationUnpublishedReleases from '@admin/pages/publication/components/PublicationUnpublishedReleases';
+import _publicationService from '@admin/services/publicationService';
+import _releaseService, {
+  ReleasePermissions,
+  ReleaseSummaryWithPermissions,
+} from '@admin/services/releaseService';
+import { PaginatedList } from '@common/services/types/pagination';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('@admin/services/publicationService');
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+
+jest.mock('@admin/services/releaseService');
+const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
+
+describe('PublicationUnpublishedReleases', () => {
+  const testPublicationId = 'publication-1';
+
+  const testPermissions: ReleasePermissions = {
+    canAddPrereleaseUsers: false,
+    canUpdateRelease: true,
+    canDeleteRelease: true,
+    canMakeAmendmentOfRelease: true,
+  };
+
+  const testRelease1: ReleaseSummaryWithPermissions = {
+    amendment: false,
+    approvalStatus: 'Approved',
+    id: 'release-1',
+    live: false,
+    permissions: testPermissions,
+    publishScheduled: '2022-01-01T00:00:00',
+    slug: 'release-1-slug',
+    title: 'Release 1',
+    timePeriodCoverage: {
+      label: 'Academic year',
+      value: 'AY',
+    },
+    type: 'NationalStatistics',
+    year: 2022,
+    yearTitle: '2022/23',
+  };
+
+  const testRelease2: ReleaseSummaryWithPermissions = {
+    amendment: false,
+    approvalStatus: 'Draft',
+    id: 'release-2',
+    live: false,
+    permissions: testPermissions,
+    slug: 'release-2-slug',
+    title: 'Release 2',
+    timePeriodCoverage: {
+      label: 'Academic year',
+      value: 'AY',
+    },
+    type: 'NationalStatistics',
+    year: 2024,
+    yearTitle: '2024/25',
+  };
+
+  const testRelease3: ReleaseSummaryWithPermissions = {
+    amendment: true,
+    approvalStatus: 'HigherLevelReview',
+    id: 'release-3',
+    live: false,
+    permissions: testPermissions,
+    slug: 'release-3-slug',
+    title: 'Release 3',
+    timePeriodCoverage: {
+      label: 'Academic year',
+      value: 'AY',
+    },
+    type: 'NationalStatistics',
+    year: 2023,
+    yearTitle: '2023/24',
+  };
+
+  const testReleasesPage1: PaginatedList<ReleaseSummaryWithPermissions> = {
+    paging: {
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+      totalResults: 3,
+    },
+    results: [testRelease1, testRelease2, testRelease3],
+  };
+
+  beforeEach(() => {
+    releaseService.getReleaseStatus.mockResolvedValue({
+      overallStage: 'Complete',
+    });
+    releaseService.getReleaseChecklist.mockResolvedValue({
+      errors: [],
+      valid: true,
+      warnings: [],
+    });
+  });
+
+  test('renders tables of unpublished releases once loaded', async () => {
+    publicationService.listReleases.mockResolvedValue(testReleasesPage1);
+
+    render(
+      <PublicationUnpublishedReleases publicationId={testPublicationId} />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Loading scheduled releases'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Loading draft releases'),
+      ).not.toBeInTheDocument();
+    });
+
+    const scheduledTable = screen.getByTestId('publication-scheduled-releases');
+    const scheduledRows = within(scheduledTable).getAllByRole('row');
+    expect(scheduledRows).toHaveLength(2);
+
+    const scheduledRow1Cells = within(scheduledRows[1]).getAllByRole('cell');
+    expect(
+      within(scheduledRow1Cells[0]).getByText('Release 1'),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Draft releases')).toBeInTheDocument();
+
+    const draftTable = screen.getByTestId('publication-draft-releases');
+    const draftRows = within(draftTable).getAllByRole('row');
+    expect(draftRows).toHaveLength(3);
+
+    const draftRow1Cells = within(draftRows[1]).getAllByRole('cell');
+    expect(
+      within(draftRow1Cells[0]).getByText('Release 2'),
+    ).toBeInTheDocument();
+
+    const draftRow2Cells = within(draftRows[2]).getAllByRole('cell');
+    expect(
+      within(draftRow2Cells[0]).getByText('Release 3'),
+    ).toBeInTheDocument();
+  });
+
+  test('shows error messages if unpublished releases could not be loaded', async () => {
+    publicationService.listReleases.mockRejectedValue(
+      new Error('Something went wrong'),
+    );
+
+    render(
+      <PublicationUnpublishedReleases publicationId={testPublicationId} />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('There was a problem loading the scheduled releases.'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('There was a problem loading the draft releases.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows empty messages if there are no unpublished releases', async () => {
+    publicationService.listReleases.mockResolvedValue({
+      paging: {
+        page: 1,
+        pageSize: 20,
+        totalPages: 1,
+        totalResults: 0,
+      },
+      results: [],
+    });
+
+    render(
+      <PublicationUnpublishedReleases publicationId={testPublicationId} />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('There are no scheduled releases.'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('There are no draft releases.'),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId('publication-scheduled-releases'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('publication-draft-releases'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('calls `onAmendmentDelete` handler when amendment is deleted', async () => {
+    publicationService.listReleases.mockResolvedValue(testReleasesPage1);
+    releaseService.getDeleteReleasePlan.mockResolvedValue({
+      scheduledMethodologies: [],
+    });
+
+    const handleAmendmentDelete = jest.fn();
+
+    render(
+      <PublicationUnpublishedReleases
+        publicationId={testPublicationId}
+        onAmendmentDelete={handleAmendmentDelete}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Loading draft releases'),
+      ).not.toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Cancel amendment for Release 3' }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Confirm you want to cancel this amended release'),
+      ).toBeInTheDocument();
+    });
+
+    const modal = within(screen.getByRole('dialog'));
+
+    expect(handleAmendmentDelete).not.toHaveBeenCalled();
+
+    userEvent.click(modal.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(handleAmendmentDelete).toHaveBeenCalled();
+    });
+  });
+});
+
+function render(element: ReactElement) {
+  return baseRender(<MemoryRouter>{element}</MemoryRouter>);
+}

--- a/src/explore-education-statistics-admin/test/render.tsx
+++ b/src/explore-education-statistics-admin/test/render.tsx
@@ -1,0 +1,36 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  render as baseRender,
+  RenderOptions,
+  RenderResult,
+} from '@testing-library/react';
+import React, { FC, ReactElement } from 'react';
+
+const DefaultWrapper: FC = ({ children }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        cacheTime: Infinity,
+        retry: false,
+      },
+    },
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+/**
+ * Custom test render function that is pre-configured with any contexts
+ * that would otherwise create unnecessary boilerplate.
+ */
+export default function render(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'queries'>,
+): RenderResult {
+  return baseRender(ui, {
+    wrapper: DefaultWrapper,
+    ...options,
+  });
+}


### PR DESCRIPTION
This PR integrates the recently updated publication releases endpoint (`/api/{publicationId}/releases`) with the 'Manage publication > Releases' page.

We have had to reorganise some of the existing component structure to correctly integrate this endpoint i.e.
- `PublicationUnpublishedReleases` - handles draft and scheduled release tables
- `PublicationPublishedReleases` handles the live/published release table

Each of the above components makes its own request to fetch the relevant releases from the publication releases endpoint.

## Introducing React Query

As part of this, we have introduced [React Query](https://tanstack.com/query) as a dependency to manage async requests. This is essentially a more feature complete version of the `useAsync*` collection of hooks that we use throughout the service. It provides useful features such as client-side caching and automatic re-fetching for stale data.

The main driver for introducing React Query was to handle the new paginated publication releases, for which we are using `useInfiniteQuery`. The alternative would have been to hand-roll our own version of this and it did not seem worthwhile to re-engineer something that is already handled by a well maintained package.

## Implications for `useAsync*` hooks

A side-effect of introducing React Query is that we also will want to consider swapping `useQuery` (from React Query) in place of `useAsyncRetry` and `useAsyncHandledRetry`. We have already introduced `useQuery` for the `ReleaseUnpublishedReleases` component, where there is no pagination.

My suggestion would be that we start to adopt React Query and aim to slowly migrate existing usages of the `useAsync*` hooks to the React Query APIs. React Query is better maintained, more feature rich, has extensive documentation and means we don't need to reinvent the wheel.

## Testing with React Query

One notable caveat to using React Query is that we need to wrap our test rendering code with a `QueryClientProvider`. This provider needs to be configured in a fairly consistent and specific way, meaning that it is useful for us to use a new custom `render` function that pre-configures this in a wrapper.

This means, that in test code which involves rendering a React Query consuming component, we should do:
```tsx
import render from '@admin-test/render';

test('my test...', () => {
  render(<MyReactQueryComponent />);
});
```

Note that currently, React Query is only in admin, hence why the alias is `@admin-test`. In the future, we will add React Query to the frontend project as well, upon which it will be aliased like `@frontend-test` instead.