### PR TITLE
EES-3677-2 disable reorder controls when release is published

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordion.tsx
@@ -1,5 +1,6 @@
 import Accordion, { AccordionProps } from '@common/components/Accordion';
 import Button from '@common/components/Button';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 import useToggle from '@common/hooks/useToggle';
 import { OmitStrict } from '@common/types';
 import reorder from '@common/utils/reorder';
@@ -24,10 +25,19 @@ export interface ReorderableAccordionProps
   extends OmitStrict<AccordionProps, 'openAll'> {
   heading?: string;
   onReorder: (sectionIds: string[]) => void;
+  canReorder: boolean;
+  reorderHiddenText?: string;
 }
 
 const ReorderableAccordion = (props: ReorderableAccordionProps) => {
-  const { children, id, heading, onReorder } = props;
+  const {
+    children,
+    id,
+    heading,
+    onReorder,
+    canReorder,
+    reorderHiddenText = 'sections',
+  } = props;
 
   const [isReordering, toggleReordering] = useToggle(false);
 
@@ -82,13 +92,16 @@ const ReorderableAccordion = (props: ReorderableAccordionProps) => {
         <h2 className="govuk-heading-l govuk-!-margin-bottom-0">{heading}</h2>
 
         {sections.length > 1 &&
+          canReorder &&
           (!isReordering ? (
             <Button
               variant="secondary"
               className="govuk-!-font-size-16 govuk-!-margin-bottom-0"
               onClick={toggleReordering.on}
+              data-testid="reorder-files"
             >
-              Reorder<span className="govuk-visually-hidden"> data files</span>
+              Reorder
+              <VisuallyHidden> {reorderHiddenText}</VisuallyHidden>
             </Button>
           ) : (
             <Button

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/ReorderableAccordion.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/ReorderableAccordion.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import noop from 'lodash/noop';
+import ReorderableAccordion from '../ReorderableAccordion';
+import ReorderableAccordionSection from '../ReorderableAccordionSection';
+
+describe('ReorderableAccordion', () => {
+  test("doesn't show controls if `canReorder` is false", () => {
+    render(
+      <ReorderableAccordion
+        canReorder={false}
+        heading="test accordion"
+        reorderHiddenText="files"
+        id="1"
+        onReorder={noop}
+      >
+        <ReorderableAccordionSection id="1" heading="test section one">
+          test accordion content section one
+        </ReorderableAccordionSection>
+
+        <ReorderableAccordionSection id="1" heading="test section two">
+          test accordion content section two
+        </ReorderableAccordionSection>
+      </ReorderableAccordion>,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Reorder files' }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('test accordion content section one'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('test accordion content section two'),
+    ).toBeInTheDocument();
+  });
+
+  test('shows controls if `canReorder` is true', () => {
+    const { container } = render(
+      <ReorderableAccordion
+        canReorder
+        heading="test accordion"
+        reorderHiddenText="files"
+        id="1"
+        onReorder={noop}
+      >
+        <ReorderableAccordionSection id="1" heading="test section one">
+          test accordion content section one
+        </ReorderableAccordionSection>
+
+        <ReorderableAccordionSection id="2" heading="test section two">
+          test accordion content section two
+        </ReorderableAccordionSection>
+      </ReorderableAccordion>,
+    );
+
+    expect(container.querySelector('.govuk-visually-hidden')).toHaveTextContent(
+      'files',
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Reorder files' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('test accordion content section one'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('test accordion content section two'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -231,8 +231,10 @@ const ReleaseDataUploadsSection = ({
       <LoadingSpinner loading={isLoading}>
         {dataFiles.length > 0 ? (
           <ReorderableAccordion
+            canReorder={canUpdateRelease}
             id="uploadedDataFiles"
             heading="Uploaded data files"
+            reorderHiddenText="files"
             onReorder={async (fileIds: string[]) => {
               setDataFiles(
                 await releaseDataFileService.updateDataFilesOrder(

--- a/tests/robot-tests/tests/admin_and_public/bau/subject_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/subject_reordering.robot
@@ -182,6 +182,17 @@ Add data guidance for all subjects
 Publish release
     user approves original release for immediate publication
 
+Check subjects can no longer be re-ordered after release has been published
+    user clicks link    Data and files
+    user waits until page contains element    id:uploadedDataFiles
+
+    user checks accordion is in position    One    1    id:uploadedDataFiles
+    user checks accordion is in position    Two    2    id:uploadedDataFiles
+    user checks accordion is in position    Three    3    id:uploadedDataFiles
+    user checks accordion is in position    Four    4    id:uploadedDataFiles
+
+    user checks element is not visible    testid:reorder-files    %{WAIT_SMALL}
+
 Check subject order in data tables
     user navigates to data tables page on public frontend
 


### PR DESCRIPTION
This PR:

disables re-order controls if a user can't update a release (such as when it's being published/approved). Previously, the re-order data-files still showed up even when a release was in the process of publishing or had the status of approved