### PR TITLE
EES-3028, EES-3029, EES-3030, EES-3032 - address combobox + page search accessibility issues

### DIFF
--- a/src/explore-education-statistics-common/src/components/PageSearchForm.module.scss
+++ b/src/explore-education-statistics-common/src/components/PageSearchForm.module.scss
@@ -6,27 +6,6 @@
   }
 }
 
-.searchButton {
-  background: $govuk-link-colour url('/assets/images/search-button.png') 1px -17px;
-  border: 2px solid $govuk-input-border-colour;
-  box-sizing: content-box;
-  cursor: pointer;
-  height: 36px;
-  padding: 0;
-  position: absolute;
-  right: 0;
-  text-indent: -5000px;
-  width: 36px;
-}
-
-.searchButton:focus,
-.searchButton:hover {
-  background: $govuk-link-hover-colour url('/assets/images/search-button.png')
-    1px -17px;
-  border: 2px solid $govuk-focus-colour;
-  outline: 0;
-}
-
 .resultsLabel {
   background-color: govuk-colour('light-grey');
   font-size: 1rem;

--- a/src/explore-education-statistics-common/src/components/PageSearchForm.tsx
+++ b/src/explore-education-statistics-common/src/components/PageSearchForm.tsx
@@ -193,19 +193,14 @@ const PageSearchForm = ({
           placeholder: 'Search this page',
         }}
         inputLabel={inputLabel}
-        afterInput={({ value }) => (
-          <button
-            type="submit"
-            className={styles.searchButton}
-            value="Search"
-            onClick={() => search(value)}
-          >
-            <span className="govuk-visually-hidden">Search</span>
-          </button>
-        )}
         listBoxLabelId={`${id}-resultsLabel`}
         listBoxLabel={() => (
-          <div id={`${id}-resultsLabel`} className={styles.resultsLabel}>
+          <div
+            id={`${id}-resultsLabel`}
+            className={styles.resultsLabel}
+            aria-live="polite"
+            aria-atomic
+          >
             Found <strong>{searchResults.length}</strong>
             {` ${searchResults.length === 1 ? 'result' : 'results'}`}
           </div>

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/PageSearchForm.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/PageSearchForm.test.tsx.snap
@@ -6,12 +6,14 @@ exports[`PageSearchForm renders results found in custom selectors 1`] = `
   class="options"
   id="pageSearchForm-options"
   role="listbox"
-  tabindex="-1"
 >
   <li
+    aria-posinset="1"
     aria-selected="false"
+    aria-setsize="2"
     id="pageSearchForm-option-0"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"
@@ -32,9 +34,12 @@ exports[`PageSearchForm renders results found in custom selectors 1`] = `
     
   </li>
   <li
+    aria-posinset="2"
     aria-selected="false"
+    aria-setsize="2"
     id="pageSearchForm-option-1"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"
@@ -67,12 +72,14 @@ exports[`PageSearchForm renders results found in default elements 1`] = `
   class="options"
   id="pageSearchForm-options"
   role="listbox"
-  tabindex="-1"
 >
   <li
+    aria-posinset="1"
     aria-selected="false"
+    aria-setsize="5"
     id="pageSearchForm-option-0"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"
@@ -93,9 +100,12 @@ exports[`PageSearchForm renders results found in default elements 1`] = `
     
   </li>
   <li
+    aria-posinset="2"
     aria-selected="false"
+    aria-setsize="5"
     id="pageSearchForm-option-1"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"
@@ -116,9 +126,12 @@ exports[`PageSearchForm renders results found in default elements 1`] = `
     
   </li>
   <li
+    aria-posinset="3"
     aria-selected="false"
+    aria-setsize="5"
     id="pageSearchForm-option-2"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"
@@ -139,9 +152,12 @@ exports[`PageSearchForm renders results found in default elements 1`] = `
     
   </li>
   <li
+    aria-posinset="4"
     aria-selected="false"
+    aria-setsize="5"
     id="pageSearchForm-option-3"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"
@@ -162,9 +178,12 @@ exports[`PageSearchForm renders results found in default elements 1`] = `
     
   </li>
   <li
+    aria-posinset="5"
     aria-selected="false"
+    aria-setsize="5"
     id="pageSearchForm-option-4"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"
@@ -193,12 +212,14 @@ exports[`PageSearchForm result locations include accordion sections 1`] = `
   class="options"
   id="pageSearchForm-options"
   role="listbox"
-  tabindex="-1"
 >
   <li
+    aria-posinset="1"
     aria-selected="false"
+    aria-setsize="2"
     id="pageSearchForm-option-0"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"
@@ -223,9 +244,12 @@ exports[`PageSearchForm result locations include accordion sections 1`] = `
     </div>
   </li>
   <li
+    aria-posinset="2"
     aria-selected="false"
+    aria-setsize="2"
     id="pageSearchForm-option-1"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"
@@ -258,12 +282,14 @@ exports[`PageSearchForm result locations include heading hierarchy 1`] = `
   class="options"
   id="pageSearchForm-options"
   role="listbox"
-  tabindex="-1"
 >
   <li
+    aria-posinset="1"
     aria-selected="false"
+    aria-setsize="1"
     id="pageSearchForm-option-0"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"
@@ -296,12 +322,14 @@ exports[`PageSearchForm result locations uses nearest heading 1`] = `
   class="options"
   id="pageSearchForm-options"
   role="listbox"
-  tabindex="-1"
 >
   <li
+    aria-posinset="1"
     aria-selected="false"
+    aria-setsize="2"
     id="pageSearchForm-option-0"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"
@@ -326,9 +354,12 @@ exports[`PageSearchForm result locations uses nearest heading 1`] = `
     </div>
   </li>
   <li
+    aria-posinset="2"
     aria-selected="false"
+    aria-setsize="2"
     id="pageSearchForm-option-1"
     role="option"
+    tabindex="-1"
   >
     <div
       class="resultHeader"

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormComboBox.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormComboBox.test.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import noop from 'lodash/noop';
-import renderer from 'react-test-renderer';
 import userEvent from '@testing-library/user-event';
 import FormComboBox from '../FormComboBox';
 
 describe('FormComboBox', () => {
   test('renders with no options by default', () => {
-    render(
+    const { container } = render(
       <FormComboBox
         id="test-combobox"
         inputLabel="Choose option"
@@ -21,23 +20,11 @@ describe('FormComboBox', () => {
 
     expect(options).toHaveLength(0);
 
-    const tree = renderer
-      .create(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={noop}
-          onSelect={noop}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      )
-      .toJSON();
-
-    expect(tree).toMatchSnapshot();
+    expect(container.innerHTML).toMatchSnapshot();
   });
 
   test('renders with options in correct order when input changes', async () => {
-    render(
+    const { container } = render(
       <FormComboBox
         id="test-combobox"
         inputLabel="Choose option"
@@ -56,19 +43,7 @@ describe('FormComboBox', () => {
     expect(options[1]).toHaveTextContent('Option 2');
     expect(options[2]).toHaveTextContent('Option 3');
 
-    const tree = renderer
-      .create(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={noop}
-          onSelect={noop}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      )
-      .toJSON();
-
-    expect(tree).toMatchSnapshot();
+    expect(container.innerHTML).toMatchSnapshot();
   });
 
   describe('input field', () => {
@@ -104,16 +79,14 @@ describe('FormComboBox', () => {
         key: 'ArrowDown',
       });
 
-      await waitFor(() => {
-        expect(option1).toHaveAttribute('aria-selected', 'true');
-        expect(option1).toHaveFocus();
+      expect(option1).toHaveAttribute('aria-selected', 'true');
+      expect(option1).toHaveFocus();
 
-        expect(option2).toHaveAttribute('aria-selected', 'false');
-        expect(option2).not.toHaveFocus();
+      expect(option2).toHaveAttribute('aria-selected', 'false');
+      expect(option2).not.toHaveFocus();
 
-        expect(option3).toHaveAttribute('aria-selected', 'false');
-        expect(option3).not.toHaveFocus();
-      });
+      expect(option3).toHaveAttribute('aria-selected', 'false');
+      expect(option3).not.toHaveFocus();
     });
 
     test('pressing ArrowDown selects the first list item', async () => {
@@ -146,16 +119,14 @@ describe('FormComboBox', () => {
         key: 'ArrowDown',
       });
 
-      await waitFor(() => {
-        expect(option1).toHaveAttribute('aria-selected', 'true');
-        expect(option1).toHaveFocus();
+      expect(option1).toHaveAttribute('aria-selected', 'true');
+      expect(option1).toHaveFocus();
 
-        expect(option2).toHaveAttribute('aria-selected', 'false');
-        expect(option2).not.toHaveFocus();
+      expect(option2).toHaveAttribute('aria-selected', 'false');
+      expect(option2).not.toHaveFocus();
 
-        expect(option3).toHaveAttribute('aria-selected', 'false');
-        expect(option3).not.toHaveFocus();
-      });
+      expect(option3).toHaveAttribute('aria-selected', 'false');
+      expect(option3).not.toHaveFocus();
     });
 
     test('pressing ArrowUp focuses the list box', async () => {
@@ -212,16 +183,14 @@ describe('FormComboBox', () => {
         key: 'ArrowUp',
       });
 
-      await waitFor(() => {
-        expect(option1).toHaveAttribute('aria-selected', 'false');
-        expect(option1).not.toHaveFocus();
+      expect(option1).toHaveAttribute('aria-selected', 'false');
+      expect(option1).not.toHaveFocus();
 
-        expect(option2).toHaveAttribute('aria-selected', 'false');
-        expect(option2).not.toHaveFocus();
+      expect(option2).toHaveAttribute('aria-selected', 'false');
+      expect(option2).not.toHaveFocus();
 
-        expect(option3).toHaveAttribute('aria-selected', 'true');
-        expect(option3).toHaveFocus();
-      });
+      expect(option3).toHaveAttribute('aria-selected', 'true');
+      expect(option3).toHaveFocus();
     });
     describe('list box', () => {
       test('pressing ArrowUp will cycle the selected item through the entire list', async () => {
@@ -229,8 +198,8 @@ describe('FormComboBox', () => {
           <FormComboBox
             id="test-combobox"
             inputLabel="Choose option"
-            onInputChange={() => {}}
-            onSelect={() => {}}
+            onInputChange={noop}
+            onSelect={noop}
             options={['Option 1', 'Option 2', 'Option 3']}
           />,
         );
@@ -254,16 +223,14 @@ describe('FormComboBox', () => {
 
         fireEvent.keyDown(listBox, { key: 'ArrowUp' });
 
-        await waitFor(() => {
-          expect(option1).toHaveAttribute('aria-selected', 'false');
-          expect(option1).not.toHaveFocus();
+        expect(option1).toHaveAttribute('aria-selected', 'false');
+        expect(option1).not.toHaveFocus();
 
-          expect(option2).toHaveAttribute('aria-selected', 'false');
-          expect(option2).not.toHaveFocus();
+        expect(option2).toHaveAttribute('aria-selected', 'false');
+        expect(option2).not.toHaveFocus();
 
-          expect(option3).toHaveAttribute('aria-selected', 'true');
-          expect(option3).toHaveFocus();
-        });
+        expect(option3).toHaveAttribute('aria-selected', 'true');
+        expect(option3).toHaveFocus();
 
         fireEvent.keyDown(listBox, { key: 'ArrowUp' });
 
@@ -278,29 +245,25 @@ describe('FormComboBox', () => {
 
         fireEvent.keyDown(listBox, { key: 'ArrowUp' });
 
-        await waitFor(() => {
-          expect(option1).toHaveAttribute('aria-selected', 'true');
-          expect(option1).toHaveFocus();
+        expect(option1).toHaveAttribute('aria-selected', 'true');
+        expect(option1).toHaveFocus();
 
-          expect(option2).toHaveAttribute('aria-selected', 'false');
-          expect(option2).not.toHaveFocus();
+        expect(option2).toHaveAttribute('aria-selected', 'false');
+        expect(option2).not.toHaveFocus();
 
-          expect(option3).toHaveAttribute('aria-selected', 'false');
-          expect(option3).not.toHaveFocus();
-        });
+        expect(option3).toHaveAttribute('aria-selected', 'false');
+        expect(option3).not.toHaveFocus();
 
         fireEvent.keyDown(listBox, { key: 'ArrowUp' });
 
-        await waitFor(() => {
-          expect(option1).toHaveAttribute('aria-selected', 'false');
-          expect(option1).not.toHaveFocus();
+        expect(option1).toHaveAttribute('aria-selected', 'false');
+        expect(option1).not.toHaveFocus();
 
-          expect(option2).toHaveAttribute('aria-selected', 'false');
-          expect(option2).not.toHaveFocus();
+        expect(option2).toHaveAttribute('aria-selected', 'false');
+        expect(option2).not.toHaveFocus();
 
-          expect(option3).toHaveAttribute('aria-selected', 'true');
-          expect(option3).toHaveFocus();
-        });
+        expect(option3).toHaveAttribute('aria-selected', 'true');
+        expect(option3).toHaveFocus();
       });
 
       test('pressing ArrowUp adjusts scroll correctly', async () => {
@@ -370,55 +333,47 @@ describe('FormComboBox', () => {
 
         fireEvent.keyDown(listBox, { key: 'ArrowDown' });
 
-        await waitFor(() => {
-          expect(option1).toHaveAttribute('aria-selected', 'true');
-          expect(option1).toHaveFocus();
+        expect(option1).toHaveAttribute('aria-selected', 'true');
+        expect(option1).toHaveFocus();
 
-          expect(option2).toHaveAttribute('aria-selected', 'false');
-          expect(option2).not.toHaveFocus();
+        expect(option2).toHaveAttribute('aria-selected', 'false');
+        expect(option2).not.toHaveFocus();
 
-          expect(option3).toHaveAttribute('aria-selected', 'false');
-          expect(option3).not.toHaveFocus();
-        });
+        expect(option3).toHaveAttribute('aria-selected', 'false');
+        expect(option3).not.toHaveFocus();
 
         fireEvent.keyDown(listBox, { key: 'ArrowDown' });
 
-        await waitFor(() => {
-          expect(option1).toHaveAttribute('aria-selected', 'false');
-          expect(option1).not.toHaveFocus();
+        expect(option1).toHaveAttribute('aria-selected', 'false');
+        expect(option1).not.toHaveFocus();
 
-          expect(option2).toHaveAttribute('aria-selected', 'true');
-          expect(option2).toHaveFocus();
+        expect(option2).toHaveAttribute('aria-selected', 'true');
+        expect(option2).toHaveFocus();
 
-          expect(option3).toHaveAttribute('aria-selected', 'false');
-          expect(option3).not.toHaveFocus();
-        });
+        expect(option3).toHaveAttribute('aria-selected', 'false');
+        expect(option3).not.toHaveFocus();
 
         fireEvent.keyDown(listBox, { key: 'ArrowDown' });
 
-        await waitFor(() => {
-          expect(option1).toHaveAttribute('aria-selected', 'false');
-          expect(option1).not.toHaveFocus();
+        expect(option1).toHaveAttribute('aria-selected', 'false');
+        expect(option1).not.toHaveFocus();
 
-          expect(option2).toHaveAttribute('aria-selected', 'false');
-          expect(option2).not.toHaveFocus();
+        expect(option2).toHaveAttribute('aria-selected', 'false');
+        expect(option2).not.toHaveFocus();
 
-          expect(option3).toHaveAttribute('aria-selected', 'true');
-          expect(option3).toHaveFocus();
-        });
+        expect(option3).toHaveAttribute('aria-selected', 'true');
+        expect(option3).toHaveFocus();
 
         fireEvent.keyDown(listBox, { key: 'ArrowDown' });
 
-        await waitFor(() => {
-          expect(option1).toHaveAttribute('aria-selected', 'true');
-          expect(option1).toHaveFocus();
+        expect(option1).toHaveAttribute('aria-selected', 'true');
+        expect(option1).toHaveFocus();
 
-          expect(option2).toHaveAttribute('aria-selected', 'false');
-          expect(option2).not.toHaveFocus();
+        expect(option2).toHaveAttribute('aria-selected', 'false');
+        expect(option2).not.toHaveFocus();
 
-          expect(option3).toHaveAttribute('aria-selected', 'false');
-          expect(option3).not.toHaveFocus();
-        });
+        expect(option3).toHaveAttribute('aria-selected', 'false');
+        expect(option3).not.toHaveFocus();
       });
 
       test('pressing ArrowDown adjusts scroll correctly', async () => {
@@ -737,7 +692,7 @@ describe('FormComboBox', () => {
 
         expect(onSelect).not.toHaveBeenCalled();
 
-        fireEvent.click(screen.getByText('Option 2'));
+        userEvent.click(screen.getByText('Option 2'));
 
         expect(onSelect).toHaveBeenCalledWith(1);
       });
@@ -755,7 +710,7 @@ describe('FormComboBox', () => {
 
         await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-        fireEvent.click(screen.getByText('Option 2'));
+        userEvent.click(screen.getByText('Option 2'));
 
         expect(screen.queryAllByRole('option')).toHaveLength(0);
       });
@@ -779,7 +734,7 @@ describe('FormComboBox', () => {
 
         expect(screen.queryAllByRole('option')).toHaveLength(3);
 
-        fireEvent.click(screen.getByText('Target'));
+        userEvent.click(screen.getByText('Target'));
 
         expect(screen.queryAllByRole('option')).toHaveLength(0);
       });
@@ -800,11 +755,11 @@ describe('FormComboBox', () => {
 
       await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      fireEvent.click(screen.getByText('Target'));
+      userEvent.click(screen.getByText('Target'));
 
       expect(screen.queryAllByRole('option')).toHaveLength(0);
 
-      fireEvent.click(screen.getByLabelText('Choose option'));
+      userEvent.click(screen.getByLabelText('Choose option'));
 
       expect(screen.queryAllByRole('option')).toHaveLength(3);
     });

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormComboBox.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormComboBox.test.tsx
@@ -1,804 +1,812 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import noop from 'lodash/noop';
+import renderer from 'react-test-renderer';
+import userEvent from '@testing-library/user-event';
 import FormComboBox from '../FormComboBox';
 
 describe('FormComboBox', () => {
   test('renders with no options by default', () => {
-    const { container } = render(
+    render(
       <FormComboBox
         id="test-combobox"
         inputLabel="Choose option"
-        onInputChange={() => {}}
-        onSelect={() => {}}
+        onInputChange={noop}
+        onSelect={noop}
         options={['Option 1', 'Option 2', 'Option 3']}
       />,
     );
 
-    const options = container.querySelectorAll('[role="option"]');
+    const options = screen.queryAllByRole('option');
 
     expect(options).toHaveLength(0);
-    expect(container.innerHTML).toMatchSnapshot();
+
+    const tree = renderer
+      .create(
+        <FormComboBox
+          id="test-combobox"
+          inputLabel="Choose option"
+          onInputChange={noop}
+          onSelect={noop}
+          options={['Option 1', 'Option 2', 'Option 3']}
+        />,
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
   });
 
-  test('renders with options in correct order when input changes', () => {
-    const { container, getByLabelText } = render(
+  test('renders with options in correct order when input changes', async () => {
+    render(
       <FormComboBox
         id="test-combobox"
         inputLabel="Choose option"
-        onInputChange={() => {}}
-        onSelect={() => {}}
+        onInputChange={noop}
+        onSelect={noop}
         options={['Option 1', 'Option 2', 'Option 3']}
       />,
     );
 
-    const input = getByLabelText('Choose option') as HTMLInputElement;
+    await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-    fireEvent.change(input, {
-      target: {
-        value: 'Test',
-      },
-    });
-
-    const options = container.querySelectorAll('[role="option"]');
+    const options = screen.queryAllByRole('option');
 
     expect(options).toHaveLength(3);
     expect(options[0]).toHaveTextContent('Option 1');
     expect(options[1]).toHaveTextContent('Option 2');
     expect(options[2]).toHaveTextContent('Option 3');
 
-    expect(container.innerHTML).toMatchSnapshot();
+    const tree = renderer
+      .create(
+        <FormComboBox
+          id="test-combobox"
+          inputLabel="Choose option"
+          onInputChange={noop}
+          onSelect={noop}
+          options={['Option 1', 'Option 2', 'Option 3']}
+        />,
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
   });
 
   describe('input field', () => {
-    test('pressing ArrowDown focuses the list box', () => {
-      const { container, getByLabelText } = render(
+    test('pressing ArrowDown focuses the first option', async () => {
+      render(
         <FormComboBox
           id="test-combobox"
           inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
+          onInputChange={noop}
+          onSelect={noop}
           options={['Option 1', 'Option 2', 'Option 3']}
         />,
       );
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
+      const input = screen.getByLabelText('Choose option') as HTMLInputElement;
 
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+      await userEvent.type(input, 'Test');
+
+      const option1 = screen.getByText('Option 1');
+      const option2 = screen.getByText('Option 2');
+      const option3 = screen.getByText('Option 3');
+
+      expect(option1).toHaveAttribute('aria-selected', 'false');
+      expect(option1).not.toHaveFocus();
+
+      expect(option2).toHaveAttribute('aria-selected', 'false');
+      expect(option2).not.toHaveFocus();
+
+      expect(option3).toHaveAttribute('aria-selected', 'false');
+      expect(option3).not.toHaveFocus();
+
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown',
       });
 
-      const listBox = container.querySelector('[role="listbox"]');
+      await waitFor(() => {
+        expect(option1).toHaveAttribute('aria-selected', 'true');
+        expect(option1).toHaveFocus();
+
+        expect(option2).toHaveAttribute('aria-selected', 'false');
+        expect(option2).not.toHaveFocus();
+
+        expect(option3).toHaveAttribute('aria-selected', 'false');
+        expect(option3).not.toHaveFocus();
+      });
+    });
+
+    test('pressing ArrowDown selects the first list item', async () => {
+      render(
+        <FormComboBox
+          id="test-combobox"
+          inputLabel="Choose option"
+          onInputChange={noop}
+          onSelect={noop}
+          options={['Option 1', 'Option 2', 'Option 3']}
+        />,
+      );
+
+      await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
+
+      const option1 = screen.getByText('Option 1');
+      const option2 = screen.getByText('Option 2');
+      const option3 = screen.getByText('Option 3');
+
+      expect(option1).toHaveAttribute('aria-selected', 'false');
+      expect(option1).not.toHaveFocus();
+
+      expect(option2).toHaveAttribute('aria-selected', 'false');
+      expect(option2).not.toHaveFocus();
+
+      expect(option3).toHaveAttribute('aria-selected', 'false');
+      expect(option3).not.toHaveFocus();
+
+      fireEvent.keyDown(screen.getByLabelText('Choose option'), {
+        key: 'ArrowDown',
+      });
+
+      await waitFor(() => {
+        expect(option1).toHaveAttribute('aria-selected', 'true');
+        expect(option1).toHaveFocus();
+
+        expect(option2).toHaveAttribute('aria-selected', 'false');
+        expect(option2).not.toHaveFocus();
+
+        expect(option3).toHaveAttribute('aria-selected', 'false');
+        expect(option3).not.toHaveFocus();
+      });
+    });
+
+    test('pressing ArrowUp focuses the list box', async () => {
+      render(
+        <FormComboBox
+          id="test-combobox"
+          inputLabel="Choose option"
+          onInputChange={noop}
+          onSelect={noop}
+          options={['Option 1', 'Option 2', 'Option 3']}
+        />,
+      );
+
+      await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
+
+      const listBox = screen.getByRole('listbox');
 
       expect(listBox).not.toHaveFocus();
 
-      fireEvent.keyDown(getByLabelText('Choose option'), { key: 'ArrowDown' });
+      fireEvent.keyDown(screen.getByLabelText('Choose option'), {
+        key: 'ArrowUp',
+      });
 
-      expect(listBox).toHaveFocus();
+      const option = screen.getByText('Option 3');
+      expect(option).toHaveFocus();
     });
 
-    test('pressing ArrowDown selects the first list item', () => {
-      const { getByLabelText, getByText } = render(
+    test('pressing ArrowUp selects the last list item', async () => {
+      render(
         <FormComboBox
           id="test-combobox"
           inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
+          onInputChange={noop}
+          onSelect={noop}
           options={['Option 1', 'Option 2', 'Option 3']}
         />,
       );
+      await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
-
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
-      });
-
-      const option1 = getByText('Option 1');
-      const option2 = getByText('Option 2');
-      const option3 = getByText('Option 3');
+      const option1 = screen.getByText('Option 1');
+      const option2 = screen.getByText('Option 2');
+      const option3 = screen.getByText('Option 3');
 
       expect(option1).toHaveAttribute('aria-selected', 'false');
+      expect(option1).not.toHaveFocus();
+
       expect(option2).toHaveAttribute('aria-selected', 'false');
+      expect(option2).not.toHaveFocus();
+
       expect(option3).toHaveAttribute('aria-selected', 'false');
+      expect(option3).not.toHaveFocus();
 
-      fireEvent.keyDown(getByLabelText('Choose option'), { key: 'ArrowDown' });
-
-      expect(option1).toHaveAttribute('aria-selected', 'true');
-      expect(option2).toHaveAttribute('aria-selected', 'false');
-      expect(option3).toHaveAttribute('aria-selected', 'false');
-    });
-
-    test('pressing ArrowUp focuses the list box', () => {
-      const { container, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
-
-      const input = getByLabelText('Choose option') as HTMLInputElement;
-
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+      fireEvent.keyDown(screen.getByLabelText('Choose option'), {
+        key: 'ArrowUp',
       });
 
-      const listBox = container.querySelector('[role="listbox"]');
+      await waitFor(() => {
+        expect(option1).toHaveAttribute('aria-selected', 'false');
+        expect(option1).not.toHaveFocus();
 
-      expect(listBox).not.toHaveFocus();
+        expect(option2).toHaveAttribute('aria-selected', 'false');
+        expect(option2).not.toHaveFocus();
 
-      fireEvent.keyDown(getByLabelText('Choose option'), { key: 'ArrowUp' });
-
-      expect(listBox).toHaveFocus();
+        expect(option3).toHaveAttribute('aria-selected', 'true');
+        expect(option3).toHaveFocus();
+      });
     });
+    describe('list box', () => {
+      test('pressing ArrowUp will cycle the selected item through the entire list', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={() => {}}
+            onSelect={() => {}}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-    test('pressing ArrowUp selects the last list item', () => {
-      const { getByLabelText, getByText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
+        await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
+        const listBox = screen.queryByRole('listbox') as HTMLElement;
 
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        const option1 = screen.getByText('Option 1');
+        const option2 = screen.getByText('Option 2');
+        const option3 = screen.getByText('Option 3');
+
+        expect(option1).toHaveAttribute('aria-selected', 'false');
+        expect(option1).not.toHaveFocus();
+
+        expect(option2).toHaveAttribute('aria-selected', 'false');
+        expect(option2).not.toHaveFocus();
+
+        expect(option3).toHaveAttribute('aria-selected', 'false');
+        expect(option3).not.toHaveFocus();
+
+        fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+
+        await waitFor(() => {
+          expect(option1).toHaveAttribute('aria-selected', 'false');
+          expect(option1).not.toHaveFocus();
+
+          expect(option2).toHaveAttribute('aria-selected', 'false');
+          expect(option2).not.toHaveFocus();
+
+          expect(option3).toHaveAttribute('aria-selected', 'true');
+          expect(option3).toHaveFocus();
+        });
+
+        fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+
+        expect(option1).toHaveAttribute('aria-selected', 'false');
+        expect(option1).not.toHaveFocus();
+
+        expect(option2).toHaveAttribute('aria-selected', 'true');
+        expect(option2).toHaveFocus();
+
+        expect(option3).toHaveAttribute('aria-selected', 'false');
+        expect(option3).not.toHaveFocus();
+
+        fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+
+        await waitFor(() => {
+          expect(option1).toHaveAttribute('aria-selected', 'true');
+          expect(option1).toHaveFocus();
+
+          expect(option2).toHaveAttribute('aria-selected', 'false');
+          expect(option2).not.toHaveFocus();
+
+          expect(option3).toHaveAttribute('aria-selected', 'false');
+          expect(option3).not.toHaveFocus();
+        });
+
+        fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+
+        await waitFor(() => {
+          expect(option1).toHaveAttribute('aria-selected', 'false');
+          expect(option1).not.toHaveFocus();
+
+          expect(option2).toHaveAttribute('aria-selected', 'false');
+          expect(option2).not.toHaveFocus();
+
+          expect(option3).toHaveAttribute('aria-selected', 'true');
+          expect(option3).toHaveFocus();
+        });
       });
 
-      const option1 = getByText('Option 1');
-      const option2 = getByText('Option 2');
-      const option3 = getByText('Option 3');
+      test('pressing ArrowUp adjusts scroll correctly', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      expect(option1).toHaveAttribute('aria-selected', 'false');
-      expect(option2).toHaveAttribute('aria-selected', 'false');
-      expect(option3).toHaveAttribute('aria-selected', 'false');
+        await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      fireEvent.keyDown(getByLabelText('Choose option'), { key: 'ArrowUp' });
+        const listBox = screen.getByRole('listbox');
 
-      expect(option1).toHaveAttribute('aria-selected', 'false');
-      expect(option2).toHaveAttribute('aria-selected', 'false');
-      expect(option3).toHaveAttribute('aria-selected', 'true');
-    });
-  });
+        expect(listBox.scrollTop).toBe(0);
 
-  describe('list box', () => {
-    test('pressing ArrowUp will cycle the selected item through the entire list', () => {
-      const { container, getByText, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
+        fireEvent.keyDown(listBox, { key: 'ArrowUp' });
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
+        expect(listBox.scrollTop).toBe(listBox.scrollHeight);
 
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+
+        expect(listBox.scrollTop).toBe(
+          listBox.scrollHeight - screen.getByText('Option 3').scrollHeight,
+        );
+
+        fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+
+        expect(listBox.scrollTop).toBe(
+          listBox.scrollHeight - screen.getByText('Option 2').scrollHeight,
+        );
+
+        fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+        expect(listBox.scrollTop).toBe(0);
       });
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+      test('pressing ArrowDown will cycle the selected item through the entire list', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      const option1 = getByText('Option 1');
-      const option2 = getByText('Option 2');
-      const option3 = getByText('Option 3');
+        await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      expect(option1).toHaveAttribute('aria-selected', 'false');
-      expect(option2).toHaveAttribute('aria-selected', 'false');
-      expect(option3).toHaveAttribute('aria-selected', 'false');
+        const listBox = screen.getByRole('combobox');
 
-      fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+        const option1 = screen.getByText('Option 1');
+        const option2 = screen.getByText('Option 2');
+        const option3 = screen.getByText('Option 3');
 
-      expect(option1).toHaveAttribute('aria-selected', 'false');
-      expect(option2).toHaveAttribute('aria-selected', 'false');
-      expect(option3).toHaveAttribute('aria-selected', 'true');
+        expect(option1).toHaveAttribute('aria-selected', 'false');
+        expect(option1).not.toHaveFocus();
 
-      fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+        expect(option2).toHaveAttribute('aria-selected', 'false');
+        expect(option2).not.toHaveFocus();
 
-      expect(option1).toHaveAttribute('aria-selected', 'false');
-      expect(option2).toHaveAttribute('aria-selected', 'true');
-      expect(option3).toHaveAttribute('aria-selected', 'false');
+        expect(option3).toHaveAttribute('aria-selected', 'false');
+        expect(option3).not.toHaveFocus();
 
-      fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+        fireEvent.keyDown(listBox, { key: 'ArrowDown' });
 
-      expect(option1).toHaveAttribute('aria-selected', 'true');
-      expect(option2).toHaveAttribute('aria-selected', 'false');
-      expect(option3).toHaveAttribute('aria-selected', 'false');
+        await waitFor(() => {
+          expect(option1).toHaveAttribute('aria-selected', 'true');
+          expect(option1).toHaveFocus();
 
-      fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+          expect(option2).toHaveAttribute('aria-selected', 'false');
+          expect(option2).not.toHaveFocus();
 
-      expect(option1).toHaveAttribute('aria-selected', 'false');
-      expect(option2).toHaveAttribute('aria-selected', 'false');
-      expect(option3).toHaveAttribute('aria-selected', 'true');
-    });
+          expect(option3).toHaveAttribute('aria-selected', 'false');
+          expect(option3).not.toHaveFocus();
+        });
 
-    test('pressing ArrowUp adjusts scroll correctly', () => {
-      const { container, getByText, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
+        fireEvent.keyDown(listBox, { key: 'ArrowDown' });
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
+        await waitFor(() => {
+          expect(option1).toHaveAttribute('aria-selected', 'false');
+          expect(option1).not.toHaveFocus();
 
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+          expect(option2).toHaveAttribute('aria-selected', 'true');
+          expect(option2).toHaveFocus();
+
+          expect(option3).toHaveAttribute('aria-selected', 'false');
+          expect(option3).not.toHaveFocus();
+        });
+
+        fireEvent.keyDown(listBox, { key: 'ArrowDown' });
+
+        await waitFor(() => {
+          expect(option1).toHaveAttribute('aria-selected', 'false');
+          expect(option1).not.toHaveFocus();
+
+          expect(option2).toHaveAttribute('aria-selected', 'false');
+          expect(option2).not.toHaveFocus();
+
+          expect(option3).toHaveAttribute('aria-selected', 'true');
+          expect(option3).toHaveFocus();
+        });
+
+        fireEvent.keyDown(listBox, { key: 'ArrowDown' });
+
+        await waitFor(() => {
+          expect(option1).toHaveAttribute('aria-selected', 'true');
+          expect(option1).toHaveFocus();
+
+          expect(option2).toHaveAttribute('aria-selected', 'false');
+          expect(option2).not.toHaveFocus();
+
+          expect(option3).toHaveAttribute('aria-selected', 'false');
+          expect(option3).not.toHaveFocus();
+        });
       });
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+      test('pressing ArrowDown adjusts scroll correctly', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      expect(listBox.scrollTop).toBe(0);
+        await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      fireEvent.keyDown(listBox, { key: 'ArrowUp' });
-      expect(listBox.scrollTop).toBe(listBox.scrollHeight);
+        const comboBox = screen.getByRole('combobox');
 
-      fireEvent.keyDown(listBox, { key: 'ArrowUp' });
-      expect(listBox.scrollTop).toBe(
-        listBox.scrollHeight - getByText('Option 3').scrollHeight,
-      );
+        expect(comboBox.scrollTop).toBe(0);
 
-      fireEvent.keyDown(listBox, { key: 'ArrowUp' });
-      expect(listBox.scrollTop).toBe(
-        listBox.scrollHeight - getByText('Option 2').scrollHeight,
-      );
+        fireEvent.keyDown(comboBox, { key: 'ArrowDown' });
+        expect(comboBox.scrollTop).toBe(0);
 
-      fireEvent.keyDown(listBox, { key: 'ArrowUp' });
-      expect(listBox.scrollTop).toBe(0);
-    });
+        fireEvent.keyDown(comboBox, { key: 'ArrowDown' });
+        expect(comboBox.scrollTop).toBe(
+          screen.getByText('Option 1').scrollHeight,
+        );
 
-    test('pressing ArrowDown will cycle the selected item through the entire list', () => {
-      const { container, getByText, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
+        fireEvent.keyDown(comboBox, { key: 'ArrowDown' });
+        expect(comboBox.scrollTop).toBe(
+          comboBox.scrollHeight + screen.getByText('Option 2').scrollHeight,
+        );
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
-
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        fireEvent.keyDown(comboBox, { key: 'ArrowDown' });
+        expect(comboBox.scrollTop).toBe(comboBox.scrollHeight);
       });
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+      test('pressing ArrowLeft focuses back to input field', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      const option1 = getByText('Option 1');
-      const option2 = getByText('Option 2');
-      const option3 = getByText('Option 3');
+        await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      expect(option1).toHaveAttribute('aria-selected', 'false');
-      expect(option2).toHaveAttribute('aria-selected', 'false');
-      expect(option3).toHaveAttribute('aria-selected', 'false');
+        const input = screen.getByLabelText('Choose option');
 
-      fireEvent.keyDown(listBox, { key: 'ArrowDown' });
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+        expect(screen.getByLabelText('Choose option')).not.toHaveFocus();
 
-      expect(option1).toHaveAttribute('aria-selected', 'true');
-      expect(option2).toHaveAttribute('aria-selected', 'false');
-      expect(option3).toHaveAttribute('aria-selected', 'false');
+        const listBox = screen.getByRole('listbox');
 
-      fireEvent.keyDown(listBox, { key: 'ArrowDown' });
+        fireEvent.keyDown(listBox, { key: 'ArrowLeft' });
 
-      expect(option1).toHaveAttribute('aria-selected', 'false');
-      expect(option2).toHaveAttribute('aria-selected', 'true');
-      expect(option3).toHaveAttribute('aria-selected', 'false');
-
-      fireEvent.keyDown(listBox, { key: 'ArrowDown' });
-
-      expect(option1).toHaveAttribute('aria-selected', 'false');
-      expect(option2).toHaveAttribute('aria-selected', 'false');
-      expect(option3).toHaveAttribute('aria-selected', 'true');
-
-      fireEvent.keyDown(listBox, { key: 'ArrowDown' });
-
-      expect(option1).toHaveAttribute('aria-selected', 'true');
-      expect(option2).toHaveAttribute('aria-selected', 'false');
-      expect(option3).toHaveAttribute('aria-selected', 'false');
-    });
-
-    test('pressing ArrowDown adjusts scroll correctly', () => {
-      const { container, getByText, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
-
-      const input = getByLabelText('Choose option') as HTMLInputElement;
-
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(screen.getByLabelText('Choose option')).toHaveFocus();
       });
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+      test('pressing ArrowLeft moves input field selection one character to the left', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      expect(listBox.scrollTop).toBe(0);
+        const input = screen.getByLabelText(
+          'Choose option',
+        ) as HTMLInputElement;
 
-      fireEvent.keyDown(listBox, { key: 'ArrowDown' });
-      expect(listBox.scrollTop).toBe(0);
+        await userEvent.type(input, 'Test');
 
-      fireEvent.keyDown(listBox, { key: 'ArrowDown' });
-      expect(listBox.scrollTop).toBe(
-        listBox.scrollHeight + getByText('Option 1').scrollHeight,
-      );
+        input.selectionStart = 2;
+        input.selectionEnd = 2;
 
-      fireEvent.keyDown(listBox, { key: 'ArrowDown' });
-      expect(listBox.scrollTop).toBe(
-        listBox.scrollHeight + getByText('Option 2').scrollHeight,
-      );
+        const listBox = screen.getByRole('listbox');
 
-      fireEvent.keyDown(listBox, { key: 'ArrowDown' });
-      expect(listBox.scrollTop).toBe(listBox.scrollHeight);
-    });
+        fireEvent.keyDown(listBox, { key: 'ArrowLeft' });
 
-    test('pressing ArrowLeft focuses back to input field', () => {
-      const { container, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
-
-      const input = getByLabelText('Choose option') as HTMLInputElement;
-
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(input.selectionStart).toBe(1);
+        expect(input.selectionEnd).toBe(1);
       });
 
-      expect(getByLabelText('Choose option')).not.toHaveFocus();
+      test('pressing ArrowRight focuses back to input field', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+        await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      fireEvent.keyDown(listBox, { key: 'ArrowLeft' });
+        const listBox = screen.getByRole('listbox');
 
-      expect(getByLabelText('Choose option')).toHaveFocus();
-    });
+        fireEvent.keyDown(listBox, { key: 'ArrowRight' });
 
-    test('pressing ArrowLeft moves input field selection one character to the left', () => {
-      const { container, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
-
-      const input = getByLabelText('Choose option') as HTMLInputElement;
-
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(screen.getByLabelText('Choose option')).toHaveFocus();
       });
 
-      input.selectionStart = 2;
-      input.selectionEnd = 2;
+      test('pressing ArrowRight moves input field selection one character to the left', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+        const input = screen.getByLabelText(
+          'Choose option',
+        ) as HTMLInputElement;
 
-      fireEvent.keyDown(listBox, { key: 'ArrowLeft' });
+        await userEvent.type(input, 'Test');
 
-      expect(input.selectionStart).toBe(1);
-      expect(input.selectionEnd).toBe(1);
-    });
+        input.selectionStart = 2;
+        input.selectionEnd = 2;
 
-    test('pressing ArrowRight focuses back to input field', () => {
-      const { container, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
+        const listBox = screen.getByRole('listbox');
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
+        fireEvent.keyDown(listBox, { key: 'ArrowRight' });
 
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(input.selectionStart).toBe(3);
+        expect(input.selectionEnd).toBe(3);
       });
 
-      expect(input).not.toHaveFocus();
+      test('pressing Home focuses input field and moves selection back to start', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+        const input = screen.getByLabelText(
+          'Choose option',
+        ) as HTMLInputElement;
 
-      fireEvent.keyDown(listBox, { key: 'ArrowRight' });
+        await userEvent.type(input, 'Test');
 
-      expect(getByLabelText('Choose option')).toHaveFocus();
-    });
+        input.value = 'Test';
+        input.selectionStart = 2;
+        input.selectionEnd = 2;
 
-    test('pressing ArrowRight moves input field selection one character to the left', () => {
-      const { container, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
+        const listBox = screen.getByRole('listbox');
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
+        fireEvent.keyDown(listBox, { key: 'Home' });
 
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(input).toHaveFocus();
+        expect(input.selectionStart).toBe(0);
+        expect(input.selectionEnd).toBe(0);
       });
 
-      input.selectionStart = 2;
-      input.selectionEnd = 2;
+      test('pressing End focuses input field and moves selection back to start', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+        const input = screen.getByLabelText(
+          'Choose option',
+        ) as HTMLInputElement;
 
-      fireEvent.keyDown(listBox, { key: 'ArrowRight' });
+        await userEvent.type(input, 'Test');
+        input.selectionStart = 2;
+        input.selectionEnd = 2;
 
-      expect(input.selectionStart).toBe(3);
-      expect(input.selectionEnd).toBe(3);
-    });
+        const listBox = screen.getByRole('listbox');
 
-    test('pressing Home focuses input field and moves selection back to start', () => {
-      const { container, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
+        fireEvent.keyDown(listBox, { key: 'End' });
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
-
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(input).toHaveFocus();
+        expect(input.selectionStart).toBe(4);
+        expect(input.selectionEnd).toBe(4);
       });
 
-      input.value = 'Test';
-      input.selectionStart = 2;
-      input.selectionEnd = 2;
+      test('pressing Enter calls `onSelect` handler with selected item index', async () => {
+        const onSelect = jest.fn();
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={onSelect}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      fireEvent.keyDown(listBox, { key: 'Home' });
+        await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      expect(input).toHaveFocus();
-      expect(input.selectionStart).toBe(0);
-      expect(input.selectionEnd).toBe(0);
-    });
+        expect(onSelect).not.toHaveBeenCalled();
 
-    test('pressing End focuses input field and moves selection back to start', () => {
-      const { container, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
+        const listBox = screen.getByRole('listbox');
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
+        fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+        fireEvent.keyDown(listBox, { key: 'Enter' });
 
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(onSelect).toHaveBeenCalledWith(2);
       });
 
-      input.selectionStart = 2;
-      input.selectionEnd = 2;
+      test('clicking option hides all options', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+        await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      fireEvent.keyDown(listBox, { key: 'End' });
+        const listBox = screen.getByRole('listbox');
 
-      expect(input).toHaveFocus();
-      expect(input.selectionStart).toBe(4);
-      expect(input.selectionEnd).toBe(4);
-    });
+        fireEvent.keyDown(listBox, { key: 'ArrowUp' });
+        fireEvent.keyDown(listBox, { key: 'Enter' });
 
-    test('pressing Enter calls `onSelect` handler with selected item index', () => {
-      const onSelect = jest.fn();
-
-      const { container, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={onSelect}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
-
-      const input = getByLabelText('Choose option') as HTMLInputElement;
-
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(screen.queryAllByRole('option')).toHaveLength(0);
       });
 
-      expect(onSelect).not.toHaveBeenCalled();
+      test('pressing Escape on list box options clears them and focuses input field', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+        const input = screen.getByLabelText(
+          'Choose option',
+        ) as HTMLInputElement;
 
-      fireEvent.keyDown(listBox, { key: 'ArrowUp' });
-      fireEvent.keyDown(listBox, { key: 'Enter' });
+        await userEvent.type(input, 'Test');
 
-      expect(onSelect).toHaveBeenCalledWith(2);
-    });
+        const listBox = screen.getByRole('listbox');
 
-    test('clicking option hides all options', () => {
-      const { container, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
+        expect(input).toHaveAttribute('value', 'Test');
+        expect(input).toHaveFocus();
+        expect(screen.queryAllByRole('option')).toHaveLength(3);
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
+        fireEvent.keyDown(listBox, { key: 'Escape' });
 
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(input).toHaveAttribute('value', '');
+        expect(input).toHaveFocus();
+        expect(screen.queryAllByRole('option')).toHaveLength(0);
+
+        fireEvent.keyDown(listBox, { key: 'Escape' });
+
+        expect(input).toHaveFocus();
       });
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+      test('pressing Escape on input field clears it and clears the list box options', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      fireEvent.keyDown(listBox, { key: 'ArrowUp' });
-      fireEvent.keyDown(listBox, { key: 'Enter' });
+        const input = screen.getByLabelText(
+          'Choose option',
+        ) as HTMLInputElement;
 
-      expect(container.querySelectorAll('[role="option"]')).toHaveLength(0);
-    });
+        await userEvent.type(input, 'Test');
 
-    test('pressing Escape on list box options clears them and focuses input field', () => {
-      const { container, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
+        expect(input).toHaveAttribute('value', 'Test');
+        expect(screen.queryAllByRole('option')).toHaveLength(3);
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
+        fireEvent.keyDown(input, { key: 'Escape' });
 
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(input).toHaveAttribute('value', '');
+        expect(screen.queryAllByRole('option')).toHaveLength(0);
       });
 
-      const listBox = container.querySelector(
-        '[role="listbox"]',
-      ) as HTMLElement;
+      test('clicking option calls `onSelect` handler', async () => {
+        const onSelect = jest.fn();
 
-      expect(input).toHaveAttribute('value', 'Test');
-      expect(input).not.toHaveFocus();
-      expect(container.querySelectorAll('[role="option"]')).toHaveLength(3);
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={onSelect}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      fireEvent.keyDown(listBox, { key: 'Escape' });
+        await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      expect(input).toHaveAttribute('value', '');
-      expect(input).toHaveFocus();
-      expect(container.querySelectorAll('[role="option"]')).toHaveLength(0);
-    });
+        expect(onSelect).not.toHaveBeenCalled();
 
-    test('pressing Escape on input field clears it and clears the list box options', () => {
-      const { container, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
+        fireEvent.click(screen.getByText('Option 2'));
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
-
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(onSelect).toHaveBeenCalledWith(1);
       });
 
-      expect(input).toHaveAttribute('value', 'Test');
-      expect(container.querySelectorAll('[role="option"]')).toHaveLength(3);
+      test('clicking option hides all options', async () => {
+        render(
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />,
+        );
 
-      fireEvent.keyDown(input, { key: 'Escape' });
+        await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      expect(input).toHaveAttribute('value', '');
-      expect(container.querySelectorAll('[role="option"]')).toHaveLength(0);
-    });
+        fireEvent.click(screen.getByText('Option 2'));
 
-    test('clicking option calls `onSelect` handler', () => {
-      const onSelect = jest.fn();
-
-      const { getByText, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={onSelect}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
-      );
-
-      const input = getByLabelText('Choose option') as HTMLInputElement;
-
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
+        expect(screen.queryAllByRole('option')).toHaveLength(0);
       });
 
-      expect(onSelect).not.toHaveBeenCalled();
+      test('clicking outside of combobox hides options', async () => {
+        render(
+          <div>
+            <p id="outside">Target</p>
 
-      fireEvent.click(getByText('Option 2'));
+            <FormComboBox
+              id="test-combobox"
+              inputLabel="Choose option"
+              onInputChange={noop}
+              onSelect={noop}
+              options={['Option 1', 'Option 2', 'Option 3']}
+            />
+          </div>,
+        );
 
-      expect(onSelect).toHaveBeenCalledWith(1);
+        await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
+
+        expect(screen.queryAllByRole('option')).toHaveLength(3);
+
+        fireEvent.click(screen.getByText('Target'));
+
+        expect(screen.queryAllByRole('option')).toHaveLength(0);
+      });
     });
-
-    test('clicking option hides all options', () => {
-      const { container, getByText, getByLabelText } = render(
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />,
+    test('re-clicking combobox re-renders options', async () => {
+      render(
+        <div>
+          <p id="outside">Target</p>
+          <FormComboBox
+            id="test-combobox"
+            inputLabel="Choose option"
+            onInputChange={noop}
+            onSelect={noop}
+            options={['Option 1', 'Option 2', 'Option 3']}
+          />
+        </div>,
       );
 
-      const input = getByLabelText('Choose option') as HTMLInputElement;
+      await userEvent.type(screen.getByLabelText('Choose option'), 'Test');
 
-      fireEvent.change(input, {
-        target: {
-          value: 'Test',
-        },
-      });
+      fireEvent.click(screen.getByText('Target'));
 
-      fireEvent.click(getByText('Option 2'));
+      expect(screen.queryAllByRole('option')).toHaveLength(0);
 
-      expect(container.querySelectorAll('[role="option"]')).toHaveLength(0);
+      fireEvent.click(screen.getByLabelText('Choose option'));
+
+      expect(screen.queryAllByRole('option')).toHaveLength(3);
     });
-  });
-
-  test('clicking outside of combobox hides options', () => {
-    const { container, getByText, getByLabelText } = render(
-      <div>
-        <p id="outside">Target</p>
-
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />
-      </div>,
-    );
-
-    const input = getByLabelText('Choose option') as HTMLInputElement;
-
-    fireEvent.change(input, {
-      target: {
-        value: 'Test',
-      },
-    });
-
-    expect(container.querySelectorAll('[role="option"]')).toHaveLength(3);
-
-    fireEvent.click(getByText('Target'));
-
-    expect(container.querySelectorAll('[role="option"]')).toHaveLength(0);
-  });
-
-  test('re-clicking combobox re-renders options', () => {
-    const { container, getByText, getByLabelText } = render(
-      <div>
-        <p id="outside">Target</p>
-
-        <FormComboBox
-          id="test-combobox"
-          inputLabel="Choose option"
-          onInputChange={() => {}}
-          onSelect={() => {}}
-          options={['Option 1', 'Option 2', 'Option 3']}
-        />
-      </div>,
-    );
-
-    const input = getByLabelText('Choose option') as HTMLInputElement;
-
-    fireEvent.change(input, {
-      target: {
-        value: 'Test',
-      },
-    });
-
-    fireEvent.click(getByText('Target'));
-
-    expect(container.querySelectorAll('[role="option"]')).toHaveLength(0);
-
-    fireEvent.click(getByLabelText('Choose option'));
-
-    expect(container.querySelectorAll('[role="option"]')).toHaveLength(3);
   });
 });

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormComboBox.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormComboBox.test.tsx.snap
@@ -1,81 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormComboBox renders with no options by default 1`] = `
-<div class="container"
-     role="none"
+<div
+  className="container"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  role="none"
 >
-  <div role="combobox"
-       aria-expanded="true"
-       aria-owns="test-combobox-options"
-       aria-haspopup="listbox"
-       class="govuk-form-group"
+  <label
+    className="govuk-label"
+    htmlFor="test-combobox-input"
   >
-    <label class="govuk-label"
-           for="test-combobox-input"
-    >
-      Choose option
-    </label>
-    <input type="text"
-           aria-autocomplete="list"
-           aria-controls="test-combobox-options"
-           class="govuk-input"
-           id="test-combobox-input"
-           value
-    >
-  </div>
+    Choose option
+  </label>
+  <input
+    aria-autocomplete="list"
+    aria-controls="test-combobox-options"
+    aria-expanded={true}
+    aria-haspopup="listbox"
+    className="searchInput govuk-input"
+    id="test-combobox-input"
+    onChange={[Function]}
+    onKeyDown={[Function]}
+    role="combobox"
+    type="text"
+    value=""
+  />
 </div>
 `;
 
 exports[`FormComboBox renders with options in correct order when input changes 1`] = `
-<div class="container"
-     role="none"
+<div
+  className="container"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  role="none"
 >
-  <div role="combobox"
-       aria-expanded="true"
-       aria-owns="test-combobox-options"
-       aria-haspopup="listbox"
-       class="govuk-form-group"
+  <label
+    className="govuk-label"
+    htmlFor="test-combobox-input"
   >
-    <label class="govuk-label"
-           for="test-combobox-input"
-    >
-      Choose option
-    </label>
-    <input type="text"
-           aria-autocomplete="list"
-           aria-controls="test-combobox-options"
-           class="govuk-input"
-           id="test-combobox-input"
-           value="Test"
-    >
-    <div role="alert"
-         class="optionsContainer"
-    >
-      <ul class="options"
-          id="test-combobox-options"
-          role="listbox"
-          tabindex="-1"
-      >
-        <li aria-selected="false"
-            id="test-combobox-option-0"
-            role="option"
-        >
-          Option 1
-        </li>
-        <li aria-selected="false"
-            id="test-combobox-option-1"
-            role="option"
-        >
-          Option 2
-        </li>
-        <li aria-selected="false"
-            id="test-combobox-option-2"
-            role="option"
-        >
-          Option 3
-        </li>
-      </ul>
-    </div>
-  </div>
+    Choose option
+  </label>
+  <input
+    aria-autocomplete="list"
+    aria-controls="test-combobox-options"
+    aria-expanded={true}
+    aria-haspopup="listbox"
+    className="searchInput govuk-input"
+    id="test-combobox-input"
+    onChange={[Function]}
+    onKeyDown={[Function]}
+    role="combobox"
+    type="text"
+    value=""
+  />
 </div>
 `;

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormComboBox.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormComboBox.test.tsx.snap
@@ -1,59 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormComboBox renders with no options by default 1`] = `
-<div
-  className="container"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  role="none"
+<div class="container"
+     role="none"
 >
-  <label
-    className="govuk-label"
-    htmlFor="test-combobox-input"
+  <label class="govuk-label"
+         for="test-combobox-input"
   >
     Choose option
   </label>
-  <input
-    aria-autocomplete="list"
-    aria-controls="test-combobox-options"
-    aria-expanded={true}
-    aria-haspopup="listbox"
-    className="searchInput govuk-input"
-    id="test-combobox-input"
-    onChange={[Function]}
-    onKeyDown={[Function]}
-    role="combobox"
-    type="text"
-    value=""
-  />
+  <input type="text"
+         role="combobox"
+         class="searchInput govuk-input"
+         id="test-combobox-input"
+         aria-autocomplete="list"
+         aria-haspopup="listbox"
+         aria-controls="test-combobox-options"
+         aria-expanded="true"
+         value
+  >
 </div>
 `;
 
 exports[`FormComboBox renders with options in correct order when input changes 1`] = `
-<div
-  className="container"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  role="none"
+<div class="container"
+     role="none"
 >
-  <label
-    className="govuk-label"
-    htmlFor="test-combobox-input"
+  <label class="govuk-label"
+         for="test-combobox-input"
   >
     Choose option
   </label>
-  <input
-    aria-autocomplete="list"
-    aria-controls="test-combobox-options"
-    aria-expanded={true}
-    aria-haspopup="listbox"
-    className="searchInput govuk-input"
-    id="test-combobox-input"
-    onChange={[Function]}
-    onKeyDown={[Function]}
-    role="combobox"
-    type="text"
-    value=""
-  />
+  <input type="text"
+         role="combobox"
+         class="searchInput govuk-input"
+         id="test-combobox-input"
+         aria-autocomplete="list"
+         aria-haspopup="listbox"
+         aria-controls="test-combobox-options"
+         aria-expanded="true"
+         value="Test"
+  >
+  <div class="optionsContainer"
+       role="alert"
+  >
+    <ul class="options"
+        id="test-combobox-options"
+        role="listbox"
+    >
+      <li aria-posinset="1"
+          aria-selected="false"
+          aria-setsize="3"
+          id="test-combobox-option-0"
+          role="option"
+          tabindex="-1"
+      >
+        Option 1
+      </li>
+      <li aria-posinset="2"
+          aria-selected="false"
+          aria-setsize="3"
+          id="test-combobox-option-1"
+          role="option"
+          tabindex="-1"
+      >
+        Option 2
+      </li>
+      <li aria-posinset="3"
+          aria-selected="false"
+          aria-setsize="3"
+          id="test-combobox-option-2"
+          role="option"
+          tabindex="-1"
+      >
+        Option 3
+      </li>
+    </ul>
+  </div>
 </div>
 `;


### PR DESCRIPTION
This PR addresses the following accessibility issues related to `PageSearchForm` & `FormComboBox` which are used on Find stats / Methodology pages.

* [EES-3028](https://dfedigital.atlassian.net/browse/EES-3028) - Ensure that all interactive components can be found both in and out of context for screen reader users
  * [EES-3029](https://dfedigital.atlassian.net/browse/EES-3029) - remove search button from `PageSearchForm` 
  * [EES-3030](https://dfedigital.atlassian.net/browse/EES-3030) - Fix the ability for screen reader users to find the search element 
  * [EES-3032](https://dfedigital.atlassian.net/browse/EES-3032) - Ensure that all interactive components can be found both in & out of context for screen reader users

Relevant changes:
* Added `aria-live="polite"` & `aria-atomic` to results label
* Adds two new aria-labels: `aria-posinset` (inform user where they are in the list) & `aria-setsize` (inform user how many items are in the list)
* Moves `role="combobox"` to `input` element


Example:
https://www.loom.com/share/66f7fb26d16c4b2f99ef7774724f025b (demonstrates using tabs + arrows etc.)

UI test run:
![image](https://user-images.githubusercontent.com/55030296/188491969-71f9951b-b114-4ba4-9d5f-82db78292666.png)
