### PR TITLE
EES-3686, EES-3684 - fix table-tool + data-catalogue accessibility issues

### DIFF
--- a/src/explore-education-statistics-common/src/components/Details.tsx
+++ b/src/explore-education-statistics-common/src/components/Details.tsx
@@ -141,7 +141,7 @@ const Details = ({
           data-testid={formatTestId(`Expand Details Section ${summary}`)}
         >
           {summary}
-          {hiddenText && <VisuallyHidden> {hiddenText}</VisuallyHidden>}
+          {hiddenText && <VisuallyHidden>{` ${hiddenText}`}</VisuallyHidden>}
         </span>
         {summaryAfter}
       </summary>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectForm.tsx
@@ -66,8 +66,12 @@ const SubjectForm = ({
         return {
           label: option.name,
           value: option.id,
-          hint: hasDetails ? (
-            <Details summary="More details" className="govuk-!-margin-bottom-2">
+          hint: hasDetails && (
+            <Details
+              summary="More details"
+              className="govuk-!-margin-bottom-2"
+              hiddenText={`for ${option.name}`}
+            >
               <h4>This subject includes the following data:</h4>
               <SummaryList>
                 {geographicLevels && (
@@ -89,7 +93,7 @@ const SubjectForm = ({
                 )}
               </SummaryList>
             </Details>
-          ) : null,
+          ),
         };
       }),
     [options],

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DownloadStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DownloadStep.tsx
@@ -98,7 +98,11 @@ const DownloadStep = ({
           label: `${subject.name} (${subject.file.extension}, ${subject.file.size})`,
           value: subject.file.id,
           hint: hasDetails ? (
-            <Details summary="More details" className="govuk-!-margin-bottom-2">
+            <Details
+              summary="More details"
+              className="govuk-!-margin-bottom-2"
+              hiddenText={`for ${subject.name}`}
+            >
               <h4>This subject includes the following data:</h4>
               <SummaryList>
                 {geographicLevels && (


### PR DESCRIPTION
This PR:
* Adds visually hidden text to the 'More details' dropdown displayed on step 2 + step 3 of the table tool & data-catalogue pages respectively. 

This addresses an accessibility issue where 'More details' are repeated multiple times on a page which can confuse screen readers / not provide them with enough context

Relevant changes:
* Updates `Details` components to ensure any visually hidden text has the appropriate spacing in the markup. 