### PR TITLE
EES-3683 - change OpenInNewTab defaultValue to be false

### DIFF
--- a/src/explore-education-statistics-admin/src/hooks/useCKEditorConfig.ts
+++ b/src/explore-education-statistics-admin/src/hooks/useCKEditorConfig.ts
@@ -101,7 +101,7 @@ const useCKEditorConfig = ({
           openInNewTab: {
             mode: 'manual',
             label: 'Open in a new tab',
-            defaultValue: true,
+            defaultValue: false,
             attributes: {
               target: '_blank',
               rel: 'noopener noreferrer',


### PR DESCRIPTION
This PR:
- changes the open in new tab CK editor functionality to always default to not open in a new tab. Currently, any links inserted into content blocks open in a new tab by default. As per conversations with Marv + information gathered from the DAC report, we should instead default this to false so that any links inserted into content blocks open in the current tab by default 