### PR TITLE
EES-3649 Add BAU endpoint to update public glossary cache

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -113,6 +114,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         }
 
         [Fact]
+        public async Task UpdatePublicCacheGlossary()
+        {
+            var glossaryCacheService = new Mock<IGlossaryCacheService>(Strict);
+
+            glossaryCacheService.Setup(s => s.UpdateGlossary())
+                .ReturnsAsync(new List<GlossaryCategoryViewModel>());
+
+            var controller = BuildController(glossaryCacheService: glossaryCacheService.Object);
+
+            var result = await controller.UpdatePublicCacheGlossary();
+
+            VerifyAllMocks(glossaryCacheService);
+
+            result.AssertNoContent();
+        }
+
+        [Fact]
         public async Task ClearPublicCacheReleases_SingleValidPath()
         {
             var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
@@ -215,7 +233,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var controller = BuildController(themeCacheService: themeCacheService.Object);
 
             var publicationTreeOption = ClearPublicCacheTreePathsViewModel.CacheEntry.PublicationTree.ToString();
-            
+
             var result = await controller.ClearPublicCacheTrees(
                 new ClearPublicCacheTreePathsViewModel
                 {
@@ -249,7 +267,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var publicationTreeOption = ClearPublicCacheTreePathsViewModel.CacheEntry.PublicationTree.ToString();
             var methodologyTreeOption = ClearPublicCacheTreePathsViewModel.CacheEntry.MethodologyTree.ToString();
-            
+
             var result = await controller.ClearPublicCacheTrees(
                 new ClearPublicCacheTreePathsViewModel
                 {
@@ -283,12 +301,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         private static BauCacheController BuildController(
             IBlobStorageService? privateBlobStorageService = null,
             IBlobStorageService? publicBlobStorageService = null,
+            IGlossaryCacheService? glossaryCacheService = null,
             IMethodologyCacheService? methodologyCacheService = null,
             IThemeCacheService? themeCacheService = null)
         {
             return new BauCacheController(
                 privateBlobStorageService ?? Mock.Of<IBlobStorageService>(Strict),
                 publicBlobStorageService ?? Mock.Of<IBlobStorageService>(Strict),
+                glossaryCacheService ?? Mock.Of<IGlossaryCacheService>(Strict),
                 methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
                 themeCacheService ?? Mock.Of<IThemeCacheService>(Strict)
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
@@ -222,7 +222,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         }
 
         [Fact]
-        public async Task ClearPublicCacheTrees_SingleValidCacheEntry()
+        public async Task UpdatePublicCacheTrees_SingleValidCacheEntry()
         {
             var themeCacheService = new Mock<IThemeCacheService>(Strict);
 
@@ -232,10 +232,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var controller = BuildController(themeCacheService: themeCacheService.Object);
 
-            var publicationTreeOption = ClearPublicCacheTreePathsViewModel.CacheEntry.PublicationTree.ToString();
+            var publicationTreeOption = UpdatePublicCacheTreePathsViewModel.CacheEntry.PublicationTree.ToString();
 
-            var result = await controller.ClearPublicCacheTrees(
-                new ClearPublicCacheTreePathsViewModel
+            var result = await controller.UpdatePublicCacheTrees(
+                new UpdatePublicCacheTreePathsViewModel
                 {
                     CacheEntries = SetOf(publicationTreeOption)
                 }
@@ -247,7 +247,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         }
 
         [Fact]
-        public async Task ClearPublicCacheTrees_AllValidCacheEntries()
+        public async Task UpdatePublicCacheTrees_AllValidCacheEntries()
         {
             var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
             var themeCacheService = new Mock<IThemeCacheService>(Strict);
@@ -265,11 +265,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 methodologyCacheService: methodologyCacheService.Object,
                 themeCacheService: themeCacheService.Object);
 
-            var publicationTreeOption = ClearPublicCacheTreePathsViewModel.CacheEntry.PublicationTree.ToString();
-            var methodologyTreeOption = ClearPublicCacheTreePathsViewModel.CacheEntry.MethodologyTree.ToString();
+            var publicationTreeOption = UpdatePublicCacheTreePathsViewModel.CacheEntry.PublicationTree.ToString();
+            var methodologyTreeOption = UpdatePublicCacheTreePathsViewModel.CacheEntry.MethodologyTree.ToString();
 
-            var result = await controller.ClearPublicCacheTrees(
-                new ClearPublicCacheTreePathsViewModel
+            var result = await controller.UpdatePublicCacheTrees(
+                new UpdatePublicCacheTreePathsViewModel
                 {
                     CacheEntries = new HashSet<string>
                     {
@@ -285,13 +285,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         }
 
         [Fact]
-        public async Task ClearPublicCacheTrees_Empty()
+        public async Task UpdatePublicCacheTrees_Empty()
         {
             var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
 
             var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
 
-            var result = await controller.ClearPublicCacheTrees(new ClearPublicCacheTreePathsViewModel());
+            var result = await controller.UpdatePublicCacheTrees(new UpdatePublicCacheTreePathsViewModel());
 
             VerifyAllMocks(publicBlobStorageService);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
@@ -25,17 +25,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
     {
         private readonly IBlobStorageService _privateBlobStorageService;
         private readonly IBlobStorageService _publicBlobStorageService;
+        private readonly IGlossaryCacheService _glossaryCacheService;
         private readonly IMethodologyCacheService _methodologyCacheService;
         private readonly IThemeCacheService _themeCacheService;
 
         public BauCacheController(
             IBlobStorageService privateBlobStorageService,
-            IBlobStorageService publicBlobStorageService, 
+            IBlobStorageService publicBlobStorageService,
+            IGlossaryCacheService glossaryCacheService,
             IMethodologyCacheService methodologyCacheService, 
             IThemeCacheService themeCacheService)
         {
             _privateBlobStorageService = privateBlobStorageService;
             _publicBlobStorageService = publicBlobStorageService;
+            _glossaryCacheService = glossaryCacheService;
             _methodologyCacheService = methodologyCacheService;
             _themeCacheService = themeCacheService;
         }
@@ -56,6 +59,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
                 );
             }
 
+            return NoContent();
+        }
+
+        [HttpPut("public-cache/glossary")]
+        public async Task<ActionResult> UpdatePublicCacheGlossary()
+        {
+            await _glossaryCacheService.UpdateGlossary();
             return NoContent();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
@@ -69,8 +69,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
             return NoContent();
         }
 
-        [HttpDelete("public-cache/trees")]
-        public async Task<ActionResult> ClearPublicCacheTrees(ClearPublicCacheTreePathsViewModel request)
+        [HttpPut("public-cache/trees")]
+        public async Task<ActionResult> UpdatePublicCacheTrees(UpdatePublicCacheTreePathsViewModel request)
         {
             if (request.CacheEntries.Any())
             {
@@ -81,18 +81,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
                         async entry =>
                         {
                             var allowedPath =
-                                EnumUtil.GetFromString<ClearPublicCacheTreePathsViewModel.CacheEntry>(entry);
+                                EnumUtil.GetFromString<UpdatePublicCacheTreePathsViewModel.CacheEntry>(entry);
                             
                             switch (allowedPath)
                             {
-                                case ClearPublicCacheTreePathsViewModel.CacheEntry.MethodologyTree: 
+                                case UpdatePublicCacheTreePathsViewModel.CacheEntry.MethodologyTree: 
                                     await _methodologyCacheService.UpdateSummariesTree();
                                     break;
-                                case ClearPublicCacheTreePathsViewModel.CacheEntry.PublicationTree:
+                                case UpdatePublicCacheTreePathsViewModel.CacheEntry.PublicationTree:
                                     await _themeCacheService.UpdatePublicationTree();
                                     break;
                                 default:
-                                    throw new ArgumentException($"Unsupported cache clearing entry {entry}");
+                                    throw new ArgumentException($"Unsupported cache entry {entry}");
                             }
                         });
             }
@@ -119,7 +119,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
             return NoContent();
         }
 
-        public class ClearPublicCacheTreePathsViewModel
+        public class UpdatePublicCacheTreePathsViewModel
         {
             public enum CacheEntry
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -78,6 +78,8 @@ using Notify.Interfaces;
 using Thinktecture;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Utils.StartupUtils;
+using IContentGlossaryService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IGlossaryService;
+using ContentGlossaryService = GovUk.Education.ExploreEducationStatistics.Content.Services.GlossaryService;
 using IContentMethodologyService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IMethodologyService;
 using ContentMethodologyService = GovUk.Education.ExploreEducationStatistics.Content.Services.MethodologyService;
 using ContentPublicationService = GovUk.Education.ExploreEducationStatistics.Content.Services.PublicationService;
@@ -406,9 +408,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             // TODO EES-3510 These services from the Content.Services namespace are used to update cached resources.
             // EES-3528 plans to send a request to the Content API to update its cached resources instead of this
             // being done from Admin directly, and so these DI dependencies should eventually be removed.
+            services.AddTransient<IContentGlossaryService, ContentGlossaryService>();
             services.AddTransient<IContentThemeService, ContentThemeService>();
             services.AddTransient<IContentMethodologyService, ContentMethodologyService>();
             services.AddTransient<IContentPublicationService, ContentPublicationService>();
+            services.AddTransient<IGlossaryCacheService, GlossaryCacheService>();
             services.AddTransient<IMethodologyCacheService, MethodologyCacheService>();
             services.AddTransient<IThemeCacheService, ThemeCacheService>();
             services.AddTransient<IPublicationCacheService, PublicationCacheService>();
@@ -617,6 +621,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                 provider => new BauCacheController(
                     privateBlobStorageService: GetBlobStorageService(provider, "CoreStorage"),
                     publicBlobStorageService: GetBlobStorageService(provider, "PublicStorage"),
+                    glossaryCacheService: provider.GetRequiredService<IGlossaryCacheService>(),
                     methodologyCacheService: provider.GetRequiredService<IMethodologyCacheService>(),
                     themeCacheService: provider.GetRequiredService<IThemeCacheService>()
                 )

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/GlossaryControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/GlossaryControllerTests.cs
@@ -10,7 +10,6 @@ using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
-using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers
 {
@@ -69,27 +68,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
             VerifyAllMocks(mocks);
 
             result.AssertOkResult(glossaryEntry);
-        }
-
-        [Fact]
-        public void GlossaryCategoryViewModel_SerialiseAndDeserialize()
-        {
-            var original = new GlossaryCategoryViewModel
-            {
-                Heading = "Glossary Category 1",
-                Entries = new List<GlossaryEntryViewModel>
-                {
-                    new()
-                    {
-                        Body = "A body",
-                        Slug = "A slug",
-                        Title = "A title"
-                    }
-                }
-            };
-
-            var converted = DeserializeObject<GlossaryCategoryViewModel>(SerializeObject(original));
-            converted.AssertDeepEqualTo(original);
         }
 
         private static (

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/GlossaryController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/GlossaryController.cs
@@ -1,11 +1,10 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Content.Api.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
@@ -13,21 +12,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
     [Route("api")]
     public class GlossaryController : ControllerBase
     {
+        private readonly IGlossaryCacheService _glossaryCacheService;
         private readonly IGlossaryService _glossaryService;
 
-        public GlossaryController(
+        public GlossaryController(IGlossaryCacheService glossaryCacheService,
             IGlossaryService glossaryService)
         {
+            _glossaryCacheService = glossaryCacheService;
             _glossaryService = glossaryService;
         }
 
         [HttpGet("glossary-entries")]
-        [BlobCache(typeof(GlossaryCacheKey))]
         public async Task<List<GlossaryCategoryViewModel>> GetAllGlossaryEntries()
         {
-            return await _glossaryService.GetAllGlossaryEntries();
+            return await _glossaryCacheService.GetGlossary();
         }
-        
+
         [HttpGet("glossary-entries/{slug}")]
         public async Task<ActionResult<GlossaryEntryViewModel>> GetGlossaryEntry(string slug)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -156,6 +156,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             services.AddTransient<IReleaseFileService, ReleaseFileService>();
             services.AddTransient<IReleaseDataFileRepository, ReleaseDataFileRepository>();
             services.AddTransient<IDataGuidanceFileWriter, DataGuidanceFileWriter>();
+            services.AddTransient<IGlossaryCacheService, GlossaryCacheService>();
             services.AddTransient<IGlossaryService, GlossaryService>();
 
             StartupSecurityConfiguration.ConfigureAuthorizationPolicies(services);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
@@ -9,6 +10,7 @@ using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
+using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cache;
 
@@ -86,6 +88,27 @@ public class GlossaryCacheServiceTests : CacheServiceTestFixture
         VerifyAllMocks(glossaryService, PublicBlobCacheService);
 
         Assert.Equal(_glossary, result);
+    }
+
+    [Fact]
+    public void GlossaryCategoryViewModel_SerializeAndDeserialize()
+    {
+        var original = new GlossaryCategoryViewModel
+        {
+            Heading = "Glossary Category 1",
+            Entries = new List<GlossaryEntryViewModel>
+            {
+                new()
+                {
+                    Body = "A body",
+                    Slug = "A slug",
+                    Title = "A title"
+                }
+            }
+        };
+
+        var converted = DeserializeObject<GlossaryCategoryViewModel>(SerializeObject(original));
+        converted.AssertDeepEqualTo(original);
     }
 
     private static GlossaryCacheService BuildService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
@@ -1,0 +1,99 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cache;
+
+[Collection(CacheServiceTests)]
+public class GlossaryCacheServiceTests : CacheServiceTestFixture
+{
+    private readonly List<GlossaryCategoryViewModel> _glossary = new()
+    {
+        new GlossaryCategoryViewModel()
+    };
+
+    [Fact]
+    public async Task GetGlossary_NoCachedGlossary()
+    {
+        var cacheKey = new GlossaryCacheKey();
+
+        PublicBlobCacheService
+            .Setup(s => s.GetItem(cacheKey, typeof(List<GlossaryCategoryViewModel>)))
+            .ReturnsAsync(null);
+
+        PublicBlobCacheService
+            .Setup(s => s.SetItem<object>(cacheKey, _glossary))
+            .Returns(Task.CompletedTask);
+
+        var glossaryService = new Mock<IGlossaryService>(Strict);
+
+        glossaryService
+            .Setup(s => s.GetAllGlossaryEntries())
+            .ReturnsAsync(_glossary);
+
+        var service = BuildService(glossaryService: glossaryService.Object);
+
+        var result = await service.GetGlossary();
+
+        VerifyAllMocks(glossaryService, PublicBlobCacheService);
+
+        Assert.Equal(_glossary, result);
+    }
+
+    [Fact]
+    public async Task GetGlossary_CachedGlossary()
+    {
+        PublicBlobCacheService
+            .Setup(s => s.GetItem(new GlossaryCacheKey(), typeof(List<GlossaryCategoryViewModel>)))
+            .ReturnsAsync(_glossary);
+
+        var service = BuildService();
+
+        var result = await service.GetGlossary();
+
+        VerifyAllMocks(PublicBlobCacheService);
+
+        Assert.Equal(_glossary, result);
+    }
+
+    [Fact]
+    public async Task UpdateGlossary()
+    {
+        var glossaryService = new Mock<IGlossaryService>(Strict);
+
+        glossaryService
+            .Setup(s => s.GetAllGlossaryEntries())
+            .ReturnsAsync(_glossary);
+
+        PublicBlobCacheService
+            .Setup(s => s.SetItem<object>(new GlossaryCacheKey(), _glossary))
+            .Returns(Task.CompletedTask);
+
+        var service = BuildService(glossaryService: glossaryService.Object);
+
+        var result = await service.UpdateGlossary();
+
+        // There should be no attempt on the cache service to get the cached resource
+
+        VerifyAllMocks(glossaryService, PublicBlobCacheService);
+
+        Assert.Equal(_glossary, result);
+    }
+
+    private static GlossaryCacheService BuildService(
+        IGlossaryService? glossaryService = null
+    )
+    {
+        return new GlossaryCacheService(
+            glossaryService: glossaryService ?? Mock.Of<IGlossaryService>(Strict)
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/MethodologyCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/MethodologyCacheServiceTests.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 using System;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/AllMethodologiesCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/AllMethodologiesCacheKey.cs
@@ -1,7 +1,8 @@
 ﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cache;
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
 
 public record AllMethodologiesCacheKey : IBlobCacheKey
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/GlossaryCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/GlossaryCacheKey.cs
@@ -2,7 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Cache
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache
 {
     public record GlossaryCacheKey : IBlobCacheKey
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/GlossaryCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/GlossaryCacheService.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
+
+public class GlossaryCacheService : IGlossaryCacheService
+{
+    private readonly IGlossaryService _glossaryService;
+
+    public GlossaryCacheService(IGlossaryService glossaryService)
+    {
+        _glossaryService = glossaryService;
+    }
+
+    [BlobCache(typeof(GlossaryCacheKey), ServiceName = "public")]
+    public Task<List<GlossaryCategoryViewModel>> GetGlossary()
+    {
+        return _glossaryService.GetAllGlossaryEntries();
+    }
+
+    [BlobCache(typeof(GlossaryCacheKey), forceUpdate: true, ServiceName = "public")]
+    public Task<List<GlossaryCategoryViewModel>> UpdateGlossary()
+    {
+        return _glossaryService.GetAllGlossaryEntries();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheKey.cs
@@ -1,8 +1,9 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache
 {
     public record PublicationCacheKey(string PublicationSlug) : IBlobCacheKey
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IGlossaryCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IGlossaryCacheService.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
+
+public interface IGlossaryCacheService
+{
+    Task<List<GlossaryCategoryViewModel>> GetGlossary();
+
+    Task<List<GlossaryCategoryViewModel>> UpdateGlossary();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
@@ -2,12 +2,12 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Extensions.Logging;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -2,11 +2,11 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
This PR adds a new BAU endpoint to update the publicly cached glossary with the latest glossary from the database.

`PUT /api/bau/public-cache/glossary`

### Other changes

* Rename `BauCacheController` method `ClearPublicCacheTrees` to `UpdatePublicCacheTrees` and change request verb from `DELETE` to `PUT` to reflect that it now updates the cache rather than deleting from it.
* Move `PublicationCacheKey` and `AllMethodologiesCacheKey` from namespace `Common.Cache` to `Content.Services.Cache` to match `GlossaryCacheKey` and `PublicationTreeCacheKey`.
* Update the Confluence page to add this new operation and reflect other recent changes.