### PR TITLE
Bugfix/EES-3648 Fix deserialisation error occurring when retrieving publications from blob cache

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
@@ -12,7 +12,6 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
-using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers
 {
@@ -108,20 +107,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
             VerifyAllMocks(methodologyCacheService);
 
             result.AssertOkResult(MethodologyThemes);
-        }
-
-        [Fact]
-        public void ThemeTree_SerialiseAndDeserialize()
-        {
-            var converted = DeserializeObject<ThemeTree<PublicationTreeNode>>(SerializeObject(Themes[0]));
-            converted.AssertDeepEqualTo(Themes[0]);
-        }
-
-        [Fact]
-        public void AllMethodologiesThemeViewModel_SerialiseAndDeserialize()
-        {
-            var converted = DeserializeObject<AllMethodologiesThemeViewModel>(SerializeObject(MethodologyThemes[0]));
-            converted.AssertDeepEqualTo(MethodologyThemes[0]);
         }
 
         private static ThemeController BuildController(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/MethodologyCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/MethodologyCacheServiceTests.cs
@@ -16,6 +16,7 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
+using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cache;
 
@@ -192,6 +193,44 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
         VerifyAllMocks(PublicBlobCacheService);
 
         result.AssertRight(new List<MethodologyVersionSummaryViewModel>());
+    }
+
+    [Fact]
+    public void AllMethodologiesThemeViewModel_SerializeAndDeserialize()
+    {
+        var viewModel = new AllMethodologiesThemeViewModel
+        {
+            Id = Guid.NewGuid(),
+            Title = "Publication title",
+            Topics = new List<AllMethodologiesTopicViewModel>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "Topic title",
+                    Publications = new List<AllMethodologiesPublicationViewModel>
+                    {
+                        new()
+                        {
+                            Id = Guid.NewGuid(),
+                            Title = "Publication title",
+                            Methodologies = new List<MethodologyVersionSummaryViewModel>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Slug = "methodology-slug",
+                                    Title = "Methodology title",
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var converted = DeserializeObject<AllMethodologiesThemeViewModel>(SerializeObject(viewModel));
+        converted.AssertDeepEqualTo(viewModel);
     }
 
     private static MethodologyCacheService SetupService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
@@ -11,6 +12,7 @@ using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
+using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cache;
 
@@ -21,7 +23,27 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
 
     private readonly PublicationViewModel _publicationViewModel = new()
     {
-        Id = Guid.NewGuid()
+        Id = Guid.NewGuid(),
+        Slug = "",
+        Title = "",
+        IsSuperseded = false,
+        Contact = new ContactViewModel
+        {
+            ContactName = "",
+            TeamEmail = "",
+            TeamName = "",
+            ContactTelNo = ""
+        },
+        ExternalMethodology = new ExternalMethodologyViewModel
+        {
+            Title = "",
+            Url = ""
+        },
+        LatestReleaseId = Guid.NewGuid(),
+        Methodologies = new List<MethodologyVersionSummaryViewModel>(),
+        LegacyReleases = new List<LegacyReleaseViewModel>(),
+        Releases = new List<ReleaseTitleViewModel>(),
+        Topic = new TopicViewModel(new ThemeViewModel(""))
     };
 
     [Fact]
@@ -94,6 +116,13 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
         VerifyAllMocks(publicationService, PublicBlobCacheService);
 
         result.AssertRight(_publicationViewModel);
+    }
+
+    [Fact]
+    public void PublicationViewModel_SerializeAndDeserialize()
+    {
+        var converted = DeserializeObject<PublicationViewModel>(SerializeObject(_publicationViewModel));
+        converted.AssertDeepEqualTo(_publicationViewModel);
     }
 
     private static PublicationCacheService BuildService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/ThemeCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/ThemeCacheServiceTests.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
@@ -14,9 +13,10 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
+using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cache;
- 
+
 [Collection(CacheServiceTests)]
 public class ThemeCacheServiceTests : CacheServiceTestFixture
 {
@@ -395,6 +395,27 @@ public class ThemeCacheServiceTests : CacheServiceTestFixture
         VerifyAllMocks(PublicBlobCacheService);
         
         publicationTree.AssertDeepEqualTo(filteredTree);
+    }
+
+    [Fact]
+    public void ThemeTree_SerializeAndDeserialize()
+    {
+        var themeTree = new ThemeTree<PublicationTreeNode>
+        {
+            Topics = new List<TopicTree<PublicationTreeNode>>
+            {
+                new()
+                {
+                    Publications = new List<PublicationTreeNode>
+                    {
+                        new()
+                    }
+                }
+            }
+        };
+
+        var converted = DeserializeObject<ThemeTree<PublicationTreeNode>>(SerializeObject(themeTree));
+        converted.AssertDeepEqualTo(themeTree);
     }
 
     private static async Task AssertPublicationTreeUnfiltered(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ContactViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ContactViewModel.cs
@@ -3,18 +3,25 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 
-public record ContactViewModel(
-    string TeamName,
-    string TeamEmail,
-    string ContactName,
-    string ContactTelNo)
+public record ContactViewModel
 {
-    public ContactViewModel(Contact contact) : this(
-        TeamName: contact.TeamName,
-        TeamEmail: contact.TeamEmail,
-        ContactName: contact.ContactName,
-        ContactTelNo: contact.ContactTelNo
-    )
+    public string TeamName { get; init; } = string.Empty;
+
+    public string TeamEmail { get; init; } = string.Empty;
+
+    public string ContactName { get; init; } = string.Empty;
+
+    public string ContactTelNo { get; init; } = string.Empty;
+
+    public ContactViewModel()
     {
+    }
+
+    public ContactViewModel(Contact contact)
+    {
+        TeamName = contact.TeamName;
+        TeamEmail = contact.TeamEmail;
+        ContactName = contact.ContactName;
+        ContactTelNo = contact.ContactTelNo;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ExternalMethodologyViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ExternalMethodologyViewModel.cs
@@ -4,14 +4,19 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 
-public record ExternalMethodologyViewModel(
-    string Title,
-    string Url)
+public record ExternalMethodologyViewModel
 {
-    public ExternalMethodologyViewModel(ExternalMethodology externalMethodology) : this(
-        Title: externalMethodology.Title,
-        Url: externalMethodology.Url
-    )
+    public string Title { get; init; } = string.Empty;
+
+    public string Url { get; init; } = string.Empty;
+
+    public ExternalMethodologyViewModel()
     {
+    }
+
+    public ExternalMethodologyViewModel(ExternalMethodology externalMethodology)
+    {
+        Title = externalMethodology.Title;
+        Url = externalMethodology.Url;
     }
 }


### PR DESCRIPTION
This PR adds default constructors to `ContactViewModel` and `ExternalMethodologyViewModel` to fix an error seen when deserializing `PublicationViewModel` from the public blob cache after https://github.com/dfe-analytical-services/explore-education-statistics/pull/3472 and adds a unit test for serialisation/deserialisation.

This error is visible in the app service logs when running the UI tests but did not cause any test failures.

### Other changes
- Move similar serialisation tests from `ThemeControllerTests` to `ThemeCacheServiceTests` and `MethodologyCacheServiceTests` since `ThemeController` isn't responsible for caching where the deserialisation happens.
