### PR TITLE
EES-3057 - address AccordionSection accesibility issues

### DIFF
--- a/src/explore-education-statistics-common/src/components/FigureFootnotes.tsx
+++ b/src/explore-education-statistics-common/src/components/FigureFootnotes.tsx
@@ -1,18 +1,22 @@
 import CollapsibleList from '@common/components/CollapsibleList';
+import { Footnote } from '@common/services/types/footnotes';
 import React from 'react';
+import VisuallyHidden from './VisuallyHidden';
 
 interface Props {
-  footnotes: {
-    id: string;
-    label: string;
-  }[];
+  footnotes: Footnote[];
+  headingHiddenText?: string;
 }
 
-const FigureFootnotes = ({ footnotes }: Props) => {
+const FigureFootnotes = ({ footnotes, headingHiddenText }: Props) => {
   return footnotes.length > 0 ? (
     <>
-      <h3 className="govuk-heading-m">Footnotes</h3>
-
+      <h3 className="govuk-heading-m">
+        Footnotes
+        {headingHiddenText && (
+          <VisuallyHidden>{` ${headingHiddenText}`}</VisuallyHidden>
+        )}
+      </h3>
       <CollapsibleList listStyle="number" collapseAfter={2} testId="footnotes">
         {footnotes.map(footnote => (
           <li key={footnote.id}>{footnote.label}</li>

--- a/src/explore-education-statistics-common/src/modules/charts/components/ChartRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/ChartRenderer.tsx
@@ -88,7 +88,10 @@ function ChartRenderer({
 
         {chart}
 
-        <FigureFootnotes footnotes={footnotes} />
+        <FigureFootnotes
+          footnotes={footnotes}
+          headingHiddenText={`for ${title}`}
+        />
 
         {source && <p className="govuk-body-s">Source: {source}</p>}
       </figure>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
@@ -14,11 +14,18 @@ interface Props extends OmitStrict<MultiHeaderTableProps, 'ariaLabelledBy'> {
   innerRef?: Ref<HTMLElement>;
   footnotes?: FullTableMeta['footnotes'];
   source?: string;
+  footnotesHeadingHiddenText?: string;
 }
 
 const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
   (props, ref) => {
-    const { caption, captionId, footnotes = [], source } = props;
+    const {
+      caption,
+      captionId,
+      footnotes = [],
+      source,
+      footnotesHeadingHiddenText,
+    } = props;
 
     const containerRef = useRef<HTMLDivElement>(null);
     const mainTableRef = useRef<HTMLTableElement>(null);
@@ -126,7 +133,10 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
           />
         </div>
 
-        <FigureFootnotes footnotes={footnotes} />
+        <FigureFootnotes
+          footnotes={footnotes}
+          headingHiddenText={footnotesHeadingHiddenText}
+        />
 
         {source && <p className="govuk-body-s">Source: {source}</p>}
       </figure>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -408,6 +408,7 @@ const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
             ref={dataTableRef}
             footnotes={subjectMeta.footnotes}
             source={source}
+            footnotesHeadingHiddenText={`for ${captionTitle}`}
           />
         </>
       );

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
@@ -13,6 +13,7 @@ import {
   logOutboundLink,
 } from '@frontend/services/googleAnalyticsService';
 import React from 'react';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 
 export interface PublicationSectionBlocksProps {
   release: Release;
@@ -53,6 +54,7 @@ const PublicationSectionBlocks = ({
                   <div className="dfe-print-hidden">
                     <h3 className="govuk-heading-m">
                       Explore and edit this data online
+                      <VisuallyHidden>{` for ${block.heading}`}</VisuallyHidden>
                     </h3>
 
                     <p>Use our table tool to explore this data.</p>


### PR DESCRIPTION
This PR: 
* Alters 'footnotes' & 'explore and edit this data online' sections on Accordion sections to have hidden text in order to provide more context for screen readers

![image](https://user-images.githubusercontent.com/55030296/190254302-996ec96a-4acf-4ab7-b9b6-05100aeb8959.png)
