### PR TITLE
EES-3685 - remove methodology heading from methodology listings

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/methodologies/components/MethodologyList.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/components/MethodologyList.tsx
@@ -16,26 +16,17 @@ function MethodologyList({ publications }: Props) {
   }
 
   return (
-    <ul>
+    <ul data-testid="methodology-list">
       {filteredPublications.map(publication => (
-        <li className="govuk-!-margin-bottom-2" key={publication.id}>
-          <h3
-            className="govuk-heading-s govuk-!-margin-bottom-0"
-            id={`methodology-heading-${publication.id}`}
-          >
-            {publication.title}
-          </h3>
-
-          <ul>
-            {publication.methodologies.map(methodology => (
-              <li key={methodology.id}>
-                <Link to={`/methodology/${methodology.slug}`}>
-                  {methodology.title}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </li>
+        <>
+          {publication.methodologies.map(methodology => (
+            <li key={methodology.id} className="govuk-!-margin-bottom-2">
+              <Link to={`/methodology/${methodology.slug}`}>
+                {methodology.title}
+              </Link>
+            </li>
+          ))}
+        </>
       ))}
     </ul>
   );

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -118,13 +118,11 @@ Verify that the methodology is visible on the public methodologies page with the
     user checks page contains methodology link
     ...    %{TEST_TOPIC_NAME}
     ...    ${PUBLICATION_NAME}
-    ...    ${PUBLICATION_NAME}
     ...    ${PUBLIC_METHODOLOGY_URL_ENDING}
 
 Verify that the methodology is publicly accessible
     user clicks methodology link
     ...    %{TEST_TOPIC_NAME}
-    ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME}
     user waits until h1 is visible    ${PUBLICATION_NAME}
     user waits until page contains title caption    Methodology
@@ -325,7 +323,6 @@ Verify that the amended methodology is visible on the public methodologies page
     user scrolls down    400
     user checks page contains methodology link
     ...    %{TEST_TOPIC_NAME}
-    ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME} - Amended methodology
     ...    ${PUBLIC_METHODOLOGY_URL_ENDING}
 

--- a/tests/robot-tests/tests/general_public/methodologies_page.robot
+++ b/tests/robot-tests/tests/general_public/methodologies_page.robot
@@ -23,14 +23,12 @@ Validate page contents
     user opens details dropdown    Exclusions
     user checks page contains methodology link
     ...    Exclusions
-    ...    Permanent and fixed-period exclusions in England
     ...    Pupil exclusion statistics: methodology
     ...    %{PUBLIC_URL}/methodology/permanent-and-fixed-period-exclusions-in-england
 
     user opens details dropdown    Pupil absence
     user checks page contains methodology link
     ...    Pupil absence
-    ...    Pupil absence in schools in England
     ...    Pupil absence statistics: methodology
     ...    %{PUBLIC_URL}/methodology/pupil-absence-in-schools-in-england
 

--- a/tests/robot-tests/tests/general_public/methodology_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/methodology_page_absence.robot
@@ -17,12 +17,10 @@ Navigate to Pupil absence in schools in England methodology page
 Go to Pupil absence methodology page
     user checks page contains methodology link
     ...    Pupil absence
-    ...    Pupil absence in schools in England
     ...    Pupil absence statistics: methodology
     ...    %{PUBLIC_URL}/methodology/pupil-absence-in-schools-in-england
     user clicks methodology link
     ...    Pupil absence
-    ...    Pupil absence in schools in England
     ...    Pupil absence statistics: methodology
     user waits until h1 is visible    Pupil absence statistics: methodology
     user waits until page contains title caption    Methodology

--- a/tests/robot-tests/tests/libs/fail_fast.py
+++ b/tests/robot-tests/tests/libs/fail_fast.py
@@ -1,6 +1,6 @@
 """
 This utility class is responsible for allowing us to control the fail-fast behaviour of Robot Test Suites if one of
-their Tests fails.  If the "fail tests suites fast" option is enabled, this file's methods are called from Robot
+their Tests fails. If the "fail tests suites fast" option is enabled, this file's methods are called from Robot
 scripts, firstly to record that a test suite is failing, and then again on subsequent Tests starting to see if they
 should continue to run or if they should fail immediately and therefore fail the test suite immediately.
 """

--- a/tests/robot-tests/tests/libs/public-utilities.py
+++ b/tests/robot-tests/tests/libs/public-utilities.py
@@ -61,38 +61,30 @@ def user_checks_other_release_is_shown_in_position(release_name, position):
 
 
 # Methodology
-def user_checks_page_contains_methodology_link(topic, publication, methodology, link_url_ending):
-    link = get_methodology_link(topic, publication, methodology)
+def user_checks_page_contains_methodology_link(topic, methodology, link_url_ending):
+    link = get_methodology_link(topic, methodology)
 
     if not link.get_attribute('href').endswith(link_url_ending):
         raise_assertion_error(
-            f'Methodology link with title "{methodology}" should be linking to "{link_url}", but is '
+            f'Methodology link with title "{methodology}" should be linking to "{link_url_ending}", but is '
             f'linking to "{link.get_attribute("href")}" instead!')
 
 
-def user_clicks_methodology_link(topic, publication, methodology):
-    get_methodology_link(topic, publication, methodology).click()
+def user_clicks_methodology_link(topic, methodology):
+    get_methodology_link(topic, methodology).click()
 
 
-def get_methodology_link(topic, publication, methodology):
+def get_methodology_link(topic, methodology):
     try:
         sl.driver.find_element(By.XPATH, f'//summary/span[text()="{topic}"]')
     except BaseException:
         raise_assertion_error(f'Cannot find theme "{topic}" on page')
 
     try:
-        sl.driver.find_element(By.XPATH,
-                               f'//summary/span[text()="{topic}"]/../..//h3[text()="{publication}"]')
-    except BaseException:
-        raise_assertion_error(f'Topic "{topic}" doesn\'t contain publication "{publication}"!')
-
-    try:
-        return sl.driver.find_element(By.XPATH,
-                                      f'//h3[text()="{publication}"]/..//a[text()="{methodology}"]')
+        return sl.driver.find_element(By.XPATH, f'//*[@data-testid="methodology-list"]//li//a[text()="{methodology}"]')
     except BaseException:
         raise_assertion_error(
             f'Could not find methodology link with title "{methodology}""!')
-
 
 # Table tool
 def user_checks_generated_permalink_is_valid():


### PR DESCRIPTION
This PR removes methodology headings from the methoolody index page in order to improve accesibility. 


- [x]  Fix methodology UI test python utils (`get_methodology_` variations) - add testid?

![image](https://user-images.githubusercontent.com/55030296/190245098-5cc92e9b-e868-46bb-ab84-570f787741ea.png)

