### PR TITLE
Bugfix/EES-3648 Fix deserialisation error occurring when retrieving publications from blob cache

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -39,9 +39,33 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
             Url = ""
         },
         LatestReleaseId = Guid.NewGuid(),
-        Methodologies = new List<MethodologyVersionSummaryViewModel>(),
-        LegacyReleases = new List<LegacyReleaseViewModel>(),
-        Releases = new List<ReleaseTitleViewModel>(),
+        Methodologies = new List<MethodologyVersionSummaryViewModel>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Slug = "",
+                Title = ""
+            }
+        },
+        LegacyReleases = new List<LegacyReleaseViewModel>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Description = "",
+                Url = ""
+            }
+        },
+        Releases = new List<ReleaseTitleViewModel>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Slug = "",
+                Title = ""
+            }
+        },
         Topic = new TopicViewModel(new ThemeViewModel(""))
     };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/LegacyReleaseViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/LegacyReleaseViewModel.cs
@@ -4,13 +4,22 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 
-public record LegacyReleaseViewModel(Guid Id, string Description, string Url)
+public record LegacyReleaseViewModel
 {
-    public LegacyReleaseViewModel(LegacyRelease legacyRelease) : this(
-        Id: legacyRelease.Id,
-        Description: legacyRelease.Description,
-        Url: legacyRelease.Url
-    )
+    public LegacyReleaseViewModel()
     {
     }
+
+    public LegacyReleaseViewModel(LegacyRelease legacyRelease)
+    {
+        Id = legacyRelease.Id;
+        Description = legacyRelease.Description;
+        Url = legacyRelease.Url;
+    }
+
+    public Guid Id { get; init; }
+
+    public string Description { get; init; } = string.Empty;
+
+    public string Url { get; init; } = string.Empty;
 }


### PR DESCRIPTION
This PR adds a default constructor to `LegacyReleaseViewModel` to fix an error seen when deserializing `PublicationViewModel` from the public blob cache after https://github.com/dfe-analytical-services/explore-education-statistics/pull/3472.

It also enhances `PublicationCacheServiceTests.PublicationViewModel_SerializeAndDeserialize` to make sure that `LegacyReleases`, `Methodologies` and `Releases` are covered by the test.