### PR TITLE
EES-3666 New Admin API endpoints for getting/updating/removing ExternalMethodology

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -402,6 +402,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task UpdateExternalMethodology()
+        {
+            var publication = new Publication
+            {
+                ExternalMethodology = new ExternalMethodology
+                {
+                    Title = "Test external methodology",
+                    Url = "http://test.external.methodology",
+                }
+            };
+
+            await PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(publication, SecurityPolicies.CanUpdateSpecificPublication)
+                .AssertForbidden(async userService =>
+                {
+                    var contentDbContext = InMemoryApplicationDbContext();
+                    await contentDbContext.Publications.AddAsync(publication);
+                    await contentDbContext.SaveChangesAsync();
+
+                    var service = BuildPublicationService(
+                        context: contentDbContext,
+                        userService: userService.Object);
+                    return await service.UpdateExternalMethodology(publication.Id, new ExternalMethodology());
+                });
+        }
+
+        [Fact]
         public void ListActiveReleases()
         {
             var userService = AlwaysTrueUserService();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -375,7 +375,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void GetLatestReleaseVersions()
+        public async Task GetExternalMethodology()
+        {
+            var publication = new Publication
+            {
+                ExternalMethodology = new ExternalMethodology
+                {
+                    Title = "Test external methodology",
+                    Url = "http://test.external.methodology",
+                }
+            };
+
+            await PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(publication, SecurityPolicies.CanViewSpecificPublication)
+                .AssertForbidden(async userService =>
+                {
+                    var contentDbContext = InMemoryApplicationDbContext();
+                    await contentDbContext.Publications.AddAsync(publication);
+                    await contentDbContext.SaveChangesAsync();
+
+                    var service = BuildPublicationService(
+                        context: contentDbContext,
+                        userService: userService.Object);
+                    return await service.GetExternalMethodology(publication.Id);
+                });
+        }
+
+        [Fact]
+        public void ListActiveReleases()
         {
             var userService = AlwaysTrueUserService();
             var publicationService = BuildPublicationService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -429,6 +429,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task RemoveExternalMethodology()
+        {
+            var publication = new Publication
+            {
+                ExternalMethodology = new ExternalMethodology
+                {
+                    Title = "Test external methodology",
+                    Url = "http://test.external.methodology",
+                }
+            };
+
+            await PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(publication, SecurityPolicies.CanUpdateSpecificPublication)
+                .AssertForbidden(async userService =>
+                {
+                    var contentDbContext = InMemoryApplicationDbContext();
+                    await contentDbContext.Publications.AddAsync(publication);
+                    await contentDbContext.SaveChangesAsync();
+
+                    var service = BuildPublicationService(
+                        context: contentDbContext,
+                        userService: userService.Object);
+                    return await service.RemoveExternalMethodology(publication.Id);
+                });
+        }
+
+        [Fact]
         public void ListActiveReleases()
         {
             var userService = AlwaysTrueUserService();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -424,7 +424,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     var service = BuildPublicationService(
                         context: contentDbContext,
                         userService: userService.Object);
-                    return await service.UpdateExternalMethodology(publication.Id, new ExternalMethodology());
+                    return await service.UpdateExternalMethodology(publication.Id, new ExternalMethodologySaveRequest());
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -2953,6 +2953,66 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task GetExternalMethodology()
+        {
+            var publication = new Publication
+            {
+                ExternalMethodology = new ExternalMethodology
+                {
+                    Title = "Test external methodology",
+                    Url = "http://test.external.methodology",
+                }
+            };
+
+            var contentDbContext = InMemoryApplicationDbContext();
+            await contentDbContext.Publications.AddAsync(publication);
+            await contentDbContext.SaveChangesAsync();
+
+            var service = BuildPublicationService(context: contentDbContext);
+
+            var result = await service.GetExternalMethodology(publication.Id);
+            var externalMethodology = result.AssertRight();
+
+            Assert.Equal(publication.ExternalMethodology.Title, externalMethodology.Title);
+            Assert.Equal(publication.ExternalMethodology.Url, externalMethodology.Url);
+        }
+
+        [Fact]
+        public async Task GetExternalMethodology_NoPublication()
+        {
+            var contentDbContext = InMemoryApplicationDbContext();
+
+            var service = BuildPublicationService(context: contentDbContext);
+
+            var result = await service.GetExternalMethodology(Guid.NewGuid());
+            result.AssertNotFound();
+        }
+
+        [Fact]
+        public async Task GetExternalMethodology_NoExternalMethodology()
+        {
+            var publication = new Publication
+            {
+                ExternalMethodology = null,
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.Publications.AddAsync(publication);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = BuildPublicationService(context: contentDbContext);
+
+                var result = await service.GetExternalMethodology(publication.Id);
+                result.AssertNotFound();
+            }
+        }
+
+        [Fact]
         public async Task ListActiveReleases()
         {
             var release1Original = new Release

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -3075,6 +3075,50 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task RemoveExternalMethodology()
+        {
+            var publication = new Publication
+            {
+                ExternalMethodology = new ExternalMethodology
+                {
+                    Title = "Original external methodology",
+                    Url = "http://test.external.methodology/original",
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.Publications.AddAsync(publication);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = BuildPublicationService(context: contentDbContext);
+
+                var result = await service.RemoveExternalMethodology(publication.Id);
+                result.AssertRight();
+
+                var dbPublication = contentDbContext.Publications
+                    .Single(p => p.Id == publication.Id);
+
+                Assert.Null(dbPublication.ExternalMethodology);
+            }
+        }
+
+        [Fact]
+        public async Task RemoveExternalMethodology_NoPublication()
+        {
+            var contentDbContext = InMemoryApplicationDbContext();
+            var service = BuildPublicationService(context: contentDbContext);
+
+            var result = await service.RemoveExternalMethodology(publicationId: Guid.NewGuid());
+
+            result.AssertNotFound();
+        }
+
+        [Fact]
         public async Task ListActiveReleases()
         {
             var release1Original = new Release

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -3034,15 +3034,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var service = BuildPublicationService(context: contentDbContext);
+                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+                publicationCacheService.Setup(s => s.UpdatePublication(publication.Slug))
+                    .ReturnsAsync(new PublicationViewModel());
+
+                var service = BuildPublicationService(context: contentDbContext,
+                    publicationCacheService: publicationCacheService.Object);
 
                 var result = await service.UpdateExternalMethodology(
                     publication.Id,
-                    new ExternalMethodology
+                    new ExternalMethodologySaveRequest
                     {
                         Title = "New external methodology",
                         Url = "http://test.external.methodology/new",
                     });
+
+                VerifyAllMocks(publicationCacheService);
+
                 var externalMethodology = result.AssertRight();
 
                 Assert.Equal("New external methodology", externalMethodology.Title);
@@ -3065,7 +3073,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var result = await service.UpdateExternalMethodology(
                 publicationId: Guid.NewGuid(),
-                new ExternalMethodology
+                new ExternalMethodologySaveRequest
                 {
                     Title = "New external methodology",
                     Url = "http://test.external.methodology/new",
@@ -3095,9 +3103,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var service = BuildPublicationService(context: contentDbContext);
+                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+                publicationCacheService.Setup(s => s.UpdatePublication(publication.Slug))
+                    .ReturnsAsync(new PublicationViewModel());
+                var service = BuildPublicationService(context: contentDbContext,
+                    publicationCacheService: publicationCacheService.Object);
 
                 var result = await service.RemoveExternalMethodology(publication.Id);
+
+                VerifyAllMocks(publicationCacheService);
+
                 result.AssertRight();
 
                 var dbPublication = contentDbContext.Publications

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -70,6 +71,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         {
             return await _publicationService
                 .GetPublication(publicationId)
+                .HandleFailuresOrOk();
+        }
+
+        [HttpGet("api/publication/{publicationId:guid}/external-methodology")]
+        public async Task<ActionResult<ExternalMethodologyViewModel>> GetExternalMethodology(Guid publicationId)
+        {
+            return await _publicationService.GetExternalMethodology(publicationId)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
@@ -88,6 +89,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             return await _publicationService.UpdateExternalMethodology(publicationId, updatedExternalMethodology)
                 .HandleFailuresOrOk();
         }
+
+        [HttpDelete("api/publication/{publicationId:guid}/external-methodology")]
+        public async Task<ActionResult<Unit>> RemoveExternalMethodology(
+            Guid publicationId)
+        {
+            return await _publicationService.RemoveExternalMethodology(publicationId)
+                .HandleFailuresOrOk();
+        }
+
 
         [HttpGet("api/publication/{publicationId}/releases")]
         public async Task<ActionResult<PaginatedListViewModel<ReleaseSummaryViewModel>>> ListActiveReleases(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -9,12 +9,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using LegacyReleaseViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.LegacyReleaseViewModel;
-using PublicationViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.PublicationViewModel;
-using ReleaseSummaryViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ReleaseSummaryViewModel;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 {
@@ -84,7 +80,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 
         [HttpPut("api/publication/{publicationId:guid}/external-methodology")]
         public async Task<ActionResult<ExternalMethodologyViewModel>> UpdateExternalMethodology(
-            Guid publicationId, ExternalMethodology updatedExternalMethodology)
+            Guid publicationId, ExternalMethodologySaveRequest updatedExternalMethodology)
         {
             return await _publicationService.UpdateExternalMethodology(publicationId, updatedExternalMethodology)
                 .HandleFailuresOrOk();
@@ -95,7 +91,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             Guid publicationId)
         {
             return await _publicationService.RemoveExternalMethodology(publicationId)
-                .HandleFailuresOrOk();
+                .HandleFailuresOrNoContent();
         }
 
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -81,6 +81,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
+        [HttpPut("api/publication/{publicationId:guid}/external-methodology")]
+        public async Task<ActionResult<ExternalMethodologyViewModel>> UpdateExternalMethodology(
+            Guid publicationId, ExternalMethodology updatedExternalMethodology)
+        {
+            return await _publicationService.UpdateExternalMethodology(publicationId, updatedExternalMethodology)
+                .HandleFailuresOrOk();
+        }
+
         [HttpGet("api/publication/{publicationId}/releases")]
         public async Task<ActionResult<PaginatedListViewModel<ReleaseSummaryViewModel>>> ListActiveReleases(
             [Required] Guid publicationId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -6,12 +6,19 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
-using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using ContactViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ContactViewModel;
+using LegacyReleaseViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.LegacyReleaseViewModel;
+using MethodologyNoteViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology.MethodologyNoteViewModel;
+using MethodologyVersionViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology.MethodologyVersionViewModel;
 using PublicationViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.PublicationViewModel;
+using ReleaseSummaryViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ReleaseSummaryViewModel;
 using ReleaseViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ReleaseViewModel;
+using ThemeViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ThemeViewModel;
+using TopicViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.TopicViewModel;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 {
@@ -74,6 +81,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                 .ForMember(
                     dest => dest.Theme,
                     m => m.MapFrom(p => p.Topic.Theme));
+
+            CreateMap<ExternalMethodology, ExternalMethodologyViewModel>();
 
             CreateMap<Publication, MyPublicationViewModel>()
                 .ForMember(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -3,22 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
-using ContactViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ContactViewModel;
-using LegacyReleaseViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.LegacyReleaseViewModel;
-using MethodologyNoteViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology.MethodologyNoteViewModel;
-using MethodologyVersionViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology.MethodologyVersionViewModel;
-using PublicationViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.PublicationViewModel;
-using ReleaseSummaryViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ReleaseSummaryViewModel;
-using ReleaseViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ReleaseViewModel;
-using ThemeViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ThemeViewModel;
-using TopicViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.TopicViewModel;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 {
@@ -81,8 +73,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                 .ForMember(
                     dest => dest.Theme,
                     m => m.MapFrom(p => p.Topic.Theme));
-
-            CreateMap<ExternalMethodology, ExternalMethodologyViewModel>();
 
             CreateMap<Publication, MyPublicationViewModel>()
                 .ForMember(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ExternalMethodologySaveRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ExternalMethodologySaveRequest.cs
@@ -1,0 +1,11 @@
+#nullable enable
+using System.ComponentModel.DataAnnotations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+
+public class ExternalMethodologySaveRequest
+{
+    [Required] public string Title { get; set; } = string.Empty;
+
+    [Required] [Url] public string Url { get; set; } = string.Empty;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/PublicationSaveRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/PublicationSaveRequest.cs
@@ -15,8 +15,6 @@ public record PublicationSaveRequest
 
         [Required] public Guid TopicId { get; set; }
 
-        public ExternalMethodology? ExternalMethodology { get; set; } = null;
-
         [Required] public ContactSaveViewModel Contact { get; set; } = null!;
 
         private string _slug = Empty;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using LegacyReleaseViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.LegacyReleaseViewModel;
@@ -31,6 +32,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             PublicationSaveRequest updatedPublication);
 
         Task<Either<ActionResult, PublicationViewModel>> GetPublication(Guid publicationId);
+
+        Task<Either<ActionResult, ExternalMethodologyViewModel>> GetExternalMethodology(Guid publicationId);
 
         Task<Either<ActionResult, PaginatedListViewModel<ReleaseSummaryViewModel>>> ListActiveReleasesPaginated(
             Guid publicationId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -6,11 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
-using LegacyReleaseViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.LegacyReleaseViewModel;
-using PublicationViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.PublicationViewModel;
-using ReleaseSummaryViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ReleaseSummaryViewModel;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
@@ -36,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, ExternalMethodologyViewModel>> GetExternalMethodology(Guid publicationId);
 
         Task<Either<ActionResult, ExternalMethodologyViewModel>> UpdateExternalMethodology(
-            Guid publicationId, ExternalMethodology updatedExternalMethodology);
+            Guid publicationId, ExternalMethodologySaveRequest updatedExternalMethodology);
 
         Task<Either<ActionResult, Unit>> RemoveExternalMethodology(
             Guid publicationId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -35,6 +35,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, ExternalMethodologyViewModel>> GetExternalMethodology(Guid publicationId);
 
+        Task<Either<ActionResult, ExternalMethodologyViewModel>> UpdateExternalMethodology(
+            Guid publicationId, ExternalMethodology updatedExternalMethodology);
+
         Task<Either<ActionResult, PaginatedListViewModel<ReleaseSummaryViewModel>>> ListActiveReleasesPaginated(
             Guid publicationId,
             int page,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -38,6 +38,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, ExternalMethodologyViewModel>> UpdateExternalMethodology(
             Guid publicationId, ExternalMethodology updatedExternalMethodology);
 
+        Task<Either<ActionResult, Unit>> RemoveExternalMethodology(
+            Guid publicationId);
+
         Task<Either<ActionResult, PaginatedListViewModel<ReleaseSummaryViewModel>>> ListActiveReleasesPaginated(
             Guid publicationId,
             int page,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -263,7 +263,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             {
                 return methodologyVersionToUpdate;
             }
-            
+
             return await _methodologyApprovalService
                 .UpdateApprovalStatus(methodologyVersionToUpdate.Id, request)
                 .OnSuccess(_ => _context
@@ -333,8 +333,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                     var methodologyVersionIdsInDeleteOrder = VersionedEntityDeletionOrderUtil
                         .Sort(methodologyVersionIds)
                         .Select(ids => Guid.Parse(ids.Id));
-                        
-                    return await methodologyVersionIdsInDeleteOrder    
+
+                    return await methodologyVersionIdsInDeleteOrder
                         .Select(methodologyVersionId => methodology.Versions.Single(version => version.Id == methodologyVersionId))
                         .Select(methodologyVersion => DeleteVersion(methodologyVersion, forceDelete))
                         .OnSuccessAll()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -351,6 +351,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
+        public async Task<Either<ActionResult, Unit>> RemoveExternalMethodology(
+            Guid publicationId)
+        {
+            return await _persistenceHelper
+                .CheckEntityExists<Publication>(publicationId)
+                .OnSuccessDo(_userService.CheckCanUpdatePublication)
+                .OnSuccess(publication =>
+                {
+                    _context.Update(publication);
+                    publication.ExternalMethodology = null;
+                    _context.SaveChangesAsync();
+
+                    return Unit.Instance;
+                });
+        }
+
         public async Task<Either<ActionResult, PaginatedListViewModel<ReleaseSummaryViewModel>>>
             ListActiveReleasesPaginated(
                 Guid publicationId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -335,6 +335,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     : NotFound<ExternalMethodologyViewModel>());
         }
 
+        public async Task<Either<ActionResult, ExternalMethodologyViewModel>> UpdateExternalMethodology(
+            Guid publicationId, ExternalMethodology updatedExternalMethodology)
+        {
+            return await _persistenceHelper
+                .CheckEntityExists<Publication>(publicationId)
+                .OnSuccessDo(_userService.CheckCanUpdatePublication)
+                .OnSuccess(publication =>
+                {
+                    _context.Update(publication);
+                    publication.ExternalMethodology = updatedExternalMethodology;
+                    _context.SaveChangesAsync();
+
+                    return _mapper.Map<ExternalMethodologyViewModel>(updatedExternalMethodology);
+                });
+        }
+
         public async Task<Either<ActionResult, PaginatedListViewModel<ReleaseSummaryViewModel>>>
             ListActiveReleasesPaginated(
                 Guid publicationId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -179,7 +179,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         Summary = publication.Summary,
                         TopicId = publication.TopicId,
                         Slug = publication.Slug,
-                        ExternalMethodology = publication.ExternalMethodology
                     });
 
                     await _context.SaveChangesAsync();
@@ -240,10 +239,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         publication.Slug = updatedPublication.Slug;
                     }
 
+                    // ExternalMethodology is absent as it's updated by a different endpoint
                     publication.Title = updatedPublication.Title;
                     publication.Summary = updatedPublication.Summary;
                     publication.TopicId = updatedPublication.TopicId;
-                    publication.ExternalMethodology = updatedPublication.ExternalMethodology;
                     publication.Updated = DateTime.UtcNow;
                     publication.SupersededById = updatedPublication.SupersededById;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -325,6 +325,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(publication => _mapper.Map<PublicationViewModel>(publication));
         }
 
+        public async Task<Either<ActionResult, ExternalMethodologyViewModel>> GetExternalMethodology(Guid publicationId)
+        {
+            return await _persistenceHelper
+                .CheckEntityExists<Publication>(publicationId)
+                .OnSuccessDo(_userService.CheckCanViewPublication)
+                .OnSuccess(publication => publication.ExternalMethodology != null
+                    ? _mapper.Map<ExternalMethodologyViewModel>(publication.ExternalMethodology)
+                    : NotFound<ExternalMethodologyViewModel>());
+        }
+
         public async Task<Either<ActionResult, PaginatedListViewModel<ReleaseSummaryViewModel>>>
             ListActiveReleasesPaginated(
                 Guid publicationId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ExternalMethodologyViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ExternalMethodologyViewModel.cs
@@ -1,7 +1,8 @@
 ﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
 public record ExternalMethodologyViewModel
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationSummaryViewModel.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
+{
+    public record PublicationSummaryViewModel
+    {
+        public Guid Id { get; set; }
+
+        public string Title { get; set; } = string.Empty;
+
+        public string Slug { get; set; } = string.Empty;
+
+        public PublicationSummaryViewModel()
+        {
+        }
+
+        public PublicationSummaryViewModel(PublicationViewModel publication)
+        {
+            Id = publication.Id;
+            Title = publication.Title;
+            Slug = publication.Slug;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModel.cs
@@ -1,9 +1,6 @@
 #nullable enable
 using System;
-using System.ComponentModel.DataAnnotations;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using static System.String;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.NamingUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -30,15 +30,10 @@ import classNames from 'classnames';
 
 export interface Props {
   publication: MyPublication;
-  topicId: string;
   onChangePublication: () => void;
 }
 
-const MethodologySummary = ({
-  publication,
-  topicId,
-  onChangePublication,
-}: Props) => {
+const MethodologySummary = ({ publication, onChangePublication }: Props) => {
   const history = useHistory();
   const [amendMethodologyId, setAmendMethodologyId] = useState<string>();
   const [deleteMethodologyDetails, setDeleteMethodologyDetails] = useState<{
@@ -52,26 +47,14 @@ const MethodologySummary = ({
   ] = useToggle(false);
 
   const {
-    contact,
     externalMethodology,
     methodologies,
     id: publicationId,
     title,
-    summary,
   } = publication;
 
   const handleRemoveExternalMethodology = async () => {
-    const updatedPublication = {
-      title,
-      summary,
-      contact,
-      topicId,
-    };
-
-    await publicationService.updatePublication(
-      publicationId,
-      updatedPublication,
-    );
+    await publicationService.removeExternalMethodology(publicationId);
     toggleRemovingExternalMethodology.off();
     onChangePublication();
   };

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
@@ -96,7 +96,6 @@ const PublicationSummary = ({
         >
           <MethodologySummary
             publication={publication}
-            topicId={topicId}
             onChangePublication={onChangePublication}
           />
         </div>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -7,7 +7,6 @@ import _publicationService, {
   ExternalMethodology,
   MyPublication,
   PublicationContactDetails,
-  UpdatePublicationRequest,
 } from '@admin/services/publicationService';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import noop from 'lodash/noop';

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -195,7 +195,6 @@ describe('MethodologySummary', () => {
         <Router history={history}>
           <MethodologySummary
             publication={testPublicationNoMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </Router>,
@@ -226,7 +225,6 @@ describe('MethodologySummary', () => {
                 canCreateMethodologies: false,
               },
             }}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -250,7 +248,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationNoMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -264,7 +261,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationNoMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -300,7 +296,6 @@ describe('MethodologySummary', () => {
                 canAdoptMethodologies: false,
               },
             }}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -330,7 +325,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -362,7 +356,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -378,7 +371,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithDraftMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -405,7 +397,6 @@ describe('MethodologySummary', () => {
                 },
               ],
             }}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -440,7 +431,6 @@ describe('MethodologySummary', () => {
                 },
               ],
             }}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -475,7 +465,6 @@ describe('MethodologySummary', () => {
                 },
               ],
             }}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -501,7 +490,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithAmendmentMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -533,7 +521,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithAmendmentMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -561,7 +548,6 @@ describe('MethodologySummary', () => {
                 },
               ],
             }}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -597,7 +583,6 @@ describe('MethodologySummary', () => {
                 },
               ],
             }}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -633,7 +618,6 @@ describe('MethodologySummary', () => {
                 },
               ],
             }}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -661,7 +645,6 @@ describe('MethodologySummary', () => {
         <Router history={history}>
           <MethodologySummary
             publication={testPublicationNoMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </Router>,
@@ -687,7 +670,6 @@ describe('MethodologySummary', () => {
           <MemoryRouter>
             <MethodologySummary
               publication={testPublicationWithExternalMethodology}
-              topicId={testTopicId}
               onChangePublication={noop}
             />
           </MemoryRouter>,
@@ -729,7 +711,6 @@ describe('MethodologySummary', () => {
                   canManageExternalMethodology: false,
                 },
               }}
-              topicId={testTopicId}
               onChangePublication={noop}
             />
           </MemoryRouter>,
@@ -764,7 +745,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithExternalMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -806,7 +786,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithExternalMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -830,17 +809,12 @@ describe('MethodologySummary', () => {
 
       userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
-      const updatedPublication: UpdatePublicationRequest = {
-        title: testPublicationWithExternalMethodology.title,
-        summary: testPublicationWithExternalMethodology.summary,
-        contact: testContact,
-        topicId: testTopicId,
-      };
-
       await waitFor(() => {
-        expect(publicationService.updatePublication).toHaveBeenCalledWith<
-          Parameters<typeof publicationService.updatePublication>
-        >(testPublicationWithExternalMethodology.id, updatedPublication);
+        expect(
+          publicationService.removeExternalMethodology,
+        ).toHaveBeenCalledWith<
+          Parameters<typeof publicationService.removeExternalMethodology>
+        >(testPublicationWithExternalMethodology.id);
       });
     });
   });
@@ -851,7 +825,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithMethodologyCanRemove}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -879,7 +852,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithMethodologyCanRemove}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -913,7 +885,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithMethodologyCanRemove}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -949,7 +920,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithMethodologyCanAmend}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -969,7 +939,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithMethodology}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -985,7 +954,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithMethodologyCanAmend}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -1034,7 +1002,6 @@ describe('MethodologySummary', () => {
         <Router history={history}>
           <MethodologySummary
             publication={testPublicationWithMethodologyCanAmend}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </Router>,
@@ -1076,7 +1043,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithMethodologyCanCancelAmend}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -1100,7 +1066,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithMethodologyCanCancelAmend}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -1135,7 +1100,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithMethodologyCanCancelAmend}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -1171,7 +1135,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithAdoptedMethodologies}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -1207,7 +1170,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithAdoptedMethodologies}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -1234,7 +1196,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithAdoptedMethodologies}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -1270,7 +1231,6 @@ describe('MethodologySummary', () => {
         <MemoryRouter>
           <MethodologySummary
             publication={testPublicationWithAdoptedMethodologies}
-            topicId={testTopicId}
             onChangePublication={noop}
           />
         </MemoryRouter>,

--- a/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/ExternalMethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/ExternalMethodologyPage.tsx
@@ -25,12 +25,7 @@ const ExternalMethodologyPage = ({
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [publication, externalMethodology] = await Promise.all([
       publicationService.getPublication(publicationId),
-      publicationService.getExternalMethodology(publicationId).catch(err => {
-        if (err.response.status !== 404) {
-          throw err;
-        }
-        return undefined;
-      }),
+      publicationService.getExternalMethodology(publicationId),
     ]);
 
     return { publication, externalMethodology };

--- a/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/ExternalMethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/ExternalMethodologyPage.tsx
@@ -7,7 +7,6 @@ import ExternalMethodologyForm from '@admin/pages/methodology/external-methodolo
 import publicationService, {
   ExternalMethodology,
   Publication,
-  UpdatePublicationRequest,
 } from '@admin/services/publicationService';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
@@ -38,20 +37,14 @@ const ExternalMethodologyPage = ({
     if (!model?.publication) {
       return;
     }
-    const updatedPublication: UpdatePublicationRequest = {
-      title: model.publication.title,
-      summary: model.publication.summary,
-      contact: model.publication.contact,
-      topicId: model.publication.topic.id,
-      externalMethodology: {
-        title: values.title,
-        url: values.url,
-      },
+    const updatedExternalMethodology: ExternalMethodology = {
+      title: values.title,
+      url: values.url,
     };
 
-    await publicationService.updatePublication(
+    await publicationService.updateExternalMethodology(
       publicationId,
-      updatedPublication,
+      updatedExternalMethodology,
     );
     history.push(dashboardRoute.path);
   };

--- a/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/ExternalMethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/ExternalMethodologyPage.tsx
@@ -25,7 +25,12 @@ const ExternalMethodologyPage = ({
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [publication, externalMethodology] = await Promise.all([
       publicationService.getPublication(publicationId),
-      publicationService.getExternalMethodology(publicationId),
+      publicationService.getExternalMethodology(publicationId).catch(err => {
+        if (err.response.status !== 404) {
+          throw err;
+        }
+        return undefined;
+      }),
     ]);
 
     return { publication, externalMethodology };

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationExternalMethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationExternalMethodologyPage.tsx
@@ -6,7 +6,6 @@ import {
 } from '@admin/routes/publicationRoutes';
 import publicationService, {
   ExternalMethodology,
-  UpdatePublicationRequest,
 } from '@admin/services/publicationService';
 import React from 'react';
 import { generatePath, useHistory } from 'react-router';
@@ -29,17 +28,14 @@ const PublicationExternalMethodologyPage = () => {
     if (!publication) {
       return;
     }
-    const updatedPublication: UpdatePublicationRequest = {
-      ...publication,
-      externalMethodology: {
-        title: values.title,
-        url: values.url,
-      },
+    const updatedExternalMethodology: ExternalMethodology = {
+      title: values.title,
+      url: values.url,
     };
 
-    await publicationService.updatePublication(
+    await publicationService.updateExternalMethodology(
       publicationId,
-      updatedPublication,
+      updatedExternalMethodology,
     );
     onReload();
     history.push(returnRoute);

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
@@ -18,7 +18,6 @@ import methodologyService, {
 } from '@admin/services/methodologyService';
 import publicationService, {
   ExternalMethodology,
-  UpdatePublicationRequest,
 } from '@admin/services/publicationService';
 import Button from '@common/components/Button';
 import ButtonText from '@common/components/ButtonText';

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
@@ -45,7 +45,12 @@ const PublicationMethodologiesPage = () => {
 
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [externalMethodology, methodologyVersions] = await Promise.all([
-      publicationService.getExternalMethodology(publication.id),
+      publicationService.getExternalMethodology(publication.id).catch(err => {
+        if (err.response.status !== 404) {
+          throw err;
+        }
+        return undefined;
+      }),
       methodologyService.listMethodologyVersions(publication.id),
     ]);
 

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
@@ -83,15 +83,7 @@ const PublicationMethodologiesPage = () => {
     if (!publication) {
       return;
     }
-    const updatedPublication: UpdatePublicationRequest = {
-      ...publication,
-      externalMethodology: undefined,
-    };
-
-    await publicationService.updatePublication(
-      publication.id,
-      updatedPublication,
-    );
+    await publicationService.removeExternalMethodology(publication.id);
     toggleRemovingExternalMethodology.off();
     onReload();
   };

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
@@ -44,12 +44,7 @@ const PublicationMethodologiesPage = () => {
 
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [externalMethodology, methodologyVersions] = await Promise.all([
-      publicationService.getExternalMethodology(publication.id).catch(err => {
-        if (err.response.status !== 404) {
-          throw err;
-        }
-        return undefined;
-      }),
+      publicationService.getExternalMethodology(publication.id),
       methodologyService.listMethodologyVersions(publication.id),
     ]);
 

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationExternalMethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationExternalMethodologyPage.test.tsx
@@ -20,7 +20,7 @@ const publicationService = _publicationService as jest.Mocked<
 
 describe('PublicationExternalMethodologyPage', () => {
   const testExternalMethodology: ExternalMethodology = {
-    title: 'External methodolology title',
+    title: 'External methodology title',
     url: 'http://test.com',
   };
 
@@ -54,7 +54,7 @@ describe('PublicationExternalMethodologyPage', () => {
     ).toBeInTheDocument();
 
     expect(screen.getByLabelText('Link title')).toHaveValue(
-      'External methodolology title',
+      'External methodology title',
     );
 
     expect(screen.getByLabelText('URL')).toHaveValue('http://test.com');
@@ -86,14 +86,11 @@ describe('PublicationExternalMethodologyPage', () => {
     userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(publicationService.updatePublication).toHaveBeenCalledWith(
+      expect(publicationService.updateExternalMethodology).toHaveBeenCalledWith(
         'publication-1',
         {
-          ...testPublication,
-          externalMethodology: {
-            title: 'The link title',
-            url: 'https://test.com',
-          },
+          title: 'The link title',
+          url: 'https://test.com',
         },
       );
     });

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
@@ -8,7 +8,6 @@ import _methodologyService, {
 import _publicationService, {
   ExternalMethodology,
   MyPublication,
-  UpdatePublicationRequest,
 } from '@admin/services/publicationService';
 import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
@@ -1492,15 +1492,12 @@ describe('PublicationMethodologiesPage', () => {
 
         userEvent.click(modal.getByRole('button', { name: 'Confirm' }));
 
-        const updatedPublication: UpdatePublicationRequest = {
-          ...testPublication,
-          externalMethodology: undefined,
-        };
-
         await waitFor(() => {
-          expect(publicationService.updatePublication).toHaveBeenCalledWith<
-            Parameters<typeof publicationService.updatePublication>
-          >(testPublication.id, updatedPublication);
+          expect(
+            publicationService.removeExternalMethodology,
+          ).toHaveBeenCalledWith<
+            Parameters<typeof publicationService.removeExternalMethodology>
+          >(testPublication.id);
         });
       });
     });

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
@@ -95,9 +95,7 @@ describe('PublicationMethodologiesPage', () => {
       testMethodology1,
       testMethodology2,
     ]);
-    publicationService.getExternalMethodology.mockRejectedValue({
-      response: { status: 404 },
-    });
+    publicationService.getExternalMethodology.mockResolvedValue(undefined);
     renderPage();
 
     await waitFor(() =>
@@ -130,9 +128,7 @@ describe('PublicationMethodologiesPage', () => {
 
   test('renders the methodologies page correctly with no methodologies', async () => {
     methodologyService.listMethodologyVersions.mockResolvedValue([]);
-    publicationService.getExternalMethodology.mockRejectedValue({
-      response: { status: 404 },
-    });
+    publicationService.getExternalMethodology.mockResolvedValue(undefined);
     renderPage();
 
     await waitFor(() =>
@@ -160,9 +156,7 @@ describe('PublicationMethodologiesPage', () => {
       };
 
       methodologyService.listMethodologyVersions.mockResolvedValue([]);
-      publicationService.getExternalMethodology.mockRejectedValue({
-        response: { status: 404 },
-      });
+      publicationService.getExternalMethodology.mockResolvedValue(undefined);
       methodologyService.createMethodology.mockResolvedValue(
         createdMethodology,
       );
@@ -201,9 +195,7 @@ describe('PublicationMethodologiesPage', () => {
 
     test('does not render the Create Methodology button if the user does not have permission to create one', async () => {
       methodologyService.listMethodologyVersions.mockResolvedValue([]);
-      publicationService.getExternalMethodology.mockRejectedValue({
-        response: { status: 404 },
-      });
+      publicationService.getExternalMethodology.mockResolvedValue(undefined);
       renderPage(
         produce(testPublication, draft => {
           draft.permissions.canCreateMethodologies = false;
@@ -226,9 +218,7 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1Draft,
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -254,9 +244,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions = noMethodologyPermissions;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -287,9 +275,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -319,9 +305,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = false;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -351,9 +335,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = false;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -379,9 +361,7 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1Draft,
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -404,9 +384,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canDeleteMethodology = false;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -429,9 +407,7 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1Draft,
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -469,9 +445,7 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1Draft,
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -504,9 +478,7 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1,
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -532,9 +504,7 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1,
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -556,9 +526,7 @@ describe('PublicationMethodologiesPage', () => {
             delete draft.published;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -580,9 +548,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canMakeAmendmentOfMethodology = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -604,9 +570,7 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1,
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -630,9 +594,7 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1Amendment,
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -666,9 +628,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canDeleteMethodology = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -691,9 +651,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canDeleteMethodology = false;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -719,9 +677,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canMakeAmendmentOfMethodology = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -769,9 +725,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canMakeAmendmentOfMethodology = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         render(
           <Router history={history}>
             <PublicationContextProvider
@@ -812,9 +766,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canDeleteMethodology = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -851,9 +803,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canDeleteMethodology = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -889,9 +839,7 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology2Draft,
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -923,9 +871,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions = noMethodologyPermissions;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -956,9 +902,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -988,9 +932,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = false;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -1020,9 +962,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = false;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -1050,9 +990,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -1075,9 +1013,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = false;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -1101,9 +1037,7 @@ describe('PublicationMethodologiesPage', () => {
           testMethodology1,
           testMethodology2,
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -1142,9 +1076,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -1168,9 +1100,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = false;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -1193,9 +1123,7 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology2Amendment,
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -1237,9 +1165,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>
@@ -1272,9 +1198,7 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = true;
           }),
         ]);
-        publicationService.getExternalMethodology.mockRejectedValue({
-          response: { status: 404 },
-        });
+        publicationService.getExternalMethodology.mockResolvedValue(undefined);
         renderPage();
 
         await waitFor(() =>

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
@@ -96,6 +96,9 @@ describe('PublicationMethodologiesPage', () => {
       testMethodology1,
       testMethodology2,
     ]);
+    publicationService.getExternalMethodology.mockRejectedValue({
+      response: { status: 404 },
+    });
     renderPage();
 
     await waitFor(() =>
@@ -128,6 +131,9 @@ describe('PublicationMethodologiesPage', () => {
 
   test('renders the methodologies page correctly with no methodologies', async () => {
     methodologyService.listMethodologyVersions.mockResolvedValue([]);
+    publicationService.getExternalMethodology.mockRejectedValue({
+      response: { status: 404 },
+    });
     renderPage();
 
     await waitFor(() =>
@@ -155,6 +161,9 @@ describe('PublicationMethodologiesPage', () => {
       };
 
       methodologyService.listMethodologyVersions.mockResolvedValue([]);
+      publicationService.getExternalMethodology.mockRejectedValue({
+        response: { status: 404 },
+      });
       methodologyService.createMethodology.mockResolvedValue(
         createdMethodology,
       );
@@ -193,6 +202,9 @@ describe('PublicationMethodologiesPage', () => {
 
     test('does not render the Create Methodology button if the user does not have permission to create one', async () => {
       methodologyService.listMethodologyVersions.mockResolvedValue([]);
+      publicationService.getExternalMethodology.mockRejectedValue({
+        response: { status: 404 },
+      });
       renderPage(
         produce(testPublication, draft => {
           draft.permissions.canCreateMethodologies = false;
@@ -215,6 +227,9 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1Draft,
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -240,6 +255,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions = noMethodologyPermissions;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -270,6 +288,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -299,6 +320,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = false;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -328,6 +352,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = false;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -353,6 +380,9 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1Draft,
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -375,6 +405,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canDeleteMethodology = false;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -397,6 +430,9 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1Draft,
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -434,6 +470,9 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1Draft,
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -466,6 +505,9 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1,
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -491,6 +533,9 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1,
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -512,6 +557,9 @@ describe('PublicationMethodologiesPage', () => {
             delete draft.published;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -533,6 +581,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canMakeAmendmentOfMethodology = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -554,6 +605,9 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1,
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -577,6 +631,9 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology1Amendment,
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -610,6 +667,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canDeleteMethodology = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -632,6 +692,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canDeleteMethodology = false;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -657,6 +720,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canMakeAmendmentOfMethodology = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -704,6 +770,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canMakeAmendmentOfMethodology = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         render(
           <Router history={history}>
             <PublicationContextProvider
@@ -744,6 +813,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canDeleteMethodology = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -780,6 +852,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canDeleteMethodology = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -815,6 +890,9 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology2Draft,
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -846,6 +924,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions = noMethodologyPermissions;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -876,6 +957,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -905,6 +989,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = false;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -934,6 +1021,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canApproveMethodology = false;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -961,6 +1051,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -983,6 +1076,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = false;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -1006,6 +1102,9 @@ describe('PublicationMethodologiesPage', () => {
           testMethodology1,
           testMethodology2,
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -1044,6 +1143,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -1067,6 +1169,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = false;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -1089,6 +1194,9 @@ describe('PublicationMethodologiesPage', () => {
         methodologyService.listMethodologyVersions.mockResolvedValue([
           testMethodology2Amendment,
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -1130,6 +1238,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>
@@ -1162,6 +1273,9 @@ describe('PublicationMethodologiesPage', () => {
             draft.permissions.canRemoveMethodologyLink = true;
           }),
         ]);
+        publicationService.getExternalMethodology.mockRejectedValue({
+          response: { status: 404 },
+        });
         renderPage();
 
         await waitFor(() =>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableToolFinalStep.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableToolFinalStep.tsx
@@ -19,7 +19,7 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 
 interface Model {
   methodologies: MethodologyVersionSummary[];
-  externalMethodology?: ExternalMethodology;
+  externalMethodology?: ExternalMethodology | undefined;
 }
 
 interface ReleasePreviewTableToolFinalStepProps {
@@ -41,12 +41,7 @@ const ReleasePreviewTableToolFinalStep = ({
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [methodologies, externalMethodology] = await Promise.all([
       methodologyService.listMethodologyVersions(publication.id),
-      publicationService.getExternalMethodology(publication.id).catch(err => {
-        if (err.response.status !== 404) {
-          throw err;
-        }
-        return undefined;
-      }),
+      publicationService.getExternalMethodology(publication.id),
     ]);
 
     return { methodologies, externalMethodology };

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableToolFinalStep.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableToolFinalStep.tsx
@@ -41,7 +41,12 @@ const ReleasePreviewTableToolFinalStep = ({
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [methodologies, externalMethodology] = await Promise.all([
       methodologyService.listMethodologyVersions(publication.id),
-      publicationService.getExternalMethodology(publication.id),
+      publicationService.getExternalMethodology(publication.id).catch(err => {
+        if (err.response.status !== 404) {
+          throw err;
+        }
+        return undefined;
+      }),
     ]);
 
     return { methodologies, externalMethodology };

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
@@ -31,7 +31,12 @@ const PreReleaseMethodologiesPage = ({
 
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [externalMethodology, methodologyVersions] = await Promise.all([
-      publicationService.getExternalMethodology(publicationId),
+      publicationService.getExternalMethodology(publicationId).catch(err => {
+        if (err.response.status !== 404) {
+          throw err;
+        }
+        return undefined;
+      }),
       methodologyService.listMethodologyVersions(publicationId),
     ]);
 

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
@@ -31,12 +31,7 @@ const PreReleaseMethodologiesPage = ({
 
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [externalMethodology, methodologyVersions] = await Promise.all([
-      publicationService.getExternalMethodology(publicationId).catch(err => {
-        if (err.response.status !== 404) {
-          throw err;
-        }
-        return undefined;
-      }),
+      publicationService.getExternalMethodology(publicationId),
       methodologyService.listMethodologyVersions(publicationId),
     ]);
 

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
@@ -38,6 +38,9 @@ describe('PreReleaseMethodologiesPage', () => {
 
   test('renders correctly with no methodologies', async () => {
     methodologyService.listMethodologyVersions.mockResolvedValue([]);
+    publicationService.getExternalMethodology.mockRejectedValue({
+      response: { status: 404 },
+    });
     renderPage();
 
     expect(screen.getByRole('heading', { name: 'Methodologies' }));
@@ -118,6 +121,9 @@ describe('PreReleaseMethodologiesPage', () => {
         status: 'Approved',
       },
     ]);
+    publicationService.getExternalMethodology.mockRejectedValue({
+      response: { status: 404 },
+    });
     renderPage();
 
     await waitFor(() => {
@@ -149,6 +155,9 @@ describe('PreReleaseMethodologiesPage', () => {
         status: 'Draft',
       },
     ]);
+    publicationService.getExternalMethodology.mockRejectedValue({
+      response: { status: 404 },
+    });
     renderPage();
 
     await waitFor(() => {
@@ -174,6 +183,9 @@ describe('PreReleaseMethodologiesPage', () => {
         previousVersionId: 'methodology-1-previous-id',
       },
     ]);
+    publicationService.getExternalMethodology.mockRejectedValue({
+      response: { status: 404 },
+    });
     renderPage();
 
     await waitFor(() => {
@@ -217,6 +229,9 @@ describe('PreReleaseMethodologiesPage', () => {
         previousVersionId: 'methodology-2-previous-id',
       },
     ]);
+    publicationService.getExternalMethodology.mockRejectedValue({
+      response: { status: 404 },
+    });
     renderPage();
 
     await waitFor(() => {

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
@@ -38,9 +38,7 @@ describe('PreReleaseMethodologiesPage', () => {
 
   test('renders correctly with no methodologies', async () => {
     methodologyService.listMethodologyVersions.mockResolvedValue([]);
-    publicationService.getExternalMethodology.mockRejectedValue({
-      response: { status: 404 },
-    });
+    publicationService.getExternalMethodology.mockResolvedValue(undefined);
     renderPage();
 
     expect(screen.getByRole('heading', { name: 'Methodologies' }));
@@ -121,9 +119,7 @@ describe('PreReleaseMethodologiesPage', () => {
         status: 'Approved',
       },
     ]);
-    publicationService.getExternalMethodology.mockRejectedValue({
-      response: { status: 404 },
-    });
+    publicationService.getExternalMethodology.mockResolvedValue(undefined);
     renderPage();
 
     await waitFor(() => {
@@ -155,9 +151,7 @@ describe('PreReleaseMethodologiesPage', () => {
         status: 'Draft',
       },
     ]);
-    publicationService.getExternalMethodology.mockRejectedValue({
-      response: { status: 404 },
-    });
+    publicationService.getExternalMethodology.mockResolvedValue(undefined);
     renderPage();
 
     await waitFor(() => {
@@ -183,9 +177,7 @@ describe('PreReleaseMethodologiesPage', () => {
         previousVersionId: 'methodology-1-previous-id',
       },
     ]);
-    publicationService.getExternalMethodology.mockRejectedValue({
-      response: { status: 404 },
-    });
+    publicationService.getExternalMethodology.mockResolvedValue(undefined);
     renderPage();
 
     await waitFor(() => {
@@ -229,9 +221,7 @@ describe('PreReleaseMethodologiesPage', () => {
         previousVersionId: 'methodology-2-previous-id',
       },
     ]);
-    publicationService.getExternalMethodology.mockRejectedValue({
-      response: { status: 404 },
-    });
+    publicationService.getExternalMethodology.mockResolvedValue(undefined);
     renderPage();
 
     await waitFor(() => {

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -33,6 +33,11 @@ export interface ExternalMethodology {
   url: string;
 }
 
+export interface ExternalMethodologySaveRequest {
+  title: string;
+  url: string;
+}
+
 export interface MyPublication {
   id: string;
   title: string;
@@ -120,24 +125,33 @@ const publicationService = {
     return client.get<MyPublication>(`/me/publication/${publicationId}`);
   },
 
-  getExternalMethodology(publicationId: string): Promise<ExternalMethodology> {
-    return client.get<ExternalMethodology>(
-      `/publication/${publicationId}/external-methodology`,
-    );
+  getExternalMethodology(
+    publicationId: string,
+  ): Promise<ExternalMethodology | undefined> {
+    return client
+      .get<ExternalMethodology>(
+        `/publication/${publicationId}/external-methodology`,
+      )
+      .catch(err => {
+        if (err.response.status !== 404) {
+          throw err;
+        }
+        return undefined;
+      });
   },
 
   updateExternalMethodology(
     publicationId: string,
-    updatedExternalMethodology: ExternalMethodology,
+    updatedExternalMethodology: ExternalMethodologySaveRequest,
   ): Promise<ExternalMethodology> {
     return client.put<ExternalMethodology>(
-      `publication/${publicationId}/external-methodology`,
+      `/publication/${publicationId}/external-methodology`,
       updatedExternalMethodology,
     );
   },
 
   removeExternalMethodology(publicationId: string): Promise<boolean> {
-    return client.delete(`publication/${publicationId}/external-methodology`);
+    return client.delete(`/publication/${publicationId}/external-methodology`);
   },
 
   listReleases<TReleaseSummary extends ReleaseSummary = ReleaseSummary>(

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -71,12 +71,10 @@ export interface PublicationMethodologyDetails {
   externalMethodology?: ExternalMethodology;
 }
 
-export interface SavePublicationRequest {
+export interface PublicationSaveRequest {
   title: string;
   summary: string;
   contact: SavePublicationContact;
-  selectedMethodologyId?: string;
-  externalMethodology?: ExternalMethodology;
   supersededById?: string;
   topicId: string;
 }
@@ -87,9 +85,6 @@ export interface ListReleasesParams {
   pageSize?: number;
   permissions?: boolean;
 }
-
-export type CreatePublicationRequest = SavePublicationRequest;
-export type UpdatePublicationRequest = SavePublicationRequest;
 
 export type UpdatePublicationLegacyRelease = Partial<
   OmitStrict<UpdateLegacyRelease, 'publicationId'>
@@ -106,15 +101,13 @@ const publicationService = {
     return client.get('/publication-summaries');
   },
 
-  createPublication(
-    publication: CreatePublicationRequest,
-  ): Promise<Publication> {
+  createPublication(publication: PublicationSaveRequest): Promise<Publication> {
     return client.post('/publications', publication);
   },
 
   updatePublication(
     publicationId: string,
-    publication: UpdatePublicationRequest,
+    publication: PublicationSaveRequest,
   ): Promise<Publication> {
     return client.put(`/publications/${publicationId}`, publication);
   },

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -133,6 +133,16 @@ const publicationService = {
     );
   },
 
+  updateExternalMethodology(
+    publicationId: string,
+    updatedExternalMethodology: ExternalMethodology,
+  ): Promise<ExternalMethodology> {
+    return client.put<ExternalMethodology>(
+      `publication/${publicationId}/external-methodology`,
+      updatedExternalMethodology,
+    );
+  },
+
   listReleases<TReleaseSummary extends ReleaseSummary = ReleaseSummary>(
     publicationId: string,
     params?: ListReleasesParams,

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -127,13 +127,10 @@ const publicationService = {
     return client.get<MyPublication>(`/me/publication/${publicationId}`);
   },
 
-  getExternalMethodology(
-    publicationId: string,
-  ): Promise<ExternalMethodology | undefined> {
-    // TODO EES-3666 Replace with external methodology request
-    return client
-      .get<MyPublication>(`/me/publication/${publicationId}`)
-      .then(response => response.externalMethodology);
+  getExternalMethodology(publicationId: string): Promise<ExternalMethodology> {
+    return client.get<ExternalMethodology>(
+      `/publication/${publicationId}/external-methodology`,
+    );
   },
 
   listReleases<TReleaseSummary extends ReleaseSummary = ReleaseSummary>(

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -143,6 +143,10 @@ const publicationService = {
     );
   },
 
+  removeExternalMethodology(publicationId: string): Promise<boolean> {
+    return client.delete(`publication/${publicationId}/external-methodology`);
+  },
+
   listReleases<TReleaseSummary extends ReleaseSummary = ReleaseSummary>(
     publicationId: string,
     params?: ListReleasesParams,


### PR DESCRIPTION
This PR adds new endpoints for use on Admin pages that get / update / remove an external methodology from a publication.

This code also changes the Admin frontend code to use these new endpoints when appropriate instead of using the `publicationService.createPublication` and `publicationService.updatePublication` endpoints. It is no longer possible to update a publication's external methodology with the `publicationService.updatePublication` endpoint.

I haven't added any UI tests. UI tests for new publication management pages will be done at the same time that they're unhidden, and it doesn't seem worth adding UI tests for the current ways of changing an external methodology as they will soon be removed.