### PR TITLE
EES-3080 - hide destination/breadcrumbs from screen reader users in s…

### DIFF
--- a/src/explore-education-statistics-common/src/components/PageSearchForm.tsx
+++ b/src/explore-education-statistics-common/src/components/PageSearchForm.tsx
@@ -212,7 +212,7 @@ const PageSearchForm = ({
                   <>
                     <div className={styles.resultHeader}>{result.text}</div>
                     {result.location && (
-                      <div className={styles.resultLocation}>
+                      <div className={styles.resultLocation} aria-hidden>
                         {result.location}
                       </div>
                     )}

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/PageSearchForm.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/PageSearchForm.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`PageSearchForm renders results found in custom selectors 1`] = `
       </span>
     </div>
     <div
+      aria-hidden="true"
       class="resultLocation"
     >
       Section 1
@@ -238,6 +239,7 @@ exports[`PageSearchForm result locations include accordion sections 1`] = `
       </span>
     </div>
     <div
+      aria-hidden="true"
       class="resultLocation"
     >
       Section 1 &gt; Section 2 &gt; Accordion section 1 &gt; Section 3
@@ -268,6 +270,7 @@ exports[`PageSearchForm result locations include accordion sections 1`] = `
       </span>
     </div>
     <div
+      aria-hidden="true"
       class="resultLocation"
     >
       Section 1 &gt; Section 2 &gt; Accordion section 2
@@ -308,6 +311,7 @@ exports[`PageSearchForm result locations include heading hierarchy 1`] = `
       </span>
     </div>
     <div
+      aria-hidden="true"
       class="resultLocation"
     >
       Section 1 &gt; Section 2 &gt; Section 3
@@ -348,6 +352,7 @@ exports[`PageSearchForm result locations uses nearest heading 1`] = `
       </span>
     </div>
     <div
+      aria-hidden="true"
       class="resultLocation"
     >
       Section 1
@@ -378,6 +383,7 @@ exports[`PageSearchForm result locations uses nearest heading 1`] = `
       </span>
     </div>
     <div
+      aria-hidden="true"
       class="resultLocation"
     >
       Section 2


### PR DESCRIPTION
This PR: 
- adds `aria-hidden` to the breadcrumbs text on page search forms in order to address an accessibility issue. This improves the screen-reader experience due to the length of text that can be under a given theme