### PR TITLE
EES-3541 - add visually hidden h2 to release intro block

### DIFF
--- a/src/explore-education-statistics-common/src/components/VisuallyHidden.tsx
+++ b/src/explore-education-statistics-common/src/components/VisuallyHidden.tsx
@@ -2,10 +2,11 @@ import React, { ReactNode } from 'react';
 
 interface Props {
   children: ReactNode;
+  as?: keyof JSX.IntrinsicElements;
 }
 
-const VisuallyHidden = ({ children }: Props) => {
-  return <span className="govuk-visually-hidden">{children}</span>;
+const VisuallyHidden = ({ as: Element = 'span', children }: Props) => {
+  return <Element className="govuk-visually-hidden">{children}</Element>;
 };
 
 export default VisuallyHidden;

--- a/src/explore-education-statistics-common/src/components/__tests__/VisuallyHidden.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/VisuallyHidden.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import VisuallyHidden from '../VisuallyHidden';
+
+describe('VisuallyHidden', () => {
+  test('renders correctly with no `as` prop', () => {
+    const { container } = render(<VisuallyHidden>Test</VisuallyHidden>);
+
+    expect(container.querySelector('.govuk-visually-hidden')).toHaveTextContent(
+      'Test',
+    );
+
+    expect(container.querySelector('.govuk-visually-hidden')).toHaveProperty(
+      'tagName',
+      'SPAN',
+    );
+  });
+
+  test('renders correctly with `as` prop', () => {
+    const { container } = render(<VisuallyHidden as="h1">Test</VisuallyHidden>);
+
+    expect(container.querySelector('.govuk-visually-hidden')).toHaveTextContent(
+      'Test',
+    );
+
+    expect(container.querySelector('.govuk-visually-hidden')).toHaveProperty(
+      'tagName',
+      'H1',
+    );
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -169,13 +169,13 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
               </Link>
             </SummaryListItem>
           </SummaryList>
-          <VisuallyHidden>
+          <VisuallyHidden as="h2">
             {/** 
               Visually hidden h2 as currently the release intro editor only starts from h3
               meaning that this breaks sequential heading order.
               @see {@link https://dfedigital.atlassian.net/browse/EES-3541}
               */}
-            <h2>Introduction</h2>
+            Introduction
           </VisuallyHidden>
           {release.summarySection.content.map(block => (
             <ContentBlockRenderer

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -33,6 +33,7 @@ import classNames from 'classnames';
 import orderBy from 'lodash/orderBy';
 import { GetServerSideProps, NextPage } from 'next';
 import React from 'react';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 import PublicationReleaseHeadlinesSection from './components/PublicationReleaseHeadlinesSection';
 import styles from './PublicationReleasePage.module.scss';
 
@@ -168,7 +169,14 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
               </Link>
             </SummaryListItem>
           </SummaryList>
-
+          <VisuallyHidden>
+            {/** 
+              Visually hidden h2 as currently the release intro editor only starts from h3
+              meaning that this breaks sequential heading order.
+              @see {@link https://dfedigital.atlassian.net/browse/EES-3541}
+              */}
+            <h2>Introduction</h2>
+          </VisuallyHidden>
           {release.summarySection.content.map(block => (
             <ContentBlockRenderer
               key={block.id}


### PR DESCRIPTION
This PR: 
- adds a visually hidden h2 element to the release intro block on publication pages. This is to ensure the structure of headings is correct in order to improve accessibility and general best practice. In the future, we may want to give users the option to add H2s to release intro blocks so I've left a comment explaining why this has been implemented the current way instead of making amends to CK editor.