### PR TITLE
EES-3706 Fix inaccessible table captions outputted by CKEditor

### DIFF
--- a/src/explore-education-statistics-common/src/components/ContentHtml.module.scss
+++ b/src/explore-education-statistics-common/src/components/ContentHtml.module.scss
@@ -1,0 +1,6 @@
+@import '~govuk-frontend/govuk/base';
+
+.tableContainer {
+  margin: govuk-spacing(6) govuk-spacing(4);
+  overflow: auto;
+}

--- a/src/explore-education-statistics-common/src/components/GlossaryEntryButton.tsx
+++ b/src/explore-education-statistics-common/src/components/GlossaryEntryButton.tsx
@@ -1,0 +1,52 @@
+import Button from '@common/components/Button';
+import ButtonText from '@common/components/ButtonText';
+import InfoIcon from '@common/components/InfoIcon';
+import Modal from '@common/components/Modal';
+import { GlossaryEntry } from '@common/services/types/glossary';
+import sanitizeHtml from '@common/utils/sanitizeHtml';
+import parseHtmlString from 'html-react-parser';
+import React, { ReactNode, useState } from 'react';
+
+interface Props {
+  children: ReactNode;
+  href: string;
+  getEntry: (slug: string) => Promise<GlossaryEntry>;
+  onToggle?: (slug: string) => void;
+}
+
+export default function GlossaryEntryButton({
+  children,
+  href,
+  getEntry,
+  onToggle,
+}: Props) {
+  const [glossaryEntry, setGlossaryEntry] = useState<GlossaryEntry>();
+
+  return (
+    <>
+      <ButtonText
+        onClick={async () => {
+          const slug = href.split('#')[1];
+          const newGlossaryEntry = await getEntry(slug);
+
+          setGlossaryEntry(newGlossaryEntry);
+
+          onToggle?.(slug);
+        }}
+      >
+        {children} <InfoIcon description="(show glossary term definition)" />
+      </ButtonText>
+
+      {glossaryEntry && (
+        <Modal
+          title={glossaryEntry.title}
+          onExit={() => setGlossaryEntry(undefined)}
+        >
+          {parseHtmlString(sanitizeHtml(glossaryEntry.body))}
+
+          <Button onClick={() => setGlossaryEntry(undefined)}>Close</Button>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/__tests__/ContentHtml.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ContentHtml.test.tsx
@@ -77,4 +77,50 @@ describe('ContentHtml', () => {
       expect(glossaryButton).toBeInTheDocument();
     });
   });
+
+  test('fixes inaccessible table markup from CKEditor', () => {
+    const html = `
+      <figure class="table">
+        <table>
+          <tbody>
+          <tr>
+            <td>Test 1</td>
+            <td>Test 2</td>
+          </tr>
+          </tbody>
+        </table>
+        <figcaption>
+          Test <strong>bold</strong> caption
+        </figcaption>
+      </figure>
+    `;
+
+    const { container } = render(<ContentHtml html={html} />);
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`
+      <div class="dfe-content">
+        <div class="tableContainer">
+          <table>
+            <caption>
+              Test
+              <strong>
+                bold
+              </strong>
+              caption
+            </caption>
+            <tbody>
+              <tr>
+                <td>
+                  Test 1
+                </td>
+                <td>
+                  Test 2
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    `);
+  });
 });

--- a/src/explore-education-statistics-common/src/styles/_content.scss
+++ b/src/explore-education-statistics-common/src/styles/_content.scss
@@ -3,20 +3,8 @@
 // Styles related to dynamic HTML content (from CKEditor)
 
 .dfe-content {
-  .table {
-    display: table;
-    margin: 0;
-    overflow: auto;
-    padding: govuk-spacing(4) govuk-spacing(4);
-    width: 100%;
-  }
-
   figcaption {
-    caption-side: top;
-    display: table-caption;
-    font-size: 1.18rem;
-    font-weight: $govuk-font-weight-bold;
-    padding: govuk-spacing(2) govuk-spacing(4);
+    font-size: 1rem;
   }
 
   .image {

--- a/src/explore-education-statistics-common/src/styles/_tables.scss
+++ b/src/explore-education-statistics-common/src/styles/_tables.scss
@@ -28,7 +28,6 @@ table,
 
   caption {
     @extend .govuk-table__caption;
-    background: #fff;
   }
 }
 


### PR DESCRIPTION
This PR fixes current accessibility issues with table markup from CKEditor that outputs something like:

```html
<figure class="table">
  <table>...</table>
  <figcaption>The caption</figcaption>
</figure>
```

Unfortunately, this isn't accessible as the caption gets read out after the table, meaning it doesn't provide further context.

To fix this, we intercept the markup in `ContentHtml` before it's rendered in the frontend and transform it into the following format:

```html
<table>
  <caption>The caption</caption>
  <tbody>...</tbody>
</table>
```

## Other changes

- Extracted `GlossaryEntryButton` component out of `ContentHtml` to tidy things up.