### PR TITLE
EES-3695 Add GetContact and UpdateContact endpoints

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/PublicationControllerTests.cs
@@ -24,8 +24,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             publicationService
                 .Setup(s => s.CreatePublication(It.IsAny<PublicationCreateRequest>()))
                 .Returns<PublicationCreateRequest>(p =>
-                    Task.FromResult(new Either<ActionResult, PublicationViewModel>(
-                        new PublicationViewModel
+                    Task.FromResult(new Either<ActionResult, PublicationCreateViewModel>(
+                        new PublicationCreateViewModel
                         {
                             Topic = new IdTitleViewModel
                             {
@@ -45,7 +45,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 TopicId = topicId
             });
 
-            Assert.IsType<PublicationViewModel>(result.Value);
+            Assert.IsType<PublicationCreateViewModel>(result.Value);
             Assert.Equal(topicId, result.Value.Topic.Id);
         }
 
@@ -55,7 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var publicationService = new Mock<IPublicationService>();
 
             var validationResponse =
-                new Either<ActionResult, PublicationViewModel>(
+                new Either<ActionResult, PublicationCreateViewModel>(
                     ValidationUtils.ValidationActionResult(SlugNotUnique));
 
             publicationService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/PublicationControllerTests.cs
@@ -22,8 +22,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var publicationService = new Mock<IPublicationService>();
 
             publicationService
-                .Setup(s => s.CreatePublication(It.IsAny<PublicationSaveRequest>()))
-                .Returns<PublicationSaveRequest>(p =>
+                .Setup(s => s.CreatePublication(It.IsAny<PublicationCreateRequest>()))
+                .Returns<PublicationCreateRequest>(p =>
                     Task.FromResult(new Either<ActionResult, PublicationViewModel>(
                         new PublicationViewModel
                         {
@@ -40,7 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var topicId = Guid.NewGuid();
 
             // Method under test
-            var result = await controller.CreatePublication(new PublicationSaveRequest()
+            var result = await controller.CreatePublication(new PublicationCreateRequest()
             {
                 TopicId = topicId
             });
@@ -59,15 +59,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                     ValidationUtils.ValidationActionResult(SlugNotUnique));
 
             publicationService
-                .Setup(s => s.CreatePublication(It.IsAny<PublicationSaveRequest>()))
-                .Returns<PublicationSaveRequest>(p => Task.FromResult(validationResponse));
+                .Setup(s => s.CreatePublication(It.IsAny<PublicationCreateRequest>()))
+                .Returns<PublicationCreateRequest>(p => Task.FromResult(validationResponse));
 
             var controller = new PublicationController(publicationService.Object);
 
             var topicId = Guid.NewGuid();
 
             // Method under test
-            var result = await controller.CreatePublication(new PublicationSaveRequest()
+            var result = await controller.CreatePublication(new PublicationCreateRequest()
             {
                 TopicId = topicId
             });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationRepositoryTests.cs
@@ -35,7 +35,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var relatedPublication1 = new Publication
             {
                 Title = "Related publication 1",
-                Topic = topic
+                Topic = topic,
+                Contact = new Contact(),
             };
 
             userReleaseRoles.AddRange(new List<UserReleaseRole>
@@ -96,7 +97,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TimePeriodCoverage = AcademicYear
                         }
                     },
-                    Topic = topic
+                    Topic = topic,
+                    Contact = new Contact(),
                 },
                 User = user,
                 Role = Owner
@@ -123,7 +125,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TimePeriodCoverage = AcademicYear
                         }
                     },
-                    Topic = topic
+                    Topic = topic,
+                    Contact = new Contact(),
                 },
                 User = user,
                 Role = ReleaseApprover
@@ -140,7 +143,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Publication = new Publication
                     {
                         Title = "Related publication 4",
-                        Topic = topic
+                        Topic = topic,
+                        Contact = new Contact(),
                     }
                 },
                 User = user,
@@ -162,6 +166,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         {
                             Theme = new Theme(),
                         },
+                        Contact = new Contact(),
                     }
                 },
                 User = user,
@@ -188,6 +193,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         Theme = new Theme(),
                     },
+                    Contact = new Contact(),
                 },
                 User = user,
                 Role = Owner
@@ -213,6 +219,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         Theme = new Theme(),
                     },
+                    Contact = new Contact(),
                 },
                 User = user,
                 Role = ReleaseApprover
@@ -283,6 +290,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             }
                         },
                         Topic = new Topic { Theme = new Theme(), },
+                        Contact = new Contact(),
                     },
                     User = user,
                     Role = Owner,
@@ -306,6 +314,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             }
                         },
                         Topic = new Topic { Theme = new Theme(), },
+                        Contact = new Contact(),
                     },
                     User = user,
                     Role = ReleaseApprover,
@@ -327,6 +336,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         {
                             Theme = new Theme(),
                         },
+                        Contact = new Contact(),
                     },
                     User = user,
                     Role = Owner,
@@ -345,6 +355,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         {
                             Title = "Release Contributor publication",
                             Topic = new Topic { Theme = new Theme(), },
+                            Contact = new Contact(),
                         },
                     },
                     User = user,
@@ -360,6 +371,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         {
                             Title = "Release Viewer publication",
                             Topic = new Topic { Theme = new Theme(), },
+                            Contact = new Contact(),
                         },
                     },
                     User = user,
@@ -375,6 +387,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         {
                             Title = "Release PrereleaseViewer publication",
                             Topic = new Topic { Theme = new Theme(), },
+                            Contact = new Contact(),
                         }
                     },
                     User = user,
@@ -393,6 +406,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             {
                                 Theme = new Theme(),
                             },
+                            Contact = new Contact(),
                         }
                     },
                     User = user,
@@ -471,6 +485,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Publication = new Publication
                     {
                         Title = "Related publication",
+                        Contact = new Contact(),
                         Methodologies = new List<PublicationMethodology>
                         {
                             new()
@@ -724,7 +739,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         Title = "Related publication 1",
                         Releases = new List<Release>(),
-                        Topic = topic
+                        Topic = topic,
+                        Contact = new Contact(),
                     },
                     User = user,
                     Role = Owner
@@ -739,6 +755,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         {
                             Theme = new Theme(),
                         },
+                        Contact = new Contact(),
                     },
                     User = user,
                     Role = Owner
@@ -786,7 +803,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication = new Publication
             {
                 Title = "Publication",
-                Topic = topic
+                Topic = topic,
+                Contact = new Contact(),
             };
 
             var release = new Release
@@ -1193,6 +1211,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     Theme = new Theme(),
                 },
+                Contact = new Contact(),
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -1233,6 +1252,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     release1,
                 },
+                Contact = new Contact(),
             };
 
             var contextId = Guid.NewGuid().ToString();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -212,6 +212,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Title = "Old publication title",
                 Slug = "publication-slug",
                 Topic = new Topic { Title = "Old topic title" },
+                Contact = new Contact(),
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -261,6 +262,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Slug = "publication-slug",
                 Topic = new Topic { Title = "Old topic title" },
                 SupersededById = Guid.NewGuid(),
+                Contact = new Contact(),
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -315,6 +317,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Title = "Publication title",
                 Slug = "publication-slug",
                 Topic = new Topic { Title = "Old topic title" },
+                Contact = new Contact(),
             };
 
             var contextId = Guid.NewGuid().ToString();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -456,6 +456,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task GetContact()
+        {
+            var publication = new Publication
+            {
+                Contact = new Contact
+                {
+                    ContactName = "contact name",
+                    ContactTelNo = "12345",
+                    TeamName = "team name",
+                    TeamEmail = "team@email.com",
+                },
+            };
+
+            await PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(publication, SecurityPolicies.CanViewSpecificPublication)
+                .AssertForbidden(async userService =>
+                {
+                    var contentDbContext = InMemoryApplicationDbContext();
+                    await contentDbContext.Publications.AddAsync(publication);
+                    await contentDbContext.SaveChangesAsync();
+
+                    var service = BuildPublicationService(
+                        context: contentDbContext,
+                        userService: userService.Object);
+                    return await service.GetContact(publication.Id);
+                });
+        }
+
+        [Fact]
         public void ListActiveReleases()
         {
             var userService = AlwaysTrueUserService();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -462,7 +462,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     var service = BuildPublicationService(
                         context: contentDbContext,
                         userService: userService.Object);
-                    return await service.GetContact(publication.Id);
+                    return await service.GetContact(publication.Id, false);
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -95,7 +95,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(
                 async service =>
-                    await service.CreatePublication(new PublicationSaveRequest
+                    await service.CreatePublication(new PublicationCreateRequest
                     {
                         TopicId = _topic.Id,
                     }),
@@ -124,13 +124,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         TopicId = _topic.Id,
                         Title = "Updated publication",
-                        Contact = new ContactSaveViewModel
-                        {
-                            TeamName = "Test team",
-                            TeamEmail = "team@test.com",
-                            ContactName = "John Smith",
-                            ContactTelNo = "0123456789"
-                        }
                     }),
                 _publication,
                 userService,
@@ -157,13 +150,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         TopicId = _topic.Id,
                         Title = "Updated publication",
-                        Contact = new ContactSaveViewModel
-                        {
-                            TeamName = "Test team",
-                            TeamEmail = "team@test.com",
-                            ContactName = "John Smith",
-                            ContactTelNo = "0123456789"
-                        }
                     }),
                 _publication,
                 userService,
@@ -190,13 +176,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         TopicId = _topic.Id,
                         Title = "Updated publication",
-                        Contact = new ContactSaveViewModel
-                        {
-                            TeamName = "Test team",
-                            TeamEmail = "team@test.com",
-                            ContactName = "John Smith",
-                            ContactTelNo = "0123456789"
-                        }
                     }),
                 _topic,
                 userService,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -485,6 +485,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task UpdateContact()
+        {
+            var publication = new Publication
+            {
+                Contact = new Contact
+                {
+                    ContactName = "test",
+                    ContactTelNo = "1234",
+                    TeamEmail = "test@test.com",
+                    TeamName = "test",
+                },
+            };
+
+            await PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(publication, SecurityPolicies.CanUpdateSpecificPublication)
+                .AssertForbidden(async userService =>
+                {
+                    var contentDbContext = InMemoryApplicationDbContext();
+                    await contentDbContext.Publications.AddAsync(publication);
+                    await contentDbContext.SaveChangesAsync();
+
+                    var service = BuildPublicationService(
+                        context: contentDbContext,
+                        userService: userService.Object);
+                    return await service.UpdateContact(publication.Id, new Contact());
+                });
+        }
+
+        [Fact]
         public void ListActiveReleases()
         {
             var userService = AlwaysTrueUserService();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -462,7 +462,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     var service = BuildPublicationService(
                         context: contentDbContext,
                         userService: userService.Object);
-                    return await service.GetContact(publication.Id, false);
+                    return await service.GetContact(publication.Id);
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -49,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     var service = BuildPublicationService(
                         context: Mock.Of<ContentDbContext>(Strict),
                         userService: userService.Object);
-                    return await service.ListPublications(permissions: false, Guid.NewGuid());
+                    return await service.ListPublications(includePermissions: false, Guid.NewGuid());
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -91,7 +91,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService: userService.Object);
 
                 var result = await publicationService
-                    .ListPublications(permissions: false, publication1.Topic.Id);
+                    .ListPublications(includePermissions: false, publication1.Topic.Id);
 
                 var publicationViewModelList = result.AssertRight();
 
@@ -162,7 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService: userService.Object);
 
                 var result = await publicationService
-                    .ListPublications(permissions: false, topic.Id);
+                    .ListPublications(includePermissions: false, topic.Id);
 
                 var publicationViewModelList = result.AssertRight();
 
@@ -222,7 +222,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService: userService.Object);
 
                 var result = await publicationService
-                    .ListPublications(permissions: false);
+                    .ListPublications(includePermissions: false);
 
                 var publicationViewModelList = result.AssertRight();
 
@@ -299,7 +299,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService: userService.Object);
 
                 var result = await publicationService
-                    .ListPublications(permissions: true, topic.Id);
+                    .ListPublications(includePermissions: true, topic.Id);
 
                 var publicationViewModelList = result.AssertRight();
 
@@ -395,7 +395,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService: userService.Object);
 
                 var result = await publicationService
-                    .ListPublications(permissions: false, topic.Id);
+                    .ListPublications(includePermissions: false, topic.Id);
 
                 var publicationViewModelList = result.AssertRight();
 
@@ -484,7 +484,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService: userService.Object);
 
                 var result = await publicationService
-                    .ListPublications(permissions: false, topic.Id);
+                    .ListPublications(includePermissions: false, topic.Id);
 
                 var publicationViewModelList = result.AssertRight();
 
@@ -577,7 +577,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService: userService.Object);
 
                 var result = await publicationService
-                    .ListPublications(permissions: false);
+                    .ListPublications(includePermissions: false);
 
                 var publicationViewModelList = result.AssertRight();
 
@@ -667,7 +667,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService: userService.Object);
 
                 var result = await publicationService
-                    .ListPublications(permissions: true, topic.Id);
+                    .ListPublications(includePermissions: true, topic.Id);
 
                 var publicationViewModelList = result.AssertRight();
 
@@ -1715,7 +1715,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var publicationService = BuildPublicationService(context,
                     userService: userService.Object);
 
-                var result = (await publicationService.GetPublication(publication.Id, permissions: true)).AssertRight();
+                var result = (await publicationService.GetPublication(publication.Id, includePermissions: true)).AssertRight();
 
                 Assert.Equal(publication.Id, result.Id);
 
@@ -1766,7 +1766,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var publicationService = BuildPublicationService(context);
 
-                var result = (await publicationService.GetPublication(publication.Id, permissions: true)).AssertRight();
+                var result = (await publicationService.GetPublication(publication.Id, includePermissions: true)).AssertRight();
 
                 Assert.Equal(publication.Id, result.Id);
 
@@ -1811,7 +1811,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var publicationService = BuildPublicationService(context);
 
-                var result = (await publicationService.GetPublication(publication.Id, permissions: true)).AssertRight();
+                var result = (await publicationService.GetPublication(publication.Id, includePermissions: true)).AssertRight();
 
                 Assert.Equal(publication.Id, result.Id);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -131,18 +131,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "A",
                 Topic = topic,
+                Contact = new Contact(),
             };
 
             var publication2 = new Publication
             {
                 Title = "B",
                 Topic = topic,
+                Contact = new Contact(),
             };
 
             var publication3 = new Publication
             {
                 Title = "C",
                 Topic = topic,
+                Contact = new Contact(),
             };
 
             var userService = new Mock<IUserService>(Strict);
@@ -188,18 +191,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "publication1",
                 Topic = new Topic { Theme = new Theme(), },
+                Contact = new Contact(),
             };
 
             var publication2 = new Publication
             {
                 Title = "publication2",
                 Topic = new Topic { Theme = new Theme(), },
+                Contact = new Contact(),
             };
 
             var publication3 = new Publication
             {
                 Title = "publication3",
                 Topic = new Topic { Theme = new Theme(), },
+                Contact = new Contact(),
             };
 
             var userService = new Mock<IUserService>(Strict);
@@ -257,6 +263,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "Test Publication",
                 Topic = topic,
+                Contact = new Contact(),
             };
 
             var userService = new Mock<IUserService>(Strict);
@@ -437,18 +444,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "A",
                 Topic = topic,
+                Contact = new Contact(),
             };
 
             var publication2 = new Publication
             {
                 Title = "B",
                 Topic = topic,
+                Contact = new Contact(),
             };
 
             var publication3 = new Publication
             {
                 Title = "C",
                 Topic = topic,
+                Contact = new Contact(),
             };
 
             var userService = new Mock<IUserService>(Strict);
@@ -516,24 +526,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "publication1",
                 Topic = new Topic { Theme = new Theme(), },
+                Contact = new Contact(),
             };
 
             var publication2 = new Publication
             {
                 Title = "publication2",
                 Topic = new Topic { Theme = new Theme(), },
+                Contact = new Contact(),
             };
 
             var publication3 = new Publication
             {
                 Title = "publication3",
                 Topic = new Topic { Theme = new Theme(), },
+                Contact = new Contact(),
             };
 
             var publication4 = new Publication
             {
                 Title = "publication4",
                 Topic = new Topic { Theme = new Theme(), },
+                Contact = new Contact(),
             };
 
             var userService = new Mock<IUserService>(Strict);
@@ -724,6 +738,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "publication1",
                 Topic = topic,
+                Contact = new Contact(),
                 Releases = new List<Release>
                 {
                     publication1Release1,
@@ -749,6 +764,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "publication2",
                 Topic = topic,
+                Contact = new Contact(),
                 Releases = ListOf(publication2Release1, publication2Release2),
             };
 
@@ -840,6 +856,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "publication1",
                 Topic = topic,
+                Contact = new Contact(),
                 Releases = ListOf(release),
                 Methodologies = ListOf(
                     new PublicationMethodology
@@ -953,6 +970,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     publication1Release3,
                     publication1Release4,
                     publication1Release1),
+                Contact = new Contact(),
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -1015,6 +1033,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "publication1",
                 Topic = topic,
+                Contact = new Contact(),
                 Releases = ListOf(publication1Release1, publication1Release2),
             };
 
@@ -1119,6 +1138,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "publication1",
                 Topic = topic,
+                Contact = new Contact(),
                 Releases = ListOf(
                     publication1Release2,
                     publication1Release3,
@@ -1142,6 +1162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "publication2",
                 Topic = topic,
+                Contact = new Contact(),
                 Releases = ListOf(publication2Release2, publication2Release1),
             };
 
@@ -1278,6 +1299,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "publication1",
                 Topic = topic,
+                Contact = new Contact(),
                 Releases = ListOf(release),
                 Methodologies = ListOf(
                     new PublicationMethodology
@@ -2650,6 +2672,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Theme = new Theme(),
                 },
                 Published = DateTime.UtcNow,
+                Contact = new Contact(),
             };
 
             var supersededPublication1 = new Publication
@@ -2657,6 +2680,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Title = "Superseded title 1",
                 Slug = "superseded-slug-1",
                 SupersededBy = publication,
+                Contact = new Contact(),
             };
 
             var supersededPublication2 = new Publication
@@ -2664,6 +2688,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Title = "Superseded title 2",
                 Slug = "superseded-slug-2",
                 SupersededBy = publication,
+                Contact = new Contact(),
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -2745,7 +2770,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Topic = new Topic
                 {
                     Title = "Test topic"
-                }
+                },
+                Contact = new Contact(),
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -2785,13 +2811,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "Test publication",
                 Slug = "test-publication",
-                Topic = topic
+                Topic = topic,
+                Contact = new Contact(),
             };
             var otherPublication = new Publication
             {
                 Title = "Duplicated title",
                 Slug = "duplicated-title",
-                Topic = topic
+                Topic = topic,
+                Contact = new Contact(),
             };
 
             var contextId = Guid.NewGuid().ToString();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -106,11 +106,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(publication1.Topic.Theme.Id, publicationViewModel.Theme.Id);
                 Assert.Equal(publication1.Topic.Theme.Title, publicationViewModel.Theme.Title);
 
-                Assert.Equal(publication1.Contact.ContactName, publicationViewModel.Contact.ContactName);
-                Assert.Equal(publication1.Contact.ContactTelNo, publicationViewModel.Contact.ContactTelNo);
-                Assert.Equal(publication1.Contact.TeamName, publicationViewModel.Contact.TeamName);
-                Assert.Equal(publication1.Contact.TeamEmail, publicationViewModel.Contact.TeamEmail);
-
                 Assert.Null(publicationViewModel.SupersededById);
                 Assert.False(publicationViewModel.IsSuperseded);
 
@@ -345,24 +340,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Summary = "Test summary",
                 Slug = "test-slug",
                 Topic = topic,
-                Contact = new Contact
-                {
-                    ContactName = "contact name",
-                    ContactTelNo = "1234",
-                    TeamName = "team name",
-                    TeamEmail = "team@email",
-                },
                 SupersededBy = null,
+                Contact = new Contact(), // EES-3576 should be removable
             };
 
             var publication2 = new Publication
             {
                 Topic = new Topic(),
+                Contact = new Contact(), // EES-3576 should be removable
             };
 
             var publication3 = new Publication
             {
                 Topic = new Topic(),
+                Contact = new Contact(), // EES-3576 should be removable
             };
 
             var userService = new Mock<IUserService>(Strict);
@@ -419,11 +410,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(publication1.Topic.Theme.Id, publicationViewModel.Theme.Id);
                 Assert.Equal(publication1.Topic.Theme.Title, publicationViewModel.Theme.Title);
 
-                Assert.Equal(publication1.Contact.ContactName, publicationViewModel.Contact.ContactName);
-                Assert.Equal(publication1.Contact.ContactTelNo, publicationViewModel.Contact.ContactTelNo);
-                Assert.Equal(publication1.Contact.TeamName, publicationViewModel.Contact.TeamName);
-                Assert.Equal(publication1.Contact.TeamEmail, publicationViewModel.Contact.TeamEmail);
-
                 Assert.Null(publicationViewModel.SupersededById);
                 Assert.False(publicationViewModel.IsSuperseded);
 
@@ -442,21 +428,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "A",
                 Topic = topic,
-                Contact = new Contact(),
+                Contact = new Contact(), // EES-3576 should be removable
             };
 
             var publication2 = new Publication
             {
                 Title = "B",
                 Topic = topic,
-                Contact = new Contact(),
+                Contact = new Contact(), // EES-3576 should be removable
             };
 
             var publication3 = new Publication
             {
                 Title = "C",
                 Topic = topic,
-                Contact = new Contact(),
+                Contact = new Contact(), // EES-3576 should be removable
             };
 
             var userService = new Mock<IUserService>(Strict);
@@ -524,21 +510,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "publication1",
                 Topic = new Topic { Theme = new Theme(), },
-                Contact = new Contact(),
+                Contact = new Contact(), // EES-3576 should be removable
             };
 
             var publication2 = new Publication
             {
                 Title = "publication2",
                 Topic = new Topic { Theme = new Theme(), },
-                Contact = new Contact(),
+                Contact = new Contact(), // EES-3576 should be removable
             };
 
             var publication3 = new Publication
             {
                 Title = "publication3",
                 Topic = new Topic { Theme = new Theme(), },
-                Contact = new Contact(),
+                Contact = new Contact(), // EES-3576 should be removable
             };
 
             var publication4 = new Publication
@@ -1632,7 +1618,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Title = "Test theme"
                     }
                 },
-                Contact = new Contact
+                Contact = new Contact // EES-3576 should be removable
                 {
                     ContactName = "Test contact",
                     ContactTelNo = "0123456789",
@@ -1665,11 +1651,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(publication.Topic.ThemeId, result.Theme.Id);
                 Assert.Equal(publication.Topic.Theme.Title, result.Theme.Title);
-
-                Assert.Equal(publication.Contact.ContactName, result.Contact.ContactName);
-                Assert.Equal(publication.Contact.ContactTelNo, result.Contact.ContactTelNo);
-                Assert.Equal(publication.Contact.TeamEmail, result.Contact.TeamEmail);
-                Assert.Equal(publication.Contact.TeamName, result.Contact.TeamName);
 
                 Assert.Null(result.SupersededById);
                 Assert.False(result.IsSuperseded);
@@ -2406,11 +2387,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("New title", viewModel.Title);
                 Assert.Equal("New summary", viewModel.Summary);
 
-                Assert.Equal("Old name", viewModel.Contact.ContactName);
-                Assert.Equal("0987654321", viewModel.Contact.ContactTelNo);
-                Assert.Equal("Old team", viewModel.Contact.TeamName);
-                Assert.Equal("old.smith@test.com", viewModel.Contact.TeamEmail);
-
                 Assert.Equal(topic.Id, viewModel.Topic.Id);
                 Assert.Equal(topic.Title, viewModel.Topic.Title);
 
@@ -2545,11 +2521,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("New title", viewModel.Title);
                 Assert.Equal("New summary", viewModel.Summary);
 
-                Assert.Equal("Old name", viewModel.Contact.ContactName);
-                Assert.Equal("0987654321", viewModel.Contact.ContactTelNo);
-                Assert.Equal("Old team", viewModel.Contact.TeamName);
-                Assert.Equal("old.smith@test.com", viewModel.Contact.TeamEmail);
-
                 Assert.Equal(topic.Id, viewModel.Topic.Id);
                 Assert.Equal(topic.Title, viewModel.Topic.Title);
 
@@ -2643,7 +2614,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal("Old title", viewModel.Title);
                 Assert.Equal("New summary", viewModel.Summary);
-                Assert.Equal("Old name", viewModel.Contact.ContactName);
                 Assert.Equal(publication.SupersededById, viewModel.SupersededById);
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -3132,6 +3132,46 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task GetContact()
+        {
+            var publication = new Publication
+            {
+                Contact = new Contact
+                {
+                    ContactName = "contact name",
+                    ContactTelNo = "12345",
+                    TeamName = "team name",
+                    TeamEmail = "team@email.com",
+                },
+            };
+
+            var contentDbContext = InMemoryApplicationDbContext();
+            await contentDbContext.Publications.AddAsync(publication);
+            await contentDbContext.SaveChangesAsync();
+
+            var service = BuildPublicationService(context: contentDbContext);
+
+            var result = await service.GetContact(publication.Id);
+            var contact = result.AssertRight();
+
+            Assert.Equal(publication.Contact.ContactName, contact.ContactName);
+            Assert.Equal(publication.Contact.ContactTelNo, contact.ContactTelNo);
+            Assert.Equal(publication.Contact.TeamName, contact.TeamName);
+            Assert.Equal(publication.Contact.TeamEmail, contact.TeamEmail);
+        }
+
+        [Fact]
+        public async Task GetContact_NoPublication()
+        {
+            var contentDbContext = InMemoryApplicationDbContext();
+
+            var service = BuildPublicationService(context: contentDbContext);
+
+            var result = await service.GetContact(Guid.NewGuid());
+            result.AssertNotFound();
+        }
+
+        [Fact]
         public async Task ListActiveReleases()
         {
             var release1Original = new Release

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -1727,6 +1727,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.False(result.Permissions.CanAdoptMethodologies);
                 Assert.False(result.Permissions.CanCreateMethodologies);
                 Assert.False(result.Permissions.CanManageExternalMethodology);
+                Assert.True(result.Permissions.CanUpdateContact);
             }
         }
 
@@ -3134,7 +3135,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var service = BuildPublicationService(context: contentDbContext);
 
-            var result = await service.GetContact(publication.Id, false);
+            var result = await service.GetContact(publication.Id);
             var contact = result.AssertRight();
 
             Assert.Equal(publication.Contact.ContactName, contact.ContactName);
@@ -3155,50 +3156,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var service = BuildPublicationService(context: contentDbContext);
 
-            var result = await service.GetContact(publication.Id, false);
+            var result = await service.GetContact(publication.Id);
             result.AssertNotFound();
-        }
-
-        [Fact]
-        public async Task GetContact_Permissions()
-        {
-            var publication = new Publication
-            {
-                Contact = new Contact
-                {
-                    ContactName = "contact name",
-                    ContactTelNo = "12345",
-                    TeamName = "team name",
-                    TeamEmail = "team@email.com",
-                },
-            };
-
-            var contentDbContext = InMemoryApplicationDbContext();
-            await contentDbContext.Publications.AddAsync(publication);
-            await contentDbContext.SaveChangesAsync();
-
-            var userService = new Mock<IUserService>(Strict);
-
-            userService.Setup(s =>
-                    s.MatchesPolicy(It.Is<Publication>(p => p.Id == publication.Id), CanViewSpecificPublication))
-                .ReturnsAsync(true);
-            userService.Setup(s =>
-                    s.MatchesPolicy(It.Is<Publication>(p => p.Id == publication.Id), CanUpdateSpecificPublication))
-                .ReturnsAsync(false);
-
-            var service = BuildPublicationService(context: contentDbContext,
-                userService: userService.Object);
-
-            var result = await service.GetContact(publication.Id, true);
-            var contact = result.AssertRight();
-
-            Assert.Equal(publication.Contact.ContactName, contact.ContactName);
-            Assert.Equal(publication.Contact.ContactTelNo, contact.ContactTelNo);
-            Assert.Equal(publication.Contact.TeamName, contact.TeamName);
-            Assert.Equal(publication.Contact.TeamEmail, contact.TeamEmail);
-
-            Assert.NotNull(contact.Permissions);
-            Assert.False(contact.Permissions!.CanUpdatePublication);
         }
 
         [Fact]
@@ -3208,7 +3167,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var service = BuildPublicationService(context: contentDbContext);
 
-            var result = await service.GetContact(Guid.NewGuid(), false);
+            var result = await service.GetContact(Guid.NewGuid());
             result.AssertNotFound();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -106,7 +106,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(publication1.Topic.Theme.Id, publicationViewModel.Theme.Id);
                 Assert.Equal(publication1.Topic.Theme.Title, publicationViewModel.Theme.Title);
 
-                Assert.Equal(publication1.Contact.Id, publicationViewModel.Contact.Id);
                 Assert.Equal(publication1.Contact.ContactName, publicationViewModel.Contact.ContactName);
                 Assert.Equal(publication1.Contact.ContactTelNo, publicationViewModel.Contact.ContactTelNo);
                 Assert.Equal(publication1.Contact.TeamName, publicationViewModel.Contact.TeamName);
@@ -420,7 +419,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(publication1.Topic.Theme.Id, publicationViewModel.Theme.Id);
                 Assert.Equal(publication1.Topic.Theme.Title, publicationViewModel.Theme.Title);
 
-                Assert.Equal(publication1.Contact.Id, publicationViewModel.Contact.Id);
                 Assert.Equal(publication1.Contact.ContactName, publicationViewModel.Contact.ContactName);
                 Assert.Equal(publication1.Contact.ContactTelNo, publicationViewModel.Contact.ContactTelNo);
                 Assert.Equal(publication1.Contact.TeamName, publicationViewModel.Contact.TeamName);
@@ -1668,7 +1666,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(publication.Topic.ThemeId, result.Theme.Id);
                 Assert.Equal(publication.Topic.Theme.Title, result.Theme.Title);
 
-                Assert.Equal(publication.Contact.Id, result.Contact.Id);
                 Assert.Equal(publication.Contact.ContactName, result.Contact.ContactName);
                 Assert.Equal(publication.Contact.ContactTelNo, result.Contact.ContactTelNo);
                 Assert.Equal(publication.Contact.TeamEmail, result.Contact.TeamEmail);
@@ -2060,7 +2057,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 // Service method under test
                 var result = await publicationService.CreatePublication(
-                    new PublicationSaveRequest
+                    new PublicationCreateRequest
                     {
                         Title = "Test publication",
                         Summary = "Test summary",
@@ -2119,7 +2116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             // Service method under test
             var result = await publicationService.CreatePublication(
-                new PublicationSaveRequest
+                new PublicationCreateRequest
                 {
                     Title = "Test publication",
                     TopicId = Guid.NewGuid()
@@ -2158,7 +2155,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 // Service method under test
                 var result = await publicationService.CreatePublication(
-                    new PublicationSaveRequest
+                    new PublicationCreateRequest
                     {
                         Title = "Test publication",
                         TopicId = topic.Id
@@ -2231,13 +2228,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         Title = "New title",
                         Summary = "New summary",
-                        Contact = new ContactSaveViewModel
-                        {
-                            ContactName = "John Smith",
-                            ContactTelNo = "0123456789",
-                            TeamName = "Test team",
-                            TeamEmail = "john.smith@test.com",
-                        },
                         TopicId = topic.Id,
                         SupersededById = newSupersededById,
                     }
@@ -2250,10 +2240,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("New title", viewModel.Title);
                 Assert.Equal("New summary", viewModel.Summary);
 
-                Assert.Equal("John Smith", viewModel.Contact.ContactName);
-                Assert.Equal("0123456789", viewModel.Contact.ContactTelNo);
-                Assert.Equal("Test team", viewModel.Contact.TeamName);
-                Assert.Equal("john.smith@test.com", viewModel.Contact.TeamEmail);
+                Assert.Equal("Old name", viewModel.Contact.ContactName);
+                Assert.Equal("0987654321", viewModel.Contact.ContactTelNo);
+                Assert.Equal("Old team", viewModel.Contact.TeamName);
+                Assert.Equal("old.smith@test.com", viewModel.Contact.TeamEmail);
 
                 Assert.Equal(topic.Id, viewModel.Topic.Id);
                 Assert.Equal(topic.Title, viewModel.Topic.Title);
@@ -2271,10 +2261,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("New title", updatedPublication.Title);
                 Assert.Equal(newSupersededById, updatedPublication.SupersededById);
 
-                Assert.Equal("John Smith", updatedPublication.Contact.ContactName);
-                Assert.Equal("0123456789", updatedPublication.Contact.ContactTelNo);
-                Assert.Equal("Test team", updatedPublication.Contact.TeamName);
-                Assert.Equal("john.smith@test.com", updatedPublication.Contact.TeamEmail);
+                Assert.Equal("Old name", updatedPublication.Contact.ContactName);
+                Assert.Equal("0987654321", updatedPublication.Contact.ContactTelNo);
+                Assert.Equal("Old team", updatedPublication.Contact.TeamName);
+                Assert.Equal("old.smith@test.com", updatedPublication.Contact.TeamEmail);
+
 
                 Assert.Equal(topic.Id, updatedPublication.TopicId);
                 Assert.Equal("New topic", updatedPublication.Topic.Title);
@@ -2323,7 +2314,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             };
 
             var contextId = Guid.NewGuid().ToString();
-
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 context.AddRange(topic, publication, supersedingPublicationToRemove, supersededPublication);
@@ -2374,13 +2364,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         Title = "New title",
                         Summary = "New summary",
-                        Contact = new ContactSaveViewModel
-                        {
-                            ContactName = "John Smith",
-                            ContactTelNo = "0123456789",
-                            TeamName = "Test team",
-                            TeamEmail = "john.smith@test.com",
-                        },
                         TopicId = topic.Id,
                         SupersededById = newSupersededById,
                     }
@@ -2396,10 +2379,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("New title", viewModel.Title);
                 Assert.Equal("New summary", viewModel.Summary);
 
-                Assert.Equal("John Smith", viewModel.Contact.ContactName);
-                Assert.Equal("0123456789", viewModel.Contact.ContactTelNo);
-                Assert.Equal("Test team", viewModel.Contact.TeamName);
-                Assert.Equal("john.smith@test.com", viewModel.Contact.TeamEmail);
+                Assert.Equal("Old name", viewModel.Contact.ContactName);
+                Assert.Equal("0987654321", viewModel.Contact.ContactTelNo);
+                Assert.Equal("Old team", viewModel.Contact.TeamName);
+                Assert.Equal("old.smith@test.com", viewModel.Contact.TeamEmail);
 
                 Assert.Equal(topic.Id, viewModel.Topic.Id);
                 Assert.Equal(topic.Title, viewModel.Topic.Title);
@@ -2418,10 +2401,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("New title", updatedPublication.Title);
                 Assert.Equal("New summary", updatedPublication.Summary);
 
-                Assert.Equal("John Smith", updatedPublication.Contact.ContactName);
-                Assert.Equal("0123456789", updatedPublication.Contact.ContactTelNo);
-                Assert.Equal("Test team", updatedPublication.Contact.TeamName);
-                Assert.Equal("john.smith@test.com", updatedPublication.Contact.TeamEmail);
+                Assert.Equal("Old name", updatedPublication.Contact.ContactName);
+                Assert.Equal("0987654321", updatedPublication.Contact.ContactTelNo);
+                Assert.Equal("Old team", updatedPublication.Contact.TeamName);
+                Assert.Equal("old.smith@test.com", updatedPublication.Contact.TeamEmail);
 
                 Assert.Equal(topic.Id, updatedPublication.TopicId);
                 Assert.Equal("New topic", updatedPublication.Topic.Title);
@@ -2483,13 +2466,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         Title = "Old title",
                         Summary = "New summary",
-                        Contact = new ContactSaveViewModel
-                        {
-                            ContactName = "John Smith",
-                            ContactTelNo = "0123456789",
-                            TeamName = "Test team",
-                            TeamEmail = "john.smith@test.com",
-                        },
                         TopicId = topic.Id,
                         SupersededById = publication.SupersededById,
                     }
@@ -2501,161 +2477,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal("Old title", viewModel.Title);
                 Assert.Equal("New summary", viewModel.Summary);
-                Assert.Equal("John Smith", viewModel.Contact.ContactName);
+                Assert.Equal("Old name", viewModel.Contact.ContactName);
                 Assert.Equal(publication.SupersededById, viewModel.SupersededById);
-            }
-        }
-
-        [Fact]
-        public async Task UpdatePublication_SavesNewContact()
-        {
-            var publication = new Publication
-            {
-                Title = "Test title",
-                Slug = "test-slug",
-                Topic = new Topic
-                {
-                    Title = "Test topic",
-                    Theme = new Theme(),
-                },
-                Contact = new Contact(),
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(publication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(Strict);
-
-                methodologyVersionRepository.Setup(mock =>
-                        mock.PublicationTitleChanged(
-                            publication.Id,
-                            publication.Slug,
-                            "New title",
-                            "new-slug"))
-                    .Returns(Task.CompletedTask);
-
-                var publicationService = BuildPublicationService(context,
-                    methodologyVersionRepository: methodologyVersionRepository.Object);
-
-                // Service method under test
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "New title",
-                        Slug = "new-slug",
-                        Contact = new ContactSaveViewModel
-                        {
-                            ContactName = "John Smith",
-                            ContactTelNo = "0123456789",
-                            TeamName = "Test team",
-                            TeamEmail = "john.smith@test.com",
-                        },
-                        TopicId = publication.TopicId
-                    }
-                );
-
-                VerifyAllMocks(methodologyVersionRepository);
-
-                var viewModel = result.AssertRight();
-
-                var updatedPublication = await context.Publications.FindAsync(viewModel.Id);
-
-                Assert.NotNull(updatedPublication);
-                Assert.Equal("John Smith", updatedPublication!.Contact.ContactName);
-                Assert.Equal("0123456789", updatedPublication.Contact.ContactTelNo);
-                Assert.Equal("Test team", updatedPublication.Contact.TeamName);
-                Assert.Equal("john.smith@test.com", updatedPublication.Contact.TeamEmail);
-            }
-        }
-
-        [Fact]
-        public async Task UpdatePublication_SavesNewContactWhenSharedWithOtherPublication()
-        {
-            var sharedContact = new Contact
-            {
-                Id = Guid.NewGuid(),
-                ContactName = "Old name",
-                ContactTelNo = "0987654321",
-                TeamName = "Old team",
-                TeamEmail = "old.smith@test.com",
-            };
-            var publication = new Publication
-            {
-                Title = "Test publication",
-                Slug = "test-publication",
-                Topic = new Topic
-                {
-                    Title = "Test topic",
-                    Theme = new Theme(),
-                },
-                Contact = sharedContact
-            };
-            var otherPublication = new Publication
-            {
-                Title = "Other publication",
-                Summary = "Other publication summary",
-                Contact = sharedContact
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.AddRangeAsync(publication, otherPublication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(Strict);
-
-                methodologyVersionRepository.Setup(mock =>
-                        mock.PublicationTitleChanged(
-                            publication.Id,
-                            publication.Slug,
-                            "New title",
-                            "new-title"))
-                    .Returns(Task.CompletedTask);
-
-                var publicationService = BuildPublicationService(context,
-                    methodologyVersionRepository: methodologyVersionRepository.Object);
-
-                // Service method under test
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "New title",
-                        Contact = new ContactSaveViewModel
-                        {
-                            ContactName = "John Smith",
-                            ContactTelNo = "0123456789",
-                            TeamName = "Test team",
-                            TeamEmail = "john.smith@test.com",
-                        },
-                        TopicId = publication.TopicId
-                    }
-                );
-
-                VerifyAllMocks(methodologyVersionRepository);
-
-                var viewModel = result.AssertRight();
-
-                var updatedPublication = await context.Publications.FindAsync(viewModel.Id);
-
-                Assert.NotNull(updatedPublication);
-                Assert.NotEqual(sharedContact.Id, updatedPublication!.Contact.Id);
-                Assert.Equal("John Smith", updatedPublication.Contact.ContactName);
-                Assert.Equal("0123456789", updatedPublication.Contact.ContactTelNo);
-                Assert.Equal("Test team", updatedPublication.Contact.TeamName);
-                Assert.Equal("john.smith@test.com", updatedPublication.Contact.TeamEmail);
             }
         }
 
@@ -2738,13 +2561,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         Title = "Test title",
                         Slug = "test-slug",
-                        Contact = new ContactSaveViewModel
-                        {
-                            ContactName = "John Smith",
-                            ContactTelNo = "0123456789",
-                            TeamName = "Test team",
-                            TeamEmail = "john.smith@test.com",
-                        },
                         TopicId = publication.TopicId,
                     }
                 );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
@@ -370,6 +370,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 contentDbContext.Add(new Publication
                 {
                     Id = publicationId,
+                    Contact = new Contact(),
                     Releases = new List<Release>
                     {
                         release

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -45,7 +45,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var publication = new Publication
             {
-                Title = "Publication"
+                Title = "Publication",
+                Contact = new Contact(),
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -124,6 +125,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         Id = new Guid("403d3c5d-a8cd-4d54-a029-0c74c86c55b2"),
                         Title = "Publication",
+                        Contact = new Contact(),
                         Releases = new List<Release>
                         {
                             new() // Template release
@@ -237,7 +239,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var publication = new Publication
             {
-                Id = Guid.NewGuid()
+                Id = Guid.NewGuid(),
+                Contact = new Contact(),
             };
 
             var notLatestRelease = new Release
@@ -639,7 +642,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var release = new Release
             {
                 Type = ReleaseType.AdHocStatistics,
-                Publication = new Publication(),
+                Publication = new Publication
+                {
+                    Contact = new Contact(),
+                },
                 ReleaseName = "2030",
                 PublishScheduled = DateTime.UtcNow,
                 NextReleaseDate = new PartialDate {Day = "15", Month = "6", Year = "2039"},
@@ -796,6 +802,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Title = "Test publication",
                 Summary = "Test summary",
                 Slug = "test-publication",
+                Contact = new Contact(),
                 Releases = new List<Release>
                 {
                     release
@@ -804,6 +811,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var publication2 = new Publication
             {
+                Contact = new Contact(),
                 Releases = new List<Release>
                 {
                     new()
@@ -817,7 +825,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             }
                         }
                     }
-                }
+                },
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -870,10 +878,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var publication = new Publication
             {
+                Contact = new Contact(),
                 Releases = new List<Release>
                 {
                     release
-                }
+                },
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -980,7 +989,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("June 2036", latest.Title);
             }
         }
-        
+
         [Fact]
         public async Task GetDeleteReleasePlan()
         {
@@ -988,7 +997,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Id = Guid.NewGuid()
             };
-            
+
             // This is just another unrelated Release that should not be affected.
             var releaseNotBeingDeleted = new Release
             {
@@ -1005,7 +1014,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     OwningPublicationTitle = "Methodology 1 owned Publication title"
                 }
             };
-            
+
             var methodology2ScheduledWithRelease1 = new MethodologyVersion
             {
                 Id = Guid.NewGuid(),
@@ -1033,7 +1042,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 await context.Releases.AddRangeAsync(releaseBeingDeleted, releaseNotBeingDeleted);
                 await context.MethodologyVersions.AddRangeAsync(
-                    methodology1ScheduledWithRelease1, 
+                    methodology1ScheduledWithRelease1,
                     methodology2ScheduledWithRelease1,
                     methodologyScheduledWithRelease2,
                     methodologyNotScheduled);
@@ -1052,7 +1061,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(2, plan.ScheduledMethodologies.Count);
                 var methodology1 = plan.ScheduledMethodologies.Single(m => m.Id == methodology1ScheduledWithRelease1.Id);
                 var methodology2 = plan.ScheduledMethodologies.Single(m => m.Id == methodology2ScheduledWithRelease1.Id);
-                
+
                 Assert.Equal("Methodology 1 with alternative title", methodology1.Title);
                 Assert.Equal("Methodology 2 with owned Publication title", methodology2.Title);
             }
@@ -1255,7 +1264,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .First(r => r.Id == anotherUserReleaseInvite.Id);
 
                 Assert.False(retrievedAnotherReleaseInvite.SoftDeleted);
-                
+
                 // Assert that Methodologies that were scheduled to go out with this Release are no longer scheduled
                 // to do so
                 var retrievedMethodology = context.MethodologyVersions.Single(m => m.Id == methodologyScheduledWithRelease.Id);
@@ -1265,11 +1274,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(MethodologyStatus.Draft, retrievedMethodology.Status);
                 Assert.InRange(DateTime.UtcNow
                     .Subtract(retrievedMethodology.Updated!.Value).Milliseconds, 0, 1500);
-                
+
                 // Assert that Methodologies that were scheduled to go out with other Releases remain unaffected
                 var unrelatedMethodology = context.MethodologyVersions.Single(m => m.Id == methodologyScheduledWithAnotherRelease.Id);
                 Assert.True(unrelatedMethodology.ScheduledForPublishingWithRelease);
-                Assert.Equal(methodologyScheduledWithAnotherRelease.ScheduledWithReleaseId, 
+                Assert.Equal(methodologyScheduledWithAnotherRelease.ScheduledWithReleaseId,
                     unrelatedMethodology.ScheduledWithReleaseId);
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -64,10 +64,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 
         [HttpGet("api/publications/{publicationId}")]
         public async Task<ActionResult<PublicationViewModel>> GetPublication(
-            [Required] Guid publicationId)
+            [Required] Guid publicationId, [FromQuery] bool permissions = false)
         {
             return await _publicationService
-                .GetPublication(publicationId)
+                .GetPublication(publicationId, permissions)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -125,7 +125,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpPost("api/publications")]
-        public async Task<ActionResult<PublicationViewModel>> CreatePublication(
+        public async Task<ActionResult<PublicationCreateViewModel>> CreatePublication(
             PublicationCreateRequest publication)
         {
             return await _publicationService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -124,7 +124,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 
         [HttpPost("api/publications")]
         public async Task<ActionResult<PublicationViewModel>> CreatePublication(
-            PublicationSaveRequest publication)
+            PublicationCreateRequest publication)
         {
             return await _publicationService
                 .CreatePublication(publication)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -96,10 +96,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 
         [HttpGet("api/publication/{publicationId:guid}/contact")]
         public async Task<ActionResult<ContactViewModel>> GetContact(
-            Guid publicationId,
-            [FromQuery] bool includePermissions = false)
+            Guid publicationId)
         {
-            return await _publicationService.GetContact(publicationId, includePermissions)
+            return await _publicationService.GetContact(publicationId)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -94,6 +94,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrNoContent();
         }
 
+        [HttpGet("api/publication/{publicationId:guid}/contact")]
+        public async Task<ActionResult<ContactViewModel>> GetContact(Guid publicationId)
+        {
+            return await _publicationService.GetContact(publicationId)
+                .HandleFailuresOrOk();
+        }
+
 
         [HttpGet("api/publication/{publicationId}/releases")]
         public async Task<ActionResult<PaginatedListViewModel<ReleaseSummaryViewModel>>> ListActiveReleases(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -101,6 +101,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
+        [HttpPut("api/publication/{publicationId:guid}/contact")]
+        public async Task<ActionResult<ContactViewModel>> UpdateContact(
+            Guid publicationId, Contact updatedContact)
+        {
+            return await _publicationService.UpdateContact(publicationId, updatedContact)
+                .HandleFailuresOrOk();
+        }
 
         [HttpGet("api/publication/{publicationId}/releases")]
         public async Task<ActionResult<PaginatedListViewModel<ReleaseSummaryViewModel>>> ListActiveReleases(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -28,11 +28,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 
         [HttpGet("api/publications")]
         public async Task<ActionResult<List<PublicationViewModel>>> ListPublications(
-            [FromQuery] bool permissions,
+            [FromQuery] bool includePermissions,
             [FromQuery] Guid? topicId)
         {
             return await _publicationService
-                .ListPublications(permissions, topicId)
+                .ListPublications(includePermissions, topicId)
                 .HandleFailuresOrOk();
         }
 
@@ -64,10 +64,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 
         [HttpGet("api/publications/{publicationId}")]
         public async Task<ActionResult<PublicationViewModel>> GetPublication(
-            [Required] Guid publicationId, [FromQuery] bool permissions = false)
+            [Required] Guid publicationId, [FromQuery] bool includePermissions = false)
         {
             return await _publicationService
-                .GetPublication(publicationId, permissions)
+                .GetPublication(publicationId, includePermissions)
                 .HandleFailuresOrOk();
         }
 
@@ -97,9 +97,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [HttpGet("api/publication/{publicationId:guid}/contact")]
         public async Task<ActionResult<ContactViewModel>> GetContact(
             Guid publicationId,
-            [FromQuery] bool permissions = false)
+            [FromQuery] bool includePermissions = false)
         {
-            return await _publicationService.GetContact(publicationId, permissions)
+            return await _publicationService.GetContact(publicationId, includePermissions)
                 .HandleFailuresOrOk();
         }
 
@@ -116,11 +116,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             [Required] Guid publicationId,
             [FromQuery, Range(1, double.PositiveInfinity)] int page = 1,
             [FromQuery, Range(0, double.PositiveInfinity)] int pageSize = 5,
-            [FromQuery] bool permissions = false,
-            [FromQuery] bool? live = null)
+            [FromQuery] bool? live = null,
+            [FromQuery] bool includePermissions = false)
         {
             return await _publicationService
-                .ListActiveReleasesPaginated(publicationId, page, pageSize, live, includePermissions: permissions)
+                .ListActiveReleasesPaginated(publicationId, page, pageSize, live, includePermissions)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -95,9 +95,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpGet("api/publication/{publicationId:guid}/contact")]
-        public async Task<ActionResult<ContactViewModel>> GetContact(Guid publicationId)
+        public async Task<ActionResult<ContactViewModel>> GetContact(
+            Guid publicationId,
+            [FromQuery] bool permissions = false)
         {
-            return await _publicationService.GetContact(publicationId)
+            return await _publicationService.GetContact(publicationId, permissions)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -72,6 +72,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                 .ForMember(
                     dest => dest.Theme,
                     m => m.MapFrom(p => p.Topic.Theme));
+            CreateMap<Publication, PublicationCreateViewModel>()
+                .ForMember(
+                    dest => dest.Theme,
+                    m => m.MapFrom(p => p.Topic.Theme));
 
             CreateMap<Publication, MyPublicationViewModel>()
                 .ForMember(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220914155611_EES3695MakePublicationsContactIdNonnullable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220914155611_EES3695MakePublicationsContactIdNonnullable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220914155611_EES3695MakePublicationsContactIdNonnullable")]
+    partial class EES3695MakePublicationsContactIdNonnullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220914155611_EES3695MakePublicationsContactIdNonnullable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220914155611_EES3695MakePublicationsContactIdNonnullable.Designer.cs
@@ -1291,7 +1291,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Contact", "Contact")
                         .WithMany()
                         .HasForeignKey("ContactId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", "SupersededBy")

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220914155611_EES3695MakePublicationsContactIdNonnullable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220914155611_EES3695MakePublicationsContactIdNonnullable.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES3695MakePublicationsContactIdNonnullable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Publications_Contacts_ContactId",
+                table: "Publications");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ContactId",
+                table: "Publications",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Publications_Contacts_ContactId",
+                table: "Publications",
+                column: "ContactId",
+                principalTable: "Contacts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Publications_Contacts_ContactId",
+                table: "Publications");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ContactId",
+                table: "Publications",
+                type: "uniqueidentifier",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Publications_Contacts_ContactId",
+                table: "Publications",
+                column: "ContactId",
+                principalTable: "Contacts",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220914155611_EES3695MakePublicationsContactIdNonnullable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20220914155611_EES3695MakePublicationsContactIdNonnullable.cs
@@ -29,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                 column: "ContactId",
                 principalTable: "Contacts",
                 principalColumn: "Id",
-                onDelete: ReferentialAction.Cascade);
+                onDelete: ReferentialAction.Restrict);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
@@ -1289,7 +1289,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Contact", "Contact")
                         .WithMany()
                         .HasForeignKey("ContactId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", "SupersededBy")

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/PublicationCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/PublicationCreateRequest.cs
@@ -1,18 +1,21 @@
 #nullable enable
 using System;
 using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using static System.String;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
-public record PublicationSaveRequest
+public record PublicationCreateRequest
 {
         [Required] public string Title { get; set; } = Empty;
 
         [Required, MaxLength(160)] public string Summary { get; set; } = Empty;
 
         [Required] public Guid TopicId { get; set; }
+
+        [Required] public ContactSaveViewModel Contact { get; set; } = null!;
 
         private string _slug = Empty;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -12,7 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IPublicationService
     {
-        Task<Either<ActionResult, List<PublicationViewModel>>> ListPublications(bool permissions, Guid? topicId);
+        Task<Either<ActionResult, List<PublicationViewModel>>> ListPublications(bool includePermissions, Guid? topicId);
 
         Task<Either<ActionResult, List<MyPublicationViewModel>>> GetMyPublicationsAndReleasesByTopic(Guid topicId);
 
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             Guid publicationId,
             PublicationSaveRequest updatedPublication);
 
-        Task<Either<ActionResult, PublicationViewModel>> GetPublication(Guid publicationId, bool permissions);
+        Task<Either<ActionResult, PublicationViewModel>> GetPublication(Guid publicationId, bool includePermissions);
 
         Task<Either<ActionResult, ExternalMethodologyViewModel>> GetExternalMethodology(Guid publicationId);
 
@@ -37,7 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, Unit>> RemoveExternalMethodology(
             Guid publicationId);
 
-        Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId, bool permissions);
+        Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId, bool includePermissions);
 
         Task<Either<ActionResult, ContactViewModel>> UpdateContact(Guid publicationId, Contact updatedContact);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -39,6 +39,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId);
 
+        Task<Either<ActionResult, ContactViewModel>> UpdateContact(Guid publicationId, Contact updatedContact);
+
         Task<Either<ActionResult, PaginatedListViewModel<ReleaseSummaryViewModel>>> ListActiveReleasesPaginated(
             Guid publicationId,
             int page,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, List<PublicationSummaryViewModel>>> ListPublicationSummaries();
 
         Task<Either<ActionResult, PublicationViewModel>> CreatePublication(
-            PublicationSaveRequest publication);
+            PublicationCreateRequest publication);
 
         Task<Either<ActionResult, PublicationViewModel>> UpdatePublication(
             Guid publicationId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -37,6 +37,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, Unit>> RemoveExternalMethodology(
             Guid publicationId);
 
+        Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId);
+
         Task<Either<ActionResult, PaginatedListViewModel<ReleaseSummaryViewModel>>> ListActiveReleasesPaginated(
             Guid publicationId,
             int page,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             Guid publicationId,
             PublicationSaveRequest updatedPublication);
 
-        Task<Either<ActionResult, PublicationViewModel>> GetPublication(Guid publicationId);
+        Task<Either<ActionResult, PublicationViewModel>> GetPublication(Guid publicationId, bool permissions);
 
         Task<Either<ActionResult, ExternalMethodologyViewModel>> GetExternalMethodology(Guid publicationId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -37,7 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, Unit>> RemoveExternalMethodology(
             Guid publicationId);
 
-        Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId, bool includePermissions);
+        Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId);
 
         Task<Either<ActionResult, ContactViewModel>> UpdateContact(Guid publicationId, Contact updatedContact);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -20,7 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, List<PublicationSummaryViewModel>>> ListPublicationSummaries();
 
-        Task<Either<ActionResult, PublicationViewModel>> CreatePublication(
+        Task<Either<ActionResult, PublicationCreateViewModel>> CreatePublication(
             PublicationCreateRequest publication);
 
         Task<Either<ActionResult, PublicationViewModel>> UpdatePublication(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -37,7 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, Unit>> RemoveExternalMethodology(
             Guid publicationId);
 
-        Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId);
+        Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId, bool permissions);
 
         Task<Either<ActionResult, ContactViewModel>> UpdateContact(Guid publicationId, Contact updatedContact);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -160,7 +160,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                                 InternalReleaseNote = latestVersion.InternalReleaseNote,
                                 MethodologyId = latestVersion.MethodologyId,
                                 PreviousVersionId = latestVersion.PreviousVersionId,
-                                Permissions = permissions
+                                Permissions = permissions,
                             };
                         })
                         .OrderBy(viewModel => viewModel.Title)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -149,7 +149,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         public async Task<Either<ActionResult, PublicationViewModel>> CreatePublication(
-            PublicationSaveRequest publication)
+            PublicationCreateRequest publication)
         {
             return await ValidateSelectedTopic(publication.TopicId)
                 .OnSuccess(async _ =>
@@ -240,19 +240,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     publication.TopicId = updatedPublication.TopicId;
                     publication.Updated = DateTime.UtcNow;
                     publication.SupersededById = updatedPublication.SupersededById;
-
-                    // Replace existing contact that is shared with another publication with a new
-                    // contact, as we want each publication to have its own contact.
-                    if (_context.Publications
-                            .Any(p => p.ContactId == publication.ContactId && p.Id != publication.Id))
-                    {
-                        publication.Contact = new Contact();
-                    }
-
-                    publication.Contact.ContactName = updatedPublication.Contact.ContactName;
-                    publication.Contact.ContactTelNo = updatedPublication.Contact.ContactTelNo;
-                    publication.Contact.TeamName = updatedPublication.Contact.TeamName;
-                    publication.Contact.TeamEmail = updatedPublication.Contact.TeamEmail;
 
                     _context.Publications.Update(publication);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -296,12 +296,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(_ => Unit.Instance);
         }
 
-        public async Task<Either<ActionResult, PublicationViewModel>> GetPublication(Guid publicationId)
+        public async Task<Either<ActionResult, PublicationViewModel>> GetPublication(
+            Guid publicationId, bool permissions = false)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Publication>(publicationId, HydratePublication)
                 .OnSuccess(_userService.CheckCanViewPublication)
-                .OnSuccess(publication => _mapper.Map<PublicationViewModel>(publication));
+                .OnSuccess(publication => GeneratePublicationViewModel(publication, permissions));
         }
 
         public async Task<Either<ActionResult, ExternalMethodologyViewModel>> GetExternalMethodology(Guid publicationId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -369,6 +369,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
+        public async Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId)
+        {
+            return await _persistenceHelper
+                .CheckEntityExists<Publication>(publicationId)
+                .OnSuccessDo(_userService.CheckCanViewPublication)
+                .OnSuccess(publication => _mapper.Map<ContactViewModel>(publication.Contact));
+        }
+
         public async Task<Either<ActionResult, PaginatedListViewModel<ReleaseSummaryViewModel>>>
             ListActiveReleasesPaginated(
                 Guid publicationId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -357,7 +357,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
-        public async Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId, bool includePermissions)
+        public async Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Publication>(publicationId, query =>
@@ -366,11 +366,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(async publication =>
                 {
                     var contact = _mapper.Map<ContactViewModel>(publication.Contact);
-
-                    if (includePermissions)
-                    {
-                        contact.Permissions = await PermissionsUtils.GetContactPermissions(_userService, publication);
-                    }
 
                     return contact;
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Util/PermissionsUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Util/PermissionsUtils.cs
@@ -61,4 +61,15 @@ public static class PermissionsUtils
                 await userService.CheckCanDropMethodologyLink(publicationMethodology).IsRight()
         };
     }
+
+    public static async Task<ContactViewModel.ContactPermissions> GetContactPermissions(
+        IUserService userService,
+        Publication publication
+    )
+    {
+        return new ContactViewModel.ContactPermissions
+        {
+            CanUpdatePublication = await userService.CheckCanUpdatePublication(publication).IsRight(),
+        };
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Util/PermissionsUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Util/PermissionsUtils.cs
@@ -28,9 +28,10 @@ public static class PermissionsUtils
         IUserService userService,
         Publication publication)
     {
+        var canUpdatePublication = await userService.CheckCanUpdatePublication(publication).IsRight();
         return new PublicationPermissions
         {
-            CanUpdatePublication = await userService.CheckCanUpdatePublication(publication).IsRight(),
+            CanUpdatePublication = canUpdatePublication,
             CanUpdatePublicationTitle = await userService.CheckCanUpdatePublicationTitle().IsRight(),
             CanUpdatePublicationSupersededBy = await userService.CheckCanUpdatePublicationSupersededBy().IsRight(),
             CanCreateReleases = await userService.CheckCanCreateReleaseForPublication(publication).IsRight(),
@@ -38,7 +39,7 @@ public static class PermissionsUtils
             CanCreateMethodologies = await userService.CheckCanCreateMethodologyForPublication(publication).IsRight(),
             CanManageExternalMethodology =
                 await userService.CheckCanManageExternalMethodologyForPublication(publication).IsRight(),
-            CanUpdateContact = await userService.CheckCanUpdatePublication(publication).IsRight(),
+            CanUpdateContact = canUpdatePublication, // EES-3576 Switch to CheckCanUpdateContact permission
         };
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Util/PermissionsUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Util/PermissionsUtils.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Secu
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using static GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.MethodologyVersionSummaryViewModel;
 using static GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.PublicationViewModel;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseRole;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Util;
 
@@ -37,6 +38,7 @@ public static class PermissionsUtils
             CanCreateMethodologies = await userService.CheckCanCreateMethodologyForPublication(publication).IsRight(),
             CanManageExternalMethodology =
                 await userService.CheckCanManageExternalMethodologyForPublication(publication).IsRight(),
+            CanUpdateContact = await userService.CheckCanUpdatePublication(publication).IsRight(),
         };
     }
 
@@ -59,17 +61,6 @@ public static class PermissionsUtils
                 await userService.CheckCanMakeAmendmentOfMethodology(methodologyVersion).IsRight(),
             CanRemoveMethodologyLink =
                 await userService.CheckCanDropMethodologyLink(publicationMethodology).IsRight()
-        };
-    }
-
-    public static async Task<ContactViewModel.ContactPermissions> GetContactPermissions(
-        IUserService userService,
-        Publication publication
-    )
-    {
-        return new ContactViewModel.ContactPermissions
-        {
-            CanUpdatePublication = await userService.CheckCanUpdatePublication(publication).IsRight(),
         };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
@@ -5,6 +5,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
     public class ContactViewModel
     {
+        // @MarkFix remove Id
         public Guid Id { get; set; }
 
         public string TeamName { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
@@ -13,11 +13,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public string ContactTelNo { get; set; } = string.Empty;
 
-        public ContactPermissions? Permissions { get; set; }
+        public ContactPermissions? Permissions { get; set; } // @MarkFix remove
 
-        public record ContactPermissions
+        public record ContactPermissions // @MarkFix remove
         {
-            public bool CanUpdatePublication { get; set; }
+            public bool CanUpdateContact { get; set; }
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
@@ -1,13 +1,9 @@
-using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
     public class ContactViewModel
     {
-        // @MarkFix remove Id
-        public Guid Id { get; set; }
-
         public string TeamName { get; set; }
 
         public string TeamEmail { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
@@ -1,31 +1,34 @@
+#nullable enable
 using System.ComponentModel.DataAnnotations;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
     public class ContactViewModel
     {
-        public string TeamName { get; set; }
+        public string TeamName { get; set; } = string.Empty;
 
-        public string TeamEmail { get; set; }
+        public string TeamEmail { get; set; } = string.Empty;
 
-        public string ContactName { get; set; }
+        public string ContactName { get; set; } = string.Empty;
 
-        public string ContactTelNo { get; set; }
+        public string ContactTelNo { get; set; } = string.Empty;
+
+        public ContactPermissions? Permissions { get; set; }
+
+        public record ContactPermissions
+        {
+            public bool CanUpdatePublication { get; set; }
+        }
     }
 
     public class ContactSaveViewModel
     {
-        [Required]
-        public string TeamName { get; set; }
+        [Required] public string TeamName { get; set; } = string.Empty;
 
-        [Required]
-        [EmailAddress]
-        public string TeamEmail { get; set; }
+        [Required, EmailAddress] public string TeamEmail { get; set; } = string.Empty;
 
-        [Required]
-        public string ContactName { get; set; }
+        [Required] public string ContactName { get; set; } = string.Empty;
 
-        [Required]
-        public string ContactTelNo { get; set; }
+        [Required] public string ContactTelNo { get; set; } = string.Empty;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ExternalMethodologyViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ExternalMethodologyViewModel.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationCreateViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationCreateViewModel.cs
@@ -1,0 +1,28 @@
+#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using static System.String;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
+{
+    public class PublicationCreateViewModel
+    {
+        public Guid Id { get; set; }
+
+        public string Title { get; set; } = Empty;
+
+        public string Summary { get; set; } = Empty;
+
+        public string Slug { get; set; } = Empty;
+
+        public Contact Contact { get; set; } = null!;
+
+        public IdTitleViewModel Topic { get; set; } = null!;
+
+        public IdTitleViewModel Theme { get; set; } = null!;
+
+        public Guid? SupersededById { get; set; }
+
+        public bool IsSuperseded { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModel.cs
@@ -18,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public IdTitleViewModel Theme { get; set; } = null!;
 
-        public ContactViewModel Contact { get; set; } = null!;
+        public ContactViewModel Contact { get; set; } = null!; // @MarkFix remove this
 
         public Guid? SupersededById { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModel.cs
@@ -20,6 +20,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public Guid? SupersededById { get; set; }
 
+        // NOTE: IsSuperseded is necessary, as a publication only becomes superseded when it's SupersededById is set
+        // _and_ that publication has a live release.
         public bool IsSuperseded { get; set; }
 
         public PublicationPermissions? Permissions { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModel.cs
@@ -35,6 +35,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
             public bool CanAdoptMethodologies { get; set; }
             public bool CanCreateMethodologies { get; set; }
             public bool CanManageExternalMethodology { get; set; }
+            public bool CanUpdateContact { get; set; }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModel.cs
@@ -18,8 +18,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public IdTitleViewModel Theme { get; set; } = null!;
 
-        public ContactViewModel Contact { get; set; } = null!; // @MarkFix remove this
-
         public Guid? SupersededById { get; set; }
 
         public bool IsSuperseded { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -33,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Topic Topic { get; set; } = null!;
 
-        public Guid? ContactId { get; set; }
+        public Guid ContactId { get; set; }
 
         public Contact Contact { get; set; } = null!;
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ManagePublicationsAndReleasesTab.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ManagePublicationsAndReleasesTab.test.tsx
@@ -96,6 +96,7 @@ describe('ManagePublicationsAndReleasesTab', () => {
         canUpdatePublicationSupersededBy: true,
         canCreateMethodologies: true,
         canManageExternalMethodology: true,
+        canUpdateContact: true,
       },
     },
     {
@@ -115,6 +116,7 @@ describe('ManagePublicationsAndReleasesTab', () => {
         canUpdatePublicationSupersededBy: true,
         canCreateMethodologies: true,
         canManageExternalMethodology: true,
+        canUpdateContact: true,
       },
     },
   ];

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ManagePublicationsAndReleasesTab.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ManagePublicationsAndReleasesTab.test.tsx
@@ -72,7 +72,6 @@ describe('ManagePublicationsAndReleasesTab', () => {
   ];
 
   const testContact: Contact = {
-    id: 'contact-1',
     contactName: 'John Smith',
     contactTelNo: '0777777777',
     teamEmail: 'john.smith@test.com',

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ManagePublicationsAndReleasesTab.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ManagePublicationsAndReleasesTab.test.tsx
@@ -2,7 +2,7 @@ import ManagePublicationsAndReleasesTab from '@admin/pages/admin-dashboard/compo
 import _permissionService from '@admin/services/permissionService';
 import _publicationService, {
   MyPublication,
-  PublicationContactDetails,
+  Contact,
 } from '@admin/services/publicationService';
 import _themeService, { Theme } from '@admin/services/themeService';
 import _storageService from '@common/services/storageService';
@@ -71,7 +71,7 @@ describe('ManagePublicationsAndReleasesTab', () => {
     },
   ];
 
-  const testContact: PublicationContactDetails = {
+  const testContact: Contact = {
     id: 'contact-1',
     contactName: 'John Smith',
     contactTelNo: '0777777777',

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -115,6 +115,7 @@ const testPublicationNoMethodology: MyPublication = {
     canUpdatePublicationSupersededBy: true,
     canCreateMethodologies: true,
     canManageExternalMethodology: true,
+    canUpdateContact: true,
   },
 };
 const testPublicationWithMethodology = produce(

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -6,7 +6,7 @@ import _methodologyService, {
 import _publicationService, {
   ExternalMethodology,
   MyPublication,
-  PublicationContactDetails,
+  Contact,
 } from '@admin/services/publicationService';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import noop from 'lodash/noop';
@@ -26,7 +26,7 @@ const publicationService = _publicationService as jest.Mocked<
   typeof _publicationService
 >;
 
-const testContact: PublicationContactDetails = {
+const testContact: Contact = {
   id: 'contact-1',
   contactName: 'John Smith',
   contactTelNo: '0777777777',

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -27,7 +27,6 @@ const publicationService = _publicationService as jest.Mocked<
 >;
 
 const testContact: Contact = {
-  id: 'contact-1',
   contactName: 'John Smith',
   contactTelNo: '0777777777',
   teamEmail: 'john.smith@test.com',

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
@@ -17,7 +17,6 @@ describe('PublicationSummary', () => {
   const testTopicId = 'test-topic';
 
   const testContact: Contact = {
-    id: 'contact-1',
     contactName: 'John Smith',
     contactTelNo: '0777777777',
     teamEmail: 'john.smith@test.com',

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
@@ -31,6 +31,7 @@ describe('PublicationSummary', () => {
     canUpdatePublicationSupersededBy: true,
     canCreateMethodologies: true,
     canManageExternalMethodology: true,
+    canUpdateContact: true,
   };
 
   const testPublication: MyPublication = {
@@ -50,6 +51,7 @@ describe('PublicationSummary', () => {
       canUpdatePublicationSupersededBy: false,
       canCreateMethodologies: false,
       canManageExternalMethodology: false,
+      canUpdateContact: false,
     },
   };
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
@@ -2,10 +2,7 @@ import { render, screen, within } from '@testing-library/react';
 import React from 'react';
 import { noop } from 'lodash';
 import PublicationSummary from '@admin/pages/admin-dashboard/components/PublicationSummary';
-import {
-  MyPublication,
-  PublicationContactDetails,
-} from '@admin/services/publicationService';
+import { MyPublication, Contact } from '@admin/services/publicationService';
 import _releaseService, {
   Release,
   ReleaseStageStatuses,
@@ -19,7 +16,7 @@ const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 describe('PublicationSummary', () => {
   const testTopicId = 'test-topic';
 
-  const testContact: PublicationContactDetails = {
+  const testContact: Contact = {
     id: 'contact-1',
     contactName: 'John Smith',
     contactTelNo: '0777777777',

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationsTab.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationsTab.test.tsx
@@ -2,7 +2,7 @@ import PublicationsTab from '@admin/pages/admin-dashboard/components/Publication
 import _permissionService from '@admin/services/permissionService';
 import _publicationService, {
   MyPublication,
-  PublicationContactDetails,
+  Contact,
 } from '@admin/services/publicationService';
 import _themeService, { Theme } from '@admin/services/themeService';
 import _storageService from '@common/services/storageService';
@@ -71,7 +71,7 @@ describe('PublicationsTab', () => {
     },
   ];
 
-  const testContact: PublicationContactDetails = {
+  const testContact: Contact = {
     id: 'contact-1',
     contactName: 'John Smith',
     contactTelNo: '0777777777',

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationsTab.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationsTab.test.tsx
@@ -72,7 +72,6 @@ describe('PublicationsTab', () => {
   ];
 
   const testContact: Contact = {
-    id: 'contact-1',
     contactName: 'John Smith',
     contactTelNo: '0777777777',
     teamEmail: 'john.smith@test.com',

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationsTab.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationsTab.test.tsx
@@ -96,6 +96,7 @@ describe('PublicationsTab', () => {
         canUpdatePublicationSupersededBy: true,
         canCreateMethodologies: true,
         canManageExternalMethodology: true,
+        canUpdateContact: true,
       },
     },
     {
@@ -115,6 +116,7 @@ describe('PublicationsTab', () => {
         canUpdatePublicationSupersededBy: true,
         canCreateMethodologies: true,
         canManageExternalMethodology: true,
+        canUpdateContact: true,
       },
     },
   ];
@@ -137,6 +139,7 @@ describe('PublicationsTab', () => {
         canUpdatePublicationSupersededBy: true,
         canCreateMethodologies: true,
         canManageExternalMethodology: true,
+        canUpdateContact: true,
       },
     },
   ];
@@ -159,6 +162,7 @@ describe('PublicationsTab', () => {
         canUpdatePublicationSupersededBy: true,
         canCreateMethodologies: true,
         canManageExternalMethodology: true,
+        canUpdateContact: true,
       },
     },
   ];
@@ -181,6 +185,7 @@ describe('PublicationsTab', () => {
         canUpdatePublicationSupersededBy: true,
         canCreateMethodologies: true,
         canManageExternalMethodology: true,
+        canUpdateContact: true,
       },
     },
   ];

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ReleaseSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ReleaseSummary.test.tsx
@@ -18,7 +18,6 @@ describe('ReleaseSummary', () => {
     contact: {
       contactName: 'Test contact name',
       contactTelNo: 'Test contact tel',
-      id: 'test-contact-idc',
       teamEmail: 'test-contact@hiveit.co.uk',
       teamName: 'Test team name',
     },

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/TopicPublications.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/TopicPublications.test.tsx
@@ -1,5 +1,5 @@
 import TopicPublications from '@admin/pages/admin-dashboard/components/TopicPublications';
-import { testPublication } from '@admin/pages/publication/__data__/testPublication';
+import { testMyPublication } from '@admin/pages/publication/__data__/testPublication';
 import _permissionService from '@admin/services/permissionService';
 import _publicationService, {
   MyPublication,
@@ -30,14 +30,14 @@ describe('TopicPublications', () => {
   };
   const testThemeTitle = 'Theme 1';
 
-  const testPublications: MyPublication[] = [
-    testPublication,
-    { ...testPublication, id: 'publication-2', title: 'Publication 2' },
+  const testMyPublications: MyPublication[] = [
+    testMyPublication,
+    { ...testMyPublication, id: 'publication-2', title: 'Publication 2' },
   ];
 
   test('renders correctly with list of publications', async () => {
     publicationService.getMyPublicationsByTopic.mockResolvedValue(
-      testPublications,
+      testMyPublications,
     );
     permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
 
@@ -80,7 +80,7 @@ describe('TopicPublications', () => {
 
   test("renders 'Create new publication' button if authorised", async () => {
     publicationService.getMyPublicationsByTopic.mockResolvedValue(
-      testPublications,
+      testMyPublications,
     );
     permissionService.canCreatePublicationForTopic.mockResolvedValue(true);
 
@@ -101,7 +101,7 @@ describe('TopicPublications', () => {
 
   test("does not render 'Create new publication' button if unauthorised", async () => {
     publicationService.getMyPublicationsByTopic.mockResolvedValue(
-      testPublications,
+      testMyPublications,
     );
     permissionService.canCreatePublicationForTopic.mockResolvedValue(false);
 

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
@@ -12,20 +12,28 @@ import useToggle from '@common/hooks/useToggle';
 import React from 'react';
 
 const PublicationContactPage = () => {
-  const { publicationId, onReload } = usePublicationContext();
+  const { publication, onReload } = usePublicationContext();
   const [readOnly, toggleReadOnly] = useToggle(true);
 
-  const { value: contact } = useAsyncHandledRetry(
-    async () => publicationService.getContact(publicationId, true),
-    [publicationId],
+  const {
+    value: contact,
+    setState: setContact,
+  } = useAsyncHandledRetry(
+    async () => publicationService.getContact(publication.id),
+    [publication],
   );
 
   const handleSubmit = async (updatedContact: PublicationContactFormValues) => {
     if (!contact) {
       return;
     }
-    await publicationService.updateContact(publicationId, updatedContact);
+    const nextContact = await publicationService.updateContact(
+      publication.id,
+      updatedContact,
+    );
 
+    setContact({ value: nextContact });
+    toggleReadOnly.on();
     onReload();
   };
 
@@ -62,7 +70,7 @@ const PublicationContactPage = () => {
               {contact.contactTelNo}
             </SummaryListItem>
           </SummaryList>
-          {contact.permissions?.canUpdatePublication && (
+          {publication.permissions.canUpdateContact && (
             <Button variant="secondary" onClick={toggleReadOnly.off}>
               Edit contact details
             </Button>

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
@@ -1,33 +1,22 @@
-import { useLastLocation } from '@admin/contexts/LastLocationContext';
 import PublicationContactForm, {
   PublicationContactFormValues,
 } from '@admin/pages/publication/components/PublicationContactForm';
 import usePublicationContext from '@admin/pages/publication/contexts/PublicationContext';
 import publicationService from '@admin/services/publicationService';
-// import Button from '@common/components/Button'; // @MarkFix
+import Button from '@common/components/Button';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import useToggle from '@common/hooks/useToggle';
 import React from 'react';
-import { useLocation } from 'react-router';
 
 const PublicationContactPage = () => {
-  const {
-    publicationId,
-    publication: contextPublication,
-    onReload,
-  } = usePublicationContext();
-  const location = useLocation();
-  const lastLocation = useLastLocation();
+  const { publicationId, onReload } = usePublicationContext();
   const [readOnly, toggleReadOnly] = useToggle(true);
 
   const { value: contact } = useAsyncHandledRetry(
-    async () =>
-      lastLocation && lastLocation !== location
-        ? publicationService.getContact(publicationId)
-        : contextPublication.contact,
+    async () => publicationService.getContact(publicationId, true),
     [publicationId],
   );
 
@@ -73,11 +62,11 @@ const PublicationContactPage = () => {
               {contact.contactTelNo}
             </SummaryListItem>
           </SummaryList>
-          {/* {publication.permissions.canUpdatePublication && ( // @MarkFix add permissions to ContactViewModel
+          {contact.permissions?.canUpdatePublication && (
             <Button variant="secondary" onClick={toggleReadOnly.off}>
               Edit contact details
             </Button>
-          )} */}
+          )}
         </>
       ) : (
         <PublicationContactForm

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
@@ -4,7 +4,7 @@ import PublicationContactForm, {
 } from '@admin/pages/publication/components/PublicationContactForm';
 import usePublicationContext from '@admin/pages/publication/contexts/PublicationContext';
 import publicationService from '@admin/services/publicationService';
-import Button from '@common/components/Button';
+// import Button from '@common/components/Button'; // @MarkFix
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
@@ -23,41 +23,26 @@ const PublicationContactPage = () => {
   const lastLocation = useLastLocation();
   const [readOnly, toggleReadOnly] = useToggle(true);
 
-  const { value: publication } = useAsyncHandledRetry(
+  const { value: contact } = useAsyncHandledRetry(
     async () =>
       lastLocation && lastLocation !== location
-        ? publicationService.getMyPublication(publicationId)
-        : contextPublication,
+        ? publicationService.getContact(publicationId)
+        : contextPublication.contact,
     [publicationId],
   );
 
-  const handleSubmit = async ({
-    teamName,
-    teamEmail,
-    contactName,
-    contactTelNo,
-  }: PublicationContactFormValues) => {
-    if (!publication) {
+  const handleSubmit = async (updatedContact: PublicationContactFormValues) => {
+    if (!contact) {
       return;
     }
-    await publicationService.updatePublication(publicationId, {
-      ...publication,
-      contact: {
-        teamName,
-        teamEmail,
-        contactName,
-        contactTelNo,
-      },
-    });
+    await publicationService.updateContact(publicationId, updatedContact);
 
     onReload();
   };
 
-  if (!publication) {
+  if (!contact) {
     return <LoadingSpinner />;
   }
-
-  const { contact } = publication;
 
   return (
     <>
@@ -88,11 +73,11 @@ const PublicationContactPage = () => {
               {contact.contactTelNo}
             </SummaryListItem>
           </SummaryList>
-          {publication.permissions.canUpdatePublication && (
+          {/* {publication.permissions.canUpdatePublication && ( // @MarkFix add permissions to ContactViewModel
             <Button variant="secondary" onClick={toggleReadOnly.off}>
               Edit contact details
             </Button>
-          )}
+          )} */}
         </>
       ) : (
         <PublicationContactForm

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
@@ -23,7 +23,7 @@ const PublicationDetailsPage = () => {
     supersededById,
     theme,
     topic,
-  } = publication as Publication;
+  } = publication;
   const [readOnly, toggleReadOnly] = useToggle(true);
 
   const {
@@ -62,7 +62,7 @@ const PublicationDetailsPage = () => {
                 : 'This publication is not archived'}
             </SummaryListItem>
           </SummaryList>
-          {permissions?.canUpdatePublication && (
+          {permissions.canUpdatePublication && (
             <Button variant="secondary" onClick={toggleReadOnly.off}>
               Edit publication details
             </Button>
@@ -71,9 +71,9 @@ const PublicationDetailsPage = () => {
       ) : (
         <PublicationDetailsForm
           canUpdatePublicationSupersededBy={
-            permissions?.canUpdatePublicationSupersededBy
+            permissions.canUpdatePublicationSupersededBy
           }
-          canUpdatePublicationTitle={permissions?.canUpdatePublicationTitle}
+          canUpdatePublicationTitle={permissions.canUpdatePublicationTitle}
           initialValues={{
             supersededById,
             title,

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
@@ -26,15 +26,16 @@ const PublicationDetailsPage = () => {
   } = publication as Publication;
   const [readOnly, toggleReadOnly] = useToggle(true);
 
-  const { value: supersedingPublication, isLoading } = useAsyncHandledRetry(
-    async () => {
-      if (!supersededById) {
-        return undefined;
-      }
+  const {
+    value: supersedingPublication,
+    isLoading,
+  } = useAsyncHandledRetry(async () => {
+    if (!supersededById) {
+      return undefined;
+    }
 
-      return publicationService.getPublication(supersededById);
-    },
-  );
+    return publicationService.getPublication(supersededById);
+  }, [supersededById]);
 
   const handleSubmit = async (values: PublicationDetailsFormValues) => {
     await publicationService.updatePublication(publication.id, {

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
@@ -15,7 +15,6 @@ import React from 'react';
 const PublicationDetailsPage = () => {
   const { publication, onReload } = usePublicationContext();
   const {
-    contact,
     id,
     permissions,
     supersededById,
@@ -47,7 +46,6 @@ const PublicationDetailsPage = () => {
   const handleSubmit = async (values: PublicationDetailsFormValues) => {
     await publicationService.updatePublication(publication.id, {
       ...values,
-      contact,
     });
     onReload();
   };

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationEditPage.tsx
@@ -112,14 +112,15 @@ const PublicationEditPage = ({
                 {
                   ...values,
                   topicId: values.topicId ?? publication?.topicId,
-                  contact: {
-                    teamName,
-                    teamEmail,
-                    contactName,
-                    contactTelNo,
-                  },
                 },
               );
+
+              await publicationService.updateContact(publication.id, {
+                teamName,
+                teamEmail,
+                contactName,
+                contactTelNo,
+              });
 
               history.push(
                 appendQuery<ThemeTopicParams>(dashboardRoute.path, {

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationExternalMethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationExternalMethodologyPage.tsx
@@ -9,11 +9,17 @@ import publicationService, {
 } from '@admin/services/publicationService';
 import React from 'react';
 import { generatePath, useHistory } from 'react-router';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 
 const PublicationExternalMethodologyPage = () => {
   const history = useHistory();
   const { publicationId, publication, onReload } = usePublicationContext();
-  const { externalMethodology } = publication;
+  const { value: externalMethodology, isLoading } = useAsyncHandledRetry<
+    ExternalMethodology | undefined
+  >(async () => publicationService.getExternalMethodology(publicationId), [
+    publicationId,
+  ]);
 
   const returnRoute = generatePath<PublicationRouteParams>(
     publicationMethodologiesRoute.path,
@@ -42,7 +48,7 @@ const PublicationExternalMethodologyPage = () => {
   };
 
   return (
-    <>
+    <LoadingSpinner loading={isLoading}>
       <h2>
         {externalMethodology
           ? 'Edit external methodology link'
@@ -53,7 +59,7 @@ const PublicationExternalMethodologyPage = () => {
         onCancel={() => history.push(returnRoute)}
         onSubmit={handleExternalMethodologySubmit}
       />
-    </>
+    </LoadingSpinner>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
@@ -99,7 +99,7 @@ const PublicationMethodologiesPage = () => {
             to an external file that contains methodology details.
           </p>
 
-          {permissions?.canCreateMethodologies && (
+          {permissions.canCreateMethodologies && (
             <Button
               className="govuk-!-margin-bottom-0"
               onClick={async () => {
@@ -294,7 +294,7 @@ const PublicationMethodologiesPage = () => {
                   <td />
                   <td />
                   <td>
-                    {permissions?.canManageExternalMethodology && (
+                    {permissions.canManageExternalMethodology && (
                       <Link
                         className="govuk-!-margin-right-4"
                         to={generatePath<PublicationRouteParams>(
@@ -323,7 +323,7 @@ const PublicationMethodologiesPage = () => {
                       </VisuallyHidden>
                     </Link>
 
-                    {permissions?.canManageExternalMethodology && (
+                    {permissions.canManageExternalMethodology && (
                       <ButtonText
                         variant="warning"
                         onClick={toggleRemovingExternalMethodology.on}
@@ -346,7 +346,7 @@ const PublicationMethodologiesPage = () => {
 
       <h3>Other options</h3>
 
-      {permissions?.canManageExternalMethodology && !externalMethodology && (
+      {permissions.canManageExternalMethodology && !externalMethodology && (
         <>
           <Link
             to={generatePath<PublicationRouteParams>(
@@ -364,7 +364,7 @@ const PublicationMethodologiesPage = () => {
         </>
       )}
 
-      {permissions?.canAdoptMethodologies && (
+      {permissions.canAdoptMethodologies && (
         <>
           <Link
             to={generatePath<PublicationRouteParams>(

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
@@ -99,7 +99,7 @@ const PublicationMethodologiesPage = () => {
             to an external file that contains methodology details.
           </p>
 
-          {permissions.canCreateMethodologies && (
+          {permissions?.canCreateMethodologies && (
             <Button
               className="govuk-!-margin-bottom-0"
               onClick={async () => {
@@ -294,7 +294,7 @@ const PublicationMethodologiesPage = () => {
                   <td />
                   <td />
                   <td>
-                    {permissions.canManageExternalMethodology && (
+                    {permissions?.canManageExternalMethodology && (
                       <Link
                         className="govuk-!-margin-right-4"
                         to={generatePath<PublicationRouteParams>(
@@ -323,7 +323,7 @@ const PublicationMethodologiesPage = () => {
                       </VisuallyHidden>
                     </Link>
 
-                    {permissions.canManageExternalMethodology && (
+                    {permissions?.canManageExternalMethodology && (
                       <ButtonText
                         variant="warning"
                         onClick={toggleRemovingExternalMethodology.on}
@@ -346,7 +346,7 @@ const PublicationMethodologiesPage = () => {
 
       <h3>Other options</h3>
 
-      {permissions.canManageExternalMethodology && !externalMethodology && (
+      {permissions?.canManageExternalMethodology && !externalMethodology && (
         <>
           <Link
             to={generatePath<PublicationRouteParams>(
@@ -364,7 +364,7 @@ const PublicationMethodologiesPage = () => {
         </>
       )}
 
-      {permissions.canAdoptMethodologies && (
+      {permissions?.canAdoptMethodologies && (
         <>
           <Link
             to={generatePath<PublicationRouteParams>(

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
@@ -18,7 +18,9 @@ import {
   publicationEditLegacyReleaseRoute,
   PublicationRouteParams,
 } from '@admin/routes/publicationRoutes';
-import publicationService from '@admin/services/publicationService';
+import publicationService, {
+  PublicationWithPermissions,
+} from '@admin/services/publicationService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import RelatedInformation from '@common/components/RelatedInformation';
 import WarningMessage from '@common/components/WarningMessage';
@@ -55,7 +57,10 @@ const PublicationPageContainer = ({
     isLoading: loadingPublication,
     retry: reloadPublication,
   } = useAsyncHandledRetry(() =>
-    publicationService.getPublication(publicationId, true),
+    publicationService.getPublication<PublicationWithPermissions>(
+      publicationId,
+      true,
+    ),
   );
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
@@ -54,8 +54,8 @@ const PublicationPageContainer = ({
     setState: setPublication,
     isLoading: loadingPublication,
     retry: reloadPublication,
-  } = useAsyncHandledRetry(
-    () => publicationService.getMyPublication(publicationId), // @MarkFix switch to getPublication
+  } = useAsyncHandledRetry(() =>
+    publicationService.getPublication(publicationId, true),
   );
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationPageContainer.tsx
@@ -54,8 +54,8 @@ const PublicationPageContainer = ({
     setState: setPublication,
     isLoading: loadingPublication,
     retry: reloadPublication,
-  } = useAsyncHandledRetry(() =>
-    publicationService.getMyPublication(publicationId),
+  } = useAsyncHandledRetry(
+    () => publicationService.getMyPublication(publicationId), // @MarkFix switch to getPublication
   );
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationReleasesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationReleasesPage.tsx
@@ -19,7 +19,7 @@ const PublicationReleasesPage = () => {
 
       <p>View, edit or amend releases contained within this publication.</p>
 
-      {publication?.permissions?.canCreateReleases && (
+      {publication?.permissions.canCreateReleases && (
         <ButtonLink
           to={generatePath<PublicationRouteParams>(releaseCreateRoute.path, {
             publicationId,

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationReleasesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationReleasesPage.tsx
@@ -19,7 +19,7 @@ const PublicationReleasesPage = () => {
 
       <p>View, edit or amend releases contained within this publication.</p>
 
-      {publication?.permissions.canCreateReleases && (
+      {publication?.permissions?.canCreateReleases && (
         <ButtonLink
           to={generatePath<PublicationRouteParams>(releaseCreateRoute.path, {
             publicationId,

--- a/src/explore-education-statistics-admin/src/pages/publication/__data__/testPublication.ts
+++ b/src/explore-education-statistics-admin/src/pages/publication/__data__/testPublication.ts
@@ -5,6 +5,9 @@ export const testContact: Contact = {
   contactTelNo: '0777777777',
   teamEmail: 'john.smith@test.com',
   teamName: 'Team Smith',
+  permissions: {
+    canUpdatePublication: true,
+  },
 };
 
 export const testPublication: MyPublication = {

--- a/src/explore-education-statistics-admin/src/pages/publication/__data__/testPublication.ts
+++ b/src/explore-education-statistics-admin/src/pages/publication/__data__/testPublication.ts
@@ -1,9 +1,6 @@
-import {
-  MyPublication,
-  PublicationContactDetails,
-} from '@admin/services/publicationService';
+import { MyPublication, Contact } from '@admin/services/publicationService';
 
-export const testContact: PublicationContactDetails = {
+export const testContact: Contact = {
   contactName: 'John Smith',
   contactTelNo: '0777777777',
   id: 'contact-id-1',

--- a/src/explore-education-statistics-admin/src/pages/publication/__data__/testPublication.ts
+++ b/src/explore-education-statistics-admin/src/pages/publication/__data__/testPublication.ts
@@ -1,4 +1,8 @@
-import { MyPublication, Contact } from '@admin/services/publicationService';
+import {
+  MyPublication,
+  Contact,
+  PublicationWithPermissions,
+} from '@admin/services/publicationService';
 
 export const testContact: Contact = {
   contactName: 'John Smith',
@@ -10,7 +14,25 @@ export const testContact: Contact = {
   },
 };
 
-export const testPublication: MyPublication = {
+export const testPublication: PublicationWithPermissions = {
+  id: 'publication-1',
+  title: 'Publication 1',
+  summary: 'Publication 1 summary',
+  slug: 'publication-1-slug',
+  theme: { id: 'theme-1', title: 'Theme 1' },
+  topic: { id: 'theme-1-topic-2', title: 'Theme 1 Topic 2' },
+  permissions: {
+    canAdoptMethodologies: true,
+    canCreateReleases: true,
+    canUpdatePublication: true,
+    canUpdatePublicationTitle: true,
+    canUpdatePublicationSupersededBy: true,
+    canCreateMethodologies: true,
+    canManageExternalMethodology: true,
+  },
+};
+
+export const testMyPublication: MyPublication = {
   id: 'publication-1',
   title: 'Publication 1',
   summary: 'Publication 1 summary',

--- a/src/explore-education-statistics-admin/src/pages/publication/__data__/testPublication.ts
+++ b/src/explore-education-statistics-admin/src/pages/publication/__data__/testPublication.ts
@@ -3,7 +3,6 @@ import { MyPublication, Contact } from '@admin/services/publicationService';
 export const testContact: Contact = {
   contactName: 'John Smith',
   contactTelNo: '0777777777',
-  id: 'contact-id-1',
   teamEmail: 'john.smith@test.com',
   teamName: 'Team Smith',
 };

--- a/src/explore-education-statistics-admin/src/pages/publication/__data__/testPublication.ts
+++ b/src/explore-education-statistics-admin/src/pages/publication/__data__/testPublication.ts
@@ -9,9 +9,6 @@ export const testContact: Contact = {
   contactTelNo: '0777777777',
   teamEmail: 'john.smith@test.com',
   teamName: 'Team Smith',
-  permissions: {
-    canUpdatePublication: true,
-  },
 };
 
 export const testPublication: PublicationWithPermissions = {
@@ -29,6 +26,7 @@ export const testPublication: PublicationWithPermissions = {
     canUpdatePublicationSupersededBy: true,
     canCreateMethodologies: true,
     canManageExternalMethodology: true,
+    canUpdateContact: true,
   },
 };
 
@@ -49,5 +47,6 @@ export const testMyPublication: MyPublication = {
     canUpdatePublicationSupersededBy: true,
     canCreateMethodologies: true,
     canManageExternalMethodology: true,
+    canUpdateContact: true,
   },
 };

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationAdoptMethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationAdoptMethodologyPage.test.tsx
@@ -3,7 +3,7 @@ import { PublicationContextProvider } from '@admin/pages/publication/contexts/Pu
 import { testPublication } from '@admin/pages/publication/__data__/testPublication';
 import { MethodologyVersion } from '@admin/services/methodologyService';
 import _publicationService, {
-  MyPublication,
+  Publication,
 } from '@admin/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -197,7 +197,7 @@ describe('PublicationAdoptMethodologyPage', () => {
   });
 });
 
-function renderPage(publication: MyPublication) {
+function renderPage(publication: Publication) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationAdoptMethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationAdoptMethodologyPage.test.tsx
@@ -3,7 +3,7 @@ import { PublicationContextProvider } from '@admin/pages/publication/contexts/Pu
 import { testPublication } from '@admin/pages/publication/__data__/testPublication';
 import { MethodologyVersion } from '@admin/services/methodologyService';
 import _publicationService, {
-  Publication,
+  PublicationWithPermissions,
 } from '@admin/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -197,7 +197,7 @@ describe('PublicationAdoptMethodologyPage', () => {
   });
 });
 
-function renderPage(publication: Publication) {
+function renderPage(publication: PublicationWithPermissions) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
@@ -17,6 +17,13 @@ const publicationService = _publicationService as jest.Mocked<
 
 describe('PublicationContactPage', () => {
   test('renders the contact page correctly', async () => {
+    publicationService.getContact.mockResolvedValue({
+      ...testPublication.contact,
+      permissions: {
+        canUpdatePublication: true,
+      },
+    });
+
     renderPage(testPublication);
 
     await waitFor(() => {
@@ -39,13 +46,14 @@ describe('PublicationContactPage', () => {
   });
 
   test('does not show the edit button if do not have permission', async () => {
-    renderPage({
-      ...testPublication,
+    publicationService.getContact.mockResolvedValue({
+      ...testPublication.contact,
       permissions: {
-        ...testPublication.permissions,
         canUpdatePublication: false,
       },
     });
+
+    renderPage(testPublication);
 
     await waitFor(() => {
       expect(
@@ -59,6 +67,13 @@ describe('PublicationContactPage', () => {
   });
 
   test('clicking the edit button shows the edit form', async () => {
+    publicationService.getContact.mockResolvedValue({
+      ...testPublication.contact,
+      permissions: {
+        canUpdatePublication: true,
+      },
+    });
+
     renderPage(testPublication);
 
     await waitFor(() => {
@@ -86,6 +101,13 @@ describe('PublicationContactPage', () => {
   });
 
   test('clicking the cancel button switches back to readOnly view', async () => {
+    publicationService.getContact.mockResolvedValue({
+      ...testPublication.contact,
+      permissions: {
+        canUpdatePublication: true,
+      },
+    });
+
     renderPage(testPublication);
 
     await waitFor(() => {
@@ -119,6 +141,13 @@ describe('PublicationContactPage', () => {
   });
 
   test('shows validation errors when there are no contact details', async () => {
+    publicationService.getContact.mockResolvedValue({
+      ...testPublication.contact,
+      permissions: {
+        canUpdatePublication: true,
+      },
+    });
+
     renderPage(testPublication);
 
     await waitFor(() => {
@@ -171,6 +200,13 @@ describe('PublicationContactPage', () => {
   });
 
   test('show validation error when contact email is not valid', async () => {
+    publicationService.getContact.mockResolvedValue({
+      ...testPublication.contact,
+      permissions: {
+        canUpdatePublication: true,
+      },
+    });
+
     renderPage(testPublication);
 
     await waitFor(() => {
@@ -199,6 +235,13 @@ describe('PublicationContactPage', () => {
   });
 
   test('shows a confirmation modal on submit', async () => {
+    publicationService.getContact.mockResolvedValue({
+      ...testPublication.contact,
+      permissions: {
+        canUpdatePublication: true,
+      },
+    });
+
     renderPage(testPublication);
 
     await waitFor(() => {
@@ -225,6 +268,13 @@ describe('PublicationContactPage', () => {
   });
 
   test('clicking confirm calls the publication service', async () => {
+    publicationService.getContact.mockResolvedValue({
+      ...testPublication.contact,
+      permissions: {
+        canUpdatePublication: true,
+      },
+    });
+
     renderPage(testPublication);
 
     await waitFor(() => {
@@ -244,17 +294,9 @@ describe('PublicationContactPage', () => {
     userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
     await waitFor(() => {
-      expect(publicationService.updatePublication).toHaveBeenCalledWith(
+      expect(publicationService.updateContact).toHaveBeenCalledWith(
         testPublication.id,
-        {
-          ...testPublication,
-          contact: {
-            contactName: 'John Smith',
-            contactTelNo: '0777777777',
-            teamEmail: 'john.smith@test.com',
-            teamName: 'Team Smith',
-          },
-        },
+        testPublication.contact,
       );
     });
   });

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
@@ -1,8 +1,11 @@
 import PublicationContactPage from '@admin/pages/publication/PublicationContactPage';
 import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
-import { testPublication } from '@admin/pages/publication/__data__/testPublication';
+import {
+  testContact,
+  testPublication,
+} from '@admin/pages/publication/__data__/testPublication';
 import _publicationService, {
-  MyPublication,
+  Publication,
 } from '@admin/services/publicationService';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
@@ -17,12 +20,7 @@ const publicationService = _publicationService as jest.Mocked<
 
 describe('PublicationContactPage', () => {
   test('renders the contact page correctly', async () => {
-    publicationService.getContact.mockResolvedValue({
-      ...testPublication.contact,
-      permissions: {
-        canUpdatePublication: true,
-      },
-    });
+    publicationService.getContact.mockResolvedValue(testContact);
 
     renderPage(testPublication);
 
@@ -47,10 +45,8 @@ describe('PublicationContactPage', () => {
 
   test('does not show the edit button if do not have permission', async () => {
     publicationService.getContact.mockResolvedValue({
-      ...testPublication.contact,
-      permissions: {
-        canUpdatePublication: false,
-      },
+      ...testContact,
+      permissions: { canUpdatePublication: false },
     });
 
     renderPage(testPublication);
@@ -67,12 +63,7 @@ describe('PublicationContactPage', () => {
   });
 
   test('clicking the edit button shows the edit form', async () => {
-    publicationService.getContact.mockResolvedValue({
-      ...testPublication.contact,
-      permissions: {
-        canUpdatePublication: true,
-      },
-    });
+    publicationService.getContact.mockResolvedValue(testContact);
 
     renderPage(testPublication);
 
@@ -101,12 +92,7 @@ describe('PublicationContactPage', () => {
   });
 
   test('clicking the cancel button switches back to readOnly view', async () => {
-    publicationService.getContact.mockResolvedValue({
-      ...testPublication.contact,
-      permissions: {
-        canUpdatePublication: true,
-      },
-    });
+    publicationService.getContact.mockResolvedValue(testContact);
 
     renderPage(testPublication);
 
@@ -141,12 +127,7 @@ describe('PublicationContactPage', () => {
   });
 
   test('shows validation errors when there are no contact details', async () => {
-    publicationService.getContact.mockResolvedValue({
-      ...testPublication.contact,
-      permissions: {
-        canUpdatePublication: true,
-      },
-    });
+    publicationService.getContact.mockResolvedValue(testContact);
 
     renderPage(testPublication);
 
@@ -200,12 +181,7 @@ describe('PublicationContactPage', () => {
   });
 
   test('show validation error when contact email is not valid', async () => {
-    publicationService.getContact.mockResolvedValue({
-      ...testPublication.contact,
-      permissions: {
-        canUpdatePublication: true,
-      },
-    });
+    publicationService.getContact.mockResolvedValue(testContact);
 
     renderPage(testPublication);
 
@@ -235,12 +211,7 @@ describe('PublicationContactPage', () => {
   });
 
   test('shows a confirmation modal on submit', async () => {
-    publicationService.getContact.mockResolvedValue({
-      ...testPublication.contact,
-      permissions: {
-        canUpdatePublication: true,
-      },
-    });
+    publicationService.getContact.mockResolvedValue(testContact);
 
     renderPage(testPublication);
 
@@ -268,12 +239,7 @@ describe('PublicationContactPage', () => {
   });
 
   test('clicking confirm calls the publication service', async () => {
-    publicationService.getContact.mockResolvedValue({
-      ...testPublication.contact,
-      permissions: {
-        canUpdatePublication: true,
-      },
-    });
+    publicationService.getContact.mockResolvedValue(testContact);
 
     renderPage(testPublication);
 
@@ -296,13 +262,13 @@ describe('PublicationContactPage', () => {
     await waitFor(() => {
       expect(publicationService.updateContact).toHaveBeenCalledWith(
         testPublication.id,
-        testPublication.contact,
+        testContact,
       );
     });
   });
 });
 
-function renderPage(publication: MyPublication) {
+function renderPage(publication: Publication) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
@@ -1,12 +1,8 @@
 import PublicationDetailsPage from '@admin/pages/publication/PublicationDetailsPage';
 import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
-import {
-  testContact,
-  testPublication,
-} from '@admin/pages/publication/__data__/testPublication';
+import { testPublication } from '@admin/pages/publication/__data__/testPublication';
 import _publicationService, {
   Publication,
-  MyPublication,
 } from '@admin/services/publicationService';
 import _themeService, { Theme } from '@admin/services/themeService';
 import { PublicationSummary } from '@common/services/publicationService';
@@ -410,7 +406,7 @@ describe('PublicationDetailsPage', () => {
   });
 });
 
-function renderPage(publication: MyPublication) {
+function renderPage(publication: Publication) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
@@ -3,6 +3,7 @@ import { PublicationContextProvider } from '@admin/pages/publication/contexts/Pu
 import { testPublication } from '@admin/pages/publication/__data__/testPublication';
 import _publicationService, {
   Publication,
+  PublicationWithPermissions,
 } from '@admin/services/publicationService';
 import _themeService, { Theme } from '@admin/services/themeService';
 import { PublicationSummary } from '@common/services/publicationService';
@@ -406,7 +407,7 @@ describe('PublicationDetailsPage', () => {
   });
 });
 
-function renderPage(publication: Publication) {
+function renderPage(publication: PublicationWithPermissions) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
@@ -400,7 +400,6 @@ describe('PublicationDetailsPage', () => {
         expect(publicationService.updatePublication).toHaveBeenCalledWith<
           Parameters<typeof publicationService.updatePublication>
         >(testPublication.id, {
-          contact: testContact,
           supersededById: 'publication-2',
           title: 'Publication 1 updated',
           summary: 'Publication 1 summary',

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationExternalMethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationExternalMethodologyPage.test.tsx
@@ -3,7 +3,7 @@ import { PublicationContextProvider } from '@admin/pages/publication/contexts/Pu
 import { testPublication } from '@admin/pages/publication/__data__/testPublication';
 import _publicationService, {
   ExternalMethodology,
-  Publication,
+  PublicationWithPermissions,
 } from '@admin/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -158,7 +158,7 @@ describe('PublicationExternalMethodologyPage', () => {
   });
 });
 
-function renderPage(publication: Publication) {
+function renderPage(publication: PublicationWithPermissions) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationExternalMethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationExternalMethodologyPage.test.tsx
@@ -3,7 +3,7 @@ import { PublicationContextProvider } from '@admin/pages/publication/contexts/Pu
 import { testPublication } from '@admin/pages/publication/__data__/testPublication';
 import _publicationService, {
   ExternalMethodology,
-  MyPublication,
+  Publication,
 } from '@admin/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -24,8 +24,16 @@ describe('PublicationExternalMethodologyPage', () => {
     url: 'http://test.com',
   };
 
-  test('renders the add an external methodology page correctly', () => {
+  test('renders the add an external methodology page correctly', async () => {
+    publicationService.getExternalMethodology.mockResolvedValue(undefined);
+
     renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(publicationService.getExternalMethodology).toBeCalledWith(
+        testPublication.id,
+      );
+    });
 
     expect(
       screen.getByRole('heading', {
@@ -41,10 +49,17 @@ describe('PublicationExternalMethodologyPage', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 
-  test('renders the edit external methodology page correctly', () => {
-    renderPage({
-      ...testPublication,
-      externalMethodology: testExternalMethodology,
+  test('renders the edit external methodology page correctly', async () => {
+    publicationService.getExternalMethodology.mockResolvedValue(
+      testExternalMethodology,
+    );
+
+    renderPage(testPublication);
+
+    await waitFor(() => {
+      expect(publicationService.getExternalMethodology).toBeCalledWith(
+        testPublication.id,
+      );
     });
 
     expect(
@@ -67,6 +82,8 @@ describe('PublicationExternalMethodologyPage', () => {
   test('handles successful form submission', async () => {
     const history = createMemoryHistory();
 
+    publicationService.getExternalMethodology.mockResolvedValue(undefined);
+
     render(
       <Router history={history}>
         <PublicationContextProvider
@@ -79,6 +96,12 @@ describe('PublicationExternalMethodologyPage', () => {
       </Router>,
     );
 
+    await waitFor(() => {
+      expect(publicationService.getExternalMethodology).toBeCalledWith(
+        testPublication.id,
+      );
+    });
+
     userEvent.type(screen.getByLabelText('Link title'), 'The link title');
 
     userEvent.type(screen.getByLabelText('URL'), 'test.com');
@@ -87,7 +110,7 @@ describe('PublicationExternalMethodologyPage', () => {
 
     await waitFor(() => {
       expect(publicationService.updateExternalMethodology).toHaveBeenCalledWith(
-        'publication-1',
+        testPublication.id,
         {
           title: 'The link title',
           url: 'https://test.com',
@@ -103,6 +126,10 @@ describe('PublicationExternalMethodologyPage', () => {
   test('handles clicking the cancel button', async () => {
     const history = createMemoryHistory();
 
+    publicationService.getExternalMethodology.mockResolvedValue(
+      testExternalMethodology,
+    );
+
     render(
       <Router history={history}>
         <PublicationContextProvider
@@ -115,6 +142,12 @@ describe('PublicationExternalMethodologyPage', () => {
       </Router>,
     );
 
+    await waitFor(() => {
+      expect(publicationService.getExternalMethodology).toBeCalledWith(
+        testPublication.id,
+      );
+    });
+
     userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(publicationService.updatePublication).not.toHaveBeenCalled();
@@ -125,7 +158,7 @@ describe('PublicationExternalMethodologyPage', () => {
   });
 });
 
-function renderPage(publication: MyPublication) {
+function renderPage(publication: Publication) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleaseCreatePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleaseCreatePage.test.tsx
@@ -2,7 +2,7 @@ import PublicationLegacyReleaseCreatePage from '@admin/pages/publication/Publica
 import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
 import { testPublication } from '@admin/pages/publication/__data__/testPublication';
 import _legacyReleaseService from '@admin/services/legacyReleaseService';
-import { MyPublication } from '@admin/services/publicationService';
+import { Publication } from '@admin/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -51,7 +51,7 @@ describe('PublicationLegacyReleaseCreatePage', () => {
   });
 });
 
-function renderPage(publication: MyPublication) {
+function renderPage(publication: Publication) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleaseCreatePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleaseCreatePage.test.tsx
@@ -2,7 +2,7 @@ import PublicationLegacyReleaseCreatePage from '@admin/pages/publication/Publica
 import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
 import { testPublication } from '@admin/pages/publication/__data__/testPublication';
 import _legacyReleaseService from '@admin/services/legacyReleaseService';
-import { Publication } from '@admin/services/publicationService';
+import { PublicationWithPermissions } from '@admin/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -51,7 +51,7 @@ describe('PublicationLegacyReleaseCreatePage', () => {
   });
 });
 
-function renderPage(publication: Publication) {
+function renderPage(publication: PublicationWithPermissions) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleaseEditPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleaseEditPage.test.tsx
@@ -8,7 +8,7 @@ import {
 import _legacyReleaseService, {
   LegacyRelease,
 } from '@admin/services/legacyReleaseService';
-import { Publication } from '@admin/services/publicationService';
+import { PublicationWithPermissions } from '@admin/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -81,7 +81,7 @@ describe('PublicationLegacyReleaseEditPage', () => {
   });
 });
 
-function renderPage(publication: Publication) {
+function renderPage(publication: PublicationWithPermissions) {
   render(
     <MemoryRouter
       initialEntries={[

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleaseEditPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleaseEditPage.test.tsx
@@ -8,7 +8,7 @@ import {
 import _legacyReleaseService, {
   LegacyRelease,
 } from '@admin/services/legacyReleaseService';
-import { MyPublication } from '@admin/services/publicationService';
+import { Publication } from '@admin/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -81,7 +81,7 @@ describe('PublicationLegacyReleaseEditPage', () => {
   });
 });
 
-function renderPage(publication: MyPublication) {
+function renderPage(publication: Publication) {
   render(
     <MemoryRouter
       initialEntries={[

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleasesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleasesPage.test.tsx
@@ -4,7 +4,7 @@ import { testPublication } from '@admin/pages/publication/__data__/testPublicati
 import _legacyReleaseService, {
   LegacyRelease,
 } from '@admin/services/legacyReleaseService';
-import { MyPublication } from '@admin/services/publicationService';
+import { Publication } from '@admin/services/publicationService';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -72,7 +72,7 @@ describe('PublicationLegacyReleasesPage', () => {
   });
 });
 
-function renderPage(publication: MyPublication) {
+function renderPage(publication: Publication) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleasesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationLegacyReleasesPage.test.tsx
@@ -4,7 +4,7 @@ import { testPublication } from '@admin/pages/publication/__data__/testPublicati
 import _legacyReleaseService, {
   LegacyRelease,
 } from '@admin/services/legacyReleaseService';
-import { Publication } from '@admin/services/publicationService';
+import { PublicationWithPermissions } from '@admin/services/publicationService';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -72,7 +72,7 @@ describe('PublicationLegacyReleasesPage', () => {
   });
 });
 
-function renderPage(publication: Publication) {
+function renderPage(publication: PublicationWithPermissions) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
@@ -7,7 +7,7 @@ import _methodologyService, {
 } from '@admin/services/methodologyService';
 import _publicationService, {
   ExternalMethodology,
-  Publication,
+  PublicationWithPermissions,
 } from '@admin/services/publicationService';
 import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -1427,7 +1427,7 @@ describe('PublicationMethodologiesPage', () => {
   });
 });
 
-function renderPage(publication: Publication = testPublication) {
+function renderPage(publication: PublicationWithPermissions = testPublication) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
@@ -7,7 +7,7 @@ import _methodologyService, {
 } from '@admin/services/methodologyService';
 import _publicationService, {
   ExternalMethodology,
-  MyPublication,
+  Publication,
 } from '@admin/services/publicationService';
 import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -1427,7 +1427,7 @@ describe('PublicationMethodologiesPage', () => {
   });
 });
 
-function renderPage(publication: MyPublication = testPublication) {
+function renderPage(publication: Publication = testPublication) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
@@ -31,7 +31,7 @@ describe('PublicationPageContainer', () => {
   };
 
   test('renders the page with the releases tab', async () => {
-    publicationService.getMyPublication.mockResolvedValue(testPublication);
+    publicationService.getPublication.mockResolvedValue(testPublication);
     publicationService.listReleases.mockResolvedValue(testEmptyReleases);
 
     renderPage();
@@ -67,7 +67,7 @@ describe('PublicationPageContainer', () => {
   });
 
   test('shows a message when the publication is archived', async () => {
-    publicationService.getMyPublication.mockResolvedValue({
+    publicationService.getPublication.mockResolvedValue({
       ...testPublication,
       isSuperseded: true,
       supersededById: 'publication-2',
@@ -86,7 +86,7 @@ describe('PublicationPageContainer', () => {
   });
 
   test('shows a message when the publication is superseded but not yet archived', async () => {
-    publicationService.getMyPublication.mockResolvedValue({
+    publicationService.getPublication.mockResolvedValue({
       ...testPublication,
       isSuperseded: false,
       supersededById: 'publication-2',

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationReleasesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationReleasesPage.test.tsx
@@ -3,7 +3,7 @@ import { testPublication } from '@admin/pages/publication/__data__/testPublicati
 import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
 import PublicationReleasesPage from '@admin/pages/publication/PublicationReleasesPage';
 import _publicationService, {
-  Publication,
+  PublicationWithPermissions,
 } from '@admin/services/publicationService';
 import _releaseService from '@admin/services/releaseService';
 import { screen, waitFor } from '@testing-library/react';
@@ -46,7 +46,7 @@ describe('PublicationReleasesPage', () => {
   });
 
   test('does not show the create release button if you do not have permission', async () => {
-    const publication: Publication = {
+    const publication: PublicationWithPermissions = {
       ...testPublication,
       permissions: {
         ...testPublication.permissions,
@@ -67,7 +67,7 @@ describe('PublicationReleasesPage', () => {
   });
 });
 
-function renderPage(publication: Publication) {
+function renderPage(publication: PublicationWithPermissions) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationReleasesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationReleasesPage.test.tsx
@@ -3,7 +3,7 @@ import { testPublication } from '@admin/pages/publication/__data__/testPublicati
 import { PublicationContextProvider } from '@admin/pages/publication/contexts/PublicationContext';
 import PublicationReleasesPage from '@admin/pages/publication/PublicationReleasesPage';
 import _publicationService, {
-  MyPublication,
+  Publication,
 } from '@admin/services/publicationService';
 import _releaseService from '@admin/services/releaseService';
 import { screen, waitFor } from '@testing-library/react';
@@ -32,7 +32,7 @@ describe('PublicationReleasesPage', () => {
   });
 
   test('shows the create release button if you have permission', async () => {
-    publicationService.getMyPublication.mockResolvedValue(testPublication);
+    publicationService.getPublication.mockResolvedValue(testPublication);
 
     renderPage(testPublication);
 
@@ -46,14 +46,14 @@ describe('PublicationReleasesPage', () => {
   });
 
   test('does not show the create release button if you do not have permission', async () => {
-    const publication: MyPublication = {
+    const publication: Publication = {
       ...testPublication,
       permissions: {
         ...testPublication.permissions,
         canCreateReleases: false,
       },
     };
-    publicationService.getMyPublication.mockResolvedValue(publication);
+    publicationService.getPublication.mockResolvedValue(publication);
 
     renderPage(publication);
 
@@ -67,7 +67,7 @@ describe('PublicationReleasesPage', () => {
   });
 });
 
-function renderPage(publication: MyPublication) {
+function renderPage(publication: Publication) {
   render(
     <MemoryRouter>
       <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleases.tsx
@@ -56,7 +56,7 @@ export default function PublicationPublishedReleases({
           live: true,
           page: pageParam,
           pageSize,
-          permissions: true,
+          includePermissions: true,
         },
       );
     },

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationUnpublishedReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationUnpublishedReleases.tsx
@@ -24,7 +24,7 @@ export default function PublicationUnpublishedReleases({
         {
           live: false,
           pageSize: 100,
-          permissions: true,
+          includePermissions: true,
         },
       ),
   );

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
@@ -452,7 +452,6 @@ describe('PublicationForm', () => {
       contact: {
         contactName: 'Test contact name',
         contactTelNo: 'Test contact tel',
-        id: 'test-contact-id',
         teamEmail: 'test-contact@hiveit.co.uk',
         teamName: 'Test team name',
       },
@@ -489,7 +488,6 @@ describe('PublicationForm', () => {
       title: 'Publication 1',
       summary: 'Publcation 1 summary',
       contact: {
-        id: 'contact-1',
         contactName: 'John Smith',
         contactTelNo: '0777777777',
         teamEmail: 'john.smith@test.com',

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
@@ -505,6 +505,7 @@ describe('PublicationForm', () => {
         canUpdatePublicationSupersededBy: true,
         canCreateMethodologies: true,
         canManageExternalMethodology: true,
+        canUpdateContact: true,
       },
     };
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationInviteNewUsersForm.test..tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationInviteNewUsersForm.test..tsx
@@ -10,7 +10,6 @@ import React from 'react';
 jest.mock('@admin/services/userService');
 
 const publication: Publication = {
-  contact: testContact,
   id: 'publication-id',
   title: 'Publication title',
   summary: 'Publication summary',

--- a/src/explore-education-statistics-admin/src/pages/publication/contexts/PublicationContext.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/contexts/PublicationContext.tsx
@@ -1,4 +1,4 @@
-import { MyPublication } from '@admin/services/publicationService';
+import { MyPublication } from '@admin/services/publicationService'; // @MarkFix switch to Publication
 import React, { createContext, ReactNode, useContext, useMemo } from 'react';
 
 export interface PublicationContextState {

--- a/src/explore-education-statistics-admin/src/pages/publication/contexts/PublicationContext.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/contexts/PublicationContext.tsx
@@ -1,10 +1,10 @@
-import { MyPublication } from '@admin/services/publicationService'; // @MarkFix switch to Publication
+import { Publication } from '@admin/services/publicationService';
 import React, { createContext, ReactNode, useContext, useMemo } from 'react';
 
 export interface PublicationContextState {
-  publication: MyPublication;
+  publication: Publication;
   publicationId: string;
-  onPublicationChange: (nextPublication: MyPublication) => void;
+  onPublicationChange: (nextPublication: Publication) => void;
   onReload: () => void;
 }
 
@@ -14,8 +14,8 @@ const PublicationContext = createContext<PublicationContextState | undefined>(
 
 interface PublicationContextProviderProps {
   children: ReactNode;
-  publication: MyPublication;
-  onPublicationChange: (nextPublication: MyPublication) => void;
+  publication: Publication;
+  onPublicationChange: (nextPublication: Publication) => void;
   onReload: () => void;
 }
 

--- a/src/explore-education-statistics-admin/src/pages/publication/contexts/PublicationContext.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/contexts/PublicationContext.tsx
@@ -1,10 +1,10 @@
-import { Publication } from '@admin/services/publicationService';
+import { PublicationWithPermissions } from '@admin/services/publicationService';
 import React, { createContext, ReactNode, useContext, useMemo } from 'react';
 
 export interface PublicationContextState {
-  publication: Publication;
+  publication: PublicationWithPermissions;
   publicationId: string;
-  onPublicationChange: (nextPublication: Publication) => void;
+  onPublicationChange: (nextPublication: PublicationWithPermissions) => void;
   onReload: () => void;
 }
 
@@ -14,8 +14,8 @@ const PublicationContext = createContext<PublicationContextState | undefined>(
 
 interface PublicationContextProviderProps {
   children: ReactNode;
-  publication: Publication;
-  onPublicationChange: (nextPublication: Publication) => void;
+  publication: PublicationWithPermissions;
+  onPublicationChange: (nextPublication: PublicationWithPermissions) => void;
   onReload: () => void;
 }
 

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
@@ -22,6 +22,9 @@ export const testRelease: Release = {
     teamEmail: 'test@test.com',
     contactName: 'Test contact name',
     contactTelNo: '1111 1111 1111',
+    permissions: {
+      canUpdatePublication: true,
+    },
   },
   previousVersionId: '',
   preReleaseAccessList: '',

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
@@ -22,9 +22,6 @@ export const testRelease: Release = {
     teamEmail: 'test@test.com',
     contactName: 'Test contact name',
     contactTelNo: '1111 1111 1111',
-    permissions: {
-      canUpdatePublication: true,
-    },
   },
   previousVersionId: '',
   preReleaseAccessList: '',

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
@@ -18,7 +18,6 @@ export const testRelease: Release = {
   title: 'Release Title',
   type: 'OfficialStatistics',
   contact: {
-    id: 'contact-1',
     teamName: 'Test name',
     teamEmail: 'test@test.com',
     contactName: 'Test contact name',

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
@@ -22,7 +22,6 @@ describe('ReleaseStatusChecklist', () => {
     title: 'Release Title',
     type: 'OfficialStatistics',
     contact: {
-      id: 'contact-1',
       teamName: 'Test name',
       teamEmail: 'test@test.com',
       contactName: 'Test contact name',

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -31,7 +31,6 @@ describe('ReleaseStatusForm', () => {
     title: 'Release Title',
     type: 'OfficialStatistics',
     contact: {
-      id: 'contact-1',
       teamName: 'Test name',
       teamEmail: 'test@test.com',
       contactName: 'Test contact name',

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableToolFinalStep.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableToolFinalStep.tsx
@@ -2,6 +2,7 @@ import Link from '@admin/components/Link';
 import publicationService, {
   Publication,
   ExternalMethodology,
+  Contact,
 } from '@admin/services/publicationService';
 import TableHeadersForm from '@common/modules/table-tool/components/TableHeadersForm';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
@@ -20,6 +21,7 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 interface Model {
   methodologies: MethodologyVersionSummary[];
   externalMethodology?: ExternalMethodology | undefined;
+  contact: Contact;
 }
 
 interface ReleasePreviewTableToolFinalStepProps {
@@ -39,12 +41,13 @@ const ReleasePreviewTableToolFinalStep = ({
   const dataTableRef = useRef<HTMLElement>(null);
 
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
-    const [methodologies, externalMethodology] = await Promise.all([
+    const [methodologies, externalMethodology, contact] = await Promise.all([
       methodologyService.listMethodologyVersions(publication.id),
       publicationService.getExternalMethodology(publication.id),
+      publicationService.getContact(publication.id),
     ]);
 
-    return { methodologies, externalMethodology };
+    return { methodologies, externalMethodology, contact };
   }, [publication]);
 
   const getMethodologyLinks = () => {
@@ -100,7 +103,7 @@ const ReleasePreviewTableToolFinalStep = ({
 
           <LoadingSpinner loading={isLoading}>
             <TableToolInfo
-              contactDetails={publication.contact}
+              contactDetails={model?.contact}
               methodologyLinks={getMethodologyLinks()}
               releaseLink={<span>{publication.title}</span>}
             />

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -25,7 +25,6 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
 >;
 
 const testContact: Contact = {
-  id: 'contact-1',
   contactName: 'John Smith',
   contactTelNo: '0777777777',
   teamEmail: 'john.smith@test.com',

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -5,7 +5,7 @@ import {
 } from '@admin/routes/releaseRoutes';
 import _publicationService, {
   Publication,
-  PublicationContactDetails,
+  Contact,
 } from '@admin/services/publicationService';
 import _tableBuilderService from '@common/services/tableBuilderService';
 import { render, screen, waitFor, within } from '@testing-library/react';
@@ -24,7 +24,7 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
   typeof _tableBuilderService
 >;
 
-const testContact: PublicationContactDetails = {
+const testContact: Contact = {
   id: 'contact-1',
   contactName: 'John Smith',
   contactTelNo: '0777777777',

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -32,7 +32,6 @@ const testContact: Contact = {
 };
 
 const testPublication: Publication = {
-  contact: testContact,
   id: 'publication-1',
   title: 'Pupil absence',
   summary: 'Pupil absence summary',

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -8,7 +8,7 @@ import _dataBlockService, {
 } from '@admin/services/dataBlockService';
 import _publicationService, {
   Publication,
-  PublicationContactDetails,
+  Contact,
 } from '@admin/services/publicationService';
 import _tableBuilderService, {
   SubjectMeta,
@@ -184,7 +184,7 @@ describe('PreReleaseTableToolPage', () => {
     ],
   };
 
-  const testContact: PublicationContactDetails = {
+  const testContact: Contact = {
     id: 'contact-1',
     contactName: 'John Smith',
     contactTelNo: '0777777777',

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -185,7 +185,6 @@ describe('PreReleaseTableToolPage', () => {
   };
 
   const testContact: Contact = {
-    id: 'contact-1',
     contactName: 'John Smith',
     contactTelNo: '0777777777',
     teamEmail: 'john.smith@test.com',

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -184,15 +184,7 @@ describe('PreReleaseTableToolPage', () => {
     ],
   };
 
-  const testContact: Contact = {
-    contactName: 'John Smith',
-    contactTelNo: '0777777777',
-    teamEmail: 'john.smith@test.com',
-    teamName: 'Team Smith',
-  };
-
   const testPublication: Publication = {
-    contact: testContact,
     id: 'publication-1',
     title: 'Pupil absence',
     summary: 'Pupil absence summary',

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
@@ -38,7 +38,6 @@ const releaseData: Release = {
   title: 'Release Title',
   type: 'OfficialStatistics',
   contact: {
-    id: '69416b29-8a20-4de1-11de-08d85fc33fc0',
     teamName: 'Test name',
     teamEmail: 'test@test.com',
     contactName: 'Test contact name',

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -52,17 +52,19 @@ export interface MyPublication {
   topicId: string;
   themeId: string;
   contact: Contact;
-  permissions: {
-    canAdoptMethodologies: boolean;
-    canCreateReleases: boolean;
-    canUpdatePublication: boolean;
-    canUpdatePublicationTitle: boolean;
-    canUpdatePublicationSupersededBy: boolean;
-    canCreateMethodologies: boolean;
-    canManageExternalMethodology: boolean;
-  };
+  permissions: PublicationPermissions;
   supersededById?: string;
   isSuperseded?: boolean;
+}
+
+export interface PublicationPermissions {
+  canAdoptMethodologies: boolean;
+  canCreateReleases: boolean;
+  canUpdatePublication: boolean;
+  canUpdatePublicationTitle: boolean;
+  canUpdatePublicationSupersededBy: boolean;
+  canCreateMethodologies: boolean;
+  canManageExternalMethodology: boolean;
 }
 
 export interface Publication {
@@ -70,9 +72,12 @@ export interface Publication {
   title: string;
   summary: string;
   slug: string;
-  contact: Contact;
+  contact: Contact; // @MarkFix remove this
   theme: IdTitlePair;
   topic: IdTitlePair;
+  supersededById?: string;
+  isSuperseded?: boolean;
+  permissions?: PublicationPermissions;
 }
 
 export interface PublicationMethodologyDetails {
@@ -130,8 +135,13 @@ const publicationService = {
     return client.put(`/publications/${publicationId}`, publication);
   },
 
-  getPublication(publicationId: string): Promise<Publication> {
-    return client.get<Publication>(`/publications/${publicationId}`);
+  getPublication(
+    publicationId: string,
+    permissions = false,
+  ): Promise<Publication> {
+    return client.get<Publication>(`/publications/${publicationId}`, {
+      params: { permissions },
+    });
   },
 
   getMyPublication(publicationId: string): Promise<MyPublication> {

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -14,14 +14,13 @@ import { PublicationSummary } from '@common/services/publicationService';
 import { PaginatedList } from '@common/services/types/pagination';
 
 export interface Contact {
-  id: string; // @MarkFix remove?
   contactName: string;
   contactTelNo: string;
   teamEmail: string;
   teamName: string;
 }
 
-export interface SavePublicationContact {
+export interface ContactSave {
   contactName: string;
   contactTelNo: string;
   teamEmail: string;
@@ -76,12 +75,17 @@ export interface PublicationMethodologyDetails {
   externalMethodology?: ExternalMethodology;
 }
 
-// @MarkFix copy to create PublicationCreateRequest
-// and remove contact from PublicationSaveRequest
 export interface PublicationSaveRequest {
   title: string;
   summary: string;
-  contact: SavePublicationContact;
+  supersededById?: string;
+  topicId: string;
+}
+
+export interface PublicationCreateRequest {
+  title: string;
+  summary: string;
+  contact: ContactSave;
   supersededById?: string;
   topicId: string;
 }
@@ -108,7 +112,9 @@ const publicationService = {
     return client.get('/publication-summaries');
   },
 
-  createPublication(publication: PublicationSaveRequest): Promise<Publication> {
+  createPublication(
+    publication: PublicationCreateRequest,
+  ): Promise<Publication> {
     return client.post('/publications', publication);
   },
 
@@ -162,7 +168,7 @@ const publicationService = {
 
   updateContact(
     publicationId: string,
-    updatedContact: SavePublicationContact,
+    updatedContact: ContactSave,
   ): Promise<Contact> {
     return client.put(`publication/${publicationId}/contact`, updatedContact);
   },

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -13,11 +13,16 @@ import { OmitStrict } from '@common/types';
 import { PublicationSummary } from '@common/services/publicationService';
 import { PaginatedList } from '@common/services/types/pagination';
 
+export interface ContactPermissions {
+  canUpdatePublication: boolean;
+}
+
 export interface Contact {
   contactName: string;
   contactTelNo: string;
   teamEmail: string;
   teamName: string;
+  permissions?: ContactPermissions;
 }
 
 export interface ContactSave {
@@ -162,8 +167,10 @@ const publicationService = {
     return client.delete(`/publication/${publicationId}/external-methodology`);
   },
 
-  getContact(publicationId: string): Promise<Contact> {
-    return client.get(`publication/${publicationId}/contact`);
+  getContact(publicationId: string, permissions: boolean): Promise<Contact> {
+    return client.get(`publication/${publicationId}/contact`, {
+      params: { permissions },
+    });
   },
 
   updateContact(

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -76,6 +76,8 @@ export interface PublicationMethodologyDetails {
   externalMethodology?: ExternalMethodology;
 }
 
+// @MarkFix copy to create PublicationCreateRequest
+// and remove contact from PublicationSaveRequest
 export interface PublicationSaveRequest {
   title: string;
   summary: string;
@@ -156,6 +158,13 @@ const publicationService = {
 
   getContact(publicationId: string): Promise<Contact> {
     return client.get(`publication/${publicationId}/contact`);
+  },
+
+  updateContact(
+    publicationId: string,
+    updatedContact: SavePublicationContact,
+  ): Promise<Contact> {
+    return client.put(`publication/${publicationId}/contact`, updatedContact);
   },
 
   listReleases<TReleaseSummary extends ReleaseSummary = ReleaseSummary>(

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -67,6 +67,10 @@ export interface PublicationPermissions {
   canManageExternalMethodology: boolean;
 }
 
+export interface PublicationWithPermissions extends Publication {
+  permissions: PublicationPermissions;
+}
+
 export interface Publication {
   id: string;
   title: string;

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -54,6 +54,8 @@ export interface MyPublication {
   contact: Contact;
   permissions: PublicationPermissions;
   supersededById?: string;
+  // NOTE: isSuperseded is necessary, as a publication only becomes superseded when it's SupersededById is set
+  // _and_ that publication has a live release.
   isSuperseded?: boolean;
 }
 
@@ -107,7 +109,7 @@ export interface ListReleasesParams {
   live?: boolean;
   page?: number;
   pageSize?: number;
-  permissions?: boolean;
+  includePermissions?: boolean;
 }
 
 export type UpdatePublicationLegacyRelease = Partial<
@@ -140,10 +142,10 @@ const publicationService = {
 
   getPublication(
     publicationId: string,
-    permissions = false,
+    includePermissions = false,
   ): Promise<Publication> {
     return client.get<Publication>(`/publications/${publicationId}`, {
-      params: { permissions },
+      params: { includePermissions },
     });
   },
 
@@ -180,9 +182,12 @@ const publicationService = {
     return client.delete(`/publication/${publicationId}/external-methodology`);
   },
 
-  getContact(publicationId: string, permissions = false): Promise<Contact> {
+  getContact(
+    publicationId: string,
+    includePermissions = false,
+  ): Promise<Contact> {
     return client.get(`publication/${publicationId}/contact`, {
-      params: { permissions },
+      params: { includePermissions },
     });
   },
 

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -13,8 +13,8 @@ import { OmitStrict } from '@common/types';
 import { PublicationSummary } from '@common/services/publicationService';
 import { PaginatedList } from '@common/services/types/pagination';
 
-export interface PublicationContactDetails {
-  id: string;
+export interface Contact {
+  id: string; // @MarkFix remove?
   contactName: string;
   contactTelNo: string;
   teamEmail: string;
@@ -47,7 +47,7 @@ export interface MyPublication {
   externalMethodology?: ExternalMethodology;
   topicId: string;
   themeId: string;
-  contact: PublicationContactDetails;
+  contact: Contact;
   permissions: {
     canAdoptMethodologies: boolean;
     canCreateReleases: boolean;
@@ -66,7 +66,7 @@ export interface Publication {
   title: string;
   summary: string;
   slug: string;
-  contact: PublicationContactDetails;
+  contact: Contact;
   theme: IdTitlePair;
   topic: IdTitlePair;
 }
@@ -152,6 +152,10 @@ const publicationService = {
 
   removeExternalMethodology(publicationId: string): Promise<boolean> {
     return client.delete(`/publication/${publicationId}/external-methodology`);
+  },
+
+  getContact(publicationId: string): Promise<Contact> {
+    return client.get(`publication/${publicationId}/contact`);
   },
 
   listReleases<TReleaseSummary extends ReleaseSummary = ReleaseSummary>(

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -13,16 +13,11 @@ import { OmitStrict } from '@common/types';
 import { PublicationSummary } from '@common/services/publicationService';
 import { PaginatedList } from '@common/services/types/pagination';
 
-export interface ContactPermissions {
-  canUpdatePublication: boolean;
-}
-
 export interface Contact {
   contactName: string;
   contactTelNo: string;
   teamEmail: string;
   teamName: string;
-  permissions?: ContactPermissions;
 }
 
 export interface ContactSave {
@@ -67,6 +62,7 @@ export interface PublicationPermissions {
   canUpdatePublicationSupersededBy: boolean;
   canCreateMethodologies: boolean;
   canManageExternalMethodology: boolean;
+  canUpdateContact: boolean;
 }
 
 export interface PublicationWithPermissions extends Publication {
@@ -140,11 +136,11 @@ const publicationService = {
     return client.put(`/publications/${publicationId}`, publication);
   },
 
-  getPublication(
+  getPublication<TPublication extends Publication = Publication>(
     publicationId: string,
     includePermissions = false,
-  ): Promise<Publication> {
-    return client.get<Publication>(`/publications/${publicationId}`, {
+  ): Promise<TPublication> {
+    return client.get<TPublication>(`/publications/${publicationId}`, {
       params: { includePermissions },
     });
   },
@@ -182,13 +178,10 @@ const publicationService = {
     return client.delete(`/publication/${publicationId}/external-methodology`);
   },
 
-  getContact(
+  getContact<TContact extends Contact = Contact>(
     publicationId: string,
-    includePermissions = false,
-  ): Promise<Contact> {
-    return client.get(`publication/${publicationId}/contact`, {
-      params: { includePermissions },
-    });
+  ): Promise<TContact> {
+    return client.get<TContact>(`publication/${publicationId}/contact`);
   },
 
   updateContact(

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -72,7 +72,6 @@ export interface Publication {
   title: string;
   summary: string;
   slug: string;
-  contact: Contact; // @MarkFix remove this
   theme: IdTitlePair;
   topic: IdTitlePair;
   supersededById?: string;
@@ -177,7 +176,7 @@ const publicationService = {
     return client.delete(`/publication/${publicationId}/external-methodology`);
   },
 
-  getContact(publicationId: string, permissions: boolean): Promise<Contact> {
+  getContact(publicationId: string, permissions = false): Promise<Contact> {
     return client.get(`publication/${publicationId}/contact`, {
       params: { permissions },
     });

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -1,7 +1,7 @@
 import { IdTitlePair, ValueLabelPair } from '@admin/services/types/common';
 import client from '@admin/services/utils/service';
 import { ReleaseApprovalStatus } from '@common/services/publicationService';
-import { PublicationContactDetails } from '@admin/services/publicationService';
+import { Contact } from '@admin/services/publicationService';
 import { ReleaseType } from '@common/services/types/releaseType';
 import { PartialDate } from '@common/utils/date/partialDate';
 
@@ -27,7 +27,7 @@ export interface Release {
   timePeriodCoverage: ValueLabelPair;
   title: string;
   type: ReleaseType;
-  contact: PublicationContactDetails;
+  contact: Contact;
   publishScheduled?: string;
   published?: string;
   nextReleaseDate?: PartialDate;

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/ContactUsSection.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/ContactUsSection.tsx
@@ -1,11 +1,11 @@
-import { PublicationContact } from '@common/services/publicationService';
+import { Contact } from '@common/services/publicationService';
 import React from 'react';
 
 const ContactUsSection = ({
   publicationContact,
   publicationTitle,
 }: {
-  publicationContact: PublicationContact;
+  publicationContact: Contact;
   publicationTitle: string;
 }) => {
   return (

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolInfo.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolInfo.tsx
@@ -1,10 +1,10 @@
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
 import React, { ReactNode } from 'react';
-import { BasicPublicationContact } from '@common/services/publicationService';
+import { Contact } from '@common/services/publicationService';
 
 interface Props {
-  contactDetails?: BasicPublicationContact;
+  contactDetails?: Contact;
   methodologyLinks?: ReactNode[];
   releaseLink?: ReactNode;
 }

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -29,7 +29,7 @@ export interface Publication {
       title: string;
     };
   };
-  contact: PublicationContact;
+  contact: Contact;
   methodologies: MethodologySummary[];
   externalMethodology?: ExternalMethodology;
   supersededById?: string;
@@ -59,15 +59,7 @@ export interface PublicationSummaryWithRelease {
   title: string;
 }
 
-export interface BasicPublicationContact {
-  id?: string;
-  contactName: string;
-  contactTelNo: string;
-  teamEmail: string;
-  teamName?: string;
-}
-
-export interface PublicationContact {
+export interface Contact {
   teamName: string;
   teamEmail: string;
   contactName: string;

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
@@ -3,7 +3,7 @@ import AccordionSection from '@common/components/AccordionSection';
 import ContactUsSection from '@common/modules/find-statistics/components/ContactUsSection';
 import NationalStatisticsSection from '@common/modules/find-statistics/components/NationalStatisticsSection';
 import OfficialStatisticsSection from '@common/modules/find-statistics/components/OfficialStatisticsSection';
-import { PublicationContact } from '@common/services/publicationService';
+import { Contact } from '@common/services/publicationService';
 import {
   ExternalMethodology,
   MethodologySummary,
@@ -23,7 +23,7 @@ interface Props {
   methodologies: MethodologySummary[];
   externalMethodology?: ExternalMethodology;
   releaseType?: ReleaseType;
-  publicationContact: PublicationContact;
+  publicationContact: Contact;
 }
 
 const PublicationReleaseHelpAndSupportSection = ({


### PR DESCRIPTION
This PR adds new endpoints to get and update contacts on a publication, and also does other various bits of cleanup in preparation for switching to the new Admin dashboard:

- Adds a GetContact endpoint. This endpoint has an optional query parameter so services can request permissions if required.
- Adds a UpdateContact endpoint.
- Make the Publications table's `ContactId` nonnullable. Since a publication should always have a contact, there isn't any reason for the column to be nullable. :rotating_light: :rotating_light: :rotating_light: Due to this change, we need to double check there aren't any instances of `ContactId` that are null on Prod before deploying :rotating_light: :rotating_light: :rotating_light: I already updated all entries with null on Dev, and Test, Preprod and Prod didn't have any instances of null.
- Create `PublicationCreateRequest` `PublicationCreateViewModel`. This is necessary as updating the contact is no longer possible via the update publication endpoint, but when creating a publication you must also create an associated contact, as every publication must have a contact, so it makes sense for a contact to be in the create publication response.
- Remove `Contact` from `PublicationViewModel`. This means that several frontend components need to make additional get and update calls to get / update contact information.
- The `GetPublication` endpoint now hydrates all parts of the `PublicationViewModel` that it returns, specifically `Permissions` and `IsSuperseded`.
- Add a query parameter for the `GetPublication` endpoint so services can choose whether they want `Permissions` returned.
- Change the frontend's `PublicationContext` to use `Publication` instead of `MyPublication`. This change has meant that some components have had to make an additional call to get other information, like publication's contact information.
- Several frontend interfaces have been renamed to match their associated backend view models.