### PR TITLE
EES-3735 - fix keyStat hiddenText always evaluating to undefined

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
@@ -141,6 +141,8 @@ const EditableKeyStat = ({
       );
     }
 
+    const dataDefinitionTitle = summary?.dataDefinitionTitle[0] || 'Help';
+
     return (
       <>
         <KeyStatTile
@@ -158,8 +160,13 @@ const EditableKeyStat = ({
 
         {summary?.dataDefinition[0] && !isReordering && (
           <Details
-            summary={summary?.dataDefinitionTitle[0] || 'Help'}
+            summary={dataDefinitionTitle}
             className={styles.definition}
+            hiddenText={
+              dataDefinitionTitle === 'Help'
+                ? `for ${keyStat.title}`
+                : undefined
+            }
           >
             <div data-testid={`${testId}-definition`}>
               {summary.dataDefinition.map(data => (

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
@@ -123,6 +123,104 @@ describe('EditableKeyStat', () => {
     });
   });
 
+  test('renders correctly with a default data definition title of "Help"', async () => {
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
+
+    render(
+      <EditableKeyStat
+        releaseId="release-1"
+        dataBlockId="block-1"
+        name="Key Stat 1"
+        onSubmit={noop}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['Help'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
+
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+
+      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+
+      expect(screen.getByTestId('keyStat-summary')).toHaveTextContent(
+        'Down from 620,330 in 2017',
+      );
+
+      expect(
+        screen.getByRole('button', {
+          name: 'Help for Number of applications received',
+        }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByTestId('keyStat-definition')).toHaveTextContent(
+        'Total number of applications received for places at primary and secondary schools.',
+      );
+    });
+  });
+
+  test('renders correctly with a blank data definition title ', async () => {
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
+
+    render(
+      <EditableKeyStat
+        releaseId="release-1"
+        dataBlockId="block-1"
+        name="Key Stat 1"
+        onSubmit={noop}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: [''],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
+
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+
+      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+
+      expect(screen.getByTestId('keyStat-summary')).toHaveTextContent(
+        'Down from 620,330 in 2017',
+      );
+
+      expect(
+        screen.getByRole('button', {
+          name: 'Help for Number of applications received',
+        }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByTestId('keyStat-definition')).toHaveTextContent(
+        'Total number of applications received for places at primary and secondary schools.',
+      );
+    });
+  });
+
   test('renders correctly without read-only summary', async () => {
     tableBuilderService.getDataBlockTableData.mockResolvedValue(
       testTableDataResponse,

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
@@ -74,7 +74,7 @@ const KeyStat = ({
                 summary={summary?.dataDefinitionTitle[0] || 'Help'}
                 className={styles.definition}
                 hiddenText={
-                  !summary?.dataDefinitionTitle[0]
+                  summary?.dataDefinitionTitle[0] === 'Help'
                     ? `for ${keyStat.title}`
                     : undefined
                 }
@@ -86,7 +86,6 @@ const KeyStat = ({
                 </div>
               </Details>
             )}
-
             {children}
           </>
         )}

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
@@ -52,6 +52,8 @@ const KeyStat = ({
     return null;
   }
 
+  const dataDefinitionTitle = summary?.dataDefinitionTitle[0] || 'Help';
+
   return (
     <KeyStatColumn testId={testId}>
       <LoadingSpinner loading={isLoading}>
@@ -71,10 +73,10 @@ const KeyStat = ({
 
             {summary?.dataDefinition[0] && (
               <Details
-                summary={summary?.dataDefinitionTitle[0] || 'Help'}
+                summary={dataDefinitionTitle}
                 className={styles.definition}
                 hiddenText={
-                  summary?.dataDefinitionTitle[0] === 'Help'
+                  dataDefinitionTitle === 'Help'
                     ? `for ${keyStat.title}`
                     : undefined
                 }

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
@@ -118,6 +118,100 @@ describe('KeyStat', () => {
     });
   });
 
+  test('renders correctly with a default data definition title of "Help"', async () => {
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
+
+    render(
+      <KeyStat
+        releaseId="release-1"
+        dataBlockId="block-1"
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['Help'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
+
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+
+      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+
+      expect(screen.getByTestId('keyStat-summary')).toHaveTextContent(
+        'Down from 620,330 in 2017',
+      );
+
+      expect(
+        screen.getByRole('button', {
+          name: 'Help for Number of applications received',
+        }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByTestId('keyStat-definition')).toHaveTextContent(
+        'Total number of applications received for places at primary and secondary schools.',
+      );
+    });
+  });
+
+  test('renders correctly with a blank data definition title', async () => {
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
+
+    render(
+      <KeyStat
+        releaseId="release-1"
+        dataBlockId="block-1"
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: [''],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
+
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+
+      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+
+      expect(screen.getByTestId('keyStat-summary')).toHaveTextContent(
+        'Down from 620,330 in 2017',
+      );
+
+      expect(
+        screen.getByRole('button', {
+          name: 'Help for Number of applications received',
+        }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByTestId('keyStat-definition')).toHaveTextContent(
+        'Total number of applications received for places at primary and secondary schools.',
+      );
+    });
+  });
+
   test('renders correctly without summary', async () => {
     tableBuilderService.getDataBlockTableData.mockResolvedValue(
       testTableDataResponse,


### PR DESCRIPTION
This PR: 
* fixes a bug whereby the `hiddenText` variable for keyStat tiles is always undefined due to `summary?.dataDefinitionTitle[0]` being set to `Help` by default. 

 
* Previously we were checking if `summary?.dataDefinitionTitle[0]` was nullable and then setting `hiddenText` if so. The guidance text for a keyStat tile is never nullable and by default is set to the string: `Help`. This caused the previous ternary op's condition to always evaluate to `undefined` & thus visually hidden text was never set on keyStat tiles with the default text of `Help`