### PR TITLE
EES-3054 & 3055 screen reader messages for shareable links

### DIFF
--- a/src/explore-education-statistics-common/src/components/ScreenReaderMessage.tsx
+++ b/src/explore-education-statistics-common/src/components/ScreenReaderMessage.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+
+/**
+ * Announces changes to screen readers.
+ * Use when just using aria-live on an existing element won't work
+ * because it announces changes multiple times.
+ */
+export default function ScreenReaderMessage({ message }: { message: string }) {
+  const [screenReaderMessage, setScreenReaderMessage] = useState('');
+
+  useEffect(() => {
+    // Clear the message then repopulate to ensure the new message is read,
+    // and only read once.
+    setScreenReaderMessage('');
+    setTimeout(() => {
+      setScreenReaderMessage(message);
+    }, 200);
+  }, [message]);
+
+  return (
+    <div
+      aria-live="assertive"
+      aria-atomic="true"
+      aria-relevant="additions"
+      className="govuk-visually-hidden"
+    >
+      {screenReaderMessage}
+    </div>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/__tests__/ScreenReaderMessage.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ScreenReaderMessage.test.tsx
@@ -1,0 +1,46 @@
+import ScreenReaderMessage from '@common/components/ScreenReaderMessage';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+describe('ScreenReaderMessage', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('sets the message after a timeout', () => {
+    const { rerender } = render(<ScreenReaderMessage message="" />);
+
+    rerender(<ScreenReaderMessage message="I am a message" />);
+
+    expect(screen.queryByText('I am a message')).not.toBeInTheDocument();
+
+    jest.advanceTimersByTime(200);
+
+    expect(screen.getByText('I am a message')).toBeInTheDocument();
+  });
+
+  test('clears and then replaces the message', () => {
+    const { rerender } = render(<ScreenReaderMessage message="" />);
+
+    rerender(<ScreenReaderMessage message="I am a message" />);
+
+    expect(screen.queryByText('I am a message')).not.toBeInTheDocument();
+
+    jest.advanceTimersByTime(200);
+
+    expect(screen.getByText('I am a message')).toBeInTheDocument();
+
+    rerender(<ScreenReaderMessage message="I am another message" />);
+
+    expect(screen.queryByText('I am a message')).not.toBeInTheDocument();
+
+    expect(screen.queryByText('I am another message')).not.toBeInTheDocument();
+
+    jest.advanceTimersByTime(200);
+
+    expect(screen.getByText('I am another message')).toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersForm.tsx
@@ -1,5 +1,6 @@
 import Button from '@common/components/Button';
 import { FormGroup } from '@common/components/form';
+import ScreenReaderMessage from '@common/components/ScreenReaderMessage';
 import useToggle from '@common/hooks/useToggle';
 import useMounted from '@common/hooks/useMounted';
 import TableHeadersAxis from '@common/modules/table-tool/components/TableHeadersAxis';
@@ -93,12 +94,7 @@ const TableHeadersForm = ({ onSubmit, initialValues }: Props) => {
         ? 'You have moved the group from row headers to column headers'
         : 'You have moved the group from column headers to row headers';
 
-    // Clear the message then repopulate to ensure the new message is read,
-    // and only read once.
-    setScreenReaderMessage('');
-    setTimeout(() => {
-      setScreenReaderMessage(message);
-    }, 200);
+    setScreenReaderMessage(message);
   };
 
   const handleDragEnd = (
@@ -262,14 +258,7 @@ const TableHeadersForm = ({ onSubmit, initialValues }: Props) => {
             </div>
           )}
 
-          <div
-            aria-live="assertive"
-            aria-atomic="true"
-            aria-relevant="additions"
-            className="govuk-visually-hidden"
-          >
-            {screenReaderMessage}
-          </div>
+          <ScreenReaderMessage message={screenReaderMessage} />
         </>
       )}
     </TableHeadersContextProvider>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
@@ -15,7 +15,7 @@ import ButtonLink from '@frontend/components/ButtonLink';
 import React, { useEffect, useState } from 'react';
 
 const linkInstructions =
-  ' Use the link below to see a version of this page that you can bookmark for future reference, or copy the link to send on to somebody else to view.';
+  'Use the link below to see a version of this page that you can bookmark for future reference, or copy the link to send on to somebody else to view.';
 
 interface Props {
   tableHeaders?: TableHeadersConfig;

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
@@ -2,6 +2,7 @@ import ButtonText from '@common/components/ButtonText';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import LoadingSpinner from '@common/components/LoadingSpinner';
+import ScreenReaderMessage from '@common/components/ScreenReaderMessage';
 import UrlContainer from '@common/components/UrlContainer';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
@@ -12,6 +13,9 @@ import {
 } from '@common/services/tableBuilderService';
 import ButtonLink from '@frontend/components/ButtonLink';
 import React, { useEffect, useState } from 'react';
+
+const linkInstructions =
+  ' Use the link below to see a version of this page that you can bookmark for future reference, or copy the link to send on to somebody else to view.';
 
 interface Props {
   tableHeaders?: TableHeadersConfig;
@@ -26,6 +30,7 @@ const TableToolShare = ({
 }: Props) => {
   const [permalinkId, setPermalinkId] = useState<string>('');
   const [permalinkLoading, setPermalinkLoading] = useState<boolean>(false);
+  const [screenReaderMessage, setScreenReaderMessage] = useState('');
 
   useEffect(() => {
     setPermalinkId('');
@@ -49,6 +54,8 @@ const TableToolShare = ({
 
     setPermalinkId(id);
     setPermalinkLoading(false);
+
+    setScreenReaderMessage(`Shareable link generated. ${linkInstructions}`);
   };
 
   const handleCopyClick = () => {
@@ -57,54 +64,55 @@ const TableToolShare = ({
     ) as HTMLInputElement;
     el?.select();
     document.execCommand('copy');
+    setScreenReaderMessage('Link copied to the clipboard.');
   };
 
-  if (!permalinkId) {
-    return (
-      <>
-        <h3 className="govuk-heading-s">Save table</h3>
-        <LoadingSpinner
-          alert
-          inline
-          loading={permalinkLoading}
-          size="sm"
-          text="Generating permanent link"
-        >
-          <ButtonText onClick={handlePermalinkClick}>
-            Generate shareable link
-          </ButtonText>
-        </LoadingSpinner>
-      </>
-    );
-  }
-
   return (
-    <div className="dfe-align--left">
-      <h3 className="govuk-heading-s">Generated share link</h3>
+    <>
+      {!permalinkId ? (
+        <>
+          <h3 className="govuk-heading-s">Save table</h3>
+          <LoadingSpinner
+            alert
+            inline
+            loading={permalinkLoading}
+            size="sm"
+            text="Generating shareable link"
+          >
+            <ButtonText onClick={handlePermalinkClick}>
+              Generate shareable link
+            </ButtonText>
+          </LoadingSpinner>
+        </>
+      ) : (
+        <>
+          <h3 className="govuk-heading-s">Generated share link</h3>
 
-      <div className="govuk-inset-text">
-        Use the link below to see a version of this page that you can bookmark
-        for future reference, or copy the link to send on to somebody else to
-        view.
-      </div>
+          <div className="govuk-inset-text" aria-hidden>
+            {linkInstructions}
+          </div>
 
-      <p className="govuk-!-margin-top-0 govuk-!-margin-bottom-2">
-        <UrlContainer
-          data-testid="permalink-generated-url"
-          url={`${window.location.origin}/data-tables/permalink/${permalinkId}`}
-        />
-      </p>
+          <p className="govuk-!-margin-top-0 govuk-!-margin-bottom-2">
+            <UrlContainer
+              data-testid="permalink-generated-url"
+              url={`${window.location.origin}/data-tables/permalink/${permalinkId}`}
+            />
+          </p>
 
-      <ButtonGroup>
-        <Button variant="secondary" onClick={handleCopyClick}>
-          Copy link
-        </Button>
+          <ButtonGroup>
+            <Button variant="secondary" onClick={handleCopyClick}>
+              Copy link
+            </Button>
 
-        <ButtonLink to={`/data-tables/permalink/${permalinkId}`}>
-          View share link
-        </ButtonLink>
-      </ButtonGroup>
-    </div>
+            <ButtonLink to={`/data-tables/permalink/${permalinkId}`}>
+              View share link
+            </ButtonLink>
+          </ButtonGroup>
+        </>
+      )}
+
+      <ScreenReaderMessage message={screenReaderMessage} />
+    </>
   );
 };
 


### PR DESCRIPTION
- Announces to screen reader users when a shareable link is generated (EES-3054) and when it is copied to the clipboard (EES-3055).
- When the link is generated I've included the instructions for it in the screen reader announcement so that it's clear what to do and aria-hidden the displayed version of the same message.
- I've added a reusable component for screen reader messages and updated table tool reordering to use this as well.