### PR TITLE
EES-3082 fix heading levels in table tool

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectForm.tsx
@@ -9,7 +9,7 @@ import ResetFormOnPreviousStep from '@common/modules/table-tool/components/Reset
 import { Subject } from '@common/services/tableBuilderService';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
-import React, { ReactNode, useMemo } from 'react';
+import React, { createElement, ReactNode, useMemo } from 'react';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 
@@ -22,6 +22,7 @@ export type SubjectFormSubmitHandler = (values: { subjectId: string }) => void;
 const formId = 'publicationSubjectForm';
 
 interface Props extends InjectedWizardProps {
+  hasFeaturedTables?: boolean;
   legend?: ReactNode;
   legendSize?: FormFieldsetProps['legendSize'];
   legendHint?: string;
@@ -31,6 +32,7 @@ interface Props extends InjectedWizardProps {
 }
 
 const SubjectForm = ({
+  hasFeaturedTables = false,
   legend,
   legendSize = 'l',
   legendHint,
@@ -72,7 +74,16 @@ const SubjectForm = ({
               className="govuk-!-margin-bottom-2"
               hiddenText={`for ${option.name}`}
             >
-              <h4>This subject includes the following data:</h4>
+              {createElement(
+                hasFeaturedTables ? 'h4' : 'h3',
+                hasFeaturedTables
+                  ? null
+                  : {
+                      className: 'govuk-heading-s',
+                    },
+                'This subject includes the following data:',
+              )}
+
               <SummaryList>
                 {geographicLevels && (
                   <SummaryListItem term="Geographic levels">
@@ -96,7 +107,7 @@ const SubjectForm = ({
           ),
         };
       }),
-    [options],
+    [hasFeaturedTables, options],
   );
   return (
     <Formik<SubjectFormValues>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectStep.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectStep.tsx
@@ -67,6 +67,7 @@ const SubjectStep = ({
           )
         }
         legendHint="Choose a subject to create your table from, more information on the data coverage can be found by viewing more details"
+        hasFeaturedTables={hasFeaturedTables}
       />
     );
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolInfo.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolInfo.tsx
@@ -31,9 +31,7 @@ const TableToolInfo = ({
             If you have a question about the data or methods used to create this
             table contact the named statistician:
           </p>
-          <h4 className="govuk-heading-s govuk-!-font-weight-bold">
-            {contactDetails.teamName}
-          </h4>
+          <h3 className="govuk-heading-s">{contactDetails.teamName}</h3>
           <p>Named statistician: {contactDetails.contactName}</p>
           <p>
             Email:{' '}


### PR DESCRIPTION
Fixes heading levels in the table tool:
- in the 'More details' on the subject step when there are not featured tables
- in the Contact us section 