### PR TITLE
EES-3083 remove tabs when only one

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -117,6 +117,7 @@ const DataBlockSourceWizard = ({
 }: DataBlockSourceWizardProps) => {
   return (
     <div className="govuk-!-margin-bottom-8">
+      <h2 className="govuk-heading-m">Data source</h2>
       <p>Configure data source for the data block</p>
       {dataBlock && dataBlock.charts.length > 0 && (
         <WarningMessage>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
@@ -106,17 +106,18 @@ describe('DataBlockPageTabs', () => {
     });
   });
 
-  test('does not render table or chart tabs when no data block is selected', async () => {
+  test('renders the data source form without other tabs when no data block is selected', async () => {
     tableBuilderService.listReleaseSubjects.mockResolvedValue(testSubjects);
 
     render(<DataBlockPageTabs releaseId="release-1" onDataBlockSave={noop} />);
 
     await waitFor(() => {
-      const tabs = screen.getAllByRole('tab', { hidden: true });
-
-      expect(tabs).toHaveLength(1);
-      expect(tabs[0]).toHaveTextContent('Data source');
+      expect(screen.getByText('Data source')).toBeInTheDocument();
     });
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    expect(screen.queryByRole('tabpanel')).not.toBeInTheDocument();
+    expect(screen.queryByText('Table')).not.toBeInTheDocument();
+    expect(screen.queryByText('Chart')).not.toBeInTheDocument();
   });
 
   test('renders fully initialised table tool when data block is selected', async () => {

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
@@ -97,7 +97,7 @@ describe('ReleasePreReleaseAccessPage', () => {
     );
   });
 
-  test('does not render the pre-release users tab for amendments', async () => {
+  test('only renders the public access list for amendments', async () => {
     const amendmentRelease = { ...releaseData, amendment: true };
     releaseService.getRelease.mockResolvedValue(amendmentRelease);
     permissionService.canUpdateRelease.mockResolvedValue(true);
@@ -110,12 +110,9 @@ describe('ReleasePreReleaseAccessPage', () => {
       ).toBeInTheDocument();
     });
 
-    expect(
-      screen.queryByRole('tab', { name: 'Pre-release users' }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('tab', { name: 'Public access list', hidden: true }),
-    ).toBeInTheDocument();
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    expect(screen.queryByRole('tabpanel')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pre-release users')).not.toBeInTheDocument();
   });
 
   test('renders the public access list tab', async () => {

--- a/src/explore-education-statistics-common/src/components/Tabs.module.scss
+++ b/src/explore-education-statistics-common/src/components/Tabs.module.scss
@@ -16,9 +16,8 @@
   }
 }
 
-.mobileHidden {
-  display: none;
+.singleTab {
   @include govuk-media-query($from: tablet) {
-    display: block;
+    border-top: 1px solid govuk-colour('mid-grey');
   }
 }

--- a/src/explore-education-statistics-common/src/components/Tabs.tsx
+++ b/src/explore-education-statistics-common/src/components/Tabs.tsx
@@ -126,7 +126,18 @@ const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
     };
   }, [sections, selectTab, selectedTabIndex]);
 
-  const hasSingleTab = sections.length === 1;
+  if (sections.length === 1) {
+    return (
+      <div
+        className={classNames('govuk-tabs', styles.tabs, styles.singleTab)}
+        id={id}
+        data-testid={testId}
+        ref={ref}
+      >
+        {sections[0]}
+      </div>
+    );
+  }
 
   return (
     <div
@@ -135,13 +146,7 @@ const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
       data-testid={testId}
       ref={ref}
     >
-      <ul
-        aria-hidden={hasSingleTab}
-        className={classNames('govuk-tabs__list', {
-          [styles.mobileHidden]: hasSingleTab,
-        })}
-        role="tablist"
-      >
+      <ul className="govuk-tabs__list" role="tablist">
         {sections.map(({ props }, index) => {
           const sectionId = props.id || `${id}-${index + 1}`;
 

--- a/src/explore-education-statistics-common/src/components/TabsSection.tsx
+++ b/src/explore-education-statistics-common/src/components/TabsSection.tsx
@@ -69,7 +69,7 @@ const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
         id={id}
         ref={ref}
         role={hasSiblings ? onMedia('tabpanel') : undefined}
-        tabIndex={onMedia(-1)}
+        tabIndex={hasSiblings ? onMedia(-1) : undefined}
       >
         {headingTitle && createElement(headingTag, null, headingTitle)}
         {children}

--- a/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
@@ -5,7 +5,7 @@ import Tabs from '../Tabs';
 import TabsSection from '../TabsSection';
 
 describe('Tabs', () => {
-  test('renders with aria-hidden tabs when there is only one section', () => {
+  test('renders without tabs when there is only one section', () => {
     const { container } = render(
       <Tabs id="test-tabs">
         <TabsSection title="Tab 1" headingTitle="Tab Heading 1">
@@ -15,16 +15,15 @@ describe('Tabs', () => {
     );
 
     expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
-    expect(screen.queryByRole('tablist', { hidden: true })).toHaveAttribute(
-      'aria-hidden',
-      'true',
-    );
-
     expect(screen.queryByRole('tab')).not.toBeInTheDocument();
     expect(screen.queryByRole('tabpanel')).not.toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: 'Tab 1' }),
     ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: 'Tab Heading 1' }),
+    ).toBeInTheDocument();
     expect(screen.getByText('Test section 1 content')).toBeInTheDocument();
 
     expect(container).toMatchSnapshot();

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`Tabs renders multiple tabs correctly with titles 1`] = `
     id="test-tabs"
   >
     <ul
-      aria-hidden="false"
       class="govuk-tabs__list"
       role="tablist"
     >
@@ -83,7 +82,6 @@ exports[`Tabs renders multiple tabs correctly without titles 1`] = `
     id="test-tabs"
   >
     <ul
-      aria-hidden="false"
       class="govuk-tabs__list"
       role="tablist"
     >
@@ -148,37 +146,15 @@ exports[`Tabs renders multiple tabs correctly without titles 1`] = `
 </div>
 `;
 
-exports[`Tabs renders with aria-hidden tabs when there is only one section 1`] = `
+exports[`Tabs renders without tabs when there is only one section 1`] = `
 <div>
   <div
-    class="govuk-tabs tabs"
+    class="govuk-tabs tabs singleTab"
     id="test-tabs"
   >
-    <ul
-      aria-hidden="true"
-      class="govuk-tabs__list mobileHidden"
-      role="tablist"
-    >
-      <li
-        class="govuk-tabs__list-item govuk-tabs__list-item--selected"
-        role="presentation"
-      >
-        <a
-          aria-controls="test-tabs-1"
-          aria-selected="true"
-          class="govuk-tabs__tab"
-          href="#test-tabs-1"
-          id="test-tabs-1-tab"
-          role="tab"
-        >
-          Tab 1
-        </a>
-      </li>
-    </ul>
     <section
       class="govuk-tabs__panel panel"
       id="test-tabs-1"
-      tabindex="-1"
     >
       <h3>
         Tab Heading 1


### PR DESCRIPTION
Removes tabs when there is only one pane of content as this can be confusing to screen reader users. 

This affects:
- Key stats when there are no secondary stats
- Data blocks when there's just a table
- Pre-release access page on amendments
- Data blocks page in the admin when creating them or viewing a published release - I've added a 'Data source' heading to the content here as its not clear otherwise what you're doing.

Tabbed content with more than one tab should be unaffected.

### Screenshots

![notabs2](https://user-images.githubusercontent.com/81572860/192746198-ffee09e6-20b1-448f-b723-f86fb19e5468.PNG)
![notabs1](https://user-images.githubusercontent.com/81572860/192746207-36a107ea-5830-4590-9d8c-3ef9bd6d7a6b.PNG)

