### PR TITLE
EES-3127 Annotate ReleaseCacheViewModel.Type with json converter StringEnumConverter

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ReleaseCacheViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ReleaseCacheViewModel.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 {
@@ -25,6 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 
         public string Slug { get; set; } = string.Empty;
 
+        [JsonConverter(typeof(StringEnumConverter))]
         public ReleaseType Type { get; set; }
 
         public PartialDate? NextReleaseDate { get; set; }


### PR DESCRIPTION
This PR is an update to https://github.com/dfe-analytical-services/explore-education-statistics/pull/3513.
It annotates `ReleaseCacheViewModel.Type` with json converter `StringEnumConverter`.

While there are no current issues without it, we see here that `Type` is being serialised as the ordinal position of the enum value.

![image](https://user-images.githubusercontent.com/4147126/192790393-9728c0e9-9eaf-4c1a-9e6e-1c95ac2bd611.png)

This will become problematic in future and introduce a bug if the order of ReleaseType changes or if values are inserted or removed.

With this change the enum is converted to and from its name string value so there can be no ambiguity:

![image](https://user-images.githubusercontent.com/4147126/192789809-20e7371d-9c7b-4dad-9aa5-5c164080e468.png)
