### PR TITLE
EES-3640 move file size into link

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -345,7 +345,7 @@ const ReleaseContent = () => {
                 )
               }
             >
-              {file.name}
+              {`${file.name} (${file.extension}, ${file.size})`}
             </ButtonText>
           )}
           renderDataGuidanceLink={

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAccordion.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAccordion.tsx
@@ -100,10 +100,7 @@ const ReleaseDataAccordion = ({
                   >
                     <ul className="govuk-list" data-testid="data-files">
                       {dataFiles.map(file => (
-                        <li key={file.id}>
-                          {renderDownloadLink(file)}
-                          {` (${file.extension}, ${file.size})`}
-                        </li>
+                        <li key={file.id}>{renderDownloadLink(file)}</li>
                       ))}
                     </ul>
                   </Details>
@@ -167,7 +164,6 @@ const ReleaseDataAccordion = ({
                     {ancillaryFiles.map(file => (
                       <li key={file.id}>
                         {renderDownloadLink(file)}
-                        {` (${file.extension}, ${file.size})`}
 
                         {file.summary && (
                           <Details

--- a/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseDataAccordion.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseDataAccordion.test.tsx
@@ -59,7 +59,9 @@ describe('ReleaseDataAccordion', () => {
   const mockAllFilesButton = <a href="#">Mock download all data (zip)</a>;
   const mockCreateTablesButton = <a href="#">Mock create tables button</a>;
   const mockDataCatalogueLink = <a href="#">Mock data catalogue link</a>;
-  const mockDownloadLink = (file: FileInfo) => <a href="/">{file.name}</a>;
+  const mockDownloadLink = (file: FileInfo) => (
+    <a href="/">{`${file.name} (${file.extension}, ${file.size})`}</a>
+  );
   const mockDataGuidanceLink = <a href="#">Mock data guidance link</a>;
 
   test('renders the download all data button if files are available', () => {
@@ -159,20 +161,14 @@ describe('ReleaseDataAccordion', () => {
 
     expect(
       within(downloadFiles[0]).getByRole('link', {
-        name: 'Test data file 1',
+        name: 'Test data file 1 (csv, 10 KB)',
       }),
-    ).toBeInTheDocument();
-    expect(
-      within(downloadFiles[0]).getByText('(csv, 10 KB)'),
     ).toBeInTheDocument();
 
     expect(
       within(downloadFiles[1]).getByRole('link', {
-        name: 'Test data file 2',
+        name: 'Test data file 2 (csv, 15 KB)',
       }),
-    ).toBeInTheDocument();
-    expect(
-      within(downloadFiles[1]).getByText('(csv, 15 KB)'),
     ).toBeInTheDocument();
   });
 
@@ -286,10 +282,9 @@ describe('ReleaseDataAccordion', () => {
     // File 1
     expect(
       within(otherFiles[0]).getByRole('link', {
-        name: 'Test ancillary file 1',
+        name: 'Test ancillary file 1 (txt, 25 KB)',
       }),
     ).toBeInTheDocument();
-    expect(within(otherFiles[0]).getByText('(txt, 25 KB)')).toBeInTheDocument();
     expect(
       within(otherFiles[0]).getByText('A Test ancillary file 1 summary'),
     ).toBeInTheDocument();
@@ -297,10 +292,9 @@ describe('ReleaseDataAccordion', () => {
     // File 2
     expect(
       within(otherFiles[1]).getByRole('link', {
-        name: 'Test ancillary file 2',
+        name: 'Test ancillary file 2 (pdf, 20 KB)',
       }),
     ).toBeInTheDocument();
-    expect(within(otherFiles[1]).getByText('(pdf, 20 KB)')).toBeInTheDocument();
     expect(
       within(otherFiles[1]).getByText('Test ancillary file 2 summary'),
     ).toBeInTheDocument();

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -449,7 +449,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                   });
                 }}
               >
-                {file.name}
+                {`${file.name} (${file.extension}, ${file.size})`}
               </Link>
             );
           }}

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -9,11 +9,9 @@ Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 
-
 *** Variables ***
 ${TOPIC_NAME}=          %{TEST_TOPIC_NAME}
 ${PUBLICATION_NAME}=    UI tests - upload files %{RUN_IDENTIFIER}
-
 
 *** Test Cases ***
 Create test publication and release via api
@@ -141,7 +139,7 @@ Validate 'Explore data and files' accordion
     user opens details dropdown    Download files
     user checks list has x items    testid:data-files    1    ${section}
     ${data_files_1}=    user gets list item element    testid:data-files    1    ${section}
-    user checks element contains button    ${data_files_1}    Updated Absence in PRUs
+    user checks element contains button    ${data_files_1}    Updated Absence in PRUs (csv, 141 Kb)
 
     # Ancillary files
     user waits until h3 is visible    All supporting files
@@ -149,7 +147,7 @@ Validate 'Explore data and files' accordion
     ${other_files}=    user gets details content element    List of all supporting files    ${section}
     ${other_files_1}=    get child element    ${other_files}    css:li:nth-child(1)
 
-    user checks element contains button    ${other_files_1}    Test 1
+    user checks element contains button    ${other_files_1}    Test 1 (txt, 12 B)
 
     user opens details dropdown    More details    ${other_files_1}
     ${other_files_1_details}=    user gets details content element    More details    ${other_files_1}

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -11,12 +11,10 @@ Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 
-
 *** Variables ***
 ${PUBLICATION_NAME}=    UI tests - publish release %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Financial Year 3000-01
 ${DATABLOCK_NAME}=      Dates data block name
-
 
 *** Test Cases ***
 Create new publication for "UI tests topic" topic
@@ -219,12 +217,12 @@ Verify release associated files
     ${other_files}=    user gets details content element    List of all supporting files
     ${other_files_1}=    get child element    ${other_files}    css:li:nth-child(1)
 
-    user waits until element contains link    ${other_files_1}    Test ancillary file 1
+    user waits until element contains link    ${other_files_1}    Test ancillary file 1 (txt, 12 B)
     user opens details dropdown    More details    ${other_files_1}
     ${other_files_1_details}=    user gets details content element    More details    ${other_files_1}
     user checks element should contain    ${other_files_1_details}    Test ancillary file 1 summary
 
-    download file    link:Test ancillary file 1    test_ancillary_file_1.txt
+    download file    link:Test ancillary file 1 (txt, 12 B)    test_ancillary_file_1.txt
     downloaded file should have first line    test_ancillary_file_1.txt    Test file 1
 
 Verify public metadata guidance document
@@ -610,19 +608,19 @@ Verify amendment files
     ${other_files_1}=    get child element    ${other_files}    css:li:nth-child(1)
     ${other_files_2}=    get child element    ${other_files}    css:li:nth-child(2)
 
-    user waits until element contains link    ${other_files_1}    Test ancillary file 1
+    user waits until element contains link    ${other_files_1}    Test ancillary file 1 (txt, 12 B)
     user opens details dropdown    More details    ${other_files_1}
     ${other_files_1_details}=    user gets details content element    More details    ${other_files_1}
     user checks element should contain    ${other_files_1_details}    Test ancillary file 1 summary
-    download file    link:Test ancillary file 1    test_ancillary_file_1.txt
+    download file    link:Test ancillary file 1 (txt, 12 B)    test_ancillary_file_1.txt
     downloaded file should have first line    test_ancillary_file_1.txt    Test file 1
 
-    user waits until element contains link    ${other_files_2}    Test ancillary file 2
+    user waits until element contains link    ${other_files_2}    Test ancillary file 2 (txt, 24 B)
     user opens details dropdown    More details    ${other_files_2}
     ${other_files_2_details}=    user gets details content element    More details    ${other_files_2}
     user checks element should contain    ${other_files_2_details}    Test ancillary file 2 summary
 
-    download file    link:Test ancillary file 2    test_ancillary_file_2.txt
+    download file    link:Test ancillary file 2 (txt, 24 B)    test_ancillary_file_2.txt
     downloaded file should have first line    test_ancillary_file_2.txt    Test file 2
 
 Verify amendment public metadata guidance document


### PR DESCRIPTION
Moves the file size and type into the links for downloads on release pages.