### PR TITLE
EES-3583 remove all data sets option

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
@@ -249,7 +249,7 @@ const ChartDataSetsConfiguration = ({
       >
         <Droppable droppableId="dataSets" isDropDisabled={!isReordering}>
           {(droppableProvided, droppableSnapshot) => (
-            <table>
+            <table data-testId="chart-data-sets">
               <thead>
                 <tr>
                   <th>Data set</th>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
@@ -255,13 +255,12 @@ const ChartDataSetsConfiguration = ({
                   <th>Data set</th>
                   {!isReordering && (
                     <th className="dfe-align--right">
-                      <VisuallyHidden>Remove data sets:</VisuallyHidden>
                       {dataSets.length > 0 && (
                         <ButtonText
                           className="govuk-!-margin-bottom-0"
                           onClick={toggleConfirmModal.on}
                         >
-                          Remove all
+                          Remove all<VisuallyHidden> data sets</VisuallyHidden>
                         </ButtonText>
                       )}
                     </th>
@@ -356,9 +355,7 @@ const ChartDataSetsConfiguration = ({
           <Button
             className="dfe-align-self-end govuk-!-margin-left-2"
             variant="secondary"
-            onClick={
-              isReordering ? toggleIsReordering.off : toggleIsReordering.on
-            }
+            onClick={toggleIsReordering}
           >
             {isReordering ? 'Finish reordering' : 'Reorder data sets'}
           </Button>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilder.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilder.test.tsx
@@ -1,0 +1,321 @@
+import { testTableData } from '@admin/pages/release/datablocks/__data__/tableToolServiceData';
+import {
+  ChartBuilderForms,
+  ChartBuilderFormsContextProvider,
+} from '@admin/pages/release/datablocks/components/chart/contexts/ChartBuilderFormsContext';
+import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
+import mapFullTableMeta from '@common/modules/table-tool/utils/mapFullTableMeta';
+import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
+import { TableDataSubjectMeta } from '@common/services/tableBuilderService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import React from 'react';
+import ChartBuilder from '../ChartBuilder';
+
+describe('ChartBuilder', () => {
+  const testFormState: ChartBuilderForms = {
+    options: {
+      isValid: true,
+      submitCount: 0,
+      id: 'options',
+      title: 'Options',
+    },
+    dataSets: {
+      isValid: true,
+      submitCount: 0,
+      id: 'dataSets',
+      title: 'Data sets',
+    },
+  };
+
+  const testTable = mapFullTable(testTableData);
+  const testMeta: TableDataSubjectMeta = {
+    publicationName: '',
+    subjectName: '',
+    geoJsonAvailable: false,
+    footnotes: [],
+    boundaryLevels: [],
+    locations: {
+      localAuthority: [
+        { id: 'barnet', label: 'Barnet', value: 'barnet' },
+        { id: 'barnsley', label: 'Barnsley', value: 'barnsley' },
+      ],
+    },
+    timePeriodRange: [
+      {
+        label: '2019/20',
+        year: 2019,
+        code: 'AY',
+      },
+      {
+        label: '2020/21',
+        year: 2020,
+        code: 'AY',
+      },
+    ],
+    indicators: [
+      {
+        value: 'authorised-absence-sessions',
+        label: 'Number of authorised absence sessions',
+        unit: '',
+        name: 'sess_authorised',
+        decimalPlaces: 2,
+      },
+      {
+        value: 'unauthorised-absence-sessions',
+        label: 'Number of unauthorised absence sessions',
+        unit: '',
+        name: 'sess_unauthorised',
+        decimalPlaces: 2,
+      },
+    ],
+    filters: {
+      Characteristic: {
+        legend: 'Characteristic',
+        name: 'characteristic',
+        options: {
+          gender: {
+            id: 'gender',
+            label: 'Gender',
+            options: [
+              {
+                value: 'male',
+                label: 'Male',
+              },
+              {
+                value: 'female',
+                label: 'Female',
+              },
+            ],
+            order: 0,
+          },
+        },
+        order: 0,
+      },
+    },
+  };
+  const testSubjectMeta: FullTableMeta = mapFullTableMeta(testMeta);
+
+  test('renders the chart type selector only when no initial value', () => {
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartBuilder
+          releaseId="release-1"
+          data={testTable.results}
+          meta={testSubjectMeta}
+          tableTitle="Table title"
+          onChartSave={jest.fn(() => Promise.resolve())}
+          onChartDelete={noop}
+          onTableQueryUpdate={jest.fn(() => Promise.resolve())}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    expect(screen.getByText('Choose chart type')).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: 'Line' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Vertical bar' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Horizontal bar' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Choose an infographic as alternative',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: 'Chart preview' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders the chart preview and tabs, with configuration selected, when a chart type is selected', () => {
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartBuilder
+          releaseId="release-1"
+          data={testTable.results}
+          meta={testSubjectMeta}
+          tableTitle="Table title"
+          onChartSave={jest.fn(() => Promise.resolve())}
+          onChartDelete={noop}
+          onTableQueryUpdate={jest.fn(() => Promise.resolve())}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Line' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Chart preview' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('tab', { name: 'Chart configuration' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Data sets' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Legend' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('tab', { name: 'X Axis (major axis)' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('tab', { name: 'Y Axis (minor axis)' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: 'Chart configuration' }),
+    ).toBeInTheDocument();
+  });
+
+  describe('data sets', () => {
+    test('adding data sets', async () => {
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartBuilder
+            releaseId="release-1"
+            data={testTable.results}
+            meta={testSubjectMeta}
+            tableTitle="Table title"
+            onChartSave={jest.fn(() => Promise.resolve())}
+            onChartDelete={noop}
+            onTableQueryUpdate={jest.fn(() => Promise.resolve())}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Line' }));
+
+      userEvent.click(screen.getByRole('tab', { name: 'Data sets' }));
+
+      expect(
+        screen.getByRole('heading', { name: 'Data sets' }),
+      ).toBeInTheDocument();
+
+      userEvent.selectOptions(screen.getByLabelText('Characteristic'), 'male');
+      userEvent.selectOptions(
+        screen.getByLabelText('Indicator'),
+        'unauthorised-absence-sessions',
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Add data set' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Remove all')).toBeInTheDocument();
+      });
+
+      const tableRows = screen.getAllByRole('row');
+      expect(tableRows).toHaveLength(2);
+      expect(tableRows[1]).toHaveTextContent(
+        'Number of unauthorised absence sessions (Male, All locations, All time periods)',
+      );
+
+      userEvent.selectOptions(
+        screen.getByLabelText('Characteristic'),
+        'female',
+      );
+      userEvent.selectOptions(
+        screen.getByLabelText('Indicator'),
+        'unauthorised-absence-sessions',
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Add data set' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Reorder data sets')).toBeInTheDocument();
+      });
+
+      const updatedTableRows = screen.getAllByRole('row');
+      expect(updatedTableRows).toHaveLength(3);
+      expect(updatedTableRows[2]).toHaveTextContent(
+        'Number of unauthorised absence sessions (Female, All locations, All time periods)',
+      );
+    });
+
+    test('removing data sets', async () => {
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartBuilder
+            releaseId="release-1"
+            data={testTable.results}
+            meta={testSubjectMeta}
+            tableTitle="Table title"
+            onChartSave={jest.fn(() => Promise.resolve())}
+            onChartDelete={noop}
+            onTableQueryUpdate={jest.fn(() => Promise.resolve())}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Line' }));
+
+      userEvent.click(screen.getByRole('tab', { name: 'Data sets' }));
+
+      expect(
+        screen.getByRole('heading', { name: 'Data sets' }),
+      ).toBeInTheDocument();
+
+      userEvent.click(screen.getByRole('button', { name: 'Add data set' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Remove all')).toBeInTheDocument();
+      });
+
+      const tableRows = screen.getAllByRole('row');
+      expect(tableRows).toHaveLength(5);
+      expect(tableRows[1]).toHaveTextContent(
+        'Number of authorised absence sessions (Male, All locations, All time periods)',
+      );
+      expect(tableRows[2]).toHaveTextContent(
+        'Number of unauthorised absence sessions (Male, All locations, All time periods)',
+      );
+      expect(tableRows[3]).toHaveTextContent(
+        'Number of authorised absence sessions (Female, All locations, All time periods)',
+      );
+      expect(tableRows[4]).toHaveTextContent(
+        'Number of unauthorised absence sessions (Female, All locations, All time periods)',
+      );
+
+      userEvent.click(
+        within(tableRows[2]).getByRole('button', { name: 'Remove' }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(
+            'Number of unauthorised absence sessions (Male, All locations, All time periods)',
+          ),
+        ).not.toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Remove all data sets' }),
+      );
+
+      const modal = within(screen.getByRole('dialog'));
+      expect(modal.getByText('Remove all data sets')).toBeInTheDocument();
+      userEvent.click(modal.getByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(
+            'Number of authorised absence sessions (Male, All locations, All time periods)',
+          ),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(
+            'Number of authorised absence sessions (Female, All locations, All time periods)',
+          ),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(
+            'Number of unauthorised absence sessions (Female, All locations, All time periods)',
+          ),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilder.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilder.test.tsx
@@ -1,12 +1,8 @@
-import { testTableData } from '@admin/pages/release/datablocks/__data__/tableToolServiceData';
+import { testFullTable } from '@admin/pages/release/datablocks/components/chart/__tests__/__data__/testTableData';
 import {
   ChartBuilderForms,
   ChartBuilderFormsContextProvider,
 } from '@admin/pages/release/datablocks/components/chart/contexts/ChartBuilderFormsContext';
-import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
-import mapFullTableMeta from '@common/modules/table-tool/utils/mapFullTableMeta';
-import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
-import { TableDataSubjectMeta } from '@common/services/tableBuilderService';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import noop from 'lodash/noop';
@@ -29,85 +25,17 @@ describe('ChartBuilder', () => {
     },
   };
 
-  const testTable = mapFullTable(testTableData);
-  const testMeta: TableDataSubjectMeta = {
-    publicationName: '',
-    subjectName: '',
-    geoJsonAvailable: false,
-    footnotes: [],
-    boundaryLevels: [],
-    locations: {
-      localAuthority: [
-        { id: 'barnet', label: 'Barnet', value: 'barnet' },
-        { id: 'barnsley', label: 'Barnsley', value: 'barnsley' },
-      ],
-    },
-    timePeriodRange: [
-      {
-        label: '2019/20',
-        year: 2019,
-        code: 'AY',
-      },
-      {
-        label: '2020/21',
-        year: 2020,
-        code: 'AY',
-      },
-    ],
-    indicators: [
-      {
-        value: 'authorised-absence-sessions',
-        label: 'Number of authorised absence sessions',
-        unit: '',
-        name: 'sess_authorised',
-        decimalPlaces: 2,
-      },
-      {
-        value: 'unauthorised-absence-sessions',
-        label: 'Number of unauthorised absence sessions',
-        unit: '',
-        name: 'sess_unauthorised',
-        decimalPlaces: 2,
-      },
-    ],
-    filters: {
-      Characteristic: {
-        legend: 'Characteristic',
-        name: 'characteristic',
-        options: {
-          gender: {
-            id: 'gender',
-            label: 'Gender',
-            options: [
-              {
-                value: 'male',
-                label: 'Male',
-              },
-              {
-                value: 'female',
-                label: 'Female',
-              },
-            ],
-            order: 0,
-          },
-        },
-        order: 0,
-      },
-    },
-  };
-  const testSubjectMeta: FullTableMeta = mapFullTableMeta(testMeta);
-
   test('renders the chart type selector only when no initial value', () => {
     render(
       <ChartBuilderFormsContextProvider initialForms={testFormState}>
         <ChartBuilder
           releaseId="release-1"
-          data={testTable.results}
-          meta={testSubjectMeta}
+          data={testFullTable.results}
+          meta={testFullTable.subjectMeta}
           tableTitle="Table title"
-          onChartSave={jest.fn(() => Promise.resolve())}
+          onChartSave={jest.fn()}
           onChartDelete={noop}
-          onTableQueryUpdate={jest.fn(() => Promise.resolve())}
+          onTableQueryUpdate={jest.fn()}
         />
       </ChartBuilderFormsContextProvider>,
     );
@@ -138,12 +66,12 @@ describe('ChartBuilder', () => {
       <ChartBuilderFormsContextProvider initialForms={testFormState}>
         <ChartBuilder
           releaseId="release-1"
-          data={testTable.results}
-          meta={testSubjectMeta}
+          data={testFullTable.results}
+          meta={testFullTable.subjectMeta}
           tableTitle="Table title"
-          onChartSave={jest.fn(() => Promise.resolve())}
+          onChartSave={jest.fn()}
           onChartDelete={noop}
-          onTableQueryUpdate={jest.fn(() => Promise.resolve())}
+          onTableQueryUpdate={jest.fn()}
         />
       </ChartBuilderFormsContextProvider>,
     );
@@ -154,17 +82,24 @@ describe('ChartBuilder', () => {
       screen.getByRole('button', { name: 'Chart preview' }),
     ).toBeInTheDocument();
 
-    expect(
-      screen.getByRole('tab', { name: 'Chart configuration' }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Data sets' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Legend' })).toBeInTheDocument();
-    expect(
-      screen.getByRole('tab', { name: 'X Axis (major axis)' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('tab', { name: 'Y Axis (minor axis)' }),
-    ).toBeInTheDocument();
+    const tabs = screen.getAllByRole('tab');
+
+    expect(tabs).toHaveLength(5);
+
+    expect(tabs[0]).toHaveTextContent('Chart configuration');
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+
+    expect(tabs[1]).toHaveTextContent('Data sets');
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+
+    expect(tabs[2]).toHaveTextContent('Legend');
+    expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
+
+    expect(tabs[3]).toHaveTextContent('X Axis (major axis)');
+    expect(tabs[3]).toHaveAttribute('aria-selected', 'false');
+
+    expect(tabs[4]).toHaveTextContent('Y Axis (minor axis)');
+    expect(tabs[4]).toHaveAttribute('aria-selected', 'false');
 
     expect(
       screen.getByRole('heading', { name: 'Chart configuration' }),
@@ -177,12 +112,12 @@ describe('ChartBuilder', () => {
         <ChartBuilderFormsContextProvider initialForms={testFormState}>
           <ChartBuilder
             releaseId="release-1"
-            data={testTable.results}
-            meta={testSubjectMeta}
+            data={testFullTable.results}
+            meta={testFullTable.subjectMeta}
             tableTitle="Table title"
-            onChartSave={jest.fn(() => Promise.resolve())}
+            onChartSave={jest.fn()}
             onChartDelete={noop}
-            onTableQueryUpdate={jest.fn(() => Promise.resolve())}
+            onTableQueryUpdate={jest.fn()}
           />
         </ChartBuilderFormsContextProvider>,
       );
@@ -195,11 +130,23 @@ describe('ChartBuilder', () => {
         screen.getByRole('heading', { name: 'Data sets' }),
       ).toBeInTheDocument();
 
-      userEvent.selectOptions(screen.getByLabelText('Characteristic'), 'male');
+      userEvent.selectOptions(
+        screen.getByLabelText('Characteristic'),
+        'ethnicity-major-chinese',
+      );
+      userEvent.selectOptions(
+        screen.getByLabelText('School type'),
+        'state-funded-primary',
+      );
       userEvent.selectOptions(
         screen.getByLabelText('Indicator'),
-        'unauthorised-absence-sessions',
+        'authorised-absence-sessions',
       );
+      userEvent.selectOptions(
+        screen.getByLabelText('Location'),
+        '{"level":"localAuthority","value":"barnet"}',
+      );
+      userEvent.selectOptions(screen.getByLabelText('Time period'), '2014_AY');
 
       userEvent.click(screen.getByRole('button', { name: 'Add data set' }));
 
@@ -210,17 +157,26 @@ describe('ChartBuilder', () => {
       const tableRows = screen.getAllByRole('row');
       expect(tableRows).toHaveLength(2);
       expect(tableRows[1]).toHaveTextContent(
-        'Number of unauthorised absence sessions (Male, All locations, All time periods)',
+        'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, Barnet, 2014/15)',
       );
 
       userEvent.selectOptions(
         screen.getByLabelText('Characteristic'),
-        'female',
+        'ethnicity-major-chinese',
+      );
+      userEvent.selectOptions(
+        screen.getByLabelText('School type'),
+        'state-funded-secondary',
       );
       userEvent.selectOptions(
         screen.getByLabelText('Indicator'),
-        'unauthorised-absence-sessions',
+        'authorised-absence-sessions',
       );
+      userEvent.selectOptions(
+        screen.getByLabelText('Location'),
+        '{"level":"localAuthority","value":"barnet"}',
+      );
+      userEvent.selectOptions(screen.getByLabelText('Time period'), '2014_AY');
 
       userEvent.click(screen.getByRole('button', { name: 'Add data set' }));
 
@@ -231,21 +187,21 @@ describe('ChartBuilder', () => {
       const updatedTableRows = screen.getAllByRole('row');
       expect(updatedTableRows).toHaveLength(3);
       expect(updatedTableRows[2]).toHaveTextContent(
-        'Number of unauthorised absence sessions (Female, All locations, All time periods)',
+        'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded secondary, Barnet, 2014/15)',
       );
     });
 
-    test('removing data sets', async () => {
+    test('removing a data set', async () => {
       render(
         <ChartBuilderFormsContextProvider initialForms={testFormState}>
           <ChartBuilder
             releaseId="release-1"
-            data={testTable.results}
-            meta={testSubjectMeta}
+            data={testFullTable.results}
+            meta={testFullTable.subjectMeta}
             tableTitle="Table title"
-            onChartSave={jest.fn(() => Promise.resolve())}
+            onChartSave={jest.fn()}
             onChartDelete={noop}
-            onTableQueryUpdate={jest.fn(() => Promise.resolve())}
+            onTableQueryUpdate={jest.fn()}
           />
         </ChartBuilderFormsContextProvider>,
       );
@@ -258,6 +214,12 @@ describe('ChartBuilder', () => {
         screen.getByRole('heading', { name: 'Data sets' }),
       ).toBeInTheDocument();
 
+      userEvent.selectOptions(
+        screen.getByLabelText('Indicator'),
+        'authorised-absence-sessions',
+      );
+      userEvent.selectOptions(screen.getByLabelText('Time period'), '2014_AY');
+
       userEvent.click(screen.getByRole('button', { name: 'Add data set' }));
 
       await waitFor(() => {
@@ -267,16 +229,16 @@ describe('ChartBuilder', () => {
       const tableRows = screen.getAllByRole('row');
       expect(tableRows).toHaveLength(5);
       expect(tableRows[1]).toHaveTextContent(
-        'Number of authorised absence sessions (Male, All locations, All time periods)',
+        'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, All locations, 2014/15)',
       );
       expect(tableRows[2]).toHaveTextContent(
-        'Number of unauthorised absence sessions (Male, All locations, All time periods)',
+        'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded secondary, All locations, 2014/15)',
       );
       expect(tableRows[3]).toHaveTextContent(
-        'Number of authorised absence sessions (Female, All locations, All time periods)',
+        'Number of authorised absence sessions (Ethnicity Major Black Total, State-funded primary, All locations, 2014/15)',
       );
       expect(tableRows[4]).toHaveTextContent(
-        'Number of unauthorised absence sessions (Female, All locations, All time periods)',
+        'Number of authorised absence sessions (Ethnicity Major Black Total, State-funded secondary, All locations, 2014/15)',
       );
 
       userEvent.click(
@@ -286,10 +248,62 @@ describe('ChartBuilder', () => {
       await waitFor(() => {
         expect(
           screen.queryByText(
-            'Number of unauthorised absence sessions (Male, All locations, All time periods)',
+            'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded secondary, All locations, 2014/15)',
           ),
         ).not.toBeInTheDocument();
       });
+      expect(screen.getAllByRole('row')).toHaveLength(4);
+    });
+
+    test('removing all data sets', async () => {
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartBuilder
+            releaseId="release-1"
+            data={testFullTable.results}
+            meta={testFullTable.subjectMeta}
+            tableTitle="Table title"
+            onChartSave={jest.fn()}
+            onChartDelete={noop}
+            onTableQueryUpdate={jest.fn()}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Line' }));
+
+      userEvent.click(screen.getByRole('tab', { name: 'Data sets' }));
+
+      expect(
+        screen.getByRole('heading', { name: 'Data sets' }),
+      ).toBeInTheDocument();
+
+      userEvent.selectOptions(
+        screen.getByLabelText('Indicator'),
+        'authorised-absence-sessions',
+      );
+      userEvent.selectOptions(screen.getByLabelText('Time period'), '2014_AY');
+
+      userEvent.click(screen.getByRole('button', { name: 'Add data set' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Remove all')).toBeInTheDocument();
+      });
+
+      const tableRows = screen.getAllByRole('row');
+      expect(tableRows).toHaveLength(5);
+      expect(tableRows[1]).toHaveTextContent(
+        'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, All locations, 2014/15)',
+      );
+      expect(tableRows[2]).toHaveTextContent(
+        'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded secondary, All locations, 2014/15)',
+      );
+      expect(tableRows[3]).toHaveTextContent(
+        'Number of authorised absence sessions (Ethnicity Major Black Total, State-funded primary, All locations, 2014/15)',
+      );
+      expect(tableRows[4]).toHaveTextContent(
+        'Number of authorised absence sessions (Ethnicity Major Black Total, State-funded secondary, All locations, 2014/15)',
+      );
 
       userEvent.click(
         screen.getByRole('button', { name: 'Remove all data sets' }),
@@ -302,20 +316,27 @@ describe('ChartBuilder', () => {
       await waitFor(() => {
         expect(
           screen.queryByText(
-            'Number of authorised absence sessions (Male, All locations, All time periods)',
+            'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, All locations, 2014/15)',
           ),
         ).not.toBeInTheDocument();
         expect(
           screen.queryByText(
-            'Number of authorised absence sessions (Female, All locations, All time periods)',
+            'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded secondary, All locations, 2014/15)',
           ),
         ).not.toBeInTheDocument();
         expect(
           screen.queryByText(
-            'Number of unauthorised absence sessions (Female, All locations, All time periods)',
+            'Number of authorised absence sessions (Ethnicity Major Black Total, State-funded primary, All locations, 2014/15)',
+          ),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(
+            'Number of authorised absence sessions (Ethnicity Major Black Total, State-funded secondary, All locations, 2014/15)',
           ),
         ).not.toBeInTheDocument();
       });
+
+      expect(screen.getAllByRole('row')).toHaveLength(1);
     });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
@@ -1022,7 +1022,9 @@ describe('ChartDataSetsConfiguration', () => {
 
       expect(handleChange).not.toHaveBeenCalled();
 
-      userEvent.click(screen.getByRole('button', { name: 'Remove all' }));
+      userEvent.click(
+        screen.getByRole('button', { name: 'Remove all data sets' }),
+      );
 
       const modal = within(screen.getByRole('dialog'));
       expect(modal.getByText('Remove all data sets')).toBeInTheDocument();

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
@@ -215,6 +215,23 @@ describe('ChartDataSetsConfiguration', () => {
     });
   });
 
+  test('submitting fails if there are no data sets', async () => {
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartDataSetsConfiguration meta={testSubjectMeta} onChange={noop} />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Save chart options' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Cannot save chart')).toBeInTheDocument();
+      expect(
+        screen.getByText('One or more data sets are required.'),
+      ).toBeInTheDocument();
+    });
+  });
+
   test('does not show the reorder button when there is only one dataset', () => {
     render(
       <ChartBuilderFormsContextProvider initialForms={testFormState}>
@@ -916,7 +933,7 @@ describe('ChartDataSetsConfiguration', () => {
     });
   });
 
-  describe('removing data set', () => {
+  describe('removing data sets', () => {
     test('calls `onChange` with only data set removed', () => {
       const handleChange = jest.fn();
 
@@ -942,7 +959,7 @@ describe('ChartDataSetsConfiguration', () => {
       expect(handleChange).toHaveBeenCalledWith([]);
     });
 
-    test('calls `onChange` with correct data set removed from multiple', () => {
+    test('calls `onChange` with correct data set removed from multiple data sets', () => {
       const handleChange = jest.fn();
 
       render(
@@ -977,6 +994,45 @@ describe('ChartDataSetsConfiguration', () => {
           indicator: 'unauthorised-absence-sessions',
         },
       ]);
+    });
+
+    test('removing all data sets', () => {
+      const handleChange = jest.fn();
+
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartDataSetsConfiguration
+            meta={testSubjectMeta}
+            dataSets={[
+              {
+                filters: ['male'],
+                indicator: 'unauthorised-absence-sessions',
+              },
+              {
+                filters: ['male'],
+                indicator: 'unauthorised-absence-sessions',
+              },
+            ]}
+            onChange={handleChange}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      expect(screen.getAllByRole('row')).toHaveLength(3);
+
+      expect(handleChange).not.toHaveBeenCalled();
+
+      userEvent.click(screen.getByRole('button', { name: 'Remove all' }));
+
+      const modal = within(screen.getByRole('dialog'));
+      expect(modal.getByText('Remove all data sets')).toBeInTheDocument();
+      expect(
+        modal.getByText('Are you sure you want to remove all data sets?'),
+      ).toBeInTheDocument();
+
+      userEvent.click(modal.getByRole('button', { name: 'Confirm' }));
+
+      expect(handleChange).toHaveBeenCalledWith([]);
     });
   });
 });

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -350,10 +350,14 @@ Validate changing data sets
     user checks chart legend item contains    id:chartBuilderPreview    2    Admission Numbers (Syon)
     user checks chart legend item contains    id:chartBuilderPreview    3    Admission Numbers (Bolton 001)
 
+    user checks table body has x rows    3    testid:chart-data-sets
+
     user clicks button    Remove all
     user clicks button    Confirm
 
     user checks page contains    Configure the chart and add data to view a preview
+
+    user checks table body has x rows    0    testid:chart-data-sets
 
 Configure line chart data sets
     user chooses select option    id:chartDataSetsConfigurationForm-location    Nailsea Youngwood

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -11,7 +11,6 @@ Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 
-
 *** Variables ***
 ${TOPIC_NAME}=              %{TEST_TOPIC_NAME}
 ${PUBLICATION_NAME}=        UI tests - create data block with chart %{RUN_IDENTIFIER}
@@ -19,7 +18,6 @@ ${DATABLOCK_NAME}=          UI test data block
 ${CONTENT_SECTION_NAME}=    Test data block section
 ${FOOTNOTE_1}=              Test footnote from bau
 ${FOOTNOTE_UPDATED}=        Updated test footnote from bau
-
 
 *** Test Cases ***
 Create test publication and release via API
@@ -337,6 +335,26 @@ Configure basic line chart
 
     user clicks link    Data sets
     user waits until h3 is visible    Data sets
+
+    user chooses select option    id:chartDataSetsConfigurationForm-location    Nailsea Youngwood
+    user clicks button    Add data set
+
+    user chooses select option    id:chartDataSetsConfigurationForm-location    Syon
+    user clicks button    Add data set
+
+    user chooses select option    id:chartDataSetsConfigurationForm-location    Bolton 001
+    user clicks button    Add data set
+
+    user checks chart legend item contains    id:chartBuilderPreview    1    Admission Numbers (Nailsea Youngwood)
+    user checks chart legend item contains    id:chartBuilderPreview    2    Admission Numbers (Syon)
+    user checks chart legend item contains    id:chartBuilderPreview    3    Admission Numbers (Bolton 001)
+
+Change data sets
+    user clicks link    Data sets
+
+    user clicks button    Remove all
+    user clicks button    Confirm
+
     user chooses select option    id:chartDataSetsConfigurationForm-location    Nailsea Youngwood
     user clicks button    Add data set
 
@@ -742,7 +760,6 @@ Delete data block
 
     user waits until h2 is visible    Data blocks
     user waits until page contains    No data blocks have been created.
-
 
 *** Keywords ***
 user counts legend form item rows

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -333,6 +333,7 @@ Configure basic line chart
     user enters text into element    id:chartConfigurationForm-height    400
     user enters text into element    id:chartConfigurationForm-width    900
 
+Validate changing data sets
     user clicks link    Data sets
     user waits until h3 is visible    Data sets
 
@@ -349,14 +350,16 @@ Configure basic line chart
     user checks chart legend item contains    id:chartBuilderPreview    2    Admission Numbers (Syon)
     user checks chart legend item contains    id:chartBuilderPreview    3    Admission Numbers (Bolton 001)
 
-Change data sets
-    user clicks link    Data sets
-
     user clicks button    Remove all
     user clicks button    Confirm
 
+    user checks page contains    Configure the chart and add data to view a preview
+
+Configure line chart data sets
     user chooses select option    id:chartDataSetsConfigurationForm-location    Nailsea Youngwood
     user clicks button    Add data set
+
+    user checks chart legend item contains    id:chartBuilderPreview    1    Admission Numbers (Nailsea Youngwood)
 
     user clicks link    Legend
     user chooses select option    id:chartLegendConfigurationForm-items-0-symbol    Circle


### PR DESCRIPTION
- Adds a 'Remove all' button for data sets in the chart builder.
- Users are asked to confirm after clicking it.
- The data sets table and save actions are now always shown
- Trying to save without any data sets shows an error

![datasets](https://user-images.githubusercontent.com/81572860/192827261-930c68da-674d-4fee-bd8d-c1d99ffbe79b.PNG)
