### PR TITLE
Adding stacktrace information to better capture details of errors whe…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateReleaseContentFunction.cs
@@ -58,7 +58,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                     executionContext.FunctionName);
                 logger.LogError("{0}", e.StackTrace);
                 await UpdateStage(message, Failed,
-                    new ReleasePublishingStatusLogMessage($"Exception in content stage: {e.Message}"));
+                    new ReleasePublishingStatusLogMessage("Exception in content stage: " +
+                                                          $"{e.Message}\n{e.StackTrace}"));
             }
 
             logger.LogInformation("{0} completed",

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -109,7 +109,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 logger.LogError("{StackTrace}", e.StackTrace);
 
                 await UpdateStage(message.ReleaseId, message.ReleaseStatusId, State.Failed,
-                    new ReleasePublishingStatusLogMessage($"Exception publishing release immediately: {e.Message}"));
+                    new ReleasePublishingStatusLogMessage("Exception publishing release immediately: " +
+                                                          $"{e.Message}\n{e.StackTrace}"));
             }
 
             logger.LogInformation("{0} completed", executionContext.FunctionName);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
@@ -83,7 +83,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 logger.LogError(e, "Exception occured while executing {0}",
                     executionContext.FunctionName);
                 await UpdateStage(message, Failed,
-                    new ReleasePublishingStatusLogMessage($"Exception in data stage: {e.Message}"));
+                    new ReleasePublishingStatusLogMessage("Exception in data stage: " +
+                                                          $"{e.Message}\n{e.StackTrace}"));
             }
 
             logger.LogInformation("{0} completed",

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
@@ -69,7 +69,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                     logger.LogError("{StackTrace}", e.StackTrace);
 
                     await UpdateStage(releaseId, releaseStatusId, Failed,
-                        new ReleasePublishingStatusLogMessage($"Exception in files stage: {e.Message}"));
+                        new ReleasePublishingStatusLogMessage("Exception in files stage: " +
+                                                              $"{e.Message}\n{e.StackTrace}"));
                 }
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishStagedReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishStagedReleaseContentFunction.cs
@@ -82,7 +82,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                         logger.LogError(e, "Exception occured while executing {0}",
                             executionContext.FunctionName);
                         await UpdateStage(releaseStatus, Failed,
-                            new ReleasePublishingStatusLogMessage($"Exception in publishing stage: {e.Message}"));
+                            new ReleasePublishingStatusLogMessage("Exception in publishing stage: " +
+                                                                  $"{e.Message}\n{e.StackTrace}"));
                     }
                 }
 
@@ -136,7 +137,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                     logger.LogError(e, "Exception occured while executing {0}",
                         executionContext.FunctionName);
                     await UpdateStage(publishedReleases, Failed,
-                        new ReleasePublishingStatusLogMessage($"Exception in publishing stage: {e.Message}"));
+                        new ReleasePublishingStatusLogMessage("Exception in publishing stage: " +
+                                                              $"{e.Message}\n{e.StackTrace}"));
                 }
             }
 


### PR DESCRIPTION
This PR:
- adds the capturing of stacktraces into publishing stage failures to help us identify issues more easily 