### PR TITLE
EES-3383 fix table bug when multiple headers with the same text

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
@@ -104,11 +104,20 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
 
           const prev = last(row);
 
-          // We only add the current header to the row if we know
-          // that the previous header doesn't match it.
+          const matchesPreviousHeader = prev?.text === current.text;
+
+          // Add the current header to the row when:
+          // - it doesn't match the previous header
+          // - it does match the previous header but it's in a sub-group so needs
+          // to be included or the layout breaks.
           // Otherwise, we want the previous header to span
           // across where the current header would be in the row.
-          if (prev?.text !== current?.text || prev?.crossSpan === 1) {
+          if (
+            !matchesPreviousHeader ||
+            (matchesPreviousHeader &&
+              current.parent &&
+              current.parent.children.length > 1)
+          ) {
             row.push({
               id: current.id,
               text: current.text,

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/MultiHeaderTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/MultiHeaderTable.test.tsx
@@ -526,6 +526,61 @@ describe('MultiHeaderTable', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
+  test('renders table with multi-span `rowgroup` header merged with 2 identical groups ', () => {
+    const { container } = render(
+      <MultiHeaderTable
+        columnHeaders={[new Header('1', '1'), new Header('2', '2')]}
+        rowHeaders={[
+          new Header('A', 'A').addChild(
+            new Header('B', 'B').addChild(new Header('C', 'C')),
+          ),
+          new Header('D', 'D').addChild(
+            new Header('D', 'D')
+              .addChild(new Header('D', 'D'))
+              .addChild(new Header('E', 'E')),
+          ),
+          new Header('F', 'F').addChild(
+            new Header('G', 'G').addChild(new Header('H', 'H')),
+          ),
+        ]}
+        rows={[
+          ['ABC1', 'ABC2'],
+          ['DDD1', 'DDD2'],
+          ['DDE1', 'DDE2'],
+          ['FGH1', 'FGH2'],
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(4);
+    expect(container.querySelectorAll('tbody td')).toHaveLength(8);
+
+    // Row 2
+    const row2Headers = container.querySelectorAll('tbody tr:nth-child(2) th');
+    expect(row2Headers).toHaveLength(2);
+
+    expect(row2Headers[0]).toHaveTextContent('D');
+    expect(row2Headers[0]).toHaveAttribute('scope', 'rowgroup');
+    expect(row2Headers[0]).toHaveAttribute('colspan', '2');
+    expect(row2Headers[0]).toHaveAttribute('rowspan', '2');
+
+    expect(row2Headers[1]).toHaveTextContent('D');
+    expect(row2Headers[1]).toHaveAttribute('scope', 'row');
+    expect(row2Headers[1]).toHaveAttribute('colspan', '1');
+    expect(row2Headers[1]).toHaveAttribute('rowspan', '1');
+
+    // Row 3
+    const row3Headers = container.querySelectorAll('tbody tr:nth-child(3) th');
+    expect(row3Headers).toHaveLength(1);
+
+    expect(row3Headers[0]).toHaveTextContent('E');
+    expect(row3Headers[0]).toHaveAttribute('scope', 'row');
+    expect(row3Headers[0]).toHaveAttribute('colspan', '1');
+    expect(row3Headers[0]).toHaveAttribute('rowspan', '1');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
   test('does not render `rowgroup` headers with multi-span subgroup with invalid rowspans and colspans', () => {
     const { container } = render(
       <MultiHeaderTable
@@ -955,6 +1010,146 @@ describe('MultiHeaderTable', () => {
     expect(row1Headers[1]).toHaveAttribute('scope', 'row');
     expect(row1Headers[1]).toHaveAttribute('rowspan', '1');
     expect(row1Headers[1]).toHaveAttribute('colspan', '2');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders table with deeply nested rows and multiple identical headers', () => {
+    const { container } = render(
+      <MultiHeaderTable
+        columnHeaders={[new Header('1', '1'), new Header('2', '2')]}
+        rowHeaders={[
+          new Header('A', 'A').addChild(
+            new Header('A', 'A').addChild(
+              new Header('A', 'A').addChild(new Header('A', 'A')),
+            ),
+          ),
+          new Header('B', 'B').addChild(
+            new Header('B', 'B')
+              .addChild(new Header('B', 'B').addChild(new Header('B', 'B')))
+              .addChild(new Header('C', 'C').addChild(new Header('D', 'D'))),
+          ),
+          new Header('E', 'E').addChild(
+            new Header('F', 'F')
+              .addChild(
+                new Header('F', 'F')
+                  .addChild(new Header('F', 'F'))
+                  .addChild(new Header('G', 'G')),
+              )
+              .addChild(
+                new Header('H', 'H')
+                  .addChild(new Header('I', 'I'))
+                  .addChild(new Header('J', 'J')),
+              ),
+          ),
+        ]}
+        rows={[
+          ['AAAA1', 'AAAA2'],
+          ['BBBB1', 'BBBB2'],
+          ['BBBC1', 'BBBC2'],
+          ['EFFF1', 'EFFF2'],
+          ['EFFG1', 'EFFG2'],
+          ['EFHI1', 'EFHI2'],
+          ['EFHJ1', 'EFHJ2'],
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(7);
+    expect(container.querySelectorAll('tbody td')).toHaveLength(14);
+
+    // Row 1
+    const row1Headers = container.querySelectorAll('tbody tr:nth-child(1) th');
+    expect(row1Headers).toHaveLength(1);
+
+    expect(row1Headers[0]).toHaveTextContent('A');
+    expect(row1Headers[0]).toHaveAttribute('scope', 'row');
+    expect(row1Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[0]).toHaveAttribute('colspan', '4');
+
+    // Row 2
+    const row2Headers = container.querySelectorAll('tbody tr:nth-child(2) th');
+    expect(row2Headers).toHaveLength(2);
+
+    expect(row2Headers[0]).toHaveTextContent('B');
+    expect(row2Headers[0]).toHaveAttribute('scope', 'rowgroup');
+    expect(row2Headers[0]).toHaveAttribute('rowspan', '2');
+    expect(row2Headers[0]).toHaveAttribute('colspan', '2');
+
+    expect(row2Headers[1]).toHaveTextContent('B');
+    expect(row2Headers[1]).toHaveAttribute('scope', 'row');
+    expect(row2Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row2Headers[1]).toHaveAttribute('colspan', '2');
+
+    // Row 3
+    const row3Headers = container.querySelectorAll('tbody tr:nth-child(3) th');
+    expect(row3Headers).toHaveLength(2);
+
+    expect(row3Headers[0]).toHaveTextContent('C');
+    expect(row3Headers[0]).toHaveAttribute('scope', 'rowgroup');
+    expect(row3Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row3Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row3Headers[1]).toHaveTextContent('D');
+    expect(row3Headers[1]).toHaveAttribute('scope', 'row');
+    expect(row3Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row3Headers[1]).toHaveAttribute('colspan', '1');
+
+    // Row 4
+    const row4Headers = container.querySelectorAll('tbody tr:nth-child(4) th');
+    expect(row4Headers).toHaveLength(4);
+
+    expect(row4Headers[0]).toHaveTextContent('E');
+    expect(row4Headers[0]).toHaveAttribute('scope', 'rowgroup');
+    expect(row4Headers[0]).toHaveAttribute('rowspan', '4');
+    expect(row4Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row4Headers[1]).toHaveTextContent('F');
+    expect(row4Headers[1]).toHaveAttribute('scope', 'rowgroup');
+    expect(row4Headers[1]).toHaveAttribute('rowspan', '4');
+    expect(row4Headers[1]).toHaveAttribute('colspan', '1');
+
+    expect(row4Headers[2]).toHaveTextContent('F');
+    expect(row4Headers[2]).toHaveAttribute('scope', 'rowgroup');
+    expect(row4Headers[2]).toHaveAttribute('rowspan', '2');
+    expect(row4Headers[2]).toHaveAttribute('colspan', '1');
+
+    expect(row4Headers[3]).toHaveTextContent('F');
+    expect(row4Headers[3]).toHaveAttribute('scope', 'row');
+    expect(row4Headers[3]).toHaveAttribute('rowspan', '1');
+    expect(row4Headers[3]).toHaveAttribute('colspan', '1');
+
+    // Row 5
+    const row5Headers = container.querySelectorAll('tbody tr:nth-child(5) th');
+    expect(row5Headers).toHaveLength(1);
+
+    expect(row5Headers[0]).toHaveTextContent('G');
+    expect(row5Headers[0]).toHaveAttribute('scope', 'row');
+    expect(row5Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row5Headers[0]).toHaveAttribute('colspan', '1');
+
+    // Row 6
+    const row6Headers = container.querySelectorAll('tbody tr:nth-child(6) th');
+    expect(row6Headers).toHaveLength(2);
+
+    expect(row6Headers[0]).toHaveTextContent('H');
+    expect(row6Headers[0]).toHaveAttribute('scope', 'rowgroup');
+    expect(row6Headers[0]).toHaveAttribute('rowspan', '2');
+    expect(row6Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row6Headers[1]).toHaveTextContent('I');
+    expect(row6Headers[1]).toHaveAttribute('scope', 'row');
+    expect(row6Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row6Headers[1]).toHaveAttribute('colspan', '1');
+
+    // Row 7
+    const row7Headers = container.querySelectorAll('tbody tr:nth-child(7) th');
+    expect(row7Headers).toHaveLength(1);
+
+    expect(row7Headers[0]).toHaveTextContent('J');
+    expect(row7Headers[0]).toHaveAttribute('scope', 'row');
+    expect(row7Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row7Headers[0]).toHaveAttribute('colspan', '1');
 
     expect(container.innerHTML).toMatchSnapshot();
   });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/MultiHeaderTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/MultiHeaderTable.test.tsx.snap
@@ -1915,6 +1915,181 @@ exports[`MultiHeaderTable renders table with \`rowgroup\` header merged with mul
 </table>
 `;
 
+exports[`MultiHeaderTable renders table with deeply nested rows and multiple identical headers 1`] = `
+<table class="govuk-table table">
+  <thead class="tableHead">
+    <tr>
+      <td colspan="4"
+          rowspan="1"
+          class="borderBottom"
+      >
+      </td>
+      <th colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        1
+      </th>
+      <th colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        2
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="4"
+          scope="row"
+      >
+        A
+      </th>
+      <td class="govuk-table__cell--numeric">
+        AAAA1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        AAAA2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="2"
+          colspan="2"
+          scope="rowgroup"
+      >
+        B
+      </th>
+      <th class
+          rowspan="1"
+          colspan="2"
+          scope="row"
+      >
+        B
+      </th>
+      <td class="govuk-table__cell--numeric">
+        BBBB1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        BBBB2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        C
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        D
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        BBBC1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        BBBC2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="4"
+          colspan="1"
+          scope="rowgroup"
+      >
+        E
+      </th>
+      <th class="borderBottom"
+          rowspan="4"
+          colspan="1"
+          scope="rowgroup"
+      >
+        F
+      </th>
+      <th class="borderBottom"
+          rowspan="2"
+          colspan="1"
+          scope="rowgroup"
+      >
+        F
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        F
+      </th>
+      <td class="govuk-table__cell--numeric">
+        EFFF1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        EFFF2
+      </td>
+    </tr>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        G
+      </th>
+      <td class="govuk-table__cell--numeric">
+        EFFG1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        EFFG2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="2"
+          colspan="1"
+          scope="rowgroup"
+      >
+        H
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        I
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        EFHI1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        EFHI2
+      </td>
+    </tr>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        J
+      </th>
+      <td class="govuk-table__cell--numeric">
+        EFHJ1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        EFHJ2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`MultiHeaderTable renders table with multi-span \`colgroup\` merged with its identical groups 1`] = `
 <table class="govuk-table table">
   <thead class="tableHead">
@@ -1995,6 +2170,129 @@ exports[`MultiHeaderTable renders table with multi-span \`colgroup\` merged with
       </td>
       <td class="govuk-table__cell--numeric borderBottom">
         CCF2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`MultiHeaderTable renders table with multi-span \`rowgroup\` header merged with 2 identical groups  1`] = `
+<table class="govuk-table table">
+  <thead class="tableHead">
+    <tr>
+      <td colspan="3"
+          rowspan="1"
+          class="borderBottom"
+      >
+      </td>
+      <th colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        1
+      </th>
+      <th colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        2
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        A
+      </th>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        B
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        C
+      </th>
+      <td class="govuk-table__cell--numeric">
+        ABC1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        ABC2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="2"
+          colspan="2"
+          scope="rowgroup"
+      >
+        D
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        D
+      </th>
+      <td class="govuk-table__cell--numeric">
+        DDD1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        DDD2
+      </td>
+    </tr>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        E
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        DDE1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        DDE2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        F
+      </th>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        G
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        H
+      </th>
+      <td class="govuk-table__cell--numeric">
+        FGH1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        FGH2
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Fixes a table tool bug where merging multiple matching row headers caused the table layout to break.

**Before:**
![table-broken](https://user-images.githubusercontent.com/81572860/193595805-5fd309c7-8387-4327-a8ef-017a59a25505.PNG)

**Now:**
![table-fixed](https://user-images.githubusercontent.com/81572860/193595825-d86b50ea-2166-463f-8dc9-0bbbb8b87e83.PNG)
