### PR TITLE
EES-3055 change permalink copy method

### DIFF
--- a/src/explore-education-statistics-common/test/setupGlobals.js
+++ b/src/explore-education-statistics-common/test/setupGlobals.js
@@ -18,6 +18,10 @@ beforeAll(() => {
   window.scroll = jest.fn();
   window.scrollTo = jest.fn();
 
+  window.navigator.clipboard = {
+    writeText: jest.fn(),
+  };
+
   URL.createObjectURL = jest.fn();
 });
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
@@ -16,7 +16,6 @@ import React, { useEffect, useState } from 'react';
 
 const linkInstructions =
   'Use the link below to see a version of this page that you can bookmark for future reference, or copy the link to send on to somebody else to view.';
-const permalinkBaseUrl = `${window.location.origin}/data-tables/permalink`;
 
 interface Props {
   tableHeaders?: TableHeadersConfig;
@@ -29,12 +28,12 @@ const TableToolShare = ({
   query,
   selectedPublication,
 }: Props) => {
-  const [permalinkId, setPermalinkId] = useState<string>('');
+  const [permalinkUrl, setPermalinkUrl] = useState('');
   const [permalinkLoading, setPermalinkLoading] = useState<boolean>(false);
   const [screenReaderMessage, setScreenReaderMessage] = useState('');
 
   useEffect(() => {
-    setPermalinkId('');
+    setPermalinkUrl('');
   }, [tableHeaders]);
 
   const handlePermalinkClick = async () => {
@@ -53,20 +52,20 @@ const TableToolShare = ({
       selectedPublication.selectedRelease.id,
     );
 
-    setPermalinkId(id);
+    setPermalinkUrl(`${window.location.origin}/data-tables/permalink/${id}`);
     setPermalinkLoading(false);
 
     setScreenReaderMessage(`Shareable link generated. ${linkInstructions}`);
   };
 
   const handleCopyClick = () => {
-    navigator.clipboard.writeText(`${permalinkBaseUrl}/${permalinkId}`);
+    navigator.clipboard.writeText(permalinkUrl);
     setScreenReaderMessage('Link copied to the clipboard.');
   };
 
   return (
     <>
-      {!permalinkId ? (
+      {!permalinkUrl ? (
         <>
           <h3 className="govuk-heading-s">Save table</h3>
           <LoadingSpinner
@@ -92,7 +91,7 @@ const TableToolShare = ({
           <p className="govuk-!-margin-top-0 govuk-!-margin-bottom-2">
             <UrlContainer
               data-testid="permalink-generated-url"
-              url={`${permalinkBaseUrl}/${permalinkId}`}
+              url={permalinkUrl}
             />
           </p>
 
@@ -101,9 +100,7 @@ const TableToolShare = ({
               Copy link
             </Button>
 
-            <ButtonLink to={`/data-tables/permalink/${permalinkId}`}>
-              View share link
-            </ButtonLink>
+            <ButtonLink to={permalinkUrl}>View share link</ButtonLink>
           </ButtonGroup>
         </>
       )}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
@@ -16,6 +16,7 @@ import React, { useEffect, useState } from 'react';
 
 const linkInstructions =
   'Use the link below to see a version of this page that you can bookmark for future reference, or copy the link to send on to somebody else to view.';
+const permalinkBaseUrl = `${window.location.origin}/data-tables/permalink`;
 
 interface Props {
   tableHeaders?: TableHeadersConfig;
@@ -59,11 +60,7 @@ const TableToolShare = ({
   };
 
   const handleCopyClick = () => {
-    const el = document.querySelector(
-      "[data-testid='permalink-generated-url']",
-    ) as HTMLInputElement;
-    el?.select();
-    document.execCommand('copy');
+    navigator.clipboard.writeText(`${permalinkBaseUrl}/${permalinkId}`);
     setScreenReaderMessage('Link copied to the clipboard.');
   };
 
@@ -95,7 +92,7 @@ const TableToolShare = ({
           <p className="govuk-!-margin-top-0 govuk-!-margin-bottom-2">
             <UrlContainer
               data-testid="permalink-generated-url"
-              url={`${window.location.origin}/data-tables/permalink/${permalinkId}`}
+              url={`${permalinkBaseUrl}/${permalinkId}`}
             />
           </p>
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
@@ -85,13 +85,6 @@ describe('TableToolShare', () => {
       id: 'permalink-id',
     } as Permalink);
 
-    const originalClipboard = { ...window.navigator.clipboard };
-    Object.assign(window.navigator, {
-      clipboard: {
-        writeText: jest.fn(),
-      },
-    });
-
     render(
       <TableToolShare
         query={testQuery}
@@ -119,11 +112,5 @@ describe('TableToolShare', () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       'http://localhost/data-tables/permalink/permalink-id',
     );
-
-    Object.assign(window.navigator, {
-      clipboard: {
-        writeText: originalClipboard,
-      },
-    });
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
@@ -52,31 +52,78 @@ describe('TableToolShare', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.queryByRole('button', {
-          name: 'Generate shareable link',
-        }),
-      ).not.toBeInTheDocument();
-
       expect(screen.getByText('Generated share link')).toBeInTheDocument();
+    });
 
-      const urlInput = screen.getByTestId('permalink-generated-url');
-      expect(urlInput).toBeInTheDocument();
-      expect(urlInput).toHaveValue(
-        'http://localhost/data-tables/permalink/permalink-id',
-      );
+    expect(
+      screen.queryByRole('button', {
+        name: 'Generate shareable link',
+      }),
+    ).not.toBeInTheDocument();
 
-      expect(
-        screen.getByRole('button', {
-          name: 'Copy link',
-        }),
-      ).toBeInTheDocument();
+    const urlInput = screen.getByTestId('permalink-generated-url');
+    expect(urlInput).toBeInTheDocument();
+    expect(urlInput).toHaveValue(
+      'http://localhost/data-tables/permalink/permalink-id',
+    );
 
-      expect(
-        screen.getByRole('link', {
-          name: 'View share link',
-        }),
-      ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Copy link',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {
+        name: 'View share link',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('copies the link to the clipboard when the copy button is clicked', async () => {
+    permalinkService.createPermalink.mockResolvedValue({
+      id: 'permalink-id',
+    } as Permalink);
+
+    const originalClipboard = { ...window.navigator.clipboard };
+    Object.assign(window.navigator, {
+      clipboard: {
+        writeText: jest.fn(),
+      },
+    });
+
+    render(
+      <TableToolShare
+        query={testQuery}
+        tableHeaders={testTableHeaders}
+        selectedPublication={testSelectedPublicationWithLatestRelease}
+      />,
+    );
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Generate shareable link',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Generated share link')).toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Copy link',
+      }),
+    );
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'http://localhost/data-tables/permalink/permalink-id',
+    );
+
+    Object.assign(window.navigator, {
+      clipboard: {
+        writeText: originalClipboard,
+      },
     });
   });
 });


### PR DESCRIPTION
The previous method of copying a permalink to the clipboard wasn't great for screen reader users as it read the permalink url as well as the 'Link copied to the clipboard' message (see https://github.com/dfe-analytical-services/explore-education-statistics/pull/3518).

This changes the copy method to use `navigator.clipboard`, instead of having to focus on the url input field, so that only the 'Link copied...' message is announced. 