### PR TITLE
EES-3751 Add high-level info about Permalinks to database

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermalinkMigrationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermalinkMigrationServicePermissionTests.cs
@@ -11,6 +11,9 @@ using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 
+/// <summary>
+/// TODO EES-3755 Remove after Permalink snapshot migration work is complete
+/// </summary>
 public class PermalinkMigrationServicePermissionTests
 {
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermalinkMigrationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermalinkMigrationServicePermissionTests.cs
@@ -1,0 +1,42 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+public class PermalinkMigrationServicePermissionTests
+{
+    [Fact]
+    public async Task MigrateAll()
+    {
+        await PolicyCheckBuilder()
+            .SetupCheck(CanRunReleaseMigrations, false)
+            .AssertForbidden(
+                async userService =>
+                {
+                    var service = SetupService(
+                        userService: userService.Object
+                    );
+
+                    return await service.MigrateAll();
+                }
+            );
+    }
+
+    private static PermalinkMigrationService SetupService(
+        IStorageQueueService? storageQueueService = null,
+        IUserService? userService = null)
+    {
+        return new PermalinkMigrationService(
+            storageQueueService ?? Mock.Of<IStorageQueueService>(Strict),
+            userService ?? Mock.Of<IUserService>(Strict)
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermalinkMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermalinkMigrationServiceTests.cs
@@ -13,6 +13,9 @@ using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.Publishe
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 
+/// <summary>
+/// TODO EES-3755 Remove after Permalink snapshot migration work is complete
+/// </summary>
 public class PermalinkMigrationServiceTests
 {
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermalinkMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermalinkMigrationServiceTests.cs
@@ -1,0 +1,81 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+public class PermalinkMigrationServiceTests
+{
+    [Fact]
+    public async Task MigrateAll_FailsWithNullMessageCount()
+    {
+        var storageQueueService = MockStorageQueueService(messageCount: null);
+
+        var service = SetupService(storageQueueService: storageQueueService.Object);
+
+        var result = await service.MigrateAll();
+
+        VerifyAllMocks(storageQueueService);
+
+        result.AssertBadRequest(NullMessageCountForPermalinksMigrationQueue);
+    }
+
+    [Fact]
+    public async Task MigrateAll_FailsWithNonZeroMessageCount()
+    {
+        var storageQueueService = MockStorageQueueService(messageCount: 1);
+
+        var service = SetupService(storageQueueService: storageQueueService.Object);
+
+        var result = await service.MigrateAll();
+
+        VerifyAllMocks(storageQueueService);
+
+        result.AssertBadRequest(NonEmptyPermalinksMigrationQueue);
+    }
+
+    [Fact]
+    public async Task MigrateAll()
+    {
+        var storageQueueService = MockStorageQueueService(messageCount: 0);
+
+        storageQueueService.Setup(mock =>
+                mock.AddMessageAsync(PermalinksMigrationQueue, new PermalinksMigrationMessage()))
+            .Returns(Task.CompletedTask);
+
+        var service = SetupService(storageQueueService: storageQueueService.Object);
+
+        var result = await service.MigrateAll();
+
+        VerifyAllMocks(storageQueueService);
+
+        result.AssertRight();
+    }
+
+    private static Mock<IStorageQueueService> MockStorageQueueService(int? messageCount)
+    {
+        var service = new Mock<IStorageQueueService>(MockBehavior.Strict);
+        service.Setup(s => s.GetApproximateMessageCount(PermalinksMigrationQueue))
+            .ReturnsAsync(messageCount);
+        return service;
+    }
+
+    private static PermalinkMigrationService SetupService(
+        IStorageQueueService? storageQueueService = null,
+        IUserService? userService = null)
+    {
+        return new PermalinkMigrationService(
+            storageQueueService ?? Mock.Of<IStorageQueueService>(MockBehavior.Strict),
+            userService ?? AlwaysTrueUserService().Object
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/PermalinkMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/PermalinkMigrationController.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+[Route("api")]
+[ApiController]
+[Authorize(Roles = GlobalRoles.RoleNames.BauUser)]
+public class PermalinkMigrationController : ControllerBase
+{
+    private readonly IPermalinkMigrationService _permalinkMigrationService;
+
+    public PermalinkMigrationController(IPermalinkMigrationService permalinkMigrationService)
+    {
+        _permalinkMigrationService = permalinkMigrationService;
+    }
+
+    [HttpPatch("bau/migrate-permalinks")]
+    public async Task<ActionResult<Unit>> MigratePermalinks()
+    {
+        return await _permalinkMigrationService
+            .MigrateAll()
+            .HandleFailuresOrOk();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/PermalinkMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/PermalinkMigrationController.cs
@@ -9,6 +9,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
 
+/// <summary>
+/// TODO EES-3755 Remove after Permalink snapshot migration work is complete
+/// </summary>
 [Route("api")]
 [ApiController]
 [Authorize(Roles = GlobalRoles.RoleNames.BauUser)]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221003123755_EES3751_AddPermalink.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221003123755_EES3751_AddPermalink.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221003123755_EES3751_AddPermalink")]
+    partial class EES3751_AddPermalink
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221003123755_EES3751_AddPermalink.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221003123755_EES3751_AddPermalink.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES3751_AddPermalink : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Permalinks",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PublicationTitle = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    DataSetTitle = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ReleaseId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SubjectId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Created = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Permalinks", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Permalinks_ReleaseId",
+                table: "Permalinks",
+                column: "ReleaseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Permalinks_SubjectId",
+                table: "Permalinks",
+                column: "SubjectId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Permalinks");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/PermalinkMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/PermalinkMigrationService.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 
+/// <summary>
+/// TODO EES-3755 Remove after Permalink snapshot migration work is complete
+/// </summary>
 public interface IPermalinkMigrationService
 {
     Task<Either<ActionResult, Unit>> MigrateAll();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/PermalinkMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/PermalinkMigrationService.cs
@@ -1,0 +1,11 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+
+public interface IPermalinkMigrationService
+{
+    Task<Either<ActionResult, Unit>> MigrateAll();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PermalinkMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PermalinkMigrationService.cs
@@ -1,0 +1,49 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using Microsoft.AspNetCore.Mvc;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+public class PermalinkMigrationService : IPermalinkMigrationService
+{
+    private readonly IStorageQueueService _storageQueueService;
+    private readonly IUserService _userService;
+
+    public PermalinkMigrationService(IStorageQueueService storageQueueService,
+        IUserService userService)
+    {
+        _storageQueueService = storageQueueService;
+        _userService = userService;
+    }
+
+    public async Task<Either<ActionResult, Unit>> MigrateAll()
+    {
+        return await _userService.CheckCanRunMigrations()
+            .OnSuccess<ActionResult, Unit, Unit>(async () =>
+            {
+                var messageCount = await _storageQueueService.GetApproximateMessageCount(PermalinksMigrationQueue);
+
+                switch (messageCount)
+                {
+                    case null:
+                        return ValidationActionResult(NullMessageCountForPermalinksMigrationQueue);
+                    case > 0:
+                        return ValidationActionResult(NonEmptyPermalinksMigrationQueue);
+                }
+
+                // Queue a new message to initiate the migration
+                await _storageQueueService.AddMessageAsync(PermalinksMigrationQueue, new PermalinksMigrationMessage());
+
+                return Unit.Instance;
+            });
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PermalinkMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PermalinkMigrationService.cs
@@ -13,6 +13,9 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.Validat
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
+/// <summary>
+/// TODO EES-3755 Remove after Permalink snapshot migration work is complete
+/// </summary>
 public class PermalinkMigrationService : IPermalinkMigrationService
 {
     private readonly IStorageQueueService _storageQueueService;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -594,6 +594,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             AddPersistenceHelper<UsersAndRolesDbContext>(services);
             services.AddTransient<AuthorizationHandlerResourceRoleService>();
 
+            // Permalinks migration
+            services.AddTransient<IPermalinkMigrationService, PermalinkMigrationService>();
+
             // This service handles the generation of the JWTs for users after they log in
             services.AddTransient<IProfileService, ApplicationUserProfileService>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -594,7 +594,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             AddPersistenceHelper<UsersAndRolesDbContext>(services);
             services.AddTransient<AuthorizationHandlerResourceRoleService>();
 
-            // Permalinks migration
+            // TODO EES-3755 Remove after Permalink snapshot migration work is complete
             services.AddTransient<IPermalinkMigrationService, PermalinkMigrationService>();
 
             // This service handles the generation of the JWTs for users after they log in

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -100,5 +100,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         NoTableHighlights,
         NoPublicPreReleaseAccessList,
         MethodologyNotApproved,
+
+        // Permalinks migration
+        NullMessageCountForPermalinksMigrationQueue,
+        NonEmptyPermalinksMigrationQueue,
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -101,7 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         NoPublicPreReleaseAccessList,
         MethodologyNotApproved,
 
-        // Permalinks migration
+        // TODO EES-3755 Remove after Permalink snapshot migration work is complete
         NullMessageCountForPermalinksMigrationQueue,
         NonEmptyPermalinksMigrationQueue,
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -63,6 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
         public DbSet<HtmlBlock> HtmlBlocks { get; set; }
         public DbSet<MarkDownBlock> MarkDownBlocks { get; set; }
         public DbSet<MethodologyNote> MethodologyNotes { get; set; }
+        public DbSet<Permalink> Permalinks { get; set; } = null!;
         public DbSet<Contact> Contacts { get; set; }
         public DbSet<ReleaseContentSection> ReleaseContentSections { get; set; }
         public DbSet<ReleaseContentBlock> ReleaseContentBlocks { get; set; }
@@ -415,6 +416,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
             modelBuilder.Entity<MarkDownBlock>()
                 .Property(block => block.Body)
                 .HasColumnName("Body");
+            
+            modelBuilder.Entity<Permalink>()
+                .Property(permalink => permalink.Created)
+                .HasConversion(
+                    v => v,
+                    v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+
+            modelBuilder.Entity<Permalink>()
+                .HasIndex(data => data.ReleaseId);
+
+            modelBuilder.Entity<Permalink>()
+                .HasIndex(data => data.SubjectId);
 
             modelBuilder.Entity<ReleaseContentSection>()
                 .HasKey(item => new {item.ReleaseId, item.ContentSectionId});

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Permalink.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Permalink.cs
@@ -1,0 +1,19 @@
+﻿#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+public class Permalink
+{
+    public Guid Id { get; init; }
+
+    public string PublicationTitle { get; init; }
+
+    public string DataSetTitle { get; init; }
+
+    public Guid? ReleaseId { get; init; }
+
+    public Guid SubjectId { get; init; }
+
+    public DateTime Created { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
@@ -116,7 +116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             blobStorageService.Setup(s => s.UploadAsJson(
                     Permalinks,
                     Capture.With(blobPathCapture),
-                    It.Is<Permalink>(p =>
+                    It.Is<LegacyPermalink>(p =>
                         p.Configuration.Equals(request.Configuration) &&
                         p.FullTable.IsDeepEqualTo(new PermalinkTableBuilderResult(tableResult)) &&
                         p.Query.Equals(request.Query)),
@@ -223,7 +223,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             blobStorageService.Setup(s => s.UploadAsJson(
                     Permalinks,
                     Capture.With(blobPathCapture),
-                    It.Is<Permalink>(p =>
+                    It.Is<LegacyPermalink>(p =>
                         p.Configuration.Equals(request.Configuration) &&
                         p.FullTable.IsDeepEqualTo(new PermalinkTableBuilderResult(tableResult)) &&
                         p.Query.Equals(request.Query)),
@@ -288,7 +288,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var subjectId = Guid.NewGuid();
 
-            var permalink = new Permalink(
+            var permalink = new LegacyPermalink(
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -377,7 +377,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 }
             };
 
-            var permalink = new Permalink(
+            var permalink = new LegacyPermalink(
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -487,7 +487,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
         [Fact]
         public async Task Get_SubjectNotFound()
         {
-            var permalink = new Permalink(
+            var permalink = new LegacyPermalink(
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -551,7 +551,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var subjectId = Guid.NewGuid();
 
-            var permalink = new Permalink(
+            var permalink = new LegacyPermalink(
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -638,7 +638,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var subjectId = Guid.NewGuid();
 
-            var permalink = new Permalink(
+            var permalink = new LegacyPermalink(
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -716,7 +716,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var subjectId = Guid.NewGuid();
 
-            var permalink = new Permalink(
+            var permalink = new LegacyPermalink(
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -797,7 +797,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var subjectId = Guid.NewGuid();
 
-            var permalink = new Permalink(
+            var permalink = new LegacyPermalink(
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -857,7 +857,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var releaseId = Guid.NewGuid();
             var subjectId = Guid.NewGuid();
 
-            var permalink = new Permalink(
+            var permalink = new LegacyPermalink(
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -100,7 +101,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var tableResult = new TableBuilderResultViewModel
             {
-                SubjectMeta = new ResultSubjectMetaViewModel()
+                SubjectMeta = new ResultSubjectMetaViewModel
+                {
+                    SubjectName = "Test data set",
+                    PublicationName = "Test publication"
+                }
             };
 
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
@@ -110,8 +115,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             // Permalink id is assigned on creation and used as the blob path
             // Capture it so we can compare it with the view model result
-            string blobPath = string.Empty;
-            var blobPathCapture = new CaptureMatch<string>(callback => blobPath = callback);
+            Guid? expectedPermalinkId = null;
+            var blobPathCapture = new CaptureMatch<string>(callback => expectedPermalinkId = Guid.Parse(callback));
 
             blobStorageService.Setup(s => s.UploadAsJson(
                     Permalinks,
@@ -123,17 +128,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     It.IsAny<JsonSerializerSettings>()))
                 .Returns(Task.CompletedTask);
 
-           releaseRepository
-               .Setup(s => s.GetLatestPublishedRelease(_publicationId))
-               .Returns(new Release
-               {
-                   Id = contentRelease.Id,
-                   PublicationId = _publicationId,
-                   TimeIdentifier = TimeIdentifier.AcademicYear,
-                   Year = 2000,
-               });
+            releaseRepository
+                .Setup(s => s.GetLatestPublishedRelease(_publicationId))
+                .Returns(new Release
+                {
+                    Id = contentRelease.Id,
+                    PublicationId = _publicationId,
+                    TimeIdentifier = TimeIdentifier.AcademicYear,
+                    Year = 2000,
+                });
 
-           subjectRepository
+            subjectRepository
                 .Setup(s => s.GetPublicationIdForSubject(subject.Id))
                 .ReturnsAsync(_publicationId);
 
@@ -176,9 +181,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     subjectRepository,
                     tableBuilderService);
 
-                Assert.Equal(Guid.Parse(blobPath), result.Id);
+                Assert.Equal(expectedPermalinkId, result.Id);
                 Assert.InRange(DateTime.UtcNow.Subtract(result.Created).Milliseconds, 0, 1500);
                 Assert.Equal(PermalinkStatus.Current, result.Status);
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var permalink = contentDbContext.Permalinks.Single(permalink => permalink.Id == expectedPermalinkId);
+                Assert.InRange(DateTime.UtcNow.Subtract(permalink.Created).Milliseconds, 0, 1500);
+                Assert.Equal("Test publication", permalink.PublicationTitle);
+                Assert.Equal("Test data set", permalink.DataSetTitle);
+                Assert.Equal(contentRelease.Id, permalink.ReleaseId);
+                Assert.Equal(subject.Id, permalink.SubjectId);
             }
         }
 
@@ -197,7 +212,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var tableResult = new TableBuilderResultViewModel
             {
-                SubjectMeta = new ResultSubjectMetaViewModel()
+                SubjectMeta = new ResultSubjectMetaViewModel
+                {
+                    SubjectName = "Test data set",
+                    PublicationName = "Test publication"
+                }
             };
 
             var release = new Content.Model.Release
@@ -217,8 +236,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             // Permalink id is assigned on creation and used as the blob path
             // Capture it so we can compare it with the view model result
-            string blobPath = string.Empty;
-            var blobPathCapture = new CaptureMatch<string>(callback => blobPath = callback);
+            Guid? expectedPermalinkId = null;
+            var blobPathCapture = new CaptureMatch<string>(callback => expectedPermalinkId = Guid.Parse(callback));
 
             blobStorageService.Setup(s => s.UploadAsJson(
                     Permalinks,
@@ -265,9 +284,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     blobStorageService,
                     tableBuilderService);
 
-                Assert.Equal(Guid.Parse(blobPath), result.Id);
+                Assert.Equal(expectedPermalinkId, result.Id);
                 Assert.InRange(DateTime.UtcNow.Subtract(result.Created).Milliseconds, 0, 1500);
                 Assert.Equal(PermalinkStatus.Current, result.Status);
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var permalink = contentDbContext.Permalinks.Single(permalink => permalink.Id == expectedPermalinkId);
+                Assert.InRange(DateTime.UtcNow.Subtract(permalink.Created).Milliseconds, 0, 1500);
+                Assert.Equal("Test publication", permalink.PublicationTitle);
+                Assert.Equal("Test data set", permalink.DataSetTitle);
+                Assert.Equal(release.Id, permalink.ReleaseId);
+                Assert.Equal(subjectId, permalink.SubjectId);
             }
         }
 
@@ -289,6 +318,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var subjectId = Guid.NewGuid();
 
             var permalink = new LegacyPermalink(
+                Guid.NewGuid(),
+                DateTime.UtcNow,
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -335,7 +366,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 MockUtils.VerifyAllMocks(blobStorageService);
 
                 Assert.Equal(permalink.Id, result.Id);
-                Assert.InRange(DateTime.UtcNow.Subtract(result.Created).Milliseconds, 0, 1500);
+                Assert.Equal(permalink.Created, result.Created);
                 Assert.Equal(PermalinkStatus.Current, result.Status);
             }
         }
@@ -378,6 +409,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             };
 
             var permalink = new LegacyPermalink(
+                Guid.NewGuid(),
+                DateTime.UtcNow,
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -488,6 +521,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
         public async Task Get_SubjectNotFound()
         {
             var permalink = new LegacyPermalink(
+                Guid.NewGuid(),
+                DateTime.UtcNow,
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -552,6 +587,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var subjectId = Guid.NewGuid();
 
             var permalink = new LegacyPermalink(
+                Guid.NewGuid(),
+                DateTime.UtcNow,
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -639,6 +676,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var subjectId = Guid.NewGuid();
 
             var permalink = new LegacyPermalink(
+                Guid.NewGuid(),
+                DateTime.UtcNow,
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -717,6 +756,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var subjectId = Guid.NewGuid();
 
             var permalink = new LegacyPermalink(
+                Guid.NewGuid(),
+                DateTime.UtcNow,
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -798,6 +839,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var subjectId = Guid.NewGuid();
 
             var permalink = new LegacyPermalink(
+                Guid.NewGuid(),
+                DateTime.UtcNow,
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {
@@ -858,6 +901,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var subjectId = Guid.NewGuid();
 
             var permalink = new LegacyPermalink(
+                Guid.NewGuid(),
+                DateTime.UtcNow,
                 new TableBuilderConfiguration(),
                 new PermalinkTableBuilderResult
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PermalinkController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PermalinkController.cs
@@ -20,7 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<PermalinkViewModel>> Get(string id)
+        public async Task<ActionResult<LegacyPermalinkViewModel>> Get(string id)
         {
             if (Guid.TryParse(id, out var idAsGuid))
             {
@@ -31,13 +31,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
         }
 
         [HttpPost]
-        public async Task<ActionResult<PermalinkViewModel>> Create([FromBody] PermalinkCreateViewModel request)
+        public async Task<ActionResult<LegacyPermalinkViewModel>> Create([FromBody] PermalinkCreateViewModel request)
         {
             return await _permalinkService.Create(request).HandleFailuresOrOk();
         }
 
         [HttpPost("release/{releaseId}")]
-        public async Task<ActionResult<PermalinkViewModel>> Create(Guid releaseId,
+        public async Task<ActionResult<LegacyPermalinkViewModel>> Create(Guid releaseId,
             [FromBody] PermalinkCreateViewModel request)
         {
             return await _permalinkService.Create(releaseId, request).HandleFailuresOrOk();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Mappings/MappingProfiles.cs
@@ -17,12 +17,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Mappings
             // Null collections will be mapped to null collections instead of empty collections.
             AllowNullCollections = true;
 
-            ConfigureForPermalinks();
+            ConfigureForLegacyPermalinks();
         }
 
-        private void ConfigureForPermalinks()
+        private void ConfigureForLegacyPermalinks()
         {
-            CreateMap<Permalink, PermalinkViewModel>();
+            CreateMap<LegacyPermalink, PermalinkViewModel>();
             CreateMap<PermalinkTableBuilderResult, TableBuilderResultViewModel>();
             CreateMap<PermalinkResultSubjectMeta, ResultSubjectMetaViewModel>()
                 .ForMember(dest => dest.Locations,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Mappings/MappingProfiles.cs
@@ -22,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Mappings
 
         private void ConfigureForLegacyPermalinks()
         {
-            CreateMap<LegacyPermalink, PermalinkViewModel>();
+            CreateMap<LegacyPermalink, LegacyPermalinkViewModel>();
             CreateMap<PermalinkTableBuilderResult, TableBuilderResultViewModel>();
             CreateMap<PermalinkResultSubjectMeta, ResultSubjectMetaViewModel>()
                 .ForMember(dest => dest.Locations,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/LegacyPermalink.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/LegacyPermalink.cs
@@ -20,12 +20,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Models
         {
         }
 
-        public LegacyPermalink(TableBuilderConfiguration configuration,
+        public LegacyPermalink(
+            Guid id,
+            DateTime created,
+            TableBuilderConfiguration configuration,
             PermalinkTableBuilderResult result,
             ObservationQueryContext query)
         {
-            Id = Guid.NewGuid();
-            Created = DateTime.UtcNow;
+            Id = id;
+            Created = created;
             Configuration = configuration;
             FullTable = result;
             Query = query;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/LegacyPermalink.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/LegacyPermalink.cs
@@ -4,7 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Models
 {
-    public class Permalink
+    public class LegacyPermalink
     {
         public Guid Id { get; set; }
 
@@ -16,11 +16,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Models
 
         public ObservationQueryContext Query { get; set; }
 
-        public Permalink()
+        public LegacyPermalink()
         {
         }
 
-        public Permalink(TableBuilderConfiguration configuration,
+        public LegacyPermalink(TableBuilderConfiguration configuration,
             PermalinkTableBuilderResult result,
             ObservationQueryContext query)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IPermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IPermalinkService.cs
@@ -9,8 +9,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interface
 {
     public interface IPermalinkService
     {
-        Task<Either<ActionResult, PermalinkViewModel>> Get(Guid id);
-        Task<Either<ActionResult, PermalinkViewModel>> Create(PermalinkCreateViewModel viewModel);
-        Task<Either<ActionResult, PermalinkViewModel>> Create(Guid releaseId, PermalinkCreateViewModel request);
+        Task<Either<ActionResult, LegacyPermalinkViewModel>> Get(Guid id);
+        Task<Either<ActionResult, LegacyPermalinkViewModel>> Create(PermalinkCreateViewModel viewModel);
+        Task<Either<ActionResult, LegacyPermalinkViewModel>> Create(Guid releaseId, PermalinkCreateViewModel request);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -53,7 +53,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             try
             {
                 var text = await _blobStorageService.DownloadBlobText(Permalinks, id.ToString());
-                var permalink = JsonConvert.DeserializeObject<Permalink>(
+                var permalink = JsonConvert.DeserializeObject<LegacyPermalink>(
                     value: text,
                     settings: BuildJsonSerializerSettings());
                 return await BuildViewModel(permalink!);
@@ -84,7 +84,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             return await _tableBuilderService.Query(releaseId, request.Query).OnSuccess(async result =>
             {
                 var permalinkTableResult = new PermalinkTableBuilderResult(result);
-                var permalink = new Permalink(request.Configuration, permalinkTableResult, request.Query);
+                var permalink = new LegacyPermalink(request.Configuration, permalinkTableResult, request.Query);
                 await _blobStorageService.UploadAsJson(containerName: Permalinks,
                     path: permalink.Id.ToString(),
                     content: permalink,
@@ -102,7 +102,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             };
         }
 
-        private async Task<PermalinkViewModel> BuildViewModel(Permalink permalink)
+        private async Task<PermalinkViewModel> BuildViewModel(LegacyPermalink permalink)
         {
             var viewModel = _mapper.Map<PermalinkViewModel>(permalink);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -49,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             _mapper = mapper;
         }
 
-        public async Task<Either<ActionResult, PermalinkViewModel>> Get(Guid id)
+        public async Task<Either<ActionResult, LegacyPermalinkViewModel>> Get(Guid id)
         {
             try
             {
@@ -66,7 +66,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             }
         }
 
-        public async Task<Either<ActionResult, PermalinkViewModel>> Create(PermalinkCreateViewModel request)
+        public async Task<Either<ActionResult, LegacyPermalinkViewModel>> Create(PermalinkCreateViewModel request)
         {
             var publicationId = await _subjectRepository.GetPublicationIdForSubject(request.Query.SubjectId);
             var release = _releaseRepository.GetLatestPublishedRelease(publicationId);
@@ -79,7 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             return await Create(release.Id, request);
         }
 
-        public async Task<Either<ActionResult, PermalinkViewModel>> Create(Guid releaseId,
+        public async Task<Either<ActionResult, LegacyPermalinkViewModel>> Create(Guid releaseId,
             PermalinkCreateViewModel request)
         {
             return await _tableBuilderService.Query(releaseId, request.Query)
@@ -123,9 +123,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             };
         }
 
-        private async Task<PermalinkViewModel> BuildViewModel(LegacyPermalink permalink)
+        private async Task<LegacyPermalinkViewModel> BuildViewModel(LegacyPermalink permalink)
         {
-            var viewModel = _mapper.Map<PermalinkViewModel>(permalink);
+            var viewModel = _mapper.Map<LegacyPermalinkViewModel>(permalink);
 
             viewModel.Status = await GetPermalinkStatus(permalink.Query.SubjectId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/LegacyPermalinkViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/LegacyPermalinkViewModel.cs
@@ -16,7 +16,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.ViewModels
         PublicationSuperseded
     }
 
-    public class PermalinkViewModel
+    public class LegacyPermalinkViewModel
     {
         public Guid Id { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/MigratePermalinksMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/MigratePermalinksMessages.cs
@@ -1,0 +1,8 @@
+﻿#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+
+public record PermalinksMigrationMessage;
+
+public record PermalinkMigrationMessage(Guid PermalinkId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
@@ -11,5 +11,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         public const string PublishTaxonomyQueue = "publish-taxonomy";
         public const string RetryStageQueue = "retry";
         public const string NotifyChangeQueue = "notify";
+
+        // Permalinks migration
+        public const string PermalinksMigrationQueue = "permalinks-migration";
+        public const string PermalinkMigrationQueue = "permalink-migration";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
@@ -12,7 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         public const string RetryStageQueue = "retry";
         public const string NotifyChangeQueue = "notify";
 
-        // Permalinks migration
+        // TODO EES-3755 Remove after Permalink snapshot migration work is complete
         public const string PermalinksMigrationQueue = "permalinks-migration";
         public const string PermalinkMigrationQueue = "permalink-migration";
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PermalinkMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PermalinkMigrationServiceTests.cs
@@ -1,0 +1,270 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+using Moq;
+using Xunit;
+using static Azure.Storage.Blobs.Models.BlobsModelFactory;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services;
+
+public class PermalinkMigrationServiceTests
+{
+    private readonly Guid _subjectId = Guid.NewGuid();
+    private readonly DateTime _created = DateTime.UtcNow;
+    private const string PublicationTitle = "Test publication";
+    private const string DataSetTitle = "Test data set";
+
+    [Fact]
+    public async Task EnumerateAllPermalinksForMigration()
+    {
+        var permalink1Id = Guid.NewGuid();
+        var permalink2Id = Guid.NewGuid();
+        var permalink3Id = Guid.NewGuid();
+        var permalink4Id = Guid.NewGuid();
+        var permalink5Id = Guid.NewGuid();
+        var permalink6Id = Guid.NewGuid();
+
+        var blobContainerClient = MockBlobContainerClient(Permalinks.Name);
+        var blobServiceClient = MockBlobServiceClient(blobContainerClient);
+        var storageQueueService = new Mock<IStorageQueueService>(Strict);
+
+        // Set up the container to return two pages of blob results
+        // Set up each page to contain multiple permalink blobs
+
+        blobContainerClient.Setup(mock => mock.GetBlobsAsync(
+                BlobTraits.None,
+                BlobStates.None,
+                null,
+                CancellationToken.None))
+            .Returns(new TestAsyncPageable(new List<Page<BlobItem>>
+            {
+                Page(
+                    BlobItem(permalink1Id.ToString()),
+                    BlobItem(permalink2Id.ToString()),
+                    BlobItem(permalink3Id.ToString())
+                ),
+                Page(
+                    BlobItem(permalink4Id.ToString()),
+                    BlobItem(permalink5Id.ToString()),
+                    BlobItem(permalink6Id.ToString())
+                )
+            }));
+
+        var sequence = new MockSequence();
+
+        // Expect migration messages to be added to the queue in batches.
+        // There should be a batch of messages added to the queue per page of blob results.
+        // Each batch of messages should contain the permalink id's taken from the blob names on that page.
+
+        storageQueueService.InSequence(sequence).Setup(mock => mock.AddMessages(
+            PermalinkMigrationQueue,
+            new List<PermalinkMigrationMessage>
+            {
+                new(permalink1Id),
+                new(permalink2Id),
+                new(permalink3Id)
+            })).Returns(Task.CompletedTask);
+
+        storageQueueService.InSequence(sequence).Setup(mock => mock.AddMessages(
+            PermalinkMigrationQueue,
+            new List<PermalinkMigrationMessage>
+            {
+                new(permalink4Id),
+                new(permalink5Id),
+                new(permalink6Id)
+            })).Returns(Task.CompletedTask);
+
+        var service = SetupService(
+            blobServiceClient: blobServiceClient.Object,
+            storageQueueService: storageQueueService.Object
+        );
+
+        await service.EnumerateAllPermalinksForMigration();
+
+        VerifyAllMocks(blobContainerClient, blobServiceClient, storageQueueService);
+    }
+
+    [Fact]
+    public async Task AddPermalinkToDbFromStorage()
+    {
+        var permalinkId = Guid.NewGuid();
+        var blobServiceClient = MockBlobServiceClientForPermalink(permalinkId);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                blobServiceClient: blobServiceClient.Object
+            );
+
+            var permalink = await service.AddPermalinkToDbFromStorage(permalinkId);
+
+            Assert.Equal(permalinkId, permalink.Id);
+            Assert.Equal(_created, permalink.Created);
+            Assert.Equal(PublicationTitle, permalink.PublicationTitle);
+            Assert.Equal(DataSetTitle, permalink.DataSetTitle);
+            Assert.Equal(_subjectId, permalink.SubjectId);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var saved = contentDbContext.Permalinks.SingleOrDefault(permalink => permalink.Id == permalinkId);
+            Assert.NotNull(saved);
+
+            Assert.Equal(permalinkId, saved!.Id);
+            Assert.Equal(_created, saved.Created);
+            Assert.Equal(PublicationTitle, saved.PublicationTitle);
+            Assert.Equal(DataSetTitle, saved.DataSetTitle);
+            Assert.Equal(_subjectId, saved.SubjectId);
+        }
+    }
+
+    [Fact]
+    public async Task AddPermalinkToDbFromStorage_PermalinkNotFound()
+    {
+        var permalinkId = Guid.NewGuid();
+        var blobServiceClient = MockBlobServiceClientForPermalink(permalinkId, exists: false);
+
+        await using var contentDbContext = InMemoryContentDbContext();
+
+        var service = SetupService(contentDbContext: contentDbContext,
+            blobServiceClient: blobServiceClient.Object
+        );
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await service.AddPermalinkToDbFromStorage(permalinkId));
+
+        Assert.Equal($"Blob not found for permalink {permalinkId}", exception.Message);
+        Assert.Null(contentDbContext.Permalinks.SingleOrDefault(permalink => permalink.Id == permalinkId));
+    }
+
+    private Mock<BlobServiceClient> MockBlobServiceClientForPermalink(Guid permalinkId,
+        bool exists = true)
+    {
+        var permalink = $@"
+        {{
+            ""Id"": ""{permalinkId}"",
+            ""Created"": ""{_created.ToString("O")}"",
+            ""FullTable"": {{
+                ""SubjectMeta"": {{
+                    ""PublicationName"": ""{PublicationTitle}"",
+                    ""SubjectName"": ""{DataSetTitle}""
+                }}
+            }},
+            ""Query"": {{
+                ""SubjectId"": ""{_subjectId}""
+            }}
+        }}";
+
+        var blobClient = MockBlobClient(permalinkId.ToString(), exists);
+        var blobContainerClient = MockBlobContainerClient(Permalinks.Name, blobClient);
+
+        if (exists)
+        {
+            blobClient.Setup(s => s.OpenReadAsync(0, null, null, default))
+                .ReturnsAsync(permalink.ToStream());
+        }
+
+        return MockBlobServiceClient(blobContainerClient);
+    }
+
+    private static Mock<BlobClient> MockBlobClient(string name, bool exists = true)
+    {
+        var blobClient = new Mock<BlobClient>(Strict);
+
+        blobClient.SetupGet(client => client.Name)
+            .Returns(name);
+
+        blobClient.Setup(client => client.ExistsAsync(default))
+            .ReturnsAsync(Response.FromValue(exists, null!));
+
+        return blobClient;
+    }
+
+    private static Mock<BlobContainerClient> MockBlobContainerClient(string containerName,
+        params Mock<BlobClient>[] blobClients)
+    {
+        var blobContainerClient = new Mock<BlobContainerClient>(Strict);
+
+        blobContainerClient
+            .SetupGet(client => client.Name)
+            .Returns(containerName);
+
+        foreach (var blobClient in blobClients)
+        {
+            blobContainerClient.Setup(client => client.GetBlobClient(blobClient.Object.Name))
+                .Returns(blobClient.Object);
+        }
+
+        return blobContainerClient;
+    }
+
+    private static Mock<BlobServiceClient> MockBlobServiceClient(
+        params Mock<BlobContainerClient>[] blobContainerClients)
+    {
+        var blobServiceClient = new Mock<BlobServiceClient>(Strict);
+
+        foreach (var blobContainerClient in blobContainerClients)
+        {
+            blobServiceClient.Setup(client => client.GetBlobContainerClient(blobContainerClient.Object.Name))
+                .Returns(blobContainerClient.Object);
+        }
+
+        return blobServiceClient;
+    }
+
+    private static Page<BlobItem> Page(params BlobItem[] blobItems)
+    {
+        return Page<BlobItem>.FromValues(blobItems, "", null!);
+    }
+
+    private class TestAsyncPageable : AsyncPageable<BlobItem>
+    {
+        private readonly IEnumerable<Page<BlobItem>> _pages;
+
+        public TestAsyncPageable(IEnumerable<Page<BlobItem>> pages)
+        {
+            _pages = pages;
+        }
+
+        public override async IAsyncEnumerable<Page<BlobItem>> AsPages(
+            string? continuationToken = null,
+            int? pageSizeHint = null)
+        {
+            foreach (var page in _pages)
+            {
+                yield return page;
+            }
+
+            await Task.CompletedTask;
+        }
+    }
+
+    private static PermalinkMigrationService SetupService(
+        BlobServiceClient blobServiceClient,
+        ContentDbContext? contentDbContext = null,
+        IStorageQueueService? storageQueueService = null)
+    {
+        return new PermalinkMigrationService(
+            contentDbContext ?? Mock.Of<ContentDbContext>(Strict),
+            blobServiceClient,
+            storageQueueService ?? Mock.Of<IStorageQueueService>(Strict)
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PermalinkMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PermalinkMigrationServiceTests.cs
@@ -23,6 +23,9 @@ using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services;
 
+/// <summary>
+/// TODO EES-3755 Remove after Permalink snapshot migration work is complete
+/// </summary>
 public class PermalinkMigrationServiceTests
 {
     private readonly Guid _subjectId = Guid.NewGuid();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PermalinkMigrationFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PermalinkMigrationFunction.cs
@@ -9,6 +9,9 @@ using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.Publishe
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions;
 
+/// <summary>
+/// TODO EES-3755 Remove after Permalink snapshot migration work is complete
+/// </summary>
 public class PermalinkMigrationFunction
 {
     private readonly IPermalinkMigrationService _permalinkMigrationService;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PermalinkMigrationFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PermalinkMigrationFunction.cs
@@ -1,30 +1,21 @@
 ﻿#nullable enable
 using System;
-using System.IO;
 using System.Threading.Tasks;
-using Azure.Storage.Blobs;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions;
 
 public class PermalinkMigrationFunction
 {
-    private readonly ContentDbContext _contentDbContext;
-    private readonly BlobServiceClient _blobServiceClient;
+    private readonly IPermalinkMigrationService _permalinkMigrationService;
 
-    public PermalinkMigrationFunction(ContentDbContext contentDbContext,
-        BlobServiceClient blobServiceClient)
+    public PermalinkMigrationFunction(IPermalinkMigrationService permalinkMigrationService)
     {
-        _contentDbContext = contentDbContext;
-        _blobServiceClient = blobServiceClient;
+        _permalinkMigrationService = permalinkMigrationService;
     }
 
     /// <summary>
@@ -40,67 +31,13 @@ public class PermalinkMigrationFunction
         ExecutionContext executionContext,
         ILogger logger)
     {
-        logger.LogInformation("{functionName} triggered: {message}",
-            executionContext.FunctionName,
-            message);
-
         try
         {
-            var permalink = await GetPermalinkFromStorage(message.PermalinkId);
-            _contentDbContext.Permalinks.Add(permalink);
-            await _contentDbContext.SaveChangesAsync();
+            await _permalinkMigrationService.AddPermalinkToDbFromStorage(message.PermalinkId);
         }
         catch (Exception e)
         {
-            logger.LogError(e, "Failed to migrate permalinks");
+            logger.LogError(e, "Failed to migrate permalink {permalinkId}", message.PermalinkId);
         }
-    }
-
-    private async Task<Permalink> GetPermalinkFromStorage(Guid permalinkId)
-    {
-        var blobContainer = _blobServiceClient.GetBlobContainerClient(Permalinks.Name);
-        var blob = blobContainer.GetBlobClient(permalinkId.ToString());
-
-        if (!await blob.ExistsAsync())
-        {
-            throw new InvalidOperationException($"Blob not found for permalink {permalinkId}");
-        }
-
-        await using var stream = await blob.OpenReadAsync();
-        using var streamReader = new StreamReader(stream);
-        using var jsonReader = new JsonTextReader(streamReader);
-
-        var jsonObject = await JToken.ReadFromAsync(jsonReader);
-
-        var id = jsonObject.Value<string>("Id");
-        var created = jsonObject.Value<DateTime>("Created");
-        
-        var subjectId = jsonObject.SelectToken("$.Query.SubjectId")?.ToObject<string>();
-        if (subjectId == null)
-        {
-            throw new InvalidOperationException("Permalink found with no SubjectId");
-        }
-
-        var publicationName = jsonObject.SelectToken("$.FullTable.SubjectMeta.PublicationName")?.ToObject<string>();
-        if (publicationName == null)
-        {
-            throw new InvalidOperationException("Permalink found with no PublicationName");
-        }
-
-        var subjectName = jsonObject.SelectToken("$.FullTable.SubjectMeta.SubjectName")?.ToObject<string>();
-        if (subjectName == null)
-        {
-            throw new InvalidOperationException("Permalink found with no SubjectName");
-        }
-
-        return new Permalink
-        {
-            Id = Guid.Parse(id),
-            PublicationTitle = publicationName,
-            DataSetTitle = subjectName,
-            ReleaseId = null,
-            SubjectId = Guid.Parse(subjectId),
-            Created = created
-        };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PermalinkMigrationFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PermalinkMigrationFunction.cs
@@ -1,0 +1,106 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions;
+
+public class PermalinkMigrationFunction
+{
+    private readonly ContentDbContext _contentDbContext;
+    private readonly BlobServiceClient _blobServiceClient;
+
+    public PermalinkMigrationFunction(ContentDbContext contentDbContext,
+        BlobServiceClient blobServiceClient)
+    {
+        _contentDbContext = contentDbContext;
+        _blobServiceClient = blobServiceClient;
+    }
+
+    /// <summary>
+    /// Azure Function which stores high level details about a Permalink in the database.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="executionContext"></param>
+    /// <param name="logger"></param>
+    [FunctionName("PermalinkMigration")]
+    public async Task PermalinkMigration(
+        [QueueTrigger(PermalinkMigrationQueue)]
+        PermalinkMigrationMessage message,
+        ExecutionContext executionContext,
+        ILogger logger)
+    {
+        logger.LogInformation("{functionName} triggered: {message}",
+            executionContext.FunctionName,
+            message);
+
+        try
+        {
+            var permalink = await GetPermalinkFromStorage(message.PermalinkId);
+            _contentDbContext.Permalinks.Add(permalink);
+            await _contentDbContext.SaveChangesAsync();
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to migrate permalinks");
+        }
+    }
+
+    private async Task<Permalink> GetPermalinkFromStorage(Guid permalinkId)
+    {
+        var blobContainer = _blobServiceClient.GetBlobContainerClient(Permalinks.Name);
+        var blob = blobContainer.GetBlobClient(permalinkId.ToString());
+
+        if (!await blob.ExistsAsync())
+        {
+            throw new InvalidOperationException($"Blob not found for permalink {permalinkId}");
+        }
+
+        await using var stream = await blob.OpenReadAsync();
+        using var streamReader = new StreamReader(stream);
+        using var jsonReader = new JsonTextReader(streamReader);
+
+        var jsonObject = await JToken.ReadFromAsync(jsonReader);
+
+        var id = jsonObject.Value<string>("Id");
+        var created = jsonObject.Value<DateTime>("Created");
+        
+        var subjectId = jsonObject.SelectToken("$.Query.SubjectId")?.ToObject<string>();
+        if (subjectId == null)
+        {
+            throw new InvalidOperationException("Permalink found with no SubjectId");
+        }
+
+        var publicationName = jsonObject.SelectToken("$.FullTable.SubjectMeta.PublicationName")?.ToObject<string>();
+        if (publicationName == null)
+        {
+            throw new InvalidOperationException("Permalink found with no PublicationName");
+        }
+
+        var subjectName = jsonObject.SelectToken("$.FullTable.SubjectMeta.SubjectName")?.ToObject<string>();
+        if (subjectName == null)
+        {
+            throw new InvalidOperationException("Permalink found with no SubjectName");
+        }
+
+        return new Permalink
+        {
+            Id = Guid.Parse(id),
+            PublicationTitle = publicationName,
+            DataSetTitle = subjectName,
+            ReleaseId = null,
+            SubjectId = Guid.Parse(subjectId),
+            Created = created
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PermalinksMigrationFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PermalinksMigrationFunction.cs
@@ -9,6 +9,9 @@ using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.Publishe
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions;
 
+/// <summary>
+/// TODO EES-3755 Remove after Permalink snapshot migration work is complete
+/// </summary>
 public class PermalinksMigrationFunction
 {
     private readonly IPermalinkMigrationService _permalinkMigrationService;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PermalinksMigrationFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PermalinksMigrationFunction.cs
@@ -1,0 +1,79 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions;
+
+public class PermalinksMigrationFunction
+{
+    private readonly BlobServiceClient _blobServiceClient;
+    private readonly IStorageQueueService _storageQueueService;
+
+    public PermalinksMigrationFunction(
+        BlobServiceClient blobServiceClient,
+        IStorageQueueService storageQueueService)
+    {
+        _blobServiceClient = blobServiceClient;
+        _storageQueueService = storageQueueService;
+    }
+
+    /// <summary>
+    /// Azure Function which enumerates all the permalink blobs in the permalinks storage container,
+    /// and queues a message to migrate each individual permalink.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="executionContext"></param>
+    /// <param name="logger"></param>
+    [FunctionName("PermalinksMigration")]
+    public async Task PermalinksMigration(
+        [QueueTrigger(PermalinksMigrationQueue)]
+        PermalinksMigrationMessage message,
+        ExecutionContext executionContext,
+        ILogger logger)
+    {
+        logger.LogInformation("{functionName} triggered", executionContext.FunctionName);
+
+        try
+        {
+            string? continuationToken = null;
+
+            var blobContainer = _blobServiceClient.GetBlobContainerClient(Permalinks.Name);
+
+            do
+            {
+                var pages = blobContainer
+                    .GetBlobsAsync(BlobTraits.None, prefix: null)
+                    .AsPages(continuationToken);
+
+                await foreach (var page in pages)
+                {
+                    var messages = page.Values.Select(blobItem =>
+                    {
+                        var name = blobItem.Name;
+                        var permalinkId = Guid.Parse(name);
+                        return new PermalinkMigrationMessage(permalinkId);
+                    }).ToList();
+
+                    await _storageQueueService.AddMessages(PermalinkMigrationQueue, messages);
+
+                    continuationToken = page.ContinuationToken;
+                }
+            } while (continuationToken != string.Empty);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to enumerate all permalinks");
+        }
+
+        logger.LogInformation("{functionName} completed", executionContext.FunctionName);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPermalinkMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPermalinkMigrationService.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+
+public interface IPermalinkMigrationService
+{
+    Task<Permalink> AddPermalinkToDbFromStorage(Guid permalinkId);
+
+    Task EnumerateAllPermalinksForMigration();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPermalinkMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPermalinkMigrationService.cs
@@ -5,6 +5,9 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 
+/// <summary>
+/// TODO EES-3755 Remove after Permalink snapshot migration work is complete
+/// </summary>
 public interface IPermalinkMigrationService
 {
     Task<Permalink> AddPermalinkToDbFromStorage(Guid permalinkId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PermalinkMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PermalinkMigrationService.cs
@@ -1,0 +1,118 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+
+public class PermalinkMigrationService : IPermalinkMigrationService
+{
+    private readonly ContentDbContext _contentDbContext;
+    private readonly BlobServiceClient _blobServiceClient;
+    private readonly IStorageQueueService _storageQueueService;
+
+    public PermalinkMigrationService(ContentDbContext contentDbContext,
+        BlobServiceClient blobServiceClient,
+        IStorageQueueService storageQueueService)
+    {
+        _contentDbContext = contentDbContext;
+        _blobServiceClient = blobServiceClient;
+        _storageQueueService = storageQueueService;
+    }
+
+    public async Task EnumerateAllPermalinksForMigration()
+    {
+        string? continuationToken = null;
+
+        var blobContainer = _blobServiceClient.GetBlobContainerClient(Permalinks.Name);
+
+        do
+        {
+            var pages = blobContainer
+                .GetBlobsAsync(BlobTraits.None, prefix: null)
+                .AsPages(continuationToken);
+
+            await foreach (var page in pages)
+            {
+                var messages = page.Values.Select(blobItem =>
+                {
+                    var name = blobItem.Name;
+                    var permalinkId = Guid.Parse(name);
+                    return new PermalinkMigrationMessage(permalinkId);
+                }).ToList();
+
+                await _storageQueueService.AddMessages(PermalinkMigrationQueue, messages);
+
+                continuationToken = page.ContinuationToken;
+            }
+        } while (continuationToken != string.Empty);
+    }
+
+    public async Task<Permalink> AddPermalinkToDbFromStorage(Guid permalinkId)
+    {
+        var permalink = await GetPermalinkFromStorage(permalinkId);
+        _contentDbContext.Permalinks.Add(permalink);
+        await _contentDbContext.SaveChangesAsync();
+        return permalink;
+    }
+
+    private async Task<Permalink> GetPermalinkFromStorage(Guid permalinkId)
+    {
+        var blobContainer = _blobServiceClient.GetBlobContainerClient(Permalinks.Name);
+        var blob = blobContainer.GetBlobClient(permalinkId.ToString());
+
+        if (!await blob.ExistsAsync())
+        {
+            throw new InvalidOperationException($"Blob not found for permalink {permalinkId}");
+        }
+
+        await using var stream = await blob.OpenReadAsync();
+        using var streamReader = new StreamReader(stream);
+        using var jsonReader = new JsonTextReader(streamReader);
+
+        var jsonObject = await JToken.ReadFromAsync(jsonReader);
+
+        var id = jsonObject.Value<string>("Id");
+        var created = jsonObject.Value<DateTime>("Created");
+
+        var subjectId = jsonObject.SelectToken("$.Query.SubjectId")?.ToObject<string>();
+        if (subjectId == null)
+        {
+            throw new InvalidOperationException("Permalink found with no SubjectId");
+        }
+
+        var publicationName = jsonObject.SelectToken("$.FullTable.SubjectMeta.PublicationName")?.ToObject<string>();
+        if (publicationName == null)
+        {
+            throw new InvalidOperationException("Permalink found with no PublicationName");
+        }
+
+        var subjectName = jsonObject.SelectToken("$.FullTable.SubjectMeta.SubjectName")?.ToObject<string>();
+        if (subjectName == null)
+        {
+            throw new InvalidOperationException("Permalink found with no SubjectName");
+        }
+
+        return new Permalink
+        {
+            Id = Guid.Parse(id),
+            PublicationTitle = publicationName,
+            DataSetTitle = subjectName,
+            ReleaseId = null,
+            SubjectId = Guid.Parse(subjectId),
+            Created = created
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PermalinkMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PermalinkMigrationService.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
@@ -63,8 +64,13 @@ public class PermalinkMigrationService : IPermalinkMigrationService
     public async Task<Permalink> AddPermalinkToDbFromStorage(Guid permalinkId)
     {
         var permalink = await GetPermalinkFromStorage(permalinkId);
-        _contentDbContext.Permalinks.Add(permalink);
-        await _contentDbContext.SaveChangesAsync();
+
+        if (!await _contentDbContext.Permalinks.AnyAsync(p => p.Id == permalinkId))
+        {
+            _contentDbContext.Permalinks.Add(permalink);
+            await _contentDbContext.SaveChangesAsync();
+        }
+
         return permalink;
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PermalinkMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PermalinkMigrationService.cs
@@ -18,6 +18,9 @@ using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.Publishe
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 
+/// <summary>
+/// TODO EES-3755 Remove after Permalink snapshot migration work is complete
+/// </summary>
 public class PermalinkMigrationService : IPermalinkMigrationService
 {
     private readonly ContentDbContext _contentDbContext;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -126,6 +126,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                         logger: provider.GetRequiredService<ILogger<QueueService>>()))
                 .AddScoped<IReleasePublishingStatusService, ReleasePublishingStatusService>()
                 .AddScoped<IValidationService, ValidationService>()
+                .AddScoped<IPermalinkMigrationService, PermalinkMigrationService>(provider =>
+                    new PermalinkMigrationService(
+                        contentDbContext: provider.GetRequiredService<ContentDbContext>(),
+                        blobServiceClient: new BlobServiceClient(
+                            GetConfigurationValue(provider, "PublicStorage")),
+                        storageQueueService: new StorageQueueService(
+                            GetConfigurationValue(provider, "PublisherStorage"),
+                            new StorageInstanceCreationUtil()
+                        )))
                 .AddScoped<IReleaseSubjectRepository, ReleaseSubjectRepository>(provider =>
                     new ReleaseSubjectRepository(
                         statisticsDbContext: provider.GetRequiredService<PublicStatisticsDbContext>(),


### PR DESCRIPTION
This PR introduces a new content database `Permalink` entity and adds a migration endpoint to add high-level info about Permalinks to the database. It's being done as part of the work to create permalink table snapshots, investigated by [EES-3665](https://dfedigital.atlassian.net/browse/EES-3665).

The content database is chosen over the statistics database to keep statistics purely related to data about statistics only.

Storing high level information about permalinks in the database gives us:

* An easier way to view the set of permalinks in existence and know its size, without browsing Azure storage.
* A way to query all Permalink id’s that we need to create snapshots for.

* A place to track the snapshot migration status as snapshots are created, until the migration is verified as complete when this temporary migration field can be removed.

* Allow for easy reporting of figures on Permalinks created by release / by data set / by time.

* Provide a place to store the `SubjectId` used for calculating the permalink ‘status' which won’t be part of the snapshot.

* Provide a place to store the Permalink title and table title which won't be part of the snapshot.
* Provide for a quicker way of retracting a Permalink in future if the need arises without needing to browse and alter Azure storage.

This PR:

* Creates the new Permalink entity with a database migration.
* Develops a re-runnable migration of high-level Permalink information from Azure storage to the database.
  * Executable by running the secured BAU endpoint `PATCH https://{adminUrl}/api/bau/migrate-permalinks`.
* Begins tracking the high-level information of new permalinks in the database for every new permalink generated from this point on.

We could add 'absolutely everything' we know about the permalink into the database here, but we'd end up with the problem we're trying to solve. We are now moving away from storing a strongly typed query, table configuration and results, to a snapshot of the table that won't cause a problem for future model changes by requiring migrations.

Referential integrity won't be possible for `ReleaseId` and `SubjectId`. Aside from being in a different database,
we know from the investigation of [EES-3068](https://dfedigital.atlassian.net/browse/EES-3068) that many Subjects no longer exist in public-statistics and it also found 61 Permalinks using 6 distinct Subjects that don't exist in the private statistics database either.

`SubjectName` and `PublicationName` of the permalink are also stored in the database. They are combined by the FE to make the permalink title and will be required in future when moving to table snapshots, where the title will not be part of the snapshot.

These could be queried but we know from previous investigations we have permalinks where release and/or subject no longer exist in any database, and the title should stay the same as it was originally when the permalink was created.