### PR TITLE
EES-3756 EES-3756 Update the publicly cached methodologies tree when managing adopted methodologies

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
@@ -11,6 +11,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
@@ -234,6 +235,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             IMethodologyRepository? methodologyRepository = null,
             IMethodologyImageService? methodologyImageService = null,
             IMethodologyApprovalService? methodologyApprovalService = null,
+            IMethodologyCacheService? methodologyCacheService = null,
             IUserService? userService = null)
         {
             return new(
@@ -244,7 +246,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 methodologyRepository ?? Mock.Of<IMethodologyRepository>(),
                 methodologyImageService ?? Mock.Of<IMethodologyImageService>(),
                 methodologyApprovalService ?? Mock.Of<IMethodologyApprovalService>(Strict),
-                userService ?? Mock.Of<IUserService>()
+                methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
+            userService ?? Mock.Of<IUserService>()
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -17,6 +17,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
@@ -33,6 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         private readonly IMethodologyRepository _methodologyRepository;
         private readonly IMethodologyImageService _methodologyImageService;
         private readonly IMethodologyApprovalService _methodologyApprovalService;
+        private readonly IMethodologyCacheService _methodologyCacheService;
         private readonly IUserService _userService;
 
         public MethodologyService(
@@ -43,6 +45,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             IMethodologyRepository methodologyRepository,
             IMethodologyImageService methodologyImageService,
             IMethodologyApprovalService methodologyApprovalService,
+            IMethodologyCacheService methodologyCacheService,
             IUserService userService)
         {
             _persistenceHelper = persistenceHelper;
@@ -52,6 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             _methodologyRepository = methodologyRepository;
             _methodologyImageService = methodologyImageService;
             _methodologyApprovalService = methodologyApprovalService;
+            _methodologyCacheService = methodologyCacheService;
             _userService = userService;
         }
 
@@ -77,6 +81,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
                     _context.Publications.Update(publication);
                     await _context.SaveChangesAsync();
+
+                    await _methodologyCacheService.UpdateSummariesTree();
 
                     return Unit.Instance;
                 });
@@ -104,6 +110,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 {
                     _context.PublicationMethodologies.Remove(link);
                     await _context.SaveChangesAsync();
+
+                    await _methodologyCacheService.UpdateSummariesTree();
                 });
         }
 


### PR DESCRIPTION
This PR updates the publicly cached methodologies tree when adopting and removing adopted methodologies from publications.

At the same time as the feature to adopt methodologies was introduced, the public 'all' methodologies page was changed from using a cached json tree view model generated by the Publisher, to operate direct from the same tree view model but produced by a database query

Since the page always reflected the database this bug would not have been present at that time.

This bug is likely to have been introduced by https://github.com/dfe-analytical-services/explore-education-statistics/pull/2703 when we added caching back into this page to address a performance issue with it.

