### PR TITLE
EES-3747 Increase statistics database size in Prod from 450Gb to 550Gb

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -78,7 +78,7 @@
       "value": 2147483648
     },
     "maxStatsDbSizeBytes": {
-      "value": 483183820800
+      "value": 590558003200
     }
   }
 }


### PR DESCRIPTION
This PR makes an ARM template parameter change to `prod.parameters.json` to increase the capacity of the `statistics` database in the Prod environment from 450Gb to 550Gb.

It follows other changes made recently to the size in https://github.com/dfe-analytical-services/explore-education-statistics/pull/3046 and https://github.com/dfe-analytical-services/explore-education-statistics/pull/3316.