### PR TITLE
EES-965 change view original buttons

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
@@ -55,7 +55,7 @@ const DraftReleaseRow = ({ isBauUser, release, onDelete }: Props) => {
               releaseId: release.previousVersionId,
             })}
           >
-            View original
+            View existing version
             <VisuallyHidden> for {release.title}</VisuallyHidden>
           </Link>
         )}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -144,7 +144,7 @@ const MethodologySummary = ({ publication, onChangePublication }: Props) => {
                               )}
                               variant="secondary"
                             >
-                              View original methodology
+                              View existing version
                             </ButtonLink>
                           )}
                         </>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/NonScheduledReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/NonScheduledReleaseSummary.tsx
@@ -69,12 +69,12 @@ const NonScheduledReleaseSummary = ({
                       releaseId: release.previousVersionId,
                     },
                   )}
-                  data-testid={`View original release link for ${
+                  data-testid={`View existing version link for ${
                     release.publicationTitle
                   }, ${getReleaseSummaryLabel(release)}`}
                   variant="secondary"
                 >
-                  View original release
+                  View existing version
                 </ButtonLink>
               </>
             ) : (

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/DraftReleasesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/DraftReleasesTable.test.tsx
@@ -147,7 +147,7 @@ describe('DraftReleasesTable', () => {
     ).not.toBeInTheDocument();
     expect(
       within(row3cells[2]).queryByRole('link', {
-        name: 'View original for Release 1',
+        name: 'View existing version for Release 1',
       }),
     ).not.toBeInTheDocument();
 
@@ -171,7 +171,7 @@ describe('DraftReleasesTable', () => {
     ).not.toBeInTheDocument();
     expect(
       within(row4cells[2]).queryByRole('link', {
-        name: 'View original for Release 3',
+        name: 'View existing version for Release 3',
       }),
     ).not.toBeInTheDocument();
 
@@ -199,7 +199,7 @@ describe('DraftReleasesTable', () => {
     ).toBeInTheDocument();
     expect(
       within(row6cells[2]).getByRole('link', {
-        name: 'View original for Release 2',
+        name: 'View existing version for Release 2',
       }),
     ).toBeInTheDocument();
     expect(
@@ -232,7 +232,7 @@ describe('DraftReleasesTable', () => {
     ).toBeInTheDocument();
     expect(
       within(row8cells[2]).queryByRole('link', {
-        name: 'View original for Release 4',
+        name: 'View existing version for Release 4',
       }),
     ).toBeInTheDocument();
   });
@@ -281,7 +281,7 @@ describe('DraftReleasesTable', () => {
     ).not.toBeInTheDocument();
     expect(
       within(row3cells[3]).queryByRole('link', {
-        name: 'View original for Release 1',
+        name: 'View existing version for Release 1',
       }),
     ).not.toBeInTheDocument();
 
@@ -305,7 +305,7 @@ describe('DraftReleasesTable', () => {
     ).not.toBeInTheDocument();
     expect(
       within(row4cells[3]).queryByRole('link', {
-        name: 'View original for Release 3',
+        name: 'View existing version for Release 3',
       }),
     ).not.toBeInTheDocument();
 
@@ -336,7 +336,7 @@ describe('DraftReleasesTable', () => {
     ).toBeInTheDocument();
     expect(
       within(row6cells[3]).getByRole('link', {
-        name: 'View original for Release 2',
+        name: 'View existing version for Release 2',
       }),
     ).toBeInTheDocument();
 
@@ -366,7 +366,7 @@ describe('DraftReleasesTable', () => {
     ).toBeInTheDocument();
     expect(
       within(row8cells[3]).queryByRole('link', {
-        name: 'View original for Release 4',
+        name: 'View existing version for Release 4',
       }),
     ).toBeInTheDocument();
   });

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/NonScheduledReleaseSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/NonScheduledReleaseSummary.test.tsx
@@ -98,7 +98,7 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.queryByRole('link', {
-        name: 'View original release',
+        name: 'View existing version',
       }),
     ).not.toBeInTheDocument();
   });
@@ -162,7 +162,7 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.queryByRole('link', {
-        name: 'View original release',
+        name: 'View existing version',
       }),
     ).not.toBeInTheDocument();
   });
@@ -226,7 +226,7 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'View original release',
+        name: 'View existing version',
       }),
     ).toBeInTheDocument();
   });
@@ -292,7 +292,7 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'View original release',
+        name: 'View existing version',
       }),
     ).toBeInTheDocument();
   });

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
@@ -216,7 +216,7 @@ const PublicationMethodologiesPage = () => {
                                 )}
                                 unvisited
                               >
-                                View original
+                                View existing version
                                 <VisuallyHidden>
                                   {` for ${methodology.title}`}
                                 </VisuallyHidden>

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationMethodologiesPage.test.tsx
@@ -617,7 +617,7 @@ describe('PublicationMethodologiesPage', () => {
 
         expect(
           within(row1Cells[4]).getByRole('link', {
-            name: 'View original for Methodology 1',
+            name: 'View existing version for Methodology 1',
           }),
         ).toHaveAttribute('href', '/methodology/previous-version-id/summary');
       });
@@ -1146,7 +1146,7 @@ describe('PublicationMethodologiesPage', () => {
 
         expect(
           within(row1Cells[4]).queryByRole('link', {
-            name: 'View original for Methodology 2',
+            name: 'View existing version for Methodology 2',
           }),
         ).not.toBeInTheDocument();
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/DraftReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/DraftReleaseRow.tsx
@@ -74,7 +74,7 @@ const DraftReleaseRow = ({ publicationId, release, onDelete }: Props) => {
               releaseId: release.previousVersionId,
             })}
           >
-            View original
+            View existing version
             <VisuallyHidden> for {release.title}</VisuallyHidden>
           </Link>
         )}

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationDraftReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationDraftReleases.test.tsx
@@ -130,7 +130,7 @@ describe('PublicationDraftReleases', () => {
 
     expect(
       within(row1Cells[4]).queryByRole('link', {
-        name: 'View original for Release 1',
+        name: 'View existing version for Release 1',
       }),
     ).not.toBeInTheDocument();
 
@@ -161,7 +161,7 @@ describe('PublicationDraftReleases', () => {
 
     expect(
       within(row2Cells[4]).queryByRole('link', {
-        name: 'View original for Release 2',
+        name: 'View existing for Release 2',
       }),
     ).not.toBeInTheDocument();
 
@@ -194,7 +194,7 @@ describe('PublicationDraftReleases', () => {
 
     expect(
       within(row3Cells[4]).getByRole('link', {
-        name: 'View original for Release 3',
+        name: 'View existing version for Release 3',
       }),
     ).toHaveAttribute(
       'href',

--- a/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
@@ -10,10 +10,8 @@ Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
-
 *** Variables ***
 ${PUBLICATION_NAME}=    UI tests - create methodology amendment publication %{RUN_IDENTIFIER}
-
 
 *** Test Cases ***
 Create publicly accessible Publication
@@ -175,7 +173,7 @@ Verify all is as expected on the Amendment after the Amendment content changes
 Revisit the original Methodology and check that its content remains unaffected by the changes to the Amendment
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user opens details dropdown    ${PUBLICATION_NAME}    ${accordion}
-    user clicks link    View original methodology    ${accordion}
+    user clicks link    View existing version    ${accordion}
     user clicks link    Manage content
     user verifies original Methodology readonly content
 
@@ -218,7 +216,6 @@ Revisit the live Amendment after the cancellation to double check it remains una
     user clicks link    View methodology
     user clicks link    Manage content
     user verifies amended Methodology readonly content
-
 
 *** Keywords ***
 user verifies original Methodology readonly content


### PR DESCRIPTION
Change the 'View original' buttons to 'View existing version' for releases and methodologies on
- admin dashboard main tab (current version only, it's not on the new one)
- admin dashboard draft releases tab (current and new versions)
- new Publication - Releases page, https://localhost:5021/publication/id/releases 
- new Publication - Methodologies page, https://localhost:5021/publication/id/methodologies