### PR TITLE
EES-3738 add glossary to footer links

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/PageFooter.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageFooter.tsx
@@ -56,6 +56,15 @@ const PageFooter = ({ wide }: Props) => (
             <li className="govuk-footer__inline-list-item">
               <Link
                 className="govuk-footer__link"
+                to="/glossary"
+                data-testid="footer--glossary-link"
+              >
+                Glossary
+              </Link>
+            </li>
+            <li className="govuk-footer__inline-list-item">
+              <Link
+                className="govuk-footer__link"
                 to="/help-support"
                 data-testid="footer--help-support-link"
               >


### PR DESCRIPTION
Adds a link to the glossary to the footer on the public site.