### PR TITLE
EES-3735 - trimming Data definition title of any leading or trailing …

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
@@ -89,6 +89,7 @@ const EditableKeyStat = ({
           onSubmit={values => {
             onSubmit({
               ...values,
+              dataDefinitionTitle: values.dataDefinitionTitle.trim(),
               dataDefinition: toMarkdown(values.dataDefinition),
             });
             toggleShowForm.off();

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
@@ -471,7 +471,7 @@ describe('EditableKeyStat', () => {
     userEvent.clear(screen.getByLabelText('Guidance title'));
     await userEvent.type(
       screen.getByLabelText('Guidance title'),
-      'New guidance title',
+      '  New guidance title  ',
     );
 
     // Note that we can't change 'Guidance text' field


### PR DESCRIPTION
This PR:
- fixes the scenario whereby an analyst adds trailing or leading whitespace to the Data Definition title of a Key Stat tile, thus making the test `dataDefinitionTitle === 'Help'` fail, and thus not adding in the visually hidden help text 