### PR TITLE
EES-3732 Fix clean-up performance test

### DIFF
--- a/tests/performance-tests/package.json
+++ b/tests/performance-tests/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "webpack": "webpack",
     "start": "docker-compose up -d influxdb grafana",
-    "stop": "docker-compose down influxdb grafana",
-    "stop-and-clear-data": "docker-compose -v down influxdb grafana",
+    "stop": "docker-compose down",
+    "stop-and-clear-data": "docker-compose down -v",
     "store-environment-details": "docker-compose run --rm --user \"$(id -u):$(id -g)\" node -r source-map-support/register dist/storeEnvironmentDetails.js ${npm_config_environment} ${npm_config_users}",
     "test": "cross-env TEST_ENVIRONMENT=${npm_config_environment} docker-compose run --rm k6 run",
     "tsc": "tsc --noEmit"

--- a/tests/performance-tests/src/tests/maintenance/cleanUp.test.ts
+++ b/tests/performance-tests/src/tests/maintenance/cleanUp.test.ts
@@ -1,8 +1,14 @@
 /* eslint-disable no-console */
+import { Options } from 'k6/options';
 import createAdminService from '../../utils/adminService';
 import getOrRefreshAccessTokens from '../../utils/getOrRefreshAccessTokens';
 import getEnvironmentAndUsersFromFile from '../../utils/environmentAndUsers';
 import testData from '../testData';
+
+export const options: Options = {
+  insecureSkipTLSVerify: true,
+  teardownTimeout: '120s',
+};
 
 const environmentAndUsers = getEnvironmentAndUsersFromFile(
   __ENV.TEST_ENVIRONMENT as string,

--- a/tests/performance-tests/src/tests/maintenance/cleanUp.test.ts
+++ b/tests/performance-tests/src/tests/maintenance/cleanUp.test.ts
@@ -4,12 +4,13 @@ import getOrRefreshAccessTokens from '../../utils/getOrRefreshAccessTokens';
 import getEnvironmentAndUsersFromFile from '../../utils/environmentAndUsers';
 import testData from '../testData';
 
+const environmentAndUsers = getEnvironmentAndUsersFromFile(
+  __ENV.TEST_ENVIRONMENT as string,
+);
+
 const performTest = () => {};
 
 export const teardown = () => {
-  const environmentAndUsers = getEnvironmentAndUsersFromFile(
-    __ENV.TEST_ENVIRONMENT as string,
-  );
   const { adminUrl, supportsRefreshTokens } = environmentAndUsers.environment;
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/tests/performance-tests/src/tests/public/getReleaseApi.test.ts
+++ b/tests/performance-tests/src/tests/public/getReleaseApi.test.ts
@@ -40,7 +40,7 @@ const performTest = () => {
   let response;
   try {
     response = http.get(
-      `${environmentAndUsers.environment.contentApiUrl}/publications/release-cache-blob-test-3-publication/releases/2001-02`,
+      `${environmentAndUsers.environment.contentApiUrl}/publications/pupil-absence-in-schools-in-england/releases/2016-17`,
       {
         timeout: '120s',
       },
@@ -59,7 +59,7 @@ const performTest = () => {
     }) &&
     check(response, {
       'response contains expected text': res =>
-        res.html().text().includes('Release cache blob test 3 publication'),
+        res.html().text().includes('Pupil absence in schools in England'),
     })
   ) {
     console.log('SUCCESS!');


### PR DESCRIPTION
This PR makes a couple of changes to the clean-up performance test `cleanUp.test.ts` to fix some errors seen when running it locally:

- `The "open()" function is only available in the init stage (i.e. the global scope)` 

- `x509: certificate is valid for localhost, not ees.local`

### Other changes

- Changes the publication slug and release slug used in `getReleaseApi.test.ts` to "Pupil absence in schools in England - 2016/17" which all environments should have.
- Fix `npm stop` command in package.json - `docker-compose down` has no service name or container option.
- Fix `npm stop-and-clear-data` command in package.json - volumes option `-v` needs to be after `docker-compose down`.