### PR TITLE
EES-3652 custom data groups for maps

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartCustomDataGroup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartCustomDataGroup.cs
@@ -1,0 +1,8 @@
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
+
+public class ChartCustomDataGroup
+{
+    public int Min;
+    public int Max; 
+}
+

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataClassification.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataClassification.cs
@@ -3,5 +3,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 public enum ChartDataClassification
 {
     EqualIntervals,
-    Quantiles
+    Quantiles,
+    Custom
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
@@ -66,7 +66,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
         
         [JsonConverter(typeof(StringEnumConverter))]
         public ChartDataClassification? DataClassification { get; set; }
+        
         public int? DataGroups { get; set; }
+
+        public List<ChartCustomDataGroup>? CustomDataGroups { get; set; }
+    
     }
 
     public class InfographicChart : Chart

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesSection.tsx
@@ -211,7 +211,7 @@ const MethodologyNotesSection = ({ methodology }: Props) => {
                     <>
                       <FormattedDate
                         className="govuk-body govuk-!-font-weight-bold"
-                        data-testId="note-displayDate"
+                        data-testid="note-displayDate"
                       >
                         {note.displayDate}
                       </FormattedDate>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
@@ -137,6 +137,20 @@ const ChartBuilder = ({
     ServerValidationErrorResponse
   >();
 
+  const dataSetsUnits = useMemo(
+    () =>
+      axes.major?.dataSets.reduce<string[]>((acc, dataSet) => {
+        const foundIndicator = meta.indicators.find(
+          indicator => indicator.value === dataSet.indicator,
+        );
+        if (foundIndicator) {
+          acc.push(foundIndicator.unit);
+        }
+        return acc;
+      }, []),
+    [axes.major?.dataSets, meta.indicators],
+  );
+
   const chartProps = useMemo<ChartBuilderChartProps | undefined>(() => {
     if (!definition || !options) {
       return undefined;
@@ -333,8 +347,9 @@ const ChartBuilder = ({
                 >
                   <ChartDataSetsConfiguration
                     buttons={deleteButton}
-                    meta={meta}
                     dataSets={axes.major?.dataSets}
+                    dataSetsUnits={dataSetsUnits}
+                    meta={meta}
                     onChange={actions.updateDataSets}
                   />
                 </TabsSection>
@@ -348,6 +363,7 @@ const ChartBuilder = ({
                 >
                   <ChartMapConfiguration
                     buttons={deleteButton}
+                    dataSetsUnits={dataSetsUnits}
                     meta={meta}
                     options={options}
                     onBoundaryLevelChange={handleBoundaryLevelChange}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
@@ -38,6 +38,7 @@ export interface FormValues {
 interface Props {
   buttons?: ReactNode;
   dataSets?: DataSet[];
+  dataSetsUnits?: string[];
   meta: FullTableMeta;
   onChange: (dataSets: DataSet[]) => void;
 }
@@ -46,6 +47,7 @@ const ChartDataSetsConfiguration = ({
   buttons,
   meta,
   dataSets = [],
+  dataSetsUnits = [],
   onChange,
 }: Props) => {
   const { forms, updateForm, submitForms } = useChartBuilderFormsContext();
@@ -64,18 +66,7 @@ const ChartDataSetsConfiguration = ({
     [meta.locations],
   );
 
-  const hasMixedUnits = useMemo(() => {
-    const units: string[] = [];
-    dataSets.forEach(dataSet => {
-      const foundIndicator = meta.indicators.find(
-        indicator => indicator.value === dataSet.indicator,
-      );
-      if (foundIndicator) {
-        units.push(foundIndicator.unit);
-      }
-    });
-    return !units.every(unit => unit === units[0]);
-  }, [dataSets, meta.indicators]);
+  const hasMixedUnits = !dataSetsUnits.every(unit => unit === dataSetsUnits[0]);
 
   useEffect(() => {
     updateForm({
@@ -249,7 +240,7 @@ const ChartDataSetsConfiguration = ({
       >
         <Droppable droppableId="dataSets" isDropDisabled={!isReordering}>
           {(droppableProvided, droppableSnapshot) => (
-            <table data-testId="chart-data-sets">
+            <table data-testid="chart-data-sets">
               <thead>
                 <tr>
                   <th>Data set</th>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapConfiguration.tsx
@@ -224,7 +224,7 @@ export default function ChartMapConfiguration({
 
           {form.values.dataClassification === 'Custom' && (
             <ChartMapCustomGroupsConfiguration
-              groups={form.values.customDataGroups}
+              groups={form.values.customDataGroups ?? []}
               id={`${formId}-customDataGroups`}
               showError={
                 hasSubmitted &&

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapConfiguration.tsx
@@ -1,4 +1,5 @@
 import ChartBuilderSaveActions from '@admin/pages/release/datablocks/components/chart/ChartBuilderSaveActions';
+import ChartMapCustomGroupsConfiguration from '@admin/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration';
 import { useChartBuilderFormsContext } from '@admin/pages/release/datablocks/components/chart/contexts/ChartBuilderFormsContext';
 import { ChartOptions } from '@admin/pages/release/datablocks/components/chart/reducers/chartBuilderReducer';
 import Effect from '@common/components/Effect';
@@ -8,13 +9,18 @@ import {
   FormFieldSelect,
 } from '@common/components/form';
 import FormFieldNumberInput from '@common/components/form/FormFieldNumberInput';
-import { DataClassification } from '@common/modules/charts/types/chart';
+import {
+  CustomDataGroup,
+  DataClassification,
+} from '@common/modules/charts/types/chart';
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import parseNumber from '@common/utils/number/parseNumber';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
 import mapValues from 'lodash/mapValues';
 import merge from 'lodash/merge';
+import omit from 'lodash/omit';
+import orderBy from 'lodash/orderBy';
 import pick from 'lodash/pick';
 import React, { ReactNode, useCallback, useMemo } from 'react';
 import { StringSchema } from 'yup';
@@ -23,12 +29,14 @@ const formId = 'chartMapConfigurationForm';
 
 interface FormValues {
   boundaryLevel?: number;
+  customDataGroups: CustomDataGroup[];
   dataClassification: DataClassification;
   dataGroups: number;
 }
 
 interface Props {
   buttons?: ReactNode;
+  dataSetsUnits?: string[];
   meta: FullTableMeta;
   options: ChartOptions;
   onBoundaryLevelChange?: (boundaryLevel: string) => void;
@@ -38,6 +46,7 @@ interface Props {
 
 export default function ChartMapConfiguration({
   buttons,
+  dataSetsUnits = [],
   meta,
   options,
   onBoundaryLevelChange,
@@ -46,15 +55,30 @@ export default function ChartMapConfiguration({
 }: Props) {
   const {
     hasSubmitted,
+    isValid,
     updateForm,
     submitForms,
   } = useChartBuilderFormsContext();
 
+  const hasMixedUnits = !dataSetsUnits.every(unit => unit === dataSetsUnits[0]);
+
   const validationSchema = useMemo(() => {
     let schema = Yup.object<FormValues>({
+      customDataGroups: Yup.array()
+        .of(
+          Yup.object({
+            max: Yup.number(),
+            min: Yup.number(),
+          }),
+        )
+        .max(100, 'The number of data groups cannot be greater than 100')
+        .when('dataClassification', {
+          is: 'Custom',
+          then: Yup.array().required('There must be at least 1 data group'),
+        }),
       dataClassification: Yup.string()
         .required('Choose a data classification')
-        .oneOf(['EqualIntervals', 'Quantiles']) as StringSchema<
+        .oneOf(['EqualIntervals', 'Quantiles', 'Custom']) as StringSchema<
         DataClassification
       >,
       dataGroups: Yup.number()
@@ -82,11 +106,14 @@ export default function ChartMapConfiguration({
     (values: FormValues): ChartOptions => {
       // Use `merge` as we want to avoid potential undefined
       // values from overwriting existing values
-      return merge({}, options, values, {
+      const result = merge({}, options, values, {
         boundaryLevel: values.boundaryLevel
           ? parseNumber(values.boundaryLevel)
           : undefined,
       });
+      // customDataGroups are removable, so don't merge - update instead
+      result.customDataGroups = [...(values.customDataGroups ?? [])];
+      return result;
     },
     [options],
   );
@@ -104,7 +131,13 @@ export default function ChartMapConfiguration({
       initialValues={initialValues}
       initialTouched={
         hasSubmitted
-          ? mapValues(validationSchema.fields, () => true)
+          ? {
+              ...mapValues(
+                omit(validationSchema.fields, 'customDataGroups'),
+                () => true,
+              ),
+              customDataGroups: [],
+            }
           : undefined
       }
       validateOnMount
@@ -171,15 +204,51 @@ export default function ChartMapConfiguration({
                 hint:
                   'Data is classified so that each group roughly has the same quantity of features.',
               },
+              {
+                label: 'Custom',
+                value: 'Custom',
+                hint: 'Define custom groups.',
+              },
             ]}
+            order={[]}
           />
 
-          <FormFieldNumberInput<FormValues>
-            name="dataGroups"
-            label="Number of data groups"
-            hint="The number of groups that the data will be classified into."
-            width={3}
-          />
+          {form.values.dataClassification !== 'Custom' && (
+            <FormFieldNumberInput<FormValues>
+              name="dataGroups"
+              label="Number of data groups"
+              hint="The number of groups that the data will be classified into."
+              width={3}
+            />
+          )}
+
+          {form.values.dataClassification === 'Custom' && (
+            <ChartMapCustomGroupsConfiguration
+              groups={form.values.customDataGroups}
+              id={`${formId}-customDataGroups`}
+              showError={
+                hasSubmitted &&
+                !isValid &&
+                form.values.dataClassification === 'Custom' &&
+                !form.values.customDataGroups.length
+              }
+              unit={!hasMixedUnits ? dataSetsUnits[0] : undefined}
+              onAddGroup={group =>
+                form.setFieldValue(
+                  'customDataGroups',
+                  orderBy([...form.values.customDataGroups, group], g => g.min),
+                )
+              }
+              onRemoveGroup={group =>
+                form.setFieldValue(
+                  'customDataGroups',
+                  form.values.customDataGroups?.filter(
+                    g => !(g.min === group.min && g.max === group.max),
+                  ),
+                )
+              }
+            />
+          )}
 
           <ChartBuilderSaveActions
             formId={formId}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration.tsx
@@ -1,0 +1,147 @@
+import Button from '@common/components/Button';
+import ErrorMessage from '@common/components/ErrorMessage';
+import FormFieldNumberInput from '@common/components/form/FormFieldNumberInput';
+import Tooltip from '@common/components/Tooltip';
+import { CustomDataGroup } from '@common/modules/charts/types/chart';
+import Yup from '@common/validation/yup';
+import { Formik } from 'formik';
+import React from 'react';
+
+interface FormValues {
+  min?: number;
+  max?: number;
+}
+
+export interface ChartMapCustomGroupsConfigurationProps {
+  groups: CustomDataGroup[];
+  id: string;
+  showError?: boolean;
+  unit?: string;
+  onAddGroup: (group: CustomDataGroup) => void;
+  onRemoveGroup: (group: CustomDataGroup) => void;
+}
+
+export default function ChartMapCustomGroupsConfiguration({
+  groups,
+  id,
+  showError = false,
+  unit,
+  onAddGroup,
+  onRemoveGroup,
+}: ChartMapCustomGroupsConfigurationProps) {
+  const unitLabel = unit ? `(${unit})` : '';
+  return (
+    <>
+      <table className="govuk-table" id={id}>
+        <caption className="govuk-heading-s">
+          Custom groups
+          {showError && (
+            <ErrorMessage>There must be at least 1 data group</ErrorMessage>
+          )}
+        </caption>
+        <thead>
+          <tr>
+            <th>{`Min ${unitLabel}`}</th>
+            <th>{`Max ${unitLabel}`}</th>
+            <th className="dfe-align--right">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {groups.map((group, index) => (
+            <tr key={`group-${index.toString()}`}>
+              <td>{group.min}</td>
+              <td>{group.max}</td>
+              <td>
+                <Button
+                  className="govuk-!-margin-bottom-0 dfe-float--right"
+                  variant="secondary"
+                  onClick={() => {
+                    onRemoveGroup(group);
+                  }}
+                >
+                  Remove group
+                </Button>
+              </td>
+            </tr>
+          ))}
+          <Formik<FormValues>
+            initialValues={{ max: undefined, min: undefined }}
+            validationSchema={Yup.object<FormValues>({
+              min: Yup.number()
+                .required('Enter a minimum value')
+                .test('noOverlap', 'Groups cannot overlap', function noOverlap(
+                  value: number,
+                ) {
+                  return !(
+                    groups.length &&
+                    groups.some(group => {
+                      return value >= group.min && value <= group.max;
+                    })
+                  );
+                }),
+              max: Yup.number()
+                .required('Enter a maximum value')
+                .moreThan(Yup.ref('min'), 'Must be greater than min')
+                .test('noOverlap', 'Groups cannot overlap', function noOverlap(
+                  value: number,
+                ) {
+                  return !(
+                    groups.length &&
+                    groups.some(group => {
+                      return value >= group.min && value <= group.max;
+                    })
+                  );
+                }),
+            })}
+            onSubmit={(values, helpers) => {
+              onAddGroup(values as CustomDataGroup);
+              helpers.resetForm();
+            }}
+          >
+            {addForm => (
+              <tr>
+                <td className="dfe-vertical-align--bottom">
+                  <FormFieldNumberInput
+                    name="min"
+                    formGroup={false}
+                    hideLabel
+                    label={`Min ${unitLabel}`}
+                    width={5}
+                  />
+                </td>
+                <td className="dfe-vertical-align--bottom">
+                  <FormFieldNumberInput
+                    name="max"
+                    formGroup={false}
+                    hideLabel
+                    label={`Max ${unitLabel}`}
+                    width={5}
+                  />
+                </td>
+                <td className="dfe-vertical-align--bottom">
+                  <Tooltip
+                    text={!addForm.isValid ? 'Cannot add invalid group' : ''}
+                    enabled={!addForm.isValid}
+                  >
+                    {({ ref }) => (
+                      <Button
+                        ariaDisabled={!addForm.isValid}
+                        className="govuk-!-margin-bottom-0 dfe-float--right"
+                        ref={ref}
+                        onClick={async () => {
+                          await addForm.submitForm();
+                        }}
+                      >
+                        Add group
+                      </Button>
+                    )}
+                  </Tooltip>
+                </td>
+              </tr>
+            )}
+          </Formik>
+        </tbody>
+      </table>
+    </>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartMapCustomGroupsConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartMapCustomGroupsConfiguration.test.tsx
@@ -1,0 +1,258 @@
+import { testFullTable } from '@admin/pages/release/datablocks/components/chart/__tests__/__data__/testTableData';
+import ChartMapCustomGroupsConfiguration, {
+  ChartMapCustomGroupsConfigurationProps,
+} from '@admin/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration';
+import createDataSetCategories from '@common/modules/charts/util/createDataSetCategories';
+import { lineChartBlockDefinition } from '@common/modules/charts/components/LineChartBlock';
+import {
+  AxisConfiguration,
+  ChartDefinitionAxis,
+} from '@common/modules/charts/types/chart';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import React from 'react';
+
+describe('ChartMapCustomGroupsConfiguration', () => {
+  const testGroups = [
+    { min: 0, max: 50 },
+    { min: 51, max: 100 },
+  ];
+  test('renders correctly without initial values', () => {
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={[]}
+        id="testId"
+        onAddGroup={noop}
+        onRemoveGroup={noop}
+      />,
+    );
+
+    expect(screen.getByText('Custom groups')).toBeInTheDocument();
+    const table = within(screen.getByRole('table'));
+    const rows = table.getAllByRole('row');
+    expect(rows).toHaveLength(2);
+    expect(within(rows[1]).getByLabelText('Min')).toBeInTheDocument();
+    expect(within(rows[1]).getByLabelText('Max')).toBeInTheDocument();
+    expect(
+      within(rows[1]).getByRole('button', { name: 'Add group' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders correctly with initial values', () => {
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={testGroups}
+        id="testId"
+        onAddGroup={noop}
+        onRemoveGroup={noop}
+      />,
+    );
+
+    expect(screen.getByText('Custom groups')).toBeInTheDocument();
+    const table = within(screen.getByRole('table'));
+    const rows = table.getAllByRole('row');
+    expect(rows).toHaveLength(4);
+
+    expect(within(rows[1]).getByText('0')).toBeInTheDocument();
+    expect(within(rows[1]).getByText('50')).toBeInTheDocument();
+    expect(
+      within(rows[1]).getByRole('button', { name: 'Remove group' }),
+    ).toBeInTheDocument();
+
+    expect(within(rows[2]).getByText('51')).toBeInTheDocument();
+    expect(within(rows[2]).getByText('100')).toBeInTheDocument();
+    expect(
+      within(rows[2]).getByRole('button', { name: 'Remove group' }),
+    ).toBeInTheDocument();
+
+    expect(within(rows[3]).getByLabelText('Min')).toBeInTheDocument();
+    expect(within(rows[3]).getByLabelText('Max')).toBeInTheDocument();
+    expect(
+      within(rows[3]).getByRole('button', { name: 'Add group' }),
+    ).toBeInTheDocument();
+  });
+
+  test('shows the unit if available', () => {
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={[]}
+        id="testId"
+        unit="%"
+        onAddGroup={noop}
+        onRemoveGroup={noop}
+      />,
+    );
+
+    expect(screen.getByText('Custom groups')).toBeInTheDocument();
+    const table = within(screen.getByRole('table'));
+    const rows = table.getAllByRole('row');
+    expect(rows).toHaveLength(2);
+    expect(within(rows[1]).getByLabelText('Min (%)')).toBeInTheDocument();
+    expect(within(rows[1]).getByLabelText('Max (%)')).toBeInTheDocument();
+    expect(
+      within(rows[1]).getByRole('button', { name: 'Add group' }),
+    ).toBeInTheDocument();
+  });
+
+  test('calls onAddGroup when add groups', async () => {
+    const handleAddGroup = jest.fn();
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={[]}
+        id="testId"
+        onAddGroup={handleAddGroup}
+        onRemoveGroup={noop}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText('Min'), '0');
+    await userEvent.type(screen.getByLabelText('Max'), '10');
+
+    expect(handleAddGroup).not.toHaveBeenCalled();
+
+    userEvent.click(screen.getByRole('button', { name: 'Add group' }));
+
+    await waitFor(() => {
+      expect(handleAddGroup).toHaveBeenCalledWith({ min: 0, max: 10 });
+    });
+
+    await userEvent.type(screen.getByLabelText('Min'), '11');
+    await userEvent.type(screen.getByLabelText('Max'), '20');
+
+    userEvent.click(screen.getByRole('button', { name: 'Add group' }));
+
+    await waitFor(() => {
+      expect(handleAddGroup).toHaveBeenCalledTimes(2);
+      expect(handleAddGroup).toHaveBeenCalledWith({ min: 11, max: 20 });
+    });
+  });
+
+  test('calls onRemoveGroup when remove groups', async () => {
+    const handleRemoveGroup = jest.fn();
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={testGroups}
+        id="testId"
+        onAddGroup={noop}
+        onRemoveGroup={handleRemoveGroup}
+      />,
+    );
+
+    const table = within(screen.getByRole('table'));
+
+    const row2 = within(table.getAllByRole('row')[2]);
+    expect(row2.getByText('51')).toBeInTheDocument();
+    expect(row2.getByText('100')).toBeInTheDocument();
+
+    expect(handleRemoveGroup).not.toHaveBeenCalled();
+
+    userEvent.click(row2.getByRole('button', { name: 'Remove group' }));
+
+    await waitFor(() => {
+      expect(handleRemoveGroup).toHaveBeenCalledWith({ min: 51, max: 100 });
+    });
+
+    const row1 = within(table.getAllByRole('row')[1]);
+    expect(row1.getByText('0')).toBeInTheDocument();
+    expect(row1.getByText('50')).toBeInTheDocument();
+    userEvent.click(row1.getByRole('button', { name: 'Remove group' }));
+
+    await waitFor(() => {
+      expect(handleRemoveGroup).toHaveBeenCalledTimes(2);
+      expect(handleRemoveGroup).toHaveBeenCalledWith({ min: 0, max: 50 });
+    });
+  });
+
+  test('shows a validation errors when submit without min and max values', async () => {
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={[]}
+        id="testId"
+        onAddGroup={noop}
+        onRemoveGroup={noop}
+      />,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Add group' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Enter a minimum value')).toBeInTheDocument();
+      expect(screen.getByText('Enter a maximum value')).toBeInTheDocument();
+    });
+  });
+
+  test('shows a validation error when the max is not greater than the min', async () => {
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={[]}
+        id="testId"
+        onAddGroup={noop}
+        onRemoveGroup={noop}
+      />,
+    );
+
+    userEvent.type(screen.getByLabelText('Min'), '10');
+    userEvent.type(screen.getByLabelText('Max'), '9');
+
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Must be greater than min')).toBeInTheDocument();
+    });
+  });
+
+  test('shows a validation error when the value overlaps an existing group', async () => {
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={testGroups}
+        id="testId"
+        onAddGroup={noop}
+        onRemoveGroup={noop}
+      />,
+    );
+
+    userEvent.type(screen.getByLabelText('Min'), '10');
+
+    const minCell = within(screen.getAllByRole('row')[3]).getAllByRole(
+      'cell',
+    )[0];
+    const maxCell = within(screen.getAllByRole('row')[3]).getAllByRole(
+      'cell',
+    )[1];
+
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        within(minCell).getByText('Groups cannot overlap'),
+      ).toBeInTheDocument();
+    });
+
+    userEvent.type(screen.getByLabelText('Max'), '50');
+
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        within(maxCell).getByText('Groups cannot overlap'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows the minimum number of groups error when showError is true', () => {
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={[]}
+        id="testId"
+        showError
+        onAddGroup={noop}
+        onRemoveGroup={noop}
+      />,
+    );
+
+    expect(
+      screen.getByText('There must be at least 1 data group'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
@@ -45,6 +45,7 @@ export const mapBlockDefinition: ChartDefinition = {
       height: 600,
       dataClassification: 'EqualIntervals',
       dataGroups: 5,
+      customDataGroups: [],
     },
   },
   legend: {

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -12,6 +12,7 @@ import generateLegendDataGroups, {
 import {
   AxisConfiguration,
   ChartProps,
+  CustomDataGroup,
   DataClassification,
 } from '@common/modules/charts/types/chart';
 import { DataSetCategory } from '@common/modules/charts/types/dataSet';
@@ -59,6 +60,7 @@ export interface MapBlockProps extends ChartProps {
     major: AxisConfiguration;
   };
   boundaryLevel?: number;
+  customDataGroups?: CustomDataGroup[];
   dataGroups?: number;
   dataClassification?: DataClassification;
   id: string;
@@ -69,6 +71,7 @@ export interface MapBlockProps extends ChartProps {
 
 export default function MapBlockInternal({
   id,
+  customDataGroups = [],
   data,
   dataGroups = 5,
   dataClassification = 'EqualIntervals',
@@ -228,12 +231,15 @@ export default function MapBlockInternal({
         dataSetCategories,
         dataGroups,
         classification: dataClassification,
+        customDataGroups,
       });
 
       setFeatures(newFeatures);
       setLegendDataGroups(newDataGroups);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    customDataGroups.length,
     dataGroups,
     dataClassification,
     dataSetCategories,
@@ -507,11 +513,13 @@ export default function MapBlockInternal({
 
 function generateFeaturesAndDataGroups({
   classification,
+  customDataGroups,
   dataSetCategories,
   dataGroups: groups,
   selectedDataSetConfig,
 }: {
   classification: DataClassification;
+  customDataGroups: CustomDataGroup[];
   dataSetCategories: MapDataSetCategory[];
   dataGroups: number;
   selectedDataSetConfig: DataSetCategoryConfig;
@@ -540,6 +548,7 @@ function generateFeaturesAndDataGroups({
   const dataGroups = generateLegendDataGroups({
     colour,
     classification,
+    customDataGroups,
     decimalPlaces,
     groups,
     values,

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/__tests__/generateLegendDataGroups.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/__tests__/generateLegendDataGroups.test.ts
@@ -1199,4 +1199,172 @@ describe('generateLegendDataGroups', () => {
       ]);
     });
   });
+
+  describe('custom', () => {
+    test('returns custom groups for integer values and groups', () => {
+      const dataClasses = generateLegendDataGroups({
+        colour: 'rgba(0, 0, 0, 1)',
+        classification: 'Custom',
+        customDataGroups: [
+          { min: 1, max: 45 },
+          {
+            min: 46,
+            max: 100,
+          },
+        ],
+        groups: 5,
+        values: [1, 24, 35, 45, 111],
+      });
+
+      expect(dataClasses).toEqual<LegendDataGroup[]>([
+        {
+          colour: 'rgba(128, 128, 128, 1)',
+          max: '45',
+          maxRaw: 45,
+          min: '1',
+          minRaw: 1,
+        },
+        {
+          colour: 'rgba(0, 0, 0, 1)',
+          max: '100',
+          maxRaw: 100,
+          min: '46',
+          minRaw: 46,
+        },
+      ]);
+    });
+
+    test('returns groups for integer custom groups and non-integer values', () => {
+      const dataClasses = generateLegendDataGroups({
+        colour: 'rgba(0, 0, 0, 1)',
+        classification: 'Custom',
+        customDataGroups: [
+          { min: 0, max: 5 },
+          {
+            min: 6,
+            max: 10,
+          },
+        ],
+        groups: 5,
+        values: [2.5, 4.9, 5.2, 6.9, 7.4, 8.9, 9.8, 12.5],
+      });
+
+      expect(dataClasses).toEqual<LegendDataGroup[]>([
+        {
+          colour: 'rgba(128, 128, 128, 1)',
+          max: '5',
+          maxRaw: 5.4,
+          min: '0',
+          minRaw: -0.5,
+        },
+        {
+          colour: 'rgba(0, 0, 0, 1)',
+          max: '10',
+          maxRaw: 10.4,
+          min: '6',
+          minRaw: 5.5,
+        },
+      ]);
+    });
+
+    test('returns groups for non-integer custom groups and non-integer values with the same number of decimal places', () => {
+      const dataClasses = generateLegendDataGroups({
+        colour: 'rgba(0, 0, 0, 1)',
+        classification: 'Custom',
+        customDataGroups: [
+          { min: 2.2, max: 5.5 },
+          {
+            min: 5.6,
+            max: 7.3,
+          },
+        ],
+        groups: 5,
+        values: [2.5, 4.9, 5.2, 6.9, 7.4, 8.9, 9.8, 12.5],
+      });
+
+      expect(dataClasses).toEqual<LegendDataGroup[]>([
+        {
+          colour: 'rgba(128, 128, 128, 1)',
+          max: '5.5',
+          maxRaw: 5.5,
+          min: '2.2',
+          minRaw: 2.2,
+        },
+        {
+          colour: 'rgba(0, 0, 0, 1)',
+          max: '7.3',
+          maxRaw: 7.3,
+          min: '5.6',
+          minRaw: 5.6,
+        },
+      ]);
+    });
+
+    test('returns groups for non-integer custom groups and non-integer values with a different number of decimal places', () => {
+      const dataClasses = generateLegendDataGroups({
+        colour: 'rgba(0, 0, 0, 1)',
+        classification: 'Custom',
+        customDataGroups: [
+          { min: 2, max: 5.5 },
+          {
+            min: 5.6,
+            max: 7.3,
+          },
+        ],
+        groups: 5,
+        values: [1.89, 2.55, 4.91, 5.52, 6.93, 7.28, 8.39, 9.83, 12.53],
+      });
+
+      expect(dataClasses).toEqual<LegendDataGroup[]>([
+        {
+          colour: 'rgba(128, 128, 128, 1)',
+          max: '5.5',
+          maxRaw: 5.54,
+          min: '2',
+          minRaw: 1.95,
+        },
+        {
+          colour: 'rgba(0, 0, 0, 1)',
+          max: '7.3',
+          maxRaw: 7.34,
+          min: '5.6',
+          minRaw: 5.55,
+        },
+      ]);
+    });
+
+    test('handles more decimal places for non-integer custom groups and non-integer values with a different number of decimal places', () => {
+      const dataClasses = generateLegendDataGroups({
+        colour: 'rgba(0, 0, 0, 1)',
+        classification: 'Custom',
+        customDataGroups: [
+          { min: 1.123, max: 4.336 },
+          {
+            min: 6.988,
+            max: 10.569,
+          },
+        ],
+        decimalPlaces: 3,
+        groups: 5,
+        values: [1.12345, 4.33642, 6.98765, 10.56935],
+      });
+
+      expect(dataClasses).toEqual<LegendDataGroup[]>([
+        {
+          colour: 'rgba(128, 128, 128, 1)',
+          max: '4.336',
+          maxRaw: 4.3364,
+          min: '1.123',
+          minRaw: 1.1225,
+        },
+        {
+          colour: 'rgba(0, 0, 0, 1)',
+          max: '10.569',
+          maxRaw: 10.5694,
+          min: '6.988',
+          minRaw: 6.9875,
+        },
+      ]);
+    });
+  });
 });

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -68,7 +68,12 @@ export type AxesConfiguration = {
   [key in AxisType]?: AxisConfiguration;
 };
 
-export type DataClassification = 'EqualIntervals' | 'Quantiles';
+export type DataClassification = 'EqualIntervals' | 'Quantiles' | 'Custom';
+
+export interface CustomDataGroup {
+  max: number;
+  min: number;
+}
 
 export interface ChartProps {
   data: TableDataResult[];
@@ -115,6 +120,7 @@ export interface ChartDefinitionOptions {
   boundaryLevel?: number;
   dataClassification?: DataClassification;
   dataGroups?: number;
+  customDataGroups?: CustomDataGroup[];
 }
 
 export interface ChartDefinition {


### PR DESCRIPTION
Allows to create custom data groups for maps.

- I've done the BE part... it seems to work
- groups cannot overlap
- groups don't have to cover the full range of data
- the unit shows if it's set and the datasets don't have different units

![mapconfig](https://user-images.githubusercontent.com/81572860/196195022-bfe7a24a-af52-4203-8ba1-8473a233901f.PNG)
