### PR TITLE
EES-3814 - upgrade Azurite docker image to 3.19.0

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   data-storage:
     container_name: ees-storage
-    image: mcr.microsoft.com/azure-storage/azurite:3.16.0
+    image: mcr.microsoft.com/azure-storage/azurite:3.19.0
     ports:
       - "10000:10000"
       - "10001:10001"


### PR DESCRIPTION
This PR: 
* upgrades Azurite version of docker image used in local environments to 3.19.0 

![image](https://user-images.githubusercontent.com/55030296/197012569-b0cf4d84-8647-4681-88ec-db56825d3448.png)
