### PR TITLE
EES-3501 - fix prerelease.robot test

### DIFF
--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -432,6 +432,7 @@ user creates public prerelease access list
     user presses keys    ${content}
     user clicks button    Save access list
     user waits until element contains    css:[data-testid="publicPreReleaseAccessListPreview"]    ${content}
+    ...    %{WAIT_SMALL}
 
 user updates public prerelease access list
     [Arguments]    ${content}


### PR DESCRIPTION
This PR: 
- fixes a small failure some people experienced when running the `prerelease.robot` locally in parallel
