### PR TITLE
EES-3830 Fix Publications table ContactId index

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221021151844_EES3830FixPublicationContactIdIndex.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221021151844_EES3830FixPublicationContactIdIndex.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221021151844_EES3830FixPublicationContactIdIndex")]
+    partial class EES3830FixPublicationContactIdIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221021151844_EES3830FixPublicationContactIdIndex.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221021151844_EES3830FixPublicationContactIdIndex.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES3830FixPublicationContactIdIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Publications_ContactId",
+                table: "Publications");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Publications_ContactId",
+                table: "Publications",
+                column: "ContactId",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Publications_ContactId",
+                table: "Publications");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Publications_ContactId",
+                table: "Publications",
+                column: "ContactId");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
         public ContentDbContext(DbContextOptions<ContentDbContext> options) : this(options, true)
         {
         }
-        
+
         public ContentDbContext(DbContextOptions<ContentDbContext> options, bool updateTimestamps = true) : base(options)
         {
             Configure(updateTimestamps);
@@ -124,7 +124,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
             modelBuilder.Entity<MethodologyVersionContent>().ToTable("MethodologyVersions");
             modelBuilder.Entity<MethodologyVersionContent>().Property<Guid>("MethodologyVersionId");
             modelBuilder.Entity<MethodologyVersionContent>().HasKey("MethodologyVersionId");
-            
+
             modelBuilder.Entity<MethodologyVersionContent>()
                 .Property(m => m.Content)
                 .HasConversion(
@@ -221,6 +221,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .HasConversion(
                     v => v,
                     v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
+
+            modelBuilder.Entity<Publication>()
+                .HasOne(p => p.Contact)
+                .WithOne()
+                .OnDelete(DeleteBehavior.Restrict);
 
             modelBuilder.Entity<PublicationMethodology>()
                 .HasKey(pm => new {pm.PublicationId, pm.MethodologyId});
@@ -416,7 +421,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
             modelBuilder.Entity<MarkDownBlock>()
                 .Property(block => block.Body)
                 .HasColumnName("Body");
-            
+
             modelBuilder.Entity<Permalink>()
                 .Property(permalink => permalink.Created)
                 .HasConversion(
@@ -451,7 +456,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
             modelBuilder.Entity<UserPublicationRole>()
                 .Property(r => r.Role)
                 .HasConversion(new EnumToStringConverter<PublicationRole>());
-            
+
             modelBuilder.Entity<UserPublicationRole>()
                 .HasQueryFilter(p => p.Deleted == null);
 
@@ -464,12 +469,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
             modelBuilder.Entity<UserReleaseRole>()
                 .Property(r => r.Role)
                 .HasConversion(new EnumToStringConverter<ReleaseRole>());
-            
+
             modelBuilder.Entity<UserReleaseRole>()
                 .HasQueryFilter(r =>
                     !r.SoftDeleted
                     && r.Deleted == null);
-            
+
             modelBuilder.Entity<UserReleaseInvite>()
                 .Property(r => r.Role)
                 .HasConversion(new EnumToStringConverter<ReleaseRole>());


### PR DESCRIPTION
This PR fixes the Publications table ContactId index. There was some configuration missing from `ContentDbContext.cs`.

The new migration ensures that there is only 1 contact per publication. I ran the below query on Dev, Test, and Prod Content DBs to ensure there were no contacts shared across multiple publications - there were no results for all three:

```
SELECT Id, ContactId FROM [dbo].[Publications]
GROUP BY Id, ContactId
HAVING COUNT(ContactId) > 1
```