### PR TITLE
EES-3652 fixes for decimals, negatives and default colour

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartCustomDataGroup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartCustomDataGroup.cs
@@ -2,7 +2,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 
 public class ChartCustomDataGroup
 {
-    public int Min;
-    public int Max; 
+  public decimal Min;
+  public decimal Max;
 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartCustomDataGroup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartCustomDataGroup.cs
@@ -2,7 +2,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 
 public class ChartCustomDataGroup
 {
-  public decimal Min;
-  public decimal Max;
+    public decimal Min;
+    public decimal Max;
 }
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration.tsx
@@ -72,16 +72,25 @@ export default function ChartMapCustomGroupsConfiguration({
                 .test('noOverlap', 'Groups cannot overlap', function noOverlap(
                   value: number,
                 ) {
-                  return !(
-                    groups.length &&
-                    groups.some(group => {
-                      return (
-                        (value >= group.min && value <= group.max) ||
-                        // eslint-disable-next-line react/no-this-in-sfc
-                        (value <= group.max && group.min <= this.parent.max)
-                      );
-                    })
+                  // show an error when:
+                  // - the min is in an existing group, or
+                  // - this new group overlaps with another group and the max isn't in a group
+                  // (if the max is in a group and the min isn't then we only want to show the
+                  // error on the max field as it's the one that requires action)
+                  /* eslint-disable react/no-this-in-sfc */
+                  const minIsInAGroup = groups.some(
+                    group => value >= group.min && value <= group.max,
                   );
+                  const maxIsInAGroup = groups.some(
+                    group =>
+                      this.parent.max >= group.min &&
+                      this.parent.max <= group.max,
+                  );
+                  const overlaps = groups.some(
+                    group => value <= group.max && group.min <= this.parent.max,
+                  );
+                  return !minIsInAGroup && !(overlaps && !maxIsInAGroup);
+                  /* eslint-enable react/no-this-in-sfc */
                 }),
               max: Yup.number()
                 .required('Enter a maximum value')
@@ -89,16 +98,25 @@ export default function ChartMapCustomGroupsConfiguration({
                 .test('noOverlap', 'Groups cannot overlap', function noOverlap(
                   value: number,
                 ) {
-                  return !(
-                    groups.length &&
-                    groups.some(group => {
-                      return (
-                        (value >= group.min && value <= group.max) ||
-                        // eslint-disable-next-line react/no-this-in-sfc
-                        (value <= group.min && group.max <= this.parent.min)
-                      );
-                    })
+                  // show an error when:
+                  // - the max is in an existing group, or
+                  // - this new group overlaps with another group and the min isn't in a group
+                  // (if the min is in a group and the min isn't then we only want to show the
+                  // error on the min field as it's the one that requires action)
+                  /* eslint-disable react/no-this-in-sfc */
+                  const minIsInAGroup = groups.some(
+                    group =>
+                      this.parent.min >= group.min &&
+                      this.parent.min <= group.max,
                   );
+                  const maxIsInAGroup = groups.some(
+                    group => value >= group.min && value <= group.max,
+                  );
+                  const overlaps = groups.some(
+                    group => this.parent.min <= group.max && group.min <= value,
+                  );
+                  return !maxIsInAGroup && !(overlaps && !minIsInAGroup);
+                  /* eslint-enable react/no-this-in-sfc */
                 }),
             })}
             onSubmit={(values, helpers) => {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration.tsx
@@ -75,7 +75,11 @@ export default function ChartMapCustomGroupsConfiguration({
                   return !(
                     groups.length &&
                     groups.some(group => {
-                      return value >= group.min && value <= group.max;
+                      return (
+                        (value >= group.min && value <= group.max) ||
+                        // eslint-disable-next-line react/no-this-in-sfc
+                        (value <= group.max && group.min <= this.parent.max)
+                      );
                     })
                   );
                 }),
@@ -88,7 +92,11 @@ export default function ChartMapCustomGroupsConfiguration({
                   return !(
                     groups.length &&
                     groups.some(group => {
-                      return value >= group.min && value <= group.max;
+                      return (
+                        (value >= group.min && value <= group.max) ||
+                        // eslint-disable-next-line react/no-this-in-sfc
+                        (value <= group.min && group.max <= this.parent.min)
+                      );
                     })
                   );
                 }),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration.tsx
@@ -69,55 +69,77 @@ export default function ChartMapCustomGroupsConfiguration({
             validationSchema={Yup.object<FormValues>({
               min: Yup.number()
                 .required('Enter a minimum value')
-                .test('noOverlap', 'Groups cannot overlap', function noOverlap(
-                  value: number,
-                ) {
-                  // show an error when:
-                  // - the min is in an existing group, or
-                  // - this new group overlaps with another group and the max isn't in a group
-                  // (if the max is in a group and the min isn't then we only want to show the
-                  // error on the max field as it's the one that requires action)
-                  /* eslint-disable react/no-this-in-sfc */
-                  const minIsInAGroup = groups.some(
-                    group => value >= group.min && value <= group.max,
-                  );
-                  const maxIsInAGroup = groups.some(
-                    group =>
-                      this.parent.max >= group.min &&
-                      this.parent.max <= group.max,
-                  );
-                  const overlaps = groups.some(
-                    group => value <= group.max && group.min <= this.parent.max,
-                  );
-                  return !minIsInAGroup && !(overlaps && !maxIsInAGroup);
-                  /* eslint-enable react/no-this-in-sfc */
-                }),
+                .test(
+                  'noOverlap',
+                  'Min cannot overlap another group',
+                  function noOverlap(value: number) {
+                    // Show error when the min is in an existing group
+                    if (
+                      groups.some(
+                        group => value >= group.min && value <= group.max,
+                      )
+                    ) {
+                      return false;
+                    }
+
+                    /* eslint-disable react/no-this-in-sfc */
+                    // This group overlaps with an existing group
+                    const overlaps = groups.some(
+                      group =>
+                        value <= group.max && group.min <= this.parent.max,
+                    );
+
+                    if (overlaps) {
+                      // Check if the max is in an existing group,
+                      // don't show the error here if it is as only want
+                      // to show the error on the field(s) that require action.
+                      return groups.some(
+                        group =>
+                          this.parent.max >= group.min &&
+                          this.parent.max <= group.max,
+                      );
+                    }
+                    /* eslint-enable react/no-this-in-sfc */
+                    return true;
+                  },
+                ),
               max: Yup.number()
                 .required('Enter a maximum value')
                 .moreThan(Yup.ref('min'), 'Must be greater than min')
-                .test('noOverlap', 'Groups cannot overlap', function noOverlap(
-                  value: number,
-                ) {
-                  // show an error when:
-                  // - the max is in an existing group, or
-                  // - this new group overlaps with another group and the min isn't in a group
-                  // (if the min is in a group and the min isn't then we only want to show the
-                  // error on the min field as it's the one that requires action)
-                  /* eslint-disable react/no-this-in-sfc */
-                  const minIsInAGroup = groups.some(
-                    group =>
-                      this.parent.min >= group.min &&
-                      this.parent.min <= group.max,
-                  );
-                  const maxIsInAGroup = groups.some(
-                    group => value >= group.min && value <= group.max,
-                  );
-                  const overlaps = groups.some(
-                    group => this.parent.min <= group.max && group.min <= value,
-                  );
-                  return !maxIsInAGroup && !(overlaps && !minIsInAGroup);
-                  /* eslint-enable react/no-this-in-sfc */
-                }),
+                .test(
+                  'noOverlap',
+                  'Max cannot overlap another group',
+                  function noOverlap(value: number) {
+                    // Show error when the max is in an existing group
+                    if (
+                      groups.some(
+                        group => value >= group.min && value <= group.max,
+                      )
+                    ) {
+                      return false;
+                    }
+
+                    /* eslint-disable react/no-this-in-sfc */
+                    // This group overlaps with an existing group
+                    const overlaps = groups.some(
+                      group =>
+                        this.parent.min <= group.max && group.min <= value,
+                    );
+
+                    if (overlaps) {
+                      // Check if the min is in an existing group,
+                      // don't show the error here if it is as only want
+                      // to show the error on the field(s) that require action.
+                      return groups.some(
+                        group =>
+                          this.parent.min >= group.min &&
+                          this.parent.min <= group.max,
+                      );
+                    }
+                    /* eslint-enable react/no-this-in-sfc */
+                    return true;
+                  },
+                ),
             })}
             onSubmit={(values, helpers) => {
               onAddGroup(values as CustomDataGroup);

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartMapCustomGroupsConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartMapCustomGroupsConfiguration.test.tsx
@@ -185,7 +185,6 @@ describe('ChartMapCustomGroupsConfiguration', () => {
 
     userEvent.type(screen.getByLabelText('Min'), '10');
     userEvent.type(screen.getByLabelText('Max'), '9');
-
     userEvent.tab();
 
     await waitFor(() => {
@@ -193,7 +192,7 @@ describe('ChartMapCustomGroupsConfiguration', () => {
     });
   });
 
-  test('shows a validation error when the value overlaps an existing group', async () => {
+  test('shows a validation error when the minimum value is in an existing group', async () => {
     render(
       <ChartMapCustomGroupsConfiguration
         groups={testGroups}
@@ -204,6 +203,8 @@ describe('ChartMapCustomGroupsConfiguration', () => {
     );
 
     userEvent.type(screen.getByLabelText('Min'), '10');
+    userEvent.type(screen.getByLabelText('Max'), '200');
+    userEvent.tab();
 
     const minCell = within(screen.getAllByRole('row')[3]).getAllByRole(
       'cell',
@@ -212,19 +213,104 @@ describe('ChartMapCustomGroupsConfiguration', () => {
       'cell',
     )[1];
 
+    await waitFor(() => {
+      expect(
+        within(minCell).getByText('Groups cannot overlap'),
+      ).toBeInTheDocument();
+      expect(
+        within(maxCell).queryByText('Groups cannot overlap'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('shows a validation error when the maximum value is in an existing group', async () => {
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={testGroups}
+        id="testId"
+        onAddGroup={noop}
+        onRemoveGroup={noop}
+      />,
+    );
+
+    userEvent.type(screen.getByLabelText('Min'), '-10');
+    userEvent.type(screen.getByLabelText('Max'), '75');
     userEvent.tab();
+
+    const minCell = within(screen.getAllByRole('row')[3]).getAllByRole(
+      'cell',
+    )[0];
+    const maxCell = within(screen.getAllByRole('row')[3]).getAllByRole(
+      'cell',
+    )[1];
+
+    await waitFor(() => {
+      expect(
+        within(minCell).queryByText('Groups cannot overlap'),
+      ).not.toBeInTheDocument();
+
+      expect(
+        within(maxCell).getByText('Groups cannot overlap'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows validation errors when both values are in an existing group', async () => {
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={testGroups}
+        id="testId"
+        onAddGroup={noop}
+        onRemoveGroup={noop}
+      />,
+    );
+
+    userEvent.type(screen.getByLabelText('Min'), '10');
+    userEvent.type(screen.getByLabelText('Max'), '75');
+    userEvent.tab();
+
+    const minCell = within(screen.getAllByRole('row')[3]).getAllByRole(
+      'cell',
+    )[0];
+    const maxCell = within(screen.getAllByRole('row')[3]).getAllByRole(
+      'cell',
+    )[1];
 
     await waitFor(() => {
       expect(
         within(minCell).getByText('Groups cannot overlap'),
       ).toBeInTheDocument();
+      expect(
+        within(maxCell).getByText('Groups cannot overlap'),
+      ).toBeInTheDocument();
     });
+  });
 
-    userEvent.type(screen.getByLabelText('Max'), '50');
+  test('shows validation errors when the new group contains an existing group', async () => {
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={testGroups}
+        id="testId"
+        onAddGroup={noop}
+        onRemoveGroup={noop}
+      />,
+    );
 
+    userEvent.type(screen.getByLabelText('Min'), '-10');
+    userEvent.type(screen.getByLabelText('Max'), '150');
     userEvent.tab();
 
+    const minCell = within(screen.getAllByRole('row')[3]).getAllByRole(
+      'cell',
+    )[0];
+    const maxCell = within(screen.getAllByRole('row')[3]).getAllByRole(
+      'cell',
+    )[1];
+
     await waitFor(() => {
+      expect(
+        within(minCell).getByText('Groups cannot overlap'),
+      ).toBeInTheDocument();
       expect(
         within(maxCell).getByText('Groups cannot overlap'),
       ).toBeInTheDocument();

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartMapCustomGroupsConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartMapCustomGroupsConfiguration.test.tsx
@@ -1,13 +1,4 @@
-import { testFullTable } from '@admin/pages/release/datablocks/components/chart/__tests__/__data__/testTableData';
-import ChartMapCustomGroupsConfiguration, {
-  ChartMapCustomGroupsConfigurationProps,
-} from '@admin/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration';
-import createDataSetCategories from '@common/modules/charts/util/createDataSetCategories';
-import { lineChartBlockDefinition } from '@common/modules/charts/components/LineChartBlock';
-import {
-  AxisConfiguration,
-  ChartDefinitionAxis,
-} from '@common/modules/charts/types/chart';
+import ChartMapCustomGroupsConfiguration from '@admin/pages/release/datablocks/components/chart/ChartMapCustomGroupsConfiguration';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import noop from 'lodash/noop';
@@ -236,6 +227,33 @@ describe('ChartMapCustomGroupsConfiguration', () => {
     await waitFor(() => {
       expect(
         within(maxCell).getByText('Groups cannot overlap'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows a validation error when groups with negative values overlap', async () => {
+    render(
+      <ChartMapCustomGroupsConfiguration
+        groups={[{ min: -2, max: 2 }]}
+        id="testId"
+        onAddGroup={noop}
+        onRemoveGroup={noop}
+      />,
+    );
+
+    userEvent.type(screen.getByLabelText('Min'), '-3');
+
+    const minCell = within(screen.getAllByRole('row')[2]).getAllByRole(
+      'cell',
+    )[0];
+
+    userEvent.type(screen.getByLabelText('Max'), '3');
+
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        within(minCell).getByText('Groups cannot overlap'),
       ).toBeInTheDocument();
     });
   });

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartMapCustomGroupsConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartMapCustomGroupsConfiguration.test.tsx
@@ -215,7 +215,7 @@ describe('ChartMapCustomGroupsConfiguration', () => {
 
     await waitFor(() => {
       expect(
-        within(minCell).getByText('Groups cannot overlap'),
+        within(minCell).getByText('Min cannot overlap another group'),
       ).toBeInTheDocument();
       expect(
         within(maxCell).queryByText('Groups cannot overlap'),
@@ -246,11 +246,11 @@ describe('ChartMapCustomGroupsConfiguration', () => {
 
     await waitFor(() => {
       expect(
-        within(minCell).queryByText('Groups cannot overlap'),
+        within(minCell).queryByText('Min cannot overlap another group'),
       ).not.toBeInTheDocument();
 
       expect(
-        within(maxCell).getByText('Groups cannot overlap'),
+        within(maxCell).getByText('Max cannot overlap another group'),
       ).toBeInTheDocument();
     });
   });
@@ -278,10 +278,10 @@ describe('ChartMapCustomGroupsConfiguration', () => {
 
     await waitFor(() => {
       expect(
-        within(minCell).getByText('Groups cannot overlap'),
+        within(minCell).getByText('Min cannot overlap another group'),
       ).toBeInTheDocument();
       expect(
-        within(maxCell).getByText('Groups cannot overlap'),
+        within(maxCell).getByText('Max cannot overlap another group'),
       ).toBeInTheDocument();
     });
   });
@@ -309,10 +309,10 @@ describe('ChartMapCustomGroupsConfiguration', () => {
 
     await waitFor(() => {
       expect(
-        within(minCell).getByText('Groups cannot overlap'),
+        within(minCell).getByText('Min cannot overlap another group'),
       ).toBeInTheDocument();
       expect(
-        within(maxCell).getByText('Groups cannot overlap'),
+        within(maxCell).getByText('Max cannot overlap another group'),
       ).toBeInTheDocument();
     });
   });
@@ -339,7 +339,7 @@ describe('ChartMapCustomGroupsConfiguration', () => {
 
     await waitFor(() => {
       expect(
-        within(minCell).getByText('Groups cannot overlap'),
+        within(minCell).getByText('Min cannot overlap another group'),
       ).toBeInTheDocument();
     });
   });

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -558,7 +558,7 @@ function generateFeaturesAndDataGroups({
   // Default to white for areas not covered by custom data sets
   // to make it clearer which aren't covered by the groups.
   const defaultColour =
-    classification === 'Custom' ? 'rgb(255, 255, 255)' : 'rgba(0,0,0,0)';
+    classification === 'Custom' ? 'rgba(255, 255, 255, 1)' : 'rgba(0,0,0,0)';
 
   const features: MapFeatureCollection = {
     type: 'FeatureCollection',

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -555,6 +555,11 @@ function generateFeaturesAndDataGroups({
     unit,
   });
 
+  // Default to white for areas not covered by custom data sets
+  // to make it clearer which aren't covered by the groups.
+  const defaultColour =
+    classification === 'Custom' ? 'rgb(255, 255, 255)' : 'rgba(0,0,0,0)';
+
   const features: MapFeatureCollection = {
     type: 'FeatureCollection',
     features: dataSetCategories.reduce<MapFeature[]>(
@@ -573,7 +578,7 @@ function generateFeaturesAndDataGroups({
               ...geoJson.properties,
               dataSets,
               // Default to transparent if no match
-              colour: matchingDataGroup?.colour ?? 'rgba(0, 0, 0, 0)',
+              colour: matchingDataGroup?.colour ?? defaultColour,
               data: value,
             },
           });


### PR DESCRIPTION
Fixes the following issues found by @N-moh during testing:

- group values with decimals were being rounded when the form is saved
- the logic to prevent overlapping groups didn't work for negative values 
- areas that aren't covered by custom groups could be hard to distinguish from those that were as they defaulted to grey which can be indistinguishable from the low end of the legend colour scale, I've changed them to white.