### PR TITLE
EES-3189 fix footnotes width in admin

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableToolFinalStep.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableToolFinalStep.tsx
@@ -88,6 +88,7 @@ const ReleasePreviewTableToolFinalStep = ({
       {table && tableHeaders && (
         <TimePeriodDataTable
           ref={dataTableRef}
+          footnotesClassName="govuk-!-width-two-thirds"
           fullTable={table}
           query={query}
           tableHeadersConfig={tableHeaders}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -78,6 +78,7 @@ const DataBlockSourceWizardFinalStep = ({
 
         <TimePeriodDataTable
           ref={dataTableRef}
+          footnotesClassName="govuk-!-width-two-thirds"
           fullTable={table}
           captionTitle={captionTitle}
           query={query}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/TableTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/TableTabSection.tsx
@@ -43,6 +43,7 @@ const TableTabSection = ({
       )}
 
       <TimePeriodDataTable
+        footnotesClassName="govuk-!-width-two-thirds"
         fullTable={table}
         tableHeadersConfig={tableHeaders}
         captionTitle={dataBlock.heading}

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseTableToolFinalStep.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseTableToolFinalStep.tsx
@@ -66,6 +66,7 @@ const PreReleaseTableToolFinalStep = ({
         <TimePeriodDataTable
           ref={dataTableRef}
           query={query}
+          footnotesClassName="govuk-!-width-two-thirds"
           fullTable={table}
           tableHeadersConfig={tableHeaders}
         />

--- a/src/explore-education-statistics-common/src/components/CollapsibleList.module.scss
+++ b/src/explore-education-statistics-common/src/components/CollapsibleList.module.scss
@@ -8,15 +8,6 @@
 }
 
 .listContainer {
-  @include govuk-media-query($from: desktop) {
-    :global(.dfe-width-container--wide) & {
-      max-width: 66.6%;
-      @media print {
-        max-width: 100%;
-      }
-    }
-  }
-
   :global(.govuk-visually-hidden) {
     @media print {
       clip: unset !important;

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -140,7 +140,6 @@ const DataBlockTabs = ({
                   captionTitle={dataBlock?.heading}
                   dataBlockId={dataBlock.id}
                   fullTable={fullTable}
-                  isInDataBlock
                   source={dataBlock?.source}
                   tableHeadersConfig={
                     dataBlock.table.tableHeaders

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -137,9 +137,10 @@ const DataBlockTabs = ({
               <ErrorBoundary fallback={errorMessage}>
                 <TimePeriodDataTable
                   key={dataBlock.id}
+                  captionTitle={dataBlock?.heading}
                   dataBlockId={dataBlock.id}
                   fullTable={fullTable}
-                  captionTitle={dataBlock?.heading}
+                  isInDataBlock
                   source={dataBlock?.source}
                   tableHeadersConfig={
                     dataBlock.table.tableHeaders

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
@@ -12,8 +12,8 @@ interface Props extends OmitStrict<MultiHeaderTableProps, 'ariaLabelledBy'> {
   caption: ReactNode;
   captionId: string;
   innerRef?: Ref<HTMLElement>;
-  isInDataBlock?: boolean;
   footnotes?: FullTableMeta['footnotes'];
+  footnotesClassName?: string;
   source?: string;
   footnotesHeadingHiddenText?: string;
 }
@@ -24,7 +24,7 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
       caption,
       captionId,
       footnotes = [],
-      isInDataBlock = false,
+      footnotesClassName,
       source,
       footnotesHeadingHiddenText,
     } = props;
@@ -135,7 +135,7 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
           />
         </div>
 
-        <div className={isInDataBlock ? undefined : 'govuk-!-width-two-thirds'}>
+        <div className={footnotesClassName}>
           <FigureFootnotes
             footnotes={footnotes}
             headingHiddenText={footnotesHeadingHiddenText}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
@@ -12,6 +12,7 @@ interface Props extends OmitStrict<MultiHeaderTableProps, 'ariaLabelledBy'> {
   caption: ReactNode;
   captionId: string;
   innerRef?: Ref<HTMLElement>;
+  isInDataBlock?: boolean;
   footnotes?: FullTableMeta['footnotes'];
   source?: string;
   footnotesHeadingHiddenText?: string;
@@ -23,6 +24,7 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
       caption,
       captionId,
       footnotes = [],
+      isInDataBlock = false,
       source,
       footnotesHeadingHiddenText,
     } = props;
@@ -133,7 +135,7 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
           />
         </div>
 
-        <div className="govuk-!-width-two-thirds">
+        <div className={isInDataBlock ? undefined : 'govuk-!-width-two-thirds'}>
           <FigureFootnotes
             footnotes={footnotes}
             headingHiddenText={footnotesHeadingHiddenText}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
@@ -133,10 +133,12 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
           />
         </div>
 
-        <FigureFootnotes
-          footnotes={footnotes}
-          headingHiddenText={footnotesHeadingHiddenText}
-        />
+        <div className="govuk-!-width-two-thirds">
+          <FigureFootnotes
+            footnotes={footnotes}
+            headingHiddenText={footnotesHeadingHiddenText}
+          />
+        </div>
 
         {source && <p className="govuk-body-s">Source: {source}</p>}
       </figure>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -220,8 +220,8 @@ interface TableCell {
 interface Props {
   captionTitle?: string;
   dataBlockId?: string;
+  footnotesClassName?: string;
   fullTable: FullTable;
-  isInDataBlock?: boolean;
   query?: ReleaseTableDataQuery;
   source?: string;
   tableHeadersConfig: TableHeadersConfig;
@@ -233,8 +233,8 @@ const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
     {
       captionTitle,
       dataBlockId,
+      footnotesClassName,
       fullTable,
-      isInDataBlock = false,
       query,
       source,
       tableHeadersConfig,
@@ -405,7 +405,7 @@ const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
             }
             captionId={captionId}
             columnHeaders={columnHeaders}
-            isInDataBlock={isInDataBlock}
+            footnotesClassName={footnotesClassName}
             rowHeaders={rowHeaders}
             rows={rows}
             ref={dataTableRef}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -221,6 +221,7 @@ interface Props {
   captionTitle?: string;
   dataBlockId?: string;
   fullTable: FullTable;
+  isInDataBlock?: boolean;
   query?: ReleaseTableDataQuery;
   source?: string;
   tableHeadersConfig: TableHeadersConfig;
@@ -233,6 +234,7 @@ const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
       captionTitle,
       dataBlockId,
       fullTable,
+      isInDataBlock = false,
       query,
       source,
       tableHeadersConfig,
@@ -403,6 +405,7 @@ const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
             }
             captionId={captionId}
             columnHeaders={columnHeaders}
+            isInDataBlock={isInDataBlock}
             rowHeaders={rowHeaders}
             rows={rows}
             ref={dataTableRef}

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -84,6 +84,7 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
 
       <div ref={tableRef}>
         <TimePeriodDataTable
+          footnotesClassName="govuk-!-width-two-thirds"
           fullTable={fullTable}
           source={`${publicationName}, ${subjectName}`}
           tableHeadersConfig={tableHeadersConfig}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
@@ -118,6 +118,7 @@ const TableToolFinalStep = ({
 
           <TimePeriodDataTable
             ref={dataTableRef}
+            footnotesClassName="govuk-!-width-two-thirds"
             fullTable={table}
             query={query}
             tableHeadersConfig={tableHeaders}


### PR DESCRIPTION
Fixes a bug where the footnotes for datablocks are only using 2/3’s of the available space in the admin (they're fine on the public site). 

This was due to a style added to restrict the width of footnotes under tables in the table tool / on permalinks that was also affecting all footnotes in the admin.

I've checked that the print style for permalinks is unaffected by this change. 