### PR TITLE
EES-3826 Add IncludeInResponse field for subject meta request

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/IncludeInResponseQuery.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/IncludeInResponseQuery.cs
@@ -1,0 +1,19 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query
+{
+    public enum SubjectMetaQueryStep
+    {
+        Locations,
+        TimePeriods,
+        FilterItems,
+        Indicators,
+    }
+
+    public record IncludeInResponseQuery
+    {
+        public SubjectMetaQueryStep Step { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/ObservationQueryContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/ObservationQueryContext.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -7,15 +8,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query
     public class ObservationQueryContext
     {
         public Guid SubjectId { get; set; }
-        public TimePeriodQuery TimePeriod { get; set; }
-        public IEnumerable<Guid> Filters { get; set; }
+        public TimePeriodQuery? TimePeriod { get; set; }
+
+        public IEnumerable<Guid>? Filters { get; set; }
         // TODO EES-3328 - remove BoundaryLevel from ObservationQueryContext as we now store it on
         // MapChart configuration instead
         public long? BoundaryLevel { get; set; }
-        public IEnumerable<Guid> Indicators { get; set; }
+        public IEnumerable<Guid>? Indicators { get; set; }
         public List<Guid> LocationIds { get; set; } = new();
         [Obsolete("Legacy Location field that exists in queries of historical Permalinks", false)]
-        public LocationQuery Locations { get; set; }
+        public LocationQuery? Locations { get; set; }
+
+        public IncludeInResponseQuery? IncludeInResponse { get; set; }
 
         public override string ToString()
         {
@@ -25,7 +29,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query
                 $"{nameof(Filters)}: [{(Filters == null ? string.Empty : Filters.JoinToString(", "))}], " +
                 $"{nameof(BoundaryLevel)}: {BoundaryLevel}, " +
                 $"{nameof(Indicators)}: [{(Indicators == null ? string.Empty : Indicators.JoinToString(", "))}], " +
-                $"{nameof(LocationIds)}: [{LocationIds.JoinToString(", ")}]";
+                $"{nameof(LocationIds)}: [{LocationIds.JoinToString(", ")}], " +
+                $"{nameof(IncludeInResponse)}: [{IncludeInResponse}]"; // @MarkFix works?
         }
     }
 }

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -140,11 +140,22 @@ export interface ReleaseTableDataQuery extends TableDataQuery {
   releaseId?: string;
 }
 
+type SubjectMetaQueryStep =
+  | 'Locations'
+  | 'TimePeriods'
+  | 'FilterItems'
+  | 'Indicators';
+
+interface IncludeInResponseQuery {
+  step: SubjectMetaQueryStep;
+}
+
 export interface ReleaseSubjectMetaQuery {
   releaseId?: string;
   subjectId: string;
   timePeriod?: TimePeriodQuery;
   locationIds?: string[];
+  includeInResponse?: IncludeInResponseQuery;
 }
 
 export interface TableDataSubjectMeta {


### PR DESCRIPTION
This PR adds an `IncludeInResponse` field when fetching subject meta data. This means the request can specify what information it wants in the response. Changes have also been made to the frontend to take advantage of this.

It was decided that for now the request cannot return multiple different types of meta data - this was done to keep the endpoint simpler for now, although it would be simple enough to make it return multiple types of meta data in the future if necessary.

I've not added any unit tests as they're time consuming to write and I may have to rework this.