### PR TITLE
EES-3845 Increase statistics database size in Prod from 550Gb to 650Gb

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -78,7 +78,7 @@
       "value": 2147483648
     },
     "maxStatsDbSizeBytes": {
-      "value": 590558003200
+      "value": 697932185600
     }
   }
 }


### PR DESCRIPTION
This PR makes an ARM template parameter change to `prod.parameters.json` to increase the capacity of the statistics database in the Prod environment from 550Gb to 650Gb.

It follows other changes made recently to the size in https://github.com/dfe-analytical-services/explore-education-statistics/pull/3544, https://github.com/dfe-analytical-services/explore-education-statistics/pull/3046 and https://github.com/dfe-analytical-services/explore-education-statistics/pull/3316.