### PR TITLE
EES-3846 - fix import errors

### DIFF
--- a/tests/robot-tests/scripts/run_tests_pipeline.py
+++ b/tests/robot-tests/scripts/run_tests_pipeline.py
@@ -1,8 +1,6 @@
 import argparse
 import subprocess
 
-from tests.libs.logger import get_logger
-
 # NOTE(mark): The slack webhook url, and admin and analyst passwords to access to Admin app are
 # stored in the CI pipeline as secret variables, which means they cannot be accessed as normal
 # environment variables, and instead must be passed as an argument to this script.
@@ -10,8 +8,6 @@ from tests.libs.logger import get_logger
 # WARNING: If any of the passwords contain a "$", bash/Azure devops will not pass the variable to run_tests.py correctly.
 # Our current solution to this is to escape any dollars where the password is stored
 # i.e. password "hello$world" should be stored as "hello\$world"
-
-logger = get_logger(__name__)
 
 
 def run_tests_pipeline():
@@ -26,7 +22,6 @@ def run_tests_pipeline():
     if args.env not in valid_environments:
         raise Exception(f"Invalid environment provided: {args.env}. Valid environments: {valid_environments}")
 
-    logger.info("Installing dependencies")
     subprocess.check_call(["google-chrome-stable", "--version"])
     subprocess.check_call("python -m pip install --upgrade pip", shell=True)
     subprocess.check_call("pip install pipenv", shell=True)


### PR DESCRIPTION
This PR: 
* removes all `lib` import references in `run_tests_pipeline.py` in order to avoid `ModuleNotFound` errors. I've purposely not replaced the logging statements with print statements. This is because `run_tests_pipeline.py` is pretty much a fancy wrapper around `run_tests.py` purely for the purpose of running tests in CI and all logging should probably come from within `run_tests.py`. This resolves errors currently occuring in the UI test & snapshot CI jobs