### PR TITLE
EES-3412 Change app service plans from Standard to Premium V2

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -6,16 +6,22 @@
       "value": "B1 Basic"
     },
     "skuData": {
-      "value": "S1 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuContent": {
-      "value": "S1 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuAdmin": {
-      "value": "S2 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuImporter": {
-      "value": "S3 Standard"
+      "value": "P2V2 PremiumV2"
+    },
+    "skuNotifier": {
+      "value": "B1 Basic"
+    },
+    "skuPublisher": {
+      "value": "B1 Basic"
     },
     "publishReleasesCronSchedule": {
       "value": "0 0 * * * *"

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -3,22 +3,28 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "skuPublic": {
-      "value": "S1 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuData": {
-      "value": "S2 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuContent": {
-      "value": "S1 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuAdmin": {
-      "value": "S2 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuAdminSignalR": {
       "value": "Standard_S1"
     },
     "skuImporter": {
-      "value": "S2 Standard"
+      "value": "P1V2 PremiumV2"
+    },
+    "skuNotifier": {
+      "value": "S1 Standard"
+    },
+    "skuPublisher": {
+      "value": "S1 Standard"
     },
     "useSubnets": {
       "value": true

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -3,22 +3,28 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "skuPublic": {
-      "value": "S1 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuData": {
-      "value": "S2 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuContent": {
-      "value": "S1 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuAdmin": {
-      "value": "S2 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuAdminSignalR": {
       "value": "Standard_S1"
     },
     "skuImporter": {
-      "value": "S3 Standard"
+      "value": "P2V2 PremiumV2"
+    },
+    "skuNotifier": {
+      "value": "S1 Standard"
+    },
+    "skuPublisher": {
+      "value": "S1 Standard"
     },
     "publicAppBasicAuth": {
       "value": "false"

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -6,16 +6,22 @@
       "value": "B1 Basic"
     },
     "skuData": {
-      "value": "S1 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuContent": {
-      "value": "S1 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuAdmin": {
-      "value": "S2 Standard"
+      "value": "P1V2 PremiumV2"
     },
     "skuImporter": {
-      "value": "S2 Standard"
+      "value": "P1V2 PremiumV2"
+    },
+    "skuNotifier": {
+      "value": "B1 Basic"
+    },
+    "skuPublisher": {
+      "value": "B1 Basic"
     },
     "publishReleasesCronSchedule": {
       "value": "0 0 * * * *"

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -26,14 +26,17 @@
     },
     "skuPublic": {
       "type": "string",
-      "defaultValue": "B1 Basic",
+      "defaultValue": "S1 Standard",
       "allowedValues": [
         "B1 Basic",
         "B2 Basic",
         "B3 Basic",
         "S1 Standard",
         "S2 Standard",
-        "S3 Standard"
+        "S3 Standard",
+        "P1V2 PremiumV2",
+        "P2V2 PremiumV2",
+        "P3V2 PremiumV2"
       ]
     },
     "skuData": {
@@ -45,7 +48,10 @@
         "B3 Basic",
         "S1 Standard",
         "S2 Standard",
-        "S3 Standard"
+        "S3 Standard",
+        "P1V2 PremiumV2",
+        "P2V2 PremiumV2",
+        "P3V2 PremiumV2"
       ]
     },
     "skuContent": {
@@ -57,7 +63,10 @@
         "B3 Basic",
         "S1 Standard",
         "S2 Standard",
-        "S3 Standard"
+        "S3 Standard",
+        "P1V2 PremiumV2",
+        "P2V2 PremiumV2",
+        "P3V2 PremiumV2"
       ]
     },
     "skuAdmin": {
@@ -69,16 +78,55 @@
         "B3 Basic",
         "S1 Standard",
         "S2 Standard",
-        "S3 Standard"
+        "S3 Standard",
+        "P1V2 PremiumV2",
+        "P2V2 PremiumV2",
+        "P3V2 PremiumV2"
       ]
     },
     "skuImporter": {
       "type": "string",
       "defaultValue": "S1 Standard",
       "allowedValues": [
+        "B1 Basic",
+        "B2 Basic",
+        "B3 Basic",
         "S1 Standard",
         "S2 Standard",
-        "S3 Standard"
+        "S3 Standard",
+        "P1V2 PremiumV2",
+        "P2V2 PremiumV2",
+        "P3V2 PremiumV2"
+      ]
+    },
+    "skuNotifier": {
+      "type": "string",
+      "defaultValue": "S1 Standard",
+      "allowedValues": [
+        "B1 Basic",
+        "B2 Basic",
+        "B3 Basic",
+        "S1 Standard",
+        "S2 Standard",
+        "S3 Standard",
+        "P1V2 PremiumV2",
+        "P2V2 PremiumV2",
+        "P3V2 PremiumV2"
+      ]
+    },
+    "skuPublisher": {
+      "type": "string",
+      "defaultValue": "S1 Standard",
+      "allowedValues": [
+        "B1 Basic",
+        "B2 Basic",
+        "B3 Basic",
+        "S1 Standard",
+        "S2 Standard",
+        "S3 Standard",
+        "P1V2 PremiumV2",
+        "P2V2 PremiumV2",
+        "P3V2 PremiumV2"
       ]
     },
     "skuAdminSignalR": {
@@ -2811,8 +2859,8 @@
         "DeploymentScript": "[parameters('deploymentScript')]"
       },
       "sku": {
-        "Tier": "Standard",
-        "Name": "S1"
+        "Tier": "[first(skip(split(parameters('skuNotifier'), ' '), 1))]",
+        "Name": "[first(split(parameters('skuNotifier'), ' '))]"
       },
       "properties": {
         "name": "[variables('notificationsPlanName')]",
@@ -3112,8 +3160,8 @@
         "DeploymentScript": "[parameters('deploymentScript')]"
       },
       "sku": {
-        "Tier": "Standard",
-        "Name": "S1"
+        "Tier": "[first(skip(split(parameters('skuPublisher'), ' '), 1))]",
+        "Name": "[first(split(parameters('skuPublisher'), ' '))]"
       },
       "properties": {
         "name": "[variables('publisherPlanName')]",


### PR DESCRIPTION
This PR proposes changes to the app service plans to take advantage of Premium v2 plans which offer better performance for similar prices.

This change is being made now after investigating slow Fast Track pages in [EES-3412](https://dfedigital.atlassian.net/browse/EES-3412) which found that slow requests in the Public app service are not because of slow dependent API requests like getting the fast track table result but because the app service appears to be constrained by available CPU resource.

Looking at the metric of CPU percentage it appears the public app service is regularly hitting 100%, so much so that on a chart of the last 30 days, it looks like a continuous line barely dipping below 100%.

![image-20221028-160939](https://user-images.githubusercontent.com/4147126/199056124-7e44afd8-bd44-41d0-b06d-3da9cd520d7b.png)

Standard plans are based on A-series compute equivalent VM's which Azure recommend for entry level workloads like dev and test, low-traffic web servers, small to medium databases and proof of concepts.

The Premium V2 service plans are based on Dv2-series compute equivalent VM's featuring a more powerful CPU and optimal CPU-to-memory configuration making them more suitable. 

How do the plans compare?

|Plan|Total ACU|Cores|Memory|
|----|----|----|----|
|B1*|100|1|1.75 Gb|
|S1|100|1|1.75 Gb|
|S2|200|2|3.50 Gb|
|S3|400|4|7 Gb|
|P1V2|210|1|3.50 Gb|
|P2V2|420|2|7 Gb|
|P3V2|840|4|14 Gb|

\* Basic tier B1 plan is not suitable for Production workloads.

> ACU is currently standardized on a Small (Standard_A1) VM being 100 and all other SKUs then represent approximately how much faster that SKU can run a standard benchmark.

# Proposed changes

* Generally any plan currently S1 or S2 is changed to P1V2.
* Generally any plan currently S3 is changed to P2V2.
* Notifier and Publisher are changed from S1 Standard to B1 Basic in Dev and Test and remain S1 in Pre-Prod and Prod.

# Before and after matrix

|Env|Service|Before|After|
|----|------|------|-----|
|Dev|Public|B1|B1|
|Dev|Data|S1|**P1V2**|
|Dev|Content|S1|**P1V2**|
|Dev|Admin|S2|**P1V2**|
|Dev|Importer|S3|**P2V2**|
|Dev|Notifier|S1|**B1**|
|Dev|Publisher|S1|**B1**|
|||||
|||||
|Test|Public|B1|B1|
|Test|Data|S1|**P1V2**|
|Test|Content|S1|**P1V2**|
|Test|Admin|S2|**P1V2**|
|Test|Importer|S2|**P1V2**|
|Test|Notifier|S1|**B1**|
|Test|Publisher|S1|**B1**|
|||||
|||||
|Pre-Prod|Public|S1|**P1V2**|
|Pre-Prod|Data|S2|**P1V2**|
|Pre-Prod|Content|S1|**P1V2**|
|Pre-Prod|Admin|S2|**P1V2**|
|Pre-Prod|Importer|S2|**P1V2**|
|Pre-Prod|Notifier|S1|S1|
|Pre-Prod|Publisher|S1|S1|
|||||
|||||
|Prod|Public|S1|**P1V2**|
|Prod|Data|S2|**P1V2**|
|Prod|Content|S3*|**P1V2**|
|Prod|Admin|S2|**P1V2**|
|Prod|Importer|S3|**P2V2**|
|Prod|Notifier|S1|S1|
|Prod|Publisher|S1|S1|

\* Prod Content API is S1 in the ARM template but has been manually scaled at S3 since 18/10/22. This PR proposes changing it to P1V2.