### PR TITLE
EES-2867 handle details open state

### DIFF
--- a/src/explore-education-statistics-common/src/components/Details.tsx
+++ b/src/explore-education-statistics-common/src/components/Details.tsx
@@ -64,14 +64,12 @@ const Details = ({
   }, []);
 
   useEffect(() => {
-    toggleOpen(defaultOpen);
-  }, [defaultOpen, toggleOpen]);
-
-  useEffect(() => {
     if (preventToggle) {
       toggleOpen(true);
+      return;
     }
-  }, [preventToggle, toggleOpen]);
+    toggleOpen(defaultOpen);
+  }, [defaultOpen, preventToggle, toggleOpen]);
 
   useEffect(() => {
     if (hasNativeDetails) {
@@ -109,7 +107,7 @@ const Details = ({
           event.preventDefault();
           if (!preventToggle) {
             onToggle?.(!open);
-            toggleOpen(!open);
+            toggleOpen();
           }
         }}
         onKeyPress={event => {

--- a/src/explore-education-statistics-common/src/components/__tests__/Details.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Details.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import Details from '../Details';
 
@@ -54,6 +55,8 @@ describe('Details', () => {
       'false',
     );
 
+    expect(screen.getByText('Test content')).toBeVisible();
+
     expect(container.innerHTML).toMatchSnapshot();
   });
 
@@ -71,11 +74,13 @@ describe('Details', () => {
 
     expect(summary).toHaveAttribute('aria-expanded', 'false');
     expect(content).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByText('Test content')).not.toBeVisible();
 
-    fireEvent.click(summary);
+    userEvent.click(summary);
 
     expect(summary).toHaveAttribute('aria-expanded', 'true');
     expect(content).toHaveAttribute('aria-hidden', 'false');
+    expect(screen.getByText('Test content')).toBeVisible();
   });
 
   test('clicking the summary collapses the content when `open` is true', () => {
@@ -92,11 +97,13 @@ describe('Details', () => {
 
     expect(summary).toHaveAttribute('aria-expanded', 'true');
     expect(content).toHaveAttribute('aria-hidden', 'false');
+    expect(screen.getByText('Test content')).toBeVisible();
 
-    fireEvent.click(summary);
+    userEvent.click(summary);
 
     expect(summary).toHaveAttribute('aria-expanded', 'false');
     expect(content).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByText('Test content')).not.toBeVisible();
   });
 
   test('changing `open` prop from false to true reveals the content', async () => {
@@ -113,6 +120,7 @@ describe('Details', () => {
 
     expect(summary).toHaveAttribute('aria-expanded', 'false');
     expect(content).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByText('Test content')).not.toBeVisible();
 
     rerender(
       <Details summary="Test summary" id="test-details" open>
@@ -122,6 +130,7 @@ describe('Details', () => {
 
     expect(summary).toHaveAttribute('aria-expanded', 'true');
     expect(content).toHaveAttribute('aria-hidden', 'false');
+    expect(screen.getByText('Test content')).toBeVisible();
   });
 
   test('changing `open` prop from true to false hides the content', () => {
@@ -138,6 +147,7 @@ describe('Details', () => {
 
     expect(summary).toHaveAttribute('aria-expanded', 'true');
     expect(content).toHaveAttribute('aria-hidden', 'false');
+    expect(screen.getByText('Test content')).toBeVisible();
 
     rerender(
       <Details summary="Test summary" id="test-details">
@@ -147,6 +157,7 @@ describe('Details', () => {
 
     expect(summary).toHaveAttribute('aria-expanded', 'false');
     expect(content).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByText('Test content')).not.toBeVisible();
   });
 
   test('onToggle handler returns true when expanded', () => {
@@ -164,13 +175,10 @@ describe('Details', () => {
 
     expect(summary).toHaveAttribute('aria-expanded', 'false');
 
-    fireEvent.click(summary);
+    userEvent.click(summary);
 
     expect(summary).toHaveAttribute('aria-expanded', 'true');
-    expect(handleToggle).toHaveBeenCalledWith(
-      true,
-      expect.objectContaining({ target: summary }),
-    );
+    expect(handleToggle).toHaveBeenCalledWith(true);
   });
 
   test('onToggle handler returns false when collapsed', () => {
@@ -186,19 +194,11 @@ describe('Details', () => {
       name: 'Test summary',
     });
 
-    fireEvent.click(summary);
-    fireEvent.click(summary);
+    userEvent.click(summary);
+    userEvent.click(summary);
 
-    expect(handleToggle).toHaveBeenNthCalledWith(
-      1,
-      true,
-      expect.objectContaining({ target: summary }),
-    );
-    expect(handleToggle).toHaveBeenNthCalledWith(
-      2,
-      false,
-      expect.objectContaining({ target: summary }),
-    );
+    expect(handleToggle).toHaveBeenNthCalledWith(1, true);
+    expect(handleToggle).toHaveBeenNthCalledWith(2, false);
   });
 
   test('passing a hiddenText prop displays visually hidden text', () => {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldCheckboxGroupsMenu.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldCheckboxGroupsMenu.tsx
@@ -3,7 +3,7 @@ import FormFieldCheckboxSearchSubGroups, {
   FormFieldCheckboxSearchSubGroupsProps,
 } from '@common/components/form/FormFieldCheckboxSearchSubGroups';
 import { useField } from 'formik';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import FormCheckboxSelectionCount from './FormCheckboxSelectedCount';
 
 interface Props<FormValues>
@@ -13,26 +13,14 @@ interface Props<FormValues>
 }
 
 function FormFieldCheckboxGroupsMenu<FormValues>(props: Props<FormValues>) {
-  const { name, legend, open: defaultOpen = false } = props;
-  const [open, setOpen] = useState(defaultOpen);
-
+  const { name, legend, open = false } = props;
   const [, meta] = useField(name);
-
-  useEffect(() => {
-    if (meta.error && meta.touched) {
-      setOpen(true);
-    }
-  }, [meta.error, meta.touched]);
 
   return (
     <DetailsMenu
       open={open}
       jsRequired
-      onToggle={(isOpen, event) => {
-        if (meta.error && meta.touched) {
-          event.preventDefault();
-        }
-      }}
+      preventToggle={!!meta.error && meta.touched}
       summary={legend}
       summaryAfter={<FormCheckboxSelectionCount name={name} />}
     >

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FormFieldCheckboxGroupsMenu.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FormFieldCheckboxGroupsMenu.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
 import noop from 'lodash/noop';
 import React from 'react';
@@ -145,6 +146,7 @@ describe('FormFieldCheckboxGroupsMenu', () => {
     expect(
       screen.getByRole('button', { name: 'Choose options' }),
     ).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('group', { name: 'Choose options' })).toBeVisible();
   });
 
   test('clicking menu does not collapse it if there is a field error', async () => {
@@ -181,9 +183,11 @@ describe('FormFieldCheckboxGroupsMenu', () => {
     const summary = screen.getByRole('button', { name: 'Choose options' });
 
     expect(summary).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('group', { name: 'Choose options' })).toBeVisible();
 
-    fireEvent.click(summary);
+    userEvent.click(summary);
 
     expect(summary).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('group', { name: 'Choose options' })).toBeVisible();
   });
 });


### PR DESCRIPTION
This changes the Details component to work correctly as a React component. Due to a known issue in React this requires preventing the default browser behaviour  so the open state can be controlled. See https://github.com/facebook/react/issues/15486

This fixes a specific bug on the filters step of the table tool where you couldn't open a filter group had an error. 

Also updated the tests to check for the visibility of the content as well as the aria attributes as they were passing incorrectly before.

The expected behaviour when you submit the filters form without selecting filters is:

If the filter group has a total option:
- total is selected
- no error is shown

If the filter group doesn't have a total option:
- an error is shown
- the group is expanded (including if it was closed before the form was submitted)
- you cannot close the group 
- when you select an option in the group the error should disappear and you can close/open the group as normal. 
