### PR TITLE
EES-3412 EES-3850 Scale down Test app services and remove autoscaling config from Pre-pod

### DIFF
--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -33,7 +33,7 @@
       "value": true
     },
     "autoscalePublicApplication": {
-      "value": true
+      "value": false
     },
     "devopsSPN": {
       "value": "702e692e-8bdf-4283-9799-9630cb781e33"

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -6,16 +6,16 @@
       "value": "B1 Basic"
     },
     "skuData": {
-      "value": "P1V2 PremiumV2"
+      "value": "B1 Basic"
     },
     "skuContent": {
-      "value": "P1V2 PremiumV2"
+      "value": "B1 Basic"
     },
     "skuAdmin": {
-      "value": "P1V2 PremiumV2"
+      "value": "B1 Basic"
     },
     "skuImporter": {
-      "value": "P1V2 PremiumV2"
+      "value": "B1 Basic"
     },
     "skuNotifier": {
       "value": "B1 Basic"


### PR DESCRIPTION
This PR makes some cost saving measures by scaling down the Test environment App Service plans to use B1 in the basic pricing tier intended for Dev/Test workloads.

It also removes autoscaling config from Pre-prod which means the Content, Data, and Public app services have previously been running with a minimum of 2 servers.

We can reverse all these changes if necessary and scale them back up when required.