### PR TITLE
EES-3782 Return not found if Fast Track isn't for latest published version of a release

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseExtensionTests.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿#nullable enable
+using System;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using Xunit;
 
@@ -7,114 +7,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
 {
     public class ReleaseExtensionTests
     {
-        [Fact]
-        public void IsLatestPublishedVersionOfRelease_PublicationHasSingleUnpublishedRelease()
-        {
-            var publication = new Publication();
-
-            var release = new Release
-            {
-                Id = Guid.NewGuid(),
-                Publication = publication,
-                Published = null,
-                PreviousVersionId = null
-            };
-
-            publication.Releases = new List<Release>
-            {
-                release
-            };
-
-            Assert.False(release.IsLatestPublishedVersionOfRelease());
-        }
-
-        [Fact]
-        public void IsLatestPublishedVersionOfRelease_PublicationHasSinglePublishedRelease()
-        {
-            var publication = new Publication();
-
-            var release = new Release
-            {
-                Id = Guid.NewGuid(),
-                Publication = publication,
-                Published = DateTime.UtcNow.AddSeconds(-1),
-                PreviousVersionId = null
-            };
-
-            publication.Releases = new List<Release>
-            {
-                release
-            };
-
-            Assert.True(release.IsLatestPublishedVersionOfRelease());
-        }
-
-        [Fact]
-        public void IsLatestPublishedVersionOfRelease_PublicationHasMultipleReleases()
-        {
-            var publication = new Publication();
-
-            // (Release 1) Published but superseded by another published Release
-            var release1Version1 = new Release
-            {
-                Id = Guid.NewGuid(),
-                Publication = publication,
-                Published = DateTime.UtcNow.AddSeconds(-1),
-                PreviousVersionId = null
-            };
-
-            // (Release 1)  Latest published version (superseded by an unpublished Release)
-            var release1Version2 = new Release
-            {
-                Id = Guid.NewGuid(),
-                Publication = publication,
-                Published = DateTime.UtcNow.AddSeconds(-1),
-                PreviousVersionId = release1Version1.Id
-            };
-
-            // (Release 1) Unpublished
-            var release1Version3 = new Release
-            {
-                Id = Guid.NewGuid(),
-                Publication = publication,
-                Published = null,
-                PreviousVersionId = release1Version2.Id
-            };
-
-            // (Release 2) Latest published version
-            var release2 = new Release
-            {
-                Id = Guid.NewGuid(),
-                Publication = publication,
-                Published = DateTime.UtcNow.AddSeconds(-1),
-                PreviousVersionId = null
-            };
-
-            // (Release 3) Unpublished
-            var release3 = new Release
-            {
-                Id = Guid.NewGuid(),
-                Publication = publication,
-                Published = null,
-                PreviousVersionId = null
-            };
-
-            publication.Releases = new List<Release>
-            {
-                release1Version1,
-                release1Version2,
-                release1Version3,
-                release2,
-                release3
-            };
-
-            Assert.False(release1Version1.IsLatestPublishedVersionOfRelease());
-            Assert.True(release1Version2.IsLatestPublishedVersionOfRelease());
-            Assert.False(release1Version3.IsLatestPublishedVersionOfRelease());
-            Assert.True(release2.IsLatestPublishedVersionOfRelease());
-            Assert.False(release3.IsLatestPublishedVersionOfRelease());
-        }
-
         [Fact]
         public void AllFilesZipPath()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/PublicationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/PublicationTests.cs
@@ -28,7 +28,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                         Published = DateTime.UtcNow.AddDays(-2),
                         PreviousVersion = null,
                         ApprovalStatus = Approved,
-
                     },
                     new()
                     {
@@ -76,7 +75,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                         TimePeriodCoverage = AcademicYear,
                         Published = DateTime.UtcNow,
                         ApprovalStatus = Approved,
-
                     },
                     new()
                     {
@@ -121,7 +119,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                         Published = null,
                         PreviousVersion = null,
                         ApprovalStatus = Draft,
-
                     },
                 },
             };
@@ -149,7 +146,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                         TimePeriodCoverage = AcademicYear,
                         Published = DateTime.UtcNow,
                         ApprovalStatus = Approved,
-
                     },
                     new()
                     {
@@ -293,6 +289,114 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
             Assert.False(publication.IsLatestVersionOfRelease(release2001Amendment.Id));
             Assert.True(publication.IsLatestVersionOfRelease(release2001Latest.Id));
             Assert.True(publication.IsLatestVersionOfRelease(release2002Latest.Id));
+        }
+
+        [Fact]
+        public void IsLatestPublishedVersionOfRelease_PublicationHasSingleUnpublishedRelease()
+        {
+            var publication = new Publication();
+
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                Published = null,
+                PreviousVersionId = null
+            };
+
+            publication.Releases = new List<Release>
+            {
+                release
+            };
+
+            Assert.False(publication.IsLatestPublishedVersionOfRelease(release));
+        }
+
+        [Fact]
+        public void IsLatestPublishedVersionOfRelease_PublicationHasSinglePublishedRelease()
+        {
+            var publication = new Publication();
+
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                Published = DateTime.UtcNow.AddSeconds(-1),
+                PreviousVersionId = null
+            };
+
+            publication.Releases = new List<Release>
+            {
+                release
+            };
+
+            Assert.True(publication.IsLatestPublishedVersionOfRelease(release));
+        }
+
+        [Fact]
+        public void IsLatestPublishedVersionOfRelease_PublicationHasMultipleReleases()
+        {
+            var publication = new Publication();
+
+            // (Release 1) Published but superseded by another published Release
+            var release1Version1 = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                Published = DateTime.UtcNow.AddSeconds(-1),
+                PreviousVersionId = null
+            };
+
+            // (Release 1)  Latest published version (superseded by an unpublished Release)
+            var release1Version2 = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                Published = DateTime.UtcNow.AddSeconds(-1),
+                PreviousVersionId = release1Version1.Id
+            };
+
+            // (Release 1) Unpublished
+            var release1Version3 = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                Published = null,
+                PreviousVersionId = release1Version2.Id
+            };
+
+            // (Release 2) Latest published version
+            var release2 = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                Published = DateTime.UtcNow.AddSeconds(-1),
+                PreviousVersionId = null
+            };
+
+            // (Release 3) Unpublished
+            var release3 = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                Published = null,
+                PreviousVersionId = null
+            };
+
+            publication.Releases = new List<Release>
+            {
+                release1Version1,
+                release1Version2,
+                release1Version3,
+                release2,
+                release3
+            };
+
+            Assert.False(publication.IsLatestPublishedVersionOfRelease(release1Version1));
+            Assert.True(publication.IsLatestPublishedVersionOfRelease(release1Version2));
+            Assert.False(publication.IsLatestPublishedVersionOfRelease(release1Version3));
+            Assert.True(publication.IsLatestPublishedVersionOfRelease(release2));
+            Assert.False(publication.IsLatestPublishedVersionOfRelease(release3));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseExtensions.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 using System;
-using System.Linq;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 
@@ -35,20 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
         /// <returns>True if the Release is the latest published version of a Release</returns>
         public static bool IsLatestPublishedVersionOfRelease(this Release release)
         {
-            if (release.Publication?.Releases == null || !release.Publication.Releases.Any())
-            {
-                throw new ArgumentException(
-                    "Release must be hydrated with Publications Releases to test the latest published version");
-            }
-
-            return
-                // Release itself must be live
-                release.Live
-                // It must also be the latest version unless the later version is a draft
-                && !release.Publication.Releases.Any(r =>
-                    r.Live
-                    && r.PreviousVersionId == release.Id
-                    && r.Id != release.Id);
+            return release.Publication.IsLatestPublishedVersionOfRelease(release);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -82,7 +82,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
                 .ToList();
         }
 
-        private bool IsLatestPublishedVersionOfRelease(Release release)
+        public bool IsLatestPublishedVersionOfRelease(Release release)
         {
             if (Releases == null || !Releases.Any())
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseRepository.cs
@@ -9,4 +9,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 public interface IReleaseRepository
 {
     Task<Either<ActionResult, Release>> GetLatestPublishedRelease(Guid publicationId);
+
+    Task<bool> IsLatestPublishedVersionOfRelease(Guid releaseId);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseRepository.cs
@@ -18,6 +18,18 @@ public class ReleaseRepository : IReleaseRepository
         _contentDbContext = contentDbContext;
     }
 
+    public async Task<bool> IsLatestPublishedVersionOfRelease(Guid releaseId)
+    {
+        var release = await _contentDbContext.Releases
+            .SingleAsync(r => r.Id == releaseId);
+
+        var publication = await _contentDbContext.Publications
+            .Include(p => p.Releases)
+            .SingleAsync(p => p.Id == release.PublicationId);
+
+        return publication.IsLatestPublishedVersionOfRelease(release);
+    }
+
     public async Task<Either<ActionResult, Release>> GetLatestPublishedRelease(Guid publicationId)
     {
         var publication = await _contentDbContext.Publications

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
@@ -330,6 +330,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                 .ReturnsAsync(_tableBuilderResults);
 
             mocks.releaseRepository
+                .Setup(s => s.IsLatestPublishedVersionOfRelease(ReleaseId))
+                .ReturnsAsync(true);
+
+            mocks.releaseRepository
                 .Setup(s => s.GetLatestPublishedRelease(PublicationId))
                 .ReturnsAsync(latestRelease);
 
@@ -354,6 +358,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             Assert.Equal(ObservationQueryContext.Filters, viewModel.Query.Filters);
             Assert.Equal(ObservationQueryContext.Indicators, viewModel.Query.Indicators);
             Assert.Equal(ObservationQueryContext.LocationIds, viewModel.Query.LocationIds);
+        }
+
+        [Fact]
+        public async Task QueryForFastTrack_NotForLatestPublishedVersionOfRelease()
+        {
+            var (controller, mocks) = BuildControllerAndDependencies();
+
+            SetupCall(mocks.persistenceHelper, ReleaseContentBlock);
+
+            mocks.releaseRepository
+                .Setup(s => s.IsLatestPublishedVersionOfRelease(ReleaseId))
+                .ReturnsAsync(false);
+
+            var result = await controller.QueryForFastTrack(DataBlockId);
+
+            VerifyAllMocks(mocks);
+
+            result.AssertNotFoundResult();
         }
 
         [Fact]
@@ -383,6 +405,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             mocks.dataBlockService
                 .Setup(s => s.GetDataBlockTableResult(ReleaseId, DataBlockId))
                 .ReturnsAsync(_tableBuilderResults);
+
+            mocks.releaseRepository
+                .Setup(s => s.IsLatestPublishedVersionOfRelease(ReleaseId))
+                .ReturnsAsync(true);
 
             mocks.releaseRepository
                 .Setup(s => s.GetLatestPublishedRelease(PublicationId))


### PR DESCRIPTION
This PR fixes a bug where requesting a Fast Track (data block id) that's not for the latest published version of the release returns a 500 error.

This was because the user didn't have permission to view that release when getting the data block table result.

We now check early if the data block is for the latest published version of the release and if not, return not found.