### PR TITLE
EES-2073 fix data block update bug

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -191,6 +191,17 @@ const DataBlockPageTabs = ({
         }
       });
 
+      await handleDataBlockSave({
+        ...(dataBlock ?? {}),
+        ...details,
+        query,
+        charts,
+        table: {
+          tableHeaders: mapUnmappedTableHeaders(tableHeaders),
+          indicators: [],
+        },
+      });
+
       setTableState({
         value: {
           ...tableState,
@@ -200,17 +211,6 @@ const DataBlockPageTabs = ({
             table,
             tableHeaders,
           },
-        },
-      });
-
-      await handleDataBlockSave({
-        ...(dataBlock ?? {}),
-        ...details,
-        query,
-        charts,
-        table: {
-          tableHeaders: mapUnmappedTableHeaders(tableHeaders),
-          indicators: [],
         },
       });
     },


### PR DESCRIPTION
Fixes a bug where changing data block options caused an error because existing datasets used filters that were no longer selected. Invalid datasets were removed from the chart correctly but the table state was updating before the data block which caused the error (if you refreshed the page there was no error).