### PR TITLE
EES-3412 Change Test env content, data & admin app services to use standard pricing plans

### DIFF
--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -6,13 +6,13 @@
       "value": "B1 Basic"
     },
     "skuData": {
-      "value": "B1 Basic"
+      "value": "S1 Standard"
     },
     "skuContent": {
-      "value": "B1 Basic"
+      "value": "S1 Standard"
     },
     "skuAdmin": {
-      "value": "B1 Basic"
+      "value": "S1 Standard"
     },
     "skuImporter": {
       "value": "B1 Basic"


### PR DESCRIPTION
This PR changes the Content, Data and Admin app services to use standard S1 service plan rather than B1 which doesn't support staging slots.

This was discovered after deploying https://github.com/dfe-analytical-services/explore-education-statistics/pull/3594 to Test which resulted in the error `The site(s) ... exceed maximum number of slots allowed for the hosting plan. Remove all deployment slots before scaling to a different mode.`