### PR TITLE
EES-257 lowercase data label position

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
@@ -3,18 +3,19 @@ using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.Chart.ChartType;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
 {
 
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter), typeof(CamelCaseNamingStrategy))]
     public enum BarChartDataLabelPosition
     {
         Inside, Outside
     }
 
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter), typeof(CamelCaseNamingStrategy))]
     public enum LineChartDataLabelPosition
     {
         Above, Below


### PR DESCRIPTION
A fix to return the data label position from the back end in camelcase. Previously it was capitalised causing the frontend to not match it when populating the position select.

Original PR for reference: https://github.com/dfe-analytical-services/explore-education-statistics/pull/3570