### PR TITLE
EES-3867 - increase prod stats DB size by 300GB

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -84,7 +84,7 @@
       "value": 2147483648
     },
     "maxStatsDbSizeBytes": {
-      "value": 697932185600
+      "value": 1020054732800
     }
   }
 }


### PR DESCRIPTION
This PR: 
* Increase the prod statistics DB size by 300GB. I've used the following sum to calculate this: 

```
1073741824 x 300
``` 

References: 
https://learn.microsoft.com/en-us/azure/azure-sql/database/single-database-scale?view=azuresql#vcore-based-purchasing-model