### PR TITLE
EES-3869 hide map custom groups option

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartMapConfiguration.tsx
@@ -204,11 +204,12 @@ export default function ChartMapConfiguration({
                 hint:
                   'Data is classified so that each group roughly has the same quantity of features.',
               },
-              {
-                label: 'Custom',
-                value: 'Custom',
-                hint: 'Define custom groups.',
-              },
+              // EES-3858 - removed until feature is reimplemented
+              // {
+              //   label: 'Custom',
+              //   value: 'Custom',
+              //   hint: 'Define custom groups.',
+              // },
             ]}
             order={[]}
           />
@@ -222,7 +223,8 @@ export default function ChartMapConfiguration({
             />
           )}
 
-          {form.values.dataClassification === 'Custom' && (
+          {/* EES-3858 - removed until feature is reimplemented
+           {form.values.dataClassification === 'Custom' && (
             <ChartMapCustomGroupsConfiguration
               groups={form.values.customDataGroups ?? []}
               id={`${formId}-customDataGroups`}
@@ -248,7 +250,7 @@ export default function ChartMapConfiguration({
                 )
               }
             />
-          )}
+          )} */}
 
           <ChartBuilderSaveActions
             formId={formId}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartMapConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartMapConfiguration.test.tsx
@@ -91,7 +91,6 @@ describe('ChartMapConfiguration', () => {
     // Data classification
     expect(screen.getByLabelText('Equal intervals')).not.toBeChecked();
     expect(screen.getByLabelText('Quantiles')).not.toBeChecked();
-    expect(screen.getByLabelText('Custom')).not.toBeChecked();
 
     expect(screen.getByLabelText('Number of data groups')).not.toHaveValue();
   });
@@ -117,7 +116,6 @@ describe('ChartMapConfiguration', () => {
     // Data classification
     expect(screen.getByLabelText('Equal intervals')).toBeChecked();
     expect(screen.getByLabelText('Quantiles')).not.toBeChecked();
-    expect(screen.getByLabelText('Custom')).not.toBeChecked();
 
     expect(screen.getByLabelText('Number of data groups')).toHaveValue(6);
   });
@@ -308,7 +306,8 @@ describe('ChartMapConfiguration', () => {
     });
   });
 
-  describe('custom data groups', () => {
+  // EES-3858 - skipped until feature is reimplemented
+  describe.skip('custom data groups', () => {
     test('adding groups', async () => {
       render(
         <ChartMapConfiguration


### PR DESCRIPTION
Hide the maps custom data groups option until it can be reimplemented in https://dfedigital.atlassian.net/browse/EES-3858