### PR TITLE
EES-3871 Inject publisher client id/secret via Key Vault reference

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -520,19 +520,6 @@
         "description": "Prerelease end time as number of minutes before a release is scheduled to be published"
       }
     },
-    "publisherClientId": {
-      "type": "string",
-      "metadata": {
-        "description": "Publisher Active Directory Application Client Id used for authentication requests"
-      }
-    },
-    "publisherClientSecret": {
-      "type": "string",
-      "metadata": {
-        "description": "Publisher Active Directory Application Client secret used to prove its identity during authentication requests"
-      }
-    },
-
     "publisherPipelineName": {
       "type": "string",
       "defaultValue": "pl_release_statistics",
@@ -3279,12 +3266,12 @@
       ],
       "properties": {
         "AzureWebJobsDashboard": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher')).secretUriWithVersion, ')')]",
-        "AzureWebJobsStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher')).secretUriWithVersion, ')')]",        
+        "AzureWebJobsStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher')).secretUriWithVersion, ')')]",
         "AzureWebJobs.PublishReleaseData.Disabled": "[parameters('publishReleaseDataFunctionDisabled')]",
         "PublishReleasesCronSchedule": "[parameters('publishReleasesCronSchedule')]",
         "PublishReleaseContentCronSchedule": "[parameters('publishReleaseContentCronSchedule')]",
-        "ClientId": "[parameters('publisherClientId')]",
-        "ClientSecret": "[parameters('publisherClientSecret')]",
+        "ClientId": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-publisher-clientid')).secretUriWithVersion, ')')]",
+        "ClientSecret": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-publisher-clientsecret')).secretUriWithVersion, ')')]",
         "DataFactoryName": "[variables('dataFactoryName')]",
         "PipelineName": "[parameters('publisherPipelineName')]",
         "ResourceGroupName": "[resourceGroup().name]",


### PR DESCRIPTION
This removes the previous usage of parameters (`publisherClientId` and `publisherClientSecret`) from DevOps as these are prone to faulty interpolation, and they are less secure than a Key Vault reference.