### PR TITLE
EES-2946 reference line label position

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
@@ -71,6 +71,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
         
         [JsonConverter(typeof(StringEnumConverter))]
         public AxisReferenceLineStyle? Style;
+
+        public int? OtherAxisPosition;
     }
 
     [SuppressMessage("ReSharper", "InconsistentNaming")]

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -71,6 +71,8 @@ const ChartAxisConfiguration = ({
     submitForms,
   } = useChartBuilderFormsContext();
 
+  const axisDefinition = definition.axes[type];
+
   const dataSetCategories = useMemo<DataSetCategory[]>(() => {
     if (type === 'minor') {
       return [];
@@ -192,8 +194,6 @@ const ChartAxisConfiguration = ({
   );
 
   const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
-    const axisDefinition = definition.axes[type];
-
     let schema: ObjectSchema<FormValues> = Yup.object({
       size: Yup.number().positive('Size of axis must be positive'),
       tickConfig: Yup.string().oneOf<TickConfig>(
@@ -259,10 +259,11 @@ const ChartAxisConfiguration = ({
 
     return schema;
   }, [
+    axisDefinition,
     capabilities.canSort,
     capabilities.hasGridLines,
     capabilities.hasReferenceLines,
-    definition.axes,
+    definition.axes.major,
     type,
   ]);
 
@@ -509,9 +510,8 @@ const ChartAxisConfiguration = ({
 
           {validationSchema.fields.referenceLines && (
             <ChartReferenceLinesConfiguration
-              axisType={type}
+              axisDefinition={axisDefinition}
               dataSetCategories={dataSetCategories}
-              definition={definition}
               id={id}
               lines={form.values.referenceLines ?? []}
               onAddLine={line => {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartReferenceLinesConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartReferenceLinesConfiguration.test.tsx
@@ -3,7 +3,6 @@ import ChartReferenceLinesConfiguration, {
   ChartReferenceLinesConfigurationProps,
 } from '@admin/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration';
 import createDataSetCategories from '@common/modules/charts/util/createDataSetCategories';
-import { lineChartBlockDefinition } from '@common/modules/charts/components/LineChartBlock';
 import {
   AxisConfiguration,
   ChartDefinitionAxis,
@@ -66,6 +65,25 @@ describe('ChartReferenceLinesConfiguration', () => {
     },
   };
 
+  const testMajorAxisDefinition: ChartDefinitionAxis = {
+    axis: 'x',
+    id: 'xaxis',
+    title: 'X Axis (major axis)',
+    type: 'major',
+    capabilities: {
+      canRotateLabel: false,
+    },
+  };
+  const testMinorAxisDefinition: ChartDefinitionAxis = {
+    axis: 'y',
+    id: 'yaxis',
+    title: 'Y Axis (minor axis)',
+    type: 'minor',
+    capabilities: {
+      canRotateLabel: true,
+    },
+  };
+
   const testTable = testFullTable;
   const testTimePeriodDataSetCategories = createDataSetCategories(
     {
@@ -79,9 +97,8 @@ describe('ChartReferenceLinesConfiguration', () => {
   test('renders correctly with existing lines when grouped by time periods', () => {
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[{ position: '2014_AY', label: 'Test label 1' }]}
         onAddLine={noop}
@@ -111,7 +128,6 @@ describe('ChartReferenceLinesConfiguration', () => {
   test('renders correctly with existing lines when grouped by filters', () => {
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={createDataSetCategories(
           {
             ...testAxisConfiguration,
@@ -120,7 +136,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[
           { position: 'ethnicity-major-chinese', label: 'Test label 1' },
@@ -162,7 +178,6 @@ describe('ChartReferenceLinesConfiguration', () => {
   test('renders correctly with existing lines when grouped by locations', () => {
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={createDataSetCategories(
           {
             ...testAxisConfiguration,
@@ -171,7 +186,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[{ position: 'barnet', label: 'Test label 1' }]}
         onAddLine={noop}
@@ -202,7 +217,6 @@ describe('ChartReferenceLinesConfiguration', () => {
   test('renders correctly with existing lines when grouped by indicators', () => {
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={createDataSetCategories(
           {
             ...testAxisConfiguration,
@@ -211,7 +225,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[
           { position: 'overall-absence-sessions', label: 'Test label 1' },
@@ -248,9 +262,8 @@ describe('ChartReferenceLinesConfiguration', () => {
   test('renders correctly with existing lines for minor axis', () => {
     render(
       <ChartReferenceLinesConfiguration
-        axisType="minor"
         dataSetCategories={[]}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMinorAxisDefinition}
         id="test-form"
         lines={[
           { position: 2000, label: 'Test label 1' },
@@ -277,9 +290,8 @@ describe('ChartReferenceLinesConfiguration', () => {
   test('shows validation error when `Position` is empty', async () => {
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[]}
         onAddLine={noop}
@@ -306,9 +318,8 @@ describe('ChartReferenceLinesConfiguration', () => {
   test('shows validation error when `Label` is empty', async () => {
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[]}
         onAddLine={noop}
@@ -333,9 +344,8 @@ describe('ChartReferenceLinesConfiguration', () => {
   test('shows error messages when adding reference line with invalid values', async () => {
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[]}
         onAddLine={noop}
@@ -367,9 +377,8 @@ describe('ChartReferenceLinesConfiguration', () => {
   test('default value for `Style` field is dashed', async () => {
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[]}
         onAddLine={noop}
@@ -388,18 +397,11 @@ describe('ChartReferenceLinesConfiguration', () => {
   test('can set default value for reference line `Style` field via chart definition', async () => {
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
-        definition={{
-          ...lineChartBlockDefinition,
-          axes: {
-            major: {
-              ...lineChartBlockDefinition.axes?.major,
-              referenceLineDefaults: {
-                style: 'none',
-              },
-            } as ChartDefinitionAxis,
-            minor: lineChartBlockDefinition.axes.minor,
+        axisDefinition={{
+          ...testMajorAxisDefinition,
+          referenceLineDefaults: {
+            style: 'none',
           },
         }}
         id="test-form"
@@ -422,9 +424,8 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[]}
         onAddLine={handleAddLine}
@@ -464,7 +465,6 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={createDataSetCategories(
           {
             ...testAxisConfiguration,
@@ -473,7 +473,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[]}
         onAddLine={handleAddLine}
@@ -511,7 +511,6 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={createDataSetCategories(
           {
             ...testAxisConfiguration,
@@ -520,7 +519,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[]}
         onAddLine={handleAddLine}
@@ -558,7 +557,6 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={createDataSetCategories(
           {
             ...testAxisConfiguration,
@@ -567,7 +565,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[]}
         onAddLine={handleAddLine}
@@ -605,9 +603,8 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="minor"
         dataSetCategories={[]}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMinorAxisDefinition}
         id="test-form"
         lines={[]}
         onAddLine={handleAddLine}
@@ -642,9 +639,8 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[]}
         onAddLine={handleAddLine}
@@ -687,9 +683,8 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[
           { position: '2014_AY', label: 'Test label 1' },
@@ -717,9 +712,8 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={testTimePeriodDataSetCategories}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[
           { position: '2014_AY', label: 'Test label 1' },
@@ -756,7 +750,6 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={createDataSetCategories(
           {
             ...testAxisConfiguration,
@@ -765,7 +758,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[
           { position: 'state-funded-primary', label: 'Test label 1' },
@@ -803,7 +796,6 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={createDataSetCategories(
           {
             ...testAxisConfiguration,
@@ -812,7 +804,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[
           { position: 'barnet', label: 'Test label 1' },
@@ -849,7 +841,6 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="major"
         dataSetCategories={createDataSetCategories(
           {
             ...testAxisConfiguration,
@@ -858,7 +849,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.results,
           testTable.subjectMeta,
         )}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMajorAxisDefinition}
         id="test-form"
         lines={[
           { position: 'authorised-absence-sessions', label: 'Test label 1' },
@@ -895,9 +886,8 @@ describe('ChartReferenceLinesConfiguration', () => {
 
     render(
       <ChartReferenceLinesConfiguration
-        axisType="minor"
         dataSetCategories={[]}
-        definition={lineChartBlockDefinition}
+        axisDefinition={testMinorAxisDefinition}
         id="test-form"
         lines={[
           { position: 1000, label: 'Test label 1' },
@@ -926,6 +916,76 @@ describe('ChartReferenceLinesConfiguration', () => {
       >({
         label: 'Test label 2',
         position: 2000,
+      });
+    });
+  });
+
+  test('setting the other axis position on a major axis reference line', async () => {
+    const handleAddLine = jest.fn();
+
+    render(
+      <ChartReferenceLinesConfiguration
+        dataSetCategories={testTimePeriodDataSetCategories}
+        axisDefinition={testMajorAxisDefinition}
+        id="test-form"
+        lines={[]}
+        onAddLine={handleAddLine}
+        onRemoveLine={noop}
+      />,
+    );
+
+    userEvent.selectOptions(screen.getByLabelText('Position'), '2015_AY');
+    userEvent.type(screen.getByLabelText('Label'), 'Test label');
+    userEvent.type(screen.getByLabelText('Y axis position'), '20000');
+
+    expect(handleAddLine).not.toHaveBeenCalled();
+
+    userEvent.click(screen.getByRole('button', { name: 'Add line' }));
+
+    await waitFor(() => {
+      expect(handleAddLine).toHaveBeenCalledTimes(1);
+      expect(handleAddLine).toHaveBeenCalledWith<
+        Parameters<ChartReferenceLinesConfigurationProps['onAddLine']>
+      >({
+        label: 'Test label',
+        otherAxisPosition: 20000,
+        position: '2015_AY',
+        style: 'dashed',
+      });
+    });
+  });
+
+  test('setting the other axis position on a minor axis reference line', async () => {
+    const handleAddLine = jest.fn();
+
+    render(
+      <ChartReferenceLinesConfiguration
+        dataSetCategories={[]}
+        axisDefinition={testMinorAxisDefinition}
+        id="test-form"
+        lines={[]}
+        onAddLine={handleAddLine}
+        onRemoveLine={noop}
+      />,
+    );
+
+    userEvent.type(screen.getByLabelText('Position'), '40000');
+    userEvent.type(screen.getByLabelText('Label'), 'Test label');
+    userEvent.type(screen.getByLabelText('X axis position'), '75');
+
+    expect(handleAddLine).not.toHaveBeenCalled();
+
+    userEvent.click(screen.getByRole('button', { name: 'Add line' }));
+
+    await waitFor(() => {
+      expect(handleAddLine).toHaveBeenCalledTimes(1);
+      expect(handleAddLine).toHaveBeenCalledWith<
+        Parameters<ChartReferenceLinesConfigurationProps['onAddLine']>
+      >({
+        label: 'Test label',
+        otherAxisPosition: 75,
+        position: 40000,
+        style: 'dashed',
       });
     });
   });

--- a/src/explore-education-statistics-common/src/modules/charts/components/CustomReferenceLineLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/CustomReferenceLineLabel.tsx
@@ -1,22 +1,38 @@
+import { Axis, AxisType } from '@common/modules/charts/types/chart';
 import { ChartData } from '@common/modules/charts/types/dataSet';
+import getReferenceLineLabelPosition from '@common/modules/charts/components/utils/getReferenceLineLabelPosition';
 import React, { memo } from 'react';
-import { ViewBox } from 'recharts';
+import { AxisDomain, ViewBox } from 'recharts';
 
-interface Props extends ViewBox {
+interface Props {
+  axis: Axis;
+  axisType: AxisType;
   chartData: ChartData[];
   label: string;
+  otherAxisDomain?: [AxisDomain, AxisDomain];
+  otherAxisPosition?: number;
   position: string | number;
+  viewBox?: ViewBox;
 }
 
 const CustomReferenceLineLabel = ({
+  axis,
+  axisType,
   chartData,
   label,
+  otherAxisDomain,
+  otherAxisPosition,
   position,
-  height = 0,
-  width = 0,
-  x = 0,
-  y = 0,
+  viewBox,
 }: Props) => {
+  const labelPosition = getReferenceLineLabelPosition({
+    axis,
+    axisType,
+    otherAxisDomain,
+    otherAxisPosition,
+    viewBox,
+  });
+
   const getTextAnchor = () => {
     if (position === chartData[0].name) {
       return 'start';
@@ -32,8 +48,9 @@ const CustomReferenceLineLabel = ({
   return (
     <text
       className="govuk-!-font-size-16"
-      x={width / 2 + x}
-      y={height / 2 + y}
+      dy={0}
+      x={labelPosition.xPosition}
+      y={labelPosition.yPosition}
       textAnchor={getTextAnchor()}
     >
       <tspan>{label}</tspan>

--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -187,8 +187,12 @@ const HorizontalBarBlock = ({
 
           {axes.major.referenceLines?.map(referenceLine =>
             createReferenceLine({
+              axis: 'y',
+              axisType: 'major',
               chartData,
               label: referenceLine.label,
+              otherAxisDomain: minorDomainTicks.domain,
+              otherAxisPosition: referenceLine.otherAxisPosition,
               position: referenceLine.position,
               style: referenceLine.style,
               y: referenceLine.position,
@@ -197,8 +201,12 @@ const HorizontalBarBlock = ({
 
           {axes.minor.referenceLines?.map(referenceLine =>
             createReferenceLine({
+              axis: 'x',
+              axisType: 'minor',
               chartData,
               label: referenceLine.label,
+              otherAxisDomain: majorDomainTicks.domain,
+              otherAxisPosition: referenceLine.otherAxisPosition,
               position: referenceLine.position,
               style: referenceLine.style,
               x: referenceLine.position,
@@ -238,6 +246,7 @@ export const horizontalBarBlockDefinition: ChartDefinition = {
   },
   axes: {
     major: {
+      axis: 'y',
       id: 'major',
       title: 'Y Axis (major axis)',
       type: 'major',
@@ -260,6 +269,7 @@ export const horizontalBarBlockDefinition: ChartDefinition = {
       },
     },
     minor: {
+      axis: 'x',
       id: 'minor',
       title: 'X Axis (minor axis)',
       type: 'minor',

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -227,8 +227,12 @@ const LineChartBlock = ({
 
           {axes.major.referenceLines?.map(referenceLine =>
             createReferenceLine({
+              axis: 'x',
+              axisType: 'major',
               chartData,
               label: referenceLine.label,
+              otherAxisDomain: minorDomainTicks.domain,
+              otherAxisPosition: referenceLine.otherAxisPosition,
               position: referenceLine.position,
               style: referenceLine.style,
               x: referenceLine.position,
@@ -237,8 +241,12 @@ const LineChartBlock = ({
 
           {axes.minor.referenceLines?.map(referenceLine =>
             createReferenceLine({
+              axis: 'y',
+              axisType: 'minor',
               chartData,
               label: referenceLine.label,
+              otherAxisDomain: majorDomainTicks.domain,
+              otherAxisPosition: referenceLine.otherAxisPosition,
               position: referenceLine.position,
               style: referenceLine.style,
               y: referenceLine.position,
@@ -278,6 +286,7 @@ export const lineChartBlockDefinition: ChartDefinition = {
   },
   axes: {
     major: {
+      axis: 'x',
       id: 'xaxis',
       title: 'X Axis (major axis)',
       type: 'major',
@@ -297,6 +306,7 @@ export const lineChartBlockDefinition: ChartDefinition = {
       },
     },
     minor: {
+      axis: 'y',
       id: 'yaxis',
       title: 'Y Axis (minor axis)',
       type: 'minor',

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -186,8 +186,12 @@ const VerticalBarBlock = ({
 
           {axes.major.referenceLines?.map(referenceLine =>
             createReferenceLine({
+              axis: 'x',
+              axisType: 'major',
               chartData,
               label: referenceLine.label,
+              otherAxisDomain: minorDomainTicks.domain,
+              otherAxisPosition: referenceLine.otherAxisPosition,
               position: referenceLine.position,
               style: referenceLine.style,
               x: referenceLine.position,
@@ -196,8 +200,12 @@ const VerticalBarBlock = ({
 
           {axes.minor.referenceLines?.map(referenceLine =>
             createReferenceLine({
+              axis: 'y',
+              axisType: 'minor',
               chartData,
               label: referenceLine.label,
+              otherAxisDomain: majorDomainTicks.domain,
+              otherAxisPosition: referenceLine.otherAxisPosition,
               position: referenceLine.position,
               style: referenceLine.style,
               y: referenceLine.position,
@@ -237,6 +245,7 @@ export const verticalBarBlockDefinition: ChartDefinition = {
   },
   axes: {
     major: {
+      axis: 'x',
       id: 'major',
       title: 'X Axis (major axis)',
       type: 'major',
@@ -259,6 +268,7 @@ export const verticalBarBlockDefinition: ChartDefinition = {
       },
     },
     minor: {
+      axis: 'y',
       id: 'minor',
       title: 'Y Axis (minor axis)',
       type: 'minor',

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/__tests__/getReferenceLineLabelPosition.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/__tests__/getReferenceLineLabelPosition.test.ts
@@ -1,0 +1,121 @@
+import getReferenceLineLabelPosition from '@common/modules/charts/components/utils/getReferenceLineLabelPosition';
+
+describe('getReferenceLineLabelPosition', () => {
+  test('returns the default position for an X axis line when otherAxisPosition is not set', () => {
+    const result = getReferenceLineLabelPosition({
+      axis: 'x',
+      axisType: 'major',
+      otherAxisDomain: [0, 50000],
+      viewBox: {
+        x: 205,
+        y: 20,
+        width: 0,
+        height: 230,
+      },
+    });
+
+    expect(result).toEqual({
+      xPosition: 205,
+      yPosition: 135,
+    });
+  });
+
+  test('returns the default position for an Y axis line when otherAxisPosition is not set', () => {
+    const result = getReferenceLineLabelPosition({
+      axis: 'y',
+      axisType: 'major',
+      otherAxisDomain: [0, 50000],
+      viewBox: {
+        x: 80,
+        y: 218,
+        width: 880,
+        height: 0,
+      },
+    });
+
+    expect(result).toEqual({
+      xPosition: 520,
+      yPosition: 218,
+    });
+  });
+
+  test('returns the correct positions for major X axis lines with an otherAxisPosition', () => {
+    const result = getReferenceLineLabelPosition({
+      axis: 'x',
+      axisType: 'major',
+      otherAxisDomain: [0, 50000],
+      otherAxisPosition: 40000,
+      viewBox: {
+        x: 205,
+        y: 20,
+        width: 0,
+        height: 230,
+      },
+    });
+
+    expect(result).toEqual({
+      xPosition: 205,
+      yPosition: 66,
+    });
+  });
+
+  test('returns the correct positions for minor X axis lines with an otherAxisPosition', () => {
+    const result = getReferenceLineLabelPosition({
+      axis: 'x',
+      axisType: 'minor',
+      otherAxisDomain: [0, 3],
+      otherAxisPosition: 20,
+      viewBox: {
+        x: 424,
+        y: 0,
+        width: 0,
+        height: 250,
+      },
+    });
+
+    expect(result).toEqual({
+      xPosition: 424,
+      yPosition: 200,
+    });
+  });
+
+  test('returns the correct positions for major Y axis lines with an otherAxisPosition', () => {
+    const result = getReferenceLineLabelPosition({
+      axis: 'y',
+      axisType: 'major',
+      otherAxisDomain: [0, 50000],
+      otherAxisPosition: 20000,
+      viewBox: {
+        x: 80,
+        y: 218,
+        width: 880,
+        height: 0,
+      },
+    });
+
+    expect(result).toEqual({
+      xPosition: 432,
+      yPosition: 218,
+    });
+  });
+
+  test('returns the correct positions for minor Y axis lines with an otherAxisPosition', () => {
+    const result = getReferenceLineLabelPosition({
+      axis: 'y',
+      axisType: 'minor',
+      otherAxisDomain: [0, 3],
+      otherAxisPosition: 20,
+      viewBox: {
+        x: 80,
+        y: 158,
+        width: 880,
+        height: 0,
+      },
+    });
+
+    expect(result).toEqual({
+      xPosition: 256,
+      yPosition: 158,
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/createReferenceLine.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/createReferenceLine.tsx
@@ -1,20 +1,32 @@
 import CustomReferenceLineLabel from '@common/modules/charts/components/CustomReferenceLineLabel';
-import { ReferenceLineStyle } from '@common/modules/charts/types/chart';
+import {
+  Axis,
+  AxisType,
+  ReferenceLineStyle,
+} from '@common/modules/charts/types/chart';
 import { ChartData } from '@common/modules/charts/types/dataSet';
 import React, { ReactElement } from 'react';
-import { ReferenceLine, ReferenceLineProps } from 'recharts';
+import { AxisDomain, ReferenceLine, ReferenceLineProps } from 'recharts';
 
 interface Props
   extends Omit<ReferenceLineProps, 'label' | 'position' | 'style'> {
+  axis: Axis;
+  axisType: AxisType;
   chartData: ChartData[];
   label: string;
+  otherAxisDomain?: [AxisDomain, AxisDomain];
+  otherAxisPosition?: number;
   position: string | number;
   style?: ReferenceLineStyle;
 }
 
 export default function createReferenceLine({
+  axis,
   chartData,
   label,
+  otherAxisPosition,
+  otherAxisDomain,
+  axisType,
   position,
   style = 'dashed',
   ...props
@@ -47,11 +59,16 @@ export default function createReferenceLine({
       {...styleProps()}
       {...props}
       key={`${position}_${label}`}
+      position="middle"
       label={(lineProps: ReferenceLineProps) => (
         <CustomReferenceLineLabel
-          {...lineProps.viewBox}
+          viewBox={lineProps.viewBox}
+          axis={axis}
+          axisType={axisType}
           chartData={chartData}
           label={label}
+          otherAxisDomain={otherAxisDomain}
+          otherAxisPosition={otherAxisPosition}
           position={position}
         />
       )}

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/getReferenceLineLabelPosition.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/getReferenceLineLabelPosition.ts
@@ -1,0 +1,47 @@
+import { Axis, AxisType } from '@common/modules/charts/types/chart';
+import { AxisDomain, ViewBox } from 'recharts';
+
+export default function getReferenceLineLabelPosition({
+  axis,
+  axisType,
+  otherAxisDomain = [0, 0],
+  otherAxisPosition,
+  viewBox,
+}: {
+  axis: Axis;
+  axisType: AxisType;
+  otherAxisDomain?: [AxisDomain, AxisDomain];
+  otherAxisPosition?: number;
+  viewBox?: ViewBox;
+}) {
+  const { height = 0, width = 0, x = 0, y = 0 } = viewBox ?? {};
+  const defaultXPosition = axis === 'x' ? x : width / 2 + x;
+  const defaultYPosition = axis === 'y' ? y : height / 2 + y;
+  // otherAxisPosition is set as a percentage on minor axis lines so max is 100.
+  const maxValue = axisType === 'minor' ? 100 : (otherAxisDomain[1] as number);
+
+  // No custom other axis position so default to middle
+  if (otherAxisPosition === undefined || !otherAxisDomain) {
+    return {
+      xPosition: defaultXPosition,
+      yPosition: defaultYPosition,
+    };
+  }
+
+  // Amount to offset from the top on horizontal bar charts so the label is visible when positioned at 100%
+  const yOffset = 15;
+  const yPosition = y + height * ((maxValue - otherAxisPosition) / maxValue);
+
+  return axis === 'y'
+    ? {
+        xPosition: x + width * (otherAxisPosition / maxValue),
+        yPosition: defaultYPosition,
+      }
+    : {
+        xPosition: defaultXPosition,
+        yPosition:
+          axisType === 'minor' && otherAxisPosition === maxValue
+            ? yPosition + yOffset
+            : yPosition,
+      };
+}

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -28,6 +28,7 @@ export type ChartSymbol =
 
 export type LineStyle = 'solid' | 'dashed' | 'dotted';
 
+export type Axis = 'x' | 'y';
 export type AxisGroupBy = 'timePeriod' | 'locations' | 'filters' | 'indicators';
 export type AxisType = 'major' | 'minor';
 export type TickConfig = 'default' | 'startEnd' | 'custom';
@@ -37,6 +38,7 @@ export type BarChartDataLabelPosition = 'inside' | 'outside';
 
 export interface ReferenceLine {
   label: string;
+  otherAxisPosition?: number;
   position: number | string;
   style?: ReferenceLineStyle;
 }
@@ -149,6 +151,7 @@ export interface ChartDefinitionAxisCapabilities {
 }
 
 export interface ChartDefinitionAxis {
+  axis?: Axis;
   id: string;
   title: string;
   type: AxisType;

--- a/src/explore-education-statistics-common/src/modules/charts/util/domainTicks.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/domainTicks.ts
@@ -8,7 +8,7 @@ import parseNumber from '@common/utils/number/parseNumber';
 import omit from 'lodash/omit';
 import { AxisDomain } from 'recharts';
 
-interface DomainTicks {
+export interface DomainTicks {
   domain?: [AxisDomain, AxisDomain];
   ticks?: (string | number)[];
 }


### PR DESCRIPTION
Adds an option to chart reference lines to be able to set the position of the label along the line.

- On reference lines on the major axis the position on the line is set as a value on the other axis (so if X is the major axis you set a value on the Y axis as the vertical position of the label).
- On reference lines on the minor axis the position on the line is set as a percentage of other axis length (so if Y is the minor axis you set a percentage along the x axis to position the label at, with 0% being the start of the axis and 100% the end).  I considered selecting a value on the major axis for lines on the minor axis but that doesn't work so well as you might not have many specific points to choose from on the other axis so wouldn't be able to make very fine-grained adjustments to the position.
- If no position is set the labels default to be in the middle of the line.

![reflines3](https://user-images.githubusercontent.com/81572860/200541137-aba35216-41ef-46ed-9a52-2367ad9cd7ea.PNG)

### Major axis config
![reflines1](https://user-images.githubusercontent.com/81572860/200541150-1a054114-3e60-4476-b787-e1b1dd791ebe.PNG)

### Minor axis config
![reflines2](https://user-images.githubusercontent.com/81572860/200541135-53acde1c-288a-4c27-a017-8ef9c9c2bf4a.PNG)
