### PR TITLE
EES-3886 new colour picker

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
@@ -111,7 +111,7 @@ describe('ChartLegendConfiguration', () => {
     expect(legendItem1.getByLabelText('Label')).toHaveValue(
       'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, Barnet)',
     );
-    expect(legendItem1.getByLabelText('Colour')).toHaveValue('#12436d');
+    expect(legendItem1.getByLabelText('Colour')).toHaveValue('#12436D');
     expect(legendItem1.getByLabelText('Symbol')).toHaveValue('none');
     expect(legendItem1.getByLabelText('Style')).toHaveValue('solid');
   });
@@ -155,7 +155,7 @@ describe('ChartLegendConfiguration', () => {
     expect(legendItem1.getByLabelText('Label')).toHaveValue(
       'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, Barnet)',
     );
-    expect(legendItem1.getByLabelText('Colour')).toHaveValue('#12436d');
+    expect(legendItem1.getByLabelText('Colour')).toHaveValue('#12436D');
     expect(legendItem1.getByLabelText('Symbol')).toHaveValue('none');
     expect(legendItem1.getByLabelText('Style')).toHaveValue('solid');
 
@@ -164,7 +164,7 @@ describe('ChartLegendConfiguration', () => {
     expect(legendItem2.getByLabelText('Label')).toHaveValue(
       'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, Barnsley)',
     );
-    expect(legendItem2.getByLabelText('Colour')).toHaveValue('#f46a25');
+    expect(legendItem2.getByLabelText('Colour')).toHaveValue('#F46A25');
     expect(legendItem2.getByLabelText('Symbol')).toHaveValue('none');
     expect(legendItem2.getByLabelText('Style')).toHaveValue('solid');
   });

--- a/src/explore-education-statistics-common/package-lock.json
+++ b/src/explore-education-statistics-common/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"devDependencies": {
+				"@hello-pangea/color-picker": "^3.2.2",
 				"@microsoft/applicationinsights-web": "^2.5.9",
 				"@popperjs/core": "^2.11.2",
 				"@reach/auto-id": "^0.16.0",
@@ -2759,12 +2760,15 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
-			"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+			"version": "7.20.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+			"integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
 			"dev": true,
 			"dependencies": {
-				"regenerator-runtime": "^0.13.2"
+				"regenerator-runtime": "^0.13.10"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
@@ -2776,6 +2780,12 @@
 				"core-js-pure": "^3.0.0",
 				"regenerator-runtime": "^0.13.4"
 			}
+		},
+		"node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+			"version": "0.13.10",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+			"integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+			"dev": true
 		},
 		"node_modules/@babel/template": {
 			"version": "7.8.6",
@@ -2981,6 +2991,23 @@
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
 			"integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
 			"dev": true
+		},
+		"node_modules/@hello-pangea/color-picker": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@hello-pangea/color-picker/-/color-picker-3.2.2.tgz",
+			"integrity": "sha512-1JIWv8zh9SVDXlfzlCtzdbsRElLWGX+Ljh5RYzJKigVFroycTToP/6I7qISoeQJr3B045Uq6sZXyE/F/cKmz3g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.1",
+				"lodash": "^4.17.21",
+				"tinycolor2": "^1.4.2"
+			},
+			"engines": {
+				"node": ">=14.6.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -4242,15 +4269,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@testing-library/dom/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/@testing-library/dom/node_modules/chalk": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -4340,15 +4358,6 @@
 				"node": ">=8",
 				"npm": ">=6",
 				"yarn": ">=1"
-			}
-		},
-		"node_modules/@testing-library/jest-dom/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
@@ -4485,24 +4494,6 @@
 				"react-test-renderer": ">=16.9.0"
 			}
 		},
-		"node_modules/@testing-library/react-hooks/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
-		"node_modules/@testing-library/react/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/@testing-library/user-event": {
 			"version": "12.1.7",
 			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.7.tgz",
@@ -4517,15 +4508,6 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
-			}
-		},
-		"node_modules/@testing-library/user-event/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/@types/aria-query": {
@@ -5274,15 +5256,6 @@
 				"node": ">=6.0"
 			}
 		},
-		"node_modules/aria-query/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -5680,15 +5653,6 @@
 				"@babel/runtime": "^7.7.2",
 				"cosmiconfig": "^6.0.0",
 				"resolve": "^1.12.0"
-			}
-		},
-		"node_modules/babel-plugin-macros/node_modules/@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/babel-plugin-macros/node_modules/resolve": {
@@ -15999,15 +15963,6 @@
 				"react-dom": "^16.8.5"
 			}
 		},
-		"node_modules/react-beautiful-dnd/node_modules/@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/react-beautiful-dnd/node_modules/memoize-one": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
@@ -16112,15 +16067,6 @@
 				"react-dom": "^16.8.0"
 			}
 		},
-		"node_modules/react-leaflet/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/react-leaflet/node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -16209,15 +16155,6 @@
 				"react-native": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/react-redux/node_modules/@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/react-redux/node_modules/react-is": {
@@ -16453,15 +16390,6 @@
 			"dependencies": {
 				"@babel/runtime": "^7.8.4",
 				"private": "^0.1.8"
-			}
-		},
-		"node_modules/regenerator-transform/node_modules/@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/regex-not": {
@@ -18788,6 +18716,15 @@
 			"integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
 			"dev": true
 		},
+		"node_modules/tinycolor2": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+			"integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -20048,15 +19985,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/yaml/node_modules/@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"node_modules/yargs": {
 			"version": "15.4.1",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -20149,15 +20077,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/yup/node_modules/@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"node_modules/zwitch": {
@@ -22651,12 +22570,20 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
-			"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+			"version": "7.20.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+			"integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
 			"dev": true,
 			"requires": {
-				"regenerator-runtime": "^0.13.2"
+				"regenerator-runtime": "^0.13.10"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.10",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+					"integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/runtime-corejs3": {
@@ -22847,6 +22774,17 @@
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
 			"integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
 			"dev": true
+		},
+		"@hello-pangea/color-picker": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@hello-pangea/color-picker/-/color-picker-3.2.2.tgz",
+			"integrity": "sha512-1JIWv8zh9SVDXlfzlCtzdbsRElLWGX+Ljh5RYzJKigVFroycTToP/6I7qISoeQJr3B045Uq6sZXyE/F/cKmz3g==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.20.1",
+				"lodash": "^4.17.21",
+				"tinycolor2": "^1.4.2"
+			}
 		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -23827,15 +23765,6 @@
 				"pretty-format": "^26.4.2"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"chalk": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -23905,15 +23834,6 @@
 				"redent": "^3.0.0"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -24006,17 +23926,6 @@
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"@testing-library/dom": "^7.24.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"@testing-library/react-hooks": {
@@ -24027,17 +23936,6 @@
 			"requires": {
 				"@babel/runtime": "^7.5.4",
 				"@types/testing-library__react-hooks": "^3.4.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"@testing-library/user-event": {
@@ -24047,17 +23945,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.10.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"@types/aria-query": {
@@ -24724,17 +24611,6 @@
 			"requires": {
 				"@babel/runtime": "^7.10.2",
 				"@babel/runtime-corejs3": "^7.10.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"arr-diff": {
@@ -25044,15 +24920,6 @@
 				"resolve": "^1.12.0"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.9.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"resolve": {
 					"version": "1.15.1",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
@@ -33185,15 +33052,6 @@
 				"use-memo-one": "^1.1.1"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.9.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"memoize-one": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
@@ -33287,15 +33145,6 @@
 				"warning": "^4.0.3"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"fast-deep-equal": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -33366,15 +33215,6 @@
 				"react-is": "^16.9.0"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.9.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"react-is": {
 					"version": "16.13.1",
 					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -33577,17 +33417,6 @@
 			"requires": {
 				"@babel/runtime": "^7.8.4",
 				"private": "^0.1.8"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.9.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"regex-not": {
@@ -35436,6 +35265,12 @@
 			"integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
 			"dev": true
 		},
+		"tinycolor2": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+			"integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
+			"dev": true
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -36441,17 +36276,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.8.7"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.9.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-					"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"yargs": {
@@ -36527,17 +36351,6 @@
 				"property-expr": "^2.0.2",
 				"synchronous-promise": "^2.0.13",
 				"toposort": "^2.0.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"zwitch": {

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "devDependencies": {
+    "@hello-pangea/color-picker": "^3.2.2",
     "@microsoft/applicationinsights-web": "^2.5.9",
     "@popperjs/core": "^2.11.2",
     "@reach/auto-id": "^0.16.0",

--- a/src/explore-education-statistics-common/src/components/form/FormColourInput.module.scss
+++ b/src/explore-education-statistics-common/src/components/form/FormColourInput.module.scss
@@ -1,0 +1,33 @@
+@import '~govuk-frontend/govuk/base';
+
+.button {
+  align-items: center;
+  background: #fff;
+  cursor: pointer;
+  display: flex;
+  height: 100%;
+  margin-left: govuk-spacing(2);
+  padding: govuk-spacing(1);
+
+  &:focus {
+    outline: $govuk-focus-colour solid $govuk-focus-width;
+  }
+}
+
+.swatch {
+  height: 100%;
+  width: govuk-spacing(8);
+}
+
+.popover {
+  position: absolute;
+  z-index: 2;
+}
+
+.cover {
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+}

--- a/src/explore-education-statistics-common/src/components/form/FormColourInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormColourInput.tsx
@@ -1,7 +1,12 @@
 import BaseFormInput, {
   FormBaseInputProps,
 } from '@common/components/form/FormBaseInput';
-import React from 'react';
+import styles from '@common/components/form/FormColourInput.module.scss';
+import React, { useEffect } from 'react';
+import { SketchPicker, ColorResult } from '@hello-pangea/color-picker';
+import useToggle from '@common/hooks/useToggle';
+import { useFormikContext } from 'formik';
+import VisuallyHidden from '../VisuallyHidden';
 
 export interface FormColourInputProps extends FormBaseInputProps {
   colours?: string[];
@@ -10,20 +15,47 @@ export interface FormColourInputProps extends FormBaseInputProps {
 
 const FormColourInput = ({
   colours = [],
-  id,
+  value,
+  name,
   ...props
 }: FormColourInputProps) => {
+  const { setFieldValue } = useFormikContext();
+  const [showPicker, togglePicker] = useToggle(false);
+
+  useEffect(() => {
+    const handleWindowKeyDown = (event: KeyboardEvent) => {
+      if (showPicker && event.key === 'Escape') {
+        togglePicker.off();
+      }
+    };
+    window.addEventListener('keydown', handleWindowKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleWindowKeyDown);
+    };
+  }, [showPicker, togglePicker]);
+
+  const handleChange = (colour: ColorResult) => {
+    setFieldValue(name, colour.hex);
+  };
+
   return (
     <>
-      <BaseFormInput {...props} id={id} type="color" list={`${id}-colours`} />
-
-      {colours.length > 0 && (
-        <datalist id={`${id}-colours`}>
-          {colours.map((colour, index) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <option key={index} value={colour} />
-          ))}
-        </datalist>
+      <BaseFormInput {...props} name={name} value={value} />
+      <button type="button" className={styles.button} onClick={togglePicker}>
+        <div className={styles.swatch} style={{ backgroundColor: value }} />
+        <VisuallyHidden>Select colour</VisuallyHidden>
+      </button>
+      {showPicker && (
+        <div className={styles.popover}>
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+          <div className={styles.cover} onClick={togglePicker.off} />
+          <SketchPicker
+            color={value}
+            presetColors={colours}
+            onChange={handleChange}
+          />
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
Replaces the browser colour picker with https://github.com/hello-pangea/color-picker (this is a fork of react-color which is no longer maintained)

<img width="128" alt="colour2" src="https://user-images.githubusercontent.com/81572860/200822544-660994c2-271e-48cd-b97b-da4571bbec92.PNG">
<img width="141" alt="colour1" src="https://user-images.githubusercontent.com/81572860/200822549-f3ec6624-ee93-417c-85e5-c8927b5e76d8.PNG">
