### PR TITLE
EES-3878 Changes to Azure Data Factory maintenance triggers

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -21,8 +21,7 @@
     "fragmentationTables": "Observation,ObservationFilterItem",
     "removeSoftDeletedSubjectsObservationLimit": "1500000",
     "removeSoftDeletedSubjectsObservationCommitBatchSize": "1000",
-    "removeSoftDeletedSubjectsObservationFilterItemCommitBatchSize": "20000",
-    "subjectsToMigrate": "5"
+    "removeSoftDeletedSubjectsObservationFilterItemCommitBatchSize": "20000"
   },
   "resources": [
     {
@@ -93,7 +92,7 @@
             "type": "SqlServerStoredProcedure",
             "dependsOn": [],
             "policy": {
-              "timeout": "0.04:00:00",
+              "timeout": "0.12:00:00",
               "retry": 0,
               "retryIntervalInSeconds": 30,
               "secureOutput": false,
@@ -153,7 +152,7 @@
             "type": "SqlServerStoredProcedure",
             "dependsOn": [],
             "policy": {
-              "timeout": "0.04:00:00",
+              "timeout": "0.12:00:00",
               "retry": 0,
               "retryIntervalInSeconds": 30,
               "secureOutput": false,
@@ -372,11 +371,15 @@
         "type": "ScheduleTrigger",
         "typeProperties": {
           "recurrence": {
-            "frequency": "Day",
+            "frequency": "Week",
             "interval": 1,
             "startTime": "2020-11-23T19:00:00",
             "timeZone": "GMT Standard Time",
-            "schedule": {}
+            "schedule": {
+              "hours": [19],
+              "minutes": [0],
+              "weekDays": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+            }
           }
         }
       },
@@ -419,9 +422,13 @@
           "recurrence": {
             "frequency": "Week",
             "interval": 1,
-            "startTime": "2020-11-29T02:00:00",
+            "startTime": "2022-11-12T19:00:00",
             "timeZone": "GMT Standard Time",
-            "schedule": {}
+            "schedule": {
+              "hours": [19],
+              "minutes": [0],
+              "weekDays": ["Saturday"]
+            }
           }
         }
       },


### PR DESCRIPTION
This PR:

- Changes the timeout of the `pl_rebuild_statistics_indexes` and `pl_rebuild_public_statistics_indexes` pipelines from 4 hours to 12 hours. We've seen the `pl_rebuild_statistics_indexes` pipeline timeout in Dev, Test and Pre-prod after 4 hours and seen the it take 11 hours to run Prod. 

- Schedules the `rebuild_indexes_trigger` to run at 7pm on Saturday instead of 2am on Sunday, to allow it more time to run between 7pm on Saturday and 7am on Sunday when the service should be quieter.

- Schedules the `purge_soft_deleted_subjects_trigger` to run at 7pm on weekdays Monday to Friday instead of 7pm daily so that it's not running at the same time as rebuilding indexes.

- Removes unused parameter `subjectsToMigrate`.