### PR TITLE
EES-3891 - fix legacy_releases.robot failing on dev

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/legacy_releases.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/legacy_releases.robot
@@ -82,6 +82,7 @@ Update legacy release
     user enters text into element    id:legacyReleaseForm-description    ${UPDATED_DESCRIPTION}
     user enters text into element    id:legacyReleaseForm-url    http://test2.com
     user clicks button    Save legacy release
+    sleep    %{WAIT_MEMORY_CACHE_EXPIRY}
 
 Validate updated legacy release
     user waits until h2 is visible    Legacy releases


### PR DESCRIPTION
This PR:
* fixes `legacy_releases` UI test on dev. Legacy releases are memory cached & as such, we should add a `sleep    %{WAIT_MEMORY_CACHE_EXPIRY}` statement in order to wait for a legacy release to be updated on the public frontend

![image](https://user-images.githubusercontent.com/55030296/201119830-3c15f70a-5a02-4636-8787-23fcf8084276.png)

