### PR TITLE
EES-3856 contact banner on prerelease

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseSummaryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseSummaryService.cs
@@ -38,7 +38,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     release.Publication.Title,
                     release.Slug,
                     release.Title,
-                    release.Publication.Contact.TeamEmail));
+                    release.Publication.Contact.TeamEmail,
+                    release.Publication.Contact.TeamName));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PreReleaseSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PreReleaseSummaryViewModel.cs
@@ -12,6 +12,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public string ContactEmail { get; }
 
+        public string ContactTeam { get; }
+
         public PreReleaseSummaryViewModel()
         {
         }
@@ -21,13 +23,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
             string publicationTitle,
             string releaseSlug,
             string releaseTitle,
-            string contactEmail)
+            string contactEmail, 
+            string contactTeam)
         {
             PublicationSlug = publicationSlug;
             ReleaseSlug = releaseSlug;
             PublicationTitle = publicationTitle;
             ReleaseTitle = releaseTitle;
             ContactEmail = contactEmail;
+            ContactTeam = contactTeam;
         }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -14,6 +14,7 @@ import preReleaseService, {
   PreReleaseSummary,
 } from '@admin/services/preReleaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
+import NotificationBanner from '@common/components/NotificationBanner';
 import { useErrorControl } from '@common/contexts/ErrorControlContext';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import { format } from 'date-fns';
@@ -52,7 +53,6 @@ const PreReleasePageContainer = ({
       const preReleaseSummary = await preReleaseService.getPreReleaseSummary(
         releaseId,
       );
-
       return {
         preReleaseWindowStatus,
         preReleaseSummary,
@@ -72,6 +72,7 @@ const PreReleasePageContainer = ({
       preReleaseWindowStatus: { access, start, end },
       preReleaseSummary: {
         contactEmail,
+        contactTeam,
         releaseSlug,
         releaseTitle,
         publicationSlug,
@@ -135,6 +136,20 @@ const PreReleasePageContainer = ({
     if (access === 'Within') {
       return (
         <>
+          <NotificationBanner
+            heading="If you have an enquiry about this release contact:"
+            title="Contact"
+          >
+            <p>
+              {`${contactTeam}: `}
+              <a
+                className='class="govuk-notification-banner__link"'
+                href={`mailto: ${contactEmail}`}
+              >
+                {contactEmail}
+              </a>
+            </p>
+          </NotificationBanner>
           <NavBar
             className="govuk-!-margin-top-0"
             routes={preReleaseNavRoutes.map(route => ({

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -144,7 +144,7 @@ const PreReleasePageContainer = ({
               {`${contactTeam}: `}
               <a
                 className='class="govuk-notification-banner__link"'
-                href={`mailto: ${contactEmail}`}
+                href={`mailto:${contactEmail}`}
               >
                 {contactEmail}
               </a>

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
@@ -6,7 +6,7 @@ import _permissionService from '@admin/services/permissionService';
 import _preReleaseService, {
   PreReleaseSummary,
 } from '@admin/services/preReleaseService';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { addHours, subHours } from 'date-fns';
 import React from 'react';
 import { generatePath, MemoryRouter } from 'react-router';
@@ -29,6 +29,7 @@ describe('PreReleasePageContainer', () => {
     releaseTitle: 'Calendar Year 2018',
     releaseSlug: '2018',
     contactEmail: 'test@test.com',
+    contactTeam: 'Test team',
   };
 
   test('renders correctly when pre-release has ended', async () => {
@@ -106,6 +107,16 @@ describe('PreReleasePageContainer', () => {
     renderPage();
 
     await waitFor(() => {
+      const banner = within(screen.getByRole('region', { name: 'Contact' }));
+      expect(
+        banner.getByText('If you have an enquiry about this release contact:'),
+      ).toBeInTheDocument();
+
+      expect(banner.getByText('Test team:')).toBeInTheDocument();
+      expect(
+        banner.getByRole('link', { name: 'test@test.com' }),
+      ).toBeInTheDocument();
+
       expect(screen.getByRole('link', { name: 'Content' })).toBeInTheDocument();
 
       expect(

--- a/src/explore-education-statistics-admin/src/services/preReleaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/preReleaseService.ts
@@ -2,6 +2,7 @@ import client from '@admin/services/utils/service';
 
 export interface PreReleaseSummary {
   contactEmail: string;
+  contactTeam: string;
   publicationSlug: string;
   publicationTitle: string;
   releaseSlug: string;

--- a/src/explore-education-statistics-common/src/components/NotificationBanner.tsx
+++ b/src/explore-education-statistics-common/src/components/NotificationBanner.tsx
@@ -1,0 +1,33 @@
+import React, { ReactNode } from 'react';
+
+interface Props {
+  children?: ReactNode;
+  heading: string;
+  title: string;
+}
+
+const NotificationBanner = ({ children, heading, title }: Props) => {
+  return (
+    <div
+      aria-labelledby="govuk-notification-banner-title"
+      className="govuk-notification-banner govuk-!-margin-bottom-6"
+      data-testid="notificationBanner"
+      role="region"
+    >
+      <div className="govuk-notification-banner__header">
+        <h2
+          className="govuk-notification-banner__title"
+          id="govuk-notification-banner-title"
+        >
+          {title}
+        </h2>
+      </div>
+      <div className="govuk-notification-banner__content">
+        <p className="govuk-notification-banner__heading">{heading}</p>
+        {children && children}
+      </div>
+    </div>
+  );
+};
+
+export default NotificationBanner;

--- a/src/explore-education-statistics-common/src/components/NotificationBanner.tsx
+++ b/src/explore-education-statistics-common/src/components/NotificationBanner.tsx
@@ -24,7 +24,7 @@ const NotificationBanner = ({ children, heading, title }: Props) => {
       </div>
       <div className="govuk-notification-banner__content">
         <p className="govuk-notification-banner__heading">{heading}</p>
-        {children && children}
+        {children}
       </div>
     </div>
   );

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -291,6 +291,10 @@ Validate prerelease has started
     user waits until element contains    id:releaseHeadlines    Test headlines summary text for ${PUBLICATION_NAME}
     ...    %{WAIT_SMALL}
 
+Validate contact banner is shown
+    user checks testid element contains    notificationBanner    If you have an enquiry about this release contact
+    user checks testid element contains    notificationBanner    UI test team name: ui_test@test.com
+
 Validate metadata guidance page
     user opens accordion section    Explore data and files
     user waits until h3 is visible    Open data


### PR DESCRIPTION
Adds a banner with the team contact name and email to the top of pre-release preview pages.
- I've added the team name to PreReleaseSummary in the backend as it already had the team email so seemed like that would be ok, let me know if not.
- Added a generic notification banner component based on https://design-system.service.gov.uk/components/notification-banner/

![prerlease](https://user-images.githubusercontent.com/81572860/201121345-f88b43bb-65ef-4542-8490-5bd0a84c21c1.PNG)
