### PR TITLE
EES-3882 Introduce Publication.LatestPublishedReleaseId

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221108181115_EES3882_AddLatestPublishedReleaseIdToPublication.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221108181115_EES3882_AddLatestPublishedReleaseIdToPublication.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221108181115_EES3882_AddLatestPublishedReleaseIdToPublication")]
+    partial class EES3882_AddLatestPublishedReleaseIdToPublication
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -293,17 +295,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasIndex("SourceId");
 
                     b.ToTable("Files");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.FreeTextRank", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<int>("Rank")
-                        .HasColumnType("int");
-
-                    b.ToTable((string)null);
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.GlossaryEntry", b =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221108181115_EES3882_AddLatestPublishedReleaseIdToPublication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221108181115_EES3882_AddLatestPublishedReleaseIdToPublication.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations;
+
+[ExcludeFromCodeCoverage]
+public partial class EES3882_AddLatestPublishedReleaseIdToPublication : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<Guid>(
+            name: "LatestPublishedReleaseId",
+            table: "Publications",
+            type: "uniqueidentifier",
+            nullable: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Publications_LatestPublishedReleaseId",
+            table: "Publications",
+            column: "LatestPublishedReleaseId",
+            unique: true,
+            filter: "[LatestPublishedReleaseId] IS NOT NULL");
+
+        migrationBuilder.AddForeignKey(
+            name: "FK_Publications_Releases_LatestPublishedReleaseId",
+            table: "Publications",
+            column: "LatestPublishedReleaseId",
+            principalTable: "Releases",
+            principalColumn: "Id");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropForeignKey(
+            name: "FK_Publications_Releases_LatestPublishedReleaseId",
+            table: "Publications");
+
+        migrationBuilder.DropIndex(
+            name: "IX_Publications_LatestPublishedReleaseId",
+            table: "Publications");
+
+        migrationBuilder.DropColumn(
+            name: "LatestPublishedReleaseId",
+            table: "Publications");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -233,6 +233,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .WithMany()  // Ideally this would be WithOne, but we would need to fix existing data to do this
                 .OnDelete(DeleteBehavior.Restrict);
 
+            modelBuilder.Entity<Publication>()
+                .HasOne(p => p.LatestPublishedReleaseNew)
+                .WithOne()
+                .HasForeignKey<Publication>(p => p.LatestPublishedReleaseId)
+                .IsRequired(false);
+
             modelBuilder.Entity<PublicationMethodology>()
                 .HasKey(pm => new {pm.PublicationId, pm.MethodologyId});
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -45,6 +45,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public bool Live => Published.HasValue && DateTime.Compare(DateTime.UtcNow, Published.Value) > 0;
 
+        public Guid? LatestPublishedReleaseId { get; set; }
+
+        // TODO EES-3881 Remove once all Publications with a published release have their LatestPublishedReleaseId set
         public Release? LatestPublishedRelease()
         {
             return Releases
@@ -53,6 +56,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
                 .ThenBy(r => r.TimePeriodCoverage)
                 .LastOrDefault();
         }
+
+        // TODO EES-3881 Rename this LatestPublishedRelease
+        public Release? LatestPublishedReleaseNew { get; set; }
 
         public Release? LatestRelease()
         {


### PR DESCRIPTION
This PR:

- Adds `Publication.LatestPublishedReleaseId` and `Publication.LatestPublishedReleaseNew`.
- Adds  and an optional one-to-one relationship between `Publication.LatestPublishedReleaseNew` and `Release`.

There will be a separate PR raised to add a migration that will set `Publication.LatestPublishedReleaseId` for all publications,
and make a change to Publisher to set `Publication.LatestPublishedReleaseId` when a release is published if applicable.

`LatestPublishedReleaseNew` will be renamed later to `LatestPublishedRelease`.