### PR TITLE
EES-3605 Add API endpoint to get publications for the new Find Statistics page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServicePermissionTests.cs
@@ -132,7 +132,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using var context = DbUtils.InMemoryApplicationDbContext();
 
             var service = new DataBlockService(
-                contentDbContext ?? Mock.Of<ContentDbContext>(Strict),
+                contentDbContext ?? Mock.Of<ContentDbContext>(),
                 persistenceHelper ?? PersistenceHelperMock().Object,
                 releaseFileService ?? Mock.Of<IReleaseFileService>(Strict),
                 releaseContentBlockRepository ?? Mock.Of<IReleaseContentBlockRepository>(Strict),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServicePermissionTests.cs
@@ -130,7 +130,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IHttpContextAccessor? httpContextAccessor = null)
         {
             return new(
-                context ?? Mock.Of<ContentDbContext>(Strict),
+                context ?? Mock.Of<ContentDbContext>(),
                 usersAndRolesDbContext ?? InMemoryUserAndRolesDbContext(),
                 configuration ?? Mock.Of<IConfiguration>(Strict),
                 emailService ?? Mock.Of<IEmailService>(Strict),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -46,7 +46,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .AssertForbidden(async userService =>
                 {
                     var service = BuildPublicationService(
-                        context: Mock.Of<ContentDbContext>(Strict),
                         userService: userService.Object);
                     return await service.ListPublications(Guid.NewGuid());
                 });
@@ -60,7 +59,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .AssertForbidden(async userService =>
                 {
                     var service = BuildPublicationService(
-                        context: Mock.Of<ContentDbContext>(Strict),
                         userService: userService.Object);
                     return await service.ListPublicationSummaries();
                 });
@@ -75,7 +73,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var userService = AlwaysTrueUserService();
             var publicationService = BuildPublicationService(
-                context: Mock.Of<ContentDbContext>(Strict),
                 userService: userService.Object);
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(
@@ -100,7 +97,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var userService = AlwaysTrueUserService();
             var publicationService = BuildPublicationService(
-                context: Mock.Of<ContentDbContext>(Strict),
                 userService: userService.Object);
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(
@@ -126,7 +122,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var userService = AlwaysTrueUserService();
             var publicationService = BuildPublicationService(
-                context: Mock.Of<ContentDbContext>(Strict),
                 userService: userService.Object);
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(
@@ -152,7 +147,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var userService = AlwaysTrueUserService();
             var publicationService = BuildPublicationService(
-                context: Mock.Of<ContentDbContext>(Strict),
                 userService: userService.Object);
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(
@@ -387,7 +381,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var userService = AlwaysTrueUserService();
             var publicationService = BuildPublicationService(
-                context: Mock.Of<ContentDbContext>(Strict),
                 userService: userService.Object);
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(
@@ -542,7 +535,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var userService = AlwaysTrueUserService();
             var publicationService = BuildPublicationService(
-                context: Mock.Of<ContentDbContext>(Strict),
                 userService: userService.Object);
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(
@@ -558,7 +550,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var userService = AlwaysTrueUserService();
             var publicationService = BuildPublicationService(
-                context: Mock.Of<ContentDbContext>(Strict),
                 userService: userService.Object);
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(
@@ -570,7 +561,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         private static PublicationService BuildPublicationService(
-            ContentDbContext context,
+            ContentDbContext? context = null,
             IUserService? userService = null,
             IPublicationRepository? publicationRepository = null,
             IMethodologyVersionRepository? methodologyVersionRepository = null,
@@ -578,6 +569,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IMethodologyCacheService? methodologyCacheService = null,
             IThemeCacheService? themeCacheService = null)
         {
+            context ??= Mock.Of<ContentDbContext>();
+
             return new(
                 context,
                 AdminMapper(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/SortOrder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/SortOrder.cs
@@ -1,0 +1,8 @@
+﻿#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public enum SortOrder
+{
+    Asc,
+    Desc
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -59,11 +60,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         }
 
         private static PublicationController BuildPublicationController(
-            IPublicationCacheService? publicationCacheService = null
+            IPublicationCacheService? publicationCacheService = null,
+            IPublicationService? publicationService = null
         )
         {
             return new PublicationController(
-                publicationCacheService ?? Mock.Of<IPublicationCacheService>(Strict)
+                publicationCacheService ?? Mock.Of<IPublicationCacheService>(Strict),
+                publicationService ?? Mock.Of<IPublicationService>(Strict)
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
@@ -1,17 +1,14 @@
 ﻿#nullable enable
-using System;
-using System.ComponentModel.DataAnnotations;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
-using static GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IPublicationService;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
 {
@@ -32,11 +29,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         }
 
         [HttpGet("publications")]
-        public async Task<ActionResult<PaginatedListViewModel<PublicationSearchResultViewModel>>> GetPublications(
-            [FromQuery] PublicationsGetRequest request)
+        public async Task<ActionResult<PaginatedListViewModel<PublicationSearchResultViewModel>>> ListPublications(
+            [FromQuery] PublicationsListRequest request)
         {
             return await _publicationService
-                .GetPublications(
+                .ListPublications(
                     request.ReleaseType,
                     request.ThemeId,
                     request.Search,
@@ -58,14 +55,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
                 })
                 .HandleFailuresOrOk();
         }
-
-        public record PublicationsGetRequest(
-            ReleaseType? ReleaseType,
-            Guid? ThemeId,
-            [MinLength(3)] string? Search,
-            PublicationsSortBy? Sort,
-            SortOrder? Order,
-            [Range(1, int.MaxValue)] int Page = 1,
-            [Range(1, int.MaxValue)] int PageSize = 10);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
@@ -1,23 +1,56 @@
 ﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
+using static GovUk.Education.ExploreEducationStatistics.Common.Model.SortOrder;
+using static GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IPublicationService;
+using static GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IPublicationService.
+    PublicationsSortBy;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
 {
+    [ApiController]
     [Route("api")]
     [Produces(MediaTypeNames.Application.Json)]
     public class PublicationController : ControllerBase
     {
         private readonly IPublicationCacheService _publicationCacheService;
+        private readonly IPublicationService _publicationService;
 
-        public PublicationController(IPublicationCacheService publicationCacheService)
+        public PublicationController(
+            IPublicationCacheService publicationCacheService,
+            IPublicationService publicationService)
         {
             _publicationCacheService = publicationCacheService;
+            _publicationService = publicationService;
+        }
+
+        [HttpGet("publications")]
+        public async Task<ActionResult<List<PublicationSearchResultViewModel>>> GetPublications(
+            [FromQuery] PublicationsGetRequest request)
+        {
+            var sort = request.Sort ?? (request.Search == null ? Title : Relevance);
+            var order = request.Order ?? (sort == Title ? Asc : Desc);
+
+            return await _publicationService
+                .GetPublications(
+                    request.ReleaseType,
+                    request.ThemeId,
+                    request.Search,
+                    sort,
+                    order,
+                    offset: request.Offset,
+                    limit: request.Limit)
+                .HandleFailuresOrOk();
         }
 
         [HttpGet("publications/{slug}/title")]
@@ -31,5 +64,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
                 })
                 .HandleFailuresOrOk();
         }
+
+        public record PublicationsGetRequest(
+            ReleaseType? ReleaseType,
+            Guid? ThemeId,
+            [MinLength(3)] string? Search,
+            PublicationsSortBy? Sort,
+            SortOrder? Order,
+            [Range(0, int.MaxValue)] int Offset = 0,
+            [Range(1, int.MaxValue)] int Limit = 10);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
@@ -1,20 +1,17 @@
 ﻿#nullable enable
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
-using static GovUk.Education.ExploreEducationStatistics.Common.Model.SortOrder;
 using static GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IPublicationService;
-using static GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IPublicationService.
-    PublicationsSortBy;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
 {
@@ -35,21 +32,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         }
 
         [HttpGet("publications")]
-        public async Task<ActionResult<List<PublicationSearchResultViewModel>>> GetPublications(
+        public async Task<ActionResult<PaginatedListViewModel<PublicationSearchResultViewModel>>> GetPublications(
             [FromQuery] PublicationsGetRequest request)
         {
-            var sort = request.Sort ?? (request.Search == null ? Title : Relevance);
-            var order = request.Order ?? (sort == Title ? Asc : Desc);
-
             return await _publicationService
                 .GetPublications(
                     request.ReleaseType,
                     request.ThemeId,
                     request.Search,
-                    sort,
-                    order,
-                    offset: request.Offset,
-                    limit: request.Limit)
+                    request.Sort,
+                    request.Order,
+                    page: request.Page,
+                    pageSize: request.PageSize)
                 .HandleFailuresOrOk();
         }
 
@@ -71,7 +65,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
             [MinLength(3)] string? Search,
             PublicationsSortBy? Sort,
             SortOrder? Order,
-            [Range(0, int.MaxValue)] int Offset = 0,
-            [Range(1, int.MaxValue)] int Limit = 10);
+            [Range(1, int.MaxValue)] int Page = 1,
+            [Range(1, int.MaxValue)] int PageSize = 10);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Requests/PublicationsListRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Requests/PublicationsListRequest.cs
@@ -1,0 +1,17 @@
+﻿#nullable enable
+using System;
+using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Requests;
+
+public record PublicationsListRequest(
+    ReleaseType? ReleaseType,
+    Guid? ThemeId,
+    [MinLength(3)] string? Search,
+    IPublicationService.PublicationsSortBy? Sort,
+    SortOrder? Order,
+    [Range(1, int.MaxValue)] int Page = 1,
+    [Range(1, int.MaxValue)] int PageSize = 10);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -43,41 +43,41 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
             }
         }
 
-        public DbSet<Methodology> Methodologies { get; set; }
-        public DbSet<MethodologyVersion> MethodologyVersions { get; set; }
-        public DbSet<MethodologyVersionContent> MethodologyContent { get; set; }
-        public DbSet<PublicationMethodology> PublicationMethodologies { get; set; }
-        public DbSet<MethodologyFile> MethodologyFiles { get; set; }
-        public DbSet<Theme> Themes { get; set; }
-        public DbSet<Topic> Topics { get; set; }
-        public DbSet<Publication> Publications { get; set; }
-        public DbSet<Release> Releases { get; set; }
-        public DbSet<ReleaseStatus> ReleaseStatus { get; set; }
-        public DbSet<LegacyRelease> LegacyReleases { get; set; }
-        public DbSet<ReleaseFile> ReleaseFiles { get; set; }
-        public DbSet<File> Files { get; set; }
-        public DbSet<ContentSection> ContentSections { get; set; }
-        public DbSet<ContentBlock> ContentBlocks { get; set; }
-        public DbSet<DataBlock> DataBlocks { get; set; }
-        public DbSet<DataImport> DataImports { get; set; }
-        public DbSet<DataImportError> DataImportErrors { get; set; }
-        public DbSet<HtmlBlock> HtmlBlocks { get; set; }
-        public DbSet<MarkDownBlock> MarkDownBlocks { get; set; }
-        public DbSet<MethodologyNote> MethodologyNotes { get; set; }
-        public DbSet<Permalink> Permalinks { get; set; } = null!;
-        public DbSet<Contact> Contacts { get; set; }
-        public DbSet<ReleaseContentSection> ReleaseContentSections { get; set; }
-        public DbSet<ReleaseContentBlock> ReleaseContentBlocks { get; set; }
-        public DbSet<Update> Update { get; set; }
-        public DbSet<User> Users { get; set; }
-        public DbSet<UserPublicationRole> UserPublicationRoles { get; set; }
-        public DbSet<UserReleaseRole> UserReleaseRoles { get; set; }
-        public DbSet<GlossaryEntry> GlossaryEntries { get; set; }
-        public DbSet<Comment> Comment { get; set; }
-        public DbSet<UserReleaseInvite> UserReleaseInvites { get; set; }
-        public DbSet<UserPublicationInvite> UserPublicationInvites { get; set; }
+        public virtual DbSet<Methodology> Methodologies { get; set; }
+        public virtual DbSet<MethodologyVersion> MethodologyVersions { get; set; }
+        public virtual DbSet<MethodologyVersionContent> MethodologyContent { get; set; }
+        public virtual DbSet<PublicationMethodology> PublicationMethodologies { get; set; }
+        public virtual DbSet<MethodologyFile> MethodologyFiles { get; set; }
+        public virtual DbSet<Theme> Themes { get; set; }
+        public virtual DbSet<Topic> Topics { get; set; }
+        public virtual DbSet<Publication> Publications { get; set; }
+        public virtual DbSet<Release> Releases { get; set; }
+        public virtual DbSet<ReleaseStatus> ReleaseStatus { get; set; }
+        public virtual DbSet<LegacyRelease> LegacyReleases { get; set; }
+        public virtual DbSet<ReleaseFile> ReleaseFiles { get; set; }
+        public virtual DbSet<File> Files { get; set; }
+        public virtual DbSet<ContentSection> ContentSections { get; set; }
+        public virtual DbSet<ContentBlock> ContentBlocks { get; set; }
+        public virtual DbSet<DataBlock> DataBlocks { get; set; }
+        public virtual DbSet<DataImport> DataImports { get; set; }
+        public virtual DbSet<DataImportError> DataImportErrors { get; set; }
+        public virtual DbSet<HtmlBlock> HtmlBlocks { get; set; }
+        public virtual DbSet<MarkDownBlock> MarkDownBlocks { get; set; }
+        public virtual DbSet<MethodologyNote> MethodologyNotes { get; set; }
+        public virtual DbSet<Permalink> Permalinks { get; set; } = null!;
+        public virtual DbSet<Contact> Contacts { get; set; }
+        public virtual DbSet<ReleaseContentSection> ReleaseContentSections { get; set; }
+        public virtual DbSet<ReleaseContentBlock> ReleaseContentBlocks { get; set; }
+        public virtual DbSet<Update> Update { get; set; }
+        public virtual DbSet<User> Users { get; set; }
+        public virtual DbSet<UserPublicationRole> UserPublicationRoles { get; set; }
+        public virtual DbSet<UserReleaseRole> UserReleaseRoles { get; set; }
+        public virtual DbSet<GlossaryEntry> GlossaryEntries { get; set; }
+        public virtual DbSet<Comment> Comment { get; set; }
+        public virtual DbSet<UserReleaseInvite> UserReleaseInvites { get; set; }
+        public virtual DbSet<UserPublicationInvite> UserPublicationInvites { get; set; }
 
-        public IQueryable<FreeTextRank> PublicationsFreeTextTable(string search) =>
+        public virtual IQueryable<FreeTextRank> PublicationsFreeTextTable(string search) =>
             FromExpression(() => PublicationsFreeTextTable(search));
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.2" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+        <PackageReference Include="MockQueryable.Moq" Version="6.0.1" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -8,9 +9,14 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using MockQueryable.Moq;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Model.SortOrder;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseType;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IPublicationService.
+    PublicationsSortBy;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 {
@@ -274,6 +280,996 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 var result = await service.Get(publicationSlug);
 
                 result.AssertNotFound();
+            }
+        }
+
+        [Fact]
+        public async Task GetPublications()
+        {
+            var publicationA = new Publication
+            {
+                Title = "Publication A",
+                Summary = "Publication A summary",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = NationalStatistics,
+                    Published = new DateTime(2020, 1, 1)
+                }
+            };
+
+            var publicationB = new Publication
+            {
+                Title = "Publication B",
+                Summary = "Publication B summary",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = OfficialStatistics,
+                    Published = new DateTime(2021, 1, 1)
+                }
+            };
+
+            var publicationC = new Publication
+            {
+                Title = "Publication C",
+                Summary = "Publication C summary",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = AdHocStatistics,
+                    Published = new DateTime(2022, 1, 1)
+                }
+            };
+
+            var themes = new List<Theme>
+            {
+                new()
+                {
+                    Title = "Theme 1 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                publicationA,
+                                publicationB
+                            }
+                        }
+                    },
+                },
+                new()
+                {
+                    Title = "Theme 2 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                publicationC
+                            }
+                        }
+                    },
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Themes.AddRangeAsync(themes);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupPublicationService(contentDbContext);
+
+                var pagedResult = (await service.GetPublications()).AssertRight();
+                var results = pagedResult.Results;
+
+                Assert.Equal(3, results.Count);
+
+                // Expect results sorted by title in ascending order
+
+                Assert.Equal(publicationA.Id, results[0].Id);
+                Assert.Equal(new DateTime(2020, 1, 1), results[0].Published);
+                Assert.Equal("Publication A", results[0].Title);
+                Assert.Equal("Publication A summary", results[0].Summary);
+                Assert.Equal("Theme 1 title", results[0].Theme);
+                Assert.Equal(NationalStatistics, results[0].Type);
+
+                Assert.Equal(publicationB.Id, results[1].Id);
+                Assert.Equal(new DateTime(2021, 1, 1), results[1].Published);
+                Assert.Equal("Publication B", results[1].Title);
+                Assert.Equal("Publication B summary", results[1].Summary);
+                Assert.Equal("Theme 1 title", results[1].Theme);
+                Assert.Equal(OfficialStatistics, results[1].Type);
+
+                Assert.Equal(publicationC.Id, results[2].Id);
+                Assert.Equal(new DateTime(2022, 1, 1), results[2].Published);
+                Assert.Equal("Publication C", results[2].Title);
+                Assert.Equal("Publication C summary", results[2].Summary);
+                Assert.Equal("Theme 2 title", results[2].Theme);
+                Assert.Equal(AdHocStatistics, results[2].Type);
+            }
+        }
+
+        [Fact]
+        public async Task GetPublications_ExcludesUnpublishedPublications()
+        {
+            // Published
+            var publicationA = new Publication
+            {
+                Title = "Publication A",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = NationalStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            // Not published (no published release)
+            var publicationB = new Publication
+            {
+                Title = "Publication B",
+                LatestPublishedReleaseNew = null
+            };
+
+            var themes = new List<Theme>
+            {
+                new()
+                {
+                    Title = "Theme 1 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                publicationA,
+                                publicationB
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Themes.AddRangeAsync(themes);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupPublicationService(contentDbContext);
+
+                var pagedResult = (await service.GetPublications()).AssertRight();
+                var results = pagedResult.Results;
+
+                Assert.Equal(publicationA.Id, results[0].Id);
+            }
+        }
+
+        [Fact]
+        public async Task GetPublications_ExcludesSupersededPublications()
+        {
+            // Published
+            var publicationA = new Publication
+            {
+                Title = "Publication A",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = NationalStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            // Published
+            var publicationB = new Publication
+            {
+                Title = "Publication B",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = NationalStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            // Not published (no published release)
+            var publicationC = new Publication
+            {
+                Title = "Publication C",
+                LatestPublishedReleaseId = null
+            };
+
+            // Not published (superseded by publicationB which is published)
+            var publicationD = new Publication
+            {
+                Title = "Publication D",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = NationalStatistics,
+                    Published = DateTime.UtcNow
+                },
+                SupersededBy = publicationB
+            };
+
+            // Published (superseded by publicationC but it's not published yet)
+            var publicationE = new Publication
+            {
+                Title = "Publication E",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = NationalStatistics,
+                    Published = DateTime.UtcNow
+                },
+                SupersededBy = publicationC
+            };
+
+            var themes = new List<Theme>
+            {
+                new()
+                {
+                    Title = "Theme 1 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                publicationA,
+                                publicationB,
+                                publicationC,
+                                publicationD,
+                                publicationE
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Themes.AddRangeAsync(themes);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupPublicationService(contentDbContext);
+
+                var pagedResult = (await service.GetPublications()).AssertRight();
+                var results = pagedResult.Results;
+
+                Assert.Equal(publicationA.Id, results[0].Id);
+                Assert.Equal(publicationB.Id, results[1].Id);
+                Assert.Equal(publicationE.Id, results[2].Id);
+            }
+        }
+
+        [Fact]
+        public async Task GetPublications_FilterByTheme()
+        {
+            var publicationA = new Publication
+            {
+                Title = "Publication A",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = NationalStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            var publicationB = new Publication
+            {
+                Title = "Publication B",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = NationalStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            var themes = new List<Theme>
+            {
+                new()
+                {
+                    Title = "Theme 1 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                publicationA,
+                                publicationB
+                            }
+                        }
+                    },
+                },
+                new()
+                {
+                    Title = "Theme 2 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                new()
+                                {
+                                    Title = "Publication C",
+                                    Summary = "Publication C summary",
+                                    LatestPublishedReleaseNew = new Release
+                                    {
+                                        Type = AdHocStatistics,
+                                        Published = new DateTime(2022, 1, 1)
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Themes.AddRangeAsync(themes);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupPublicationService(contentDbContext);
+
+                var pagedResult = (await service.GetPublications(
+                    themeId: themes[0].Id
+                )).AssertRight();
+                var results = pagedResult.Results;
+
+                Assert.Equal(2, results.Count);
+
+                Assert.Equal(publicationA.Id, results[0].Id);
+                Assert.Equal("Theme 1 title", results[0].Theme);
+
+                Assert.Equal(publicationB.Id, results[1].Id);
+                Assert.Equal("Theme 1 title", results[1].Theme);
+            }
+        }
+
+        [Fact]
+        public async Task GetPublications_FilterByReleaseType()
+        {
+            var publicationA = new Publication
+            {
+                Title = "Publication A",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = NationalStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            var publicationB = new Publication
+            {
+                Title = "Publication B",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = OfficialStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            var publicationC = new Publication
+            {
+                Title = "Publication C",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = AdHocStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            var themes = new List<Theme>
+            {
+                new()
+                {
+                    Title = "Theme 1 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                publicationA,
+                                publicationB
+                            }
+                        }
+                    },
+                },
+                new()
+                {
+                    Title = "Theme 2 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                publicationC
+                            }
+                        }
+                    },
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Themes.AddRangeAsync(themes);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupPublicationService(contentDbContext);
+
+                var pagedResult = (await service.GetPublications(
+                    releaseType: OfficialStatistics
+                )).AssertRight();
+                var results = pagedResult.Results;
+
+                Assert.Single(results);
+
+                Assert.Equal(publicationB.Id, results[0].Id);
+                Assert.Equal(OfficialStatistics, results[0].Type);
+            }
+        }
+
+        [Fact]
+        public async Task GetPublications_Search_SortByRelevance_Desc()
+        {
+            var releaseA = new Release
+            {
+                Id = Guid.NewGuid(),
+                Type = NationalStatistics,
+                Published = DateTime.UtcNow
+            };
+
+            var releaseB = new Release
+            {
+                Id = Guid.NewGuid(),
+                Type = NationalStatistics,
+                Published = DateTime.UtcNow
+            };
+
+            var releaseC = new Release
+            {
+                Id = Guid.NewGuid(),
+                Type = NationalStatistics,
+                Published = DateTime.UtcNow
+            };
+
+            var topic = new Topic
+            {
+                Theme = new Theme
+                {
+                    Title = "Theme title"
+                }
+            };
+
+            var publications = new List<Publication>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "Publication B",
+                    LatestPublishedReleaseId = releaseB.Id,
+                    LatestPublishedReleaseNew = releaseB,
+                    Topic = topic
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "Publication C",
+                    LatestPublishedReleaseId = releaseC.Id,
+                    LatestPublishedReleaseNew = releaseC,
+                    Topic = topic
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "Publication A",
+                    LatestPublishedReleaseId = releaseA.Id,
+                    LatestPublishedReleaseNew = releaseA,
+                    Topic = topic
+                },
+            };
+
+            var freeTextRanks = new List<FreeTextRank>
+            {
+                new(publications[1].Id, 100),
+                new(publications[2].Id, 300),
+                new(publications[0].Id, 200)
+            };
+
+            var contentDbContext = new Mock<ContentDbContext>();
+            contentDbContext.Setup(context => context.Publications)
+                .Returns(publications.AsQueryable().BuildMockDbSet().Object);
+            contentDbContext.Setup(context => context.PublicationsFreeTextTable("term"))
+                .Returns(freeTextRanks.AsQueryable().BuildMockDbSet().Object);
+
+            var service = SetupPublicationService(contentDbContext.Object);
+
+            var pagedResult = (await service.GetPublications(
+                search: "term",
+                sort: null, // Sort should default to relevance
+                order: null // Order should default to descending
+            )).AssertRight();
+            var results = pagedResult.Results;
+
+            Assert.Equal(3, results.Count);
+
+            // Expect results sorted by relevance in descending order
+
+            Assert.Equal(publications[2].Id, results[0].Id);
+            Assert.Equal(300, results[0].Rank);
+
+            Assert.Equal(publications[0].Id, results[1].Id);
+            Assert.Equal(200, results[1].Rank);
+
+            Assert.Equal(publications[1].Id, results[2].Id);
+            Assert.Equal(100, results[2].Rank);
+        }
+
+        [Fact]
+        public async Task GetPublications_Search_SortByRelevance_Asc()
+        {
+            var releaseA = new Release
+            {
+                Id = Guid.NewGuid(),
+                Type = NationalStatistics,
+                Published = DateTime.UtcNow
+            };
+
+            var releaseB = new Release
+            {
+                Id = Guid.NewGuid(),
+                Type = NationalStatistics,
+                Published = DateTime.UtcNow
+            };
+
+            var releaseC = new Release
+            {
+                Id = Guid.NewGuid(),
+                Type = NationalStatistics,
+                Published = DateTime.UtcNow
+            };
+
+            var topic = new Topic
+            {
+                Theme = new Theme
+                {
+                    Title = "Theme title"
+                }
+            };
+
+            var publications = new List<Publication>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "Publication B",
+                    LatestPublishedReleaseId = releaseB.Id,
+                    LatestPublishedReleaseNew = releaseB,
+                    Topic = topic
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "Publication C",
+                    LatestPublishedReleaseId = releaseC.Id,
+                    LatestPublishedReleaseNew = releaseC,
+                    Topic = topic
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "Publication A",
+                    LatestPublishedReleaseId = releaseA.Id,
+                    LatestPublishedReleaseNew = releaseA,
+                    Topic = topic
+                },
+            };
+
+            var freeTextRanks = new List<FreeTextRank>
+            {
+                new(publications[1].Id, 100),
+                new(publications[2].Id, 300),
+                new(publications[0].Id, 200)
+            };
+
+            var contentDbContext = new Mock<ContentDbContext>();
+            contentDbContext.Setup(context => context.Publications)
+                .Returns(publications.AsQueryable().BuildMockDbSet().Object);
+            contentDbContext.Setup(context => context.PublicationsFreeTextTable("term"))
+                .Returns(freeTextRanks.AsQueryable().BuildMockDbSet().Object);
+
+            var service = SetupPublicationService(contentDbContext.Object);
+
+            var pagedResult = (await service.GetPublications(
+                search: "term",
+                sort: null, // Sort should default to relevance
+                order: Asc
+            )).AssertRight();
+            var results = pagedResult.Results;
+
+            Assert.Equal(3, results.Count);
+
+            // Expect results sorted by relevance in ascending order
+
+            Assert.Equal(publications[1].Id, results[0].Id);
+            Assert.Equal(100, results[0].Rank);
+
+            Assert.Equal(publications[0].Id, results[1].Id);
+            Assert.Equal(200, results[1].Rank);
+
+            Assert.Equal(publications[2].Id, results[2].Id);
+            Assert.Equal(300, results[2].Rank);
+        }
+
+        [Fact]
+        public async Task GetPublications_SortByPublished_Desc()
+        {
+            var releaseA = new Release
+            {
+                Type = NationalStatistics,
+                Published = new DateTime(2020, 1, 1)
+            };
+
+            var releaseB = new Release
+            {
+                Type = NationalStatistics,
+                Published = new DateTime(2021, 1, 1)
+            };
+
+            var releaseC = new Release
+            {
+                Type = NationalStatistics,
+                Published = new DateTime(2022, 1, 1)
+            };
+
+            var publicationA = new Publication
+            {
+                Title = "Publication A",
+                LatestPublishedReleaseNew = releaseA
+            };
+
+            var publicationB = new Publication
+            {
+                Title = "Publication B",
+                LatestPublishedReleaseNew = releaseB
+            };
+
+            var publicationC = new Publication
+            {
+                Title = "Publication C",
+                LatestPublishedReleaseNew = releaseC
+            };
+
+            var themes = new List<Theme>
+            {
+                new()
+                {
+                    Title = "Theme 1 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                publicationB,
+                                publicationC,
+                                publicationA
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Themes.AddRangeAsync(themes);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupPublicationService(contentDbContext);
+
+                var pagedResult = (await service.GetPublications(
+                    sort: Published,
+                    order: null // Order should default to descending
+                )).AssertRight();
+                var results = pagedResult.Results;
+
+                Assert.Equal(3, results.Count);
+
+                // Expect results sorted by published date in descending order
+
+                Assert.Equal(publicationC.Id, results[0].Id);
+                Assert.Equal(new DateTime(2022, 1, 1), results[0].Published);
+
+                Assert.Equal(publicationB.Id, results[1].Id);
+                Assert.Equal(new DateTime(2021, 1, 1), results[1].Published);
+
+                Assert.Equal(publicationA.Id, results[2].Id);
+                Assert.Equal(new DateTime(2020, 1, 1), results[2].Published);
+            }
+        }
+
+        [Fact]
+        public async Task GetPublications_SortByPublished_Asc()
+        {
+            var releaseA = new Release
+            {
+                Type = NationalStatistics,
+                Published = new DateTime(2020, 1, 1)
+            };
+
+            var releaseB = new Release
+            {
+                Type = NationalStatistics,
+                Published = new DateTime(2021, 1, 1)
+            };
+
+            var releaseC = new Release
+            {
+                Type = NationalStatistics,
+                Published = new DateTime(2022, 1, 1)
+            };
+
+            var publicationA = new Publication
+            {
+                Title = "Publication A",
+                LatestPublishedReleaseNew = releaseA
+            };
+
+            var publicationB = new Publication
+            {
+                Title = "Publication B",
+                LatestPublishedReleaseNew = releaseB
+            };
+
+            var publicationC = new Publication
+            {
+                Title = "Publication C",
+                LatestPublishedReleaseNew = releaseC
+            };
+
+            var themes = new List<Theme>
+            {
+                new()
+                {
+                    Title = "Theme 1 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                publicationB,
+                                publicationC,
+                                publicationA
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Themes.AddRangeAsync(themes);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupPublicationService(contentDbContext);
+
+                var pagedResult = (await service.GetPublications(
+                    sort: Published,
+                    order: Asc
+                )).AssertRight();
+                var results = pagedResult.Results;
+
+                Assert.Equal(3, results.Count);
+
+                // Expect results sorted by published date in ascending order
+
+                Assert.Equal(publicationA.Id, results[0].Id);
+                Assert.Equal(new DateTime(2020, 1, 1), results[0].Published);
+
+                Assert.Equal(publicationB.Id, results[1].Id);
+                Assert.Equal(new DateTime(2021, 1, 1), results[1].Published);
+
+                Assert.Equal(publicationC.Id, results[2].Id);
+                Assert.Equal(new DateTime(2022, 1, 1), results[2].Published);
+            }
+        }
+
+        [Fact]
+        public async Task GetPublications_SortByTitle_Desc()
+        {
+            var publicationA = new Publication
+            {
+                Title = "Publication A",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = NationalStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            var publicationB = new Publication
+            {
+                Title = "Publication B",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = OfficialStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            var publicationC = new Publication
+            {
+                Title = "Publication C",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = AdHocStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            var themes = new List<Theme>
+            {
+                new()
+                {
+                    Title = "Theme 1 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                publicationB,
+                                publicationC,
+                                publicationA
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Themes.AddRangeAsync(themes);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupPublicationService(contentDbContext);
+
+                var pagedResult = (await service.GetPublications(
+                    sort: null, // Sort should default to title
+                    order: Desc
+                )).AssertRight();
+                var results = pagedResult.Results;
+
+                Assert.Equal(3, results.Count);
+
+                // Expect results sorted by title in descending order
+
+                Assert.Equal(publicationC.Id, results[0].Id);
+                Assert.Equal("Publication C", results[0].Title);
+
+                Assert.Equal(publicationB.Id, results[1].Id);
+                Assert.Equal("Publication B", results[1].Title);
+
+                Assert.Equal(publicationA.Id, results[2].Id);
+                Assert.Equal("Publication A", results[2].Title);
+            }
+        }
+
+        [Fact]
+        public async Task GetPublications_SortByTitle_Asc()
+        {
+            var publicationA = new Publication
+            {
+                Title = "Publication A",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = NationalStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            var publicationB = new Publication
+            {
+                Title = "Publication B",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = OfficialStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            var publicationC = new Publication
+            {
+                Title = "Publication C",
+                LatestPublishedReleaseNew = new Release
+                {
+                    Type = AdHocStatistics,
+                    Published = DateTime.UtcNow
+                }
+            };
+
+            var themes = new List<Theme>
+            {
+                new()
+                {
+                    Title = "Theme 1 title",
+                    Topics = new List<Topic>
+                    {
+                        new()
+                        {
+                            Publications = new List<Publication>
+                            {
+                                publicationB,
+                                publicationC,
+                                publicationA
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Themes.AddRangeAsync(themes);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupPublicationService(contentDbContext);
+
+                var pagedResult = (await service.GetPublications(
+                    sort: null, // Sort should default to title
+                    order: null // Order should default to ascending
+                )).AssertRight();
+                var results = pagedResult.Results;
+
+                Assert.Equal(3, results.Count);
+
+                // Expect results sorted by title in ascending order
+
+                Assert.Equal(publicationA.Id, results[0].Id);
+                Assert.Equal("Publication A", results[0].Title);
+
+                Assert.Equal(publicationB.Id, results[1].Id);
+                Assert.Equal("Publication B", results[1].Title);
+
+                Assert.Equal(publicationC.Id, results[2].Id);
+                Assert.Equal("Publication C", results[2].Title);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -284,7 +284,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetPublications()
+        public async Task ListPublications()
         {
             var publicationA = new Publication
             {
@@ -363,7 +363,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupPublicationService(contentDbContext);
 
-                var pagedResult = (await service.GetPublications()).AssertRight();
+                var pagedResult = (await service.ListPublications()).AssertRight();
                 var results = pagedResult.Results;
 
                 Assert.Equal(3, results.Count);
@@ -394,7 +394,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetPublications_ExcludesUnpublishedPublications()
+        public async Task ListPublications_ExcludesUnpublishedPublications()
         {
             // Published
             var publicationA = new Publication
@@ -444,7 +444,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupPublicationService(contentDbContext);
 
-                var pagedResult = (await service.GetPublications()).AssertRight();
+                var pagedResult = (await service.ListPublications()).AssertRight();
                 var results = pagedResult.Results;
 
                 Assert.Equal(publicationA.Id, results[0].Id);
@@ -452,7 +452,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetPublications_ExcludesSupersededPublications()
+        public async Task ListPublications_ExcludesSupersededPublications()
         {
             // Published
             var publicationA = new Publication
@@ -540,7 +540,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupPublicationService(contentDbContext);
 
-                var pagedResult = (await service.GetPublications()).AssertRight();
+                var pagedResult = (await service.ListPublications()).AssertRight();
                 var results = pagedResult.Results;
 
                 Assert.Equal(publicationA.Id, results[0].Id);
@@ -550,7 +550,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetPublications_FilterByTheme()
+        public async Task ListPublications_FilterByTheme()
         {
             var publicationA = new Publication
             {
@@ -625,7 +625,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupPublicationService(contentDbContext);
 
-                var pagedResult = (await service.GetPublications(
+                var pagedResult = (await service.ListPublications(
                     themeId: themes[0].Id
                 )).AssertRight();
                 var results = pagedResult.Results;
@@ -641,7 +641,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetPublications_FilterByReleaseType()
+        public async Task ListPublications_FilterByReleaseType()
         {
             var publicationA = new Publication
             {
@@ -717,7 +717,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupPublicationService(contentDbContext);
 
-                var pagedResult = (await service.GetPublications(
+                var pagedResult = (await service.ListPublications(
                     releaseType: OfficialStatistics
                 )).AssertRight();
                 var results = pagedResult.Results;
@@ -730,7 +730,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetPublications_Search_SortByRelevance_Desc()
+        public async Task ListPublications_Search_SortByRelevance_Desc()
         {
             var releaseA = new Release
             {
@@ -804,7 +804,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             var service = SetupPublicationService(contentDbContext.Object);
 
-            var pagedResult = (await service.GetPublications(
+            var pagedResult = (await service.ListPublications(
                 search: "term",
                 sort: null, // Sort should default to relevance
                 order: null // Order should default to descending
@@ -826,7 +826,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetPublications_Search_SortByRelevance_Asc()
+        public async Task ListPublications_Search_SortByRelevance_Asc()
         {
             var releaseA = new Release
             {
@@ -900,7 +900,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             var service = SetupPublicationService(contentDbContext.Object);
 
-            var pagedResult = (await service.GetPublications(
+            var pagedResult = (await service.ListPublications(
                 search: "term",
                 sort: null, // Sort should default to relevance
                 order: Asc
@@ -922,7 +922,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetPublications_SortByPublished_Desc()
+        public async Task ListPublications_SortByPublished_Desc()
         {
             var releaseA = new Release
             {
@@ -991,7 +991,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupPublicationService(contentDbContext);
 
-                var pagedResult = (await service.GetPublications(
+                var pagedResult = (await service.ListPublications(
                     sort: Published,
                     order: null // Order should default to descending
                 )).AssertRight();
@@ -1013,7 +1013,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetPublications_SortByPublished_Asc()
+        public async Task ListPublications_SortByPublished_Asc()
         {
             var releaseA = new Release
             {
@@ -1082,7 +1082,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupPublicationService(contentDbContext);
 
-                var pagedResult = (await service.GetPublications(
+                var pagedResult = (await service.ListPublications(
                     sort: Published,
                     order: Asc
                 )).AssertRight();
@@ -1104,7 +1104,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetPublications_SortByTitle_Desc()
+        public async Task ListPublications_SortByTitle_Desc()
         {
             var publicationA = new Publication
             {
@@ -1167,7 +1167,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupPublicationService(contentDbContext);
 
-                var pagedResult = (await service.GetPublications(
+                var pagedResult = (await service.ListPublications(
                     sort: null, // Sort should default to title
                     order: Desc
                 )).AssertRight();
@@ -1189,7 +1189,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetPublications_SortByTitle_Asc()
+        public async Task ListPublications_SortByTitle_Asc()
         {
             var publicationA = new Publication
             {
@@ -1252,7 +1252,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var service = SetupPublicationService(contentDbContext);
 
-                var pagedResult = (await service.GetPublications(
+                var pagedResult = (await service.ListPublications(
                     sort: null, // Sort should default to title
                     order: null // Order should default to ascending
                 )).AssertRight();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
@@ -13,7 +13,7 @@ public interface IPublicationService
 {
     Task<Either<ActionResult, PublicationCacheViewModel>> Get(string publicationSlug);
 
-    Task<Either<ActionResult, PaginatedListViewModel<PublicationSearchResultViewModel>>> GetPublications(
+    Task<Either<ActionResult, PaginatedListViewModel<PublicationSearchResultViewModel>>> ListPublications(
         ReleaseType? releaseType = null,
         Guid? themeId = null,
         string? search = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
@@ -1,8 +1,8 @@
 ﻿#nullable enable
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -13,14 +13,14 @@ public interface IPublicationService
 {
     Task<Either<ActionResult, PublicationCacheViewModel>> Get(string publicationSlug);
 
-    Task<Either<ActionResult, List<PublicationSearchResultViewModel>>> GetPublications(
-        ReleaseType? releaseType,
-        Guid? themeId,
-        string? search,
-        PublicationsSortBy sort,
-        SortOrder order,
-        int offset,
-        int limit);
+    Task<Either<ActionResult, PaginatedListViewModel<PublicationSearchResultViewModel>>> GetPublications(
+        ReleaseType? releaseType = null,
+        Guid? themeId = null,
+        string? search = null,
+        PublicationsSortBy? sort = null,
+        SortOrder? order = null,
+        int page = 1,
+        int pageSize = 10);
 
     public enum PublicationsSortBy
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
@@ -1,6 +1,9 @@
 ﻿#nullable enable
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 
@@ -8,5 +11,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces
 
 public interface IPublicationService
 {
-    public Task<Either<ActionResult, PublicationCacheViewModel>> Get(string publicationSlug);
+    Task<Either<ActionResult, PublicationCacheViewModel>> Get(string publicationSlug);
+
+    Task<Either<ActionResult, List<PublicationSearchResultViewModel>>> GetPublications(
+        ReleaseType? releaseType,
+        Guid? themeId,
+        string? search,
+        PublicationsSortBy sort,
+        SortOrder order,
+        int offset,
+        int limit);
+
+    public enum PublicationsSortBy
+    {
+        Published,
+        Relevance,
+        Title
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -50,7 +50,7 @@ public class PublicationService : IPublicationService
             });
     }
 
-    public async Task<Either<ActionResult, PaginatedListViewModel<PublicationSearchResultViewModel>>> GetPublications(
+    public async Task<Either<ActionResult, PaginatedListViewModel<PublicationSearchResultViewModel>>> ListPublications(
         ReleaseType? releaseType = null,
         Guid? themeId = null,
         string? search = null,
@@ -114,16 +114,16 @@ public class PublicationService : IPublicationService
         var results = await orderedQueryable
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
-            .Select(p =>
+            .Select(tuple =>
                 new PublicationSearchResultViewModel
                 {
-                    Id = p.Publication.Id,
-                    Summary = p.Publication.Summary,
-                    Title = p.Publication.Title,
-                    Theme = p.Publication.Topic.Theme.Title,
-                    Published = p.Publication.LatestPublishedReleaseNew!.Published!.Value,
-                    Type = p.Publication.LatestPublishedReleaseNew!.Type,
-                    Rank = p.Rank
+                    Id = tuple.Publication.Id,
+                    Summary = tuple.Publication.Summary,
+                    Title = tuple.Publication.Title,
+                    Theme = tuple.Publication.Topic.Theme.Title,
+                    Published = tuple.Publication.LatestPublishedReleaseNew!.Published!.Value,
+                    Type = tuple.Publication.LatestPublishedReleaseNew!.Type,
+                    Rank = tuple.Rank
                 }).ToListAsync();
 
         return new PaginatedListViewModel<PublicationSearchResultViewModel>(results, totalResults, page, pageSize);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -11,6 +11,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IPublicationService;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
 
@@ -45,12 +46,25 @@ public class PublicationService : IPublicationService
             });
     }
 
+    public async Task<Either<ActionResult, List<PublicationSearchResultViewModel>>> GetPublications(
+        ReleaseType? releaseType,
+        Guid? themeId,
+        string? search,
+        PublicationsSortBy sort,
+        SortOrder order,
+        int offset,
+        int limit)
+    {
+        return await Task.FromResult(new List<PublicationSearchResultViewModel>());
+    }
+
     private static Either<ActionResult, Release> GetLatestRelease(Publication publication)
     {
         return publication.LatestPublishedRelease() ?? new Either<ActionResult, Release>(new NotFoundResult());
     }
 
-    private async Task<PublicationCacheViewModel> BuildPublicationViewModel(Publication publication, Release latestRelease)
+    private async Task<PublicationCacheViewModel> BuildPublicationViewModel(Publication publication,
+        Release latestRelease)
     {
         return new PublicationCacheViewModel
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationSearchResultViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationSearchResultViewModel.cs
@@ -1,0 +1,21 @@
+﻿#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+
+public record PublicationSearchResultViewModel
+{
+    public Guid Id { get; init; }
+    public string Summary { get; init; }
+    public string Title { get; init; }
+    public string Theme { get; init; }
+    public DateTime Published { get; init; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public ReleaseType Type { get; init; }
+
+    public int? Rank { get; set; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
@@ -985,7 +985,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             ISubjectRepository? subjectRepository = null)
         {
             return new(
-                contentDbContext ?? Mock.Of<ContentDbContext>(MockBehavior.Strict),
+                contentDbContext ?? Mock.Of<ContentDbContext>(),
                 tableBuilderService ?? Mock.Of<ITableBuilderService>(MockBehavior.Strict),
                 blobStorageService ?? Mock.Of<IBlobStorageService>(MockBehavior.Strict),
                 subjectRepository ?? Mock.Of<ISubjectRepository>(MockBehavior.Strict),

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PermalinkMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PermalinkMigrationServiceTests.cs
@@ -319,7 +319,7 @@ public class PermalinkMigrationServiceTests
         IStorageQueueService? storageQueueService = null)
     {
         return new PermalinkMigrationService(
-            contentDbContext ?? Mock.Of<ContentDbContext>(Strict),
+            contentDbContext ?? Mock.Of<ContentDbContext>(),
             blobServiceClient,
             storageQueueService ?? Mock.Of<IStorageQueueService>(Strict)
         );

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -517,7 +517,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             IReleaseSubjectRepository? releaseSubjectRepository = null)
         {
             return new(
-                contentDbContext ?? Mock.Of<ContentDbContext>(Strict),
+                contentDbContext ?? Mock.Of<ContentDbContext>(),
                 statisticsDbContext ?? Mock.Of<StatisticsDbContext>(Strict),
                 publicStatisticsDbContext ?? Mock.Of<PublicStatisticsDbContext>(),
                 methodologyService ?? Mock.Of<IMethodologyService>(Strict),


### PR DESCRIPTION
⚠️ This PR depends on [EES-3882](https://dfedigital.atlassian.net/browse/EES-3882) added by https://github.com/dfe-analytical-services/explore-education-statistics/pull/3631. Technically it doesn't need the associated migration described by [EES-3894](https://dfedigital.atlassian.net/browse/EES-3894) to be run before it's merged, but it won't consider any existing publications as published and return them without it. With this being a brand new API endpoint awaiting front-end development, this probably isn't an issue.

This PR adds a new Content API endpoint that can be used to get published publications for the new Find Statistics page described by [EES-3517](https://dfedigital.atlassian.net/browse/EES-3517).

It uses query parameters to allow controlling filtering, a free-text search, sorting and pagination. By default it returns publications as long as they are published and not superseded, according to the defaults of all the parameters described below.

### Filtering

- By theme - `/publications?themeId=574eefe7-0afa-488b-9d0a-11a661fcd776`
- By latest release type - `/publications?releaseType=OfficialStatistics`

### Free-text search

Matches are generated on meaning, rather than on exact words, phrases or sentences, if any term in the publication title or summary is found. This uses word stemming to generate relevance ranked results.

`/publications?search=admission%20appeals`

### Sorting

Provides three different sorting options:

- `published` - Latest release published date
- `title` - Publication title  (default without search)
- `relevance` - relevance of results ranked against the search term - (default with search)

in either `asc` or `desc` order. The default order is descending unless sorting by title and then it's ascending.

`/publications?sort=title&order=desc`

### Pagination

Uses parameters `page` and `pageSize` to return a paginated response using offset pagination defaulting to a page size of 10.

The response is a `PaginatedListViewModel<PublicationSearchResultViewModel>` with a `PagingViewModel` containing `page`, `pageSize`, `totalResults` and `totalPages`.

- Return publications from 1 to 10 - `/publications`
- Return publications from 1 to 5 - `/publications?pageSize=5`
- Return publications 6 to 10 - `/publications?page=2&pageSize=5`

### Validation

- `search` min length is 3 characters.
- `releaseType`, `sort`,  and `order` must be valid enum values.
- `themeId` must be a `Guid`.
- Pagination `page` and `pageSize` must be greater than 0.

### Examples

- Example using every parameter:

```
GET /api/publications?releaseType=OfficialStatistics&themeId=574eefe7-0afa-488b-9d0a-11a661fcd776&search=admission%appeals&sort=relevance&order=desc&page=1&pageSize=5
```