### PR TITLE
EES-2946 move y axis ref lines up a tad

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/CustomReferenceLineLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/CustomReferenceLineLabel.tsx
@@ -68,7 +68,7 @@ const CustomReferenceLineLabel = ({
   return (
     <text
       className="govuk-!-font-size-16"
-      dy={0}
+      dy={axis === 'y' ? -4 : 0}
       x={labelPosition.x}
       y={labelPosition.y}
       textAnchor={getTextAnchor()}


### PR DESCRIPTION
Moves the label on y axis reference lines up a little bit so they don't overlap with the line.

Before:
![before](https://user-images.githubusercontent.com/81572860/201640595-157edafb-a9f3-4b08-85c9-51edfaee1f91.PNG)

After:
![now](https://user-images.githubusercontent.com/81572860/201640599-8384ec16-5e2f-47f1-8daa-bc24fd6862a6.PNG)
