### PR TITLE
EES-3877 - fix bad methodology ids being generated in Accordion sections

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
@@ -129,9 +129,8 @@ const MethodologyAccordionSection = ({
       {...props}
       anchorLinkUrl={
         editingMode === 'preview'
-          ? `${PublicAppUrl}/methodology/${
-              currentMethodology.slug
-            }#${heading.toLowerCase().split(' ').join('-')}`
+          ? id =>
+              `${PublicAppUrl}/methodology/${currentMethodology.slug}/#${id}`
           : undefined
       }
       heading={heading}

--- a/src/explore-education-statistics-common/src/components/Accordion.tsx
+++ b/src/explore-education-statistics-common/src/components/Accordion.tsx
@@ -64,7 +64,7 @@ const Accordion = ({
   );
 
   const { isMounted } = useMounted(() => {
-    const goToHash = async () => {
+    const goToAndOpenHash = async () => {
       setTimeout(() => {
         if (!ref.current || !window.location.hash) {
           return;
@@ -74,7 +74,9 @@ const Accordion = ({
 
         try {
           locationHashEl = ref.current.querySelector(window.location.hash);
-        } catch (_) {
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.error(e);
           return;
         }
 
@@ -108,10 +110,10 @@ const Accordion = ({
       }, 200);
     };
 
-    goToHash();
-    window.addEventListener('hashchange', goToHash);
+    goToAndOpenHash();
+    window.addEventListener('hashchange', goToAndOpenHash);
 
-    return () => window.removeEventListener('hashchange', goToHash);
+    return () => window.removeEventListener('hashchange', goToAndOpenHash);
   });
 
   useEffect(() => {

--- a/src/explore-education-statistics-common/src/components/AccordionSection.tsx
+++ b/src/explore-education-statistics-common/src/components/AccordionSection.tsx
@@ -2,6 +2,7 @@ import CopyLinkButton from '@common/components/CopyLinkButton';
 import useMounted from '@common/hooks/useMounted';
 import findAllParents from '@common/utils/dom/findAllParents';
 import classNames from 'classnames';
+import kebabCase from 'lodash/kebabCase';
 import React, { createElement, memo, ReactNode } from 'react';
 import styles from './AccordionSection.module.scss';
 import GoToTopLink from './GoToTopLink';
@@ -18,7 +19,7 @@ export interface AccordionSectionProps {
         contentId: string;
       }) => ReactNode);
   className?: string;
-  anchorLinkUrl?: string;
+  anchorLinkUrl?: (id: string) => string;
   goToTop?: boolean;
   header?: ReactNode;
   heading: string;
@@ -28,6 +29,7 @@ export interface AccordionSectionProps {
    */
   headingTag?: 'h2' | 'h3' | 'h4';
   id?: string;
+  anchorLinkIdPrefix?: string;
   open?: boolean;
   testId?: string;
   onToggle?: ToggleHandler;
@@ -53,6 +55,7 @@ const AccordionSection = ({
   heading,
   headingTag = 'h2',
   id = 'accordionSection',
+  anchorLinkIdPrefix = 'section',
   open = false,
   onToggle,
 }: AccordionSectionProps) => {
@@ -73,7 +76,7 @@ const AccordionSection = ({
         {anchorLinkUrl && (
           <CopyLinkButton
             className={styles.copyLinkButton}
-            url={anchorLinkUrl}
+            url={anchorLinkUrl(id)}
           />
         )}
         {header ??
@@ -81,7 +84,7 @@ const AccordionSection = ({
             headingTag,
             {
               className: classes.sectionHeading,
-              id: heading.toLowerCase().split(' ').join('-'),
+              id: `${anchorLinkIdPrefix}-${kebabCase(heading)}`,
             },
             isMounted ? (
               <button

--- a/src/explore-education-statistics-common/src/components/CopyLinkButton.tsx
+++ b/src/explore-education-statistics-common/src/components/CopyLinkButton.tsx
@@ -8,13 +8,12 @@ import useToggle from '@common/hooks/useToggle';
 import classNames from 'classnames';
 import React from 'react';
 
-const CopyLinkButton = ({
-  className,
-  url,
-}: {
+interface Props {
   className?: string;
   url: string;
-}) => {
+}
+
+const CopyLinkButton = ({ className, url }: Props) => {
   const [copied, toggleCopied] = useToggle(false);
   const [showModal, toggleModal] = useToggle(false);
 

--- a/src/explore-education-statistics-common/src/components/__tests__/AccordionSection.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/AccordionSection.test.tsx
@@ -48,13 +48,13 @@ describe('AccordionSection', () => {
     );
     expect(
       screen.getByRole('heading', { name: 'Test heading' }),
-    ).toHaveAttribute('id', 'test-heading');
+    ).toHaveAttribute('id', 'section-test-heading');
   });
 
   test('adds a copy link button when anchorLinkUrl is set', () => {
     const testUrl = 'http://test.com/1#test-heading';
     render(
-      <AccordionSection anchorLinkUrl={testUrl} heading="Test heading">
+      <AccordionSection anchorLinkUrl={() => testUrl} heading="Test heading">
         <p>Test content</p>
       </AccordionSection>,
     );

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`AccordionSection renders correctly with required props 1`] = `
 >
   <div class="govuk-accordion__section-header">
     <h2 class="govuk-accordion__section-heading"
-        id="test-heading"
+        id="section-test-heading"
     >
       <button aria-controls="accordionSection-content"
               aria-expanded="false"
@@ -48,7 +48,7 @@ exports[`AccordionSection renders with caption 1`] = `
 >
   <div class="govuk-accordion__section-header">
     <h2 class="govuk-accordion__section-heading"
-        id="test-heading"
+        id="section-test-heading"
     >
       <button aria-controls="accordionSection-content"
               aria-expanded="false"
@@ -92,7 +92,7 @@ exports[`AccordionSection renders with different heading size 1`] = `
 >
   <div class="govuk-accordion__section-header">
     <h3 class="govuk-accordion__section-heading"
-        id="test-heading"
+        id="section-test-heading"
     >
       <button aria-controls="accordionSection-content"
               aria-expanded="false"

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
@@ -141,6 +141,7 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
             return (
               <AccordionSection
                 id={`content-section-${order}`}
+                anchorLinkIdPrefix="content-section"
                 heading={heading}
                 caption={caption}
                 key={order}
@@ -176,6 +177,7 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
             {data.annexes.map(({ heading, caption, order, content }) => {
               return (
                 <AccordionSection
+                  anchorLinkIdPrefix="annex-section"
                   heading={heading}
                   caption={caption}
                   key={order}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -42,6 +42,21 @@ Add content to methodology
     user adds content to accordion section text block    Methodology content section 2    1
     ...    Content 2    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
 
+    # regression test for EES-3877
+    user creates new content section    3    3.test-title 3
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user adds text block to editable accordion section    3.test-title 3
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user adds content to accordion section text block    3.test-title 3    1
+    ...    Content 3    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+
+    user creates new content section    4    4.-test-.title 4
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user adds text block to editable accordion section    4.-test-.title 4
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user adds content to accordion section text block    4.-test-.title 4    1
+    ...    Content 4    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+
 Add annexe content to methodology
     user creates new content section    1    Methodology annexe section 1
     ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
@@ -130,12 +145,33 @@ Verify that the methodology is publicly accessible
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME}
     user waits until h1 is visible    ${PUBLICATION_NAME}
-    user waits until page contains title caption    Methodology
+    user waits until page contains title caption    Methodology    %{WAIT_SMALL}
+    ${METHODOLOGY_URL}=    get location
+    set suite variable    ${METHODOLOGY_URL}
+
+Verify that methodology hash links open accoridon sections correctly
+    [Documentation]    EES-3877
+    user navigates to public frontend    ${METHODOLOGY_URL}#content-section-3-test-title-3
+    user waits until h1 is visible    ${PUBLICATION_NAME}
+    user waits until page contains title caption    Methodology    %{WAIT_SMALL}
+    user checks page contains    3.test-title 3
+    user checks page contains    Content 3
+
+    user navigates to public frontend    ${METHODOLOGY_URL}#content-section-4-test-title-4
+    user waits for page to finish loading
+
+    user checks page contains    4.-test-.title 4
+    user checks page contains    Content 4
 
 Verify that the methodology displays a link to the publication
+    user navigates to public frontend    ${METHODOLOGY_URL}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
+    user waits until page contains title caption    Methodology    %{WAIT_SMALL}
+
     user checks element contains child element
     ...    css:[aria-labelledby="related-information"]
     ...    xpath://h3[text()="Publications"]
+
     user checks page contains link with text and url
     ...    ${PUBLICATION_NAME}
     ...    /find-statistics/ui-tests-publish-methodology-%{RUN_IDENTIFIER}
@@ -148,7 +184,10 @@ Verify that the methodology content is correct
     user checks accordion is in position    Methodology content section 1    1    id:content
     user checks accordion is in position    Methodology content section 2    2    id:content
 
-    user checks there are x accordion sections    2    id:content
+    user checks accordion is in position    3.test-title 3    3    id:content
+    user checks accordion is in position    4.-test-.title 4    4    id:content
+
+    user checks there are x accordion sections    4    id:content
 
     user opens accordion section    Methodology content section 1
     ${content_section_1}=    user gets accordion section content element    Methodology content section 1
@@ -286,7 +325,10 @@ Verify that the amended methodology content is correct
     user checks accordion is in position    Methodology content section 2    1    id:content
     user checks accordion is in position    Methodology content section 1 updated    2    id:content
 
-    user checks there are x accordion sections    2    id:content
+    user checks accordion is in position    3.test-title 3    3    id:content
+    user checks accordion is in position    4.-test-.title 4    4    id:content
+
+    user checks there are x accordion sections    4    id:content
 
     user opens accordion section    Methodology content section 2
     ${content_section_2}=    user gets accordion section content element    Methodology content section 2


### PR DESCRIPTION
This PR:
- replaces any methodology/accordion section IDs that start with a number at the start with `section-` which causes this error. This resolves an error whereby methodology URLs with a hash (linking to accordion content) wouldn't open

```
DOMException: Failed to execute 'querySelector' on 'Element': '#6.test-title' is not a valid selector.
```

![image](https://user-images.githubusercontent.com/55030296/202713923-3a8701d4-ea11-42da-9d46-7b6aaa483b46.png)