### PR TITLE
EES-3893 fix table tool summary list margin

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.module.scss
@@ -15,9 +15,6 @@
 
   :global(.govuk-summary-list) {
     margin-bottom: 0;
-    @include govuk-media-query($from: tablet) {
-      margin-left: govuk-spacing(9) + govuk-spacing(5);
-    }
   }
 }
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.module.scss
@@ -2,10 +2,8 @@
 
 .stepEnabled {
   @include govuk-media-query($from: tablet) {
-    left: 0;
     line-height: 1;
-    margin: 0;
-    position: absolute;
-    top: -2px;
+    margin: -2px govuk-spacing(2) 0 0;
+    min-width: 75px;
   }
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepSummary.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepSummary.module.scss
@@ -15,7 +15,12 @@
   flex-grow: 1;
 
   @include govuk-media-query($from: tablet) {
+    display: flex;
     max-width: 75%;
+
+    :global(.govuk-summary-list__key) {
+      width: 36%;
+    }
   }
 }
 


### PR DESCRIPTION
Adjusts the CSS to not cause the overflow when subject details are expanded in the table tool. The margin that caused the problem was used for spacing on the inactive step headings so I've changed them a bit.

Before: 
![overflow](https://user-images.githubusercontent.com/81572860/202209882-afc60d3d-9116-44a6-8510-13f2771b467a.PNG)

After:
![margin-after](https://user-images.githubusercontent.com/81572860/202208725-fd7b3f9d-4bb2-4e58-9677-2c8b1fe4bd53.PNG)
