### PR TITLE
EES-3785 fix legend label on small screens

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.module.scss
@@ -1,5 +1,9 @@
 @import '~govuk-frontend/govuk/base';
 
+.container {
+  overflow-x: auto;
+}
+
 .item {
   border-bottom: 1px solid govuk-colour('mid-grey');
   margin-bottom: govuk-spacing(4);
@@ -23,6 +27,7 @@
 .labelInput {
   composes: configurationInput;
   flex-grow: 1;
+  min-width: 200px;
 }
 
 .colourInput {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.module.scss
@@ -1,9 +1,5 @@
 @import '~govuk-frontend/govuk/base';
 
-.container {
-  overflow-x: auto;
-}
-
 .item {
   border-bottom: 1px solid govuk-colour('mid-grey');
   margin-bottom: govuk-spacing(4);

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
@@ -331,9 +331,8 @@ const ChartLegendConfiguration = ({
             </>
           )}
 
-          <div className="govuk-!-margin-bottom-6">
-            <h4>Legend items</h4>
-
+          <h4>Legend items</h4>
+          <div className={`${styles.container} govuk-!-margin-bottom-6`}>
             {form.values.items?.length > 0 ? (
               <>
                 {form.values.items?.map((dataSet, index) => {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
@@ -332,7 +332,7 @@ const ChartLegendConfiguration = ({
           )}
 
           <h4>Legend items</h4>
-          <div className={`${styles.container} govuk-!-margin-bottom-6`}>
+          <div className="dfe-overflow-x--auto govuk-!-margin-bottom-6">
             {form.values.items?.length > 0 ? (
               <>
                 {form.values.items?.map((dataSet, index) => {

--- a/src/explore-education-statistics-common/src/styles/_all.scss
+++ b/src/explore-education-statistics-common/src/styles/_all.scss
@@ -17,5 +17,6 @@
 @import './utils/flex';
 @import './utils/js-hidden';
 @import './utils/modifiers';
+@import './utils/overflow';
 @import './utils/position';
 @import './utils/text';

--- a/src/explore-education-statistics-common/src/styles/utils/_overflow.scss
+++ b/src/explore-education-statistics-common/src/styles/utils/_overflow.scss
@@ -1,0 +1,3 @@
+.dfe-overflow-x--auto {
+  overflow-x: auto;
+}


### PR DESCRIPTION
Fixes a bug where the legend label was unusable on small screens. Also, adds `overflow-x: auto` to the container so you can scroll across the list more easily on small screens.

**Before:**
![legend-label-1](https://user-images.githubusercontent.com/81572860/202490408-5134d9ca-f887-4601-bc93-e123e18e87a8.PNG)

**After:**
![legend-label-2](https://user-images.githubusercontent.com/81572860/202490414-b4402271-8f03-4b41-b138-fcc89fdf1e51.PNG)
