### PR TITLE
EES-3882 migration to set Publication.LatestPublishedReleaseId and change Publisher to set it for all publications affected when publishing

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationMigrationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationMigrationServicePermissionTests.cs
@@ -1,0 +1,46 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+/// <summary>
+/// TODO EES-3882 Remove after migration has been run by EES-3894
+/// </summary>
+public class PublicationMigrationServicePermissionTests
+{
+    [Fact]
+    public async Task SetLatestPublishedReleases()
+    {
+        await PermissionTestUtil.PolicyCheckBuilder()
+            .SetupCheck(SecurityPolicies.CanRunReleaseMigrations, false)
+            .AssertForbidden(
+                async userService =>
+                {
+                    var service = SetupService(
+                        userService: userService.Object
+                    );
+
+                    return await service.SetLatestPublishedReleases();
+                }
+            );
+    }
+
+    private static PublicationMigrationService SetupService(
+        ContentDbContext? contentDbContext = null,
+        IUserService? userService = null,
+        ILogger<PublicationMigrationService>? logger = null)
+    {
+        return new PublicationMigrationService(
+            contentDbContext ?? DbUtils.InMemoryApplicationDbContext(),
+            userService ?? Mock.Of<IUserService>(MockBehavior.Strict),
+            logger ?? Mock.Of<ILogger<PublicationMigrationService>>()
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationMigrationServiceTests.cs
@@ -1,0 +1,532 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+/// <summary>
+/// TODO EES-3882 Remove after migration has been run by EES-3894
+/// </summary>
+public class PublicationMigrationServiceTests
+{
+    [Fact]
+    public async Task SetLatestPublishedReleases_SetsCorrectReleaseInTimeSeries()
+    {
+        var release2021Week21 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2021",
+            TimePeriodCoverage = TimeIdentifier.Week21,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var release2022Week1 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.Week1,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var release2022Week2 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.Week2,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var release2022Week3 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.Week3,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var release2022Week10 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.Week10,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        // Latest in time series
+        var release2022Week21 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.Week21,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var publication = new Publication
+        {
+            Releases = new List<Release>
+            {
+                // Set the releases so that they are not in time series order
+
+                // Include a range of releases to make sure they are being correctly ordered by the
+                // time identifiers enum entry position rather than in alphanumeric order by value
+
+                release2022Week3,
+                release2022Week21,
+                release2022Week10,
+                release2021Week21,
+                release2022Week2,
+                release2022Week1
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddAsync(publication);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            var service = SetupService(context);
+            var result = await service.SetLatestPublishedReleases();
+            result.AssertRight();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            // Release 2022 week 21 should be the latest published
+            await AssertLatestPublishedReleaseIdEqual(release2022Week21.Id, publication.Id, context);
+        }
+    }
+
+    [Fact]
+    public async Task SetLatestPublishedReleases_SetsCorrectReleaseInTimeSeries_LatestInSeriesNotPublished()
+    {
+        var release2021Week21 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2021",
+            TimePeriodCoverage = TimeIdentifier.Week21,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var release2022Week1 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.Week1,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var release2022Week2 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.Week2,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var release2022Week3 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.Week3,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        // Latest published in time series
+        var release2022Week10 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.Week10,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        // Latest in time series (not published)
+        var release2022Week21 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.Week21,
+            Published = null
+        };
+
+        var publication = new Publication
+        {
+            Releases = new List<Release>
+            {
+                // Set the releases so that they are not in time series order
+
+                // Include a range of releases to make sure they are being correctly ordered by the
+                // time identifiers enum entry position rather than in alphanumeric order by value
+
+                release2022Week3,
+                release2022Week21,
+                release2022Week10,
+                release2021Week21,
+                release2022Week2,
+                release2022Week1
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddAsync(publication);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            var service = SetupService(context);
+            var result = await service.SetLatestPublishedReleases();
+            result.AssertRight();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            // Release 2022 week 10 should be the latest published
+            await AssertLatestPublishedReleaseIdEqual(release2022Week10.Id, publication.Id, context);
+        }
+    }
+
+    [Fact]
+    public async Task SetLatestPublishedReleases_SetsCorrectReleaseVersion()
+    {
+        var releaseVersion0 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.CalendarYear,
+            Version = 0,
+            PreviousVersionId = null,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var releaseVersion1 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.CalendarYear,
+            Version = 1,
+            PreviousVersionId = releaseVersion0.Id,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var releaseVersion2 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.CalendarYear,
+            Version = 2,
+            PreviousVersionId = releaseVersion1.Id,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var publication = new Publication
+        {
+            Releases = new List<Release>
+            {
+                // Set the releases so that they are not in version order
+                releaseVersion1,
+                releaseVersion2,
+                releaseVersion0
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddAsync(publication);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            var service = SetupService(context);
+            var result = await service.SetLatestPublishedReleases();
+            result.AssertRight();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            // Release version 2 should be the latest published 
+            await AssertLatestPublishedReleaseIdEqual(releaseVersion2.Id, publication.Id, context);
+        }
+    }
+
+    [Fact]
+    public async Task SetLatestPublishedReleases_SetsCorrectReleaseVersion_LatestVersionNotPublished()
+    {
+        var releaseVersion0 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.CalendarYear,
+            Version = 0,
+            PreviousVersionId = null,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var releaseVersion1 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.CalendarYear,
+            Version = 1,
+            PreviousVersionId = releaseVersion0.Id,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        // Latest published version
+        var releaseVersion2 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.CalendarYear,
+            Version = 2,
+            PreviousVersionId = releaseVersion1.Id,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        // Latest version (not published)
+        var releaseVersion3 = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.CalendarYear,
+            Version = 3,
+            PreviousVersionId = releaseVersion2.Id,
+            Published = null
+        };
+
+        var publication = new Publication
+        {
+            Releases = new List<Release>
+            {
+                // Set the releases so that they are not in version order
+                releaseVersion1,
+                releaseVersion3,
+                releaseVersion2,
+                releaseVersion0
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddAsync(publication);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            var service = SetupService(context);
+            var result = await service.SetLatestPublishedReleases();
+            result.AssertRight();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            // Release version 2 should be the latest published
+            await AssertLatestPublishedReleaseIdEqual(releaseVersion2.Id, publication.Id, context);
+        }
+    }
+
+    [Fact]
+    public async Task SetLatestPublishedReleases_IgnoresMigratedPublications()
+    {
+        var release = new Release
+        {
+            Id = Guid.NewGuid(),
+            ReleaseName = "2022",
+            TimePeriodCoverage = TimeIdentifier.CalendarYear,
+            Published = DateTime.UtcNow.AddDays(-1)
+        };
+
+        // Set up a publication with a published release, but with a LatestPublishedReleaseId that's different to the id
+        // of the release. We can use this to test if it's touched or not.
+        var publication = new Publication
+        {
+            LatestPublishedReleaseId = Guid.NewGuid(),
+            Releases = new List<Release>
+            {
+                release
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            await context.Releases.AddAsync(release);
+            await context.Publications.AddAsync(publication);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            var service = SetupService(context);
+            var result = await service.SetLatestPublishedReleases();
+            result.AssertRight();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            var found = await context.Publications.SingleAsync(p => p.Id == publication.Id);
+
+            // Publication shouldn't have been updated since it already had a value of LatestPublishedReleaseId
+            Assert.Equal(publication.LatestPublishedReleaseId, found.LatestPublishedReleaseId);
+        }
+    }
+
+    [Fact]
+    public async Task SetLatestPublishedReleases_IgnoresPublicationWithoutReleases()
+    {
+        // Published
+        var publicationA = new Publication
+        {
+            Releases = new List<Release>
+            {
+                new()
+                {
+                    ReleaseName = "2022",
+                    TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                    Published = DateTime.UtcNow.AddDays(-1)
+                }
+            }
+        };
+
+        // Not published (no releases)
+        var publicationB = new Publication
+        {
+            Releases = new List<Release>()
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddRangeAsync(publicationA, publicationB);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            var service = SetupService(context);
+            var result = await service.SetLatestPublishedReleases();
+            result.AssertRight();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            // Publication A should have a LatestPublishedReleaseId since it's published 
+            await AssertLatestPublishedReleaseIdEqual(publicationA.Releases[0].Id, publicationA.Id, context);
+
+            // Publication B should have no LatestPublishedReleaseId
+            await AssertLatestPublishedReleaseIdNull(publicationB.Id, context);
+        }
+    }
+
+    [Fact]
+    public async Task SetLatestPublishedReleases_IgnoresPublicationWithoutPublishedReleases()
+    {
+        // Published
+        var publicationA = new Publication
+        {
+            Releases = new List<Release>
+            {
+                new()
+                {
+                    ReleaseName = "2022",
+                    TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                    Published = DateTime.UtcNow.AddDays(-1)
+                }
+            }
+        };
+
+        // Not published (only release is not published) 
+        var publicationB = new Publication
+        {
+            Releases = new List<Release>
+            {
+                new()
+                {
+                    ReleaseName = "2018",
+                    TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                    Published = null
+                }
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddRangeAsync(publicationA, publicationB);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            var service = SetupService(context);
+            var result = await service.SetLatestPublishedReleases();
+            result.AssertRight();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            // Publication A should have a LatestPublishedReleaseId since it's published 
+            await AssertLatestPublishedReleaseIdEqual(publicationA.Releases[0].Id, publicationA.Id, context);
+
+            // Publication B should have no LatestPublishedReleaseId
+            await AssertLatestPublishedReleaseIdNull(publicationB.Id, context);
+        }
+    }
+
+    private static async Task AssertLatestPublishedReleaseIdEqual(Guid? expected,
+        Guid publicationId,
+        ContentDbContext context)
+    {
+        var publication = await context.Publications.SingleAsync(publication => publication.Id == publicationId);
+        Assert.Equal(expected, publication.LatestPublishedReleaseId);
+    }
+
+    private static async Task AssertLatestPublishedReleaseIdNull(Guid publicationId,
+        ContentDbContext context)
+    {
+        var publication = await context.Publications.SingleAsync(publication => publication.Id == publicationId);
+        Assert.Null(publication.LatestPublishedReleaseId);
+    }
+
+    private static PublicationMigrationService SetupService(
+        ContentDbContext? context = null,
+        IUserService? userService = null,
+        ILogger<PublicationMigrationService>? logger = null)
+
+    {
+        return new PublicationMigrationService(
+            context ?? DbUtils.InMemoryApplicationDbContext(),
+            userService ?? MockUtils.AlwaysTrueUserService().Object,
+            logger ?? Mock.Of<ILogger<PublicationMigrationService>>()
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/PublicationMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/PublicationMigrationController.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+/// <summary>
+/// TODO EES-3882 Remove after migration has been run by EES-3894
+/// </summary>
+[Route("api")]
+[ApiController]
+[Authorize(Roles = GlobalRoles.RoleNames.BauUser)]
+public class PublicationMigrationController
+{
+    private readonly IPublicationMigrationService _publicationMigrationService;
+
+    public PublicationMigrationController(IPublicationMigrationService publicationMigrationService)
+    {
+        _publicationMigrationService = publicationMigrationService;
+    }
+
+    [HttpPatch("bau/set-latest-published-releases")]
+    public async Task<ActionResult<Unit>> SetLatestPublishedReleases()
+    {
+        return await _publicationMigrationService
+            .SetLatestPublishedReleases()
+            .HandleFailuresOrOk();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationMigrationService.cs
@@ -1,0 +1,14 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+
+/// <summary>
+/// TODO EES-3882 Remove after migration has been run by EES-3894
+/// </summary>
+public interface IPublicationMigrationService
+{
+    Task<Either<ActionResult, Unit>> SetLatestPublishedReleases();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationMigrationService.cs
@@ -1,0 +1,92 @@
+﻿#nullable enable
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+/// <summary>
+/// TODO EES-3882 Remove after migration has been run by EES-3894
+/// </summary>
+public class PublicationMigrationService : IPublicationMigrationService
+{
+    private readonly ContentDbContext _contentDbContext;
+    private readonly IUserService _userService;
+    private readonly ILogger<PublicationMigrationService> _logger;
+
+    public PublicationMigrationService(
+        ContentDbContext contentDbContext,
+        IUserService userService,
+        ILogger<PublicationMigrationService> logger)
+    {
+        _contentDbContext = contentDbContext;
+        _userService = userService;
+        _logger = logger;
+    }
+
+    public async Task<Either<ActionResult, Unit>> SetLatestPublishedReleases()
+    {
+        return await _userService.CheckCanRunMigrations()
+            .OnSuccessVoid(async () =>
+            {
+                // Get the list of publication id's to migrate filtering out
+                // publications with a LatestPublishedReleaseId already set and publications without Releases
+                var publicationsIdsToMigrate = await _contentDbContext.Publications
+                    .Where(p => !p.LatestPublishedReleaseId.HasValue && p.Releases.Any())
+                    .Select(p => p.Id)
+                    .ToListAsync();
+
+                var totalCount = publicationsIdsToMigrate.Count;
+                _logger.LogInformation("Found {count} Publications to migrate", totalCount);
+
+                // Iterate through the publications setting LatestPublishedReleaseId
+                await publicationsIdsToMigrate
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(async (publicationId, index) =>
+                    {
+                        _logger.LogInformation("Migrating Publication {index}/{totalCount}: {publicationId}",
+                            index + 1,
+                            totalCount,
+                            publicationId);
+
+                        var publication = await _contentDbContext.Publications
+                            .SingleAsync(publication => publication.Id == publicationId);
+
+                        await _contentDbContext
+                            .Entry(publication)
+                            .Collection(p => p.Releases)
+                            .LoadAsync();
+
+                        var publishedReleases = publication.GetPublishedReleases();
+                        if (publishedReleases.Any())
+                        {
+                            var latestPublishedRelease = publishedReleases
+                                .OrderBy(r => r.Year)
+                                .ThenBy(r => r.TimePeriodCoverage)
+                                .Last();
+
+                            _logger.LogDebug(
+                                "Setting LatestPublishedRelease: {latestPublishedReleaseId} for Publication: {publicationId}",
+                                latestPublishedRelease.Id,
+                                publicationId);
+
+                            publication.LatestPublishedReleaseId = latestPublishedRelease.Id;
+                            _contentDbContext.Update(publication);
+                            await _contentDbContext.SaveChangesAsync();
+                        }
+                        else
+                        {
+                            _logger.LogDebug("Ignoring Publication with no published Release: {publicationId}",
+                                publicationId);
+                        }
+                    });
+            });
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -597,6 +597,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                         new StorageInstanceCreationUtil()),
                     userService: provider.GetRequiredService<IUserService>()));
 
+            // TODO EES-3882 Remove after migration has been run by EES-3894
+            services.AddTransient<IPublicationMigrationService, PublicationMigrationService>();
+
             // This service handles the generation of the JWTs for users after they log in
             services.AddTransient<IProfileService, ApplicationUserProfileService>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublicationServiceTests.cs
@@ -2,14 +2,15 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+using Microsoft.EntityFrameworkCore;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 {
@@ -120,7 +121,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Id = new Guid("240ca03c-6c22-4b9d-9f15-40fc9017890e"),
             PublicationId = PublicationA.Id,
             ReleaseName = "2018",
-            TimePeriodCoverage = AcademicYearQ1,
+            TimePeriodCoverage = TimeIdentifier.AcademicYearQ1,
             Published = new DateTime(2019, 1, 01),
             Slug = "publication-a-release-2018-q1",
             ApprovalStatus = Approved,
@@ -133,7 +134,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Id = new Guid("cf02f125-91da-4606-bf80-c2058092a653"),
             PublicationId = PublicationA.Id,
             ReleaseName = "2018",
-            TimePeriodCoverage = AcademicYearQ1,
+            TimePeriodCoverage = TimeIdentifier.AcademicYearQ1,
             Published = new DateTime(2019, 1, 01),
             Slug = "publication-a-release-2018-q1",
             ApprovalStatus = Approved,
@@ -147,7 +148,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Id = new Guid("9da67d6d-a75f-424d-8b8b-975f151292a4"),
             PublicationId = PublicationA.Id,
             ReleaseName = "2018",
-            TimePeriodCoverage = AcademicYearQ1,
+            TimePeriodCoverage = TimeIdentifier.AcademicYearQ1,
             Published = new DateTime(2019, 1, 01),
             Slug = "publication-a-release-2018-q1",
             ApprovalStatus = Approved,
@@ -160,7 +161,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Id = new Guid("874d4e4f-5568-482f-a5a4-d41e5bf6632a"),
             PublicationId = PublicationA.Id,
             ReleaseName = "2018",
-            TimePeriodCoverage = AcademicYearQ2,
+            TimePeriodCoverage = TimeIdentifier.AcademicYearQ2,
             Published = new DateTime(2019, 1, 01),
             Slug = "publication-a-release-2018-q2",
             ApprovalStatus = Approved,
@@ -173,7 +174,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Id = new Guid("676ff979-9b1d-4bd2-a3f1-f126c4e2e8d4"),
             PublicationId = PublicationA.Id,
             ReleaseName = "2017",
-            TimePeriodCoverage = AcademicYearQ4,
+            TimePeriodCoverage = TimeIdentifier.AcademicYearQ4,
             Published = new DateTime(2019, 1, 01),
             Slug = "publication-a-release-2017-q4",
             ApprovalStatus = Approved,
@@ -186,7 +187,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Id = new Guid("e66247d7-b350-4d81-a223-3080edc55623"),
             PublicationId = PublicationB.Id,
             ReleaseName = "2018",
-            TimePeriodCoverage = AcademicYearQ1,
+            TimePeriodCoverage = TimeIdentifier.AcademicYearQ1,
             Published = null,
             Slug = "publication-b-release-2018-q1",
             ApprovalStatus = Draft,
@@ -205,7 +206,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Id = new Guid("3c7b1338-4c41-43b4-b4ae-67c21c8734fb"),
                 PublicationId = PublicationA.Id,
                 ReleaseName = "2018",
-                TimePeriodCoverage = AcademicYearQ3,
+                TimePeriodCoverage = TimeIdentifier.AcademicYearQ3,
                 Published = null,
                 Slug = "publication-a-release-2018-q3",
                 ApprovalStatus = Draft,
@@ -249,15 +250,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contentDbContextId))
             {
                 await contentDbContext.AddAsync(publication);
                 await contentDbContext.SaveChangesAsync();
             }
 
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildPublicationService(contentDbContext);
+                var service = SetupService(contentDbContext);
 
                 Assert.True(await service.IsPublicationPublished(publication.Id));
             }
@@ -270,15 +271,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contentDbContextId))
             {
                 await contentDbContext.AddAsync(publication);
                 await contentDbContext.SaveChangesAsync();
             }
 
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildPublicationService(contentDbContext);
+                var service = SetupService(contentDbContext);
 
                 Assert.False(await service.IsPublicationPublished(publication.Id));
             }
@@ -298,23 +299,440 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contentDbContextId))
             {
                 await contentDbContext.AddAsync(publication);
                 await contentDbContext.SaveChangesAsync();
             }
 
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildPublicationService(contentDbContext);
+                var service = SetupService(contentDbContext);
 
                 Assert.False(await service.IsPublicationPublished(publication.Id));
             }
         }
 
-        private PublicationService BuildPublicationService(
+        [Fact]
+        public async Task UpdateLatestPublishedRelease_SetsCorrectReleaseInTimeSeries()
+        {
+            var release2021Week21 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2021",
+                TimePeriodCoverage = TimeIdentifier.Week21,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var release2022Week1 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.Week1,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var release2022Week2 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.Week2,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var release2022Week3 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.Week3,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var release2022Week10 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.Week10,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            // Latest in time series
+            var release2022Week21 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.Week21,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var publication = new Publication
+            {
+                Releases = new List<Release>
+                {
+                    // Set the releases so that they are not in time series order
+
+                    // Include a range of releases to make sure they are being correctly ordered by the
+                    // time identifiers enum entry position rather than in alphanumeric order by value
+
+                    release2022Week3,
+                    release2022Week21,
+                    release2022Week10,
+                    release2021Week21,
+                    release2022Week2,
+                    release2022Week1
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.Publications.AddAsync(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var service = SetupService(context);
+                await service.UpdateLatestPublishedRelease(publication.Id);
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var found = await context.Publications.SingleAsync(p => p.Id == publication.Id);
+
+                // Release 2022 week 21 should be the latest published
+                Assert.Equal(release2022Week21.Id, found.LatestPublishedReleaseId);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateLatestPublishedRelease_SetsCorrectReleaseInTimeSeries_LatestInSeriesNotPublished()
+        {
+            var release2021Week21 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2021",
+                TimePeriodCoverage = TimeIdentifier.Week21,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var release2022Week1 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.Week1,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var release2022Week2 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.Week2,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var release2022Week3 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.Week3,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            // Latest published in time series
+            var release2022Week10 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.Week10,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            // Latest in time series (not published)
+            var release2022Week21 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.Week21,
+                Published = null
+            };
+
+            var publication = new Publication
+            {
+                Releases = new List<Release>
+                {
+                    // Set the releases so that they are not in time series order
+
+                    // Include a range of releases to make sure they are being correctly ordered by the
+                    // time identifiers enum entry position rather than in alphanumeric order by value
+
+                    release2022Week3,
+                    release2022Week21,
+                    release2022Week10,
+                    release2021Week21,
+                    release2022Week2,
+                    release2022Week1
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.Publications.AddAsync(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var service = SetupService(context);
+                await service.UpdateLatestPublishedRelease(publication.Id);
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var found = await context.Publications.SingleAsync(p => p.Id == publication.Id);
+
+                // Release 2022 week 10 should be the latest published
+                Assert.Equal(release2022Week10.Id, found.LatestPublishedReleaseId);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateLatestPublishedRelease_SetsCorrectReleaseVersion()
+        {
+            var releaseVersion0 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                Version = 0,
+                PreviousVersionId = null,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var releaseVersion1 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                Version = 1,
+                PreviousVersionId = releaseVersion0.Id,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var releaseVersion2 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                Version = 2,
+                PreviousVersionId = releaseVersion1.Id,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var publication = new Publication
+            {
+                Releases = new List<Release>
+                {
+                    // Set the releases so that they are not in version order
+                    releaseVersion1,
+                    releaseVersion2,
+                    releaseVersion0
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.Publications.AddAsync(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var service = SetupService(context);
+                await service.UpdateLatestPublishedRelease(publication.Id);
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var found = await context.Publications.SingleAsync(p => p.Id == publication.Id);
+
+                // Release version 2 should be the latest published
+                Assert.Equal(releaseVersion2.Id, found.LatestPublishedReleaseId);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateLatestPublishedRelease_SetsCorrectReleaseVersion_LatestVersionNotPublished()
+        {
+            var releaseVersion0 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                Version = 0,
+                PreviousVersionId = null,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            var releaseVersion1 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                Version = 1,
+                PreviousVersionId = releaseVersion0.Id,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            // Latest published version
+            var releaseVersion2 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                Version = 2,
+                PreviousVersionId = releaseVersion1.Id,
+                Published = DateTime.UtcNow.AddDays(-1)
+            };
+
+            // Latest version (not published)
+            var releaseVersion3 = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                Version = 3,
+                PreviousVersionId = releaseVersion2.Id,
+                Published = null
+            };
+
+            var publication = new Publication
+            {
+                Releases = new List<Release>
+                {
+                    // Set the releases so that they are not in version order
+                    releaseVersion1,
+                    releaseVersion3,
+                    releaseVersion2,
+                    releaseVersion0
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.Publications.AddAsync(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var service = SetupService(context);
+                await service.UpdateLatestPublishedRelease(publication.Id);
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var found = await context.Publications.SingleAsync(p => p.Id == publication.Id);
+
+                // Release version 2 should be the latest published
+                Assert.Equal(releaseVersion2.Id, found.LatestPublishedReleaseId);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateLatestPublishedRelease_PublicationWithoutReleasesThrowsError()
+        {
+            // Set up a publication with no releases
+            var publication = new Publication
+            {
+                Releases = new List<Release>()
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.Publications.AddAsync(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var service = SetupService(context);
+                var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                    service.UpdateLatestPublishedRelease(publication.Id));
+
+                Assert.Equal(
+                    $"Expected publication to have at least one published release. Publication id: {publication.Id}",
+                    exception.Message);
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var found = await context.Publications.SingleAsync(p => p.Id == publication.Id);
+
+                // Publication shouldn't have been updated since it has no releases
+                Assert.Null(found.LatestPublishedReleaseId);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateLatestPublishedRelease_PublicationWithoutPublishedReleasesThrowsError()
+        {
+            // Set up a publication where the only release is not published
+            var publication = new Publication
+            {
+                Releases = new List<Release>
+                {
+                    new()
+                    {
+                        ReleaseName = "2022",
+                        TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                        Published = null
+                    }
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.Publications.AddAsync(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var service = SetupService(context);
+                var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                    service.UpdateLatestPublishedRelease(publication.Id));
+
+                Assert.Equal(
+                    $"Expected publication to have at least one published release. Publication id: {publication.Id}",
+                    exception.Message);
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var found = await context.Publications.SingleAsync(p => p.Id == publication.Id);
+
+                // Publication shouldn't have been updated since the only release is not published
+                Assert.Null(found.LatestPublishedReleaseId);
+            }
+        }
+
+        private static PublicationService SetupService(
             ContentDbContext contentDbContext
-        ) {
+        )
+        {
             return new(
                 contentDbContext: contentDbContext
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -22,6 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         private readonly IContentService _contentService;
         private readonly INotificationsService _notificationsService;
         private readonly IPublicationCacheService _publicationCacheService;
+        private readonly IPublicationService _publicationService;
         private readonly IReleaseService _releaseService;
         private readonly IReleasePublishingStatusService _releasePublishingStatusService;
 
@@ -30,6 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             IContentService contentService,
             INotificationsService notificationsService,
             IPublicationCacheService publicationCacheService,
+            IPublicationService publicationService,
             IReleaseService releaseService,
             IReleasePublishingStatusService releasePublishingStatusService)
         {
@@ -37,6 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             _contentService = contentService;
             _notificationsService = notificationsService;
             _publicationCacheService = publicationCacheService;
+            _publicationService = publicationService;
             _releaseService = releaseService;
             _releasePublishingStatusService = releasePublishingStatusService;
         }
@@ -79,6 +82,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 }
 
                 var release = await _releaseService.Get(message.ReleaseId);
+                
+                // TODO EES-3369 (Read Replica-2) This call needs moving to the new PublishingCompletionService 
+                await _publicationService.UpdateLatestPublishedRelease(release.PublicationId);
 
                 // Update the cached publication and any cached superseded publications.
                 // If this is the first live release of the publication, the superseding is now enforced

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublicationService.cs
@@ -11,5 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         List<Publication> GetPublicationsWithPublishedReleases();
 
         Task<bool> IsPublicationPublished(Guid publicationId);
+
+        Task UpdateLatestPublishedRelease(Guid publicationId);
     }
 }


### PR DESCRIPTION
⚠️ This has faffy deploy ticket [EES-3894](https://dfedigital.atlassian.net/browse/EES-3894) associated with running the migration.

This PR:

- Adds a migration endpoint that will set `Publication.LatestPublishedReleaseId` for all publications.
- Makes a change to Publisher to update `Publication.LatestPublishedReleaseId` for all publications affected when publishing one or more releases.

Once the migration is run and the new field is set, we can get rid of the computed method `Publication.LatestPublishedRelease()`. This change has already been prepared by https://github.com/dfe-analytical-services/explore-education-statistics/pull/3633.

LatestPublishedRelease() which looks like this, had two problems:

```
  public Release? LatestPublishedRelease()
  {
      return Releases
          .Where(IsLatestPublishedVersionOfRelease)
          .OrderBy(r => r.Year)
          .ThenBy(r => r.TimePeriodCoverage)
          .LastOrDefault();
  }
```

- It’s a computed method that can’t be executed on the database - It depends on another method which stops translation to SQL. Also an SQL query wouldn’t be able to correctly determine the latest published release of a publication.

The natural order of time periods (NVARCHAR field), would mean releases Week 1, Week2, Week3, Week 10, Week21 would be ordered Week 1, Week 10, Week 2, Week 21, Week 3.

- `IsLatestPublishedVersionOfRelease` requires the Publication to be loaded from the database with all of its Releases (all versions) to work out which is the latest version of each release.

### Benefits to adding LatestPublishedReleaseId:

- Prevent unnecessary loading of all Releases where we only want to know the latest published release or it's id.
- Add's the ability to chain `.Include(p => p.LatestPublishedRelease)` where we want to get the latest published release.
- Means that the presence of `LatestPublishedReleaseId` can be used to determine if the publication is published or not. This could be useful to simplify determining if a publication's superseding publication is published or not (although `p.SupersededBy.Published.HasValue` looks like it will be just as useful in simplifying it).

### UI Tests report

![image](https://user-images.githubusercontent.com/4147126/203291335-9f3efcf9-2f58-4dd0-af9e-7b06dbe1845b.png)
