### PR TITLE
EES-3908 - notify approvers

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -376,11 +376,11 @@
       "type": "securestring",
       "defaultValue": "change-me"
     },
-    "notifyReleaseApproversTemplateId": {
+    "notifyHigherReviewersTemplateId": {
       "type": "securestring",
       "defaultValue": "change-me",
       "metadata": {
-        "description": "Gov UK Notify service template ID for release approver notifications"
+        "description": "Gov UK Notify service template ID for approver notifications"
       }
     },
     "teamEmailAddresses": {
@@ -1792,7 +1792,7 @@
         "NotifyReleaseRoleTemplateId": "[parameters('notifyReleaseRoleTemplateId')]",
         "NotifyPreReleaseTemplateId": "[parameters('notifyPreReleaseTemplateId')]",
         "NotifyContributorTemplateId": "[parameters('notifyContributorTemplateId')]",
-        "NotifyReleaseApproversTemplateId": "[parameters('notifyReleaseApproversTemplateId')]",
+        "NotifyHigherReviewersTemplateId": "[parameters('NotifyHigherReviewersTemplateId')]",
         "AdminUri": "[parameters('adminUri')]",
         "Azure:SignalR:ConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-signalr-admin-connectionstring'), '2018-02-14').secretUriWithVersion, ')')]",
         "PublicAppUrl": "[variables('publicAppUrl')]",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/EmailTemplateServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/EmailTemplateServiceTests.cs
@@ -159,9 +159,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void SendReleaseApproverEmail()
+        public void SendHigherReviewEmail()
         {
-            const string expectedTemplateId = "notify-release-approvers-template-id";
+            const string expectedTemplateId = "notify-higher-reviewers-template-id";
             var release = new Release
             {
                 Id = Guid.NewGuid(),
@@ -193,7 +193,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var service = SetupEmailTemplateService(emailService: emailService.Object);
 
-            var result = service.SendReleaseApproverEmail("test@test.com", release);
+            var result = service.SendHigherReviewEmail("test@test.com", release);
 
             emailService.Verify(
                 s => s.SendEmail(
@@ -214,7 +214,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 TupleOf("NotifyInviteWithRolesTemplateId", "invite-with-roles-template-id"),
                 TupleOf("NotifyPublicationRoleTemplateId", "publication-role-template-id"),
                 TupleOf("NotifyReleaseRoleTemplateId", "release-role-template-id"),
-                TupleOf("NotifyReleaseApproversTemplateId", "notify-release-approvers-template-id"),
+                TupleOf("NotifyHigherReviewersTemplateId", "notify-higher-reviewers-template-id"),
                 TupleOf("AdminUri", "admin-uri"));
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221125141506_EES3908RemoveNotifyReleaseApproversFromReleaseStatus.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221125141506_EES3908RemoveNotifyReleaseApproversFromReleaseStatus.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221125141506_EES3908RemoveNotifyReleaseApproversFromReleaseStatus")]
+    partial class EES3908RemoveNotifyReleaseApproversFromReleaseStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221125141506_EES3908RemoveNotifyReleaseApproversFromReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221125141506_EES3908RemoveNotifyReleaseApproversFromReleaseStatus.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES3908RemoveNotifyReleaseApproversFromReleaseStatus : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NotifyReleaseApprovers",
+                table: "ReleaseStatus");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "NotifyReleaseApprovers",
+                table: "ReleaseStatus",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/EmailTemplateService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/EmailTemplateService.cs
@@ -103,10 +103,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return _emailService.SendEmail(email, template, emailValues);
         }
         
-        public Either<ActionResult, Unit> SendReleaseApproverEmail(string email, Release release)
+        public Either<ActionResult, Unit> SendHigherReviewEmail(string email, Release release)
         {
             var uri = _configuration.GetValue<string>("AdminUri");
-            var template = _configuration.GetValue<string>("NotifyReleaseApproversTemplateId");
+            var template = _configuration.GetValue<string>("NotifyHigherReviewersTemplateId");
             
             var emailValues = new Dictionary<string, dynamic>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IEmailTemplateService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IEmailTemplateService.cs
@@ -23,6 +23,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             Release release,
             ReleaseRole role);
 
-        Either<ActionResult, Unit> SendReleaseApproverEmail(string email, Release release);
+        Either<ActionResult, Unit> SendHigherReviewEmail(string email, Release release);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationRoleRepository.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -6,7 +6,7 @@
   "NotifyReleaseRoleTemplateId": "change-me",
   "NotifyPreReleaseTemplateId": "change-me",
   "NotifyContributorTemplateId": "change-me",
-  "NotifyReleaseApproversTemplateId": "change-me",
+  "NotifyHigherReviewersTemplateId": "change-me",
   "PublicAppUrl": "http://localhost:3000",
   "enableSwagger": true,
   "enableThemeDeletion": true,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
@@ -16,8 +16,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public bool NotifySubscribers { get; set; }
         
-        public bool NotifyReleaseApprovers { get; set; }
-
         public DateTime? NotifiedOn { get; set; }
 
         public ReleaseApprovalStatus ApprovalStatus { get; set; }

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -212,8 +212,7 @@ const ReleaseStatusForm = ({
                   disabled: !statusPermissions?.canMarkDraft,
                 },
                 {
-                  label:
-                    'Ready for higher review (this will notify release approvers)',
+                  label: 'Ready for higher review (this will notify approvers)',
                   value: 'HigherLevelReview',
                   disabled: !statusPermissions?.canMarkHigherLevelReview,
                 },

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -192,7 +192,7 @@ describe('ReleaseStatusForm', () => {
     expect(statuses.getByLabelText('In draft')).not.toBeChecked();
     expect(
       statuses.getByLabelText(
-        'Ready for higher review (this will notify release approvers)',
+        'Ready for higher review (this will notify approvers)',
       ),
     ).toBeChecked();
     expect(
@@ -256,7 +256,7 @@ describe('ReleaseStatusForm', () => {
 
       userEvent.click(
         screen.getByLabelText(
-          'Ready for higher review (this will notify release approvers)',
+          'Ready for higher review (this will notify approvers)',
         ),
       );
       await userEvent.type(
@@ -410,7 +410,7 @@ describe('ReleaseStatusForm', () => {
       expect(statuses.getByLabelText('In draft')).not.toBeChecked();
       expect(
         statuses.getByLabelText(
-          'Ready for higher review (this will notify release approvers)',
+          'Ready for higher review (this will notify approvers)',
         ),
       ).not.toBeChecked();
 
@@ -445,7 +445,7 @@ describe('ReleaseStatusForm', () => {
       expect(statuses.getByLabelText('In draft')).not.toBeChecked();
       expect(
         statuses.getByLabelText(
-          'Ready for higher review (this will notify release approvers)',
+          'Ready for higher review (this will notify approvers)',
         ),
       ).not.toBeChecked();
       expect(statuses.getByLabelText('Approved for publication')).toBeChecked();

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -81,7 +81,7 @@ Go to "Sign off" page
     user clicks button    Edit release status
 
 Check publication owner can edit release status to "Ready for higher review"
-    user clicks radio    Ready for higher review (this will notify release approvers)
+    user clicks radio    Ready for higher review (this will notify approvers)
     user enters text into element    id:releaseStatusForm-latestInternalReleaseNote
     ...    ready for higher review (publication owner)
     user clicks button    Update status

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -36,7 +36,7 @@ Go to release sign off page and verify initial release checklist
     user checks page does not contain testid    releaseChecklist-success
 
 Submit release for Higher Review
-    user clicks radio    Ready for higher review (this will notify release approvers)
+    user clicks radio    Ready for higher review (this will notify approvers)
     user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Submitted for Higher Review
     user enters text into element    id:releaseStatusForm-nextReleaseDate-month    12
     user enters text into element    id:releaseStatusForm-nextReleaseDate-year    3001

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -551,7 +551,7 @@ user puts release into higher level review
     user waits until h2 is visible    Sign off    %{WAIT_SMALL}
     user clicks button    Edit release status
     user waits until h2 is visible    Edit release status    %{WAIT_SMALL}
-    user clicks radio    Ready for higher review (this will notify release approvers)
+    user clicks radio    Ready for higher review (this will notify approvers)
     user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Ready for higher review
     user clicks button    Update status
     user waits until element is visible    id:CurrentReleaseStatus-Awaiting higher review    %{WAIT_SMALL}


### PR DESCRIPTION
This PR:
* Notifies publication owners & publication release approvers when a release is moved into higher review. Previously, only release approvers were notified however it turned out that the intention behind this work was to notify both publication owners/releaseApprovers and release approvers