### PR TITLE
EES-3899 EES-3906 fixes for charts with negative values

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -33,6 +33,7 @@ import {
   LegendType,
   Line,
   LineChart,
+  ReferenceLine,
   ResponsiveContainer,
   Symbols,
   SymbolsProps,
@@ -46,27 +47,6 @@ const lineStyles: Dictionary<string> = {
   solid: '',
   dashed: '5 5',
   dotted: '2 2',
-};
-
-// eslint-disable-next-line react/display-name
-const getDot = (symbol: ChartSymbol | 'none' = 'circle') => (
-  props: SymbolsProps,
-) => {
-  if (symbol === 'none') {
-    return undefined;
-  }
-
-  return <Symbols {...props} type={symbol} />;
-};
-
-const getLegendType = (
-  symbol: LegendType | undefined = 'square',
-): LegendType | undefined => {
-  if (symbol === 'none') {
-    return undefined;
-  }
-
-  return symbol;
 };
 
 export interface LineChartProps extends ChartProps {
@@ -126,6 +106,8 @@ const LineChartBlock = ({
     minorAxisUnit,
   });
   const xAxisHeight = parseNumber(axes.major.size);
+  const chartHasNegativeValues =
+    (parseNumber(minorDomainTicks.domain?.[0]) ?? 0) < 0;
 
   return (
     <ChartContainer
@@ -181,6 +163,7 @@ const LineChartBlock = ({
           <XAxis
             {...majorDomainTicks}
             type="category"
+            axisLine={!chartHasNegativeValues}
             dataKey="name"
             hide={!axes.major.visible}
             unit={axes.major.unit}
@@ -224,6 +207,8 @@ const LineChartBlock = ({
               )}
             />
           ))}
+
+          {chartHasNegativeValues && <ReferenceLine y={0} stroke="#666" />}
 
           {axes.major.referenceLines?.map(referenceLine =>
             createReferenceLine({
@@ -327,3 +312,24 @@ export const lineChartBlockDefinition: ChartDefinition = {
 };
 
 export default memo(LineChartBlock);
+
+// eslint-disable-next-line react/display-name
+const getDot = (symbol: ChartSymbol | 'none' = 'circle') => (
+  props: SymbolsProps,
+) => {
+  if (symbol === 'none') {
+    return undefined;
+  }
+
+  return <Symbols {...props} type={symbol} />;
+};
+
+const getLegendType = (
+  symbol: LegendType | undefined = 'square',
+): LegendType | undefined => {
+  if (symbol === 'none') {
+    return undefined;
+  }
+
+  return symbol;
+};

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/LineChartBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/LineChartBlock.test.tsx
@@ -250,7 +250,7 @@ describe('LineChartBlock', () => {
             referenceLines: [
               {
                 label: 'hello',
-                position: 0,
+                position: 5,
               },
             ],
           },
@@ -259,7 +259,7 @@ describe('LineChartBlock', () => {
     );
 
     expect(
-      container.querySelector('.recharts-reference-line'),
+      container.querySelectorAll('.recharts-reference-line')[1],
     ).toHaveTextContent('hello');
   });
 

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/domainTicks.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/domainTicks.test.ts
@@ -1,0 +1,423 @@
+import { AxisConfiguration } from '@common/modules/charts/types/chart';
+import { ChartData } from '@common/modules/charts/types/dataSet';
+import {
+  calculateMinorAxisDomainValues,
+  getMajorAxisDomainTicks,
+  getMinorAxisDomainTicks,
+} from '@common/modules/charts/util/domainTicks';
+import generateDataSetKey from '@common/modules/charts/util/generateDataSetKey';
+
+describe('domainTicks', () => {
+  const testKey = generateDataSetKey({
+    indicator: 'indicator-1',
+    filters: ['filter-1'],
+    location: {
+      level: 'country',
+      value: 'location-1',
+    },
+  });
+
+  const testChartData: ChartData[] = [
+    {
+      [testKey]: 50,
+      name: '2014_T1',
+    },
+    {
+      [testKey]: 32,
+      name: '2015_T1',
+    },
+    {
+      [testKey]: 28,
+      name: '2016_T1',
+    },
+    {
+      [testKey]: 48,
+      name: '2017_T1',
+    },
+    {
+      [testKey]: 54,
+      name: '2018_T1',
+    },
+  ];
+
+  const testAxisConfig: AxisConfiguration = {
+    dataSets: [],
+    referenceLines: [],
+    visible: true,
+    type: 'minor',
+  };
+
+  describe('calculateMinorAxisDomainValues', () => {
+    describe('min', () => {
+      test('returns the axis min when set', () => {
+        const result = calculateMinorAxisDomainValues(testChartData, {
+          ...testAxisConfig,
+          min: 1.5,
+        });
+
+        expect(result.min).toBe(1.5);
+      });
+
+      test('returns 0 for the min when it is positive', () => {
+        const result = calculateMinorAxisDomainValues(
+          testChartData,
+          testAxisConfig,
+        );
+
+        expect(result.min).toBe(0);
+      });
+
+      test('returns the correct min for a negative value that is odd when rounded down to one significant figure', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            ...testChartData,
+            {
+              [testKey]: -24.654,
+              name: '2019_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.min).toBe(-40);
+      });
+
+      test('returns the correct min for a negative value that is even when rounded down to one significant figure', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            ...testChartData,
+            {
+              [testKey]: -51300,
+              name: '2019_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.min).toBe(-60000);
+      });
+
+      test('returns the correct min for a negative value that starts with 5 when rounded down to one significant figure', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            ...testChartData,
+            {
+              [testKey]: -4500,
+              name: '2019_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.min).toBe(-5000);
+      });
+
+      test('returns the correct min for a negative value between 0 and -1', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            ...testChartData,
+            {
+              [testKey]: -0.51,
+              name: '2019_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.min).toBe(-0.6);
+      });
+    });
+
+    describe('max', () => {
+      test('returns the axis max when set', () => {
+        const result = calculateMinorAxisDomainValues(testChartData, {
+          ...testAxisConfig,
+          max: 6,
+        });
+
+        expect(result.max).toBe(6);
+      });
+
+      test('returns 0 when max is 0', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            {
+              [testKey]: 0,
+              name: '2019_T1',
+            },
+            {
+              [testKey]: -3,
+              name: '2020_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.max).toBe(0);
+      });
+
+      test('returns the correct max for a value that is odd when rounded up to one significant figure', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            {
+              [testKey]: 61000,
+              name: '2019_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.max).toBe(80000);
+      });
+
+      test('returns the correct max for a value that is even when rounded up to one significant figure', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            {
+              [testKey]: 80000,
+              name: '2019_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.max).toBe(80000);
+      });
+
+      test('returns the correct max for a value that starts with 5 when rounded up to one significant figure', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            {
+              [testKey]: 45000,
+              name: '2019_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.max).toBe(50000);
+      });
+
+      test('returns the correct max for a value that is between 0 and 1', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            {
+              [testKey]: 0.56,
+              name: '2019_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.max).toBe(0.6);
+      });
+
+      test('returns the correct max for a value that is between 0 and -1', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            {
+              [testKey]: -0.45,
+              name: '2019_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.max).toBe(-0.4);
+      });
+
+      test('returns the correct max for a negative value that is even when rounded up to one significant figure', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            {
+              [testKey]: -271.5,
+              name: '2019_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.max).toBe(-200);
+      });
+
+      test('returns the correct max for a negative value that is odd when rounded up to one significant figure', () => {
+        const result = calculateMinorAxisDomainValues(
+          [
+            {
+              [testKey]: -351.5,
+              name: '2019_T1',
+            },
+          ],
+          testAxisConfig,
+        );
+
+        expect(result.max).toBe(-200);
+      });
+    });
+  });
+
+  describe('getMinorAxisDomainTicks', () => {
+    test('returns the correct axis domain and ticks when tickConfig is undefined', () => {
+      const result = getMinorAxisDomainTicks(testChartData, testAxisConfig);
+      expect(result.domain).toEqual([0, 60]);
+      expect(result.ticks).toBeUndefined();
+    });
+
+    test('returns the correct axis domain and ticks when tickConfig is `default`', () => {
+      const result = getMinorAxisDomainTicks(testChartData, {
+        ...testAxisConfig,
+        tickConfig: 'default',
+      });
+      expect(result.domain).toEqual([0, 60]);
+      expect(result.ticks).toBeUndefined();
+    });
+
+    test('returns the correct axis domain and ticks when tickConfig is `startEnd`', () => {
+      const result = getMinorAxisDomainTicks(testChartData, {
+        ...testAxisConfig,
+        tickConfig: 'startEnd',
+      });
+      expect(result.domain).toEqual([0, 60]);
+      expect(result.ticks).toEqual([0, 60]);
+    });
+
+    describe('custom tick spacing', () => {
+      test('returns the correct axis domain and ticks when tickConfig is `custom` and `tickSpacing is 5', () => {
+        const result = getMinorAxisDomainTicks(testChartData, {
+          ...testAxisConfig,
+          tickConfig: 'custom',
+          tickSpacing: 5,
+        });
+        expect(result.domain).toEqual([0, 60]);
+        expect(result.ticks).toEqual([
+          0,
+          5,
+          10,
+          15,
+          20,
+          25,
+          30,
+          35,
+          40,
+          45,
+          50,
+          55,
+          60,
+        ]);
+      });
+
+      test('returns the correct axis domain and ticks when tickConfig is `custom` and `tickSpacing is 7', () => {
+        const result = getMinorAxisDomainTicks(testChartData, {
+          ...testAxisConfig,
+          tickConfig: 'custom',
+          tickSpacing: 7,
+        });
+        expect(result.domain).toEqual([0, 60]);
+        expect(result.ticks).toEqual([0, 7, 14, 21, 28, 35, 42, 49, 56, 60]);
+      });
+
+      test('returns the correct axis domain and ticks when tickConfig is `custom` and `tickSpacing is 10', () => {
+        const result = getMinorAxisDomainTicks(testChartData, {
+          ...testAxisConfig,
+          tickConfig: 'custom',
+          tickSpacing: 10,
+        });
+        expect(result.domain).toEqual([0, 60]);
+        expect(result.ticks).toEqual([0, 10, 20, 30, 40, 50, 60]);
+      });
+    });
+  });
+
+  describe('getMajorAxisDomainTicks', () => {
+    test('returns the correct axis domain and ticks when tickConfig is undefined', () => {
+      const result = getMajorAxisDomainTicks(testChartData, testAxisConfig);
+      expect(result.domain).toEqual([0, 4]);
+      expect(result.ticks).toBeUndefined();
+    });
+
+    test('returns the correct axis domain and ticks when tickConfig is `default`', () => {
+      const result = getMajorAxisDomainTicks(testChartData, {
+        ...testAxisConfig,
+        tickConfig: 'default',
+      });
+      expect(result.domain).toEqual([0, 4]);
+      expect(result.ticks).toBeUndefined();
+    });
+
+    test('returns the correct axis domain and ticks when tickConfig is `startEnd`', () => {
+      const result = getMajorAxisDomainTicks(testChartData, {
+        ...testAxisConfig,
+        tickConfig: 'startEnd',
+      });
+      expect(result.domain).toEqual([0, 4]);
+      expect(result.ticks).toEqual(['2014_T1', '2018_T1']);
+    });
+
+    describe('custom tick spacing', () => {
+      const extendedTestChartData: ChartData[] = [
+        ...testChartData,
+        {
+          [testKey]: 54,
+          name: '2019_T1',
+        },
+        {
+          [testKey]: 54,
+          name: '2020_T1',
+        },
+        {
+          [testKey]: 54,
+          name: '2021_T1',
+        },
+        {
+          [testKey]: 54,
+          name: '2022_T1',
+        },
+      ];
+      test('returns the correct axis domain and ticks when tickConfig is `custom` and `tickSpacing is 1', () => {
+        const result = getMajorAxisDomainTicks(extendedTestChartData, {
+          ...testAxisConfig,
+          tickConfig: 'custom',
+          tickSpacing: 1,
+        });
+        expect(result.domain).toEqual([0, 8]);
+        expect(result.ticks).toEqual([
+          '2014_T1',
+          '2015_T1',
+          '2016_T1',
+          '2017_T1',
+          '2018_T1',
+          '2019_T1',
+          '2020_T1',
+          '2021_T1',
+          '2022_T1',
+        ]);
+      });
+
+      test('returns the correct axis domain and ticks when tickConfig is `custom` and `tickSpacing is 2', () => {
+        const result = getMajorAxisDomainTicks(extendedTestChartData, {
+          ...testAxisConfig,
+          tickConfig: 'custom',
+          tickSpacing: 2,
+        });
+        expect(result.domain).toEqual([0, 8]);
+        expect(result.ticks).toEqual([
+          '2014_T1',
+          '2016_T1',
+          '2018_T1',
+          '2020_T1',
+          '2022_T1',
+        ]);
+      });
+
+      test('returns the correct axis domain and ticks when tickConfig is `custom` and `tickSpacing is 5', () => {
+        const result = getMajorAxisDomainTicks(extendedTestChartData, {
+          ...testAxisConfig,
+          tickConfig: 'custom',
+          tickSpacing: 5,
+        });
+        expect(result.domain).toEqual([0, 8]);
+        expect(result.ticks).toEqual(['2014_T1', '2019_T1', '2022_T1']);
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/charts/util/domainTicks.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/domainTicks.ts
@@ -13,28 +13,39 @@ export interface DomainTicks {
   ticks?: (string | number)[];
 }
 
-function getNiceMaxValue(maxValue: number): number {
-  if (maxValue === 0) {
+/**
+ * Return a nice rounded number for the min and max axis values:
+ * Max:
+ * - round up to one significant figure and return the next 'nice' value (even or starting with 5), e.g.
+ *   - 222 rounded up to next s.f. is 300, return 400
+ *   - 367 rounded up to next s.f. is 400, return 400
+ *   - 429 rounded up to next s.f. is 500, return 500
+ * Min:
+ * - if it's positive return 0
+ * - if it's negative round down to one significant figure and return the next 'nice' value (even or starting with 5)
+ */
+function getNiceMinMaxValue(initialValue: number, isMin = false): number {
+  if (initialValue === 0 || (isMin && initialValue > 0)) {
     return 0;
   }
 
-  const maxIsLessThanOne = Math.abs(maxValue) < 1;
-  let max = maxValue;
-  if (maxIsLessThanOne) {
-    max = maxValue * 100;
-  }
+  const valueIsLessThanOne = Math.abs(initialValue) < 1;
+  const value = valueIsLessThanOne ? initialValue * 100 : initialValue;
+  const numberOf0s = 10 ** Math.floor(Math.log10(Math.abs(value)));
 
-  const numberOf0s = 10 ** Math.floor(Math.log10(Math.abs(max)));
-  const maxReducedToLessThan10 = Math.ceil(max / numberOf0s);
+  // round up for max and down for min
+  const roundedAndReducedToLessThan10 = !isMin
+    ? Math.ceil(value / numberOf0s)
+    : Math.floor(value / numberOf0s);
 
-  if (maxReducedToLessThan10 % 2 && maxReducedToLessThan10 % 5) {
-    return maxIsLessThanOne
-      ? ((maxReducedToLessThan10 + 1) * numberOf0s) / 100
-      : (maxReducedToLessThan10 + 1) * numberOf0s;
-  }
-  return maxIsLessThanOne
-    ? (maxReducedToLessThan10 * numberOf0s) / 100
-    : maxReducedToLessThan10 * numberOf0s;
+  // adjust up by 1 for max and down for min
+  const adjustBy = isMin ? -1 : 1;
+
+  const rounded =
+    roundedAndReducedToLessThan10 % 2 && roundedAndReducedToLessThan10 % 5
+      ? (roundedAndReducedToLessThan10 + adjustBy) * numberOf0s
+      : roundedAndReducedToLessThan10 * numberOf0s;
+  return valueIsLessThanOne ? rounded / 100 : rounded;
 }
 
 function calculateMinorTicks(
@@ -54,7 +65,7 @@ function calculateMinorTicks(
   }
 
   if (config === 'custom') {
-    const minimumSpacingValue = getNiceMaxValue(
+    const minimumSpacingValue = getNiceMinMaxValue(
       Math.floor((Number(max) - Number(min)) / 100),
     );
 
@@ -134,8 +145,8 @@ export function calculateMinorAxisDomainValues(
   );
 
   return {
-    min: parseNumber(axis.min) ?? (min >= 0 ? 0 : min),
-    max: parseNumber(axis.max) ?? getNiceMaxValue(max),
+    min: parseNumber(axis.min) ?? getNiceMinMaxValue(min, true),
+    max: parseNumber(axis.max) ?? getNiceMinMaxValue(max),
   };
 }
 
@@ -180,6 +191,5 @@ export function getMajorAxisDomainTicks(
     max,
     axis.tickSpacing,
   );
-
   return { domain, ticks };
 }


### PR DESCRIPTION
Fixes the following problems for charts with negative values:
- EES-3899 Charts with negative values should have a line at 0 on the minor axis (note that while the line now shows at 0, there won't always be a zero tick point as this depends on how the tick spacing is generated)
- EES-3906 data labels on bar charts positioned 'inside' were on the wrong place 
- negative minimum values in the minor axis domain weren't rounded to 'nice' values like max values are, resulting in non rounded tick points

Before:
![chart-neg-dev](https://user-images.githubusercontent.com/81572860/203786210-5690a431-9c7d-424e-9908-fd580d39d9c4.PNG)

Now:
![chart-neg-pr](https://user-images.githubusercontent.com/81572860/203786208-34c5465c-4987-43a7-8c6c-20d0b4592760.PNG)

