### PR TITLE
EES-3921 Update PublicationController.ListPublications to return publication Slug in response

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -288,6 +288,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         {
             var publicationA = new Publication
             {
+                Slug = "publication-a",
                 Title = "Publication A",
                 Summary = "Publication A summary",
                 LatestPublishedReleaseNew = new Release
@@ -299,6 +300,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             var publicationB = new Publication
             {
+                Slug = "publication-b",
                 Title = "Publication B",
                 Summary = "Publication B summary",
                 LatestPublishedReleaseNew = new Release
@@ -310,6 +312,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             var publicationC = new Publication
             {
+                Slug = "publication-c",
                 Title = "Publication C",
                 Summary = "Publication C summary",
                 LatestPublishedReleaseNew = new Release
@@ -371,6 +374,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 // Expect results sorted by title in ascending order
 
                 Assert.Equal(publicationA.Id, results[0].Id);
+                Assert.Equal("publication-a", results[0].Slug);
                 Assert.Equal(new DateTime(2020, 1, 1), results[0].Published);
                 Assert.Equal("Publication A", results[0].Title);
                 Assert.Equal("Publication A summary", results[0].Summary);
@@ -378,6 +382,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 Assert.Equal(NationalStatistics, results[0].Type);
 
                 Assert.Equal(publicationB.Id, results[1].Id);
+                Assert.Equal("publication-b", results[1].Slug);
                 Assert.Equal(new DateTime(2021, 1, 1), results[1].Published);
                 Assert.Equal("Publication B", results[1].Title);
                 Assert.Equal("Publication B summary", results[1].Summary);
@@ -385,6 +390,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 Assert.Equal(OfficialStatistics, results[1].Type);
 
                 Assert.Equal(publicationC.Id, results[2].Id);
+                Assert.Equal("publication-c", results[2].Slug);
                 Assert.Equal(new DateTime(2022, 1, 1), results[2].Published);
                 Assert.Equal("Publication C", results[2].Title);
                 Assert.Equal("Publication C summary", results[2].Summary);
@@ -601,7 +607,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                                 new()
                                 {
                                     Title = "Publication C",
-                                    Summary = "Publication C summary",
                                     LatestPublishedReleaseNew = new Release
                                     {
                                         Type = AdHocStatistics,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -118,6 +118,7 @@ public class PublicationService : IPublicationService
                 new PublicationSearchResultViewModel
                 {
                     Id = tuple.Publication.Id,
+                    Slug = tuple.Publication.Slug,
                     Summary = tuple.Publication.Summary,
                     Title = tuple.Publication.Title,
                     Theme = tuple.Publication.Topic.Theme.Title,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationSearchResultViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationSearchResultViewModel.cs
@@ -9,6 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 public record PublicationSearchResultViewModel
 {
     public Guid Id { get; init; }
+    public string Slug { get; init; }
     public string Summary { get; init; }
     public string Title { get; init; }
     public string Theme { get; init; }


### PR DESCRIPTION
This PR updates the Content API  `PublicationController.ListPublications` to return publication `Slug` in the response.

It's required so that we can link to publications from results in the Find Statistics page.