### PR TITLE
EES-3910 - reduce flakiness in release_content_authoring test

### DIFF
--- a/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
@@ -37,7 +37,7 @@ Switch to analyst1 to work on release content blocks
 
 Navigate to content section as analyst1
     user clicks link    Content
-    user waits until h1 is visible    ${PUBLICATION_NAME}
+    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
 
 Add first content section
     user closes Set Page View box
@@ -63,6 +63,7 @@ Switch to bau1 to view release
     ...    ${RELEASE_NAME}
 
     user clicks link    Content
+    user waits until h2 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
     user closes Set Page View box
 
 Check second text block is locked as bau1
@@ -86,7 +87,7 @@ Switch to bau1 to add review comments for first text block
     ${comments}=    get comments sidebar    ${block}
 
     # ensure 'Set page view' box doesn't intercept button click
-    user scrolls down    100
+    user scrolls down    150
     user presses keys    CTRL+a
     user clicks button    Add comment    ${toolbar}
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -752,4 +752,4 @@ user gets resolved comment
 
 user closes Set Page View box
     user clicks element    id:pageViewToggleButton
-    user waits until element is not visible    id:editingMode
+    user waits until element is not visible    id:editingMode    %{WAIT_SMALL}

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -280,7 +280,7 @@ user adds content to accordion section text block
     user presses keys    BACKSPACE
     user presses keys    ${content}
     user clicks button    Save    ${block}
-    user waits until element contains    ${block}    ${content}
+    user waits until element contains    ${block}    ${content}    %{WAIT_SMALL}
 
 user adds content to autosaving accordion section text block
     [Arguments]
@@ -351,7 +351,7 @@ user removes image from accordion section text block
 user saves autosaving text block
     [Arguments]    ${parent}
     user clicks button    Save & close    ${parent}
-    user waits until parent does not contain button    ${parent}    Save & close
+    user waits until parent does not contain button    ${parent}    Save & close    %{WAIT_SMALL}
 
 user checks accordion section text block contains
     [Arguments]
@@ -394,7 +394,7 @@ user deletes editable accordion section content block
     user clicks button    Confirm
     # avoid blocks being lazy loaded
     user waits until page does not contain loading spinner
-    Sleep    0.5
+    Sleep    0.75
     user scrolls down    1
 
 user deletes editable accordion section


### PR DESCRIPTION
This PR:
* Alters release_content_authoring to prevent flakiness when testing in a CI environment against dev



![image](https://user-images.githubusercontent.com/55030296/203815342-0114d394-f119-4c45-8ceb-50fa4a627181.png)
