### PR TITLE
EES-3668 hook up new find stats paginated list and sorting

### DIFF
--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -5,6 +5,7 @@ import {
   MethodologySummary,
   ExternalMethodology,
 } from '@common/services/types/methodology';
+import { Paging } from '@common/services/types/pagination';
 import { PartialDate } from '@common/utils/date/partialDate';
 import { contentApi } from './api';
 
@@ -42,21 +43,20 @@ export interface PublicationSummary {
   title: string;
 }
 
-// TODO EES-3517 a guess at the new type for the find stats page.
-export interface PublicationSummaryWithRelease {
+export interface PublicationListSummary {
   id: string;
-  legacyPublicationUrl?: string;
-  latestRelease?: {
-    id: string;
-    published: string;
-    type: ReleaseType;
-  };
+  published: Date;
+  rank: number;
   slug: string;
   summary?: string;
-  theme: {
-    title: string;
-  };
+  theme: string;
   title: string;
+  type: ReleaseType;
+}
+
+interface PublicationsResponse {
+  results: PublicationListSummary[];
+  paging: Paging;
 }
 
 export interface Contact {
@@ -91,18 +91,22 @@ export interface ContentSection<BlockType> {
   content: BlockType[];
 }
 
-export const publicationSortOptions = [
-  'newest',
-  'oldest',
-  'alphabetical',
-] as const;
+export const publicationSortOptions = ['newest', 'oldest', 'title'] as const;
 
 export type PublicationSortOption = typeof publicationSortOptions[number];
 
-// TODO EES-3517 expand to include filters and search
-export interface ListPublicationsRequest {
+export type PublicationSortParam = 'published' | 'title' | 'relevance';
+
+export type PublicationOrderParam = 'asc' | 'desc';
+
+interface PublicationListRequest {
+  order?: PublicationOrderParam;
   page?: number;
-  sortBy?: PublicationSortOption;
+  pageSize?: number;
+  releaseType?: ReleaseType;
+  search?: string;
+  sort?: PublicationSortParam;
+  themeId?: string;
 }
 
 export interface Release<
@@ -205,5 +209,12 @@ export default {
     return contentApi.get(
       `/publications/${publicationSlug}/releases/${releaseSlug}/prerelease-access-list`,
     );
+  },
+  listPublications(
+    params: PublicationListRequest,
+  ): Promise<PublicationsResponse> {
+    return contentApi.get(`/publications`, {
+      params,
+    });
   },
 };

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageNew.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageNew.tsx
@@ -5,7 +5,7 @@ import RelatedInformation from '@common/components/RelatedInformation';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import { useMobileMedia } from '@common/hooks/useMedia';
 import {
-  PublicationSummaryWithRelease,
+  PublicationListSummary,
   PublicationSortOption,
 } from '@common/services/publicationService';
 import { Paging } from '@common/services/types/pagination';
@@ -21,7 +21,7 @@ import React from 'react';
 
 interface Props {
   paging: Paging;
-  publications: PublicationSummaryWithRelease[];
+  publications: PublicationListSummary[];
   sortBy?: PublicationSortOption;
 }
 
@@ -30,7 +30,7 @@ const FindStatisticsPageNew: NextPage<Props> = ({
   publications,
   sortBy = 'newest',
 }) => {
-  const { page = 1, totalPages, totalResults } = paging;
+  const { page, totalPages, totalResults } = paging;
 
   const router = useRouter();
   const isLoading = useRouterLoading();
@@ -42,6 +42,7 @@ const FindStatisticsPageNew: NextPage<Props> = ({
         pathname: '/find-statistics',
         query: {
           ...router.query,
+          page: 1,
           sortBy: nextSortBy,
         },
       },

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPageNew.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPageNew.test.tsx
@@ -67,9 +67,6 @@ describe('FindStatisticsPageNew', () => {
     expect(
       screen.getByRole('heading', { name: 'Publication 3' }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { name: 'Publication 4' }),
-    ).toBeInTheDocument();
 
     const pagination = within(
       screen.getByRole('navigation', { name: 'Pagination' }),

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testPublications.ts
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testPublications.ts
@@ -1,56 +1,36 @@
-import { PublicationSummaryWithRelease } from '@common/services/publicationService';
+import { PublicationListSummary } from '@common/services/publicationService';
 
 // eslint-disable-next-line import/prefer-default-export
-export const testPublications: PublicationSummaryWithRelease[] = [
+export const testPublications: PublicationListSummary[] = [
   {
     id: '1',
-    latestRelease: {
-      id: 'release-1',
-      published: '2021-06-08T00:00:00',
-      type: 'AdHocStatistics',
-    },
+    published: new Date('2021-06-08T00:00:00'),
+    rank: 0,
+    type: 'AdHocStatistics',
     slug: 'publication-1-slug',
     summary: 'Publication 1 summary',
-    theme: {
-      title: 'Theme 1',
-    },
+    theme: 'Theme 1',
     title: 'Publication 1',
   },
   {
     id: '2',
-    latestRelease: {
-      id: 'release-1',
-      published: '2022-01-01T00:00:00',
-      type: 'ExperimentalStatistics',
-    },
+    published: new Date('2022-01-01T00:00:00'),
+    rank: 0,
+    type: 'ExperimentalStatistics',
     slug: 'publication-2-slug',
     summary: 'Publication 2 summary',
-    theme: {
-      title: 'Theme 2',
-    },
+    theme: 'Theme 2',
     title: 'Publication 2',
   },
+
   {
     id: '3',
-    legacyPublicationUrl: 'http://test.com',
+    published: new Date('2021-08-08T00:00:00'),
+    rank: 0,
+    type: 'NationalStatistics',
     slug: 'publication-3-slug',
+    summary: 'Publication 3 summary',
+    theme: 'Theme 3',
     title: 'Publication 3',
-    theme: {
-      title: 'Theme 2',
-    },
-  },
-  {
-    id: '4',
-    latestRelease: {
-      id: 'release-1',
-      published: '2021-08-08T00:00:00',
-      type: 'NationalStatistics',
-    },
-    slug: 'publication-4-slug',
-    summary: 'Publication 4 summary',
-    theme: {
-      title: 'Theme 3',
-    },
-    title: 'Publication 4',
   },
 ];

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSummary.tsx
@@ -1,60 +1,43 @@
 import FormattedDate from '@common/components/FormattedDate';
-import { PublicationSummaryWithRelease } from '@common/services/publicationService';
+import { PublicationListSummary } from '@common/services/publicationService';
 import { releaseTypes } from '@common/services/types/releaseType';
 import styles from '@frontend/modules/find-statistics/components/PublicationSummary.module.scss';
 import Link from '@frontend/components/Link';
 import React from 'react';
 
 interface Props {
-  publication: PublicationSummaryWithRelease;
+  publication: PublicationListSummary;
 }
 
 const PublicationSummary = ({ publication }: Props) => {
-  const {
-    legacyPublicationUrl,
-    latestRelease,
-    slug,
-    summary,
-    theme,
-    title,
-  } = publication;
+  const { published, slug, summary, theme, title, type } = publication;
   return (
     <li className={`${styles.container} govuk-!-margin-top-4`}>
       <h3 className="govuk-!-margin-bottom-2">
-        <Link to={legacyPublicationUrl ?? `/find-statistics/${slug}`}>
-          {title}
-        </Link>
+        <Link to={`/find-statistics/${slug}`}>{title}</Link>
       </h3>
-      <p>
-        {legacyPublicationUrl
-          ? 'Not yet on this service. Currently available via Statistics at DfE.'
-          : summary}
-      </p>
+      <p>{summary}</p>
 
-      {latestRelease && (
-        <dl>
-          <div className="dfe-flex">
-            <dt>Release type:</dt>
-            <dd className="govuk-!-margin-left-2" data-testid="release-type">
-              {releaseTypes[latestRelease.type]}
-            </dd>
-          </div>
-          <div className="dfe-flex">
-            <dt>Published:</dt>
-            <dd className="govuk-!-margin-left-2" data-testid="published">
-              <FormattedDate format="d MMM yyyy">
-                {latestRelease.published}
-              </FormattedDate>
-            </dd>
-          </div>
-          <div className="dfe-flex">
-            <dt>Theme:</dt>
-            <dd className="govuk-!-margin-left-2" data-testid="theme">
-              {theme?.title}
-            </dd>
-          </div>
-        </dl>
-      )}
+      <dl>
+        <div className="dfe-flex">
+          <dt>Release type:</dt>
+          <dd className="govuk-!-margin-left-2" data-testid="release-type">
+            {releaseTypes[type]}
+          </dd>
+        </div>
+        <div className="dfe-flex">
+          <dt>Published:</dt>
+          <dd className="govuk-!-margin-left-2" data-testid="published">
+            <FormattedDate format="d MMM yyyy">{published}</FormattedDate>
+          </dd>
+        </div>
+        <div className="dfe-flex">
+          <dt>Theme:</dt>
+          <dd className="govuk-!-margin-left-2" data-testid="theme">
+            {theme}
+          </dd>
+        </div>
+      </dl>
     </li>
   );
 };

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/SortControls.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/SortControls.tsx
@@ -13,7 +13,7 @@ interface Option {
 const options: Option[] = [
   { label: 'Newest', value: 'newest' },
   { label: 'Oldest', value: 'oldest' },
-  { label: 'A to Z', value: 'alphabetical' },
+  { label: 'A to Z', value: 'title' },
 ];
 
 const formId = 'sortControlsForm';

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/__tests__/PublicationSummary.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/__tests__/PublicationSummary.test.tsx
@@ -19,19 +19,4 @@ describe('PublicationSummary', () => {
     expect(screen.getByTestId('published')).toHaveTextContent('8 Jun 2021');
     expect(screen.getByTestId('theme')).toHaveTextContent('Theme 1');
   });
-
-  test('renders a legacy publication correctly', () => {
-    render(<PublicationSummary publication={testPublications[2]} />);
-
-    const heading = screen.getByRole('heading', { name: 'Publication 3' });
-    expect(
-      within(heading).getByRole('link', { name: 'Publication 3' }),
-    ).toHaveAttribute('href', 'http://test.com');
-    expect(
-      screen.getByText(
-        'Not yet on this service. Currently available via Statistics at DfE.',
-      ),
-    ).toBeInTheDocument();
-    expect(screen.queryByRole('list')).not.toBeInTheDocument();
-  });
 });

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/__tests__/SortControls.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/__tests__/SortControls.test.tsx
@@ -69,14 +69,14 @@ describe('SortControls', () => {
       expect(sortOptions[1]).toHaveValue('oldest');
       expect(sortOptions[1].selected).toBe(false);
       expect(sortOptions[2]).toHaveTextContent('A to Z');
-      expect(sortOptions[2]).toHaveValue('alphabetical');
+      expect(sortOptions[2]).toHaveValue('title');
       expect(sortOptions[2].selected).toBe(false);
 
       expect(screen.queryByRole('radio')).not.toBeInTheDocument();
     });
 
     test('setting the intial sortBy selects the correct option', () => {
-      render(<SortControls sortBy="alphabetical" onChange={noop} />);
+      render(<SortControls sortBy="title" onChange={noop} />);
 
       const sortDropdown = within(screen.getByLabelText('Sort results'));
       const sortOptions = sortDropdown.getAllByRole(
@@ -90,7 +90,7 @@ describe('SortControls', () => {
       expect(sortOptions[1]).toHaveValue('oldest');
       expect(sortOptions[1].selected).toBe(false);
       expect(sortOptions[2]).toHaveTextContent('A to Z');
-      expect(sortOptions[2]).toHaveValue('alphabetical');
+      expect(sortOptions[2]).toHaveValue('title');
       expect(sortOptions[2].selected).toBe(true);
     });
   });


### PR DESCRIPTION
Hooks up the paginated list and sort controls in the new Find Statistics UI to the new endpoint. See https://github.com/dfe-analytical-services/explore-education-statistics/pull/3459 for the original UI work and https://github.com/dfe-analytical-services/explore-education-statistics/pull/3635 for details of the endpoint.

Legacy release will no longer be shown on this page (they should all have been removed by the time it goes live).

The existing page should not be affected, to see the new one use the newDesign=true query parameter, e.g. http://localhost:3000/find-statistics?newDesign=true

You'll need to have the the latest database (ees-mssql-data-53.zip) locally for the list to be populated.