### PR TITLE
    EES-3877-2 - fix methodology content linking

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
@@ -6,6 +6,7 @@ import { ContentSectionKeys } from '@admin/pages/methodology/edit-methodology/co
 import useMethodologyContentActions from '@admin/pages/methodology/edit-methodology/content/context/useMethodologyContentActions';
 import MethodologyAccordionSection from '@admin/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection';
 import React, { useCallback } from 'react';
+import kebabCase from 'lodash/kebabCase';
 
 export interface MethodologyAccordionProps {
   id?: string;
@@ -71,7 +72,7 @@ const MethodologyAccordion = ({
       {methodology[sectionKey].map(section => (
         <MethodologyAccordionSection
           key={section.id}
-          id={`${id}-${section.id}`}
+          id={`content-section-${kebabCase(section.heading)}`}
           methodologyId={methodology.id}
           section={section}
           sectionKey={sectionKey}

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
@@ -129,8 +129,7 @@ const MethodologyAccordionSection = ({
       {...props}
       anchorLinkUrl={
         editingMode === 'preview'
-          ? id =>
-              `${PublicAppUrl}/methodology/${currentMethodology.slug}/#${id}`
+          ? id => `${PublicAppUrl}/methodology/${currentMethodology.slug}#${id}`
           : undefined
       }
       heading={heading}


### PR DESCRIPTION
This PR:
* fixes incorrect methodology IDs from being generated on the admin side when copying methodology accordion content sections. This resulted in copied links not working on the public frontend due to the dynamically generated IDs not matching what is applied to methodology accordions on the public frontend 