### PR TITLE
EES-3883 Add new endpoint to get all public themes for Find Statistics

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Moq;
@@ -66,10 +67,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         }
 
         private static ThemeController BuildController(
-            IMethodologyCacheService? methodologyCacheService = null)
+            IMethodologyCacheService? methodologyCacheService = null,
+            IThemeService? themeService = null)
         {
             return new ThemeController(
-                methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict));
+                methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
+                themeService ?? Mock.Of<IThemeService>(Strict));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ThemeController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ThemeController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -14,11 +15,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
     public class ThemeController : ControllerBase
     {
         private readonly IMethodologyCacheService _methodologyCacheService;
+        private readonly IThemeService _themeService;
 
         public ThemeController(
-            IMethodologyCacheService methodologyCacheService)
+            IMethodologyCacheService methodologyCacheService,
+            IThemeService themeService)
         {
             _methodologyCacheService = methodologyCacheService;
+            _themeService = themeService;
         }
 
         [HttpGet("methodology-themes")]
@@ -27,6 +31,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
             return await _methodologyCacheService
                 .GetSummariesTree()
                 .HandleFailuresOrOk();
+        }
+
+        [HttpGet("themes")]
+        public async Task<IList<ThemeViewModel>> ListThemes()
+        {
+            return await _themeService
+                .ListThemes();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -163,6 +163,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             services.AddTransient<IDataGuidanceFileWriter, DataGuidanceFileWriter>();
             services.AddTransient<IGlossaryCacheService, GlossaryCacheService>();
             services.AddTransient<IGlossaryService, GlossaryService>();
+            services.AddTransient<IThemeService, ThemeService>();
 
             StartupSecurityConfiguration.ConfigureAuthorizationPolicies(services);
             StartupSecurityConfiguration.ConfigureResourceBasedAuthorization(services);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -61,7 +61,12 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
                 Title = ""
             }
         },
-        Topic = new TopicViewModel(new ThemeViewModel(""))
+        Topic = new TopicViewModel(new ThemeViewModel
+        {
+            Id = Guid.NewGuid(),
+            Slug = "",
+            Title = ""
+        })
     };
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -61,12 +61,12 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
                 Title = ""
             }
         },
-        Topic = new TopicViewModel(new ThemeViewModel
-        {
-            Id = Guid.NewGuid(),
-            Slug = "",
-            Title = ""
-        })
+        Topic = new TopicViewModel(new ThemeViewModel(
+            Guid.NewGuid(),
+            Slug: "",
+            Title: "",
+            Summary: ""
+        ))
     };
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -92,6 +92,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     {
                         Title = "Test theme",
                         Slug = "test-theme",
+                        Summary = "Test theme summary"
                     }
                 },
                 Contact = new Contact
@@ -148,6 +149,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 Assert.Equal(publication.Topic.Theme.Id, publicationViewModel.Topic.Theme.Id);
                 Assert.Equal(publication.Topic.Theme.Slug, publicationViewModel.Topic.Theme.Slug);
                 Assert.Equal(publication.Topic.Theme.Title, publicationViewModel.Topic.Theme.Title);
+                Assert.Equal(publication.Topic.Theme.Summary, publicationViewModel.Topic.Theme.Summary);
 
                 Assert.Equal(publication.Contact.TeamName, publicationViewModel.Contact.TeamName);
                 Assert.Equal(publication.Contact.TeamEmail, publicationViewModel.Contact.TeamEmail);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -145,6 +145,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     publicationViewModel.LegacyReleases[0].Description);
                 Assert.Equal(publication.LegacyReleases[0].Url, publicationViewModel.LegacyReleases[0].Url);
 
+                Assert.Equal(publication.Topic.Theme.Id, publicationViewModel.Topic.Theme.Id);
+                Assert.Equal(publication.Topic.Theme.Slug, publicationViewModel.Topic.Theme.Slug);
                 Assert.Equal(publication.Topic.Theme.Title, publicationViewModel.Topic.Theme.Title);
 
                 Assert.Equal(publication.Contact.TeamName, publicationViewModel.Contact.TeamName);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ThemeServiceTests.cs
@@ -1,0 +1,295 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests;
+
+public class ThemeServiceTests
+{
+    [Fact]
+    public async Task ListThemes()
+    {
+        var themes = new List<Theme>
+        {
+            new()
+            {
+                Slug = "theme-c",
+                Title = "Theme C",
+                Topics = new List<Topic>
+                {
+                    new()
+                    {
+                        Publications = new List<Publication>
+                        {
+                            new()
+                            {
+                                LatestPublishedReleaseId = Guid.NewGuid()
+                            }
+                        }
+                    }
+                }
+            },
+            new()
+            {
+                Slug = "theme-a",
+                Title = "Theme A",
+                Topics = new List<Topic>
+                {
+                    new()
+                    {
+                        Publications = new List<Publication>
+                        {
+                            new()
+                            {
+                                LatestPublishedReleaseId = Guid.NewGuid()
+                            }
+                        }
+                    }
+                }
+            },
+            new()
+            {
+                Slug = "theme-b",
+                Title = "Theme B",
+                Topics = new List<Topic>
+                {
+                    new()
+                    {
+                        Publications = new List<Publication>
+                        {
+                            new()
+                            {
+                                LatestPublishedReleaseId = Guid.NewGuid()
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryContentDbContext(contextId))
+        {
+            await context.Themes.AddRangeAsync(themes);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryContentDbContext(contextId))
+        {
+            var service = BuildThemeService(context);
+
+            var result = await service.ListThemes();
+
+            Assert.Equal(3, result.Count);
+
+            Assert.Equal(themes[1].Id, result[0].Id);
+            Assert.Equal("theme-a", result[0].Slug);
+            Assert.Equal("Theme A", result[0].Title);
+
+            Assert.Equal(themes[2].Id, result[1].Id);
+            Assert.Equal("theme-b", result[1].Slug);
+            Assert.Equal("Theme B", result[1].Title);
+
+            Assert.Equal(themes[0].Id, result[2].Id);
+            Assert.Equal("theme-c", result[2].Slug);
+            Assert.Equal("Theme C", result[2].Title);
+        }
+    }
+
+    [Fact]
+    public async Task ListThemes_ExcludesThemesWithNoPublishedReleases()
+    {
+        var themes = new List<Theme>
+        {
+            // Theme has no topics and should be excluded
+            new()
+            {
+                Title = "Theme A",
+                Topics = new List<Topic>()
+            },
+            // Theme has topic with no publications and should be excluded
+            new()
+            {
+                Title = "Theme B",
+                Topics = new List<Topic>
+                {
+                    new()
+                    {
+                        Publications = new List<Publication>()
+                    }
+                }
+            },
+            // Theme has topic with publication that's not published and should be excluded
+            new()
+            {
+                Title = "Theme C",
+                Topics = new List<Topic>
+                {
+                    new()
+                    {
+                        Publications = new List<Publication>
+                        {
+                            new()
+                            {
+                                LatestPublishedReleaseId = null
+                            }
+                        }
+                    }
+                }
+            },
+            // Theme has published releases
+            new()
+            {
+                Title = "Theme D",
+                Topics = new List<Topic>
+                {
+                    new()
+                    {
+                        Publications = new List<Publication>
+                        {
+                            new()
+                            {
+                                LatestPublishedReleaseId = Guid.NewGuid()
+                            }
+                        }
+                    },
+                    new()
+                    {
+                        Publications = new List<Publication>()
+                    }
+                }
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryContentDbContext(contextId))
+        {
+            await context.Themes.AddRangeAsync(themes);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryContentDbContext(contextId))
+        {
+            var service = BuildThemeService(context);
+
+            var result = await service.ListThemes();
+
+            var theme = Assert.Single(result);
+            Assert.Equal(themes[3].Id, theme.Id);
+            Assert.Equal("Theme D", theme.Title);
+        }
+    }
+
+    [Fact]
+    public async Task ListThemes_ExcludesThemesWithOnlySupersededPublications()
+    {
+        var themes = new List<Theme>
+        {
+            // Theme has superseded publication and should be excluded
+            new()
+            {
+                Title = "Theme A",
+                Topics = new List<Topic>
+                {
+                    new()
+                    {
+                        Publications = new List<Publication>
+                        {
+                            new()
+                            {
+                                LatestPublishedReleaseId = Guid.NewGuid(),
+                                SupersededBy = new Publication
+                                {
+                                    // Superseding publication is published
+                                    LatestPublishedReleaseId = Guid.NewGuid()
+                                }
+                            }
+                        }
+                    },
+                    new()
+                    {
+                        Publications = new List<Publication>()
+                    }
+                }
+            },
+            // Theme has superseded publication but the superseding publication is not published yet
+            new()
+            {
+                Title = "Theme B",
+                Topics = new List<Topic>
+                {
+                    new()
+                    {
+                        Publications = new List<Publication>
+                        {
+                            new()
+                            {
+                                LatestPublishedReleaseId = Guid.NewGuid(),
+                                SupersededBy = new Publication
+                                {
+                                    // Superseding publication is not published
+                                    LatestPublishedReleaseId = null
+                                }
+                            }
+                        }
+                    },
+                    new()
+                    {
+                        Publications = new List<Publication>()
+                    }
+                }
+            },
+            // Theme has publication which is not superseded
+            new()
+            {
+                Title = "Theme C",
+                Topics = new List<Topic>
+                {
+                    new()
+                    {
+                        Publications = new List<Publication>
+                        {
+                            new()
+                            {
+                                LatestPublishedReleaseId = Guid.NewGuid()
+                            }
+                        }
+                    },
+                }
+            },
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryContentDbContext(contextId))
+        {
+            await context.Themes.AddRangeAsync(themes);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryContentDbContext(contextId))
+        {
+            var service = BuildThemeService(context);
+
+            var result = await service.ListThemes();
+
+            Assert.Equal(2, result.Count);
+
+            Assert.Equal(themes[1].Id, result[0].Id);
+            Assert.Equal("Theme B", result[0].Title);
+
+            Assert.Equal(themes[2].Id, result[1].Id);
+            Assert.Equal("Theme C", result[1].Title);
+        }
+    }
+
+    private static ThemeService BuildThemeService(
+        ContentDbContext contentDbContext)
+    {
+        return new ThemeService(contentDbContext: contentDbContext);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ThemeServiceTests.cs
@@ -20,6 +20,7 @@ public class ThemeServiceTests
             {
                 Slug = "theme-c",
                 Title = "Theme C",
+                Summary = "Theme C summary",
                 Topics = new List<Topic>
                 {
                     new()
@@ -38,6 +39,7 @@ public class ThemeServiceTests
             {
                 Slug = "theme-a",
                 Title = "Theme A",
+                Summary = "Theme A summary",
                 Topics = new List<Topic>
                 {
                     new()
@@ -56,6 +58,7 @@ public class ThemeServiceTests
             {
                 Slug = "theme-b",
                 Title = "Theme B",
+                Summary = "Theme B summary",
                 Topics = new List<Topic>
                 {
                     new()
@@ -90,14 +93,17 @@ public class ThemeServiceTests
             Assert.Equal(themes[1].Id, result[0].Id);
             Assert.Equal("theme-a", result[0].Slug);
             Assert.Equal("Theme A", result[0].Title);
+            Assert.Equal("Theme A summary", result[0].Summary);
 
             Assert.Equal(themes[2].Id, result[1].Id);
             Assert.Equal("theme-b", result[1].Slug);
             Assert.Equal("Theme B", result[1].Title);
+            Assert.Equal("Theme B summary", result[1].Summary);
 
             Assert.Equal(themes[0].Id, result[2].Id);
             Assert.Equal("theme-c", result[2].Slug);
             Assert.Equal("Theme C", result[2].Title);
+            Assert.Equal("Theme C summary", result[2].Summary);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IThemeService.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+
+public interface IThemeService
+{
+    Task<IList<ThemeViewModel>> ListThemes();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -159,12 +159,12 @@ public class PublicationService : IPublicationService
         Publication publication,
         bool isSuperseded)
     {
-        var topic = new TopicViewModel(new ThemeViewModel
-        {
-            Id = publication.Topic.Theme.Id,
-            Slug = publication.Topic.Theme.Slug,
-            Title = publication.Topic.Theme.Title
-        });
+        var topic = new TopicViewModel(new ThemeViewModel(
+            publication.Topic.Theme.Id,
+            Slug: publication.Topic.Theme.Slug,
+            Title: publication.Topic.Theme.Title,
+            Summary: publication.Topic.Theme.Summary
+        ));
 
         return new PublicationCacheViewModel
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -159,6 +159,13 @@ public class PublicationService : IPublicationService
         Publication publication,
         bool isSuperseded)
     {
+        var topic = new TopicViewModel(new ThemeViewModel
+        {
+            Id = publication.Topic.Theme.Id,
+            Slug = publication.Topic.Theme.Slug,
+            Title = publication.Topic.Theme.Title
+        });
+
         return new PublicationCacheViewModel
         {
             Id = publication.Id,
@@ -168,7 +175,7 @@ public class PublicationService : IPublicationService
                 .OrderByDescending(legacyRelease => legacyRelease.Order)
                 .Select(legacyRelease => new LegacyReleaseViewModel(legacyRelease))
                 .ToList(),
-            Topic = new TopicViewModel(new ThemeViewModel(publication.Topic.Theme.Title)),
+            Topic = topic,
             Contact = new ContactViewModel(publication.Contact),
             ExternalMethodology = publication.ExternalMethodology != null
                 ? new ExternalMethodologyViewModel(publication.ExternalMethodology)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ThemeService.cs
@@ -28,11 +28,11 @@ public class ThemeService : IThemeService
                         (publication.SupersededById == null ||
                          !publication.SupersededBy!.LatestPublishedReleaseId.HasValue))))
             .OrderBy(theme => theme.Title)
-            .Select(theme => new ThemeViewModel
-            {
-                Id = theme.Id,
-                Slug = theme.Slug,
-                Title = theme.Title
-            }).ToListAsync();
+            .Select(theme => new ThemeViewModel(
+                theme.Id,
+                theme.Slug,
+                theme.Title,
+                theme.Summary
+            )).ToListAsync();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ThemeService.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
+
+public class ThemeService : IThemeService
+{
+    private readonly ContentDbContext _contentDbContext;
+
+    public ThemeService(ContentDbContext contentDbContext)
+    {
+        _contentDbContext = contentDbContext;
+    }
+
+    public async Task<IList<ThemeViewModel>> ListThemes()
+    {
+        return await _contentDbContext.Themes
+            .Where(theme =>
+                theme.Topics.Any(topic =>
+                    topic.Publications.Any(publication =>
+                        publication.LatestPublishedReleaseId.HasValue &&
+                        (publication.SupersededById == null ||
+                         !publication.SupersededBy!.LatestPublishedReleaseId.HasValue))))
+            .OrderBy(theme => theme.Title)
+            .Select(theme => new ThemeViewModel
+            {
+                Id = theme.Id,
+                Slug = theme.Slug,
+                Title = theme.Title
+            }).ToListAsync();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ThemeViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ThemeViewModel.cs
@@ -1,5 +1,12 @@
 ﻿#nullable enable
 
+using System;
+
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 
-public record ThemeViewModel(string Title);
+public record ThemeViewModel
+{
+    public Guid Id { get; init; }
+    public string Slug { get; init; }
+    public string Title { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ThemeViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ThemeViewModel.cs
@@ -4,9 +4,4 @@ using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
 
-public record ThemeViewModel
-{
-    public Guid Id { get; init; }
-    public string Slug { get; init; }
-    public string Title { get; init; }
-}
+public record ThemeViewModel(Guid Id, string Slug, string Title, string Summary);


### PR DESCRIPTION
⚠️ Depends on https://github.com/dfe-analytical-services/explore-education-statistics/pull/3679 ⚠️ 

This PR adds a new Content API endpoint to get the list of all public themes.

It's required for the upcoming work in [EES-3610](https://dfedigital.atlassian.net/browse/EES-3610) which will add filtering by theme to the new Find Statistics page.

Themes are considered public if they have any publications which have published releases and are not superseded. Themes are ordered alphabetically by title.

`GET https://{contentApiUrl}/api/themes`

Example response:

```
[
  {
    "id": "ee1855ca-d1e1-4f04-a795-cbd61d326a1f",
    "slug": "pupils-and-schools",
    "title": "Pupils and schools",
    "summary": "Including absence, application and offers, capacity exclusion and special educational needs (SEN) statistics"
  },
  {
    "id": "07db2102-6bcb-4e72-b1db-08d93c9b4c83",
    "slug": "test-theme",
    "title": "Test theme",
    "summary": "Test theme summary"
  }
]
```

### UI test report

![image](https://user-images.githubusercontent.com/4147126/204814989-f31c4540-7b09-4378-ab37-2648d3fb6d69.png)

