### PR TITLE
EES-3937 fix reordering methodology sections

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
@@ -6,7 +6,6 @@ import { ContentSectionKeys } from '@admin/pages/methodology/edit-methodology/co
 import useMethodologyContentActions from '@admin/pages/methodology/edit-methodology/content/context/useMethodologyContentActions';
 import MethodologyAccordionSection from '@admin/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection';
 import React, { useCallback } from 'react';
-import kebabCase from 'lodash/kebabCase';
 
 export interface MethodologyAccordionProps {
   id?: string;
@@ -72,7 +71,7 @@ const MethodologyAccordion = ({
       {methodology[sectionKey].map(section => (
         <MethodologyAccordionSection
           key={section.id}
-          id={`${sectionKey}-section-${kebabCase(section.heading)}`}
+          id={`${id}-${section.id}`}
           methodologyId={methodology.id}
           section={section}
           sectionKey={sectionKey}

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
@@ -127,6 +127,7 @@ const MethodologyAccordionSection = ({
   return (
     <EditableAccordionSection
       {...props}
+      anchorLinkIdPrefix={sectionKey}
       anchorLinkUrl={
         editingMode === 'preview'
           ? id => `${PublicAppUrl}/methodology/${currentMethodology.slug}#${id}`

--- a/src/explore-education-statistics-common/src/components/AccordionSection.tsx
+++ b/src/explore-education-statistics-common/src/components/AccordionSection.tsx
@@ -63,6 +63,7 @@ const AccordionSection = ({
 
   const headingId = `${id}-heading`;
   const contentId = `${id}-content`;
+  const anchorId = `${anchorLinkIdPrefix}-${kebabCase(heading)}`;
 
   return (
     <div
@@ -76,7 +77,7 @@ const AccordionSection = ({
         {anchorLinkUrl && (
           <CopyLinkButton
             className={styles.copyLinkButton}
-            url={anchorLinkUrl(id)}
+            url={anchorLinkUrl(anchorId)}
           />
         )}
         {header ??
@@ -84,7 +85,7 @@ const AccordionSection = ({
             headingTag,
             {
               className: classes.sectionHeading,
-              id: `${anchorLinkIdPrefix}-${kebabCase(heading)}`,
+              id: anchorId,
             },
             isMounted ? (
               <button

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
@@ -141,7 +141,7 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
             return (
               <AccordionSection
                 id={`content-section-${order}`}
-                anchorLinkIdPrefix="content-section"
+                anchorLinkIdPrefix="content"
                 heading={heading}
                 caption={caption}
                 key={order}
@@ -177,7 +177,7 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
             {data.annexes.map(({ heading, caption, order, content }) => {
               return (
                 <AccordionSection
-                  anchorLinkIdPrefix="annexes-section"
+                  anchorLinkIdPrefix="annexes"
                   heading={heading}
                   caption={caption}
                   key={order}


### PR DESCRIPTION
Changing the id to not be the section id (with the guid in) was breaking the reordering, so I've reverted that and added and anchorId instead.