### PR TITLE
EES-3609 find stats search

### DIFF
--- a/src/explore-education-statistics-common/src/components/SearchIcon.tsx
+++ b/src/explore-education-statistics-common/src/components/SearchIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const SearchIcon = ({ className }: { className?: string }) => (
+  <svg
+    aria-hidden="true"
+    className={className}
+    focusable="false"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 36 36"
+    width="40"
+    height="40"
+  >
+    <path
+      d="M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+export default SearchIcon;

--- a/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
@@ -11,6 +11,8 @@ import React, {
 } from 'react';
 
 export interface FormBaseInputProps extends FormLabelProps {
+  addOn?: ReactNode;
+  addOnContainerClassName?: string;
   className?: string;
   disabled?: boolean;
   error?: ReactNode | string;
@@ -27,24 +29,32 @@ export interface FormBaseInputProps extends FormLabelProps {
 
 interface HiddenProps {
   defaultValue?: string | number;
-  type?: 'text' | 'number' | 'color';
+  type?: 'text' | 'number' | 'color' | 'search';
   value?: string | number;
 }
 
 const FormBaseInput = ({
+  addOn,
+  addOnContainerClassName,
   className,
   error,
   hint,
   id,
   hideLabel,
   label,
+  labelSize,
   width,
   type = 'text',
   ...props
 }: FormBaseInputProps & HiddenProps) => {
   return (
     <>
-      <FormLabel id={id} label={label} hideLabel={hideLabel} />
+      <FormLabel
+        id={id}
+        label={label}
+        labelSize={labelSize}
+        hideLabel={hideLabel}
+      />
 
       {hint && (
         <span id={`${id}-hint`} className="govuk-hint">
@@ -53,23 +63,32 @@ const FormBaseInput = ({
       )}
 
       {error && <ErrorMessage id={`${id}-error`}>{error}</ErrorMessage>}
-
-      <input
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
-        aria-describedby={
-          classNames({
-            [`${id}-error`]: !!error,
-            [`${id}-hint`]: !!hint,
-          }) || undefined
-        }
-        className={classNames('govuk-input', className, {
-          [`govuk-input--width-${width}`]: width !== undefined,
-          'govuk-input--error': !!error,
-        })}
-        id={id}
-        type={type}
-      />
+      <div
+        className={classNames(
+          {
+            'dfe-flex': !!addOn,
+          },
+          addOnContainerClassName,
+        )}
+      >
+        <input
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...props}
+          aria-describedby={
+            classNames({
+              [`${id}-error`]: !!error,
+              [`${id}-hint`]: !!hint,
+            }) || undefined
+          }
+          className={classNames('govuk-input', className, {
+            [`govuk-input--width-${width}`]: width !== undefined,
+            'govuk-input--error': !!error,
+          })}
+          id={id}
+          type={type}
+        />
+        {addOn}
+      </div>
     </>
   );
 };

--- a/src/explore-education-statistics-common/src/components/form/FormLabel.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormLabel.tsx
@@ -6,12 +6,20 @@ export interface FormLabelProps {
   id: string;
   hideLabel?: boolean;
   label: string | ReactNode;
+  labelSize?: 'xl' | 'l' | 'm' | 's';
 }
 
-const FormLabel = ({ className, id, hideLabel, label }: FormLabelProps) => {
+const FormLabel = ({
+  className,
+  id,
+  hideLabel,
+  label,
+  labelSize,
+}: FormLabelProps) => {
   return (
     <label
       className={classNames('govuk-label', className, {
+        [`govuk-label--${labelSize}`]: labelSize,
         'govuk-visually-hidden': hideLabel,
       })}
       htmlFor={id}

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormBaseInput.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormBaseInput.test.tsx
@@ -120,4 +120,20 @@ describe('FormTextInput', () => {
     expect(container.querySelector('.govuk-input--width-20')).not.toBeNull();
     expect(container.innerHTML).toMatchSnapshot();
   });
+
+  test('renders with an add on', () => {
+    const { container, getByRole } = render(
+      <FormBaseInput
+        addOn={<button type="button">Click me!</button>}
+        id="test-input"
+        label="Test input"
+        name="testInput"
+        hint="Fill me in"
+        width={20}
+      />,
+    );
+
+    expect(getByRole('button', { name: 'Click me!' })).toBeInTheDocument();
+    expect(container.innerHTML).toMatchSnapshot();
+  });
 });

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormBaseInput.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormBaseInput.test.tsx.snap
@@ -14,12 +14,14 @@ exports[`FormTextInput renders correctly with error 1`] = `
   </span>
   Field is required
 </span>
-<input name="testInput"
-       aria-describedby="test-input-error"
-       class="govuk-input govuk-input--error"
-       id="test-input"
-       type="text"
->
+<div class>
+  <input name="testInput"
+         aria-describedby="test-input-error"
+         class="govuk-input govuk-input--error"
+         id="test-input"
+         type="text"
+  >
+</div>
 `;
 
 exports[`FormTextInput renders correctly with hint 1`] = `
@@ -33,12 +35,14 @@ exports[`FormTextInput renders correctly with hint 1`] = `
 >
   Fill me in
 </span>
-<input name="testInput"
-       aria-describedby="test-input-hint"
-       class="govuk-input"
-       id="test-input"
-       type="text"
->
+<div class>
+  <input name="testInput"
+         aria-describedby="test-input-hint"
+         class="govuk-input"
+         id="test-input"
+         type="text"
+  >
+</div>
 `;
 
 exports[`FormTextInput renders correctly with required props 1`] = `
@@ -47,11 +51,13 @@ exports[`FormTextInput renders correctly with required props 1`] = `
 >
   Test input
 </label>
-<input name="testInput"
-       class="govuk-input"
-       id="test-input"
-       type="text"
->
+<div class>
+  <input name="testInput"
+         class="govuk-input"
+         id="test-input"
+         type="text"
+  >
+</div>
 `;
 
 exports[`FormTextInput renders with a specific width class 1`] = `
@@ -65,10 +71,36 @@ exports[`FormTextInput renders with a specific width class 1`] = `
 >
   Fill me in
 </span>
-<input name="testInput"
-       aria-describedby="test-input-hint"
-       class="govuk-input govuk-input--width-20"
-       id="test-input"
-       type="text"
+<div class>
+  <input name="testInput"
+         aria-describedby="test-input-hint"
+         class="govuk-input govuk-input--width-20"
+         id="test-input"
+         type="text"
+  >
+</div>
+`;
+
+exports[`FormTextInput renders with an add on 1`] = `
+<label class="govuk-label"
+       for="test-input"
 >
+  Test input
+</label>
+<span id="test-input-hint"
+      class="govuk-hint"
+>
+  Fill me in
+</span>
+<div class="dfe-flex">
+  <input name="testInput"
+         aria-describedby="test-input-hint"
+         class="govuk-input govuk-input--width-20"
+         id="test-input"
+         type="text"
+  >
+  <button type="button">
+    Click me!
+  </button>
+</div>
 `;

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchGroup.test.tsx.snap
@@ -13,12 +13,14 @@ exports[`FormCheckboxSearchGroup without searchOnly renders list of checkboxes i
     >
       Search options
     </label>
-    <input name="testCheckboxes-search"
-           class="govuk-input searchInput govuk-input--width-20"
-           id="test-checkboxes-search"
-           type="text"
-           value
-    >
+    <div class>
+      <input name="testCheckboxes-search"
+             class="govuk-input searchInput govuk-input--width-20"
+             id="test-checkboxes-search"
+             type="text"
+             value
+      >
+    </div>
     <div class="optionsContainer">
       <span aria-live="polite"
             aria-atomic="true"

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchSubGroups.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchSubGroups.test.tsx.snap
@@ -20,12 +20,14 @@ exports[`FormCheckboxSearchSubGroups renders groups of checkboxes in correct ord
     >
       Search options
     </label>
-    <input name="testCheckboxes-search"
-           class="govuk-input searchInput govuk-input--width-20"
-           id="test-checkboxes-search"
-           type="text"
-           value
-    >
+    <div class>
+      <input name="testCheckboxes-search"
+             class="govuk-input searchInput govuk-input--width-20"
+             id="test-checkboxes-search"
+             type="text"
+             value
+      >
+    </div>
     <div class="optionsContainer"
          aria-live="assertive"
     >
@@ -149,12 +151,14 @@ exports[`FormCheckboxSearchSubGroups renders single group of checkboxes correctl
     >
       Search options
     </label>
-    <input name="testCheckboxes-search"
-           class="govuk-input searchInput govuk-input--width-20"
-           id="test-checkboxes-search"
-           type="text"
-           value
-    >
+    <div class>
+      <input name="testCheckboxes-search"
+             class="govuk-input searchInput govuk-input--width-20"
+             id="test-checkboxes-search"
+             type="text"
+             value
+      >
+    </div>
     <div class="optionsContainer"
          aria-live="assertive"
     >

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldDateInput.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldDateInput.test.tsx.snap
@@ -14,12 +14,14 @@ exports[`FormFieldDateInput renders correctly 1`] = `
       >
         Day
       </label>
-      <input name="startDate.day"
-             class="govuk-input govuk-input--width-2"
-             id="startDate-day"
-             type="number"
-             value
-      >
+      <div class>
+        <input name="startDate.day"
+               class="govuk-input govuk-input--width-2"
+               id="startDate-day"
+               type="number"
+               value
+        >
+      </div>
     </div>
     <div class="govuk-form-group govuk-date-input__item">
       <label class="govuk-label"
@@ -27,12 +29,14 @@ exports[`FormFieldDateInput renders correctly 1`] = `
       >
         Month
       </label>
-      <input name="startDate.month"
-             class="govuk-input govuk-input--width-2"
-             id="startDate-month"
-             type="number"
-             value
-      >
+      <div class>
+        <input name="startDate.month"
+               class="govuk-input govuk-input--width-2"
+               id="startDate-month"
+               type="number"
+               value
+        >
+      </div>
     </div>
     <div class="govuk-form-group govuk-date-input__item">
       <label class="govuk-label"
@@ -40,12 +44,14 @@ exports[`FormFieldDateInput renders correctly 1`] = `
       >
         Year
       </label>
-      <input name="startDate.year"
-             class="govuk-input govuk-input--width-4"
-             id="startDate-year"
-             type="number"
-             value
-      >
+      <div class>
+        <input name="startDate.year"
+               class="govuk-input govuk-input--width-4"
+               id="startDate-year"
+               type="number"
+               value
+        >
+      </div>
     </div>
   </fieldset>
 </div>

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormNumberInput.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormNumberInput.test.tsx.snap
@@ -6,10 +6,12 @@ exports[`FormNumberInput renders correctly with minimal props 1`] = `
 >
   Test input
 </label>
-<input name="test"
-       class="govuk-input"
-       id="test-input"
-       type="number"
-       value
->
+<div class>
+  <input name="test"
+         class="govuk-input"
+         id="test-input"
+         type="number"
+         value
+  >
+</div>
 `;

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormRadioSearchGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormRadioSearchGroup.test.tsx.snap
@@ -13,12 +13,14 @@ exports[`FormRadioSearchGroup renders list of radio buttons in correct order 1`]
     >
       Search
     </label>
-    <input name="testRadios-search"
-           class="govuk-input govuk-!-margin-bottom-4 searchInput govuk-input--width-20"
-           id="test-radios-search"
-           type="text"
-           value
-    >
+    <div class>
+      <input name="testRadios-search"
+             class="govuk-input govuk-!-margin-bottom-4 searchInput govuk-input--width-20"
+             id="test-radios-search"
+             type="text"
+             value
+      >
+    </div>
     <div aria-live="assertive">
       <div class="govuk-radios">
         <div class="govuk-radios__item"

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormTextSearchInput.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormTextSearchInput.test.tsx.snap
@@ -14,13 +14,15 @@ exports[`FormTextSearchInput renders correctly with error 1`] = `
   </span>
   Field is required
 </span>
-<input name="testInput"
-       aria-describedby="test-input-error"
-       class="govuk-input searchInput govuk-input--error"
-       id="test-input"
-       type="text"
-       value
->
+<div class>
+  <input name="testInput"
+         aria-describedby="test-input-error"
+         class="govuk-input searchInput govuk-input--error"
+         id="test-input"
+         type="text"
+         value
+  >
+</div>
 `;
 
 exports[`FormTextSearchInput renders correctly with hint 1`] = `
@@ -34,13 +36,15 @@ exports[`FormTextSearchInput renders correctly with hint 1`] = `
 >
   Fill me in
 </span>
-<input name="testInput"
-       aria-describedby="test-input-hint"
-       class="govuk-input searchInput"
-       id="test-input"
-       type="text"
-       value
->
+<div class>
+  <input name="testInput"
+         aria-describedby="test-input-hint"
+         class="govuk-input searchInput"
+         id="test-input"
+         type="text"
+         value
+  >
+</div>
 `;
 
 exports[`FormTextSearchInput renders correctly with required props 1`] = `
@@ -49,12 +53,14 @@ exports[`FormTextSearchInput renders correctly with required props 1`] = `
 >
   Test input
 </label>
-<input name="testInput"
-       class="govuk-input searchInput"
-       id="test-input"
-       type="text"
-       value
->
+<div class>
+  <input name="testInput"
+         class="govuk-input searchInput"
+         id="test-input"
+         type="text"
+         value
+  >
+</div>
 `;
 
 exports[`FormTextSearchInput renders with a specific width class 1`] = `
@@ -68,11 +74,13 @@ exports[`FormTextSearchInput renders with a specific width class 1`] = `
 >
   Fill me in
 </span>
-<input name="testInput"
-       aria-describedby="test-input-hint"
-       class="govuk-input searchInput govuk-input--width-20"
-       id="test-input"
-       type="text"
-       value
->
+<div class>
+  <input name="testInput"
+         aria-describedby="test-input-hint"
+         class="govuk-input searchInput govuk-input--width-20"
+         id="test-input"
+         type="text"
+         value
+  >
+</div>
 `;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
@@ -25,13 +25,17 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
   >
     Search options
   </label>
-  <input
-    class="govuk-input searchInput govuk-input--width-20"
-    id="test-search"
-    name="test-search"
-    type="text"
-    value=""
-  />
+  <div
+    class=""
+  >
+    <input
+      class="govuk-input searchInput govuk-input--width-20"
+      id="test-search"
+      name="test-search"
+      type="text"
+      value=""
+    />
+  </div>
   <div
     aria-live="assertive"
     class="optionsContainer"
@@ -193,13 +197,17 @@ exports[`FormFieldCheckboxGroupsMenu renders single checkbox group with search i
   >
     Search options
   </label>
-  <input
-    class="govuk-input searchInput govuk-input--width-20"
-    id="test-search"
-    name="test-search"
-    type="text"
-    value=""
-  />
+  <div
+    class=""
+  >
+    <input
+      class="govuk-input searchInput govuk-input--width-20"
+      id="test-search"
+      name="test-search"
+      type="text"
+      value=""
+    />
+  </div>
   <div
     aria-live="assertive"
     class="optionsContainer"

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -92,7 +92,12 @@ export interface ContentSection<BlockType> {
   content: BlockType[];
 }
 
-export const publicationSortOptions = ['newest', 'oldest', 'title'] as const;
+export const publicationSortOptions = [
+  'newest',
+  'oldest',
+  'relevance',
+  'title',
+] as const;
 
 export type PublicationSortOption = typeof publicationSortOptions[number];
 
@@ -100,7 +105,7 @@ export type PublicationSortParam = 'published' | 'title' | 'relevance';
 
 export type PublicationOrderParam = 'asc' | 'desc';
 
-interface PublicationListRequest {
+export interface PublicationListRequest {
   order?: PublicationOrderParam;
   page?: number;
   pageSize?: number;

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
@@ -1,4 +1,5 @@
 import publicationService, {
+  PublicationListRequest,
   PublicationListSummary,
   PublicationOrderParam,
   PublicationSortOption,
@@ -18,6 +19,7 @@ interface Props {
   newDesign?: boolean; // TODO EES-3517 flag
   paging?: Paging | null; // TODO EES-3517 won't be optional or null
   publications?: PublicationListSummary[]; // TODO EES-3517 won't be optional
+  search?: string;
   sortBy?: PublicationSortOption;
   themes: Theme[];
 }
@@ -26,6 +28,7 @@ const FindStatisticsPage: NextPage<Props> = ({
   newDesign = false,
   paging,
   publications,
+  search,
   sortBy,
   themes = [],
 }) => {
@@ -35,6 +38,7 @@ const FindStatisticsPage: NextPage<Props> = ({
       <FindStatisticsPageNew
         paging={paging}
         publications={publications}
+        searchTerm={search}
         sortBy={sortBy}
       />
     );
@@ -50,11 +54,18 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({
     ? query.sortBy
     : 'newest';
   const { order, sort } = getSortParams(sortBy);
+  const minSearchCharacters = 3;
+  const searchQuery = Array.isArray(query.search)
+    ? query.search[0]
+    : query.search;
+  const search =
+    searchQuery && searchQuery.length >= minSearchCharacters ? searchQuery : '';
 
-  const params = {
+  const params: PublicationListRequest = {
     order,
     page: parseNumber(query.page) ?? 1,
     sort,
+    ...(search && { search }),
   };
 
   // TODO EES-3517 - remove newDesign check
@@ -82,6 +93,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({
       newDesign: !!newDesign,
       paging: newDesign ? publicationsResponse.paging : null,
       publications: newDesign ? publicationsResponse.results : [],
+      search,
       sortBy,
       themes,
     },

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageNew.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageNew.tsx
@@ -1,5 +1,5 @@
 import Button from '@common/components/Button';
-import InsetText from '@common/components/InsetText';
+import ButtonText from '@common/components/ButtonText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import RelatedInformation from '@common/components/RelatedInformation';
 import VisuallyHidden from '@common/components/VisuallyHidden';
@@ -9,53 +9,107 @@ import {
   PublicationSortOption,
 } from '@common/services/publicationService';
 import { Paging } from '@common/services/types/pagination';
+import { ReleaseType } from '@common/services/types/releaseType';
 import Page from '@frontend/components/Page';
 import Pagination from '@frontend/components/Pagination';
 import useRouterLoading from '@frontend/hooks/useRouterLoading';
+import FilterClearButton from '@frontend/modules/find-statistics/components/FilterClearButton';
 import PublicationSummary from '@frontend/modules/find-statistics/components/PublicationSummary';
+import SearchForm from '@frontend/modules/find-statistics/components/SearchForm';
 import SortControls from '@frontend/modules/find-statistics/components/SortControls';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
+import omit from 'lodash/omit';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
+import { ParsedUrlQuery } from 'querystring';
 import React from 'react';
+
+interface FindStatisticsPageQuery {
+  page?: number;
+  releaseType?: ReleaseType;
+  search?: string;
+  sortBy?: PublicationSortOption;
+  themeId?: string;
+}
 
 interface Props {
   paging: Paging;
   publications: PublicationListSummary[];
+  searchTerm?: string;
   sortBy?: PublicationSortOption;
 }
 
 const FindStatisticsPageNew: NextPage<Props> = ({
   paging,
   publications,
+  searchTerm,
   sortBy = 'newest',
 }) => {
   const { page, totalPages, totalResults } = paging;
-
   const router = useRouter();
   const isLoading = useRouterLoading();
   const { isMedia: isMobileMedia } = useMobileMedia();
 
-  const handleSortPublications = async (nextSortBy: PublicationSortOption) => {
+  // TODO EES-3517 - include filtering by theme etc here;
+  const isFiltered = !!searchTerm;
+
+  const updateQueryParams = async (query: FindStatisticsPageQuery) => {
     await router.push(
       {
         pathname: '/find-statistics',
-        query: {
-          ...router.query,
-          page: 1,
-          sortBy: nextSortBy,
-        },
+        query: query as ParsedUrlQuery,
       },
       undefined,
       {
         scroll: false,
       },
     );
+  };
+
+  const handleSortPublications = async (nextSortBy: PublicationSortOption) => {
+    await updateQueryParams({
+      ...omit(router.query, 'page'),
+      sortBy: nextSortBy,
+    });
 
     logEvent({
       category: 'Find statistics and data',
       action: 'Publications sorted',
       label: nextSortBy,
+    });
+  };
+
+  const handleSearchPublications = async (nextSearchTerm: string) => {
+    await updateQueryParams({
+      ...omit(router.query, 'page'),
+      search: nextSearchTerm,
+      sortBy: 'relevance',
+    });
+
+    logEvent({
+      category: 'Find statistics and data',
+      action: 'Publications searched',
+      label: nextSearchTerm,
+    });
+  };
+
+  const clearSearch = async () => {
+    await updateQueryParams(omit(router.query, 'search', 'page'));
+
+    logEvent({
+      category: 'Find statistics and data',
+      action: 'Clear search filter',
+    });
+  };
+
+  const clearAllFilters = async () => {
+    await updateQueryParams(
+      omit(router.query, 'page', 'releaseType', 'search', 'themeId'),
+    );
+
+    logEvent({
+      category: 'Find statistics and data',
+      action: 'Clear all filters',
     });
   };
 
@@ -120,18 +174,52 @@ const FindStatisticsPageNew: NextPage<Props> = ({
       </div>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-third">
-          Search and filters here
+          <SearchForm
+            searchTerm={searchTerm}
+            onSubmit={handleSearchPublications}
+          />
+          <a href="#searchResults" className="govuk-skip-link">
+            Skip to search results
+          </a>
         </div>
         <div className="govuk-grid-column-two-thirds">
-          <div aria-live="polite" aria-atomic="true">
-            <h2 className="govuk-!-margin-bottom-2">
+          <div>
+            <h2
+              aria-live="polite"
+              aria-atomic="true"
+              className="govuk-!-margin-bottom-2"
+            >
               {`${totalResults} ${totalResults !== 1 ? 'results' : 'result'}`}
             </h2>
 
-            <p className="govuk-!-margin-top-1">
-              {`Page ${page} of ${paging.totalPages}, showing all publications`}
-              <VisuallyHidden>{` sorted by ${sortBy}`}</VisuallyHidden>
-            </p>
+            <div className="dfe-flex dfe-justify-content--space-between dfe-align-items-start">
+              <p className="govuk-!-margin-bottom-2">
+                {`${
+                  totalResults ? `Page ${page} of ${totalPages}` : '0 pages'
+                }, ${
+                  isFiltered ? 'filtered by: ' : 'showing all publications'
+                }`}
+                {searchTerm && <VisuallyHidden>{searchTerm}</VisuallyHidden>}
+
+                <VisuallyHidden>{`. Sorted by ${
+                  sortBy === 'title' ? 'A to Z' : sortBy
+                }`}</VisuallyHidden>
+              </p>
+
+              {isFiltered && (
+                <ButtonText onClick={clearAllFilters}>
+                  Clear all filters
+                </ButtonText>
+              )}
+            </div>
+
+            {isFiltered && (
+              <div className="govuk-!-margin-bottom-5">
+                {searchTerm && (
+                  <FilterClearButton name={searchTerm} onClick={clearSearch} />
+                )}
+              </div>
+            )}
           </div>
 
           <a href="#searchResults" className="govuk-skip-link">
@@ -140,14 +228,34 @@ const FindStatisticsPageNew: NextPage<Props> = ({
 
           {isMobileMedia && <Button>Filter results</Button>}
 
-          <SortControls sortBy={sortBy} onChange={handleSortPublications} />
+          {publications.length > 0 && (
+            <SortControls
+              hasSearch={!!searchTerm}
+              sortBy={sortBy}
+              onChange={handleSortPublications}
+            />
+          )}
 
           <LoadingSpinner loading={isLoading} className="govuk-!-margin-top-4">
-            {/* TODO EES-3517 show different message if search / filter returns no results  */}
             {publications.length === 0 ? (
-              <InsetText id="searchResults">
-                No data currently published.
-              </InsetText>
+              <div className="govuk-!-margin-top-5" id="searchResults">
+                {isFiltered ? (
+                  <>
+                    <p className="govuk-!-font-weight-bold">
+                      There are no matching results.
+                    </p>
+                    <p>Improve your search results by:</p>
+                    <ul>
+                      <li>removing filters</li>
+                      <li>double-checking your spelling</li>
+                      <li>using fewer keywords</li>
+                      <li>searching for something less specific</li>
+                    </ul>
+                  </>
+                ) : (
+                  <p>No data currently published.</p>
+                )}
+              </div>
             ) : (
               <ul className="govuk-list" id="searchResults">
                 {publications.map(publication => (

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPageNew.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPageNew.test.tsx
@@ -58,6 +58,8 @@ describe('FindStatisticsPageNew', () => {
     expect(sortOptions[2]).toEqual(sortGroup.getByLabelText('A to Z'));
     expect(sortOptions[2]).not.toBeChecked();
 
+    expect(screen.getByLabelText('Search')).toBeInTheDocument();
+
     expect(
       screen.getByRole('heading', { name: 'Publication 1' }),
     ).toBeInTheDocument();
@@ -97,8 +99,7 @@ describe('FindStatisticsPageNew', () => {
     render(
       <FindStatisticsPageNew
         paging={{
-          page: 1,
-          pageSize: 10,
+          ...testPaging,
           totalPages: 0,
           totalResults: 0,
         }}
@@ -113,5 +114,69 @@ describe('FindStatisticsPageNew', () => {
     expect(
       screen.queryByRole('navigation', { name: 'Pagination navigation' }),
     ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly when searched and has results', () => {
+    render(
+      <FindStatisticsPageNew
+        paging={{ ...testPaging, totalPages: 1, totalResults: 1 }}
+        publications={[testPublications[1], testPublications[2]]}
+        searchTerm="Find me"
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: '1 result' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Page 1 of 1, filtered by:')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Remove filter: Find me' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Clear all filters' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: 'Publication 2' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: 'Publication 3' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText('There are no matching results.'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly when searched and has no results', () => {
+    render(
+      <FindStatisticsPageNew
+        paging={{ ...testPaging, totalPages: 0, totalResults: 0 }}
+        publications={[]}
+        searchTerm="Can't find me"
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: '0 results' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('0 pages, filtered by:')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: "Remove filter: Can't find me" }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Clear all filters' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('There are no matching results.'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/FilterClearButton.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/FilterClearButton.module.scss
@@ -1,0 +1,20 @@
+@import '~govuk-frontend/govuk/base';
+
+.button {
+  background: govuk-colour('light-grey');
+  border: 1px solid govuk-colour('mid-grey');
+  border-radius: 6px;
+  box-shadow: none;
+  line-height: 1;
+  margin: 0 govuk-spacing(1) 0 0;
+  padding: 8px;
+
+  &:focus {
+    background: $govuk-focus-colour;
+  }
+
+  &:hover {
+    background: darken(govuk-colour('light-grey'), 4);
+    cursor: pointer;
+  }
+}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/FilterClearButton.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/FilterClearButton.tsx
@@ -1,0 +1,19 @@
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import styles from '@frontend/modules/find-statistics/components/FilterClearButton.module.scss';
+import React from 'react';
+
+interface Props {
+  name: string;
+  onClick: () => void;
+}
+
+const FilterClearButton = ({ name, onClick }: Props) => {
+  return (
+    <button className={styles.button} type="button" onClick={onClick}>
+      <span aria-hidden>✕</span>
+      <VisuallyHidden>Remove filter:</VisuallyHidden> {name}
+    </button>
+  );
+};
+
+export default FilterClearButton;

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/SearchForm.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/SearchForm.module.scss
@@ -1,0 +1,30 @@
+@import '~govuk-frontend/govuk/base';
+
+.button {
+  background: $govuk-brand-colour;
+  border: 0;
+  color: govuk-colour('white');
+  cursor: pointer;
+  height: 40px;
+  margin-bottom: 0;
+  padding: 0;
+  width: 40px;
+
+  &:focus {
+    box-shadow: inset 0 0 0 4px govuk-colour('black');
+    outline: $govuk-focus-colour solid $govuk-focus-width;
+  }
+}
+
+.icon {
+  height: 100%;
+}
+
+.input {
+  border-right-width: 0;
+
+  &:focus {
+    border-right-width: 2px;
+    z-index: 1;
+  }
+}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/SearchForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/SearchForm.tsx
@@ -1,0 +1,75 @@
+import FormBaseInput from '@common/components/form/FormBaseInput';
+import FormGroup from '@common/components/form/FormGroup';
+import SearchIcon from '@common/components/SearchIcon';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import styles from '@frontend/modules/find-statistics/components/SearchForm.module.scss';
+import React, { useEffect, useState } from 'react';
+import useToggle from '@common/hooks/useToggle';
+
+const minCharacters = 3;
+
+interface Props {
+  searchTerm?: string;
+  onSubmit: (searchTerm: string) => void;
+}
+
+const SearchForm = ({
+  searchTerm: initialSearchTerm = '',
+  onSubmit,
+}: Props) => {
+  const [searchTerm, setSearchTerm] = useState<string>(initialSearchTerm);
+  const [showError, toggleError] = useToggle(false);
+
+  useEffect(() => {
+    setSearchTerm(initialSearchTerm);
+  }, [initialSearchTerm]);
+
+  return (
+    <form
+      id="searchForm"
+      className="govuk-!-margin-bottom-2"
+      onSubmit={e => {
+        e.preventDefault();
+        if (searchTerm.length >= minCharacters) {
+          toggleError.off();
+          return onSubmit(searchTerm);
+        }
+        return toggleError.on();
+      }}
+    >
+      <FormGroup hasError={showError}>
+        <FormBaseInput
+          addOn={
+            <button className={styles.button} type="submit">
+              <SearchIcon className={styles.icon} />
+              <VisuallyHidden>Search</VisuallyHidden>
+            </button>
+          }
+          className={styles.input}
+          id="searchTerm"
+          name="search"
+          error={
+            showError
+              ? `Search must be at least ${minCharacters} characters`
+              : undefined
+          }
+          label="Search"
+          labelSize="m"
+          type="search"
+          value={searchTerm}
+          onChange={e => {
+            setSearchTerm(e.target.value);
+            if (
+              e.target.value.length >= minCharacters ||
+              !e.target.value.length
+            ) {
+              toggleError.off();
+            }
+          }}
+        />
+      </FormGroup>
+    </form>
+  );
+};
+
+export default SearchForm;

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/SortControls.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/SortControls.tsx
@@ -10,7 +10,7 @@ interface Option {
   value: PublicationSortOption;
 }
 
-const options: Option[] = [
+const defaultOptions: Option[] = [
   { label: 'Newest', value: 'newest' },
   { label: 'Oldest', value: 'oldest' },
   { label: 'A to Z', value: 'title' },
@@ -20,12 +20,17 @@ const formId = 'sortControlsForm';
 const fieldId = `${formId}-sortBy`;
 
 interface Props {
+  hasSearch?: boolean;
   sortBy: PublicationSortOption;
   onChange: (nextSortBy: PublicationSortOption) => void;
 }
 
-const SortControls = ({ sortBy, onChange }: Props) => {
+const SortControls = ({ hasSearch = false, sortBy, onChange }: Props) => {
   const { isMedia: isMobileMedia } = useMobileMedia();
+
+  const options = hasSearch
+    ? [...defaultOptions, { label: 'Relevance', value: 'relevance' }]
+    : defaultOptions;
 
   return (
     <form id={formId} className={styles.form}>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/__tests__/SearchForm.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/__tests__/SearchForm.test.tsx
@@ -1,0 +1,53 @@
+import SearchForm from '@frontend/modules/find-statistics/components/SearchForm';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import noop from 'lodash/noop';
+import userEvent from '@testing-library/user-event';
+
+describe('SearchForm', () => {
+  test('renders correctly', () => {
+    render(<SearchForm onSubmit={noop} />);
+    expect(screen.getByLabelText('Search')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
+  });
+
+  test('renders correctly with an initial search term', () => {
+    render(<SearchForm searchTerm="find me" onSubmit={noop} />);
+    expect(screen.getByLabelText('Search')).toHaveValue('find me');
+  });
+
+  test('calls onSubmit when submitted with a valid length string', () => {
+    const handleSubmit = jest.fn();
+    render(<SearchForm onSubmit={handleSubmit} />);
+    userEvent.type(screen.getByLabelText('Search'), 'find me');
+    userEvent.click(screen.getByRole('button', { name: 'Search' }));
+    expect(handleSubmit).toHaveBeenCalledWith('find me');
+  });
+
+  test('does not call onSubmit and shows and error when submitted with an invalid length string', () => {
+    const handleSubmit = jest.fn();
+    render(<SearchForm onSubmit={handleSubmit} />);
+    userEvent.type(screen.getByLabelText('Search'), 'fi');
+    userEvent.click(screen.getByRole('button', { name: 'Search' }));
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(
+      screen.getByText('Search must be at least 3 characters'),
+    ).toBeInTheDocument();
+  });
+
+  test('removes the validation error when the input becomes valid', () => {
+    const handleSubmit = jest.fn();
+    render(<SearchForm onSubmit={handleSubmit} />);
+    userEvent.type(screen.getByLabelText('Search'), 'fi');
+    userEvent.click(screen.getByRole('button', { name: 'Search' }));
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(
+      screen.getByText('Search must be at least 3 characters'),
+    ).toBeInTheDocument();
+
+    userEvent.type(screen.getByLabelText('Search'), 'fin');
+    expect(
+      screen.queryByText('Search must be at least 3 characters'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/__tests__/SortControls.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/__tests__/SortControls.test.tsx
@@ -47,6 +47,26 @@ describe('SortControls', () => {
       expect(sortOptions[2]).toEqual(sortGroup.getByLabelText('A to Z'));
       expect(sortOptions[2]).not.toBeChecked();
     });
+
+    test('setting hasSearch to true shows the relevance option', () => {
+      render(<SortControls hasSearch sortBy="relevance" onChange={noop} />);
+
+      const sortGroup = within(
+        screen.getByRole('group', { name: 'Sort results' }),
+      );
+      const sortOptions = sortGroup.getAllByRole('radio');
+      expect(sortOptions).toHaveLength(4);
+      expect(sortOptions[0]).toEqual(sortGroup.getByLabelText('Newest'));
+      expect(sortOptions[0]).not.toBeChecked();
+      expect(sortOptions[1]).toEqual(sortGroup.getByLabelText('Oldest'));
+      expect(sortOptions[1]).not.toBeChecked();
+      expect(sortOptions[2]).toEqual(sortGroup.getByLabelText('A to Z'));
+      expect(sortOptions[2]).not.toBeChecked();
+      expect(sortOptions[3]).toEqual(sortGroup.getByLabelText('Relevance'));
+      expect(sortOptions[3]).toBeChecked();
+
+      expect(screen.queryByLabelText('Sort results')).not.toBeInTheDocument();
+    });
   });
 
   describe('mobile', () => {
@@ -92,6 +112,28 @@ describe('SortControls', () => {
       expect(sortOptions[2]).toHaveTextContent('A to Z');
       expect(sortOptions[2]).toHaveValue('title');
       expect(sortOptions[2].selected).toBe(true);
+    });
+
+    test('setting hasSearch to true shows the relevance option', () => {
+      render(<SortControls hasSearch sortBy="relevance" onChange={noop} />);
+
+      const sortDropdown = within(screen.getByLabelText('Sort results'));
+      const sortOptions = sortDropdown.getAllByRole(
+        'option',
+      ) as HTMLOptionElement[];
+      expect(sortOptions).toHaveLength(4);
+      expect(sortOptions[0]).toHaveTextContent('Newest');
+      expect(sortOptions[0]).toHaveValue('newest');
+      expect(sortOptions[0].selected).toBe(false);
+      expect(sortOptions[1]).toHaveTextContent('Oldest');
+      expect(sortOptions[1]).toHaveValue('oldest');
+      expect(sortOptions[1].selected).toBe(false);
+      expect(sortOptions[2]).toHaveTextContent('A to Z');
+      expect(sortOptions[2]).toHaveValue('title');
+      expect(sortOptions[2].selected).toBe(false);
+      expect(sortOptions[3]).toHaveTextContent('Relevance');
+      expect(sortOptions[3]).toHaveValue('relevance');
+      expect(sortOptions[3].selected).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Adds search to the new Find Statistics page:

- minimum 3 characters for the search term
- the URL query params are updated to include the search term
- the search can be removed by clicking the tag style button above the search results
- a clear all filters button has been added
- shows a message if there are no search results (I've copied this from the gov.uk search message)
- when searching an extra sort option 'Relevance' is added and selected

![search](https://user-images.githubusercontent.com/81572860/204778537-374f9015-d94e-46ee-b6d2-a7ff43fdef52.PNG)
