### PR TITLE
EES-3942 Call ToList before ToAsyncEnumerable

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishStagedReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishStagedReleaseContentFunction.cs
@@ -100,9 +100,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                         .ToList();
 
                     // TODO EES-3369 (Read Replica-2) This needs moving to the new PublishingCompletionService
-                    await _contentDbContext.Publications
+                    var publicationIds = await _contentDbContext.Publications
                         .Where(publication => publishedPublications.Contains(publication.Slug))
                         .Select(publication => publication.Id)
+                        .ToListAsync();
+
+                    await publicationIds
                         .ToAsyncEnumerable()
                         .ForEachAwaitAsync(_publicationService.UpdateLatestPublishedRelease);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -49,7 +49,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .Where(release => ids.Contains(release.Id))
                 .Include(release => release.Publication)
                 .Include(release => release.PreviousVersion)
-                .ToAsyncEnumerable()
                 .ToListAsync();
         }
 
@@ -113,7 +112,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             await _methodologyService.SetPublishedDatesByPublication(contentRelease.PublicationId, published);
 
             await _contentDbContext.SaveChangesAsync();
-            
+
             var statisticsRelease = await _statisticsDbContext.Release
                 .AsQueryable()
                 .SingleOrDefaultAsync(r => r.Id == id);
@@ -129,7 +128,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 _statisticsDbContext.Release.Update(statisticsRelease);
                 await _statisticsDbContext.SaveChangesAsync();
             }
-            
+
             if (publicStatisticsRelease != null)
             {
                 publicStatisticsRelease.Published ??= published;


### PR DESCRIPTION
This fixes a bug on publishing multiple scheduled releases at the same time.

Also fixed a separate piece of code in `ReleaseService` which could potentially cause the same issue.