### PR TITLE
EES-3904 fix ref lines on charts grouped by location

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -28,6 +28,7 @@ import createDataSetCategories, {
   toChartData,
 } from '@common/modules/charts/util/createDataSetCategories';
 import { calculateMinorAxisDomainValues } from '@common/modules/charts/util/domainTicks';
+import { LocationFilter } from '@common/modules/table-tool/types/filters';
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import { TableDataResult } from '@common/services/tableBuilderService';
 import { OmitStrict } from '@common/types';
@@ -298,7 +299,12 @@ const ChartAxisConfiguration = ({
         onSubmit({
           ...nextConfiguration,
           referenceLines: nextConfiguration.referenceLines.filter(line =>
-            groupByFilters.some(filter => filter.value === line.position),
+            groupByFilters.some(filter => {
+              if (filter instanceof LocationFilter) {
+                return LocationFilter.createId(filter) === line.position;
+              }
+              return filter.value === line.position;
+            }),
           ),
         });
       } else {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
@@ -3,6 +3,7 @@ import Button from '@common/components/Button';
 import FormFieldNumberInput from '@common/components/form/FormFieldNumberInput';
 import FormFieldSelect from '@common/components/form/FormFieldSelect';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
+import FormSelect, { SelectOption } from '@common/components/form/FormSelect';
 import Tooltip from '@common/components/Tooltip';
 import {
   ChartDefinitionAxis,
@@ -11,10 +12,8 @@ import {
 } from '@common/modules/charts/types/chart';
 import { DataSetCategory } from '@common/modules/charts/types/dataSet';
 import { MinorAxisDomainValues } from '@common/modules/charts/util/domainTicks';
+import { LocationFilter } from '@common/modules/table-tool/types/filters';
 import Yup from '@common/validation/yup';
-import FormSelect, {
-  SelectOption,
-} from 'explore-education-statistics-common/src/components/form/FormSelect';
 import { Formik } from 'formik';
 import upperFirst from 'lodash/upperFirst';
 import React, { useMemo } from 'react';
@@ -52,7 +51,10 @@ export default function ChartReferenceLinesConfiguration({
 
     return dataSetCategories.map(({ filter }) => ({
       label: filter.label,
-      value: filter.value,
+      value:
+        filter instanceof LocationFilter
+          ? LocationFilter.createId(filter)
+          : filter.value,
     }));
   }, [type, dataSetCategories]);
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartReferenceLinesConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartReferenceLinesConfiguration.test.tsx
@@ -7,6 +7,7 @@ import {
   AxisConfiguration,
   ChartDefinitionAxis,
 } from '@common/modules/charts/types/chart';
+import { LocationFilter } from '@common/modules/table-tool/types/filters';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import noop from 'lodash/noop';
@@ -96,6 +97,15 @@ describe('ChartReferenceLinesConfiguration', () => {
   );
 
   const testMinorAxisDomain: MinorAxisDomainValues = { min: 0, max: 50000 };
+
+  const barnsleyId = LocationFilter.createId({
+    level: 'localAuthority',
+    value: 'barnsley',
+  });
+  const barnetId = LocationFilter.createId({
+    level: 'localAuthority',
+    value: 'barnet',
+  });
 
   test('renders correctly with existing lines when grouped by time periods', () => {
     render(
@@ -190,7 +200,7 @@ describe('ChartReferenceLinesConfiguration', () => {
           testTable.subjectMeta,
         )}
         axisDefinition={testMajorAxisDefinition}
-        lines={[{ position: 'barnet', label: 'Test label 1' }]}
+        lines={[{ position: barnetId, label: 'Test label 1' }]}
         minorAxisDomain={testMinorAxisDomain}
         onAddLine={noop}
         onRemoveLine={noop}
@@ -214,7 +224,7 @@ describe('ChartReferenceLinesConfiguration', () => {
     expect(options[0]).toHaveTextContent('Choose position');
     expect(options[0]).toHaveAttribute('value', '');
     expect(options[1]).toHaveTextContent('Barnsley');
-    expect(options[1]).toHaveAttribute('value', 'barnsley');
+    expect(options[1]).toHaveAttribute('value', barnsleyId);
   });
 
   test('renders correctly with existing lines when grouped by indicators', () => {
@@ -633,9 +643,10 @@ describe('ChartReferenceLinesConfiguration', () => {
     );
     expect(referenceLines.getAllByRole('row')).toHaveLength(2);
 
-    userEvent.selectOptions(referenceLines.getByLabelText('Position'), [
-      'barnsley',
-    ]);
+    userEvent.selectOptions(
+      referenceLines.getByLabelText('Position'),
+      barnsleyId,
+    );
 
     await userEvent.type(referenceLines.getByLabelText('Label'), 'Test label');
 
@@ -647,7 +658,7 @@ describe('ChartReferenceLinesConfiguration', () => {
         Parameters<ChartReferenceLinesConfigurationProps['onAddLine']>
       >({
         label: 'Test label',
-        position: 'barnsley',
+        position: barnsleyId,
         style: 'dashed',
       });
     });
@@ -907,8 +918,8 @@ describe('ChartReferenceLinesConfiguration', () => {
         )}
         axisDefinition={testMajorAxisDefinition}
         lines={[
-          { position: 'barnet', label: 'Test label 1' },
-          { position: 'barnsley', label: 'Test label 2' },
+          { position: barnetId, label: 'Test label 1' },
+          { position: barnsleyId, label: 'Test label 2' },
         ]}
         minorAxisDomain={testMinorAxisDomain}
         onAddLine={noop}
@@ -932,7 +943,7 @@ describe('ChartReferenceLinesConfiguration', () => {
         Parameters<ChartReferenceLinesConfigurationProps['onRemoveLine']>
       >({
         label: 'Test label 2',
-        position: 'barnsley',
+        position: barnsleyId,
       });
     });
   });

--- a/src/explore-education-statistics-common/src/modules/charts/components/CustomReferenceLineLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/CustomReferenceLineLabel.tsx
@@ -36,7 +36,7 @@ const CustomReferenceLineLabel = ({
   const labelPosition = getReferenceLineLabelPosition({
     axis,
     axisType,
-    otherAxisDomainMin: axisType === 'major' ? otherAxisDomainMax : 0,
+    otherAxisDomainMin: axisType === 'major' ? otherAxisDomainMin : 0,
     otherAxisDomainMax: axisType === 'major' ? otherAxisDomainMax : 100, // otherAxisPosition is set as a percentage on minor axis lines
     otherAxisPosition,
     viewBox,


### PR DESCRIPTION
Fixes a bug where reference lines on charts didn't show if you grouped the major axis by location. This was caused by the chart data using the location filter id and the reference lines using the filter value, meaning that they didn't match up. I've updated it to use the id for the lines.

Also, I fixed a typo in CustomReferenceLineLabel which caused the other axis position on major axis lines not to work (they would always be in the middle not matter what value you put for the other axis position).

