### PR TITLE
EES-3919 - removed old code from location-codes-to-location-ids migra…

### DIFF
--- a/useful-scripts/get_data_block_responses/get_data_block_responses.py
+++ b/useful-scripts/get_data_block_responses/get_data_block_responses.py
@@ -1,10 +1,11 @@
-import requests
-import json
-import csv
-import time
-import os
-import datetime
 import argparse
+import csv
+import datetime
+import json
+import os
+import time
+
+import requests
 
 """
 To generate datablocks.csv, use this SQL query against the Content DB:
@@ -47,44 +48,51 @@ responses, as they contain unique traceIds):
 diff -I"^time for response:.*" -I "Not Found" -r results_dev1/responses results_dev2/responses
 """
 
-parser = argparse.ArgumentParser(prog="python get_data_block_responses.py",
-                                 description="Used to get and time data block responses from "
-                                             "an environment")
-parser.add_argument("-e", "--env",
-                    dest="env",
-                    default="dev",
-                    choices=["local", "dev", "test", "preprod", "prod"],
-                    help="the environment to run again")
-parser.add_argument("--stage",
-                    dest="stage",
-                    default="table",
-                    choices=["table", "filters", "time_periods"],
-                    help="the stage of the table tool to wish to get the response for")
-parser.add_argument("-f", "--file",
-                    dest="datablocks_csv",
-                    default="datablocks.csv",
-                    help="CSV of data blocks (see comment in this script)")
-parser.add_argument("-s", "-sleep",
-                    dest="sleep_duration",
-                    default=1,
-                    help="duration to sleep between requests",
-                    type=int)
+parser = argparse.ArgumentParser(
+    prog="python get_data_block_responses.py",
+    description="Used to get and time data block responses from " "an environment",
+)
+parser.add_argument(
+    "-e",
+    "--env",
+    dest="env",
+    default="dev",
+    choices=["local", "dev", "test", "preprod", "prod"],
+    help="the environment to run again",
+)
+parser.add_argument(
+    "--stage",
+    dest="stage",
+    default="table",
+    choices=["table", "filters", "time_periods"],
+    help="the stage of the table tool to wish to get the response for",
+)
+parser.add_argument(
+    "-f",
+    "--file",
+    dest="datablocks_csv",
+    default="datablocks.csv",
+    help="CSV of data blocks (see comment in this script)",
+)
+parser.add_argument(
+    "-s", "-sleep", dest="sleep_duration", default=1, help="duration to sleep between requests", type=int
+)
 args = parser.parse_args()
 
 data_api_urls = {
-    'local': 'http://localhost:5000/api',
-    'dev': 'https://data.dev.explore-education-statistics.service.gov.uk/api',
-    'test': 'https://data.test.explore-education-statistics.service.gov.uk/api',
-    'preprod': 'https://data.pre-production.explore-education-statistics.service.gov.uk/api',
-    'prod': 'https://data.explore-education-statistics.service.gov.uk/api',
+    "local": "http://localhost:5000/api",
+    "dev": "https://data.dev.explore-education-statistics.service.gov.uk/api",
+    "test": "https://data.test.explore-education-statistics.service.gov.uk/api",
+    "preprod": "https://data.pre-production.explore-education-statistics.service.gov.uk/api",
+    "prod": "https://data.explore-education-statistics.service.gov.uk/api",
 }
 
 data_api_url = data_api_urls[args.env]
 
 date = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-results_dir = f'results_{args.env}_{args.stage}_{date}'
-requests_dir = f'{results_dir}/requests'
-responses_dir = f'{results_dir}/responses'
+results_dir = f"results_{args.env}_{args.stage}_{date}"
+requests_dir = f"{results_dir}/requests"
+responses_dir = f"{results_dir}/responses"
 
 if not os.path.exists(requests_dir):
     os.makedirs(requests_dir)
@@ -92,54 +100,51 @@ if not os.path.exists(requests_dir):
 if not os.path.exists(responses_dir):
     os.makedirs(responses_dir)
 
-with open(f'{results_dir}/console_output', 'w') as output_file:
-    output_file.write('Console output:\n\n')
+with open(f"{results_dir}/console_output", "w") as output_file:
+    output_file.write("Console output:\n\n")
 
-output_file = open(f'{results_dir}/console_output', 'a')
+output_file = open(f"{results_dir}/console_output", "a")
 
 
 def print_to_console(text):
-    output_file.write(text + '\n')
+    output_file.write(text + "\n")
     print(text)
 
 
 def write_block_to_file(
-        block_guid,
-        release_guid,
-        subject_guid,
-        request_dict,
-        status_code,
-        response_time,
-        response_dict):
+    block_guid, release_guid, subject_guid, request_dict, status_code, response_time, response_dict
+):
     try:
-        with open(f'{requests_dir}/block_{block_guid}_request', 'w') as block_request_file:
+        with open(f"{requests_dir}/block_{block_guid}_request", "w") as block_request_file:
             block_request_file.write(
-                f'block: {block_guid}\n'
-                f'release: {release_guid}\n'
-                f'subject: {subject_guid}\n'
-                f'request:\n{json.dumps(request_dict, sort_keys=True, indent=2)}'
+                f"block: {block_guid}\n"
+                f"release: {release_guid}\n"
+                f"subject: {subject_guid}\n"
+                f"request:\n{json.dumps(request_dict, sort_keys=True, indent=2)}"
             )
 
-        with open(f'{responses_dir}/block_{block_guid}_response', 'w') as block_response_file:
+        with open(f"{responses_dir}/block_{block_guid}_response", "w") as block_response_file:
             block_response_file.write(
-                f'block: {block_guid}\n'
-                f'release: {release_guid}\n'
-                f'subject: {subject_guid}\n'
-                f'response status: {status_code}\n'
-                f'time for response: {response_time}\n'
-                f'response:\n{json.dumps(response_dict, sort_keys=True, indent=2)}'
+                f"block: {block_guid}\n"
+                f"release: {release_guid}\n"
+                f"subject: {subject_guid}\n"
+                f"response status: {status_code}\n"
+                f"time for response: {response_time}\n"
+                f"response:\n{json.dumps(response_dict, sort_keys=True, indent=2)}"
             )
-        print_to_console(f'Successfully processed block {block_guid} for subject {subject_guid}!')
+        print_to_console(f"Successfully processed block {block_guid} for subject {subject_guid}!")
     except Exception as exception:
-        print_to_console(f'block_file.write failed with block {block_guid} subject {subject_guid}\n'
-                         f'Response: {json.dumps(response_dict)}\n Exception: {exception}')
+        print_to_console(
+            f"block_file.write failed with block {block_guid} subject {subject_guid}\n"
+            f"Response: {json.dumps(response_dict)}\n Exception: {exception}"
+        )
 
 
 processed = 0
 processed_successfully = 0
 datablocks = []
-with open(args.datablocks_csv, 'r') as csv_file:
-    csv_reader = csv.reader(csv_file, delimiter=',')
+with open(args.datablocks_csv, "r") as csv_file:
+    csv_reader = csv.reader(csv_file, delimiter=",")
     for row in csv_reader:
         if row[0] == "ContentBlockId":
             continue
@@ -156,15 +161,15 @@ for datablock in datablocks:
     query_dict = json.loads(datablock[3])
 
     if args.stage == "table":
-        url = f'{data_api_url}/tablebuilder/release/{release_id}'
+        url = f"{data_api_url}/tablebuilder/release/{release_id}"
 
     if args.stage == "filters":
-        url = f'{data_api_url}/meta/subject'
+        url = f"{data_api_url}/meta/subject"
         query_dict.pop("Filters")
         query_dict.pop("Indicators")
 
     if args.stage == "time_periods":
-        url = f'{data_api_url}/meta/subject'
+        url = f"{data_api_url}/meta/subject"
         query_dict.pop("Filters")
         query_dict.pop("Indicators")
         query_dict.pop("TimePeriod")
@@ -182,60 +187,39 @@ for datablock in datablocks:
 
     block_time_start = time.perf_counter()
     try:
-        resp = requests.post(url=url,
-                             headers={'Content-Type': 'application/json'},
-                             data=json.dumps(query_dict),
-                             timeout=60)
+        resp = requests.post(
+            url=url, headers={"Content-Type": "application/json"}, data=json.dumps(query_dict), timeout=60
+        )
     except requests.Timeout as e:
-        print_to_console(f'request timeout with block {block_id} subject {subject_id}, {e}')
-        write_this_block(
-            status_code=-1,
-            response_time=-1,
-            response_dict={'error': f'request timeout, {e}'})
+        print_to_console(f"request timeout with block {block_id} subject {subject_id}, {e}")
+        write_this_block(status_code=-1, response_time=-1, response_dict={"error": f"request timeout, {e}"})
         continue
     except Exception as e:
-        print_to_console(f'request exception with block {block_id} subject {subject_id}, {e}')
-        write_this_block(
-            status_code=-1,
-            response_time=-1,
-            response_dict={'error': f'request exception thrown, {e}'})
+        print_to_console(f"request exception with block {block_id} subject {subject_id}, {e}")
+        write_this_block(status_code=-1, response_time=-1, response_dict={"error": f"request exception thrown, {e}"})
         continue
     block_time_end = time.perf_counter()
 
-    json_response = None
-    try:
-        json_response = json.loads(resp.text)
-        if json_response['results']:
-            for result in json_response['results']:
-                result.pop('location', None)
-
-    except Exception as e:
-        print_to_console(
-            f'Failed to convert response text to json with block {block_id} subject {subject_id}, {e}. status code: {resp.status_code}')
-        write_this_block(
-            status_code=resp.status_code,
-            response_time=block_time_end - block_time_start,
-            response_dict={'error': f'Failed to process response text, exception {e}\n\nResponse:\n\n{json_response}'})
-        continue
+    json_response = json.loads(resp.text)
 
     if resp.status_code == 200:
         processed_successfully += 1
 
     write_this_block(
-        status_code=resp.status_code,
-        response_time=block_time_end - block_time_start,
-        response_dict=json_response)
+        status_code=resp.status_code, response_time=block_time_end - block_time_start, response_dict=json_response
+    )
 
 end_time = time.perf_counter()
 processing_time = round(end_time - start_time)
 sleep_time = args.sleep_duration * len(datablocks)
 processing_time_minus_sleep_time = round(processing_time - sleep_time)
 
-print_to_console(f'Total processed: {processed}')
-print_to_console(f'Total successes: {processed_successfully}')
-print_to_console(f'Total failures: {processed - processed_successfully}')
-print_to_console(f'Total time: {processing_time} seconds')
-print_to_console(f'Sleep time: {sleep_time} seconds')
-print_to_console(f'Total minus sleep time: {processing_time_minus_sleep_time} seconds')
+print_to_console(f"Total processed: {processed}")
+print_to_console(f"Total successes: {processed_successfully}")
+print_to_console(f"Total failures: {processed - processed_successfully}")
+print_to_console(f"Total time: {processing_time} seconds")
+print_to_console(f"Sleep time: {sleep_time} seconds")
+print_to_console(f"Total minus sleep time: {processing_time_minus_sleep_time} seconds")
 print_to_console(
-    f'Average processing time per block: {round(processing_time_minus_sleep_time / len(datablocks), 2)} seconds')
+    f"Average processing time per block: {round(processing_time_minus_sleep_time / len(datablocks), 2)} seconds"
+)


### PR DESCRIPTION
This PR:
- removes an old piece of code from `get_data_block_responses.py` that was a leftover from the location code to location id migration work
- formats the script (done automatically by commit hook - not manually by me!)

As well as not being necessary anymore, this piece of code was breaking the "filters" and "time_periods" stages of the script which do not contain a "results" array from which to remove location ids.  It looks like efforts were made to add safety to this scenario by checking for the "results" key in the HTTP response JSON, but it wasn't working. 