### PR TITLE
EES-3906 fix bar chart data label position

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -4,14 +4,10 @@ import useLegend from '@common/modules/charts/components/hooks/useLegend';
 import createReferenceLine from '@common/modules/charts/components/utils/createReferenceLine';
 import {
   AxisConfiguration,
-  BarChartDataLabelPosition,
   ChartDefinition,
   StackedBarProps,
 } from '@common/modules/charts/types/chart';
-import {
-  ChartData,
-  DataSetCategory,
-} from '@common/modules/charts/types/dataSet';
+import { DataSetCategory } from '@common/modules/charts/types/dataSet';
 import { LegendConfiguration } from '@common/modules/charts/types/legend';
 import createDataSetCategories, {
   toChartData,
@@ -178,12 +174,10 @@ const HorizontalBarBlock = ({
                 showDataLabels
                   ? {
                       fontSize: 14,
-                      position: getDataLabelPosition({
-                        chartData,
-                        chartHasNegativeValues,
-                        dataKey,
-                        dataLabelPosition,
-                      }),
+                      position:
+                        dataLabelPosition === 'inside'
+                          ? 'insideRight'
+                          : 'right',
                       formatter: (value: string | number) =>
                         formatPretty(
                           value.toString(),
@@ -306,22 +300,3 @@ export const horizontalBarBlockDefinition: ChartDefinition = {
 };
 
 export default memo(HorizontalBarBlock);
-
-function getDataLabelPosition({
-  chartData,
-  chartHasNegativeValues,
-  dataKey,
-  dataLabelPosition,
-}: {
-  chartData: ChartData[];
-  chartHasNegativeValues: boolean;
-  dataKey: string;
-  dataLabelPosition?: BarChartDataLabelPosition;
-}) {
-  const dataValue =
-    parseNumber(chartData.find(d => d[dataKey])?.[dataKey]) ?? 0;
-  if (!chartHasNegativeValues || !dataLabelPosition || dataValue >= 0) {
-    return dataLabelPosition === 'inside' ? 'insideRight' : 'right';
-  }
-  return dataLabelPosition === 'inside' ? 'right' : 'insideRight';
-}

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -4,14 +4,10 @@ import useLegend from '@common/modules/charts/components/hooks/useLegend';
 import createReferenceLine from '@common/modules/charts/components/utils/createReferenceLine';
 import {
   AxisConfiguration,
-  BarChartDataLabelPosition,
   ChartDefinition,
   StackedBarProps,
 } from '@common/modules/charts/types/chart';
-import {
-  ChartData,
-  DataSetCategory,
-} from '@common/modules/charts/types/dataSet';
+import { DataSetCategory } from '@common/modules/charts/types/dataSet';
 import { LegendConfiguration } from '@common/modules/charts/types/legend';
 import createDataSetCategories, {
   toChartData,
@@ -179,12 +175,7 @@ const VerticalBarBlock = ({
                 showDataLabels
                   ? {
                       fontSize: 14,
-                      offset: getOffset({
-                        chartData,
-                        chartHasNegativeValues,
-                        dataKey,
-                        dataLabelPosition,
-                      }),
+                      offset: 5,
                       position:
                         dataLabelPosition === 'inside' ? 'insideTop' : 'top',
                       formatter: (value: string | number) =>
@@ -309,26 +300,3 @@ export const verticalBarBlockDefinition: ChartDefinition = {
 };
 
 export default memo(VerticalBarBlock);
-
-function getOffset({
-  chartData,
-  chartHasNegativeValues,
-  dataKey,
-  dataLabelPosition,
-}: {
-  chartData: ChartData[];
-  chartHasNegativeValues: boolean;
-  dataKey: string;
-  dataLabelPosition?: BarChartDataLabelPosition;
-}) {
-  if (
-    !chartHasNegativeValues ||
-    !dataLabelPosition ||
-    dataLabelPosition !== 'inside'
-  ) {
-    return 5;
-  }
-  const dataValue =
-    parseNumber(chartData.find(d => d[dataKey])?.[dataKey]) ?? 0;
-  return dataValue < 0 ? 15 : 5;
-}


### PR DESCRIPTION
Fixes the position of data labels on bar charts. I think maybe the recharts upgrade changed something here as the custom functions for position and offset are no longer needed.

Horizontal bar chart - data labels `inside`
![horizontalbar-inside](https://user-images.githubusercontent.com/81572860/205959154-219ef06b-707b-4c6c-a190-f876ee655a28.PNG)
Horizontal bar chart - data labels `outside`
![horizontalbar-outside](https://user-images.githubusercontent.com/81572860/205959155-fa5ebbe7-4d21-422d-9edc-193c56fab590.PNG)
Vertical bar chart - data labels `inside`
![verticalbar-inside](https://user-images.githubusercontent.com/81572860/205959146-397739da-0b56-4610-bee7-ca520401227f.PNG)
Horizontal bar chart - data labels `outside`
![verticalbar-outside](https://user-images.githubusercontent.com/81572860/205959151-a0a677c8-a61e-436a-bb47-f0b0b730c961.PNG)
