### PR TITLE
Bump Newtonsoft.Json from 12.0.3 to 13.0.2

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
         <PackageReference Include="Namotion.Reflection" Version="2.0.10" />
         <PackageReference Include="NCrontab.Signed" Version="3.3.2" />
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
         <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="IsExternalInit" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Thinktecture.EntityFrameworkCore.BulkOperations" Version="4.1.0" />
   </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/GovUk.Education.ExploreEducationStatistics.Data.Processor.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/GovUk.Education.ExploreEducationStatistics.Data.Processor.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.18.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="9.0.0" />
         <PackageReference Include="IsExternalInit" Version="1.0.2" PrivateAssets="all" />
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model\GovUk.Education.ExploreEducationStatistics.Content.Model.csproj" />


### PR DESCRIPTION
This PR bumps Newtonsoft.Json from 12.0.3 to 13.0.2, replacing dependabot PR's https://github.com/dfe-analytical-services/explore-education-statistics/pull/3698, https://github.com/dfe-analytical-services/explore-education-statistics/pull/3700, https://github.com/dfe-analytical-services/explore-education-statistics/pull/3701, https://github.com/dfe-analytical-services/explore-education-statistics/pull/3702 and https://github.com/dfe-analytical-services/explore-education-statistics/pull/3703 which failed to build.

### UI test report

![image](https://user-images.githubusercontent.com/4147126/206518637-3f5847ec-5543-4754-b86b-46f143d42ce2.png)
