### PR TITLE
EES-3947 Add expiredinvite user to UI test run scripts

### DIFF
--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -147,6 +147,12 @@ environment variables, and instead must be passed as an argument to this script.
 parser.add_argument("--slack-webhook-url", dest="slack_webhook_url", default=None, help="URL for Slack webhook")
 parser.add_argument("--admin-pass", dest="admin_pass", default=None, help="manually specify the admin password")
 parser.add_argument("--analyst-pass", dest="analyst_pass", default=None, help="manually specify the analyst password")
+parser.add_argument(
+    "--expiredinvite-pass",
+    dest="expiredinvite_pass",
+    default=None,
+    help="manually specify the expiredinvite user password",
+)
 args = parser.parse_args()
 
 if args.custom_env:
@@ -167,6 +173,7 @@ assert os.getenv("WAIT_SMALL") is not None
 assert os.getenv("FAIL_TEST_SUITES_FAST") is not None
 assert os.getenv("IDENTITY_PROVIDER") is not None
 assert os.getenv("WAIT_MEMORY_CACHE_EXPIRY") is not None
+assert os.getenv("EXPIRED_INVITE_USER_EMAIL") is not None
 
 
 if args.slack_webhook_url:
@@ -177,6 +184,9 @@ if args.admin_pass:
 
 if args.analyst_pass:
     os.environ["ANALYST_PASSWORD"] = args.analyst_pass
+
+if args.expiredinvite_pass:
+    os.environ["EXPIRED_INVITE_USER_PASSWORD"] = args.expiredinvite_pass
 
 # Install chromedriver and add it to PATH
 get_webdriver(args.chromedriver_version or "latest")

--- a/tests/robot-tests/scripts/run_tests_pipeline.py
+++ b/tests/robot-tests/scripts/run_tests_pipeline.py
@@ -11,8 +11,9 @@ import subprocess
 
 
 def run_tests_pipeline():
-    assert args.admin_password, "Provide an admin password with an '--admin-pass PASS' argument"
-    assert args.analyst_password, "Provide an analyst password with an '--analyst-pass PASS' argument"
+    assert args.admin_pass, "Provide an admin password with an '--admin-pass PASS' argument"
+    assert args.analyst_pass, "Provide an analyst password with an '--analyst-pass PASS' argument"
+    assert args.expiredinvite_pass, "Provide an expiredinvite password with an '--expiredinvite-pass PASS' argument"
     assert args.slack_webhook_url, "Please provide slack webhook URL"
     assert args.env, "Provide an environment with an '--env ENV' argument"
     assert args.file, "Provide a file/dir to run with an '--file FILE/DIR' argument"
@@ -29,9 +30,9 @@ def run_tests_pipeline():
 
     def get_test_command() -> str:
         if args.file == "tests/general_public/check_snapshots.robot":
-            return f"pipenv run python run_tests.py --admin-pass {args.admin_password} --analyst-pass {args.analyst_password} --slack-webhook-url {args.slack_webhook_url} --env {args.env} --file {args.file} --ci --processes {args.processes}"
+            return f"pipenv run python run_tests.py --admin-pass {args.admin_password} --analyst-pass {args.analyst_password} --expiredinvite-pass {args.expiredinvite_password} --slack-webhook-url {args.slack_webhook_url} --env {args.env} --file {args.file} --ci --processes {args.processes}"
         else:
-            return f"pipenv run python run_tests.py --admin-pass {args.admin_password} --analyst-pass {args.analyst_password} --slack-webhook-url {args.slack_webhook_url} --env {args.env} --file {args.file} --ci --processes {args.processes} --enable-slack"
+            return f"pipenv run python run_tests.py --admin-pass {args.admin_password} --analyst-pass {args.analyst_password} --expiredinvite-pass {args.expiredinvite_password} --slack-webhook-url {args.slack_webhook_url} --env {args.env} --file {args.file} --ci --processes {args.processes} --enable-slack"
 
     subprocess.run(get_test_command(), shell=True)
 
@@ -42,9 +43,13 @@ if __name__ == "__main__":
         description="Use this script in a CI environment to run UI tests",
     )
 
-    parser.add_argument("--admin-password", dest="admin_password", help="BAU admin password", required=True)
+    parser.add_argument("--admin-pass", dest="admin_pass", help="BAU admin password", required=True)
 
-    parser.add_argument("--analyst-password", dest="analyst_password", help="Analyst password", required=True)
+    parser.add_argument("--analyst-pass", dest="analyst_pass", help="Analyst password", required=True)
+
+    parser.add_argument(
+        "--expiredinvite-pass", dest="expiredinvite_pass", help="ExpiredInvite account password", required=True
+    )
 
     parser.add_argument(
         "--slack-webhook-url",


### PR DESCRIPTION
This PR allows the ExpiredInvite user password to be passed to UI test run scripts such that it can be accessed during CI pipeline runs.

I've also updated the various password options in `run_tests_pipeline.py` so that they're consistent with `run_tests.py` - so `--admin-password` is now `--admin-pass`