### PR TITLE
EES-3862 - disabling "Add Embed Block" option from content editing un…

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -23,10 +23,12 @@ import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 export interface ReleaseContentAccordionSectionProps {
   id: string;
   section: ContentSection<EditableBlock>;
+  embedBlocksEnabled?: boolean; // EES-3862 - remove to enable Embed Blocks
 }
 
 const ReleaseContentAccordionSection = ({
   section,
+  embedBlocksEnabled = false,
   ...props
 }: ReleaseContentAccordionSectionProps) => {
   const { id: sectionId, caption, content: sectionContent = [] } = section;
@@ -232,13 +234,17 @@ const ReleaseContentAccordionSection = ({
                     Add data block
                   </Button>
                 )}
-                {!showEmbedDashboardForm && (
-                  <Button
-                    variant="secondary"
-                    onClick={toggleEmbedDashboardForm.on}
-                  >
-                    Add embed block
-                  </Button>
+                {embedBlocksEnabled && (
+                  <>
+                    {!showEmbedDashboardForm && (
+                      <Button
+                        variant="secondary"
+                        onClick={toggleEmbedDashboardForm.on}
+                      >
+                        Add embed block
+                      </Button>
+                    )}
+                  </>
                 )}
               </ButtonGroup>
             </>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContentAccordionSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContentAccordionSection.test.tsx
@@ -73,6 +73,7 @@ describe('ReleaseContentAccordionSection', () => {
                   ...testSection,
                   content: [testBlock],
                 }}
+                embedBlocksEnabled
               />
             </EditableAccordion>
           </ReleaseContentHubContextProvider>
@@ -101,6 +102,56 @@ describe('ReleaseContentAccordionSection', () => {
     ).toBeInTheDocument();
   });
 
+  test('disables the Add Embed block option by default', () => {
+    render(
+      <EditingContextProvider editingMode="edit">
+        <ReleaseContentProvider
+          value={{
+            release: testEditableRelease,
+            canUpdateRelease: true,
+            availableDataBlocks: [],
+          }}
+        >
+          <ReleaseContentHubContextProvider releaseId={testEditableRelease.id}>
+            <EditableAccordion
+              onAddSection={noop}
+              id="test-accordion"
+              onReorder={noop}
+            >
+              <ReleaseContentAccordionSection
+                id="test-section-1"
+                section={{
+                  ...testSection,
+                  content: [testBlock],
+                }}
+              />
+            </EditableAccordion>
+          </ReleaseContentHubContextProvider>
+        </ReleaseContentProvider>
+      </EditingContextProvider>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Edit section title' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Reorder this section' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remove this section' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Add text block' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Add data block' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Add embed block' }),
+    ).not.toBeInTheDocument();
+  });
+
   test('renders correctly in preview mode', () => {
     render(
       <EditingContextProvider editingMode="preview">
@@ -123,6 +174,7 @@ describe('ReleaseContentAccordionSection', () => {
                   ...testSection,
                   content: [testBlock],
                 }}
+                embedBlocksEnabled
               />
             </EditableAccordion>
           </ReleaseContentHubContextProvider>

--- a/tests/robot-tests/report-modifiers/CheckForAtLeastOnePassingRunPrerebotModifier.py
+++ b/tests/robot-tests/report-modifiers/CheckForAtLeastOnePassingRunPrerebotModifier.py
@@ -9,9 +9,16 @@ class CheckForAtLeastOnePassingRunPrerebotModifier(SuiteVisitor):
         pass
 
     def visit_test(self, test):
-        if "PASS" in test.message and "Test has been re-executed and results merged." in test.message:
-            self.logger.info(
-                f'CheckForAtLeastOnePassingRunPrerebotModifier - marking test "{test}" as PASS because it passed in at least one of the test runs.'
-            )
-            test.status = "PASS"
-            test.message = f'Marking test "{test}" as PASS because it passed in at least one of the test runs.  Previous message is {test.message}'
+        if "Test has been re-executed and results merged." in test.message:
+            if "PASS" in test.message:
+                self.logger.info(
+                    f'CheckForAtLeastOnePassingRunPrerebotModifier - marking test "{test}" as PASS because it passed in at least one of the test runs.'
+                )
+                test.status = "PASS"
+                test.message = f'Marking test "{test}" as PASS because it passed in at least one of the test runs.  Previous message is {test.message}'
+            elif "SKIP" in test.message:
+                self.logger.info(
+                    f'CheckForAtLeastOnePassingRunPrerebotModifier - marking test "{test}" as SKIPPED because it was skipped in the latter run.'
+                )
+                test.status = "SKIP"
+                test.message = f'Marking test "{test}" as SKIP because it was skipped in the latter test run.  Previous message is {test.message}'

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -130,8 +130,10 @@ Add three accordion sections to release
     user changes accordion section title    1    Dates data block
     user clicks button    Add new section
     user changes accordion section title    2    Test text
-    user clicks button    Add new section
-    user changes accordion section title    3    Test embedded dashboard section
+
+    # EES-3682 - reinstate when embed blocks are enabled
+    # user clicks button    Add new section
+    # user changes accordion section title    3    Test embedded dashboard section
 
 Add data block to first accordion section
     user adds data block to editable accordion section    Dates data block    ${DATABLOCK_NAME}
@@ -160,6 +162,8 @@ Add test text to second accordion section
     ...    id:releaseMainContent
 
 Add embedded dashboard to third accordion section
+    Skip    EES-3682 - skipping adding embedded blocks until functionailty is enabled
+
     user adds embedded dashboard to editable accordion section
     ...    Test embedded dashboard section
     ...    Test embedded dashboard title
@@ -307,10 +311,14 @@ Verify accordions are correct
     user checks there are x accordion sections    1    id:data-accordion
     user checks accordion is in position    Explore data and files    1    id:data-accordion
 
-    user checks there are x accordion sections    3    id:content
+    # EES-3682 - reinstate the check for 3 rows when embed blocks are enabled
+    # user checks there are x accordion sections    3    id:content
+    user checks there are x accordion sections    2    id:content
     user checks accordion is in position    Dates data block    1    id:content
     user checks accordion is in position    Test text    2    id:content
-    user checks accordion is in position    Test embedded dashboard section    3    id:content
+
+    # EES-3682 - reinstate when embed blocks are enabled
+    # user checks accordion is in position    Test embedded dashboard section    3    id:content
 
     user checks there are x accordion sections    2    id:help-and-support
     user checks accordion is in position    National statistics    1    id:help-and-support
@@ -354,6 +362,8 @@ Verify Test text accordion section contains correct text
     user closes accordion section    Test text    id:content
 
 Verify embedded dashboard accordion section contains dashboard
+    Skip    EES-3682 - skipping adding embedded blocks until functionailty is enabled
+
     user opens accordion section    Test embedded dashboard section    id:content
     ${section}=    user gets accordion section content element    Test embedded dashboard section    id:content
     user waits until parent contains element    ${section}    xpath:.//iframe[@title="Test embedded dashboard title"]
@@ -583,6 +593,8 @@ Update second accordion section text for amendment
     ...    id:releaseMainContent
 
 Update embedded dashboard title
+    Skip    EES-3682 - skipping adding embedded blocks until functionailty is enabled
+
     user updates embedded dashboard in editable accordion section
     ...    Test embedded dashboard section
     ...    Test embedded dashboard title updated
@@ -724,7 +736,9 @@ Verify amendment accordions are correct
     user goes to release page via breadcrumb    ${PUBLICATION_NAME}    ${RELEASE_NAME}
     user checks accordion is in position    Dates data block    1    id:content
     user checks accordion is in position    Test text    2    id:content
-    user checks accordion is in position    Test embedded dashboard section    3    id:content
+
+    # EES-3682 - reinstate this line when embed blocks are enabled
+    # user checks accordion is in position    Test embedded dashboard section    3    id:content
 
     user checks accordion is in position    Experimental statistics    1    id:help-and-support
     user checks accordion is in position    Contact us    2    id:help-and-support
@@ -774,6 +788,8 @@ Verify amendment Test text accordion section contains correct text
     user closes accordion section    Test text    id:content
 
 Verify amendment embedded dashboard accordion section is correct
+    Skip    EES-3682 - skipping adding embedded blocks until functionailty is enabled
+
     user opens accordion section    Test embedded dashboard section    id:content
     ${section}=    user gets accordion section content element    Test embedded dashboard section    id:content
     user checks element contains child element    ${section}


### PR DESCRIPTION
This PR hides the "Add Embed Block" option from Release content editing until bugfixes with embedded blocks have been resolved.

![image](https://user-images.githubusercontent.com/12444316/208097252-7821a5e2-9773-4b34-9003-fee978f4aa59.png)
