### PR TITLE
EES-3682 reinstate embed blocks and remove custom error handling

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -23,12 +23,10 @@ import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 export interface ReleaseContentAccordionSectionProps {
   id: string;
   section: ContentSection<EditableBlock>;
-  embedBlocksEnabled?: boolean; // EES-3862 - remove to enable Embed Blocks
 }
 
 const ReleaseContentAccordionSection = ({
   section,
-  embedBlocksEnabled = false,
   ...props
 }: ReleaseContentAccordionSectionProps) => {
   const { id: sectionId, caption, content: sectionContent = [] } = section;
@@ -234,17 +232,13 @@ const ReleaseContentAccordionSection = ({
                     Add data block
                   </Button>
                 )}
-                {embedBlocksEnabled && (
-                  <>
-                    {!showEmbedDashboardForm && (
-                      <Button
-                        variant="secondary"
-                        onClick={toggleEmbedDashboardForm.on}
-                      >
-                        Add embed block
-                      </Button>
-                    )}
-                  </>
+                {!showEmbedDashboardForm && (
+                  <Button
+                    variant="secondary"
+                    onClick={toggleEmbedDashboardForm.on}
+                  >
+                    Add embed block
+                  </Button>
                 )}
               </ButtonGroup>
             </>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContentAccordionSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContentAccordionSection.test.tsx
@@ -73,7 +73,6 @@ describe('ReleaseContentAccordionSection', () => {
                   ...testSection,
                   content: [testBlock],
                 }}
-                embedBlocksEnabled
               />
             </EditableAccordion>
           </ReleaseContentHubContextProvider>
@@ -102,56 +101,6 @@ describe('ReleaseContentAccordionSection', () => {
     ).toBeInTheDocument();
   });
 
-  test('disables the Add Embed block option by default', () => {
-    render(
-      <EditingContextProvider editingMode="edit">
-        <ReleaseContentProvider
-          value={{
-            release: testEditableRelease,
-            canUpdateRelease: true,
-            availableDataBlocks: [],
-          }}
-        >
-          <ReleaseContentHubContextProvider releaseId={testEditableRelease.id}>
-            <EditableAccordion
-              onAddSection={noop}
-              id="test-accordion"
-              onReorder={noop}
-            >
-              <ReleaseContentAccordionSection
-                id="test-section-1"
-                section={{
-                  ...testSection,
-                  content: [testBlock],
-                }}
-              />
-            </EditableAccordion>
-          </ReleaseContentHubContextProvider>
-        </ReleaseContentProvider>
-      </EditingContextProvider>,
-    );
-
-    expect(
-      screen.getByRole('button', { name: 'Edit section title' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Reorder this section' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Remove this section' }),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('button', { name: 'Add text block' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Add data block' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Add embed block' }),
-    ).not.toBeInTheDocument();
-  });
-
   test('renders correctly in preview mode', () => {
     render(
       <EditingContextProvider editingMode="preview">
@@ -174,7 +123,6 @@ describe('ReleaseContentAccordionSection', () => {
                   ...testSection,
                   content: [testBlock],
                 }}
-                embedBlocksEnabled
               />
             </EditableAccordion>
           </ReleaseContentHubContextProvider>

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/EmbedBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/EmbedBlock.tsx
@@ -1,5 +1,4 @@
 import LoadingSpinner from '@common/components/LoadingSpinner';
-import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import IframeResizer from 'iframe-resizer-react';
 import React from 'react';
@@ -15,21 +14,17 @@ interface Props {
 
 const EmbedBlock = ({ title, url }: Props) => {
   const [isLoading, toggleIsLoading] = useToggle(true);
-  const [isInitialised, toggleIsInitialised] = useToggle(false);
 
   return (
     <>
       {isLoading && <LoadingSpinner hideText text={`Loading ${title}`} />}
-      {!isLoading && !isInitialised && (
-        <WarningMessage>Could not load iframe.</WarningMessage>
-      )}
+
       <IframeResizer
         heightCalculationMethod="lowestElement"
         src={url}
         style={{ border: 0, minWidth: '100%', width: '1px' }}
         title={title}
         checkOrigin={allowedEmbedDomains}
-        onInit={toggleIsInitialised.on}
         onLoad={toggleIsLoading.off}
       />
     </>

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -130,10 +130,8 @@ Add three accordion sections to release
     user changes accordion section title    1    Dates data block
     user clicks button    Add new section
     user changes accordion section title    2    Test text
-
-    # EES-3682 - reinstate when embed blocks are enabled
-    # user clicks button    Add new section
-    # user changes accordion section title    3    Test embedded dashboard section
+    user clicks button    Add new section
+    user changes accordion section title    3    Test embedded dashboard section
 
 Add data block to first accordion section
     user adds data block to editable accordion section    Dates data block    ${DATABLOCK_NAME}
@@ -162,8 +160,6 @@ Add test text to second accordion section
     ...    id:releaseMainContent
 
 Add embedded dashboard to third accordion section
-    Skip    EES-3682 - skipping adding embedded blocks until functionailty is enabled
-
     user adds embedded dashboard to editable accordion section
     ...    Test embedded dashboard section
     ...    Test embedded dashboard title
@@ -311,14 +307,11 @@ Verify accordions are correct
     user checks there are x accordion sections    1    id:data-accordion
     user checks accordion is in position    Explore data and files    1    id:data-accordion
 
-    # EES-3682 - reinstate the check for 3 rows when embed blocks are enabled
-    # user checks there are x accordion sections    3    id:content
+    user checks there are x accordion sections    3    id:content
     user checks there are x accordion sections    2    id:content
     user checks accordion is in position    Dates data block    1    id:content
     user checks accordion is in position    Test text    2    id:content
-
-    # EES-3682 - reinstate when embed blocks are enabled
-    # user checks accordion is in position    Test embedded dashboard section    3    id:content
+    user checks accordion is in position    Test embedded dashboard section    3    id:content
 
     user checks there are x accordion sections    2    id:help-and-support
     user checks accordion is in position    National statistics    1    id:help-and-support
@@ -362,8 +355,6 @@ Verify Test text accordion section contains correct text
     user closes accordion section    Test text    id:content
 
 Verify embedded dashboard accordion section contains dashboard
-    Skip    EES-3682 - skipping adding embedded blocks until functionailty is enabled
-
     user opens accordion section    Test embedded dashboard section    id:content
     ${section}=    user gets accordion section content element    Test embedded dashboard section    id:content
     user waits until parent contains element    ${section}    xpath:.//iframe[@title="Test embedded dashboard title"]
@@ -593,8 +584,6 @@ Update second accordion section text for amendment
     ...    id:releaseMainContent
 
 Update embedded dashboard title
-    Skip    EES-3682 - skipping adding embedded blocks until functionailty is enabled
-
     user updates embedded dashboard in editable accordion section
     ...    Test embedded dashboard section
     ...    Test embedded dashboard title updated
@@ -736,10 +725,7 @@ Verify amendment accordions are correct
     user goes to release page via breadcrumb    ${PUBLICATION_NAME}    ${RELEASE_NAME}
     user checks accordion is in position    Dates data block    1    id:content
     user checks accordion is in position    Test text    2    id:content
-
-    # EES-3682 - reinstate this line when embed blocks are enabled
-    # user checks accordion is in position    Test embedded dashboard section    3    id:content
-
+    user checks accordion is in position    Test embedded dashboard section    3    id:content
     user checks accordion is in position    Experimental statistics    1    id:help-and-support
     user checks accordion is in position    Contact us    2    id:help-and-support
 
@@ -788,8 +774,6 @@ Verify amendment Test text accordion section contains correct text
     user closes accordion section    Test text    id:content
 
 Verify amendment embedded dashboard accordion section is correct
-    Skip    EES-3682 - skipping adding embedded blocks until functionailty is enabled
-
     user opens accordion section    Test embedded dashboard section    id:content
     ${section}=    user gets accordion section content element    Test embedded dashboard section    id:content
     user checks element contains child element    ${section}


### PR DESCRIPTION
Reinstates Embed blocks and removes the flaky custom error handling. 

Now if a dashboard errors:
- if it 404's it'll show a small white space (about 150px high)
- show the Shiny apps error message for other errors, Cam's going to look into making these nicer. 