### PR TITLE
EES-3914 reorder footnotes

### DIFF
--- a/src/explore-education-statistics-admin/package.json
+++ b/src/explore-education-statistics-admin/package.json
@@ -183,6 +183,7 @@
       "^@common/(.*)$": "<rootDir>/../explore-education-statistics-common/src/$1",
       "^@common-test/(.*)$": "<rootDir>/../explore-education-statistics-common/test/$1",
       "^react$": "<rootDir>/node_modules/react",
+      "^react-dom$": "<rootDir>/node_modules/react-dom",
       "^formik$": "<rootDir>/node_modules/formik",
       "^@tanstack/react-query$": "<rootDir>/node_modules/@tanstack/react-query",
       "\\.worker.js":"<rootDir>/../explore-education-statistics-common/__mocks__/mock.worker.ts"

--- a/src/explore-education-statistics-admin/src/components/DraggableItem.module.scss
+++ b/src/explore-education-statistics-admin/src/components/DraggableItem.module.scss
@@ -1,0 +1,56 @@
+@import '~govuk-frontend/govuk/base';
+
+$vertical-spacing: govuk-spacing(3);
+
+.draggable {
+  background: govuk-colour('white');
+  border-bottom: 1px solid govuk-colour('dark-grey');
+  margin-bottom: 0;
+  padding: $vertical-spacing govuk-spacing(1) $vertical-spacing 40px;
+  position: relative;
+
+  &:hover {
+    background: govuk-colour('light-grey');
+  }
+
+  &:focus {
+    @include govuk-focused-text;
+    z-index: 1;
+  }
+}
+
+.isDragging {
+  @include govuk-focused-text;
+  z-index: 1;
+}
+
+.isDraggedOutside {
+  opacity: 0.7;
+}
+
+.dragHandle {
+  color: govuk-colour('dark-grey');
+  font-size: 1.6rem;
+  left: 4px;
+  line-height: 1;
+  position: absolute;
+  top: $vertical-spacing;
+}
+
+.hideDragHandle {
+  padding-left: 0;
+  &::before {
+    content: none;
+  }
+}
+
+/* stylelint-disable selector-no-qualifying-type */
+tr.draggable {
+  border-bottom: 0;
+  display: table-row;
+
+  &.isDragging {
+    display: table;
+  }
+}
+/* stylelint-enable */

--- a/src/explore-education-statistics-admin/src/components/DraggableItem.tsx
+++ b/src/explore-education-statistics-admin/src/components/DraggableItem.tsx
@@ -1,0 +1,76 @@
+import styles from '@admin/components/DraggableItem.module.scss';
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+import { Draggable } from 'react-beautiful-dnd';
+
+export const DragHandle = ({ className }: { className?: string }) => (
+  <span aria-hidden className={className ?? styles.dragHandle}>
+    ☰
+  </span>
+);
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+  // draggableClassName replaces the default draggable style
+  draggableClassName?: string;
+  dragHandle?: ReactNode;
+  // dragHandleClassName replaces the default dragHandle style
+  dragHandleClassName?: string;
+  hideDragHandle?: boolean;
+  id: string;
+  index: number;
+  isDisabled?: boolean;
+  isReordering: boolean;
+  tag?: 'div' | 'li' | 'tr';
+  testId?: string;
+}
+
+const DraggableItem = ({
+  children,
+  className,
+  draggableClassName,
+  dragHandleClassName,
+  dragHandle: overrideDragHandle,
+  hideDragHandle = false,
+  id,
+  index,
+  isDisabled = false,
+  isReordering,
+  tag: Element = 'div',
+  testId,
+}: Props) => {
+  return (
+    <Draggable
+      draggableId={id}
+      index={index}
+      isDragDisabled={isDisabled || !isReordering}
+    >
+      {(draggableProvided, draggableSnapshot) => (
+        <Element
+          {...draggableProvided.draggableProps}
+          {...draggableProvided.dragHandleProps}
+          className={classNames(className, draggableClassName, {
+            [styles.draggable]: isReordering && !draggableClassName,
+            [styles.isDragging]: draggableSnapshot.isDragging,
+            [styles.isDraggedOutside]:
+              draggableSnapshot.isDragging && !draggableSnapshot.draggingOver,
+            [styles.hideDragHandle]: hideDragHandle,
+          })}
+          data-testid={testId}
+          ref={draggableProvided.innerRef}
+        >
+          {!hideDragHandle && (
+            <>
+              {overrideDragHandle ??
+                DragHandle({ className: dragHandleClassName })}
+            </>
+          )}
+          {children}
+        </Element>
+      )}
+    </Draggable>
+  );
+};
+
+export default DraggableItem;

--- a/src/explore-education-statistics-admin/src/components/DroppableArea.module.scss
+++ b/src/explore-education-statistics-admin/src/components/DroppableArea.module.scss
@@ -1,0 +1,14 @@
+@import '~govuk-frontend/govuk/base';
+
+/* stylelint-disable selector-no-qualifying-type */
+ol.dropArea,
+ul.dropArea {
+  list-style: none;
+  padding: 0;
+}
+/* stylelint-enable */
+
+.dropAreaActive {
+  background: govuk-colour('light-grey');
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+}

--- a/src/explore-education-statistics-admin/src/components/DroppableArea.tsx
+++ b/src/explore-education-statistics-admin/src/components/DroppableArea.tsx
@@ -1,0 +1,38 @@
+import styles from '@admin/components/DroppableArea.module.scss';
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+import { DroppableProvided, DroppableStateSnapshot } from 'react-beautiful-dnd';
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+  droppableProvided: DroppableProvided;
+  droppableSnapshot: DroppableStateSnapshot;
+  tag?: 'div' | 'ol' | 'tbody';
+  testId?: string;
+}
+
+const DroppableArea = ({
+  children,
+  className,
+  droppableProvided,
+  droppableSnapshot,
+  tag: Element = 'div',
+  testId,
+}: Props) => {
+  return (
+    <Element
+      {...droppableProvided.droppableProps}
+      className={classNames(className, styles.dropArea, {
+        [styles.dropAreaActive]: droppableSnapshot.isDraggingOver,
+      })}
+      data-testid={testId}
+      ref={droppableProvided.innerRef}
+    >
+      {children}
+      {droppableProvided.placeholder}
+    </Element>
+  );
+};
+
+export default DroppableArea;

--- a/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordion.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordion.module.scss
@@ -1,9 +1,5 @@
 @import '~govuk-frontend/govuk/base';
 
-.dragover {
-  background: govuk-colour('light-grey');
-}
-
 // Override the default dnd style as it causes accordion sections within the dnd area to sometime open in the wrong direction.
 .container [data-rbd-droppable-context-id] {
   overflow-anchor: auto;

--- a/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordion.tsx
@@ -1,10 +1,10 @@
+import DroppableArea from '@admin/components/DroppableArea';
 import Accordion, { AccordionProps } from '@common/components/Accordion';
 import Button from '@common/components/Button';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import useToggle from '@common/hooks/useToggle';
 import { OmitStrict } from '@common/types';
 import reorder from '@common/utils/reorder';
-import classNames from 'classnames';
 import React, {
   cloneElement,
   isValidElement,
@@ -119,18 +119,13 @@ const ReorderableAccordion = (props: ReorderableAccordionProps) => {
           isDropDisabled={!isReordering}
           type="accordion"
         >
-          {(droppableProvided, snapshot) => (
-            <div
-              // eslint-disable-next-line react/jsx-props-no-spreading
-              {...droppableProvided.droppableProps}
-              ref={droppableProvided.innerRef}
-              className={classNames({
-                [styles.dragover]: snapshot.isDraggingOver && isReordering,
-              })}
+          {(droppableProvided, droppableSnapshot) => (
+            <DroppableArea
+              droppableProvided={droppableProvided}
+              droppableSnapshot={droppableSnapshot}
             >
               {accordion}
-              {droppableProvided.placeholder}
-            </div>
+            </DroppableArea>
           )}
         </Droppable>
       </DragDropContext>

--- a/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordionSection.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordionSection.module.scss
@@ -1,21 +1,16 @@
 @import '~govuk-frontend/govuk/base';
 
-.dragContainer {
+.draggable {
+  background: govuk-colour('white');
   position: relative;
 
-  &::before {
-    color: govuk-colour('dark-grey');
-    content: '\2630';
-    cursor: grab;
-    font-size: 2.25rem;
-    height: 2.25rem;
-    position: absolute;
-    right: 0;
-    top: govuk-spacing(1);
+  &:hover {
+    background: govuk-colour('light-grey');
   }
 
   &:focus {
     @include govuk-focused-text;
+    z-index: 1;
   }
 
   :global(.govuk-accordion__section-header) {
@@ -24,14 +19,15 @@
 
   :global(.govuk-accordion__section-heading) {
     font-size: 1.5rem;
+    font-weight: $govuk-font-weight-bold;
   }
 }
 
-.isDragging {
-  @include govuk-focused-text;
-
-  :global(.govuk-accordion__section-header) {
-    cursor: grabbing;
-    font-size: 1.5rem;
-  }
+.dragHandle {
+  color: govuk-colour('dark-grey');
+  font-size: 2.25rem;
+  height: 2.25rem;
+  position: absolute;
+  right: 0;
+  top: govuk-spacing(1);
 }

--- a/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/ReorderableAccordionSection.tsx
@@ -1,11 +1,10 @@
 import styles from '@admin/components/editable/ReorderableAccordionSection.module.scss';
+import DraggableItem from '@admin/components/DraggableItem';
 import AccordionSection, {
   accordionSectionClasses,
   AccordionSectionProps,
 } from '@common/components/AccordionSection';
-import classNames from 'classnames';
 import React, { createElement, ReactNode, useMemo } from 'react';
-import { Draggable } from 'react-beautiful-dnd';
 
 export interface DraggableAccordionSectionProps {
   index: number;
@@ -43,37 +42,21 @@ const ReorderableAccordionSection = (
   }
 
   return (
-    <Draggable draggableId={id} isDragDisabled={!isReordering} index={index}>
-      {(draggableProvided, snapshot) => (
-        <div
-          // eslint-disable-next-line react/jsx-props-no-spreading
-          {...draggableProvided.draggableProps}
-          // eslint-disable-next-line react/jsx-props-no-spreading
-          {...draggableProvided.dragHandleProps}
-          ref={draggableProvided.innerRef}
-          className={classNames({
-            [styles.dragContainer]: isReordering,
-            [styles.isDragging]: snapshot.isDragging,
-          })}
-          data-testid="reorderableAccordionSection"
-        >
-          <AccordionSection
-            {...props}
-            id={id}
-            heading={heading}
-            header={header}
-          >
-            {sectionProps => (
-              <>
-                {typeof children === 'function'
-                  ? children(sectionProps)
-                  : children}
-              </>
-            )}
-          </AccordionSection>
-        </div>
-      )}
-    </Draggable>
+    <DraggableItem
+      draggableClassName={styles.draggable}
+      dragHandleClassName={styles.dragHandle}
+      id={id}
+      index={index}
+      isReordering={isReordering}
+    >
+      <AccordionSection {...props} id={id} heading={heading} header={header}>
+        {sectionProps => (
+          <>
+            {typeof children === 'function' ? children(sectionProps) : children}
+          </>
+        )}
+      </AccordionSection>
+    </DraggableItem>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/LegacyReleasesTable.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/LegacyReleasesTable.module.scss
@@ -1,32 +1,6 @@
 @import '~govuk-frontend/govuk/base';
 
-.tableDraggingOver {
-  tbody tr {
-    background: govuk-colour('light-grey');
-  }
-}
-
-.reorderingRow {
-  &:focus {
-    background: govuk-colour('white');
-    outline: $govuk-focus-width solid $govuk-focus-colour;
-    outline-offset: 0;
-  }
-
-  &:hover {
-    background: govuk-colour('light-grey');
-  }
-}
-
-.reorderingRowDragging {
-  background: govuk-colour('white') !important;
-  display: table;
-  outline: $govuk-focus-width solid $govuk-focus-colour;
-  outline-offset: 0;
-}
-
 .dragHandle {
-  font-size: 1.6rem;
   text-align: center;
   width: 1.6rem;
 }

--- a/src/explore-education-statistics-admin/src/pages/publication/components/LegacyReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/LegacyReleasesTable.tsx
@@ -1,3 +1,5 @@
+import DraggableItem from '@admin/components/DraggableItem';
+import DroppableArea from '@admin/components/DroppableArea';
 import {
   publicationCreateLegacyReleaseRoute,
   PublicationRouteParams,
@@ -17,7 +19,7 @@ import reorder from '@common/utils/reorder';
 import styles from '@admin/pages/publication/components/LegacyReleasesTable.module.scss';
 import classNames from 'classnames';
 import React, { useState } from 'react';
-import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import { generatePath } from 'react-router';
 import { useHistory } from 'react-router-dom';
 import ButtonText from '@common/components/ButtonText';
@@ -65,8 +67,6 @@ const LegacyReleasesTable = ({
         publication.
       </p>
 
-      <h3>Legacy release order</h3>
-
       {legacyReleases.length > 0 ? (
         <DragDropContext
           onDragEnd={result => {
@@ -102,89 +102,76 @@ const LegacyReleasesTable = ({
                     {!isReordering && <th>Actions</th>}
                   </tr>
                 </thead>
-                <tbody>
+                <DroppableArea
+                  droppableProvided={droppableProvided}
+                  droppableSnapshot={droppableSnapshot}
+                  tag="tbody"
+                >
                   {legacyReleases.map((release, index) => (
-                    <Draggable
-                      draggableId={release.id}
-                      isDragDisabled={!isReordering}
-                      key={release.id}
+                    <DraggableItem
+                      hideDragHandle
+                      id={release.id}
                       index={index}
+                      isReordering={isReordering}
+                      key={release.id}
+                      tag="tr"
                     >
-                      {(draggableProvided, draggableSnapshot) => (
-                        <tr
-                          // eslint-disable-next-line react/jsx-props-no-spreading
-                          {...draggableProvided.draggableProps}
-                          // eslint-disable-next-line react/jsx-props-no-spreading
-                          {...draggableProvided.dragHandleProps}
-                          ref={draggableProvided.innerRef}
-                          className={classNames({
-                            [styles.reorderingRow]: isReordering,
-                            [styles.reorderingRowDragging]:
-                              draggableSnapshot.isDragging,
-                          })}
+                      {isReordering && <td className={styles.dragHandle}>⬍</td>}
+
+                      <td>{release.order}</td>
+
+                      <td>{release.description}</td>
+                      <td
+                        className={classNames({
+                          'govuk-!-width-one-half': isReordering,
+                        })}
+                      >
+                        <a
+                          className="govuk-link--no-visited-state"
+                          href={release.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          tabIndex={isReordering ? -1 : undefined}
                         >
-                          {isReordering && (
-                            <td className={styles.dragHandle}>⬍</td>
-                          )}
+                          {release.url}
+                        </a>
+                      </td>
 
-                          <td>{release.order}</td>
-
-                          <td>{release.description}</td>
-                          <td
-                            className={classNames({
-                              'govuk-!-width-one-half': isReordering,
-                            })}
-                          >
-                            <a
-                              className="govuk-link--no-visited-state"
-                              href={release.url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              tabIndex={isReordering ? -1 : undefined}
+                      {!isReordering && (
+                        <td>
+                          <ButtonGroup className="govuk-!-margin-bottom-0">
+                            <ButtonText
+                              onClick={() =>
+                                setConfirmAction({
+                                  type: 'edit',
+                                  id: release.id,
+                                })
+                              }
                             >
-                              {release.url}
-                            </a>
-                          </td>
-
-                          {!isReordering && (
-                            <td>
-                              <ButtonGroup className="govuk-!-margin-bottom-0">
-                                <ButtonText
-                                  onClick={() =>
-                                    setConfirmAction({
-                                      type: 'edit',
-                                      id: release.id,
-                                    })
-                                  }
-                                >
-                                  Edit
-                                  <VisuallyHidden>
-                                    {' '}
-                                    {release.description}
-                                  </VisuallyHidden>
-                                </ButtonText>
-                                <ButtonText
-                                  variant="warning"
-                                  onClick={() => {
-                                    setDeleteLegacyRelease(release);
-                                  }}
-                                >
-                                  Delete
-                                  <VisuallyHidden>
-                                    {' '}
-                                    {release.description}
-                                  </VisuallyHidden>
-                                </ButtonText>
-                              </ButtonGroup>
-                            </td>
-                          )}
-                        </tr>
+                              Edit
+                              <VisuallyHidden>
+                                {' '}
+                                {release.description}
+                              </VisuallyHidden>
+                            </ButtonText>
+                            <ButtonText
+                              variant="warning"
+                              onClick={() => {
+                                setDeleteLegacyRelease(release);
+                              }}
+                            >
+                              Delete
+                              <VisuallyHidden>
+                                {' '}
+                                {release.description}
+                              </VisuallyHidden>
+                            </ButtonText>
+                          </ButtonGroup>
+                        </td>
                       )}
-                    </Draggable>
+                    </DraggableItem>
                   ))}
-
-                  {droppableProvided.placeholder}
-                </tbody>
+                </DroppableArea>
               </table>
             )}
           </Droppable>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.module.scss
@@ -1,72 +1,45 @@
 @import '~govuk-frontend/govuk/base';
 
-.dropArea {
-  background: govuk-colour('light-grey');
-  list-style: none;
-  margin: 0 govuk-spacing(2) govuk-spacing(2) 0;
-  padding: 0;
-}
+.isExpandedItem {
+  background: govuk-colour('light-grey') !important;
 
-.dropAreaActive {
-  outline: $govuk-focus-width solid $govuk-focus-colour;
-}
-
-.draggable {
-  background: govuk-colour('white');
-  border-bottom: 1px solid govuk-colour('dark-grey');
-  margin-bottom: 0;
-  padding: 0 0 0 govuk-spacing(7);
-  position: relative;
-
-  &::before {
-    color: govuk-colour('dark-grey');
-    content: '\2630';
-    cursor: grab;
-    font-size: 1.6rem;
-    left: 4px;
-    position: absolute;
-    top: 7px;
-  }
-
-  &:focus,
-  &.isDragging {
-    @include govuk-focused-text;
-  }
-
-  &.isDraggedOutside {
-    opacity: 0.7;
-  }
-}
-
-.draggable.isDisabled {
-  &::before {
-    content: none;
-  }
-}
-
-.draggable.isExpanded {
-  background: govuk-colour('light-grey');
-
-  &::before {
-    content: '\25BC';
-    font-size: 1rem;
-    left: 8px;
-    top: 12px;
-  }
-
-  .isExpanded {
+  .isExpandedItem {
     background: lighten(govuk-colour('light-grey'), 2);
   }
 }
 
+.dragHandle {
+  font-size: 1rem;
+  left: 12px;
+  position: absolute;
+  top: govuk-spacing(3);
+}
+
 .draggableInner {
+  align-items: center;
   display: flex;
   flex-grow: 1;
   justify-content: space-between;
-  padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+  padding: 0 govuk-spacing(2) 0 0;
 }
+
 .optionLabel {
   &.isExpanded {
     font-weight: $govuk-font-weight-bold;
+  }
+
+  &.hideDragHandle {
+    padding-left: 40px;
+  }
+}
+
+.inner {
+  width: 100%;
+}
+
+.dropArea {
+  margin-bottom: govuk-spacing(6);
+  .dropArea & {
+    margin: govuk-spacing(2) govuk-spacing(1) govuk-spacing(4) 0;
   }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderList.tsx
@@ -1,9 +1,11 @@
+import DroppableArea from '@admin/components/DroppableArea';
+import DraggableItem from '@admin/components/DraggableItem';
 import styles from '@admin/pages/release/data/components/ReorderList.module.scss';
 import ButtonText from '@common/components/ButtonText';
 import reorder from '@common/utils/reorder';
 import classNames from 'classnames';
 import React, { useState } from 'react';
-import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 
 export interface FormattedOption {
   id: string;
@@ -127,86 +129,79 @@ const ReorderList = ({
     >
       <Droppable droppableId="droppablegroups">
         {(droppableProvided, droppableSnapshot) => (
-          <ol
-            className={classNames(styles.dropArea, {
-              [styles.dropAreaActive]: droppableSnapshot.isDraggingOver,
-            })}
-            data-testid={testId ? `${testId}-reorder-list` : 'reorder-list'}
-            ref={droppableProvided.innerRef}
+          <DroppableArea
+            className={styles.dropArea}
+            droppableProvided={droppableProvided}
+            droppableSnapshot={droppableSnapshot}
+            tag="ol"
+            testId={testId ? `${testId}-reorder-list` : 'reorder-list'}
           >
             {options.map((option, index) => {
               const key = option.id || `key-${index}`;
               const isExpanded = reorderingGroups.includes(key);
               const { childOptions, parentGroupId } = getChildItems(option);
               return (
-                <Draggable
-                  draggableId={key}
-                  isDragDisabled={reorderingGroups.length !== 0}
-                  key={key}
+                <DraggableItem
+                  className={classNames({
+                    [styles.isExpandedItem]: isExpanded,
+                  })}
+                  hideDragHandle={reorderingGroups.length > 0 && !isExpanded}
+                  dragHandle={
+                    isExpanded ? (
+                      <span aria-hidden className={styles.dragHandle}>
+                        ▼
+                      </span>
+                    ) : undefined
+                  }
+                  id={key}
                   index={index}
+                  isDisabled={reorderingGroups.length !== 0}
+                  isReordering
+                  key={key}
+                  tag="li"
                 >
-                  {(draggableProvided, draggableSnapshot) => {
-                    return (
-                      <li
-                        // eslint-disable-next-line react/jsx-props-no-spreading
-                        {...draggableProvided.draggableProps}
-                        // eslint-disable-next-line react/jsx-props-no-spreading
-                        {...draggableProvided.dragHandleProps}
-                        className={classNames(styles.draggable, {
-                          [styles.isDisabled]:
-                            reorderingGroups.length && !isExpanded,
+                  <div className={styles.inner}>
+                    <span className={styles.draggableInner}>
+                      <span
+                        className={classNames(styles.optionLabel, {
                           [styles.isExpanded]: isExpanded,
-                          [styles.isDragging]: draggableSnapshot.isDragging,
-                          [styles.isDraggedOutside]:
-                            draggableSnapshot.isDragging &&
-                            !draggableSnapshot.draggingOver,
+                          [styles.hideDragHandle]:
+                            reorderingGroups.length > 0 && !isExpanded,
                         })}
-                        ref={draggableProvided.innerRef}
                       >
-                        <span className={styles.draggableInner}>
-                          <span
-                            className={classNames(styles.optionLabel, {
-                              [styles.isExpanded]: isExpanded,
-                            })}
-                          >
-                            {option.label}
-                          </span>
-                          {childOptions && (
-                            <ButtonText
-                              className="govuk-!-margin-bottom-0"
-                              onClick={() => {
-                                setReorderingGroups(
-                                  isExpanded
-                                    ? reorderingGroups.filter(
-                                        item => item !== key,
-                                      )
-                                    : [...reorderingGroups, key],
-                                );
-                              }}
-                            >
-                              {isExpanded
-                                ? 'Done'
-                                : 'Reorder options within this group'}
-                            </ButtonText>
-                          )}
-                        </span>
-                        {childOptions && isExpanded && (
-                          <ReorderList
-                            listItems={childOptions}
-                            categoryId={categoryId || option.id}
-                            groupId={parentGroupId}
-                            testId={option.label}
-                            onReorder={onReorder}
-                          />
-                        )}
-                      </li>
-                    );
-                  }}
-                </Draggable>
+                        {option.label}
+                      </span>
+                      {childOptions && (
+                        <ButtonText
+                          className="govuk-!-margin-bottom-0"
+                          onClick={() => {
+                            setReorderingGroups(
+                              isExpanded
+                                ? reorderingGroups.filter(item => item !== key)
+                                : [...reorderingGroups, key],
+                            );
+                          }}
+                        >
+                          {isExpanded
+                            ? 'Done'
+                            : 'Reorder options within this group'}
+                        </ButtonText>
+                      )}
+                    </span>
+                    {childOptions && isExpanded && (
+                      <ReorderList
+                        listItems={childOptions}
+                        categoryId={categoryId || option.id}
+                        groupId={parentGroupId}
+                        testId={option.label}
+                        onReorder={onReorder}
+                      />
+                    )}
+                  </div>
+                </DraggableItem>
               );
             })}
-            {droppableProvided.placeholder}
-          </ol>
+          </DroppableArea>
         )}
       </Droppable>
     </DragDropContext>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.module.scss
@@ -24,30 +24,14 @@
   }
 }
 
-.dropArea {
-  background: govuk-colour('light-grey');
-  outline: $govuk-focus-width solid $govuk-focus-colour;
-}
-
-.item {
-  background: govuk-colour('white');
-
-  &:focus,
-  &.isDragging {
-    @include govuk-focused-text;
-  }
-}
-
 .labelReordering {
-  cursor: grab;
-  cursor: move;
   display: flex;
   justify-content: space-between;
+}
 
-  &::after {
-    color: govuk-colour('dark-grey');
-    content: '\2630';
-    font-size: 1.6rem;
-    line-height: 1;
-  }
+.dragHandle {
+  color: govuk-colour('dark-grey');
+  font-size: 1.6rem;
+  line-height: 1;
+  margin-right: govuk-spacing(1);
 }

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
@@ -1,3 +1,5 @@
+import DroppableArea from '@admin/components/DroppableArea';
+import DraggableItem, { DragHandle } from '@admin/components/DraggableItem';
 import ChartBuilderSaveActions from '@admin/pages/release/datablocks/components/chart/ChartBuilderSaveActions';
 import styles from '@admin/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.module.scss';
 import { useChartBuilderFormsContext } from '@admin/pages/release/datablocks/components/chart/contexts/ChartBuilderFormsContext';
@@ -23,7 +25,7 @@ import difference from 'lodash/difference';
 import mapValues from 'lodash/mapValues';
 import orderBy from 'lodash/orderBy';
 import React, { ReactNode, useEffect, useMemo } from 'react';
-import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import classNames from 'classnames';
 
 const formId = 'chartDataSetsConfigurationForm';
@@ -258,13 +260,10 @@ const ChartDataSetsConfiguration = ({
                   )}
                 </tr>
               </thead>
-              <tbody
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                {...droppableProvided.droppableProps}
-                ref={droppableProvided.innerRef}
-                className={classNames({
-                  [styles.dropArea]: droppableSnapshot.isDraggingOver,
-                })}
+              <DroppableArea
+                droppableProvided={droppableProvided}
+                droppableSnapshot={droppableSnapshot}
+                tag="tbody"
               >
                 {orderBy(dataSets, 'order').map((dataSet, index) => {
                   const expandedDataSet = expandDataSet(dataSet, meta);
@@ -272,52 +271,43 @@ const ChartDataSetsConfiguration = ({
                   const key = generateDataSetKey(dataSet);
 
                   return (
-                    <Draggable
-                      draggableId={key}
-                      isDragDisabled={!isReordering}
-                      key={key}
+                    <DraggableItem
+                      hideDragHandle
+                      id={key}
                       index={index}
+                      isReordering={isReordering}
+                      key={key}
+                      tag="tr"
                     >
-                      {(draggableProvided, draggableSnapshot) => (
-                        <tr
-                          // eslint-disable-next-line react/jsx-props-no-spreading
-                          {...draggableProvided.draggableProps}
-                          // eslint-disable-next-line react/jsx-props-no-spreading
-                          {...draggableProvided.dragHandleProps}
-                          className={classNames(styles.item, {
-                            [styles.isDragging]: draggableSnapshot.isDragging,
-                            [styles.isReordering]: isReordering,
-                          })}
-                          ref={draggableProvided.innerRef}
-                        >
-                          <td
-                            className={classNames({
-                              [styles.labelReordering]: isReordering,
-                            })}
+                      <td
+                        className={classNames({
+                          [styles.labelReordering]: isReordering,
+                        })}
+                      >
+                        {label}
+
+                        {isReordering && (
+                          <DragHandle className={styles.dragHandle} />
+                        )}
+                      </td>
+                      {!isReordering && (
+                        <td className="dfe-align--right">
+                          <ButtonText
+                            className="govuk-!-margin-bottom-0"
+                            onClick={() => {
+                              const nextDataSets = [...dataSets];
+                              nextDataSets.splice(index, 1);
+                              onChange(nextDataSets);
+                            }}
                           >
-                            {label}
-                          </td>
-                          {!isReordering && (
-                            <td className="dfe-align--right">
-                              <ButtonText
-                                className="govuk-!-margin-bottom-0"
-                                onClick={() => {
-                                  const nextDataSets = [...dataSets];
-                                  nextDataSets.splice(index, 1);
-                                  onChange(nextDataSets);
-                                }}
-                              >
-                                Remove
-                              </ButtonText>
-                            </td>
-                          )}
-                        </tr>
+                            Remove
+                          </ButtonText>
+                        </td>
                       )}
-                    </Draggable>
+                    </DraggableItem>
                   );
                 })}
-                {droppableProvided.placeholder}
-              </tbody>
+              </DroppableArea>
             </table>
           )}
         </Droppable>

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/__tests__/ReleaseFootnotesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/__tests__/ReleaseFootnotesPage.test.tsx
@@ -1,0 +1,297 @@
+import ReleaseFootnotesPage from '@admin/pages/release/footnotes/ReleaseFootnotesPage';
+import {
+  releaseFootnotesRoute,
+  ReleaseRouteParams,
+} from '@admin/routes/releaseRoutes';
+import _footnoteService, {
+  Footnote,
+  FootnoteMeta,
+} from '@admin/services/footnoteService';
+import _permissionService from '@admin/services/permissionService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { generatePath, Route, Router } from 'react-router-dom';
+
+jest.mock('@admin/services/footnoteService');
+const footnoteService = _footnoteService as jest.Mocked<
+  typeof _footnoteService
+>;
+
+jest.mock('@admin/services/permissionService');
+const permissionService = _permissionService as jest.Mocked<
+  typeof _permissionService
+>;
+
+describe('ReleaseFootnotesPage', () => {
+  const testFootnoteMeta: FootnoteMeta = {
+    subjects: {
+      'test-subject-1': {
+        subjectId: 'test-subject-1',
+        subjectName: 'Test subject 1',
+        indicators: {},
+        filters: {},
+      },
+    },
+  };
+
+  const testFootnotes: Footnote[] = [
+    { id: 'footnote-1', content: 'Footnote 1 content', subjects: {} },
+    { id: 'footnote-2', content: 'Footnote 2 content', subjects: {} },
+    { id: 'footnote-3', content: 'Footnote 3 content', subjects: {} },
+  ];
+
+  describe('with footnotes', () => {
+    test('renders the page with footnotes', async () => {
+      permissionService.canUpdateRelease.mockResolvedValue(true);
+      footnoteService.getFootnoteMeta.mockResolvedValue(testFootnoteMeta);
+      footnoteService.getFootnotes.mockResolvedValue(testFootnotes);
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Footnotes')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('link', { name: 'Create footnote' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Reorder footnotes' }),
+      ).toBeInTheDocument();
+
+      const footnote1 = within(
+        screen.getByTestId('Footnote - Footnote 1 content'),
+      );
+      expect(footnote1.getByText('Footnote 1 content')).toBeInTheDocument();
+      expect(
+        footnote1.getByRole('link', { name: 'Edit footnote' }),
+      ).toBeInTheDocument();
+      expect(
+        footnote1.getByRole('button', { name: 'Delete footnote' }),
+      ).toBeInTheDocument();
+      expect(
+        footnote1.getByRole('button', {
+          name: 'See matching criteria',
+        }),
+      ).toBeInTheDocument();
+
+      const footnote2 = within(
+        screen.getByTestId('Footnote - Footnote 2 content'),
+      );
+      expect(footnote2.getByText('Footnote 2 content')).toBeInTheDocument();
+      expect(
+        footnote2.getByRole('link', { name: 'Edit footnote' }),
+      ).toBeInTheDocument();
+      expect(
+        footnote2.getByRole('button', { name: 'Delete footnote' }),
+      ).toBeInTheDocument();
+      expect(
+        footnote2.getByRole('button', {
+          name: 'See matching criteria',
+        }),
+      ).toBeInTheDocument();
+
+      const footnote3 = within(
+        screen.getByTestId('Footnote - Footnote 3 content'),
+      );
+      expect(footnote3.getByText('Footnote 3 content')).toBeInTheDocument();
+      expect(
+        footnote3.getByRole('link', { name: 'Edit footnote' }),
+      ).toBeInTheDocument();
+      expect(
+        footnote3.getByRole('button', { name: 'Delete footnote' }),
+      ).toBeInTheDocument();
+      expect(
+        footnote3.getByRole('button', {
+          name: 'See matching criteria',
+        }),
+      ).toBeInTheDocument();
+    });
+
+    test('shows the reordering UI when the reorder button is clicked', async () => {
+      permissionService.canUpdateRelease.mockResolvedValue(true);
+      footnoteService.getFootnoteMeta.mockResolvedValue(testFootnoteMeta);
+      footnoteService.getFootnotes.mockResolvedValue(testFootnotes);
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Footnotes')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole('button', { name: 'Save order' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Create footnote' }),
+      ).toBeInTheDocument();
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Reorder footnotes' }),
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'Save order' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Reorder footnotes' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: 'Create footnote' }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('link', { name: 'Edit footnote' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Delete footnote' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'See matching criteria' }),
+      ).not.toBeInTheDocument();
+
+      expect(screen.getByTestId('Footnote - Footnote 1 content')).toBe(
+        screen.getByRole('button', { name: 'Footnote 1 content' }),
+      );
+      expect(screen.getByTestId('Footnote - Footnote 3 content')).toBe(
+        screen.getByRole('button', { name: 'Footnote 3 content' }),
+      );
+      expect(screen.getByTestId('Footnote - Footnote 3 content')).toBe(
+        screen.getByRole('button', { name: 'Footnote 3 content' }),
+      );
+    });
+
+    test('calls the footnotes service when save order is clicked', async () => {
+      permissionService.canUpdateRelease.mockResolvedValue(true);
+      footnoteService.getFootnoteMeta.mockResolvedValue(testFootnoteMeta);
+      footnoteService.getFootnotes.mockResolvedValue(testFootnotes);
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Footnotes')).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Reorder footnotes' }),
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Save order')).toBeInTheDocument();
+      });
+      userEvent.click(screen.getByRole('button', { name: 'Save order' }));
+
+      expect(
+        footnoteService.updateFootnotesOrder,
+      ).toHaveBeenCalledWith('release-1', [
+        'footnote-1',
+        'footnote-2',
+        'footnote-3',
+      ]);
+    });
+  });
+
+  test('renders correctly without footnotes', async () => {
+    permissionService.canUpdateRelease.mockResolvedValue(true);
+    footnoteService.getFootnoteMeta.mockResolvedValue(testFootnoteMeta);
+    footnoteService.getFootnotes.mockResolvedValue([]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Footnotes')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('link', { name: 'Create footnote' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Reorder footnotes' }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('No footnotes have been created.'),
+    ).toBeInTheDocument();
+  });
+
+  test('renders correctly with no footnoteMeta', async () => {
+    permissionService.canUpdateRelease.mockResolvedValue(true);
+    footnoteService.getFootnoteMeta.mockResolvedValue({ subjects: {} });
+    footnoteService.getFootnotes.mockResolvedValue([]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Footnotes')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('link', { name: 'Create footnote' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Reorder footnotes' }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        /Before footnotes can be created, relevant data files need to be uploaded./,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('renders correctly with no update permissions', async () => {
+    permissionService.canUpdateRelease.mockResolvedValue(false);
+    footnoteService.getFootnoteMeta.mockResolvedValue(testFootnoteMeta);
+    footnoteService.getFootnotes.mockResolvedValue(testFootnotes);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Footnotes')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('link', { name: 'Create footnote' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Reorder footnotes' }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        'This release has been approved, and can no longer be updated.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId('Footnote - Footnote 1 content'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('Footnote - Footnote 2 content'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('Footnote - Footnote 3 content'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('link', { name: 'Edit footnote' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Delete footnote' }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+function renderPage() {
+  const history = createMemoryHistory();
+  history.push(
+    generatePath<ReleaseRouteParams>(releaseFootnotesRoute.path, {
+      publicationId: 'publication-1',
+      releaseId: 'release-1',
+    }),
+  );
+
+  render(
+    <Router history={history}>
+      <Route
+        path={releaseFootnotesRoute.path}
+        component={ReleaseFootnotesPage}
+      />
+    </Router>,
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnotesList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnotesList.tsx
@@ -1,4 +1,6 @@
-import ButtonLink from '@admin/components/ButtonLink';
+import DroppableArea from '@admin/components/DroppableArea';
+import DraggableItem from '@admin/components/DraggableItem';
+import Link from '@admin/components/Link';
 import generateFootnoteMetaMap from '@admin/pages/release/footnotes/utils/generateFootnoteMetaMap';
 import styles from '@admin/pages/release/footnotes/components/FootnotesList.module.scss';
 import FootnoteSubjectSelection from '@admin/pages/release/footnotes/components/FootnoteSubjectSelection';
@@ -7,13 +9,16 @@ import {
   releaseFootnotesEditRoute,
 } from '@admin/routes/releaseRoutes';
 import { Footnote, FootnoteMeta } from '@admin/services/footnoteService';
-import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
+import ButtonText from '@common/components/ButtonText';
 import Details from '@common/components/Details';
 import InsetText from '@common/components/InsetText';
 import ModalConfirm from '@common/components/ModalConfirm';
+import reorder from '@common/utils/reorder';
+import classNames from 'classnames';
 import React, { useMemo, useState } from 'react';
 import { generatePath } from 'react-router';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 
 interface Props {
   publicationId: string;
@@ -21,7 +26,9 @@ interface Props {
   footnoteMeta: FootnoteMeta;
   footnotes: Footnote[];
   canUpdateRelease: boolean;
+  isReordering: boolean;
   onDelete: (footnote: Footnote) => void;
+  onReorder: (footnotes: Footnote[]) => void;
 }
 
 const FootnotesList = ({
@@ -30,7 +37,9 @@ const FootnotesList = ({
   footnotes,
   footnoteMeta,
   canUpdateRelease,
+  isReordering,
   onDelete,
+  onReorder,
 }: Props) => {
   const [deleteFootnote, setDeleteFootnote] = useState<Footnote>();
 
@@ -44,70 +53,100 @@ const FootnotesList = ({
 
   return (
     <>
-      {footnotes.map(footnote => {
-        const { id, content } = footnote;
-
-        return (
-          <div
-            key={id}
-            className={styles.itemContainer}
-            data-testid={`Footnote - ${content}`}
-          >
-            <div className={styles.row}>
-              <div className={styles.rowContent}>{content}</div>
-
-              {canUpdateRelease && (
-                <ButtonGroup className={styles.rowActions}>
-                  <ButtonLink
-                    to={generatePath<ReleaseFootnoteRouteParams>(
-                      releaseFootnotesEditRoute.path,
-                      {
-                        publicationId,
-                        releaseId,
-                        footnoteId: footnote.id,
-                      },
-                    )}
-                  >
-                    Edit footnote
-                  </ButtonLink>
-                  <Button
-                    variant="secondary"
-                    onClick={() => setDeleteFootnote(footnote)}
-                  >
-                    Delete footnote
-                  </Button>
-                </ButtonGroup>
-              )}
-            </div>
-            <Details
-              summary="See matching criteria"
-              className="govuk-!-margin-0"
+      <DragDropContext
+        onDragEnd={result => {
+          if (!result.destination) {
+            return;
+          }
+          const reorderedFootnotes = reorder(
+            footnotes,
+            result.source.index,
+            result.destination.index,
+          );
+          onReorder(reorderedFootnotes);
+        }}
+      >
+        <Droppable droppableId="footnotes" isDropDisabled={!isReordering}>
+          {(droppableProvided, droppableSnapshot) => (
+            <DroppableArea
+              droppableProvided={droppableProvided}
+              droppableSnapshot={droppableSnapshot}
             >
-              <table className={styles.footnoteSelectionTable}>
-                <thead>
-                  <tr>
-                    <th>Subjects</th>
-                    <th>Indicators</th>
-                    <th>Filters</th>
-                  </tr>
-                </thead>
-                <tbody className="govuk-body-s">
-                  {Object.entries(footnote.subjects).map(
-                    ([subjectId, selection]) => (
-                      <FootnoteSubjectSelection
-                        key={subjectId}
-                        subjectId={subjectId}
-                        subject={selection}
-                        footnoteMetaGetters={footnoteMetaGetters}
-                      />
-                    ),
-                  )}
-                </tbody>
-              </table>
-            </Details>
-          </div>
-        );
-      })}
+              {footnotes.map((footnote, index) => {
+                const { id, content } = footnote;
+
+                return (
+                  <DraggableItem
+                    className={classNames({
+                      [styles.itemContainer]: !isReordering,
+                    })}
+                    id={id}
+                    index={index}
+                    isReordering={isReordering}
+                    key={id}
+                    testId={`Footnote - ${content}`}
+                  >
+                    <div className={styles.row}>
+                      <div className={styles.rowContent}>{content}</div>
+
+                      {!isReordering && canUpdateRelease && (
+                        <ButtonGroup className={styles.rowActions}>
+                          <Link
+                            to={generatePath<ReleaseFootnoteRouteParams>(
+                              releaseFootnotesEditRoute.path,
+                              {
+                                publicationId,
+                                releaseId,
+                                footnoteId: id,
+                              },
+                            )}
+                          >
+                            Edit footnote
+                          </Link>
+                          <ButtonText
+                            variant="warning"
+                            onClick={() => setDeleteFootnote(footnote)}
+                          >
+                            Delete footnote
+                          </ButtonText>
+                        </ButtonGroup>
+                      )}
+                    </div>
+                    {!isReordering && (
+                      <Details
+                        summary="See matching criteria"
+                        className="govuk-!-margin-0"
+                      >
+                        <table className={styles.footnoteSelectionTable}>
+                          <thead>
+                            <tr>
+                              <th>Subjects</th>
+                              <th>Indicators</th>
+                              <th>Filters</th>
+                            </tr>
+                          </thead>
+                          <tbody className="govuk-body-s">
+                            {Object.entries(footnote.subjects).map(
+                              ([subjectId, selection]) => (
+                                <FootnoteSubjectSelection
+                                  key={subjectId}
+                                  subjectId={subjectId}
+                                  subject={selection}
+                                  footnoteMetaGetters={footnoteMetaGetters}
+                                />
+                              ),
+                            )}
+                          </tbody>
+                        </table>
+                      </Details>
+                    )}
+                  </DraggableItem>
+                );
+              })}
+            </DroppableArea>
+          )}
+        </Droppable>
+      </DragDropContext>
 
       {deleteFootnote && (
         <ModalConfirm

--- a/src/explore-education-statistics-admin/src/services/footnoteService.ts
+++ b/src/explore-education-statistics-admin/src/services/footnoteService.ts
@@ -106,6 +106,14 @@ const footnoteService = {
   deleteFootnote(releaseId: string, id: string): Promise<void> {
     return client.delete(`/releases/${releaseId}/footnotes/${id}`);
   },
+  updateFootnotesOrder(
+    releaseId: string,
+    footnoteIds: string[],
+  ): Promise<string[]> {
+    return client.patch(`/releases/${releaseId}/footnotes/`, {
+      footnoteIds,
+    });
+  },
 };
 
 export default footnoteService;

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -402,6 +402,28 @@ Check footnote was updated on data block
     user checks list has x items    testid:footnotes    3
     user checks list item contains    testid:footnotes    3    ${FOOTNOTE_ALL_FILTER}
 
+Reorder footnotes
+    user clicks link    Footnotes
+    user waits until h2 is visible    Footnotes
+    user clicks button    Reorder footnotes
+    user sets focus to element    testid:Footnote - ${FOOTNOTE_ALL}
+    user presses keys    ${SPACE}
+    user presses keys    ARROW_DOWN
+    user presses keys    ${SPACE}
+    user clicks button    Save order
+
+Check footnotes were reordered on data block
+    user sets focus to element    //a[text()="Data blocks"]    //*[@aria-label="Release"]
+    user clicks link    Data blocks
+
+    user waits until h2 is visible    Data blocks    %{WAIT_SMALL}
+
+    user clicks link    Edit block    css:tbody > tr:first-child
+    user waits until table is visible
+    user checks list has x items    testid:footnotes    2
+    user checks list item contains    testid:footnotes    1    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
+    user checks list item contains    testid:footnotes    2    ${FOOTNOTE_ALL}
+
 Add public prerelease access list for release
     user clicks link    Pre-release access
     user creates public prerelease access list    Test public access list
@@ -507,8 +529,8 @@ Validate table
 
 Validate table has footnotes
     user checks list has x items    testid:footnotes    2
-    user checks list item contains    testid:footnotes    1    ${FOOTNOTE_ALL}
-    user checks list item contains    testid:footnotes    2    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
+    user checks list item contains    testid:footnotes    1    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
+    user checks list item contains    testid:footnotes    2    ${FOOTNOTE_ALL}
 
     user clicks button    Show 1 more footnote
     user checks list has x items    testid:footnotes    3
@@ -582,8 +604,8 @@ Validate table rows for featured table
 
 Validate featured table has footnotes
     user checks list has x items    testid:footnotes    2
-    user checks list item contains    testid:footnotes    1    ${FOOTNOTE_ALL}
-    user checks list item contains    testid:footnotes    2    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
+    user checks list item contains    testid:footnotes    1    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
+    user checks list item contains    testid:footnotes    2    ${FOOTNOTE_ALL}
 
     user clicks button    Show 1 more footnote
     user checks list has x items    testid:footnotes    3
@@ -673,9 +695,9 @@ Validate data guidance document footnotes
     user opens details dropdown    Footnotes    ${subject_1_content}
 
     user checks list has x items    testid:Footnotes    9    ${subject_1_content}
-    user checks list item contains    testid:Footnotes    1    ${FOOTNOTE_ALL}    ${subject_1_content}
-    user checks list item contains    testid:Footnotes    2    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
+    user checks list item contains    testid:Footnotes    1    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
     ...    ${subject_1_content}
+    user checks list item contains    testid:Footnotes    2    ${FOOTNOTE_ALL}    ${subject_1_content}
     user checks list item contains    testid:Footnotes    3    ${FOOTNOTE_ALL_FILTER}    ${subject_1_content}
     user checks list item contains    testid:Footnotes    4    ${FOOTNOTE_SUBJECT_1}    ${subject_1_content}
     user checks list item contains    testid:Footnotes    5    ${FOOTNOTE_SUBJECT_1_INDICATOR}    ${subject_1_content}
@@ -690,7 +712,7 @@ Validate data guidance document footnotes
     user opens details dropdown    Footnotes    ${subject_2_content}
 
     user checks list has x items    testid:Footnotes    3    ${subject_2_content}
-    user checks list item contains    testid:Footnotes    1    ${FOOTNOTE_ALL}    ${subject_2_content}
-    user checks list item contains    testid:Footnotes    2    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
+    user checks list item contains    testid:Footnotes    1    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
     ...    ${subject_2_content}
+    user checks list item contains    testid:Footnotes    2    ${FOOTNOTE_ALL}    ${subject_2_content}
     user checks list item contains    testid:Footnotes    3    ${FOOTNOTE_ALL_FILTER}    ${subject_2_content}


### PR DESCRIPTION
Adds the front end for reordering footnotes.

As part of this I've created some generic components for DroppableArea and DraggableItem so we don't have to duplicate the styles every time we add a new reordering UI. I've used these for footnotes and for the other reordering UI's where it was relatively simple to swap them out:
- filters and indicators
- data files
- data sets for charts
- legacy releases