### PR TITLE
EES-3964 BE Tidy up after switching to new Find Statistics page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221221090846_EES3964_DropPublicationLegacyPublicationUrl.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221221090846_EES3964_DropPublicationLegacyPublicationUrl.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221221090846_EES3964_DropPublicationLegacyPublicationUrl")]
+    partial class EES3964_DropPublicationLegacyPublicationUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221221090846_EES3964_DropPublicationLegacyPublicationUrl.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20221221090846_EES3964_DropPublicationLegacyPublicationUrl.cs
@@ -1,0 +1,26 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations;
+
+[ExcludeFromCodeCoverage]
+public partial class EES3964_DropPublicationLegacyPublicationUrl : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "LegacyPublicationUrl",
+            table: "Publications");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "LegacyPublicationUrl",
+            table: "Publications",
+            type: "nvarchar(max)",
+            nullable: true);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -69,7 +69,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
             var controller = BuildPublicationController(publicationCacheService: publicationCacheService.Object);
 
             publicationCacheService
-                .Setup(s => s.GetPublicationTree(PublicationTreeFilter.FindStatistics))
+                .Setup(s => s.GetPublicationTree(PublicationTreeFilter.DataCatalogue))
                 .ReturnsAsync(new List<PublicationTreeThemeViewModel>
                 {
                     new()
@@ -87,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
                     }
                 });
 
-            var result = await controller.GetPublicationTree(PublicationTreeFilter.FindStatistics);
+            var result = await controller.GetPublicationTree(PublicationTreeFilter.DataCatalogue);
 
             VerifyAllMocks(publicationCacheService);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -209,12 +209,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .IsRequired(false);
 
             modelBuilder.Entity<Publication>()
-                .Property(p => p.LegacyPublicationUrl)
-                .HasConversion(
-                    p => p.ToString(),
-                    p => new Uri(p));
-
-            modelBuilder.Entity<Publication>()
                 .OwnsOne(p => p.ExternalMethodology)
                 .ToTable("ExternalMethodology");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -23,8 +23,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public ExternalMethodology? ExternalMethodology { get; set; }
 
-        public Uri? LegacyPublicationUrl { get; set; }
-
         public List<LegacyRelease> LegacyReleases { get; set; } = new();
 
         public DateTime? Published { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -153,8 +153,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
                     Publications = ListOf(new PublicationTreePublicationViewModel
                     {
                         Title = "Publication A",
-                        IsSuperseded = false,
-                        HasLiveRelease = true
+                        AnyLiveReleaseHasData = true
                     })
                 }
             }
@@ -178,7 +177,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
 
         var service = BuildService(publicationService.Object);
 
-        var result = await service.GetPublicationTree(PublicationTreeFilter.FindStatistics);
+        var result = await service.GetPublicationTree(PublicationTreeFilter.DataCatalogue);
 
         VerifyAllMocks(PublicBlobCacheService);
 
@@ -200,8 +199,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
                     Publications = ListOf(new PublicationTreePublicationViewModel
                     {
                         Title = "Publication A",
-                        IsSuperseded = false,
-                        HasLiveRelease = true
+                        AnyLiveReleaseHasData = true
                     })
                 }
             }
@@ -214,108 +212,12 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
 
         var service = BuildService();
 
-        var result = await service.GetPublicationTree(PublicationTreeFilter.FindStatistics);
+        var result = await service.GetPublicationTree(PublicationTreeFilter.DataCatalogue);
 
         VerifyAllMocks(PublicBlobCacheService);
 
         var filteredTree = result.AssertRight();
         filteredTree.AssertDeepEqualTo(ListOf(publicationTree));
-    }
-
-    [Fact]
-    public async Task GetPublicationTree_FindStatistics_NonSupersededPublicationWithLiveRelease_Included()
-    {
-        var publicationTree = new PublicationTreeThemeViewModel
-        {
-            Title = "Theme A",
-            Topics = new List<PublicationTreeTopicViewModel>
-            {
-                new()
-                {
-                    Title = "Topic A",
-                    Publications = ListOf(new PublicationTreePublicationViewModel
-                    {
-                        Title = "Publication A",
-                        IsSuperseded = false,
-                        HasLiveRelease = true
-                    })
-                }
-            }
-        };
-
-        await AssertPublicationTreeUnfiltered(publicationTree, PublicationTreeFilter.FindStatistics);
-    }
-
-    [Fact]
-    public async Task GetPublicationTree_FindStatistics_NonSupersededPublicationWithLegacyRelease_Included()
-    {
-        var publicationTree = new PublicationTreeThemeViewModel
-        {
-            Title = "Theme A",
-            Topics = new List<PublicationTreeTopicViewModel>
-            {
-                new()
-                {
-                    Title = "Topic A",
-                    Publications = ListOf(new PublicationTreePublicationViewModel
-                    {
-                        Title = "Publication A",
-                        IsSuperseded = false,
-                        Type = PublicationType.Legacy
-                    })
-                }
-            }
-        };
-
-        await AssertPublicationTreeUnfiltered(publicationTree, PublicationTreeFilter.FindStatistics);
-    }
-
-    [Fact]
-    public async Task GetPublicationTree_FindStatistics_SupersededPublicationWithLiveRelease_Excluded()
-    {
-        var publicationTree = new PublicationTreeThemeViewModel
-        {
-            Title = "Theme A",
-            Topics = new List<PublicationTreeTopicViewModel>
-            {
-                new()
-                {
-                    Title = "Topic A",
-                    Publications = ListOf(new PublicationTreePublicationViewModel
-                    {
-                        Title = "Publication A",
-                        IsSuperseded = true,
-                        HasLiveRelease = true
-                    })
-                }
-            }
-        };
-
-        await AssertPublicationTreeEmpty(publicationTree, PublicationTreeFilter.FindStatistics);
-    }
-
-    [Fact]
-    public async Task GetPublicationTree_FindStatistics_SupersededPublicationWithLegacyRelease_Excluded()
-    {
-        var publicationTree = new PublicationTreeThemeViewModel
-        {
-            Title = "Theme A",
-            Topics = new List<PublicationTreeTopicViewModel>
-            {
-                new()
-                {
-                    Title = "Topic A",
-                    Publications = ListOf(new PublicationTreePublicationViewModel
-                    {
-                        Title = "Publication A",
-                        IsSuperseded = true,
-                        Type = PublicationType.Legacy
-                    })
-                }
-            }
-        };
-
-        await AssertPublicationTreeEmpty(publicationTree, PublicationTreeFilter.FindStatistics);
     }
 
     [Fact]
@@ -344,12 +246,6 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
     [Fact]
     public async Task GetPublicationTree_DataCatalogue_NoLiveReleaseHasData_Excluded()
     {
-        var publication = new PublicationTreePublicationViewModel
-        {
-            Title = "Publication A",
-            AnyLiveReleaseHasData = false
-        };
-
         var publicationTree = new PublicationTreeThemeViewModel
         {
             Title = "Theme A",
@@ -358,7 +254,11 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
                 new()
                 {
                     Title = "Topic A",
-                    Publications = ListOf(publication)
+                    Publications = ListOf(new PublicationTreePublicationViewModel
+                    {
+                        Title = "Publication A",
+                        AnyLiveReleaseHasData = false
+                    })
                 }
             }
         };
@@ -464,12 +364,6 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
     [Fact]
     public async Task GetPublicationTree_FastTrack_NoLiveReleaseHasData_Excluded()
     {
-        var publication = new PublicationTreePublicationViewModel
-        {
-            Title = "Publication A",
-            AnyLiveReleaseHasData = false
-        };
-
         var publicationTree = new PublicationTreeThemeViewModel
         {
             Title = "Theme A",
@@ -478,7 +372,11 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
                 new()
                 {
                     Title = "Topic A",
-                    Publications = ListOf(publication)
+                    Publications = ListOf(new PublicationTreePublicationViewModel
+                    {
+                        Title = "Publication A",
+                        AnyLiveReleaseHasData = false
+                    })
                 }
             }
         };

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -352,15 +352,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 ReleaseName = "2020",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.OfficialStatistics,
-                Published = DateTime.UtcNow,
+                Type = OfficialStatistics,
+                Published = DateTime.UtcNow
             };
             var releaseB = new Release
             {
                 ReleaseName = "2020",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.NationalStatistics,
-                Published = DateTime.UtcNow,
+                Type = NationalStatistics,
+                Published = DateTime.UtcNow
+            };
+            var releaseC = new Release
+            {
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                Type = NationalStatistics,
+                Published = DateTime.UtcNow
             };
 
             var publicationA = new Publication
@@ -387,7 +394,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 Title = "Publication C",
                 Slug = "publication-c",
-                LegacyPublicationUrl = new Uri("https://legacy.url/")
+                LatestPublishedRelease = releaseC,
+                Releases = new List<Release>
+                {
+                    releaseC
+                }
             };
 
             var themes = new List<Theme>
@@ -460,7 +471,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 Assert.Equal("publication-a", topicAPublications[0].Slug);
                 Assert.Equal("Publication A", topicAPublications[0].Title);
                 Assert.Equal(PublicationType.NationalAndOfficial, topicAPublications[0].Type);
-                Assert.True(topicAPublications[0].HasLiveRelease);
                 Assert.False(topicAPublications[0].LatestReleaseHasData);
                 Assert.False(topicAPublications[0].AnyLiveReleaseHasData);
 
@@ -470,7 +480,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 Assert.Equal("publication-b", topicBPublications[0].Slug);
                 Assert.Equal("Publication B", topicBPublications[0].Title);
                 Assert.Equal(PublicationType.NationalAndOfficial, topicBPublications[0].Type);
-                Assert.True(topicBPublications[0].HasLiveRelease);
                 Assert.False(topicBPublications[0].LatestReleaseHasData);
                 Assert.False(topicBPublications[0].AnyLiveReleaseHasData);
 
@@ -479,11 +488,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 Assert.Single(topicCPublications);
                 Assert.Equal("publication-c", topicCPublications[0].Slug);
                 Assert.Equal("Publication C", topicCPublications[0].Title);
-                Assert.Equal(PublicationType.Legacy, topicCPublications[0].Type);
-                Assert.False(topicCPublications[0].HasLiveRelease);
+                Assert.Equal(PublicationType.NationalAndOfficial, topicCPublications[0].Type);
                 Assert.False(topicCPublications[0].LatestReleaseHasData);
                 Assert.False(topicCPublications[0].AnyLiveReleaseHasData);
-                Assert.Equal("https://legacy.url/", topicCPublications[0].LegacyPublicationUrl);
             }
         }
 
@@ -494,7 +501,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 ReleaseName = "2020",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.OfficialStatistics,
+                Type = OfficialStatistics,
                 Published = DateTime.UtcNow,
             };
 
@@ -570,46 +577,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task GetPublicationTree_ThemesWithNoVisiblePublications_Excluded()
         {
-            var releaseB = new Release
+            var releaseA = new Release
             {
-                ReleaseName = "2020",
+                ReleaseName = "2022",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.OfficialStatistics,
-                Published = DateTime.UtcNow,
+                Type = NationalStatistics,
+                Published = DateTime.UtcNow
             };
 
-            var publicationA = new Publication
+            var releaseB = new Release
             {
-                Title = "Publication A",
-            };
-            var publicationB = new Publication
-            {
-                Title = "Publication B",
-                LatestPublishedRelease = releaseB,
-                Releases = new List<Release>
-                {
-                    releaseB
-                }
-            };
-            var publicationC = new Publication
-            {
-                Title = "Publication C",
-                LegacyPublicationUrl = new Uri("https://legacy.url/")
-            };
-            var publicationD = new Publication
-            {
-                Title = "Publication D",
-                Releases = new List<Release>
-                {
-                    // Not published
-                    new()
-                    {
-                        ReleaseName = "2020",
-                        TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                        Type = ReleaseType.NationalStatistics,
-                        Published = null,
-                    }
-                }
+                ReleaseName = "2022",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                Type = NationalStatistics,
+                Published = DateTime.UtcNow
             };
 
             var themes = new List<Theme>
@@ -622,8 +603,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                         new()
                         {
                             Title = "Topic A",
-                            Publications = ListOf(publicationA)
-                        },
+                            Publications = new List<Publication>
+                            {
+                                // Publication has a published release
+                                new()
+                                {
+                                    Title = "Publication A",
+                                    LatestPublishedRelease = releaseB,
+                                    Releases = new List<Release>
+                                    {
+                                        releaseB
+                                    }
+                                }
+                            }
+                        }
                     }
                 },
                 new()
@@ -634,9 +627,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                         new()
                         {
                             Title = "Topic B",
-                            Publications = ListOf(publicationB)
-                        },
-                    },
+                            Publications = new List<Publication>
+                            {
+                                // Publication has a published and an unpublished release
+                                new()
+                                {
+                                    Title = "Publication B",
+                                    LatestPublishedRelease = releaseA,
+                                    Releases = new List<Release>
+                                    {
+                                        releaseA,
+                                        new()
+                                        {
+                                            ReleaseName = "2021",
+                                            TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                                            Type = NationalStatistics,
+                                            Published = null
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 },
                 new()
                 {
@@ -646,9 +658,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                         new()
                         {
                             Title = "Topic C",
-                            Publications = ListOf(publicationC)
-                        },
-                    },
+                            Publications = new List<Publication>
+                            {
+                                // Publication has no releases
+                                new()
+                                {
+                                    Title = "Publication C",
+                                }
+                            }
+                        }
+                    }
                 },
                 new()
                 {
@@ -658,9 +677,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                         new()
                         {
                             Title = "Topic D",
-                            Publications = ListOf(publicationD)
-                        },
-                    },
+                            Publications = new List<Publication>
+                            {
+                                // Publication has no published releases
+                                new()
+                                {
+                                    Title = "Publication D",
+                                    LatestPublishedRelease = null,
+                                    Releases = new List<Release>
+                                    {
+                                        new()
+                                        {
+                                            ReleaseName = "2022",
+                                            TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                                            Type = NationalStatistics,
+                                            Published = null
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             };
 
@@ -668,7 +705,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                await context.AddRangeAsync(themes);
+                await context.Releases.AddRangeAsync(releaseA, releaseB);
+                await context.Themes.AddRangeAsync(themes);
                 await context.SaveChangesAsync();
             }
 
@@ -677,167 +715,45 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 var service = SetupPublicationService(context);
 
                 var publicationTree = await service.GetPublicationTree();
+
+                // Theme A / Topic A should be included as Publication A has a published release
+                // Theme B / Topic B should be included as Publication B has a published and unpublished releases
+                // Theme C / Topic C should be excluded as Publication C has no releases
+                // Theme D / Topic D should be excluded as Publication D only has an unpublished release
 
                 Assert.Equal(2, publicationTree.Count);
-                Assert.Equal("Theme B", publicationTree[0].Title);
-                Assert.Equal("Theme C", publicationTree[1].Title);
-
-                Assert.Single(publicationTree[0].Topics);
-                Assert.Equal("Topic B", publicationTree[0].Topics[0].Title);
-
-                Assert.Single(publicationTree[1].Topics);
-                Assert.Equal("Topic C", publicationTree[1].Topics[0].Title);
-
-                var topicBPublications = publicationTree[0].Topics[0].Publications;
-
-                // Publication has a published release, hence it is visible
-                Assert.Single(topicBPublications);
-                Assert.Equal("Publication B", topicBPublications[0].Title);
-                Assert.Equal(PublicationType.NationalAndOfficial, topicBPublications[0].Type);
-                Assert.Null(topicBPublications[0].LegacyPublicationUrl);
-
-                var topicCPublications = publicationTree[1].Topics[0].Publications;
-
-                // Publication has a legacy URL, hence it is visible
-                Assert.Single(topicCPublications);
-                Assert.Equal("Publication C", topicCPublications[0].Title);
-                Assert.Equal(PublicationType.Legacy, topicCPublications[0].Type);
-                Assert.Equal("https://legacy.url/", topicCPublications[0].LegacyPublicationUrl);
-            }
-        }
-
-        [Fact]
-        public async Task GetPublicationTree_LegacyPublicationUrl()
-        {
-            var releaseA = new Release
-            {
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.NationalStatistics,
-                Published = DateTime.UtcNow,
-            };
-            var releaseB = new Release
-            {
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.NationalStatistics,
-                Published = DateTime.UtcNow,
-            };
-
-            var publicationA = new Publication
-            {
-                Title = "Publication A",
-                Slug = "publication-a",
-                LatestPublishedRelease = releaseA,
-                Releases = new List<Release>
-                {
-                    releaseA
-                },
-                LegacyPublicationUrl = new Uri("https://legacy.url/")
-            };
-            var publicationB = new Publication
-            {
-                Title = "Publication B",
-                Slug = "publication-b",
-                LatestPublishedRelease = releaseB,
-                Releases = new List<Release>
-                {
-                    releaseB
-                }
-            };
-            var publicationC = new Publication
-            {
-                Title = "Publication C",
-                Slug = "publication-c",
-                LegacyPublicationUrl = new Uri("https://legacy.url/")
-            };
-
-            var theme = new Theme
-            {
-                Title = "Theme A",
-                Summary = "Theme A summary",
-                Topics = new List<Topic>
-                {
-                    new()
-                    {
-                        Title = "Topic A",
-                        // Publications are in random order
-                        // to check that ordering is done by title
-                        Publications = ListOf(publicationB, publicationC, publicationA)
-                    },
-                },
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryContentDbContext(contextId))
-            {
-                await context.Themes.AddRangeAsync(theme);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryContentDbContext(contextId))
-            {
-                var service = SetupPublicationService(context);
-
-                var publicationTree = await service.GetPublicationTree();
-
-                Assert.Single(publicationTree);
                 Assert.Equal("Theme A", publicationTree[0].Title);
-                Assert.Equal("Theme A summary", publicationTree[0].Summary);
+                Assert.Equal("Theme B", publicationTree[1].Title);
 
                 Assert.Single(publicationTree[0].Topics);
                 Assert.Equal("Topic A", publicationTree[0].Topics[0].Title);
 
-                var publications = publicationTree[0].Topics[0].Publications;
+                var topicAPublications = publicationTree[0].Topics[0].Publications;
 
-                Assert.Equal(3, publications.Count);
-                Assert.Equal("publication-a", publications[0].Slug);
-                Assert.Equal("Publication A", publications[0].Title);
-                Assert.Equal(PublicationType.NationalAndOfficial, publications[0].Type);
-                // Publication has a legacy url but it's not set because Releases exist
-                Assert.Null(publications[0].LegacyPublicationUrl);
+                Assert.Single(topicAPublications);
+                Assert.Equal("Publication A", topicAPublications[0].Title);
+                Assert.Equal(PublicationType.NationalAndOfficial, topicAPublications[0].Type);
 
-                Assert.Equal("publication-b", publications[1].Slug);
-                Assert.Equal("Publication B", publications[1].Title);
-                Assert.Equal(PublicationType.NationalAndOfficial, publications[1].Type);
-                Assert.Null(publications[1].LegacyPublicationUrl);
+                Assert.Single(publicationTree[1].Topics);
+                Assert.Equal("Topic B", publicationTree[1].Topics[0].Title);
 
-                Assert.Equal("publication-c", publications[2].Slug);
-                Assert.Equal("Publication C", publications[2].Title);
-                Assert.Equal(PublicationType.Legacy, publications[2].Type);
-                Assert.Equal("https://legacy.url/", publications[2].LegacyPublicationUrl);
+                var topicBPublications = publicationTree[1].Topics[0].Publications;
+
+                Assert.Single(topicBPublications);
+                Assert.Equal("Publication B", topicBPublications[0].Title);
+                Assert.Equal(PublicationType.NationalAndOfficial, topicBPublications[0].Type);
             }
         }
 
         [Fact]
-        public async Task GetPublicationTree_PublicationsWithNoReleasesAndNoLegacyUrl_Excluded()
+        public async Task GetPublicationTree_PublicationsWithNoReleases_Excluded()
         {
             var releaseA = new Release
             {
                 ReleaseName = "2020",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.OfficialStatistics,
-                Published = new DateTime(2020, 1, 1),
-            };
-
-            var publicationA = new Publication
-            {
-                Title = "Publication A",
-                LatestPublishedRelease = releaseA,
-                Releases = new List<Release>
-                {
-                    releaseA
-                }
-            };
-            var publicationB = new Publication
-            {
-                Title = "Publication B",
-            };
-            var publicationC = new Publication
-            {
-                Title = "Publication C",
-                LegacyPublicationUrl = new Uri("https://legacy.url/")
+                Type = OfficialStatistics,
+                Published = DateTime.UtcNow
             };
 
             var theme = new Theme
@@ -850,9 +766,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                         Title = "Topic A",
                         Publications = new List<Publication>
                         {
-                            publicationA,
-                            publicationB,
-                            publicationC
+                            // Publication has a published release
+                            new()
+                            {
+                                Title = "Publication A",
+                                LatestPublishedRelease = releaseA,
+                                Releases = new List<Release>
+                                {
+                                    releaseA
+                                }
+                            },
+                            // Publication has no releases
+                            new()
+                            {
+                                Title = "Publication B",
+                                Releases = new List<Release>()
+                            }
                         }
                     }
                 }
@@ -874,14 +803,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
                 var publications = publicationTree[0].Topics[0].Publications;
 
-                Assert.Equal(2, publications.Count);
+                Assert.Single(publications);
                 Assert.Equal("Publication A", publications[0].Title);
                 Assert.Equal(PublicationType.NationalAndOfficial, publications[0].Type);
-                Assert.Null(publications[0].LegacyPublicationUrl);
-
-                Assert.Equal("Publication C", publications[1].Title);
-                Assert.Equal(PublicationType.Legacy, publications[1].Type);
-                Assert.Equal("https://legacy.url/", publications[1].LegacyPublicationUrl);
             }
         }
 
@@ -892,7 +816,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 ReleaseName = "2020",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.OfficialStatistics,
+                Type = OfficialStatistics,
                 Published = DateTime.UtcNow,
             };
 
@@ -900,7 +824,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 ReleaseName = "2021",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.NationalStatistics,
+                Type = NationalStatistics,
                 Published = DateTime.UtcNow,
             };
 
@@ -908,7 +832,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 ReleaseName = "2022",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.AdHocStatistics,
+                Type = AdHocStatistics,
                 Published = null,
             };
 
@@ -976,35 +900,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
                 ReleaseName = "2020",
-                Type = ReleaseType.OfficialStatistics,
+                Type = OfficialStatistics,
                 Published = new DateTime(2020, 1, 1),
-            };
-
-            // Not published
-            var releaseB = new Release
-            {
-                TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                ReleaseName = "2020",
-                Type = ReleaseType.NationalStatistics
-            };
-
-            var publicationA = new Publication
-            {
-                Title = "Publication A",
-                LatestPublishedRelease = releaseA,
-                Releases = new List<Release>
-                {
-                    releaseA
-                }
-            };
-            var publicationB = new Publication
-            {
-                Title = "Publication B",
-                LatestPublishedRelease = null,
-                Releases = new List<Release>
-                {
-                    releaseB
-                }
             };
 
             var themes = new List<Theme>
@@ -1014,15 +911,45 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     Title = "Theme A",
                     Topics = new List<Topic>
                     {
+                        // Topic has a publication with a published release
                         new()
                         {
                             Title = "Topic A",
-                            Publications = ListOf(publicationA)
+                            Publications = new List<Publication>
+                            {
+                                // Publication has a published release
+                                new()
+                                {
+                                    Title = "Publication A",
+                                    LatestPublishedRelease = releaseA,
+                                    Releases = new List<Release>
+                                    {
+                                        releaseA
+                                    }
+                                }
+                            }
                         },
+                        // Topic only has a publication with no published release
                         new()
                         {
                             Title = "Topic B",
-                            Publications = ListOf(publicationB),
+                            Publications = new List<Publication>
+                            {
+                                new()
+                                {
+                                    Title = "Publication B",
+                                    LatestPublishedRelease = null,
+                                    Releases = new List<Release>
+                                    {
+                                        new()
+                                        {
+                                            TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                                            ReleaseName = "2020",
+                                            Type = NationalStatistics
+                                        }
+                                    }
+                                }
+                            }
                         },
                     }
                 }
@@ -1032,6 +959,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             await using (var context = InMemoryContentDbContext(contextId))
             {
+                await context.Releases.AddAsync(releaseA);
                 await context.Themes.AddRangeAsync(themes);
                 await context.SaveChangesAsync();
             }
@@ -1042,6 +970,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
                 var publicationTree = await service.GetPublicationTree();
 
+                // Topic A should be included as Publication A has a published release
+                // Topic B should be excluded as Publication B only has an unpublished release
+                
                 Assert.Single(publicationTree);
                 Assert.Equal("Theme A", publicationTree[0].Title);
 
@@ -1050,7 +981,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
                 var topicAPublications = publicationTree[0].Topics[0].Publications;
 
-                // Publication has a published release, hence it is visible
                 Assert.Single(topicAPublications);
                 Assert.Equal(PublicationType.NationalAndOfficial, topicAPublications[0].Type);
                 Assert.Equal("Publication A", topicAPublications[0].Title);
@@ -1064,7 +994,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 ReleaseName = "2021",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.OfficialStatistics,
+                Type = OfficialStatistics,
                 Published = DateTime.UtcNow,
             };
 
@@ -1079,7 +1009,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     {
                         ReleaseName = "2020",
                         TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                        Type = ReleaseType.OfficialStatistics,
+                        Type = OfficialStatistics,
                         Published = new DateTime(2020, 1, 1),
                     }
                 }
@@ -1159,7 +1089,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 ReleaseName = "2021",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.OfficialStatistics,
+                Type = OfficialStatistics,
                 Published = DateTime.UtcNow,
             };
 
@@ -1174,7 +1104,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     {
                         ReleaseName = "2020",
                         TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                        Type = ReleaseType.OfficialStatistics,
+                        Type = OfficialStatistics,
                         Published = new DateTime(2020, 1, 1),
                     }
                 }
@@ -1254,7 +1184,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 ReleaseName = "2020",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.OfficialStatistics,
+                Type = OfficialStatistics,
                 Published = DateTime.UtcNow,
             };
 
@@ -1262,7 +1192,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 ReleaseName = "2020",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.OfficialStatistics,
+                Type = OfficialStatistics,
                 Published = null,
             };
 
@@ -1348,14 +1278,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 ReleaseName = "2020",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.OfficialStatistics,
+                Type = OfficialStatistics,
                 Published = DateTime.UtcNow,
             };
             var releaseB = new Release
             {
                 ReleaseName = "2020",
                 TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                Type = ReleaseType.NationalStatistics,
+                Type = NationalStatistics,
                 Published = DateTime.UtcNow,
             };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
@@ -108,10 +108,6 @@ public class PublicationCacheService : IPublicationCacheService
     {
         switch (filter)
         {
-            case PublicationTreeFilter.FindStatistics:
-                return !publication.IsSuperseded
-                       && (publication.HasLiveRelease
-                           || publication.Type == PublicationType.Legacy);
             case PublicationTreeFilter.DataTables:
                 return publication.LatestReleaseHasData
                        && !publication.IsSuperseded;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -221,9 +221,8 @@ public class PublicationService : IPublicationService
     private async Task<PublicationTreeTopicViewModel> BuildPublicationTreeTopic(Topic topic)
     {
         var publications = await topic.Publications
+            .Where(publication => publication.LatestPublishedReleaseId != null)
             .ToAsyncEnumerable()
-            .Where(publication =>
-                publication.LatestPublishedReleaseId != null || publication.LegacyPublicationUrl != null)
             .SelectAwait(async publication =>
                 await BuildPublicationTreePublication(publication))
             .OrderBy(publication => publication.Title)
@@ -248,11 +247,7 @@ public class PublicationService : IPublicationService
             Title = publication.Title,
             Slug = publication.Slug,
             Type = type,
-            LegacyPublicationUrl = type == PublicationType.Legacy
-                ? publication.LegacyPublicationUrl?.ToString()
-                : null,
             IsSuperseded = await _publicationRepository.IsSuperseded(publication.Id),
-            HasLiveRelease = latestPublishedReleaseId != null,
             LatestReleaseHasData = latestPublishedReleaseId != null &&
                                    await HasAnyDataFiles(latestPublishedReleaseId.Value),
             AnyLiveReleaseHasData = await publication.Releases
@@ -273,7 +268,7 @@ public class PublicationService : IPublicationService
     {
         if (publication.LatestPublishedReleaseId == null)
         {
-            return PublicationType.Legacy;
+            throw new ArgumentException($"Publication must have a published release", nameof(publication));
         }
 
         await _contentDbContext.Entry(publication)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/PublicationTreeFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/PublicationTreeFilter.cs
@@ -4,7 +4,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Requests
 {
     public enum PublicationTreeFilter
     {
-        FindStatistics,
         DataTables,
         DataCatalogue,
         FastTrack,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationTreePublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationTreePublicationViewModel.cs
@@ -13,14 +13,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 
         public string Slug { get; init; } = string.Empty;
 
-        public string? LegacyPublicationUrl { get; init; }
-
         [JsonConverter(typeof(StringEnumConverter))]
         public PublicationType Type { get; set; }
 
         public bool IsSuperseded { get; set; }
-
-        public bool HasLiveRelease { get; set; }
 
         public bool LatestReleaseHasData { get; set; }
 
@@ -32,7 +28,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
         NationalAndOfficial,
         AdHoc,
         Experimental,
-        ManagementInformation,
-        Legacy
+        ManagementInformation
     }
 }

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -195,11 +195,7 @@ export interface Theme {
 }
 
 interface PublicationTreeOptions {
-  publicationFilter?:
-    | 'FindStatistics'
-    | 'DataTables'
-    | 'DataCatalogue'
-    | 'FastTrack';
+  publicationFilter?: 'DataTables' | 'DataCatalogue' | 'FastTrack';
 }
 
 export default {


### PR DESCRIPTION
⚠️Depends on https://github.com/dfe-analytical-services/explore-education-statistics/pull/3723 ⚠️
⚠️ This has faffy deploy ticket https://dfedigital.atlassian.net/browse/EES-3967 ⚠️ 

This PR removes the `FindStatistics` option from `PublicationTreeFilter` which is the type of the `publicationFilter` query parameter in the Content API GET request `/api/publication-tree?publicationFilter=FindStatistics`.

It also removes `Publication.LegacyPublicationUrl` and drops the corresponding database column from the Publications table.

Both of these are no longer relevant after switching to the new Find Statistics page which neither uses the publication 'tree' or displays legacy publications without releases.

### UI test report

![image](https://user-images.githubusercontent.com/4147126/209031148-33f0ad3c-c8af-4d22-8ee4-7d7bef713f04.png)
