### PR TITLE
EES-3965 - fix test-ids being applied to pagination components

### DIFF
--- a/src/explore-education-statistics-common/src/components/Pagination.tsx
+++ b/src/explore-education-statistics-common/src/components/Pagination.tsx
@@ -17,7 +17,7 @@ type Params = {
 interface LinkRenderProps {
   'aria-current'?: 'page' | undefined;
   'aria-label'?: string;
-  'data-testid'?: string;
+  testId?: string;
   children: ReactNode;
   className: string;
   rel?: 'next' | 'prev';
@@ -60,7 +60,7 @@ const Pagination = ({
           {renderLink({
             className: paginationLinkClassName,
             rel: 'prev',
-            'data-testid': 'pagination-previous',
+            testId: 'pagination-previous',
             to: appendQuery<Params>(baseUrl, {
               ...queryParams,
               page: currentPage - 1,
@@ -115,7 +115,7 @@ const Pagination = ({
           {renderLink({
             className: paginationLinkClassName,
             rel: 'next',
-            'data-testid': 'pagination-next',
+            testId: 'pagination-next',
             to: appendQuery<Params>(baseUrl, {
               ...queryParams,
               page: currentPage + 1,


### PR DESCRIPTION
This PR: 
* Fixes test IDs not being applied to frontend pagination components (in order to aid in the find-stats snapshot script refresh)