### PR TITLE
EES-3966 Fix deleting footnotes when removing a subject belonging to previous release versions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FootnoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FootnoteService.cs
@@ -130,7 +130,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(_ => _statisticsPersistenceHelper.CheckEntityExists<Footnote>(footnoteId)
                 .OnSuccessVoid(async footnote =>
                 {
-                    await _footnoteRepository.DeleteFootnote(releaseId, footnote.Id);
+                    await _footnoteRepository.DeleteFootnote(releaseId: releaseId,
+                        footnoteId: footnote.Id);
 
                     await _dataBlockService.InvalidateCachedDataBlocks(releaseId);
                 }));
@@ -174,7 +175,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     // TODO EES-2979 Remove this delete link and create call once all footnotes only belong to one release
                     // If this amendment of the footnote affects other release then break the link with the old
                     // and create a new one
-                    await _footnoteRepository.DeleteReleaseFootnoteLinkAsync(releaseId, footnote.Id);
+                    await _footnoteRepository.DeleteReleaseFootnoteLink(releaseId, footnote.Id);
 
                     return await _footnoteRepository.CreateFootnote(
                         releaseId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Repository/ReleaseSubjectRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Repository/ReleaseSubjectRepositoryTests.cs
@@ -34,7 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
 
             var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
 
-            footnoteRepository.Setup(mock => mock.DeleteAllFootnotesBySubject(
+            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(
                     releaseSubject.ReleaseId,
                     releaseSubject.SubjectId))
                 .Returns(Task.CompletedTask);
@@ -85,7 +85,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
 
             var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
 
-            footnoteRepository.Setup(mock => mock.DeleteAllFootnotesBySubject(
+            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(
                     releaseSubject.ReleaseId, releaseSubject.SubjectId))
                 .Returns(Task.CompletedTask);
 
@@ -136,7 +136,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
 
             var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
 
-            footnoteRepository.Setup(mock => mock.DeleteAllFootnotesBySubject(
+            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(
                     releaseSubject2.ReleaseId, releaseSubject2.SubjectId))
                 .Returns(Task.CompletedTask);
 
@@ -180,7 +180,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
 
             var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
 
-            footnoteRepository.Setup(mock => mock.DeleteAllFootnotesBySubject(
+            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(
                     It.IsAny<Guid>(), It.IsAny<Guid>()))
                 .Returns(Task.CompletedTask);
 
@@ -235,7 +235,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
 
             var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
 
-            footnoteRepository.Setup(mock => mock.DeleteAllFootnotesBySubject(release.Id,
+            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(release.Id,
                     It.IsIn(releaseSubject1.SubjectId, releaseSubject2.SubjectId)))
                 .Returns(Task.CompletedTask);
 
@@ -299,7 +299,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
 
             var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
 
-            footnoteRepository.Setup(mock => mock.DeleteAllFootnotesBySubject(release.Id,
+            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(release.Id,
                     It.IsIn(releaseSubject1.SubjectId, releaseSubject2.SubjectId)))
                 .Returns(Task.CompletedTask);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IFootnoteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IFootnoteRepository.cs
@@ -32,10 +32,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Inter
 
         Task DeleteFootnote(Guid releaseId, Guid footnoteId);
 
-        Task DeleteAllFootnotesBySubject(Guid releaseId, Guid subjectId);
+        Task DeleteFootnotesBySubject(Guid releaseId, Guid subjectId);
 
         Task<bool> IsFootnoteExclusiveToRelease(Guid releaseId, Guid footnoteId);
 
-        Task DeleteReleaseFootnoteLinkAsync(Guid releaseId, Guid footnoteId);
+        Task DeleteReleaseFootnoteLink(Guid releaseId, Guid footnoteId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/ReleaseSubjectRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/ReleaseSubjectRepository.cs
@@ -76,7 +76,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
                 .FirstOrDefaultAsync(rs => rs.ReleaseId == releaseId && rs.SubjectId == subjectId);
 
             await DeleteReleaseSubjectIfExists(releaseSubject);
-            await _footnoteRepository.DeleteAllFootnotesBySubject(releaseId, subjectId);
+            await _footnoteRepository.DeleteFootnotesBySubject(releaseId, subjectId);
 
             if (releaseSubject?.Subject != null)
             {


### PR DESCRIPTION
This PR fixes a bug where removing a data file fails to remove links between footnotes of the release and the subject or its filter items/filter groups/filters.

It manifests itself as a publishing failure in the data factory stage of publishing.
See [EES-3966](https://dfedigital.atlassian.net/browse/EES-3966) for the exact steps to reproduce that which involves replacing a file before deleting it.

Even in the local environment or an environment without data factory, the footnote links are still present after deleting a subject, and it doesn't require a data file replacement to observe that at the database level.

This PR also attempts to tidy up the `FootnoteRepository.DeleteFootnote` method which previously had a bit of a nasty signature and in certain cases did not delete the footnote.

```
        private async Task DeleteFootnote(Guid releaseId,
            Footnote footnote,
            bool canRemoveReleaseFootnote,
            bool canRemoveFootnote)
```

### Other changes

- Rename method `DeleteReleaseFootnoteLinkAsync` to `DeleteReleaseFootnoteLink`
- Rename method `DeleteAllFootnotesBySubject` to `DeleteFootnotesBySubject`
- Add lots of TODO's related to [EES-2979](https://dfedigital.atlassian.net/browse/EES-2979) which will remove `ReleaseFootnote` and make this code a lot cleaner.

UI test report

![image](https://user-images.githubusercontent.com/4147126/209103077-a77844c5-a083-4e6c-a9b3-e11e01cc3701.png)

\* with local change to `tests/admin_and_public_2/bau/publish_release_and_amend.robot` to include recent fix not on master branch.