### PR TITLE
EES-3965 - add testid to total results

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageNew.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageNew.tsx
@@ -233,6 +233,7 @@ const FindStatisticsPageNew: NextPage = () => {
               aria-live="polite"
               aria-atomic="true"
               className="govuk-!-margin-bottom-2"
+              data-testid="total-results"
             >
               {`${totalResults} ${totalResults !== 1 ? 'results' : 'result'}`}
             </h2>


### PR DESCRIPTION
This PR:
* Adds a test ID to the total results heading on the new find statistics page. This is to support the refresh of the find statistics snapshot script 