### PR TITLE
Public snapshot changes

### DIFF
--- a/tests/robot-tests/tests/snapshots/data_catalogue_snapshot.json
+++ b/tests/robot-tests/tests/snapshots/data_catalogue_snapshot.json
@@ -20,7 +20,8 @@
       "Coronavirus (COVID-19) Reporting in Higher Education Providers",
       "COVID mass testing data in education",
       "Delivery of air cleaning units",
-      "Laptops and tablets data"
+      "Laptops and tablets data",
+      "Vulnerable children and young people survey"
     ],
     "theme_heading": "COVID-19"
   },
@@ -38,6 +39,7 @@
   },
   {
     "publications": [
+      "Childcare and early years provider survey",
       "Childcare and early years survey of parents",
       "Early years foundation stage profile results",
       "Education provision: children under 5 years of age"

--- a/tests/robot-tests/tests/snapshots/find_stats_snapshot.json
+++ b/tests/robot-tests/tests/snapshots/find_stats_snapshot.json
@@ -128,6 +128,19 @@
             "publication_type_heading": "Management information",
             "publications": [
               {
+                "publication_heading": "Vulnerable children and young people survey"
+              }
+            ]
+          }
+        ],
+        "topic_heading": "Children's social care"
+      },
+      {
+        "publication_types": [
+          {
+            "publication_type_heading": "Management information",
+            "publications": [
+              {
                 "publication_heading": "CO2 monitors: cumulative delivery statistics"
               }
             ]
@@ -270,15 +283,10 @@
             "publication_type_heading": "National and official statistics",
             "publications": [
               {
-                "publication_heading": "Childcare and early years survey of parents"
-              }
-            ]
-          },
-          {
-            "publication_type_heading": "Not yet on this service",
-            "publications": [
-              {
                 "publication_heading": "Childcare and early years provider survey"
+              },
+              {
+                "publication_heading": "Childcare and early years survey of parents"
               }
             ]
           }
@@ -417,12 +425,6 @@
             "publications": [
               {
                 "publication_heading": "Graduate labour market statistics"
-              },
-              {
-                "publication_heading": "Graduate outcomes (LEO)"
-              },
-              {
-                "publication_heading": "Graduate outcomes (LEO): postgraduate outcomes"
               },
               {
                 "publication_heading": "LEO Graduate and Postgraduate Outcomes"

--- a/tests/robot-tests/tests/snapshots/table_tool_snapshot.json
+++ b/tests/robot-tests/tests/snapshots/table_tool_snapshot.json
@@ -20,7 +20,8 @@
       "Coronavirus (COVID-19) Reporting in Higher Education Providers",
       "COVID mass testing data in education",
       "Delivery of air cleaning units",
-      "Laptops and tablets data"
+      "Laptops and tablets data",
+      "Vulnerable children and young people survey"
     ],
     "theme_heading": "COVID-19"
   },
@@ -38,6 +39,7 @@
   },
   {
     "publications": [
+      "Childcare and early years provider survey",
       "Childcare and early years survey of parents",
       "Early years foundation stage profile results",
       "Education provision: children under 5 years of age"
@@ -71,8 +73,6 @@
   {
     "publications": [
       "Graduate labour market statistics",
-      "Graduate outcomes (LEO)",
-      "Graduate outcomes (LEO): postgraduate outcomes",
       "Higher Level Learners in England",
       "LEO Graduate and Postgraduate Outcomes",
       "LEO Graduate outcomes provider level data",


### PR DESCRIPTION
PR to review differences in the public snapshots since the last run.

It seems like the snapshots diverged from the Prod service on 15th December when a number of releases went live but the differences have not been caught (we haven't been alerted to them).

### Examples

**Early Years / Early Years Survery / Childcare and early years provider survey**

According to the snapshot it's in legacy Publication type "Not yet on this service", but looking at the Prod service we see it's not (its first release was published 15 December 2022):

![image](https://user-images.githubusercontent.com/4147126/209023025-1e99e15f-a34a-4c29-b0dc-a3f91d58c049.png)

**Higher education / Higher education graduate employment and earnings**

According to the snapshot it should have publications Graduate outcomes (LEO) and Graduate outcomes (LEO): postgraduate outcomes which are not appearing on the Prod service.

![image](https://user-images.githubusercontent.com/4147126/209023691-782940f4-0c8f-4a01-950b-84a2d5a766e4.png)

**COVID-19 / Children's social care / Vulnerable children and young people survey**

This publication wasn't in the snapshot but is in the Prod service.

![image](https://user-images.githubusercontent.com/4147126/209024017-eebeaa6c-4d00-4604-973f-e9461830544d.png)


