### PR TITLE
EES-3968 - fix silent snapshot failures

### DIFF
--- a/tests/robot-tests/scripts/run_tests_pipeline.py
+++ b/tests/robot-tests/scripts/run_tests_pipeline.py
@@ -34,7 +34,7 @@ def run_tests_pipeline():
         else:
             return f"pipenv run python run_tests.py --admin-pass {args.admin_pass} --analyst-pass {args.analyst_pass} --expiredinvite-pass {args.expiredinvite_pass} --slack-webhook-url {args.slack_webhook_url} --env {args.env} --file {args.file} --ci --processes {args.processes} --enable-slack-notifications"
 
-    subprocess.run(get_test_command(), shell=True)
+    subprocess.check_call(get_test_command(), shell=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR:
* Amends `run_tests_pipeline.py` to use `subprocess.check_call` instead of `subprocess.run`. `subprocess.check_call` will raise a `CalledProcessError` exception if the exit code is not `0` which means that when things such as environment variables are missing that `run_tests.py` requires, the CI job will fail & alert us that something needs to be fixed for the snapshot pipeline to run