### PR TITLE
EES-3974 Make 'Add embed block' button only visible to BAU users.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockMigrationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockMigrationServicePermissionTests.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task Migrate()
         {
             await PolicyCheckBuilder()
-                .SetupCheck(SecurityPolicies.CanRunReleaseMigrations, false)
+                .SetupCheck(SecurityPolicies.IsBauUser, false)
                 .AssertForbidden(
                     async userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermalinkMigrationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermalinkMigrationServicePermissionTests.cs
@@ -1,11 +1,11 @@
 ﻿#nullable enable
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using Moq;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
 using static Moq.MockBehavior;
 
@@ -20,7 +20,7 @@ public class PermalinkMigrationServicePermissionTests
     public async Task MigrateAll()
     {
         await PolicyCheckBuilder()
-            .SetupCheck(CanRunReleaseMigrations, false)
+            .SetupCheck(SecurityPolicies.IsBauUser, false)
             .AssertForbidden(
                 async userService =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -55,7 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task ListPublicationSummaries()
         {
             await PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectCheckToFail(SecurityPolicies.CanManageUsersOnSystem)
+                .ExpectCheckToFail(SecurityPolicies.CanViewAllPublications)
                 .AssertForbidden(async userService =>
                 {
                     var service = BuildPublicationService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Security/PermissionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Security/PermissionsController.cs
@@ -45,8 +45,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Secur
                 CanAccessAnalystPages: await _userService.CheckCanAccessAnalystPages().IsRight(),
                 CanAccessAllImports: await _userService.CheckCanViewAllImports().IsRight(),
                 CanAccessPrereleasePages: await _userService.CheckCanAccessPrereleasePages().IsRight(),
-                CanAccessUserAdministrationPages: await _userService.CheckCanManageAllUsers().IsRight(),
-                CanManageAllTaxonomy: await _userService.CheckCanManageAllTaxonomy().IsRight());
+                CanManageAllTaxonomy: await _userService.CheckCanManageAllTaxonomy().IsRight(),
+                IsBauUser: await _userService.CheckIsBauUser().IsRight());
         }
 
         [HttpGet("permissions/topic/{topicId:guid}/publication/create")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Security/PermissionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Security/PermissionsController.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -15,7 +16,7 @@ using static System.DateTime;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Security
 {
-    [Route("api/[controller]")]
+    [Route("api")]
     [ApiController]
     [Authorize]
     public class PermissionsController : ControllerBase
@@ -36,43 +37,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Secur
             _preReleaseService = preReleaseService;
         }
 
-        public class GlobalPermissions
+        [HttpGet("permissions/access")]
+        public async Task<ActionResult<GlobalPermissionsViewModel>> GetGlobalPermissions()
         {
-            public bool CanAccessSystem { get; set; }
-            public bool CanAccessPrereleasePages { get; set; }
-            public bool CanAccessAnalystPages { get; set; }
-            public bool CanAccessAllImports { get; set; }
-            public bool CanAccessUserAdministrationPages { get; set; }
-            public bool CanManageAllTaxonomy { get; set; }
+            return new GlobalPermissionsViewModel(
+                CanAccessSystem: await _userService.CheckCanAccessSystem().IsRight(),
+                CanAccessAnalystPages: await _userService.CheckCanAccessAnalystPages().IsRight(),
+                CanAccessAllImports: await _userService.CheckCanViewAllImports().IsRight(),
+                CanAccessPrereleasePages: await _userService.CheckCanAccessPrereleasePages().IsRight(),
+                CanAccessUserAdministrationPages: await _userService.CheckCanManageAllUsers().IsRight(),
+                CanManageAllTaxonomy: await _userService.CheckCanManageAllTaxonomy().IsRight());
         }
 
-        [HttpGet("access")]
-        public ActionResult<GlobalPermissions> CanAccessSystem()
-        {
-            return new GlobalPermissions
-            {
-                CanAccessSystem = _userService.CheckCanAccessSystem().Result.IsRight,
-                CanAccessAnalystPages = _userService.CheckCanAccessAnalystPages().Result.IsRight,
-                CanAccessAllImports = _userService.CheckCanViewAllImports().Result.IsRight,
-                CanAccessPrereleasePages = _userService.CheckCanAccessPrereleasePages().Result.IsRight,
-                CanAccessUserAdministrationPages = _userService.CheckCanManageAllUsers().Result.IsRight,
-                CanManageAllTaxonomy = _userService.CheckCanManageAllTaxonomy().Result.IsRight
-            };
-        }
-
-        [HttpGet("topic/{topicId}/publication/create")]
+        [HttpGet("permissions/topic/{topicId:guid}/publication/create")]
         public Task<ActionResult<bool>> CanCreatePublicationForTopic(Guid topicId)
         {
             return CheckPolicyAgainstEntity<Topic>(topicId, _userService.CheckCanCreatePublicationForTopic);
         }
 
-        [HttpGet("publication/{publicationId}/release/create")]
+        [HttpGet("permissions/publication/{publicationId:guid}/release/create")]
         public Task<ActionResult<bool>> CanCreateReleaseForPublication(Guid publicationId)
         {
             return CheckPolicyAgainstEntity<Publication>(publicationId, _userService.CheckCanCreateReleaseForPublication);
         }
 
-        [HttpGet("release/{releaseId}/update")]
+        [HttpGet("permissions/release/{releaseId:guid}/update")]
         public Task<ActionResult<bool>> CanUpdateRelease(Guid releaseId)
         {
             return CheckPolicyAgainstEntity<Release>(releaseId, _userService.CheckCanUpdateRelease);
@@ -85,7 +74,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Secur
             public bool CanMarkApproved = false;
         }
 
-        [HttpGet("release/{releaseId}/status")]
+        [HttpGet("permissions/release/{releaseId:guid}/status")]
         public async Task<ActionResult<ReleaseStatusPermissionsViewModel>> GetReleaseStatusPermissions(Guid releaseId)
         {
             return await _persistenceHelper.CheckEntityExists<Release, Guid>(releaseId)
@@ -98,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Secur
                 .OrElse(() => new ReleaseStatusPermissionsViewModel());
         }
 
-        [HttpGet("release/{releaseId}/data/{fileId}")]
+        [HttpGet("permissions/release/{releaseId:guid}/data/{fileId:guid}")]
         public async Task<ActionResult<DataFilePermissions>> GetDataFilePermissions(Guid releaseId, Guid fileId)
         {
             return await _releaseFileService
@@ -110,13 +99,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Secur
                 .HandleFailuresOrOk();
         }
 
-        [HttpGet("release/{releaseId}/amend")]
+        [HttpGet("permissions/release/{releaseId:guid}/amend")]
         public Task<ActionResult<bool>> CanMakeAmendmentOfRelease(Guid releaseId)
         {
             return CheckPolicyAgainstEntity<Release>(releaseId, _userService.CheckCanMakeAmendmentOfRelease);
         }
 
-        [HttpGet("release/{releaseId}/prerelease/status")]
+        [HttpGet("permissions/release/{releaseId:guid}/prerelease/status")]
         public async Task<ActionResult<PreReleaseWindowStatus>> GetPreReleaseWindowStatus(Guid releaseId)
         {
             return await _persistenceHelper
@@ -126,21 +115,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Secur
                 .HandleFailuresOrOk();
         }
 
-        [HttpGet("methodology/{methodologyId}/update")]
+        [HttpGet("permissions/methodology/{methodologyId:guid}/update")]
         public Task<ActionResult<bool>> CanUpdateMethodology(Guid methodologyId)
         {
             return CheckPolicyAgainstEntity<MethodologyVersion>(methodologyId,
                 _userService.CheckCanUpdateMethodologyVersion);
         }
 
-        [HttpGet("methodology/{methodologyId}/status/draft")]
+        [HttpGet("permissions/methodology/{methodologyId:guid}/status/draft")]
         public Task<ActionResult<bool>> CanMarkMethodologyAsDraft(Guid methodologyId)
         {
             return CheckPolicyAgainstEntity<MethodologyVersion>(methodologyId,
                 _userService.CheckCanMarkMethodologyVersionAsDraft);
         }
 
-        [HttpGet("methodology/{methodologyId}/status/approve")]
+        [HttpGet("permissions/methodology/{methodologyId:guid}/status/approve")]
         public Task<ActionResult<bool>> CanApproveMethodology(Guid methodologyId)
         {
             return CheckPolicyAgainstEntity<MethodologyVersion>(methodologyId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
@@ -12,6 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
         CanAccessPrereleasePages,
         CanManageUsersOnSystem,
         CanAccessAllImports,
+        IsBauUser,
 
         /**
          * Publication management
@@ -34,7 +35,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
         CanSubmitSpecificReleaseToHigherReview,
         CanApproveSpecificRelease,
         CanMakeAmendmentOfSpecificRelease,
-        CanRunReleaseMigrations,
         CanPublishSpecificRelease,
         CanDeleteSpecificRelease,
         CanViewSpecificPreReleaseSummary,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
@@ -27,6 +27,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
                 options.AddPolicy(SecurityPolicies.CanAccessSystem.ToString(), policy =>
                     policy.RequireClaim(SecurityClaimTypes.ApplicationAccessGranted.ToString()));
 
+                // does this user have the Bau user role?
+                options.AddPolicy(SecurityPolicies.IsBauUser.ToString(), policy =>
+                    policy.RequireRole(RoleNames.BauUser));
+
                 // does this user have permissions to access analyst pages?
                 options.AddPolicy(SecurityPolicies.CanAccessAnalystPages.ToString(), policy =>
                     policy.RequireClaim(SecurityClaimTypes.AnalystPagesAccessGranted.ToString()));
@@ -102,10 +106,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
                 // does this user have permission to make an amendment of an existing release?
                 options.AddPolicy(SecurityPolicies.CanMakeAmendmentOfSpecificRelease.ToString(), policy =>
                     policy.Requirements.Add(new MakeAmendmentOfSpecificReleaseRequirement()));
-
-                // does this user have permission to run release migration endpoints?
-                options.AddPolicy(SecurityPolicies.CanRunReleaseMigrations.ToString(), policy =>
-                    policy.RequireRole(RoleNames.BauUser));
 
                 // does this user have permission to publish a specific Release?
                 options.AddPolicy(SecurityPolicies.CanPublishSpecificRelease.ToString(), policy =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockMigrationService.cs
@@ -80,7 +80,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, List<MapMigrationResult>>> MigrateMaps(bool dryRun = true)
         {
             return await _userService
-                .CheckCanRunMigrations()
+                .CheckIsBauUser()
                 .OnSuccess(() => DoMapMigration(dryRun));
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
@@ -18,6 +18,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
             return userService.CheckPolicy(SecurityPolicies.CanAccessSystem);
         }
 
+        public static Task<Either<ActionResult, Unit>> CheckIsBauUser(this IUserService userService)
+        {
+            return userService.CheckPolicy(SecurityPolicies.IsBauUser);
+        }
+
         public static Task<Either<ActionResult, Unit>> CheckCanAccessAnalystPages(this IUserService userService)
         {
             return userService.CheckPolicy(SecurityPolicies.CanAccessAnalystPages);
@@ -246,12 +251,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
             this IUserService userService, Release release)
         {
             return userService.CheckPolicy(release, SecurityPolicies.CanMakeAmendmentOfSpecificRelease);
-        }
-
-        public static Task<Either<ActionResult, Unit>> CheckCanRunMigrations(
-            this IUserService userService)
-        {
-            return userService.CheckPolicy(SecurityPolicies.CanRunReleaseMigrations);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanViewPrereleaseContactsList(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PermalinkMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PermalinkMigrationService.cs
@@ -30,7 +30,7 @@ public class PermalinkMigrationService : IPermalinkMigrationService
 
     public async Task<Either<ActionResult, Unit>> MigrateAll()
     {
-        return await _userService.CheckCanRunMigrations()
+        return await _userService.CheckIsBauUser()
             .OnSuccess<ActionResult, Unit, Unit>(async () =>
             {
                 var messageCount = await _storageQueueService.GetApproximateMessageCount(PermalinksMigrationQueue);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -87,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, List<PublicationSummaryViewModel>>> ListPublicationSummaries()
         {
             return await _userService
-                .CheckCanManageAllUsers()
+                .CheckCanViewAllPublications()
                 .OnSuccess(_ =>
                 {
                     return _context.Publications

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/GlobalPermissionsViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/GlobalPermissionsViewModel.cs
@@ -1,0 +1,9 @@
+﻿#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+
+public record GlobalPermissionsViewModel(bool CanAccessSystem,
+    bool CanAccessAnalystPages,
+    bool CanAccessAllImports,
+    bool CanAccessPrereleasePages,
+    bool CanAccessUserAdministrationPages,
+    bool CanManageAllTaxonomy);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/GlobalPermissionsViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/GlobalPermissionsViewModel.cs
@@ -1,9 +1,10 @@
 ﻿#nullable enable
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
-public record GlobalPermissionsViewModel(bool CanAccessSystem,
+public record GlobalPermissionsViewModel(
+    bool CanAccessSystem,
     bool CanAccessAnalystPages,
     bool CanAccessAllImports,
     bool CanAccessPrereleasePages,
-    bool CanAccessUserAdministrationPages,
-    bool CanManageAllTaxonomy);
+    bool CanManageAllTaxonomy,
+    bool IsBauUser);

--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -93,9 +93,7 @@ function App() {
                       {/* <Route path="/prototypes" component={PrototypesEntry} /> */}
                       <ProtectedRoute
                         path="/prototypes"
-                        protectionAction={user =>
-                          user.permissions.canAccessUserAdministrationPages
-                        }
+                        protectionAction={user => user.permissions.isBauUser}
                         component={PrototypesEntry}
                       />
 

--- a/src/explore-education-statistics-admin/src/components/PageFooter.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageFooter.tsx
@@ -21,7 +21,7 @@ const PageFooter = ({ wide }: Props) => {
           <div className="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 className="govuk-visually-hidden">Support links</h2>
             <ul className="govuk-footer__inline-list">
-              {user?.permissions.canAccessUserAdministrationPages && (
+              {user?.permissions.isBauUser && (
                 <>
                   <li className="govuk-footer__inline-list-item">
                     <a className="govuk-footer__link" href="/docs">

--- a/src/explore-education-statistics-admin/src/components/PageHeader.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageHeader.tsx
@@ -122,7 +122,7 @@ const LoggedInLinks = ({ user }: LoggedInLinksProps) => (
       </li>
     )} */}
 
-    {user.permissions.canAccessUserAdministrationPages && (
+    {user.permissions.isBauUser && (
       <li className="govuk-header__navigation-item">
         <a className="govuk-header__link" href="/administration">
           Platform administration

--- a/src/explore-education-statistics-admin/src/contexts/AuthContext.tsx
+++ b/src/explore-education-statistics-admin/src/contexts/AuthContext.tsx
@@ -24,9 +24,9 @@ const defaultPermissions: GlobalPermissions = {
   canAccessSystem: false,
   canAccessPrereleasePages: false,
   canAccessAnalystPages: false,
-  canAccessUserAdministrationPages: false,
   canAccessAllImports: false,
   canManageAllTaxonomy: false,
+  isBauUser: false,
 };
 
 export interface AuthContextState {

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
@@ -15,7 +15,7 @@ import React, { useState } from 'react';
 
 const AdminDashboardPage = () => {
   const { user } = useAuthContext();
-  const isBauUser = user?.permissions.canAccessUserAdministrationPages ?? false;
+  const isBauUser = user?.permissions.isBauUser ?? false;
 
   const [totalDraftReleases, setTotalDraftReleases] = useState<number>(0);
 

--- a/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
@@ -35,7 +35,7 @@ const BauDashboardPage = () => {
         Access to the service
       </h2>
       <div className="govuk-grid-row govuk-!-margin-bottom-9">
-        {user?.permissions.canAccessUserAdministrationPages && (
+        {user?.permissions.isBauUser && (
           <>
             <div className="govuk-grid-column-one-third">
               <h3 className="govuk-heading-s govuk-!-margin-bottom-0">

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -1,5 +1,6 @@
 import EditableAccordionSection from '@admin/components/editable/EditableAccordionSection';
 import EditableSectionBlocks from '@admin/components/editable/EditableSectionBlocks';
+import { useAuthContext } from '@admin/contexts/AuthContext';
 import { useEditingContext } from '@admin/contexts/EditingContext';
 import DataBlockSelectForm from '@admin/pages/release/content/components/DataBlockSelectForm';
 import EditableEmbedForm, {
@@ -39,6 +40,8 @@ const ReleaseContentAccordionSection = ({
 
   const { release } = useReleaseContentState();
   const actions = useReleaseContentActions();
+
+  const { user } = useAuthContext();
 
   const [isReordering, setIsReordering] = useState(false);
   const [showDataBlockForm, toggleDataBlockForm] = useToggle(false);
@@ -232,13 +235,17 @@ const ReleaseContentAccordionSection = ({
                     Add data block
                   </Button>
                 )}
-                {!showEmbedDashboardForm && (
-                  <Button
-                    variant="secondary"
-                    onClick={toggleEmbedDashboardForm.on}
-                  >
-                    Add embed block
-                  </Button>
+                {user?.permissions.isBauUser && (
+                  <>
+                    {!showEmbedDashboardForm && (
+                      <Button
+                        variant="secondary"
+                        onClick={toggleEmbedDashboardForm.on}
+                      >
+                        Add embed block
+                      </Button>
+                    )}
+                  </>
                 )}
               </ButtonGroup>
             </>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContentAccordionSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContentAccordionSection.test.tsx
@@ -1,9 +1,11 @@
+import { AuthContextTestProvider } from '@admin/contexts/AuthContext';
 import EditableAccordion from '@admin/components/editable/EditableAccordion';
 import { EditingContextProvider } from '@admin/contexts/EditingContext';
 import { ReleaseContentHubContextProvider } from '@admin/contexts/ReleaseContentHubContext';
 import { testEditableRelease } from '@admin/pages/release/__data__/testEditableRelease';
 import ReleaseContentAccordionSection from '@admin/pages/release/content/components/ReleaseContentAccordionSection';
 import { ReleaseContentProvider } from '@admin/pages/release/content/contexts/ReleaseContentContext';
+import { GlobalPermissions } from '@admin/services/permissionService';
 import {
   EditableBlock,
   EditableContentBlock,
@@ -78,6 +80,68 @@ describe('ReleaseContentAccordionSection', () => {
           </ReleaseContentHubContextProvider>
         </ReleaseContentProvider>
       </EditingContextProvider>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Edit section title' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Reorder this section' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remove this section' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Add text block' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Add data block' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Add embed block' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders the add embed block button for BAU users', () => {
+    render(
+      <AuthContextTestProvider
+        user={{
+          id: 'user-1',
+          name: 'Jane Doe',
+          permissions: {
+            isBauUser: true,
+          } as GlobalPermissions,
+        }}
+      >
+        <EditingContextProvider editingMode="edit">
+          <ReleaseContentProvider
+            value={{
+              release: testEditableRelease,
+              canUpdateRelease: true,
+              availableDataBlocks: [],
+            }}
+          >
+            <ReleaseContentHubContextProvider
+              releaseId={testEditableRelease.id}
+            >
+              <EditableAccordion
+                onAddSection={noop}
+                id="test-accordion"
+                onReorder={noop}
+              >
+                <ReleaseContentAccordionSection
+                  id="test-section-1"
+                  section={{
+                    ...testSection,
+                    content: [testBlock],
+                  }}
+                />
+              </EditableAccordion>
+            </ReleaseContentHubContextProvider>
+          </ReleaseContentProvider>
+        </EditingContextProvider>
+      </AuthContextTestProvider>,
     );
 
     expect(

--- a/src/explore-education-statistics-admin/src/routes/administrationRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/administrationRoutes.ts
@@ -10,7 +10,7 @@ import UserInvitePage from '@admin/pages/users/UserInvitePage';
 export const administrationIndexRoute: ProtectedRouteProps = {
   path: '/administration',
   component: BauDashboardPage,
-  protectionAction: user => user.permissions.canAccessUserAdministrationPages,
+  protectionAction: user => user.permissions.isBauUser,
   exact: true,
 };
 
@@ -24,35 +24,35 @@ export const administrationImportsRoute: ProtectedRouteProps = {
 export const administrationUsersRoute: ProtectedRouteProps = {
   path: '/administration/users',
   component: BauUsersPage,
-  protectionAction: user => user.permissions.canAccessUserAdministrationPages,
+  protectionAction: user => user.permissions.isBauUser,
   exact: true,
 };
 
 export const administrationUserInviteRoute: ProtectedRouteProps = {
   path: '/administration/users/invites/create',
   component: UserInvitePage,
-  protectionAction: user => user.permissions.canAccessUserAdministrationPages,
+  protectionAction: user => user.permissions.isBauUser,
   exact: true,
 };
 
 export const administrationInvitedUsersRoute: ProtectedRouteProps = {
   path: '/administration/users/invites',
   component: InvitedUsersPage,
-  protectionAction: user => user.permissions.canAccessUserAdministrationPages,
+  protectionAction: user => user.permissions.isBauUser,
   exact: true,
 };
 
 export const administrationPreReleaseUsersRoute: ProtectedRouteProps = {
   path: '/administration/users/pre-release',
   component: PreReleaseUsersPage,
-  protectionAction: user => user.permissions.canAccessUserAdministrationPages,
+  protectionAction: user => user.permissions.isBauUser,
   exact: true,
 };
 
 export const administrationUserManageRoute: ProtectedRouteProps = {
   path: '/administration/users/:userId',
   component: ManageUserPage,
-  protectionAction: user => user.permissions.canAccessUserAdministrationPages,
+  protectionAction: user => user.permissions.isBauUser,
 };
 
 const administrationRoutes = {

--- a/src/explore-education-statistics-admin/src/services/permissionService.ts
+++ b/src/explore-education-statistics-admin/src/services/permissionService.ts
@@ -6,9 +6,9 @@ export interface GlobalPermissions {
   canAccessSystem: boolean;
   canAccessPrereleasePages: boolean;
   canAccessAnalystPages: boolean;
-  canAccessUserAdministrationPages: boolean;
   canAccessAllImports: boolean;
   canManageAllTaxonomy: boolean;
+  isBauUser: boolean;
 }
 
 export interface ReleaseStatusPermissions {


### PR DESCRIPTION
This PR makes the 'Add embed block' button within the admin's content section editor only visible to BAU users. It will be made accessible to all contributors again at a later date.

To restrict visibility of the button it introduces a new front-end and back-end global permission `IsBauUser` which is determined from a new policy of the same name.

### Other changes

* Slight tidy up of  back-end `PermissionsController` - Introduces new record type view model `GlobalPermissionsViewModel`. Constrains all Guid parameter types in api routes. Stops using the controller route `[controller]` and prefixes all routes with `permissions/` instead which isn't susceptible to breaking if the controller class is renamed.
* Removes back-end user extension method `CheckCanRunMigrations` and security policy `SecurityPolicies.CanRunReleaseMigrations` which are replaced by `CheckIsBauUser`.
* Changes back-end `PublicationService.ListPublicationSummaries` to use permission check `CheckIsBauUser` rather than `CheckCanManageAllUsers`.

### UI test report

![image](https://user-images.githubusercontent.com/4147126/210392549-18aa13dd-676a-4e62-ab97-232797b6a649.png)