### PR TITLE
EES-3980 - fixing scheduled Releases not copying staged content consistently

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleasePublishingStatusState.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleasePublishingStatusState.cs
@@ -125,7 +125,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         Failed,
         Queued,
         NotStarted,
-        Started
+        Started,
+        Scheduled
     }
 
     public enum ReleasePublishingStatusFilesStage

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleasesFunction.cs
@@ -7,7 +7,6 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleasePublishingStatusPublishingStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
@@ -77,7 +76,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         {
             return await _releasePublishingStatusService.GetWherePublishingDueTodayWithStages(
                 content: ReleasePublishingStatusContentStage.Scheduled,
-                publishing: Scheduled);
+                files: ReleasePublishingStatusFilesStage.Complete,
+                publishing: ReleasePublishingStatusPublishingStage.Scheduled);
         }
 
         private async Task UpdateContentStage(

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/StageReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/StageReleaseContentFunction.cs
@@ -53,7 +53,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 }).GetNextOccurrence(DateTime.UtcNow);
                 var context = new PublishContext(nextScheduledPublishingTime, true);
                 await _contentService.UpdateContent(context, message.Releases.Select(tuple => tuple.ReleaseId).ToArray());
-                await UpdateContentStage(message, Complete);
+                await UpdateContentStage(message, Scheduled);
             }
             catch (Exception e)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublishingCompletionService.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 
@@ -11,9 +10,5 @@ public interface IPublishingCompletionService
 {
     Task CompletePublishingIfAllPriorStagesComplete(
         IEnumerable<(Guid ReleaseId, Guid ReleaseStatusId)> releaseAndReleaseStatusIds, 
-        DateTime publishedDate);
-    
-    Task CompletePublishingIfAllPriorStagesComplete(
-        ReleasePublishingStatus[] releaseStatuses, 
         DateTime publishedDate);
 }

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -116,7 +116,8 @@ type TaskStage =
   | 'Failed'
   | 'Queued'
   | 'NotStarted'
-  | 'Started';
+  | 'Started'
+  | 'Scheduled';
 
 export interface ReleaseStageStatuses {
   releaseId?: string;


### PR DESCRIPTION
This PR:
- stops the PublishReleaseFilesFunction inadvertently triggering the early completion of Release publishing before the PublishScheduledReleasesFunction has had a chance to successfully unstage the staged content

# Existing behaviour

Prior to this change, at "midnight", the StageScheduledReleasesFunction triggers both the StageReleaseContentFunction and PublishReleaseFilesFunction concurrently for all Releases that are scheduled but not yet published.

The StageReleaseContentFunction marks the "Content" Stage as Complete after content is staged.

The PublishReleaseFilesFunction marks the "Files" Stage as Complete after files are copied.

If the PublishReleaseFilesFunction completes *after* the StageReleaseContentFunction has finished, it calls `_publishingCompletionService.CompletePublishingIfAllPriorStagesComplete()` - and because both the Files and Content stages are both marked as complete at this point, it triggers the completion of the publishing process too early, thus meaning that `PublishScheduledReleasesFunction` doesn't pick up those Releases (as they're already Published), and so the staged content is never moved.

# New behaviour

At "midnight", the StageScheduledReleasesFunction triggers both the StageReleaseContentFunction and PublishReleaseFilesFunction concurrently for all Releases that are scheduled but not yet published.

The StageReleaseContentFunction marks the "Content" Stage as *Scheduled* after content is staged.

The PublishReleaseFilesFunction marks the "Files" Stage as Complete after files are copied.

If the PublishReleaseFilesFunction completes *after* the StageReleaseContentFunction has finished, it calls `_publishingCompletionService.CompletePublishingIfAllPriorStagesComplete()` - and because the Content stage is not yet marked as "Complete" but only "Scheduled", they are now *not* marked as complete at this point.

At "930am", the PublishScheduledReleasesFunction picks up those Releases (as they're scheduled and not yet fully Published), and so the staged content is moved successfully.  It then calls  `_publishingCompletionService.CompletePublishingIfAllPriorStagesComplete() and completes the publishing process at the correct time.

# Still to determine

The above bugfix would imply that the failures would show most prominently in Releases with large Subjects, as this bug is caused by the PublishReleaseFilesFunction completing *after* the Content staging completes.  However, the opposite hs been observed, with this bug showing more prominently (or exclusively) with Releases with *no* Subjects.

# UI test results

![image](https://user-images.githubusercontent.com/12444316/210773166-624bae3b-c1c5-4f03-b60f-b0b493c4f7e9.png)
