### PR TITLE
EES-3967 Switch UI test 'Verify existing theme and topics' to only depend on 'Pupils and schools'

### DIFF
--- a/tests/robot-tests/tests/admin/bau/themes_and_topics.robot
+++ b/tests/robot-tests/tests/admin/bau/themes_and_topics.robot
@@ -24,19 +24,18 @@ Go to 'Manage themes and topics'
     user waits until h1 is visible    Manage themes and topics
 
 Verify existing theme and topics
-    user waits until page contains accordion section    Children, early years and social care
-    user opens accordion section    Children, early years and social care
+    user waits until page contains accordion section    Pupils and schools
+    user opens accordion section    Pupils and schools
     user checks summary list contains    Summary
-    ...    Including children in need, EYFS, and looked after children and social workforce statistics
-    user checks topic is in correct position    Children, early years and social care    1    Childcare and early years
-    user checks topic is in correct position    Children, early years and social care    2
-    ...    Children in need and child protection
-    user checks topic is in correct position    Children, early years and social care    3
-    ...    Children's social work workforce
-    user checks topic is in correct position    Children, early years and social care    4
-    ...    Early years foundation stage profile
-    user checks topic is in correct position    Children, early years and social care    5    Looked-after children
-    user checks topic is in correct position    Children, early years and social care    6    Secure children's homes
+    ...    Including absence, application and offers, capacity exclusion and special educational needs (SEN) statistics
+    user checks topic is in correct position    Pupils and schools    1
+    ...    Exclusions
+    user checks topic is in correct position    Pupils and schools    2
+    ...    Pupil absence
+    user checks topic is in correct position    Pupils and schools    3
+    ...    School and pupil numbers
+    user checks topic is in correct position    Pupils and schools    4
+    ...    School applications
 
 Create theme
     user clicks link    Create theme


### PR DESCRIPTION
This PR changes the UI test 'Verify existing theme and topics' in `admin/bau/themes_and_topic.robot` to only depend on the 'Pupils and schools' seed data rather than 'Children, early years and social care'.

'Children, early years and social care' was a legacy publication which is being removed in the non-prod environments as part of EES-3967 after the switchover to the new Find Stats page.

In Prod all existing legacy publications have either already been removed over time or now have EES releases except for a couple waiting to be cleaned up by EES-3967.