### PR TITLE
EES-3985 Fix general public Find Statistics UI test

### DIFF
--- a/tests/robot-tests/tests/general_public/statistics_page.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page.robot
@@ -14,7 +14,7 @@ Navigate to Find Statistics page
     environment variable should be set    PUBLIC_URL
     user navigates to find statistics page on public frontend
 
-check bootstrapped data
+Validate bootstrapped themes filters exist
     [Tags]    Local    Dev    NotAgainstProd
     user checks radio is checked    All themes
     user checks page contains radio    Pupils and schools
@@ -57,7 +57,6 @@ Validate publications list exists
 Filter by theme
     [Tags]    Local    Dev
     user clicks radio    Pupils and schools
-    user waits until page contains    2 results
     user checks page contains button    Pupils and schools
 
 Remove theme filter


### PR DESCRIPTION
This PR removes a check in UI test `statistics_page.robot - Filter by theme` on the number of results within the Pupils and schools theme because it's different between environments.