### PR TITLE
EES-3990 Fix failing `FindStatisticsPage` tests

### DIFF
--- a/src/explore-education-statistics-common/src/components/Pagination.tsx
+++ b/src/explore-education-statistics-common/src/components/Pagination.tsx
@@ -17,7 +17,7 @@ type Params = {
 interface LinkRenderProps {
   'aria-current'?: 'page' | undefined;
   'aria-label'?: string;
-  testId?: string;
+  'data-testid'?: string;
   children: ReactNode;
   className: string;
   rel?: 'next' | 'prev';
@@ -60,7 +60,7 @@ const Pagination = ({
           {renderLink({
             className: paginationLinkClassName,
             rel: 'prev',
-            testId: 'pagination-previous',
+            'data-testid': 'pagination-previous',
             to: appendQuery<Params>(baseUrl, {
               ...queryParams,
               page: currentPage - 1,
@@ -115,7 +115,7 @@ const Pagination = ({
           {renderLink({
             className: paginationLinkClassName,
             rel: 'next',
-            testId: 'pagination-next',
+            'data-testid': 'pagination-next',
             to: appendQuery<Params>(baseUrl, {
               ...queryParams,
               page: currentPage + 1,

--- a/src/explore-education-statistics-common/src/components/__tests__/Pagination.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Pagination.test.tsx
@@ -493,7 +493,7 @@ function render({
       baseUrl="/test-url"
       currentPage={currentPage}
       // eslint-disable-next-line jsx-a11y/anchor-has-content, react/jsx-props-no-spreading
-      renderLink={({ ...props }) => <a {...props} href={props.to} />}
+      renderLink={props => <a {...props} href={props.to} />}
       totalPages={totalPages}
     />,
   );

--- a/src/explore-education-statistics-frontend/src/components/Pagination.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Pagination.tsx
@@ -22,8 +22,13 @@ const Pagination = ({
       {...props}
       baseUrl={baseUrl ?? router.pathname}
       queryParams={queryParams ?? router.query}
-      renderLink={({ ...linkProps }) => (
-        <Link {...linkProps} scroll={scroll} shallow={shallow} />
+      renderLink={({ 'data-testid': testId, ...linkProps }) => (
+        <Link
+          {...linkProps}
+          testId={testId}
+          scroll={scroll}
+          shallow={shallow}
+        />
       )}
     />
   );

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPage.test.tsx
@@ -232,6 +232,7 @@ describe('FindStatisticsPage', () => {
       results: [testPublications[1], testPublications[2]],
       paging: { ...testPaging, totalPages: 1, totalResults: 2 },
     });
+
     render(<FindStatisticsPage />);
 
     await waitFor(() => {
@@ -270,6 +271,7 @@ describe('FindStatisticsPage', () => {
       results: [],
       paging: { ...testPaging, totalPages: 0, totalResults: 0 },
     });
+
     render(<FindStatisticsPage />);
 
     await waitFor(() => {
@@ -299,6 +301,7 @@ describe('FindStatisticsPage', () => {
       results: [testPublications[1], testPublications[2]],
       paging: { ...testPaging, totalPages: 1, totalResults: 2 },
     });
+
     render(<FindStatisticsPage />);
 
     await waitFor(() => {
@@ -337,10 +340,13 @@ describe('FindStatisticsPage', () => {
       results: [],
       paging: { ...testPaging, totalPages: 0, totalResults: 0 },
     });
+
     render(<FindStatisticsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('0 results')).toBeInTheDocument();
+      expect(
+        screen.getByText('There are no matching results.'),
+      ).toBeInTheDocument();
     });
 
     expect(
@@ -357,10 +363,6 @@ describe('FindStatisticsPage', () => {
       screen.getByRole('button', { name: 'Clear all filters' }),
     ).toBeInTheDocument();
 
-    expect(
-      screen.getByText('There are no matching results.'),
-    ).toBeInTheDocument();
-
     expect(screen.queryByTestId('publicationsList')).not.toBeInTheDocument();
   });
 
@@ -370,6 +372,7 @@ describe('FindStatisticsPage', () => {
       results: [testPublications[1], testPublications[2]],
       paging: { ...testPaging, totalPages: 1, totalResults: 2 },
     });
+
     render(<FindStatisticsPage />);
 
     await waitFor(() => {
@@ -410,10 +413,13 @@ describe('FindStatisticsPage', () => {
       results: [],
       paging: { ...testPaging, totalPages: 0, totalResults: 0 },
     });
+
     render(<FindStatisticsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('0 results')).toBeInTheDocument();
+      expect(
+        screen.getByText('There are no matching results.'),
+      ).toBeInTheDocument();
     });
 
     expect(screen.getByText('0 pages, filtered by:')).toBeInTheDocument();
@@ -428,10 +434,6 @@ describe('FindStatisticsPage', () => {
       screen.getByRole('button', { name: 'Clear all filters' }),
     ).toBeInTheDocument();
 
-    expect(
-      screen.getByText('There are no matching results.'),
-    ).toBeInTheDocument();
-
     expect(screen.queryByTestId('publicationsList')).not.toBeInTheDocument();
   });
 
@@ -443,6 +445,7 @@ describe('FindStatisticsPage', () => {
       results: [testPublications[1], testPublications[2]],
       paging: { ...testPaging, totalPages: 1, totalResults: 2 },
     });
+
     render(<FindStatisticsPage />);
 
     await waitFor(() => {
@@ -477,10 +480,6 @@ describe('FindStatisticsPage', () => {
     expect(
       publicationsList.getByRole('heading', { name: 'Publication 3' }),
     ).toBeInTheDocument();
-
-    expect(
-      screen.queryByText('There are no matching results.'),
-    ).not.toBeInTheDocument();
   });
 
   test('adding filters', async () => {
@@ -941,6 +940,7 @@ describe('FindStatisticsPage', () => {
         results: testPublications,
         paging: testPaging,
       });
+
     render(<FindStatisticsPage />);
 
     await waitFor(() => {


### PR DESCRIPTION
This PR fixes the failing `FindStatisticsPage` tests in the pipeline. These are being caused by relevant test cases not waiting for the correct text to render in the page.

## Other changes

- Changed the `Pagination` component to provide a `data-testid` (instead of `testId`) in its `renderLink` props. This is to prevent potential future bugs from incorrectly spreading it into `<a>` elements.