### PR TITLE
EES-3777 Updates to controller integration tests

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
@@ -1,0 +1,81 @@
+#nullable enable
+using System.Net.Http;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Xunit;
+using static System.Net.HttpStatusCode;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class HttpResponseMessageTestExtensions
+{
+    public static void AssertOk(this HttpResponseMessage message)
+    {
+        Assert.Equal(OK, message.StatusCode);
+    }
+
+    public static T AssertOk<T>(this HttpResponseMessage message)
+    {
+        Assert.Equal(OK, message.StatusCode);
+
+        var body = message.Content.ReadFromJson<T>();
+
+        return Assert.IsType<T>(body);
+    }
+
+    public static string AssertOk(this HttpResponseMessage message, string expectedBody)
+    {
+        Assert.Equal(OK, message.StatusCode);
+        return message.AssertBodyEqualTo(expectedBody);
+    }
+
+    public static T AssertOk<T>(this HttpResponseMessage message, T expectedBody)
+    {
+        Assert.Equal(OK, message.StatusCode);
+        return message.AssertBodyEqualTo(expectedBody);
+    }
+
+    public static void AssertNoContent(this HttpResponseMessage message)
+    {
+        Assert.Equal(NoContent, message.StatusCode);
+        Assert.Empty(message.Content.ReadAsStream().ReadToEnd());
+    }
+
+    public static void AssertNotFound(this HttpResponseMessage message)
+    {
+        Assert.Equal(NotFound, message.StatusCode);
+    }
+
+    public static void AssertForbidden(this HttpResponseMessage message)
+    {
+        Assert.Equal(Forbidden, message.StatusCode);
+    }
+
+    public static void AssertUnauthorized(this HttpResponseMessage message)
+    {
+        Assert.Equal(Unauthorized, message.StatusCode);
+    }
+
+    public static void AssertNotModified(this HttpResponseMessage message)
+    {
+        Assert.Equal(NotModified, message.StatusCode);
+    }
+
+    public static string AssertBodyEqualTo(this HttpResponseMessage message, string expected)
+    {
+        var actual = message.Content.ReadAsStream().ReadToEnd();
+
+        Assert.Equal(expected, actual);
+
+        return actual;
+    }
+
+    public static T AssertBodyEqualTo<T>(this HttpResponseMessage message, T expected)
+    {
+        var body = message.Content.ReadFromJson<T>();
+
+        body = Assert.IsType<T>(body);
+        body.AssertDeepEqualTo(expected);
+
+        return body;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/WebApplicationFactoryExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/WebApplicationFactoryExtensions.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using System;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class WebApplicationFactoryExtensions
+{
+    public static WebApplicationFactory<TEntrypoint> ConfigureServices<TEntrypoint>(
+        this WebApplicationFactory<TEntrypoint> app,
+        Action<IServiceCollection> configureServices) where TEntrypoint : class
+    {
+        return app.WithWebHostBuilder(builder => builder.ConfigureServices(configureServices));
+    }
+
+    public static WebApplicationFactory<TEntrypoint> ResetDbContext<TDbContext, TEntrypoint>(
+        this WebApplicationFactory<TEntrypoint> app
+    )
+        where TDbContext : DbContext
+        where TEntrypoint : class
+    {
+        return app.WithWebHostBuilder(builder => builder.ResetDbContext<TDbContext>());
+    }
+
+    public static WebApplicationFactory<TEntrypoint> AddTestData<TDbContext, TEntrypoint>(
+        this WebApplicationFactory<TEntrypoint> app,
+        Action<TDbContext> testData
+    )
+        where TDbContext : DbContext
+        where TEntrypoint : class
+    {
+        return app.WithWebHostBuilder(builder => builder.AddTestData(testData));
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/WebHostBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/WebHostBuilderExtensions.cs
@@ -4,27 +4,44 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class WebHostBuilderExtensions
 {
-    public static class WebApplicationFactoryExtensions
+    public static IWebHostBuilder ResetDbContext<TDbContext>(this IWebHostBuilder builder) where TDbContext : DbContext
     {
-        public static IWebHostBuilder AddTestData<TDbContext>(
-            this IWebHostBuilder builder,
-            Action<TDbContext> testDataSupplier) where TDbContext : DbContext
-        {
-            return builder.ConfigureServices(
-                services =>
-                {
-                    var provider = services.BuildServiceProvider();
+        return builder.ConfigureServices(
+            services =>
+            {
+                var provider = services.BuildServiceProvider();
 
-                    using var scope = provider.CreateScope();
-                    using var db = scope.ServiceProvider.GetRequiredService<TDbContext>();
+                using var scope = provider.CreateScope();
+                using var db = scope.ServiceProvider.GetRequiredService<TDbContext>();
 
-                    db.Database.EnsureCreated();
+                db.Database.EnsureDeleted();
+                db.Database.EnsureCreated();
+            }
+        );
+    }
 
-                    testDataSupplier(db);
-                }
-            );
-        }
+    public static IWebHostBuilder AddTestData<TDbContext>(
+        this IWebHostBuilder builder,
+        Action<TDbContext> testData) where TDbContext : DbContext
+    {
+        return builder.ConfigureServices(
+            services =>
+            {
+                var provider = services.BuildServiceProvider();
+
+                using var scope = provider.CreateScope();
+                using var db = scope.ServiceProvider.GetRequiredService<TDbContext>();
+
+                db.Database.EnsureCreated();
+
+                testData(db);
+
+                db.SaveChanges();
+            }
+        );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/HttpClientExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/HttpClientExtensions.cs
@@ -1,0 +1,84 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class HttpClientExtensions
+{
+    public static Task<HttpResponseMessage> GetAsync(
+        this HttpClient client,
+        string uri,
+        IDictionary<string, string> headers,
+        CancellationToken cancellationToken = default)
+    {
+        return client.SendAsync(HttpMethod.Get, uri, headers: headers, cancellationToken: cancellationToken);
+    }
+
+    public static Task<HttpResponseMessage> PostAsync(
+        this HttpClient client,
+        string uri,
+        HttpContent content,
+        IDictionary<string, string> headers,
+        CancellationToken cancellationToken = default)
+    {
+        return client.SendAsync(HttpMethod.Post, uri, content, headers, cancellationToken);
+    }
+
+    public static Task<HttpResponseMessage> PatchAsync(
+        this HttpClient client,
+        string uri,
+        HttpContent content,
+        IDictionary<string, string> headers,
+        CancellationToken cancellationToken = default)
+    {
+        return client.SendAsync(HttpMethod.Patch, uri, content, headers, cancellationToken);
+    }
+
+
+    public static Task<HttpResponseMessage> PutAsync(
+        this HttpClient client,
+        string uri,
+        HttpContent content,
+        IDictionary<string, string> headers,
+        CancellationToken cancellationToken = default)
+    {
+        return client.SendAsync(HttpMethod.Put, uri, content, headers, cancellationToken);
+    }
+
+    public static Task<HttpResponseMessage> DeleteAsync(
+        this HttpClient client,
+        string uri,
+        HttpContent content,
+        IDictionary<string, string> headers,
+        CancellationToken cancellationToken = default)
+    {
+        return client.SendAsync(HttpMethod.Delete, uri, content, headers, cancellationToken);
+    }
+
+    private static Task<HttpResponseMessage> SendAsync(
+        this HttpClient client,
+        HttpMethod method,
+        string uri,
+        HttpContent? content = null,
+        IDictionary<string, string>? headers = null,
+        CancellationToken cancellationToken = default)
+    {
+        var message = new HttpRequestMessage
+        {
+            Method = method,
+            RequestUri = new Uri(uri, UriKind.RelativeOrAbsolute),
+            Content = content,
+        };
+
+        if (headers is not null)
+        {
+            message.AddHeaders(headers);
+        }
+
+        return client.SendAsync(message, cancellationToken);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/HttpContentExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/HttpContentExtensions.cs
@@ -1,0 +1,122 @@
+#nullable enable
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class HttpContentExtensions
+{
+    public static Task<T?> ReadFromJsonAsync<T>(
+        this HttpContent content,
+        JsonSerializerSettings? settings = null,
+        CancellationToken cancellationToken = default)
+    {
+        return content.ReadFromJsonAsync<T>(Encoding.UTF8, settings, cancellationToken);
+    }
+
+    /// <summary>
+    /// Read JSON serialised content using <see cref="Newtonsoft.Json"/> asynchronously.
+    /// </summary>
+    ///
+    /// <remarks>
+    /// <para>
+    /// This should be used instead of the method from <see cref="System.Net.Http.Json.HttpContentJsonExtensions"/>,
+    /// which uses the newer <see cref="System.Text.Json"/> APIs.
+    /// </para>
+    /// <para>
+    /// Ideally, we'll want to remove this extension if we ever migrate to <see cref="System.Text.Json"/>
+    /// for our API requests and responses.
+    /// </para>
+    /// </remarks>
+    ///
+    /// <param name="content">The JSON serialised HTTP content.</param>
+    /// <param name="sourceEncoding">The content's character encoding.</param>
+    /// <param name="settings">The settings for deserializing the JSON.</param>
+    /// <param name="cancellationToken">A token to signal that the read should be cancelled.</param>
+    /// <typeparam name="T">The type of the object that the JSON should deserialize to.</typeparam>
+    /// <returns>The deserialized object.</returns>
+    public static async Task<T?> ReadFromJsonAsync<T>(
+        this HttpContent content,
+        Encoding sourceEncoding,
+        JsonSerializerSettings? settings = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var contentStream =
+            await GetContentStreamAsync(content, sourceEncoding, cancellationToken).ConfigureAwait(false);
+
+        using var streamReader = new StreamReader(contentStream);
+        await using var reader = new JsonTextReader(streamReader);
+
+        // This isn't actually asynchronous. It doesn't look like
+        // Json.NET is likely to ever implement this option.
+        // See: https://github.com/JamesNK/Newtonsoft.Json/issues/1193.
+        return JsonSerializer.Create(settings).Deserialize<T>(reader);
+    }
+
+    public static T? ReadFromJson<T>(
+        this HttpContent content,
+        JsonSerializerSettings? settings = null,
+        CancellationToken cancellationToken = default)
+    {
+        return content.ReadFromJson<T>(Encoding.UTF8, settings, cancellationToken);
+    }
+
+    /// <summary>
+    /// Read JSON serialised content using <see cref="Newtonsoft.Json"/>.
+    /// </summary>
+    ///
+    /// <remarks>
+    /// Prefer to use asynchronous version of this method, however, it can be acceptable
+    /// to use this in test code.
+    /// </remarks>
+    ///
+    /// <param name="content">The JSON serialised HTTP content.</param>
+    /// <param name="sourceEncoding">The content's character encoding.</param>
+    /// <param name="settings">The settings for deserializing the JSON.</param>
+    /// <param name="cancellationToken">A token to signal that the read should be cancelled.</param>
+    /// <typeparam name="T">The type of the object that the JSON should deserialize to.</typeparam>
+    /// <returns>The deserialized object.</returns>
+    public static T? ReadFromJson<T>(
+        this HttpContent content,
+        Encoding sourceEncoding,
+        JsonSerializerSettings? settings = null,
+        CancellationToken cancellationToken = default)
+    {
+        using var contentStream = GetContentStream(content, sourceEncoding, cancellationToken);
+        using var streamReader = new StreamReader(contentStream);
+        using var reader = new JsonTextReader(streamReader);
+
+        return JsonSerializer.Create(settings).Deserialize<T>(reader);
+    }
+
+    private static Stream GetContentStream(
+        HttpContent content,
+        Encoding sourceEncoding,
+        CancellationToken cancellationToken)
+    {
+        var contentStream = content.ReadAsStream(cancellationToken);
+
+        return sourceEncoding.Equals(Encoding.UTF8)
+            ? contentStream
+            : GetTranscodingStream(contentStream, sourceEncoding);
+    }
+
+    private static async Task<Stream> GetContentStreamAsync(
+        HttpContent content,
+        Encoding sourceEncoding,
+        CancellationToken cancellationToken)
+    {
+        var contentStream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        return sourceEncoding.Equals(Encoding.UTF8)
+            ? contentStream
+            : GetTranscodingStream(contentStream, sourceEncoding);
+    }
+
+    private static Stream GetTranscodingStream(Stream contentStream, Encoding sourceEncoding) =>
+        Encoding.CreateTranscodingStream(contentStream, sourceEncoding, Encoding.UTF8);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/HttpRequestMessageExtensions.cs
@@ -1,0 +1,16 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class HttpRequestMessageExtensions
+{
+    public static void AddHeaders(this HttpRequestMessage message, IDictionary<string, string> headers)
+    {
+        foreach (var header in headers)
+        {
+            message.Headers.Add(header.Key, header.Value);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/TimePeriodQuery.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/TimePeriodQuery.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query
 {
-    public class TimePeriodQuery
+    public record TimePeriodQuery
     {
         public int StartYear { get; set; }
 
@@ -26,19 +26,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query
             StartCode = startCode;
             EndYear = endYear;
             EndCode = endCode;
-        }
-
-        public TimePeriodQuery Clone()
-        {
-            return (TimePeriodQuery)MemberwiseClone();
-        }
-
-        public override string ToString()
-        {
-            return $"{nameof(StartYear)}: {StartYear}, " +
-                   $"{nameof(StartCode)}: {StartCode.GetEnumValue()}, " +
-                   $"{nameof(EndYear)}: {EndYear}, " +
-                   $"{nameof(EndCode)}: {EndCode.GetEnumValue()}";
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/JsonNetContent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/JsonNetContent.cs
@@ -1,0 +1,33 @@
+#nullable enable
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+/// <summary>
+/// Provides content as a JSON string serialised using <see cref="Newtonsoft.Json"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This class is not to be confused with <see cref="System.Net.Http.Json.JsonContent"/>,
+/// which is intended for use with the newer <see cref="System.Text.Json"/> APIs.
+/// </para>
+/// <para>
+/// We will need remove this in favour of <see cref="System.Net.Http.Json.JsonContent"/>
+/// if we ever intend migrate to <see cref="System.Text.Json"/>.
+/// </para>
+/// </remarks>
+public class JsonNetContent : StringContent
+{
+    private static readonly Encoding DefaultEncoding = Encoding.UTF8;
+    private const string MediaType = MediaTypeNames.Application.Json;
+
+    public JsonNetContent(object content, JsonSerializerSettings? settings = null, Encoding? encoding = null) : base(
+        content: JsonConvert.SerializeObject(content, settings),
+        encoding: encoding ?? DefaultEncoding,
+        mediaType: MediaType)
+    {
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
@@ -23,6 +23,8 @@
     <ItemGroup>
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Api\GovUk.Education.ExploreEducationStatistics.Content.Api.csproj" />
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common.Tests\GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj" />
+        <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model.Tests\GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj" />
+        <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Model.Tests\GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/TestStartup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/TestStartup.cs
@@ -2,8 +2,11 @@
 using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
@@ -54,6 +57,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests
         public void Configure(IApplicationBuilder app)
         {
             app.UseMvc();
+        }
+    }
+
+    public static class TestStartupExtensions
+    {
+        public static WebApplicationFactory<TestStartup> ResetDbContexts(this WebApplicationFactory<TestStartup> testApp)
+        {
+            return testApp
+                .ResetContentDbContext()
+                .ResetStatisticsDbContext();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Utils/ContentDbUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Utils/ContentDbUtils.cs
@@ -1,5 +1,8 @@
+#nullable enable
 using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils
@@ -28,6 +31,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils
         public static ContentDbContext InMemoryContentDbContext(bool updateTimestamps = true)
         {
             return new ContentDbContext(InMemoryContentDbContextOptions(), updateTimestamps);
+        }
+
+        public static WebApplicationFactory<TEntrypoint> ResetContentDbContext<TEntrypoint>(
+            this WebApplicationFactory<TEntrypoint> app)
+            where TEntrypoint : class
+        {
+            return app.ResetDbContext<ContentDbContext, TEntrypoint>();
+        }
+
+        public static WebApplicationFactory<TEntrypoint> AddContentDbTestData<TEntrypoint>(
+            this WebApplicationFactory<TEntrypoint> app,
+            Action<ContentDbContext> testData
+        )
+            where TEntrypoint : class
+        {
+            return app.AddTestData(testData);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/TestStartup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/TestStartup.cs
@@ -1,0 +1,72 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using static GovUk.Education.ExploreEducationStatistics.Common.Utils.StartupUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests;
+
+/// <summary>
+/// Generic test application startup for use in integration tests.
+/// </summary>
+/// <remarks>
+/// Use in combination with <see cref="TestApplicationFactory{TStartup}"/>
+/// as a test class fixture.
+/// </remarks>
+public class TestStartup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddMvcCore(options => { options.EnableEndpointRouting = false; })
+            .AddNewtonsoftJson(
+                options => { options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore; }
+            );
+
+        services.AddControllers(
+                options => { options.ModelBinderProviders.Insert(0, new SeparatedQueryModelBinderProvider(",")); }
+            )
+            .AddApplicationPart(typeof(Startup).Assembly);
+
+        services.AddDbContext<StatisticsDbContext>(
+            options =>
+                options.UseInMemoryDatabase(
+                    "TestStatisticsDb",
+                    b => b.EnableNullChecks(false)
+                )
+        );
+
+        services.AddDbContext<ContentDbContext>(
+            options =>
+                options.UseInMemoryDatabase(
+                    "TestContentDb",
+                    b => b.EnableNullChecks(false)
+                )
+        );
+
+        AddPersistenceHelper<ContentDbContext>(services);
+        AddPersistenceHelper<StatisticsDbContext>(services);
+    }
+
+    public void Configure(IApplicationBuilder app)
+    {
+        app.UseMvc();
+    }
+}
+
+public static class TestStartupExtensions
+{
+    public static WebApplicationFactory<TestStartup> ResetDbContexts(this WebApplicationFactory<TestStartup> testApp)
+    {
+        return testApp
+            .ResetContentDbContext()
+            .ResetStatisticsDbContext();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/TableBuilderQueryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/TableBuilderQueryViewModel.cs
@@ -5,15 +5,26 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.ViewModels;
 
-public record TableBuilderQueryViewModel(Guid PublicationId,
-    Guid SubjectId,
-    TimePeriodQuery TimePeriod,
-    IEnumerable<Guid> Filters,
-    IEnumerable<Guid> Indicators,
-    IEnumerable<Guid> LocationIds)
+public record TableBuilderQueryViewModel
 {
-    public TableBuilderQueryViewModel(Guid publicationId, ObservationQueryContext query) :
-        this(publicationId, query.SubjectId, query.TimePeriod, query.Filters, query.Indicators, query.LocationIds)
+    public Guid PublicationId { get; init; }
+    public Guid SubjectId { get; init; }
+    public TimePeriodQuery TimePeriod { get; init; }
+    public IEnumerable<Guid> Filters { get; init; }
+    public IEnumerable<Guid> Indicators { get; init; }
+    public IEnumerable<Guid> LocationIds { get; init; }
+
+    public TableBuilderQueryViewModel()
     {
+    }
+
+    public TableBuilderQueryViewModel(Guid publicationId, ObservationQueryContext query)
+    {
+        PublicationId = publicationId;
+        SubjectId = query.SubjectId;
+        TimePeriod = query.TimePeriod;
+        Filters = query.Filters;
+        Indicators = query.Indicators;
+        LocationIds = query.LocationIds;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Utils/StatisticsDbUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Utils/StatisticsDbUtils.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils;
@@ -17,5 +19,22 @@ public static class StatisticsDbUtils
     public static StatisticsDbContext InMemoryStatisticsDbContext(bool updateTimestamps = true)
     {
         return InMemoryStatisticsDbContext(Guid.NewGuid().ToString());
+    }
+
+    public static WebApplicationFactory<TEntrypoint> ResetStatisticsDbContext<TEntrypoint>(
+        this WebApplicationFactory<TEntrypoint> app
+    )
+        where TEntrypoint : class
+    {
+        return app.ResetDbContext<StatisticsDbContext, TEntrypoint>();
+    }
+
+    public static WebApplicationFactory<TEntrypoint> AddStatisticsDbTestData<TEntrypoint>(
+        this WebApplicationFactory<TEntrypoint> app,
+        Action<StatisticsDbContext> testData
+    )
+        where TEntrypoint : class
+    {
+        return app.AddTestData(testData);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
@@ -96,7 +96,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
                 ChangeTracker.Tracked += DbContextUtils.UpdateTimestamps;
             }
 
-            if (timeout.HasValue)
+            if (timeout.HasValue && Database.IsRelational())
             {
                 Database.SetCommandTimeout(timeout);
             }


### PR DESCRIPTION
This PR updates existing integration testing code to have better ergonomics and be more inline with other unit test code.

## Integration test setup

The main change is that we can now avoid setup in the integration test class constructor and setup our integration test like we would any other unit test.

> Previously, the pattern was to perform setup in the constructor, including for test data. This isn't great as it's not particularly convenient and doesn't follow typical unit test conventions.

The pattern so far is something like this:

```cs
public TestApplicationFactory<TestStartup> SetupApp(IYourService? yourService = null)
{
  return _testApp
      .ResetDbContexts()
      .ConfigureServices(services => {
        services.AddTransient(_ => yourService ?? Mock.Of<IYourService>);
      });
}
```

This can then be used in a test like:

```cs
var yourService = new Mock<IYourService>(Strict);

var client = SetupApp(yourService: yourService.Object).CreateClient();
```

### Note on resetting databases

As a test application is injected as a property of a test class, it preserves state between test methods. This means that we need a way to reset the database state between tests as we typically don't rely on state to be preserved between tests (could easily cause bugs in tests).

To do this, we have added a `ResetDbContexts` extension method that should be called as part of the test app's setup e.g.

```cs
public TestApplicationFactory<TestStartup> SetupApp()
{
    return _testApp.ResetDbContexts();
}
```

Each `TestStartup` class should define it's own `ResetDatabases` method to do this.

## Adding test data to test cases

Test data can be added in a manner similar to unit tests. This is done like the following:

```cs
_testApp
    .AddContentDbTestData(context => {
        context.ContentEntity.Add(contentEntity);
    });
    .AddStatisticsDbTestData(context => {
        context.StatsEntity.Add(statsEntity);
    });
```

Note that these extensions automatically save the changes, so we don't need to call `SaveChanges` at the end of the callback.

## Asserting on HTTP responses

To provide additional conveniences, we have implemented various extensions to work with our test application's HTTP responses.

The API of this is very similar to how we assert on `ActionResult` in unit tests. This looks like:

```cs
var response = await client.GetAsync("/api/your-endpoint");

var expected = new SomeViewModel
{
    Stuff = "Some stuff"
}

response.AssertOk(); // Assert 200 OK
response.AssertOk(expected); // Assert 200 OK and the body is expected deserialised JSON
response.AssertOk(@"{""stuff": ""Some stuff""}"); // Assert OK and the body is expected text
response.AssertNotFound(); // Assert 404 Not Found
// etc...
```

### Note on JSON serialisation

Currently, we are using the `Newtonsoft.Json` project for JSON serialisation/deserialisation. Unfortunately, this comes with some big caveats in that:
- The project isn't really being maintained properly anymore and seems to have gone into a frozen state
- Microsoft have introduced native, performant JSON serialisation via the `System.Text.Json` APIs. These are the natural successor to `Newtonsoft.Json`.

The `System.Text.Json` APIs are very similar to `Newtonsoft.Json`, but doesn't quite have feature parity. See this [migration guide](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/migrate-from-newtonsoft?pivots=dotnet-6-0).

The main issue with not using the `System.Text.Json` APIs is that we don't get access to a bunch of extension methods that .NET already provides for reading JSON. This is particularly important for our integration tests as we are working with raw JSON that needs to be dseserialised.

Consequently, I've had to re-implement a bunch of .NET code for working with JSON in the `HttpContentExtensions` and `JsonNetContent` classes. Ideally, we should try to migrate to the `System.Text.Json` APIs in the future so we can remove this code completely and rely on the built-ins.