### PR TITLE
EES-3999 Update 'Related information' links on Find statistics page

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
@@ -18,6 +18,7 @@ import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import { useMobileMedia } from '@common/hooks/useMedia';
+import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
 import Pagination from '@frontend/components/Pagination';
 import FilterClearButton from '@frontend/modules/find-statistics/components/FilterClearButton';
@@ -172,40 +173,15 @@ const FindStatisticsPage: NextPage = () => {
           <RelatedInformation heading="Related information">
             <ul className="govuk-list">
               <li>
-                <a
-                  href="https://www.gov.uk/government/organisations/ofsted/about/statistics"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Ofsted statistics
-                </a>
+                <Link to="/data-catalogue">
+                  Education statistics: data catalogue
+                </Link>
               </li>
               <li>
-                <a
-                  href="https://www.education-ni.gov.uk/topics/statistics-and-research/statistics"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Educational statistics for Northern Ireland
-                </a>
+                <Link to="/methodology">Education statistics: methodology</Link>
               </li>
               <li>
-                <a
-                  href="https://www.gov.scot/statistics-and-research/?cat=filter&amp;topics=Education"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Educational statistics for Scotland
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://statswales.gov.wales/Catalogue/Education-and-Skills"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Educational statistics for Wales
-                </a>
+                <Link to="/glossary">Education statistics: glossary</Link>
               </li>
             </ul>
           </RelatedInformation>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPage.test.tsx
@@ -55,16 +55,15 @@ describe('FindStatisticsPage', () => {
       'link',
     );
 
-    expect(relatedInformationLinks).toHaveLength(4);
-    expect(relatedInformationLinks[0]).toHaveTextContent('Ofsted statistics');
+    expect(relatedInformationLinks).toHaveLength(3);
+    expect(relatedInformationLinks[0]).toHaveTextContent(
+      'Education statistics: data catalogue',
+    );
     expect(relatedInformationLinks[1]).toHaveTextContent(
-      'Educational statistics for Northern Ireland',
+      'Education statistics: methodology',
     );
     expect(relatedInformationLinks[2]).toHaveTextContent(
-      'Educational statistics for Scotland',
-    );
-    expect(relatedInformationLinks[3]).toHaveTextContent(
-      'Educational statistics for Wales',
+      'Education statistics: glossary',
     );
   });
 

--- a/tests/robot-tests/tests/general_public/statistics_page.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page.robot
@@ -14,6 +14,24 @@ Navigate to Find Statistics page
     environment variable should be set    PUBLIC_URL
     user navigates to find statistics page on public frontend
 
+Validate Related information section and links exist
+    ${relatedInformation}=    get webelement    css:[aria-labelledby="related-information"]
+
+    user checks element contains child element    ${relatedInformation}    xpath://h2[text()="Related information"]
+
+    user checks page contains link with text and url
+    ...    Education statistics: data catalogue
+    ...    /data-catalogue
+    ...    ${relatedInformation}
+    user checks page contains link with text and url
+    ...    Education statistics: methodology
+    ...    /methodology
+    ...    ${relatedInformation}
+    user checks page contains link with text and url
+    ...    Education statistics: glossary
+    ...    /glossary
+    ...    ${relatedInformation}
+
 Validate bootstrapped themes filters exist
     [Tags]    Local    Dev    NotAgainstProd
     user checks radio is checked    All themes


### PR DESCRIPTION
This PR updates the links in the Related Information section of the new Find statistics page to be the same as they were on the old Find statistics page with the exception of adding one new link to the Data catalogue page.

It also adds a UI test for the links.

Before (new page):

![image](https://user-images.githubusercontent.com/4147126/212359007-ec0c198f-0576-404e-92ad-6f53e5ef363c.png)

Before (old page):

![image](https://user-images.githubusercontent.com/4147126/212359285-dd460c09-ee23-454e-9cb9-5c419679d5c4.png)

After (new page):

![image](https://user-images.githubusercontent.com/4147126/212359167-71ab65c0-6260-4055-92ba-04a9876aae75.png)

### UI test report

![image](https://user-images.githubusercontent.com/4147126/212359406-a56578bd-09a9-491b-9b3c-a33f1432f50f.png)

