### PR TITLE
EES-3975 - add notice to new find stats page denoting the page has changed

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/Page.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Page.tsx
@@ -37,7 +37,6 @@ const Page = ({
   breadcrumbs = [],
 }: Props) => {
   const router = useRouter();
-
   return (
     <>
       <CookieBanner wide={wide} />

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
@@ -31,6 +31,9 @@ import compact from 'lodash/compact';
 import omit from 'lodash/omit';
 import { useRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
+import InsetText from '@common/components/InsetText';
+import classNames from 'classnames';
+import Link from '@frontend/components/Link';
 
 export interface FindStatisticsPageQuery {
   page?: number;
@@ -161,6 +164,21 @@ const FindStatisticsPage: NextPage = () => {
           : undefined
       }
     >
+      <InsetText>
+        <h2 className="govuk-heading-m">This page has changed</h2>
+        <p className={classNames('govuk-body', 'govuk-warning-text')}>
+          Following user feedback we’ve made some changes to this page to make
+          our publications easier to find, if you have any comments on the new
+          design please let us know via the{' '}
+          <Link
+            to="https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-XMiKzsnr8xJoWM_DeGwIu9UNDJHOEJDRklTNVA1SDdLOFJITEwyWU1OQS4u"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            survey
+          </Link>
+        </p>
+      </InsetText>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <p className="govuk-body-l">


### PR DESCRIPTION
This PR: 
* adds a notice to the new find statistics page which denotes that the design has changed & prompts the user to provide feedback via the beta survey link
![Screenshot 2023-01-13 at 16 34 47](https://user-images.githubusercontent.com/55030296/212371570-06105c20-44a7-46fc-b726-73f271696c1b.png)

