### PR TITLE
EES-4000 Reorder release types guidance

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/FilterModals.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/FilterModals.tsx
@@ -26,26 +26,6 @@ export const ReleaseTypesModal = ({
     {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
     <div className={styles.content} tabIndex={0}>
       <SummaryList>
-        <SummaryListItem term="Ad hoc statistics">
-          Releases of statistics which are not part of DfE's regular annual
-          official statistical release calendar.
-        </SummaryListItem>
-        <SummaryListItem term="Experimental statistics">
-          Experimental statistics are newly developed or innovative official
-          statistics that are undergoing evaluation. They are published to
-          involve users and stakeholders in the assessment of their suitability
-          and quality at an early stage. These statistics will reach a point
-          where the label, experimental statistics, can be removed, or should be
-          discontinued.
-        </SummaryListItem>
-        <SummaryListItem term="Management information (MI)">
-          Management information describes aggregate information collated and
-          used in the normal course of business to inform operational delivery,
-          policy development or the management of organisational performance. It
-          is usually based on administrative data but can also be a product of
-          survey data. The terms administrative data and management information
-          are sometimes used interchangeably.
-        </SummaryListItem>
         <SummaryListItem term="National statistics">
           National statistics are official statistics that have been assessed by
           the Office for Statistics Regulation as fully compliant with the Code
@@ -58,6 +38,26 @@ export const ReleaseTypesModal = ({
           agencies), the Devolved Administrations in Scotland, Wales and
           Northern Ireland, any other person acting on behalf of the Crown or
           any other organisation named on an Official Statistics Order.
+        </SummaryListItem>
+        <SummaryListItem term="Experimental statistics">
+          Experimental statistics are newly developed or innovative official
+          statistics that are undergoing evaluation. They are published to
+          involve users and stakeholders in the assessment of their suitability
+          and quality at an early stage. These statistics will reach a point
+          where the label, experimental statistics, can be removed, or should be
+          discontinued.
+        </SummaryListItem>
+        <SummaryListItem term="Ad hoc statistics">
+          Releases of statistics which are not part of DfE's regular annual
+          official statistical release calendar.
+        </SummaryListItem>
+        <SummaryListItem term="Management information (MI)">
+          Management information describes aggregate information collated and
+          used in the normal course of business to inform operational delivery,
+          policy development or the management of organisational performance. It
+          is usually based on administrative data but can also be a product of
+          survey data. The terms administrative data and management information
+          are sometimes used interchangeably.
         </SummaryListItem>
       </SummaryList>
     </div>


### PR DESCRIPTION
This PR updates the release type guidance in the relate type filters modal 'What are release types?' on the Find Statistics page

It changes the order of the release types to reflect their priority

- National statistics
- Official statistics
- Experimental statistics
- Ad hoc statistics
- Management information

Before:

![image](https://user-images.githubusercontent.com/4147126/212648326-4498684b-8a7f-42b1-a246-556a82e6d050.png)

After:

![image](https://user-images.githubusercontent.com/4147126/212647985-29425c6e-ff65-494e-8841-18f5cddb0c83.png)

