### PR TITLE
Fix bug getting the total number of pages on the find statistics page

### DIFF
--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -1,6 +1,7 @@
 import argparse
 import base64
 import json
+import math
 import os
 
 import requests
@@ -51,7 +52,7 @@ class SnapshotService:
 
         total_results = driver.find_element(By.XPATH, "//*[@data-testid='total-results']").text.split(" ")[0]
 
-        total_pages = int(total_results) // self.page_size
+        total_pages = math.ceil(int(total_results) / self.page_size)
 
         # A-Z sort in order to get all the publications
         driver.find_element(By.CSS_SELECTOR, "input[value='title']").click()


### PR DESCRIPTION
Small bug fix to correct the total number of pages that the script iterates over on the find statistics page.

It was previously using the `//` to perform floor division, rounding down. This is changed to use `match.ceil` to round up to the nearest whole number.