### PR TITLE
EES-3939 add overflow to tables in content

### DIFF
--- a/src/explore-education-statistics-common/src/styles/_content.scss
+++ b/src/explore-education-statistics-common/src/styles/_content.scss
@@ -18,6 +18,10 @@
     max-width: 100%;
     min-width: 50px;
   }
+
+  .table {
+    overflow: auto;
+  }
 }
 
 .dfe-content-overflow {


### PR DESCRIPTION
Tables added in CKEditor could overflow the page on small screens, I've added overflow:auto to their container so that it will scroll instead.

**Before:**
![table-before](https://user-images.githubusercontent.com/81572860/212927619-8fb43968-f6ba-4c20-835d-e56db5cc5ef4.PNG)

**After:**
![table-after](https://user-images.githubusercontent.com/81572860/212927633-b55859ed-35eb-48d4-a00b-fdb21cb62cec.PNG)
