### PR TITLE
EES-4008 Prod UI test fixes after new Find Statistics page

### DIFF
--- a/tests/robot-tests/tests/general_public/no_javascript.robot
+++ b/tests/robot-tests/tests/general_public/no_javascript.robot
@@ -10,10 +10,11 @@ Force Tags      GeneralPublic    Local    Dev    Test    Preprod    Prod
 *** Test Cases ***
 Parse Find Statistics page HTML
     [Documentation]    EES-1186
-    # sortBy oldest here so Pupil absence is on the page.
-    ${parsed_page}=    user gets parsed html from page    %{PUBLIC_URL}/find-statistics?sortBy=oldest
+    # search by keywords here so Pupil absence is on the page.
+    ${parsed_page}=    user gets parsed html from page
+    ...    %{PUBLIC_URL}/find-statistics?sortBy=relevance&search=Pupil+absence+in+schools+in+England
     set suite variable    ${parsed_page}
 
-Validate Pupils absence publication on page
+Validate Pupil absence publication on page
     ${list}=    user_gets_publications_list    ${parsed_page}
     user_checks_list_contains_publication    ${list}    Pupil absence in schools in England

--- a/tests/robot-tests/tests/general_public/notifications_absence.robot
+++ b/tests/robot-tests/tests/general_public/notifications_absence.robot
@@ -11,20 +11,8 @@ Test Setup          fail test fast if required
 *** Test Cases ***
 Navigate to Absence publication
     [Tags]    Local
-    user navigates to public frontend
-    user waits until page contains    Explore our statistics and data
-
-    user clicks link    Explore
-    user waits until page contains
-    ...    Find statistics and data
-    ...    %{WAIT_MEDIUM}
-    user waits for page to finish loading
-
-    user clicks radio    Oldest
-    user waits until page contains link    Pupil absence in schools in England
-    user clicks link    Pupil absence in schools in England
+    user navigates to public frontend    %{PUBLIC_URL}/find-statistics/pupil-absence-in-schools-in-england
     user waits until h1 is visible    Pupil absence in schools in England    %{WAIT_MEDIUM}
-    user checks url contains    %{PUBLIC_URL}/find-statistics/pupil-absence-in-schools-in-england
 
 Go to Notify me page for Absence publication
     [Tags]    Local

--- a/tests/robot-tests/tests/libs/no_javascript.py
+++ b/tests/robot-tests/tests/libs/no_javascript.py
@@ -23,9 +23,7 @@ def user_gets_publications_list(parsed_page):
 
 
 def user_checks_list_contains_publication(list, publication):
-    publication_tag = list.select_one(".govuk-link")
-    if not publication_tag:
-        raise AssertionError("No publication found!")
-    if publication_tag.string == publication:
-        return list
+    for publication_link in list.select(".govuk-link"):
+        if publication_link.string == publication:
+            return list
     raise AssertionError(f'Could not find publication "{publication}"')


### PR DESCRIPTION
This PR:

- Changes `notifications_absence.robot` to navigate direct to the latest Pupil Absence release page before beginning the notificiations tests.

- Changes `no_javascript.robot` to search the Find Statistics page by keywords rather than sorting by "oldest" since the Pupil Absence publication is not guaranteed to be on the first page when sorted by "oldest".

- Changes python function `user_checks_list_contains_publication` to inspect multiple publications rather than expecting the publication to be the first element in the list.