### PR TITLE
EES-4008 Fix snapshots script when running via robot test

### DIFF
--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -38,7 +38,7 @@ class SnapshotService:
         assert response.status_code == 200, f"Requests response wasn't 200!\nResponse: {response}"
         return BeautifulSoup(response.text, "html.parser")
 
-    def _write_to_file(self, name: str, snapshot: list) -> None:
+    def write_to_file(self, name: str, snapshot: list) -> None:
         path = "tests/snapshots"
         if not os.path.exists(path):
             os.makedirs(path)
@@ -48,7 +48,7 @@ class SnapshotService:
         with open(path_to_file, "w") as file:
             file.write(snapshot)
 
-    def create_find_statistics_snapshot(self) -> None:
+    def create_find_statistics_snapshot(self) -> str:
         driver = self.driver
         driver.get(f"{self.public_url}/find-statistics")
 
@@ -116,10 +116,10 @@ class SnapshotService:
                 driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
                 driver.find_element(By.XPATH, "//*[@data-testid='pagination-next']").click()
             except NoSuchElementException:
-                self._write_to_file("find_statistics_snapshot.json", json.dumps(publications, sort_keys=True, indent=2))
                 break
+        return json.dumps(publications, sort_keys=True, indent=2)
 
-    def create_table_tool_snapshot(self) -> None:
+    def create_table_tool_snapshot(self) -> str:
         driver = self.driver
         driver.get(f"{self.public_url}/data-tables")
 
@@ -138,9 +138,9 @@ class SnapshotService:
 
             themes.append(theme)
 
-        self._write_to_file("table_tool_snapshot.json", json.dumps(themes, sort_keys=True, indent=2))
+        return json.dumps(themes, sort_keys=True, indent=2)
 
-    def create_data_catalogue_snapshot(self) -> None:
+    def create_data_catalogue_snapshot(self) -> str:
         driver = self.driver
         driver.get(f"{self.public_url}/data-catalogue")
 
@@ -159,9 +159,9 @@ class SnapshotService:
 
             themes.append(theme)
 
-        self._write_to_file("data_catalogue_snapshot.json", json.dumps(themes, sort_keys=True, indent=2))
+        return json.dumps(themes, sort_keys=True, indent=2)
 
-    def create_methodologies_snapshot(self) -> None:
+    def create_methodologies_snapshot(self) -> str:
         parsed_html = self._gets_parsed_html_from_page(f"{self.public_url}/methodology")
 
         methodologies_accordion = parsed_html.find(id="themes")
@@ -189,7 +189,7 @@ class SnapshotService:
                 theme["topics"].append(topic)
 
             themes.append(theme)
-        self._write_to_file("methodologies_snapshot.json", json.dumps(themes, sort_keys=True, indent=2))
+        return json.dumps(themes, sort_keys=True, indent=2)
 
 
 if __name__ == "__main__":
@@ -241,8 +241,16 @@ if __name__ == "__main__":
 
     snapshot_service = SnapshotService(args.public_url, driver)
 
-    snapshot_service.create_find_statistics_snapshot()
-    snapshot_service.create_table_tool_snapshot()
-    snapshot_service.create_data_catalogue_snapshot()
-    snapshot_service.create_methodologies_snapshot()
+    find_statistics_snapshot = snapshot_service.create_find_statistics_snapshot()
+    snapshot_service.write_to_file("find_statistics_snapshot.json", find_statistics_snapshot)
+
+    table_tool_snapshot = snapshot_service.create_table_tool_snapshot()
+    snapshot_service.write_to_file("table_tool_snapshot.json", table_tool_snapshot)
+
+    data_catalogue_snapshot = snapshot_service.create_data_catalogue_snapshot()
+    snapshot_service.write_to_file("data_catalogue_snapshot.json", data_catalogue_snapshot)
+
+    methodologies_snapshot = snapshot_service.create_methodologies_snapshot()
+    snapshot_service.write_to_file("methodologies_snapshot.json", methodologies_snapshot)
+
     driver.quit()

--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -26,9 +26,10 @@ Optional flags:
 class SnapshotService:
     requests.sessions.HTTPAdapter(pool_connections=50, pool_maxsize=50, max_retries=3)
 
-    def __init__(self):
+    def __init__(self, public_url, driver):
         self.session = requests.Session()
-        self.public_url = args.public_url
+        self.driver = driver
+        self.public_url = public_url
         self.timeout = 10
         self.page_size = 10
 
@@ -48,6 +49,7 @@ class SnapshotService:
             file.write(snapshot)
 
     def create_find_statistics_snapshot(self) -> None:
+        driver = self.driver
         driver.get(f"{self.public_url}/find-statistics")
 
         total_results = driver.find_element(By.XPATH, "//*[@data-testid='total-results']").text.split(" ")[0]
@@ -118,6 +120,7 @@ class SnapshotService:
                 break
 
     def create_table_tool_snapshot(self) -> None:
+        driver = self.driver
         driver.get(f"{self.public_url}/data-tables")
 
         theme_labels = driver.find_elements(By.CSS_SELECTOR, 'label[for^="publicationForm-themes-"]')
@@ -138,6 +141,7 @@ class SnapshotService:
         self._write_to_file("table_tool_snapshot.json", json.dumps(themes, sort_keys=True, indent=2))
 
     def create_data_catalogue_snapshot(self) -> None:
+        driver = self.driver
         driver.get(f"{self.public_url}/data-catalogue")
 
         theme_labels = driver.find_elements(By.CSS_SELECTOR, 'label[for^="publicationForm-themes-"]')
@@ -235,7 +239,7 @@ if __name__ == "__main__":
         token = base64.b64encode(f"{args.basic_auth_user}:{args.basic_auth_pass}".encode())
         driver.execute_cdp_cmd("Network.setExtraHTTPHeaders", {"headers": {"Authorization": f"Basic {token.decode()}"}})
 
-    snapshot_service = SnapshotService()
+    snapshot_service = SnapshotService(args.public_url, driver)
 
     snapshot_service.create_find_statistics_snapshot()
     snapshot_service.create_table_tool_snapshot()

--- a/tests/robot-tests/tests/libs/snapshots.py
+++ b/tests/robot-tests/tests/libs/snapshots.py
@@ -1,11 +1,6 @@
 import os
 
-from scripts.create_snapshots import (
-    create_all_methodologies_snapshot,
-    create_data_catalogue_snapshot,
-    create_find_statistics_snapshot,
-    create_table_tool_snapshot,
-)
+from scripts.create_snapshots import SnapshotService
 from scripts.get_webdriver import get_webdriver
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
@@ -17,16 +12,16 @@ chrome_options = Options()
 chrome_options.add_argument("--headless")
 driver = webdriver.Chrome(options=chrome_options)
 
+public_url = os.getenv("PUBLIC_URL")
 
 slack_service = SlackService()
-
-public_url = os.getenv("PUBLIC_URL")
+snapshot_service = SnapshotService(public_url=public_url, driver=driver)
 
 
 def validate_find_stats_snapshot():
-    with open("tests/snapshots/find_stats_snapshot.json", "r") as file:
+    with open("tests/snapshots/find_statistics_snapshot.json", "r") as file:
         snapshot = file.read()
-    new_snapshot = create_find_statistics_snapshot(public_url)
+    new_snapshot = snapshot_service.create_find_statistics_snapshot()
     if snapshot != new_snapshot:
         slack_service.send_snapshot_alert(f"Find Statistics page snapshot doesn't match current page on {public_url}")
         raise_assertion_error(f"Find Statistics page snapshot doesn't match current page on {public_url}")
@@ -35,7 +30,7 @@ def validate_find_stats_snapshot():
 def validate_table_tool_snapshot():
     with open("tests/snapshots/table_tool_snapshot.json", "r") as file:
         snapshot = file.read()
-    new_snapshot = create_table_tool_snapshot(public_url, driver)
+    new_snapshot = snapshot_service.create_table_tool_snapshot()
     if snapshot != new_snapshot:
         slack_service.send_snapshot_alert(f"Table tool page snapshot doesn't match current page on {public_url}")
         raise_assertion_error(f"Table tool page snapshot doesn't match current page on {public_url}")
@@ -45,7 +40,7 @@ def validate_table_tool_snapshot():
 def validate_data_catalogue_snapshot():
     with open("tests/snapshots/data_catalogue_snapshot.json", "r") as file:
         snapshot = file.read()
-    new_snapshot = create_data_catalogue_snapshot(public_url, driver)
+    new_snapshot = snapshot_service.create_data_catalogue_snapshot()
     if snapshot != new_snapshot:
         slack_service.send_snapshot_alert(
             f"Data catalogue page snapshot doesn't match current page on {os.getenv('PUBLIC_URL')}"
@@ -54,9 +49,9 @@ def validate_data_catalogue_snapshot():
 
 
 def validate_all_methodologies_snapshot():
-    with open("tests/snapshots/all_methodologies_snapshot.json", "r") as file:
+    with open("tests/snapshots/methodologies_snapshot.json", "r") as file:
         snapshot = file.read()
-    new_snapshot = create_all_methodologies_snapshot(public_url)
+    new_snapshot = snapshot_service.create_methodologies_snapshot()
     if snapshot != new_snapshot:
-        slack_service.send_snapshot_alert(f"All methodologies page snapshot doesn't match current page on {public_url}")
-        raise_assertion_error(f"All methodologies page snapshot doesn't match current page on {public_url}")
+        slack_service.send_snapshot_alert(f"Methodologies page snapshot doesn't match current page on {public_url}")
+        raise_assertion_error(f"Methodologies page snapshot doesn't match current page on {public_url}")

--- a/tests/robot-tests/tests/libs/snapshots.py
+++ b/tests/robot-tests/tests/libs/snapshots.py
@@ -4,7 +4,8 @@ from scripts.create_snapshots import SnapshotService
 from scripts.get_webdriver import get_webdriver
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
-from tests.libs.slack import SlackService
+
+# from tests.libs.slack import SlackService
 from utilities import raise_assertion_error
 
 get_webdriver("latest")
@@ -14,7 +15,7 @@ driver = webdriver.Chrome(options=chrome_options)
 
 public_url = os.getenv("PUBLIC_URL")
 
-slack_service = SlackService()
+# slack_service = SlackService()
 snapshot_service = SnapshotService(public_url=public_url, driver=driver)
 
 
@@ -23,7 +24,7 @@ def validate_find_stats_snapshot():
         snapshot = file.read()
     new_snapshot = snapshot_service.create_find_statistics_snapshot()
     if snapshot != new_snapshot:
-        slack_service.send_snapshot_alert(f"Find Statistics page snapshot doesn't match current page on {public_url}")
+        # slack_service.send_snapshot_alert(f"Find Statistics page snapshot doesn't match current page on {public_url}")
         raise_assertion_error(f"Find Statistics page snapshot doesn't match current page on {public_url}")
 
 
@@ -32,7 +33,7 @@ def validate_table_tool_snapshot():
         snapshot = file.read()
     new_snapshot = snapshot_service.create_table_tool_snapshot()
     if snapshot != new_snapshot:
-        slack_service.send_snapshot_alert(f"Table tool page snapshot doesn't match current page on {public_url}")
+        # slack_service.send_snapshot_alert(f"Table tool page snapshot doesn't match current page on {public_url}")
         raise_assertion_error(f"Table tool page snapshot doesn't match current page on {public_url}")
     pass
 
@@ -42,9 +43,9 @@ def validate_data_catalogue_snapshot():
         snapshot = file.read()
     new_snapshot = snapshot_service.create_data_catalogue_snapshot()
     if snapshot != new_snapshot:
-        slack_service.send_snapshot_alert(
-            f"Data catalogue page snapshot doesn't match current page on {os.getenv('PUBLIC_URL')}"
-        )
+        # slack_service.send_snapshot_alert(
+        #     f"Data catalogue page snapshot doesn't match current page on {os.getenv('PUBLIC_URL')}"
+        # )
         raise_assertion_error(f"Data catalogue page snapshot doesn't match current page on {public_url}")
 
 
@@ -53,5 +54,5 @@ def validate_all_methodologies_snapshot():
         snapshot = file.read()
     new_snapshot = snapshot_service.create_methodologies_snapshot()
     if snapshot != new_snapshot:
-        slack_service.send_snapshot_alert(f"Methodologies page snapshot doesn't match current page on {public_url}")
+        # slack_service.send_snapshot_alert(f"Methodologies page snapshot doesn't match current page on {public_url}")
         raise_assertion_error(f"Methodologies page snapshot doesn't match current page on {public_url}")


### PR DESCRIPTION
This PR fixes the snapshots when they are run via the `check_snapshots.robot` test (as opposed to running the create_snapshots.py script direct.

There were errors in the `snapshots.py` library used by `check_snapshots.robot` causing keyword failures.

This has been happening when running in the UI test pipelines as part of the general public tests, and when it's run in the Validate UI snapshots pipeline.