### PR TITLE
EES-4015 Cleanup fetching latest release/subjects in data API

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -290,7 +290,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             footnoteRepository.Setup(service => service.GetFootnotes(release.Id, subject.Id))
                 .ReturnsAsync(new List<Footnote>());
 
-            subjectRepository.Setup(service => service.Get(subject.Id)).ReturnsAsync(subject);
+            subjectRepository.Setup(service => service.Find(subject.Id)).ReturnsAsync(subject);
 
             releaseDataFileService.Setup(service => service.Delete(release.Id, file.Id, false))
                 .ReturnsAsync(Unit.Instance);
@@ -448,8 +448,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     service.GetFootnotes(release.Id, It.IsIn(subject.Id, replacementSubject.Id)))
                 .ReturnsAsync(new List<Footnote>());
 
-            subjectRepository.Setup(service => service.Get(subject.Id)).ReturnsAsync(subject);
-            subjectRepository.Setup(service => service.Get(replacementSubject.Id)).ReturnsAsync(replacementSubject);
+            subjectRepository.Setup(service => service.Find(subject.Id)).ReturnsAsync(subject);
+            subjectRepository.Setup(service => service.Find(replacementSubject.Id)).ReturnsAsync(replacementSubject);
 
             releaseDataFileService
                 .Setup(service => service.Delete(release.Id, It.IsIn(file.Id, replacementFile.Id), false))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -455,7 +455,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(async file =>
                 {
                     var subject = file.SubjectId.HasValue
-                        ? await _subjectRepository.Get(file.SubjectId.Value)
+                        ? await _subjectRepository.Find(file.SubjectId.Value)
                         : null;
 
                     var footnotes = subject == null

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTaskExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTaskExtensionsTests.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class EitherTaskExtensionsTests
+{
+    public class OrNotFound
+    {
+        [Fact]
+        public async Task ValueType_NotNull()
+        {
+            var result = await Task.FromResult<int?>(123).OrNotFound();
+
+            var value = result.AssertRight();
+            Assert.Equal(123, value);
+        }
+
+        [Fact]
+        public async Task ValueType_Null()
+        {
+            var result = await Task.FromResult<int?>(null).OrNotFound();
+
+            result.AssertNotFound();
+        }
+
+        [Fact]
+        public async Task ReferenceType_NotNull()
+        {
+            var result = await Task.FromResult<Test?>(new Test()).OrNotFound();
+
+            var value = result.AssertRight();
+            Assert.Equal(new Test(), value);
+        }
+
+        [Fact]
+        public async Task ReferenceTypeType_Null()
+        {
+            var result = await Task.FromResult<Test?>(null).OrNotFound();
+
+            result.AssertNotFound();
+        }
+
+        private record Test;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EitherTaskExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EitherTaskExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -7,6 +8,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 {
     public static class EitherTaskExtensions
     {
+        public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this Task<TRight?> task)
+            where TRight : struct
+        {
+            var result = await task;
+
+            return result is not null ? result : new NotFoundResult();
+        }
+
+        public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this Task<TRight?> task)
+            where TRight : class?
+        {
+            var result = await task;
+
+            return result is not null ? result : new NotFoundResult();
+        }
+
         public static async Task<ActionResult> HandleFailures<TRight>(
             this Task<Either<ActionResult, TRight>> task) where TRight : ActionResult
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseRepository.cs
@@ -34,8 +34,8 @@ public class ReleaseRepository : IReleaseRepository
     {
         var publication = await _contentDbContext.Publications
             .Include(p => p.LatestPublishedRelease)
-            .SingleAsync(p => p.Id == publicationId);
+            .SingleOrDefaultAsync(p => p.Id == publicationId);
 
-        return publication.LatestPublishedRelease ?? new Either<ActionResult, Release>(new NotFoundResult());
+        return publication?.LatestPublishedRelease ?? new Either<ActionResult, Release>(new NotFoundResult());
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
@@ -59,7 +59,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 .ReturnsAsync(new NotFoundResult());
 
             subjectRepository
-                .Setup(s => s.GetPublicationIdForSubject(request.Query.SubjectId))
+                .Setup(s => s.FindPublicationIdForSubject(request.Query.SubjectId))
                 .ReturnsAsync(_publicationId);
 
             var service = BuildService(releaseRepository: releaseRepository.Object,
@@ -139,7 +139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 .ReturnsAsync(release);
 
             subjectRepository
-                .Setup(s => s.GetPublicationIdForSubject(subject.Id))
+                .Setup(s => s.FindPublicationIdForSubject(subject.Id))
                 .ReturnsAsync(_publicationId);
 
             tableBuilderService

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -71,8 +72,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
 
         public async Task<Either<ActionResult, LegacyPermalinkViewModel>> Create(PermalinkCreateViewModel request)
         {
-            var publicationId = await _subjectRepository.GetPublicationIdForSubject(request.Query.SubjectId);
-            return await _releaseRepository.GetLatestPublishedRelease(publicationId)
+            return await _subjectRepository.FindPublicationIdForSubject(request.Query.SubjectId)
+                .OrNotFound()
+                .OnSuccess(publicationId => _releaseRepository.GetLatestPublishedRelease(publicationId))
                 .OnSuccess(release => Create(release.Id, request));
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Repository/SubjectRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Repository/SubjectRepositoryTests.cs
@@ -11,7 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
     public class SubjectRepositoryTests
     {
         [Fact]
-        public async Task Get_WithSubjectId()
+        public async Task Find_WithSubjectId()
         {
             var subject = new Subject();
             var contextId = Guid.NewGuid().ToString();
@@ -25,7 +25,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
             await using (var context = InMemoryStatisticsDbContext(contextId))
             {
                 var service = BuildSubjectService(context);
-                var result = await service.Get(subject.Id);
+                var result = await service.Find(subject.Id);
 
                 Assert.NotNull(result);
                 Assert.Equal(subject.Id, result!.Id);
@@ -34,21 +34,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
 
 
         [Fact]
-        public async Task Get_WithSubjectId_NotFound()
+        public async Task Find_WithSubjectId_NotFound()
         {
             var contextId = Guid.NewGuid().ToString();
 
             await using (var context = InMemoryStatisticsDbContext(contextId))
             {
                 var service = BuildSubjectService(context);
-                var result = await service.Get(Guid.NewGuid());
+                var result = await service.Find(Guid.NewGuid());
 
                 Assert.Null(result);
             }
         }
 
         [Fact]
-        public async Task GetPublicationIdForSubject()
+        public async Task FindPublicationIdForSubject()
         {
             var releaseSubject = new ReleaseSubject
             {
@@ -70,29 +70,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
             await using (var context = InMemoryStatisticsDbContext(contextId))
             {
                 var service = BuildSubjectService(context);
-                var result = await service.GetPublicationIdForSubject(releaseSubject.SubjectId);
+                var result = await service.FindPublicationIdForSubject(releaseSubject.SubjectId);
 
                 Assert.Equal(releaseSubject.Release.PublicationId, result);
             }
         }
 
         [Fact]
-        public async Task GetPublicationIdForSubject_NotFoundThrows()
+        public async Task FindPublicationIdForSubject_NotFound()
         {
             var contextId = Guid.NewGuid().ToString();
 
             await using (var context = InMemoryStatisticsDbContext(contextId))
             {
                 var service = BuildSubjectService(context);
+                var result = await service.FindPublicationIdForSubject(Guid.NewGuid());
 
-                await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => service.GetPublicationIdForSubject(Guid.NewGuid())
-                );
+                Assert.Null(result);
             }
         }
 
-        private static SubjectRepository BuildSubjectService(
-            StatisticsDbContext statisticsDbContext)
+        private static SubjectRepository BuildSubjectService(StatisticsDbContext statisticsDbContext)
         {
             return new SubjectRepository(
                 statisticsDbContext

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/ISubjectRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/ISubjectRepository.cs
@@ -6,8 +6,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Inter
 {
     public interface ISubjectRepository
     {
-        Task<Subject?> Get(Guid subjectId);
+        Task<Subject?> Find(Guid subjectId);
 
-        Task<Guid> GetPublicationIdForSubject(Guid subjectId);
+        Task<Guid?> FindPublicationIdForSubject(Guid subjectId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/SubjectRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/SubjectRepository.cs
@@ -17,20 +17,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
             _context = context;
         }
 
-        public async Task<Subject?> Get(Guid subjectId)
+        public async Task<Subject?> Find(Guid subjectId)
         {
             return await _context
                 .Subject
                 .FindAsync(subjectId);
         }
 
-        public async Task<Guid> GetPublicationIdForSubject(Guid subjectId)
+        public async Task<Guid?> FindPublicationIdForSubject(Guid subjectId)
         {
-            var firstReleaseSubject = await _context.ReleaseSubject
+            var releaseSubject = await _context.ReleaseSubject
                 .Include(rs => rs.Release)
                 .Where(rs => rs.SubjectId == subjectId)
-                .FirstAsync();
-            return firstReleaseSubject.Release.PublicationId;
+                .FirstOrDefaultAsync();
+            
+            return releaseSubject?.Release.PublicationId;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ResultSubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ResultSubjectMetaServiceTests.cs
@@ -149,7 +149,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             releaseDataFileRepository.Setup(s => s.GetBySubject(release.Id, subject.Id))
                 .ReturnsAsync(releaseFile);
 
-            subjectRepository.Setup(s => s.GetPublicationIdForSubject(subject.Id))
+            subjectRepository.Setup(s => s.FindPublicationIdForSubject(subject.Id))
                 .ReturnsAsync(publication.Id);
 
             timePeriodService
@@ -326,7 +326,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             releaseDataFileRepository.Setup(s => s.GetBySubject(release.Id, subject.Id))
                 .ReturnsAsync(new ReleaseFile());
 
-            subjectRepository.Setup(s => s.GetPublicationIdForSubject(subject.Id))
+            subjectRepository.Setup(s => s.FindPublicationIdForSubject(subject.Id))
                 .ReturnsAsync(publication.Id);
 
             timePeriodService
@@ -549,7 +549,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             releaseDataFileRepository.Setup(s => s.GetBySubject(release.Id, subject.Id))
                 .ReturnsAsync(new ReleaseFile());
 
-            subjectRepository.Setup(s => s.GetPublicationIdForSubject(subject.Id))
+            subjectRepository.Setup(s => s.FindPublicationIdForSubject(subject.Id))
                 .ReturnsAsync(publication.Id);
 
             timePeriodService
@@ -809,7 +809,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             releaseDataFileRepository.Setup(s => s.GetBySubject(release.Id, subject.Id))
                 .ReturnsAsync(new ReleaseFile());
 
-            subjectRepository.Setup(s => s.GetPublicationIdForSubject(subject.Id))
+            subjectRepository.Setup(s => s.FindPublicationIdForSubject(subject.Id))
                 .ReturnsAsync(publication.Id);
 
             timePeriodService

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
@@ -52,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                         var subjectRepository = new Mock<ISubjectRepository>(MockBehavior.Strict);
 
                         subjectRepository
-                            .Setup(s => s.GetPublicationIdForSubject(_subject.Id))
+                            .Setup(s => s.FindPublicationIdForSubject(_subject.Id))
                             .ReturnsAsync(PublicationId);
 
                         var releaseRepository = new Mock<IReleaseRepository>(MockBehavior.Strict);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
@@ -177,7 +177,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 var subjectRepository = new Mock<ISubjectRepository>(Strict);
 
                 subjectRepository
-                    .Setup(s => s.GetPublicationIdForSubject(query.SubjectId))
+                    .Setup(s => s.FindPublicationIdForSubject(query.SubjectId))
                     .ReturnsAsync(publicationId);
 
                 var releaseRepository = new Mock<IReleaseRepository>(Strict);
@@ -247,7 +247,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 var subjectRepository = new Mock<ISubjectRepository>(Strict);
 
                 subjectRepository
-                    .Setup(s => s.GetPublicationIdForSubject(query.SubjectId))
+                    .Setup(s => s.FindPublicationIdForSubject(query.SubjectId))
                     .ReturnsAsync(publicationId);
 
                 var releaseRepository = new Mock<IReleaseRepository>(Strict);
@@ -286,7 +286,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var subjectRepository = new Mock<ISubjectRepository>(Strict);
 
             subjectRepository
-                .Setup(s => s.GetPublicationIdForSubject(query.SubjectId))
+                .Setup(s => s.FindPublicationIdForSubject(query.SubjectId))
                 .ReturnsAsync(publicationId);
 
             var releaseRepository = new Mock<IReleaseRepository>(Strict);
@@ -372,7 +372,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 var subjectRepository = new Mock<ISubjectRepository>(Strict);
 
                 subjectRepository
-                    .Setup(s => s.GetPublicationIdForSubject(query.SubjectId))
+                    .Setup(s => s.FindPublicationIdForSubject(query.SubjectId))
                     .ReturnsAsync(publicationId);
 
                 var releaseRepository = new Mock<IReleaseRepository>(Strict);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
@@ -117,7 +117,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     _logger.LogTrace("Got Time Periods in {Time} ms", stopwatch.Elapsed.TotalMilliseconds);
                     stopwatch.Restart();
 
-                    var publicationId = await _subjectRepository.GetPublicationIdForSubject(releaseSubject.SubjectId);
+                    var publicationId = await _subjectRepository.FindPublicationIdForSubject(releaseSubject.SubjectId);
                     var publicationTitle = (await _contentDbContext.Publications.FindAsync(publicationId))!.Title;
 
                     var releaseFile =

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
@@ -66,10 +66,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             ObservationQueryContext queryContext,
             CancellationToken cancellationToken = default)
         {
-            return await _subjectRepository.FindPublicationIdForSubject(queryContext.SubjectId)
-                .OrNotFound()
-                .OnSuccess(publicationId => _releaseRepository.GetLatestPublishedRelease(publicationId))
-                .OnSuccess(release => Query(release.Id, queryContext, cancellationToken));
+            return await FindLatestPublishedReleaseId(queryContext.SubjectId)
+                .OnSuccess(releaseId => Query(releaseId, queryContext, cancellationToken));
         }
 
         public async Task<Either<ActionResult, TableBuilderResultViewModel>> Query(
@@ -142,6 +140,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 countOfTimePeriods: TimePeriodUtil.Range(queryContext.TimePeriod).Count,
                 countsOfFilterItemsByFilter: countsOfFilterItemsByFilter
             );
+        }
+
+        private async Task<Either<ActionResult, Guid>> FindLatestPublishedReleaseId(Guid subjectId)
+        {
+            return await _subjectRepository.FindPublicationIdForSubject(subjectId)
+                .OrNotFound()
+                .OnSuccess(publicationId => _releaseRepository.GetLatestPublishedRelease(publicationId))
+                .OnSuccess(release => release.Id);
         }
 
         private Task<Either<ActionResult, ReleaseSubject>> CheckReleaseSubjectExists(Guid subjectId, Guid releaseId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -65,9 +66,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             ObservationQueryContext queryContext,
             CancellationToken cancellationToken = default)
         {
-            var publicationId = await _subjectRepository.GetPublicationIdForSubject(queryContext.SubjectId);
-
-            return await _releaseRepository.GetLatestPublishedRelease(publicationId)
+            return await _subjectRepository.FindPublicationIdForSubject(queryContext.SubjectId)
+                .OrNotFound()
+                .OnSuccess(publicationId => _releaseRepository.GetLatestPublishedRelease(publicationId))
                 .OnSuccess(release => Query(release.Id, queryContext, cancellationToken));
         }
 


### PR DESCRIPTION
## :warning: Depends on #3761 

This PR performs various cleanup around the data API to prevent errors being thrown if the latest release or subject can't be found (resulting in a 500). Instead, we now correctly return a 404 response instead.

## `OrNotFound` extension

One notable change here is the addition of a new `OrNotFound` extension method for `EitherTasks`. This allows us to conveniently return a `NotFoundResult` (i.e. 404) for tasks that have a nullable result (e.g. `Task<T?>`).

Usage is simply:
```cs
return await someService.SomeNullableResult()
  .OrNotFound() // Return a 404 if null
  .OnSuccess(...); // Do something else if not null
```

The main benefit to this extension is that we can use this to wrap many repository methods that return `Task<T?>`. We no longer need to adapt these methods to use eithers (e.g. `Task<Either<ActionResult, T>>`) to be compatible with the rest of our service methods.