### PR TITLE
EES-3984 Fix failing UI tests

### DIFF
--- a/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_release_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_release_approver.robot
@@ -129,12 +129,25 @@ Put release back into draft
     user puts release into draft
 
 Approve release for scheduled release
-    user approves release for scheduled publication    2    12    3001
+    ${days_until_release}=    set variable    2
+    ${publish_date_day}=    get current datetime    %-d    ${days_until_release}
+    ${publish_date_month}=    get current datetime    %-m    ${days_until_release}
+    ${publish_date_month_word}=    get current datetime    %B    ${days_until_release}
+    ${publish_date_year}=    get current datetime    %Y    ${days_until_release}
+
+    user approves release for scheduled publication
+    ...    ${publish_date_day}
+    ...    ${publish_date_month}
+    ...    ${publish_date_year}
+    ...    12
+    ...    3001
+
+    set suite variable    ${EXPECTED_SCHEDULED_DATE}
+    ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}
 
 Verify release is scheduled
     user checks summary list contains    Current status    Approved
-    user checks summary list contains    Scheduled release
-    ...    ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}
+    user checks summary list contains    Scheduled release    ${EXPECTED_SCHEDULED_DATE}
     user checks summary list contains    Next release expected    December 3001
 
 Put release back into draft again

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -212,16 +212,35 @@ Add public prerelease access list
     user creates public prerelease access list    Test public access list
 
 Approve release for scheduled publication
-    user approves release for scheduled publication    0    12    3001
+    ${days_until_release}=    set variable    0
+    ${publish_date_day}=    get current datetime    %-d    ${days_until_release}
+    ${publish_date_month}=    get current datetime    %-m    ${days_until_release}
+    ${publish_date_month_word}=    get current datetime    %B    ${days_until_release}
+    ${publish_date_year}=    get current datetime    %Y    ${days_until_release}
+
+    user approves release for scheduled publication
+    ...    ${publish_date_day}
+    ...    ${publish_date_month}
+    ...    ${publish_date_year}
+    ...    12
+    ...    3001
+
+    set suite variable    ${EXPECTED_SCHEDULED_DATE}
+    ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}
 
 Verify release is scheduled
     user checks summary list contains    Current status    Approved
-    user checks summary list contains    Scheduled release
-    ...    ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}
+    user checks summary list contains    Scheduled release    ${EXPECTED_SCHEDULED_DATE}
     user checks summary list contains    Next release expected    December 3001
 
 Publish the scheduled release
     user waits for scheduled release to be published immediately
+
+    ${publish_date_day}=    get current datetime    %-d
+    ${publish_date_month_word}=    get current datetime    %B
+    ${publish_date_year}=    get current datetime    %Y
+    set suite variable    ${EXPECTED_PUBLISHED_DATE}
+    ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}
 
 Verify newly published release is on Find Statistics page
     user checks publication is on find statistics page    ${PUBLICATION_NAME}
@@ -235,14 +254,7 @@ Verify release URL and page caption
     user waits until page contains title caption    ${RELEASE_NAME}
 
 Verify publish and update dates
-    ${PUBLISH_DATE_DAY}=    get current datetime    %-d
-    ${PUBLISH_DATE_MONTH_WORD}=    get current datetime    %B
-    ${PUBLISH_DATE_YEAR}=    get current datetime    %Y
-    set suite variable    ${PUBLISH_DATE_DAY}
-    set suite variable    ${PUBLISH_DATE_MONTH_WORD}
-    set suite variable    ${PUBLISH_DATE_YEAR}
-    user checks summary list contains    Published
-    ...    ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}
+    user checks summary list contains    Published    ${EXPECTED_PUBLISHED_DATE}
     user checks summary list contains    Next update    December 3001
 
 Verify release associated files
@@ -333,7 +345,7 @@ Verify public pre-release access list
     user waits until h1 is visible    ${PUBLICATION_NAME}
 
     user waits until h2 is visible    Pre-release access list
-    user waits until page contains    Published ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}
+    user waits until page contains    Published ${EXPECTED_PUBLISHED_DATE}
     user waits until page contains    Test public access list
 
 Verify accordions are correct
@@ -638,8 +650,27 @@ Update public prerelease access list for amendment
     user updates public prerelease access list    Amended public access list
 
 Approve amendment for scheduled release
-    user approves release for scheduled publication    1    12    3001
+    ${days_until_release}=    set variable    1
+    ${publish_date_day}=    get current datetime    %-d    ${days_until_release}
+    ${publish_date_month}=    get current datetime    %-m    ${days_until_release}
+    ${publish_date_month_word}=    get current datetime    %B    ${days_until_release}
+    ${publish_date_year}=    get current datetime    %Y    ${days_until_release}
+
+    user approves release for scheduled publication
+    ...    ${publish_date_day}
+    ...    ${publish_date_month}
+    ...    ${publish_date_year}
+    ...    12
+    ...    3001
+
     user waits for scheduled release to be published immediately
+
+    ${publish_date_day}=    get current datetime    %-d
+    ${publish_date_month}=    get current datetime    %-m
+    ${publish_date_month_word}=    get current datetime    %B
+    ${publish_date_year}=    get current datetime    %Y
+    set suite variable    ${EXPECTED_PUBLISHED_DATE}
+    ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}
 
 Verify amendment is on Find Statistics page again
     user checks publication is on find statistics page    ${PUBLICATION_NAME}
@@ -661,8 +692,7 @@ Verify amendment is displayed as the latest release
     user checks page does not contain    See other releases (1)
 
 Verify amendment is published
-    user checks summary list contains    Published
-    ...    ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}
+    user checks summary list contains    Published    ${EXPECTED_PUBLISHED_DATE}
     user checks summary list contains    Next update    December 3001
 
 Verify amendment files
@@ -747,7 +777,7 @@ Verify amendment public pre-release access list
     user waits until h1 is visible    ${PUBLICATION_NAME}
 
     user waits until h2 is visible    Pre-release access list
-    user waits until page contains    Published ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}
+    user waits until page contains    Published ${EXPECTED_PUBLISHED_DATE}
     user waits until page contains    Amended public access list
 
 Verify amendment accordions are correct
@@ -826,7 +856,16 @@ Leave release note for amendment
     user clicks button    Save note
 
 Approve release amendment for scheduled publication
-    user approves release for scheduled publication    2    8    4001
+    ${days_until_release}=    set variable    2
+    ${publish_date_day}=    get current datetime    %-d    ${days_until_release}
+    ${publish_date_month}=    get current datetime    %-m    ${days_until_release}
+    ${publish_date_year}=    get current datetime    %Y    ${days_until_release}
+    user approves release for scheduled publication
+    ...    ${publish_date_day}
+    ...    ${publish_date_month}
+    ...    ${publish_date_year}
+    ...    8
+    ...    4001
     user waits for scheduled release to be published immediately
 
 Save public release link for later use

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -580,16 +580,12 @@ user puts release into higher level review
     user waits until element is visible    id:CurrentReleaseStatus-Awaiting higher review    %{WAIT_SMALL}
 
 user approves release for scheduled publication
-    [Arguments]    ${DAYS_UNTIL_RELEASE}    ${NEXT_RELEASE_MONTH}=01    ${NEXT_RELEASE_YEAR}=2200
-    ${PUBLISH_DATE_DAY}=    get current datetime    %-d    ${DAYS_UNTIL_RELEASE}
-    ${PUBLISH_DATE_MONTH}=    get current datetime    %-m    ${DAYS_UNTIL_RELEASE}
-    ${PUBLISH_DATE_MONTH_WORD}=    get current datetime    %B    ${DAYS_UNTIL_RELEASE}
-    ${PUBLISH_DATE_YEAR}=    get current datetime    %Y    ${DAYS_UNTIL_RELEASE}
-    set suite variable    ${PUBLISH_DATE_DAY}
-    set suite variable    ${PUBLISH_DATE_MONTH}
-    set suite variable    ${PUBLISH_DATE_MONTH_WORD}
-    set suite variable    ${PUBLISH_DATE_YEAR}
-
+    [Arguments]
+    ...    ${publish_date_day}
+    ...    ${publish_date_month}
+    ...    ${publish_date_year}
+    ...    ${next_release_month}=01
+    ...    ${next_release_year}=2200
     user clicks link    Sign off
     user waits until page does not contain loading spinner
     user waits until h2 is visible    Sign off    %{WAIT_SMALL}
@@ -602,11 +598,11 @@ user approves release for scheduled publication
     user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Approved by UI tests
     user clicks radio    On a specific date
     user waits until page contains    Publish date
-    user enters text into element    id:releaseStatusForm-publishScheduled-day    ${PUBLISH_DATE_DAY}
-    user enters text into element    id:releaseStatusForm-publishScheduled-month    ${PUBLISH_DATE_MONTH}
-    user enters text into element    id:releaseStatusForm-publishScheduled-year    ${PUBLISH_DATE_YEAR}
-    user enters text into element    id:releaseStatusForm-nextReleaseDate-month    ${NEXT_RELEASE_MONTH}
-    user enters text into element    id:releaseStatusForm-nextReleaseDate-year    ${NEXT_RELEASE_YEAR}
+    user enters text into element    id:releaseStatusForm-publishScheduled-day    ${publish_date_day}
+    user enters text into element    id:releaseStatusForm-publishScheduled-month    ${publish_date_month}
+    user enters text into element    id:releaseStatusForm-publishScheduled-year    ${publish_date_year}
+    user enters text into element    id:releaseStatusForm-nextReleaseDate-month    ${next_release_month}
+    user enters text into element    id:releaseStatusForm-nextReleaseDate-year    ${next_release_year}
 
     user clicks button    Update status
     user waits until h2 is visible    Confirm publish date    %{WAIT_SMALL}

--- a/tests/robot-tests/tests/libs/bootstrap_data/bootstrap_common.robot
+++ b/tests/robot-tests/tests/libs/bootstrap_data/bootstrap_common.robot
@@ -45,7 +45,14 @@ user creates a fully populated approved release
     ...    ${RELEASE_TIME_PERIOD}
     ...    ${RELEASE_YEAR}
     ...    ${RELEASE_TYPE}
-    user approves release for scheduled publication    10000
+    ${days_until_release}=    set variable    10000
+    ${publish_date_day}=    get current datetime    %-d    ${days_until_release}
+    ${publish_date_month}=    get current datetime    %-m    ${days_until_release}
+    ${publish_date_year}=    get current datetime    %Y    ${days_until_release}
+    user approves release for scheduled publication
+    ...    ${publish_date_day}
+    ...    ${publish_date_month}
+    ...    ${publish_date_year}
 
 user creates a fully populated published release
     [Arguments]


### PR DESCRIPTION
This PR fixes failing robot tests in `admin_and_public_2/bau/publish_release_and_amend.robot`.

`publish_release_and_amend` is changed to set new variables `EXPECTED_SCHEDULED_DATE` after scheduling if we need to check the value of the scheduled date after approving, and `EXPECTED_PUBLISHED_DATE` after publishing if we need to check the value of the published date after publishing.

The two dates can be different, i.e. when scheduling publishing a number of days in advance, but then triggering the publishing of that scheduled release immediately.

Expecting them to be the same date was the cause of the test failure.

It also changes the keyword `user approves release for scheduled publication` in `admin-common.robot` to take the publish day/month/year as arguments to make it a little clearer what scheduled date is being set.

It was setting the day/month/year as global variables which made it difficult to read through `publish_release_and_amend` which set these variables directly in one other place and it was not obvious when/how they were set and what the current values would be.