### PR TITLE
EES-3960 Fix UI test related to checking archived publication warning

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -286,10 +286,11 @@ Check data catalogue page contains superseded warning for archived publication (
     user clicks button    Next step
     user waits for page to finish loading
 
-    user waits until page contains    Choose a release
-    user waits until page contains    ${RELEASE_NAME_ARCHIVE}
+    user checks summary list contains    Publication    ${PUBLICATION_NAME_ARCHIVE}
 
+    user waits until page contains    Choose a release
     user checks page contains radio    ${RELEASE_NAME_ARCHIVE}
+
     user checks page does not contain    This is the latest data
     user checks page contains element    testid:superseded-warning
     user checks page contains element    testid:superseded-by-link
@@ -310,9 +311,9 @@ Check that superseded warning link takes user to superseding-publication data-ca
     user clicks radio    ${PUBLICATION_NAME_ARCHIVE}
     user clicks button    Next step
 
-    user waits until page contains    Choose a release
-    user waits until page contains    ${RELEASE_NAME_ARCHIVE}
+    user checks summary list contains    Publication    ${PUBLICATION_NAME_ARCHIVE}
 
+    user waits until page contains    Choose a release
     user checks page contains radio    ${RELEASE_NAME_ARCHIVE}
 
     user checks page contains element    testid:superseded-warning
@@ -326,13 +327,13 @@ Check that superseded warning link takes user to superseding-publication data-ca
 
     user clicks element    testid:superseded-by-link
 
-    user waits until page contains    Browse our open data    %{WAIT_SMALL}
+    user waits until h1 is visible    Browse our open data
 
-    user waits until page contains    ${PUBLICATION_NAME_SUPERSEDE}    %{WAIT_SMALL}
+    user checks summary list contains    Publication    ${PUBLICATION_NAME_SUPERSEDE}
+    user checks page contains radio    ${RELEASE_NAME_SUPERSEDE}
 
-    user checks page does not contain    ${PUBLICATION_NAME_ARCHIVE}
-
-    user checks page for details dropdown    ${PUBLICATION_NAME_ARCHIVE}
+    user checks page does not contain element    testid:superseded-warning
+    user checks page does not contain element    testid:superseded-by-link
 
 Check archive-publication permalink has out-of-date warning
     user navigates to public frontend    ${PERMALINK_URL}


### PR DESCRIPTION
This PR fixes a failing UI test which was failing on 

```
user checks page does not contain    ${PUBLICATION_NAME_ARCHIVE}
```

because it did exist in the page data even though it wasn't visible.

![image (13)](https://user-images.githubusercontent.com/4147126/214096774-ace7a229-84be-4c72-a939-4b32f2905726.png)

This is fixed by checking the visible publication in the Step 1 summary list is correct

```
user checks summary list contains    Publication    ${PUBLICATION_NAME_SUPERSEDE}
```

I've also removed

```
user checks page for details dropdown    ${PUBLICATION_NAME_ARCHIVE}
```

because I can't see the details section which it's intending to check.

### UI test report

![image](https://user-images.githubusercontent.com/4147126/214096193-a211eed1-9afb-4f10-babe-351df6f9987a.png)
