### PR TITLE
EES-3977 EES-4034 UI test fixes for running against Dev

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/users/components/PublicationAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/PublicationAccessForm.tsx
@@ -43,7 +43,7 @@ const PublicationAccessForm = ({
       enableReinitialize
       onSubmit={onSubmit}
     >
-      {() => {
+      {form => {
         return (
           <Form id={`${user.id}-publicationRole`}>
             <FormFieldset
@@ -76,7 +76,11 @@ const PublicationAccessForm = ({
                 </div>
                 <div className="govuk-grid-column-one-quarter">
                   {user && (
-                    <Button type="submit" className="govuk-!-margin-top-6">
+                    <Button
+                      type="submit"
+                      disabled={form.isSubmitting}
+                      className="govuk-!-margin-top-6"
+                    >
                       Add publication access
                     </Button>
                   )}

--- a/src/explore-education-statistics-admin/src/pages/users/components/ReleaseAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/ReleaseAccessForm.tsx
@@ -41,7 +41,7 @@ const ReleaseAccessForm = ({
       enableReinitialize
       onSubmit={onSubmit}
     >
-      {() => {
+      {form => {
         return (
           <Form id={`${user.id}-releaseRole`}>
             <FormFieldset
@@ -74,7 +74,11 @@ const ReleaseAccessForm = ({
                 </div>
                 <div className="govuk-grid-column-one-quarter">
                   {user && (
-                    <Button type="submit" className="govuk-!-margin-top-6">
+                    <Button
+                      type="submit"
+                      disabled={form.isSubmitting}
+                      className="govuk-!-margin-top-6"
+                    >
                       Add release access
                     </Button>
                   )}

--- a/tests/robot-tests/tests/admin/analyst/invite_contributor_as_publication_owner.robot
+++ b/tests/robot-tests/tests/admin/analyst/invite_contributor_as_publication_owner.robot
@@ -49,10 +49,16 @@ Assign various release access permissions to analysts
     user gives analyst publication owner access    ${PUBLICATION_NAME}
     ...    EES-test.ANALYST1@education.gov.uk
 
-    user gives release access to analyst    ${PUBLICATION_NAME} - Academic Year 2000/01    Contributor
+    user gives release access to analyst
+    ...    ${PUBLICATION_NAME}
+    ...    Academic Year 2000/01
+    ...    Contributor
     ...    EES-test.ANALYST3@education.gov.uk
 
-    user gives release access to analyst    ${PUBLICATION_NAME} - Academic Year 2001/02    Contributor
+    user gives release access to analyst
+    ...    ${PUBLICATION_NAME}
+    ...    Academic Year 2001/02
+    ...    Contributor
     ...    EES-test.ANALYST2@education.gov.uk
 
 Sign in as analyst1 and go to Manage team access page

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -139,7 +139,10 @@ Check publication owner can add data guidance to ${SUBJECT_NAME} on new release
 Swap the publication owner role for release approver to test approving the methodology
     user changes to bau1
     user removes publication owner access from analyst    ${PUBLICATION_NAME}
-    user gives release access to analyst    ${RELEASE_NAME}    Approver
+    user gives release access to analyst
+    ...    ${PUBLICATION_NAME}
+    ...    ${RELEASE_TYPE}
+    ...    Approver
 
 Check release approver can approve methodology for publication
     user changes to analyst1
@@ -159,7 +162,10 @@ Check publication owner cannot remove approved methodology
 Swap the publication owner role for release approver to test unapproving the methodology
     user changes to bau1
     user removes publication owner access from analyst    ${PUBLICATION_NAME}
-    user gives release access to analyst    ${RELEASE_NAME}    Approver
+    user gives release access to analyst
+    ...    ${PUBLICATION_NAME}
+    ...    ${RELEASE_TYPE}
+    ...    Approver
 
 Check release approver can unapprove methodology
     user changes to analyst1
@@ -220,7 +226,10 @@ Check publication owner can create and cancel methodology amendments on a live p
 Swap the publication owner role for release approver to test approving methodology amendments
     user changes to bau1
     user removes publication owner access from analyst    ${PUBLICATION_NAME}
-    user gives release access to analyst    ${RELEASE_NAME}    Approver
+    user gives release access to analyst
+    ...    ${PUBLICATION_NAME}
+    ...    ${RELEASE_TYPE}
+    ...    Approver
 
 Check release approver can approve methodology amendments on a live publication
     user changes to analyst1
@@ -243,7 +252,10 @@ Create a new methodology amendment
 Swap the publication owner role for release approver to test approving the methodology amendment
     user changes to bau1
     user removes publication owner access from analyst    ${PUBLICATION_NAME}
-    user gives release access to analyst    ${RELEASE_NAME}    Approver
+    user gives release access to analyst
+    ...    ${PUBLICATION_NAME}
+    ...    ${RELEASE_TYPE}
+    ...    Approver
 
 Check release approver can approve the methodology amendment for publishing with the release amendment
     user changes to analyst1

--- a/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
@@ -82,33 +82,22 @@ Switch to bau1 to add review comments for first text block
     user opens accordion section    ${SECTION_1_TITLE}    id:releaseMainContent
     ${block}=    user starts editing accordion section text block    First content section    1
     ...    id:releaseMainContent
-    ${editor}=    get editor    ${block}
-    ${toolbar}=    get editor toolbar    ${block}
-    ${comments}=    get comments sidebar    ${block}
 
     # ensure 'Set page view' box doesn't intercept button click
     user scrolls down    150
     user presses keys    CTRL+a
-    user clicks button    Add comment    ${toolbar}
-
-    user waits until parent contains element    ${comments}    testid:comment-textarea
-    ${textarea}=    get child element    ${comments}    testid:comment-textarea
-    user enters text into element    ${textarea}    Test comment 1
-    user clicks button    Add comment    ${comments}
+    user adds comment to selected text    ${block}    Test comment 1
 
     user checks list has x items    testid:unresolvedComments    1    ${block}
     user checks list item contains    testid:unresolvedComments    1    Test comment 1    ${block}
 
+    ${editor}=    get editor    ${block}
     user sets focus to element    ${editor}
 
     # Selects the rest of the line
-    user presses keys    END    ${\n}    Block 1 another sentence    SHIFT+ARROW_LEFT    SHIFT+HOME
-    user clicks button    Add comment    ${toolbar}
-
-    user waits until parent contains element    ${comments}    testid:comment-textarea
-    ${textarea}=    get child element    ${comments}    testid:comment-textarea
-    user enters text into element    ${textarea}    Test comment 2
-    user clicks button    Add comment    ${comments}
+    user presses keys    END    RETURN    Block 1 another sentence    SHIFT+HOME
+    sleep    0.1    # Prevent intermittent failure where toolbar button is disabled
+    user adds comment to selected text    ${block}    Test comment 2
 
     user checks list has x items    testid:unresolvedComments    2    ${block}
     user checks list item contains    testid:unresolvedComments    1    Test comment 1    ${block}
@@ -120,19 +109,11 @@ Add review comment for second text block as bau1
     user opens accordion section    ${SECTION_1_TITLE}    id:releaseMainContent
     ${block}=    user starts editing accordion section text block    First content section    2
     ...    id:releaseMainContent
-    ${editor}=    get editor    ${block}
-    ${toolbar}=    get editor toolbar    ${block}
-    ${comments}=    get comments sidebar    ${block}
 
     # ensure 'Set page view' box doesn't intercept button click
     user scrolls down    100
     user presses keys    CTRL+a
-    user clicks button    Add comment    ${toolbar}
-
-    user waits until parent contains element    ${comments}    testid:comment-textarea
-    ${textarea}=    get child element    ${comments}    testid:comment-textarea
-    user enters text into element    ${textarea}    Test comment 3
-    user clicks button    Add comment    ${comments}
+    user adds comment to selected text    ${block}    Test comment 3
 
     user checks list has x items    testid:unresolvedComments    1    ${block}
     user checks list item contains    testid:unresolvedComments    1    Test comment 3    ${block}
@@ -270,3 +251,18 @@ Delete unresolved comment as bau1
     user waits until parent does not contain element    ${block}    testid:unresolvedComments
 
     user saves autosaving text block    ${block}
+
+
+*** Keywords ***
+user adds comment to selected text
+    [Arguments]    ${block}    ${text}
+    ${toolbar}=    get editor toolbar    ${block}
+    ${button}=    user gets button element    Add comment    ${toolbar}
+    user checks element does not have class    ${button}    ck-disabled
+    user clicks element    ${button}
+
+    ${comments}=    get comments sidebar    ${block}
+    user waits until parent contains element    ${comments}    testid:comment-textarea
+    ${textarea}=    get child element    ${comments}    testid:comment-textarea
+    user enters text into element    ${textarea}    ${text}
+    user clicks button    Add comment    ${comments}

--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -256,6 +256,7 @@ Check data catalogue page contains archive and superseding publication subjects
     user checks page contains    This is not the latest data
 
     user clicks button    Change publication
+    user waits for page to finish loading
     user waits until page contains    Choose a publication
 
     user clicks radio    %{TEST_THEME_NAME}
@@ -419,6 +420,7 @@ Check data catalogue page is correct after archive-publication has been unarchiv
     user checks page does not contain    This is not the latest data
 
     user clicks button    Change publication
+    user waits for page to finish loading
     user waits until page contains    Choose a publication
 
     user clicks radio    %{TEST_THEME_NAME}

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -415,6 +415,7 @@ Return to Admin and Create amendment
 Change the Release type
     user waits until page contains link    Edit release summary
     user clicks link    Edit release summary
+    user waits until page does not contain loading spinner
     user waits until h2 is visible    Edit release summary
     user checks page contains radio    Experimental statistics
     user clicks radio    Experimental statistics

--- a/tests/robot-tests/tests/bootstrap_data/release_and_publication_role_permissions_data.robot
+++ b/tests/robot-tests/tests/bootstrap_data/release_and_publication_role_permissions_data.robot
@@ -91,7 +91,7 @@ user gives release access to all releases of publication to analyst
     [Arguments]
     ...    ${PUBLICATION_NAME}
     ...    ${ROLE}
-    user gives release access to analyst    ${PUBLICATION_NAME} - ${DRAFT_RELEASE_TYPE}    ${ROLE}
-    user gives release access to analyst    ${PUBLICATION_NAME} - ${HIGHER_REVIEW_RELEASE_TYPE}    ${ROLE}
-    user gives release access to analyst    ${PUBLICATION_NAME} - ${APPROVED_RELEASE_TYPE}    ${ROLE}
-    user gives release access to analyst    ${PUBLICATION_NAME} - ${PUBLISHED_RELEASE_TYPE}    ${ROLE}
+    user gives release access to analyst    ${PUBLICATION_NAME}    ${DRAFT_RELEASE_TYPE}    ${ROLE}
+    user gives release access to analyst    ${PUBLICATION_NAME}    ${HIGHER_REVIEW_RELEASE_TYPE}    ${ROLE}
+    user gives release access to analyst    ${PUBLICATION_NAME}    ${APPROVED_RELEASE_TYPE}    ${ROLE}
+    user gives release access to analyst    ${PUBLICATION_NAME}    ${PUBLISHED_RELEASE_TYPE}    ${ROLE}

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -192,6 +192,7 @@ user navigates to publication page from dashboard
     user clicks link    ${publication}
     user waits until h1 is visible    ${publication}
     user waits until h2 is visible    Manage releases
+    user waits until page does not contain loading spinner
 
 user creates methodology for publication
     [Arguments]
@@ -697,7 +698,8 @@ user gives publication access to analyst
     user waits until element is enabled    css:[name="selectedPublicationRole"]
     user chooses select option    css:[name="selectedPublicationRole"]    ${ROLE}
     user clicks button    Add publication access
-    user waits until page does not contain loading spinner
+    user waits until parent contains element    testid:publicationAccessTable
+    ...    xpath://tbody/tr[td[//th[text()="Publication"] and text()="${PUBLICATION_NAME}"] and td[//th[text()="Role"] and text()="${ROLE}"]]
 
 user removes publication access from analyst
     [Arguments]
@@ -712,14 +714,19 @@ user removes publication access from analyst
     user waits until page does not contain loading spinner
 
 user gives release access to analyst
-    [Arguments]    ${RELEASE_NAME}    ${ROLE}    ${ANALYST_EMAIL}=EES-test.ANALYST1@education.gov.uk
+    [Arguments]
+    ...    ${PUBLICATION_NAME}
+    ...    ${RELEASE_NAME}
+    ...    ${ROLE}
+    ...    ${ANALYST_EMAIL}=EES-test.ANALYST1@education.gov.uk
     user goes to manage user    ${ANALYST_EMAIL}
     user scrolls to element    css:[name="selectedReleaseId"]
-    user chooses select option    css:[name="selectedReleaseId"]    ${RELEASE_NAME}
+    user chooses select option    css:[name="selectedReleaseId"]    ${PUBLICATION_NAME} - ${RELEASE_NAME}
     user waits until element is enabled    css:[name="selectedReleaseRole"]
     user chooses select option    css:[name="selectedReleaseRole"]    ${ROLE}
     user clicks button    Add release access
-    user waits until page does not contain loading spinner
+    user waits until parent contains element    testid:releaseAccessTable
+    ...    xpath://tbody/tr[td[//th[text()="Publication"] and text()="${PUBLICATION_NAME}"] and td[//th[text()="Release"] and text()="${RELEASE_NAME}"] and td[//th[text()="Role"] and text()="${ROLE}"]]
 
 user removes release access from analyst
     [Arguments]    ${PUBLICATION_NAME}    ${RELEASE_NAME}    ${ROLE}    ${ANALYST_EMAIL}=EES-test.ANALYST1@education.gov.uk

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -448,6 +448,12 @@ user checks element has class
     ${classes}=    get element attribute    ${element}    class
     should contain    ${classes}    ${class}
 
+user checks element does not have class
+    [Arguments]    ${selector}    ${class}    ${parent}=css:body
+    ${element}=    lookup or return webelement    ${selector}    ${parent}
+    ${classes}=    get element attribute    ${element}    class
+    should not contain    ${classes}    ${class}
+
 user waits until element is enabled
     [Arguments]    ${element}    ${wait}=${timeout}
     wait until element is enabled    ${element}    ${wait}


### PR DESCRIPTION
This PR experiments with a few changes to see if any fix intermittent UI tests seen when running against the Dev environment

1.  `bau/create_publication_and_release.robot` failing in `Verify new publication has no releases` - `Page should have contained text 'You have no scheduled releases.' but did not`.

2. `admin_and_public_2/bau/publish_release_and_amend.robot` failing in `Change the release type` - `Page should have contained radio button 'xpath://label[text()="Experimental statistics"]/../input[@type="radio"]' but did not.`

3. `/admin/bau/release_content_authoring.robot` failing in `Switch to bau1 to add review comments for first text block` - `Parent ... did not contain 'testid:comment-textarea'`.

4. Multiple occurrences of `StaleElementReferenceException` in `bau/archive_publication.robot`.

5. `admin/analyst/invite_contiributor_as_publication_owner.robot` failing in `Check Manage team access button is not visible` - Publication is missing from Admin dashboard which appears to be down to the release role not being granted. Tests fails with `Element 'xpath://a[text()="UI tests - invite contributor 20230118-190228"]' did not appear in...`

### UI test report

![image](https://user-images.githubusercontent.com/4147126/214318412-b0b6afa5-079c-481f-bfc4-33c30e945b48.png)

