### PR TITLE
fix(frontend): fix app insights being hoisted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+tsconfig.tsbuildinfo
 
 ## Tests
 

--- a/.npmrc
+++ b/.npmrc
@@ -14,3 +14,4 @@ shamefully-hoist=true
 hoist-pattern[]=!react/*
 hoist-pattern[]=!react-dom/*
 hoist-pattern[]=!formik/*
+hoist-pattern[]=!applicationinsights/*


### PR DESCRIPTION
This PR fixes a problem whereby applicationinsights was being hoisted out of the frontend's relative `node_modules` directory causing the frontend to not start properly in a production setting:

```
Application has thrown an uncaught exception and is terminated:Error: Cannot find module 'diagnostic-channel-publishers'Require stack:- D:\home\site\wwwroot\node_modules\applicationinsights\out\AutoCollection\diagnostic-channel\initialization.js- D:\home\site\wwwroot\node_modules\applicationinsights\out\AutoCollection\CorrelationContextManager.js- D:\home\site\wwwroot\node_modules\applicationinsights\out\applicationinsights.js- D:\home\site\wwwroot\server.js- D:\Program Files\iisnode\interceptor.jsat Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)at Function.Module._load (internal/modules/cjs/loader.js:725:27)at Module.require (internal/modules/cjs/loader.js:952:19)at require (internal/modules/cjs/helpers.js:88:18)at Object.<anonymous> (D:\home\site\wwwroot\node_modules\applicationinsights\out\AutoCollection\diagnostic-channel\initialization.js:10:22)at Module._compile (internal/modules/cjs/loader.js:1063:30)at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)at Module.load (internal/modules/cjs/loader.js:928:32)at Function.Module._load (internal/modules/cjs/loader.js:769:14)at Module.require (internal/modules/cjs/loader.js:952:19)
```