### PR TITLE
EES-4047 show not latest data tag on release page

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -6,6 +6,7 @@ import RelatedAside from '@common/components/RelatedAside';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import Tag from '@common/components/Tag';
+import TagGroup from '@common/components/TagGroup';
 import ContentBlockRenderer from '@common/modules/find-statistics/components/ContentBlockRenderer';
 import ReleaseDataAccordion from '@common/modules/release/components/ReleaseDataAccordion';
 import publicationService, {
@@ -90,24 +91,30 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
         <div className="govuk-grid-column-two-thirds">
           <div className="dfe-flex dfe-align-items--center dfe-justify-content--space-between govuk-!-margin-bottom-3">
             <div>
-              {!release.publication.isSuperseded &&
-                (release.latestRelease ? (
-                  <Tag className="govuk-!-margin-right-3 govuk-!-margin-bottom-3">
-                    This is the latest data
-                  </Tag>
-                ) : (
-                  <Link
-                    className="dfe-print-hidden dfe-block govuk-!-margin-bottom-3"
-                    unvisited
-                    to={`/find-statistics/${release.publication.slug}`}
-                  >
-                    View latest data:{' '}
-                    <span className="govuk-!-font-weight-bold">
-                      {release.publication.releases[0].title}
-                    </span>
-                  </Link>
-                ))}
-              {release.type && <Tag>{releaseTypes[release.type]}</Tag>}
+              {!release.publication.isSuperseded && !release.latestRelease && (
+                <Link
+                  className="dfe-print-hidden dfe-block govuk-!-margin-bottom-3"
+                  unvisited
+                  to={`/find-statistics/${release.publication.slug}`}
+                >
+                  View latest data:{' '}
+                  <span className="govuk-!-font-weight-bold">
+                    {release.publication.releases[0].title}
+                  </span>
+                </Link>
+              )}
+              <TagGroup>
+                {!release.publication.isSuperseded && (
+                  <>
+                    {release.latestRelease ? (
+                      <Tag>This is the latest data</Tag>
+                    ) : (
+                      <Tag colour="orange">This is not the latest data</Tag>
+                    )}
+                  </>
+                )}
+                {release.type && <Tag>{releaseTypes[release.type]}</Tag>}
+              </TagGroup>
             </div>
             {release.type === 'NationalStatistics' && (
               <img

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
@@ -6,22 +6,14 @@ import React from 'react';
 import { testPublication, testRelease } from './__data__/testReleaseData';
 
 describe('PublicationReleasePage', () => {
-  test('renders national statistics image', () => {
-    const { container } = render(
-      <PublicationReleasePage release={testRelease} />,
-    );
-
-    expect(
-      container.querySelector(
-        'img[alt="UK statistics authority quality mark"]',
-      ),
-    ).toBeDefined();
-  });
-
   test('renders latest data tag', () => {
     render(<PublicationReleasePage release={testRelease} />);
 
     expect(screen.queryByText('This is the latest data')).toBeInTheDocument();
+
+    expect(
+      screen.queryByText('This is not the latest data'),
+    ).not.toBeInTheDocument();
   });
 
   test('does not render latest data tag when publication is superseded', () => {
@@ -34,6 +26,25 @@ describe('PublicationReleasePage', () => {
     expect(
       screen.queryByText('This is the latest data'),
     ).not.toBeInTheDocument();
+  });
+
+  test('renders not latest data link and tag when publication is not the latest', () => {
+    const testReleaseNotLatest: Release = {
+      ...testRelease,
+      latestRelease: false,
+    };
+    render(<PublicationReleasePage release={testReleaseNotLatest} />);
+
+    expect(screen.getByText('This is not the latest data')).toBeInTheDocument();
+    expect(
+      screen.queryByText('This is the latest data'),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {
+        name: 'View latest data: Academic Year 2018/19',
+      }),
+    ).toBeInTheDocument();
   });
 
   test('renders superseded warning text when publication is superseded', () => {
@@ -64,7 +75,7 @@ describe('PublicationReleasePage', () => {
     );
   });
 
-  test('does not render superseded warning text when publication is superseded', () => {
+  test('does not render superseded warning text when publication is not superseded', () => {
     const testReleaseSuperseded: Release = {
       ...testRelease,
       publication: {
@@ -224,6 +235,18 @@ describe('PublicationReleasePage', () => {
     );
   });
 
+  test('renders national statistics image', () => {
+    const { container } = render(
+      <PublicationReleasePage release={testRelease} />,
+    );
+
+    expect(
+      container.querySelector(
+        'img[alt="UK statistics authority quality mark"]',
+      ),
+    ).toBeInTheDocument();
+  });
+
   test('renders national statistics section', () => {
     render(<PublicationReleasePage release={testRelease} />);
 
@@ -235,7 +258,7 @@ describe('PublicationReleasePage', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('renders official statistics image', () => {
+  test('does not render image for official statistics', () => {
     const { container } = render(
       <PublicationReleasePage
         release={{
@@ -249,7 +272,7 @@ describe('PublicationReleasePage', () => {
       container.querySelector(
         'img[alt="UK statistics authority quality mark"]',
       ),
-    ).toBeNull();
+    ).not.toBeInTheDocument();
   });
 
   test('renders official statistics section', () => {


### PR DESCRIPTION
Adds the 'This is not the latest data' tag to release pages.
![notlatestdata](https://user-images.githubusercontent.com/81572860/214803931-a961eba5-0fbb-4f27-9c5b-d5c25c69e9fe.PNG)
