### PR TITLE
test: fix intermittent failures for no matching results on `FindStatisticsPage` suite

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPage.test.tsx
@@ -288,7 +288,7 @@ describe('FindStatisticsPage', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText('There are no matching results.'),
+      await screen.findByText('There are no matching results.'),
     ).toBeInTheDocument();
 
     expect(screen.queryByTestId('publicationsList')).not.toBeInTheDocument();
@@ -342,11 +342,9 @@ describe('FindStatisticsPage', () => {
 
     render(<FindStatisticsPage />);
 
-    await waitFor(() => {
-      expect(
-        screen.getByText('There are no matching results.'),
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText('There are no matching results.'),
+    ).toBeInTheDocument();
 
     expect(
       screen.getByRole('heading', { name: '0 results' }),
@@ -415,11 +413,9 @@ describe('FindStatisticsPage', () => {
 
     render(<FindStatisticsPage />);
 
-    await waitFor(() => {
-      expect(
-        screen.getByText('There are no matching results.'),
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText('There are no matching results.'),
+    ).toBeInTheDocument();
 
     expect(screen.getByText('0 pages, filtered by:')).toBeInTheDocument();
 


### PR DESCRIPTION
This also swaps existing `waitFor` calls to use `screen.findByText` instead as this is a little more ergonomic.