### PR TITLE
EES-4042 change iframe resizer height calculation method

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/EmbedBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/EmbedBlock.tsx
@@ -20,7 +20,7 @@ const EmbedBlock = ({ title, url }: Props) => {
       {isLoading && <LoadingSpinner hideText text={`Loading ${title}`} />}
 
       <IframeResizer
-        heightCalculationMethod="lowestElement"
+        heightCalculationMethod="bodyScroll"
         src={url}
         style={{ border: 0, minWidth: '100%', width: '1px' }}
         title={title}


### PR DESCRIPTION
Fixes a bug with the embedded Tiny Shiny dashboard (https://department-for-education.shinyapps.io/dfe-tiny-shiny/) where hovering over the dropdown options caused the iframe height to adjust.

This was caused by the accessibility add on for the Selectize plugin, https://github.com/SLMNBJ/selectize-plugin-a11y/, which adds a hidden div with the option text which is announced to screen readers. The div is added at the bottom of the content so changes to it triggered the iframeResizer height calculation method as it was set to `lowestElement`. Changing it to `bodyScroll` fixes the problem and doesn't create any new problems with the other test dashboards.