### PR TITLE
EES-4054 Fix XPath expressions getting publication details when creating the Find Statistics snapshot

### DIFF
--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -108,15 +108,9 @@ class SnapshotService:
                 lambda driver: driver.find_element(By.XPATH, "//*[@data-testid='publicationsList']")
             )
 
-            publications_list = driver.find_element(By.XPATH, "//*[@data-testid='publicationsList']")
+            publications_list_items = driver.find_elements(By.XPATH, "//*[@data-testid='publicationsList']/li")
 
-            all_publications = publications_list.find_elements(By.CSS_SELECTOR, "li")
-
-            for publication in all_publications:
-                publication.click()
-
-                publication_details = publication.find_element(By.CSS_SELECTOR, "dl")
-
+            for publication in publications_list_items:
                 publication_title = publication.find_element(By.CSS_SELECTOR, "h3").text
 
                 try:
@@ -124,15 +118,11 @@ class SnapshotService:
                 except NoSuchElementException:
                     publication_summary = ""
 
-                release_type = publication_details.find_element(
-                    By.XPATH, "//*[dl]//div//dd[@data-testid='release-type']"
-                ).text
+                release_type = publication.find_element(By.XPATH, "./dl//dd[@data-testid='release-type']").text
 
-                theme = publication_details.find_element(By.XPATH, "//*[dl]//div//dd[@data-testid='theme']").text
+                theme = publication.find_element(By.XPATH, "./dl//dd[@data-testid='theme']").text
 
-                published = publication_details.find_element(
-                    By.XPATH, "//*[dl]//div//dd[@data-testid='published']"
-                ).text
+                published = publication.find_element(By.XPATH, "./dl//dd[@data-testid='published']").text
 
                 publications.append(
                     {
@@ -204,7 +194,7 @@ class SnapshotService:
         methodologies_accordion = parsed_html.find(id="themes")
 
         if methodologies_accordion is None:
-            return []
+            return "[]"
 
         theme_sections = methodologies_accordion.select('[data-testid="accordionSection"]') or []
 


### PR DESCRIPTION
This PR fixes the expressions getting the details of each publication for creating/validating the Find Statistics snapshot.

It was incorrectly getting the details from the first publication list item on the page meaning that large parts of the snapshot data are incorrect.

It results in false negative reports that there are no snapshot differences during validation, when there are changes, as seen on 26/01/2023.

Here's an example where release type, published date and theme in the snapshot data are wrong.

Publication data in the snapshot:

![image-20230127-090012](https://user-images.githubusercontent.com/4147126/215049546-190f98bb-0b9c-4c0e-85b4-85bdd7a0997e.png)

Current view of the same publication on the Prod Find Statistics page:

![image-20230127-085929](https://user-images.githubusercontent.com/4147126/215049461-a174811a-f86c-43a4-aa48-9b01b41ac4a3.png)


