### PR TITLE
EES-4056 Tidy up of approving releases ahead of EES-4001

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -299,14 +300,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         [Fact]
         public async Task CreateReleaseStatus()
         {
-            var releaseStatusViewModel = new ReleaseStatusCreateViewModel();
+            var request = new ReleaseStatusCreateRequest();
             var returnedReleaseViewModel = new ReleaseViewModel();
             
             var mocks = Mocks();
 
             mocks
                 .ReleaseApprovalService
-                .Setup(s => s.CreateReleaseStatus(_releaseId, releaseStatusViewModel))
+                .Setup(s => s.CreateReleaseStatus(_releaseId, request))
                 .ReturnsAsync(Unit.Instance);
             
             mocks
@@ -317,7 +318,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var controller = ReleasesControllerWithMocks(mocks);
 
             // Call the method under test
-            var result = await controller.CreateReleaseStatus(releaseStatusViewModel, _releaseId);
+            var result = await controller.CreateReleaseStatus(request, _releaseId);
             VerifyAllMocks(mocks);
             
             result.AssertOkResult(returnedReleaseViewModel);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
@@ -249,7 +249,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
                 Assert.NotNull(contentRelease);
                 Assert.Equal(release.Id, contentRelease.Id);
                 Assert.Equal("Academic Year", contentRelease.CoverageTitle);
-                Assert.NotNull(contentRelease.DataLastPublished);
                 Assert.True(contentRelease.HasDataGuidance);
                 Assert.True(contentRelease.HasPreReleaseAccessList);
                 Assert.Equal(release.KeyStatisticsSection.Id, contentRelease.KeyStatisticsSection.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -1046,7 +1046,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     TeamName = "Old team",
                     TeamEmail = "old.smith@test.com",
                 },
-                Published = new DateTime(2020, 8, 12),
+                LatestPublishedRelease = new Release(),
                 SupersededBy = supersedingPublicationToRemove,
             };
 
@@ -1229,7 +1229,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Title = "Test topic",
                     Theme = new Theme(),
                 },
-                Published = DateTime.UtcNow,
+                LatestPublishedRelease = new Release()
             };
 
             var supersededPublication1 = new Publication

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServicePermissionTests.cs
@@ -1,11 +1,11 @@
 #nullable enable
 using System;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.ManageContent;
-using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -64,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         var service = BuildService(userService.Object);
                         return service.CreateReleaseStatus(
                             _release.Id,
-                            new ReleaseStatusCreateViewModel
+                            new ReleaseStatusCreateRequest
                             {
                                 ApprovalStatus = ReleaseApprovalStatus.Draft
                             }
@@ -85,7 +85,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         var service = BuildService(userService.Object);
                         return service.CreateReleaseStatus(
                             _release.Id,
-                            new ReleaseStatusCreateViewModel
+                            new ReleaseStatusCreateRequest
                             {
                                 ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview
                             }
@@ -106,7 +106,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         var service = BuildService(userService.Object);
                         return service.CreateReleaseStatus(
                             _release.Id,
-                            new ReleaseStatusCreateViewModel
+                            new ReleaseStatusCreateRequest
                             {
                                 ApprovalStatus = ReleaseApprovalStatus.Approved
                             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.ManageContent;
@@ -89,7 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         amendedRelease.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             PublishScheduled = "2051-06-30",
                             ApprovalStatus = ReleaseApprovalStatus.Draft
@@ -156,7 +157,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await releaseService
                     .CreateReleaseStatus(
                         releaseId,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
@@ -241,7 +242,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -287,7 +288,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -329,7 +330,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -385,7 +386,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -446,7 +447,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -504,7 +505,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -565,7 +566,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -623,7 +624,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -682,7 +683,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -731,7 +732,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Draft,
                         }
@@ -800,7 +801,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -875,7 +876,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -980,7 +981,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         amendedRelease.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             PublishScheduled = "2051-06-30",
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
@@ -1081,7 +1082,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         amendedRelease.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             PublishScheduled = "2051-06-30",
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
@@ -1138,7 +1139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Draft,
                             LatestInternalReleaseNote = "Test note",
@@ -1232,7 +1233,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         releaseId,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = nextReleaseDateEdited,
@@ -1354,7 +1355,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await releaseService
                     .CreateReleaseStatus(
                         releaseId,
-                        new ReleaseStatusCreateViewModel
+                        new ReleaseStatusCreateRequest
                         {
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = nextReleaseDateEdited,
@@ -1685,7 +1686,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await releaseService
                     .CreateReleaseStatus(
-                        release.Id, new ReleaseStatusCreateViewModel
+                        release.Id, new ReleaseStatusCreateRequest
                         {
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
@@ -1762,7 +1763,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await releaseService
                     .CreateReleaseStatus(
-                        release.Id, new ReleaseStatusCreateViewModel
+                        release.Id, new ReleaseStatusCreateRequest
                         {
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
@@ -1831,7 +1832,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await releaseService
                     .CreateReleaseStatus(
-                        release.Id, new ReleaseStatusCreateViewModel
+                        release.Id, new ReleaseStatusCreateRequest
                         {
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
@@ -163,7 +163,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = nextReleaseDateEdited,
                             ApprovalStatus = ReleaseApprovalStatus.Draft,
-                            LatestInternalReleaseNote = "Test internal note"
+                            InternalReleaseNote = "Test internal note"
                         }
                     );
 
@@ -245,7 +245,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note",
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = new PartialDate {Month="12", Year="2000"}
@@ -291,7 +291,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note",
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = null,
                             NextReleaseDate = new PartialDate {Month="12", Year="2000"}
@@ -333,7 +333,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note",
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "",
                             NextReleaseDate = new PartialDate {Month="12", Year="2000"}
@@ -389,7 +389,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note",
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2022-12-31",
                             NextReleaseDate = new PartialDate {Month="12", Year="2000"}
@@ -450,7 +450,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note",
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2023-06-06",
                             NextReleaseDate = new PartialDate { Month = "12", Year = "2000" }
@@ -508,7 +508,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note",
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2023-01-01",
                             NextReleaseDate = new PartialDate { Month = "12", Year = "2000" }
@@ -569,7 +569,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note",
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2023-06-07",
                             NextReleaseDate = new PartialDate { Month = "12", Year = "2000" }
@@ -627,7 +627,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note",
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2023-01-08", // Sunday
                             NextReleaseDate = new PartialDate { Month = "12", Year = "2000" }
@@ -686,7 +686,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note",
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2023-01-01",
                             NextReleaseDate = new PartialDate { Month = "12", Year = "2000" }
@@ -804,7 +804,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note",
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = new PartialDate {Month="12", Year="2000"}
@@ -879,7 +879,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note",
                             // No need to include NotifySubscribers - should default to true for original releases
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
@@ -1142,7 +1142,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new ReleaseStatusCreateRequest
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Draft,
-                            LatestInternalReleaseNote = "Test note",
+                            InternalReleaseNote = "Test note"
                         }
                     );
 
@@ -1238,7 +1238,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = nextReleaseDateEdited,
                             ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview,
-                            LatestInternalReleaseNote = "Internal note"
+                            InternalReleaseNote = "Internal note"
                         }
                     );
 
@@ -1360,7 +1360,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = nextReleaseDateEdited,
                             ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview,
-                            LatestInternalReleaseNote = "Test internal note"
+                            InternalReleaseNote = "Test internal note"
                         }
                     );
 
@@ -1691,7 +1691,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
                             ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview,
-                            LatestInternalReleaseNote = "Test internal note",
+                            InternalReleaseNote = "Test internal note",
                             NextReleaseDate = new PartialDate { Month = "12", Year = "2077" }
                         });
 
@@ -1768,7 +1768,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
                             ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview,
-                            LatestInternalReleaseNote = "Test internal note",
+                            InternalReleaseNote = "Test internal note",
                             NextReleaseDate = new PartialDate { Month = "12", Year = "2077" },
                         });
 
@@ -1837,7 +1837,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
                             ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview,
-                            LatestInternalReleaseNote = "Test internal note",
+                            InternalReleaseNote = "Test internal note",
                             NextReleaseDate = new PartialDate { Month = "12", Year = "2077" },
                         });
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -712,11 +712,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     new()
                     {
-                       InternalReleaseNote = "Release note null Created date",
-                       Created = null
-                    },
-                    new()
-                    {
                        InternalReleaseNote = "Latest release note - 1 day ago",
                        Created = DateTime.UtcNow.Subtract(TimeSpan.FromDays(1))
                     },

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -179,7 +180,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpPost("releases/{releaseId}/status")]
-        public async Task<ActionResult<ReleaseViewModel>> CreateReleaseStatus(ReleaseStatusCreateViewModel request,
+        public async Task<ActionResult<ReleaseViewModel>> CreateReleaseStatus(ReleaseStatusCreateRequest request,
             Guid releaseId)
         {
             return await _releaseApprovalService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130104636_EES4056UpdateReleaseStatusInternalReleaseNoteCanBeNull.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130104636_EES4056UpdateReleaseStatusInternalReleaseNoteCanBeNull.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230130104636_EES4056UpdateReleaseStatusInternalReleaseNoteCanBeNull")]
+    partial class EES4056UpdateReleaseStatusInternalReleaseNoteCanBeNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130104636_EES4056UpdateReleaseStatusInternalReleaseNoteCanBeNull.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130104636_EES4056UpdateReleaseStatusInternalReleaseNoteCanBeNull.cs
@@ -1,0 +1,34 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations;
+
+[ExcludeFromCodeCoverage]
+public partial class EES4056UpdateReleaseStatusInternalReleaseNoteCanBeNull : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "InternalReleaseNote",
+            table: "ReleaseStatus",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "InternalReleaseNote",
+            table: "ReleaseStatus",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130105412_EES4056AddReleaseNotifySubscribersAndNotifiedOn.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130105412_EES4056AddReleaseNotifySubscribersAndNotifiedOn.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230130105412_EES4056AddReleaseNotifySubscribersAndNotifiedOn")]
+    partial class EES4056AddReleaseNotifySubscribersAndNotifiedOn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130105412_EES4056AddReleaseNotifySubscribersAndNotifiedOn.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130105412_EES4056AddReleaseNotifySubscribersAndNotifiedOn.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations;
+
+[ExcludeFromCodeCoverage]
+public partial class EES4056AddReleaseNotifySubscribersAndNotifiedOn : Migration
+{
+    private const string MigrationId = "20230130105412";
+
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<DateTime>(
+            name: "NotifiedOn",
+            table: "Releases",
+            type: "datetime2",
+            nullable: true);
+
+        migrationBuilder.AddColumn<bool>(
+            name: "NotifySubscribers",
+            table: "Releases",
+            type: "bit",
+            nullable: false,
+            defaultValue: false);
+
+        migrationBuilder.SqlFromFile(MigrationConstants.ContentMigrationsPath,
+            $"{MigrationId}_EES4056AddReleaseNotifySubscribersAndNotifiedOn.sql");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "NotifiedOn",
+            table: "Releases");
+
+        migrationBuilder.DropColumn(
+            name: "NotifySubscribers",
+            table: "Releases");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130105412_EES4056AddReleaseNotifySubscribersAndNotifiedOn.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130105412_EES4056AddReleaseNotifySubscribersAndNotifiedOn.sql
@@ -1,0 +1,16 @@
+﻿-- Migrate NotifySubscribers and NotifiedOn from the latest 'Approved' release status of the release if one exists
+
+UPDATE Releases
+SET Releases.NotifySubscribers = LatestReleaseStatus.NotifySubscribers,
+    Releases.NotifiedOn        = LatestReleaseStatus.NotifiedOn
+    FROM Releases
+         CROSS APPLY
+     (SELECT TOP (1) NotifySubscribers,
+                     NotifiedOn
+      FROM ReleaseStatus
+      WHERE ReleaseStatus.ApprovalStatus = 'Approved'
+        AND ReleaseStatus.ReleaseId = Releases.Id
+      ORDER BY ReleaseStatus.Created DESC) LatestReleaseStatus
+
+-- ReleaseStatus.NotifySubscribers and ReleaseStatus.NotifiedOn will be dropped by a further migration
+-- once this has been successfully run in all environments. See EES-4058.

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseStatusCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseStatusCreateRequest.cs
@@ -16,7 +16,7 @@ public record ReleaseStatusCreateRequest
     [JsonConverter(typeof(StringEnumConverter))]
     public ReleaseApprovalStatus ApprovalStatus { get; init; }
 
-    public string LatestInternalReleaseNote { get; init; } = string.Empty;
+    public string? InternalReleaseNote { get; init; }
 
     public bool? NotifySubscribers { get; init; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseStatusCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseStatusCreateRequest.cs
@@ -1,0 +1,50 @@
+﻿#nullable enable
+using System;
+using System.Globalization;
+using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+
+public record ReleaseStatusCreateRequest
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public ReleaseApprovalStatus ApprovalStatus { get; init; }
+
+    public string LatestInternalReleaseNote { get; init; } = string.Empty;
+
+    public bool? NotifySubscribers { get; init; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public PublishMethod? PublishMethod { get; init; }
+
+    [DateTimeFormatValidator("yyyy-MM-dd")]
+    public string? PublishScheduled { get; init; }
+
+    public DateTime? PublishScheduledDate
+    {
+        get
+        {
+            if (PublishScheduled.IsNullOrEmpty())
+            {
+                return null;
+            }
+
+            DateTime.TryParseExact(
+                PublishScheduled,
+                "yyyy-MM-dd",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var dateTime
+            );
+            return dateTime.AsStartOfDayUtcForTimeZone();
+        }
+    }
+
+    [PartialDateValidator] public PartialDate? NextReleaseDate { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseApprovalService.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
@@ -12,6 +13,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     {
         Task<Either<ActionResult, List<ReleaseStatusViewModel>>> GetReleaseStatuses(Guid releaseId);
 
-        Task<Either<ActionResult, Unit>> CreateReleaseStatus(Guid releaseId, ReleaseStatusCreateViewModel request);
+        Task<Either<ActionResult, Unit>> CreateReleaseStatus(Guid releaseId, ReleaseStatusCreateRequest request);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -218,9 +218,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     if (publication.Live)
                     {
-                        publication.Published = DateTime.UtcNow;
-                        await _context.SaveChangesAsync();
-
                         await _methodologyCacheService.UpdateSummariesTree();
                         await _publicationCacheService.UpdatePublicationTree();
                         await _publicationCacheService.UpdatePublication(publication.Slug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
@@ -142,7 +142,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     var releaseStatus = new ReleaseStatus
                     {
                         Release = release,
-                        InternalReleaseNote = request.LatestInternalReleaseNote,
+                        InternalReleaseNote = request.InternalReleaseNote,
                         NotifySubscribers = notifySubscribers,
                         ApprovalStatus = request.ApprovalStatus,
                         Created = _dateTimeProvider.UtcNow,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Cronos;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
@@ -109,7 +110,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         public async Task<Either<ActionResult, Unit>> CreateReleaseStatus(
-            Guid releaseId, ReleaseStatusCreateViewModel request)
+            Guid releaseId,
+            ReleaseStatusCreateRequest request)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Release>(releaseId, ReleaseChecklistService.HydrateReleaseForChecklist)
@@ -229,7 +231,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
-        private Either<ActionResult, Unit> ValidatePublishDate(ReleaseStatusCreateViewModel request)
+        private Either<ActionResult, Unit> ValidatePublishDate(ReleaseStatusCreateRequest request)
         {
             if (request.ApprovalStatus == ReleaseApprovalStatus.Approved
                 && request.PublishMethod == PublishMethod.Scheduled)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
@@ -129,23 +129,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     release.ApprovalStatus = request.ApprovalStatus;
                     release.NextReleaseDate = request.NextReleaseDate;
-                    release.PublishScheduled = request.PublishMethod == PublishMethod.Immediate &&
-                                               request.ApprovalStatus == ReleaseApprovalStatus.Approved
+                    release.NotifySubscribers = release.Version == 0 || request.NotifySubscribers == true;
+                    release.PublishScheduled = request.PublishMethod == PublishMethod.Immediate
                         ? _dateTimeProvider.UtcNow
                         : request.PublishScheduledDate;
-
-                    // NOTE: Subscribers should be notified if the release is approved and isn't amended,
-                    //       OR if the release is an amendment, is approved, and NotifySubscribers is true
-                    var notifySubscribers = request.ApprovalStatus == ReleaseApprovalStatus.Approved &&
-                        (!release.Amendment || request.NotifySubscribers.HasValue && request.NotifySubscribers.Value);
 
                     var releaseStatus = new ReleaseStatus
                     {
                         Release = release,
                         InternalReleaseNote = request.InternalReleaseNote,
-                        NotifySubscribers = notifySubscribers,
                         ApprovalStatus = request.ApprovalStatus,
-                        Created = _dateTimeProvider.UtcNow,
                         CreatedById = _userService.GetUserId()
                     };
 
@@ -167,9 +160,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                     request.PublishMethod == PublishMethod.Immediate
                                 );
                             }
-
-                            _context.Update(release);
-                            await _context.SaveChangesAsync();
 
                             switch (request.ApprovalStatus)
                             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/ManageContentPageViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/ManageContentPageViewModel.cs
@@ -69,14 +69,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageCont
             public PartialDate NextReleaseDate { get; set; }
 
             public List<Link> RelatedInformation { get; set; } = new List<Link>();
-
-            private DateTime? dataLastPublished;
-
-            public DateTime? DataLastPublished
-            {
-                get => dataLastPublished;
-                set => dataLastPublished = value ?? DateTime.UtcNow;
-            }
         }
 
         public class PublicationViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseStatusViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseStatusViewModel.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
@@ -5,18 +6,18 @@ using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
-    public class ReleaseStatusViewModel
+    public record ReleaseStatusViewModel
     {
         public Guid ReleaseStatusId { get; set; }
 
-        public string InternalReleaseNote { get; set; }
+        public string? InternalReleaseNote { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public ReleaseApprovalStatus ApprovalStatus { get; set; }
 
         public DateTime? Created { get; set; }
 
-        public string CreatedByEmail { get; set; }
+        public string? CreatedByEmail { get; set; }
 
         public int ReleaseVersion { get; set; }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -146,44 +146,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public int Year { get; init; }
     }
 
-    public class ReleaseStatusCreateViewModel
-    {
-        [JsonConverter(typeof(StringEnumConverter))]
-        public ReleaseApprovalStatus ApprovalStatus { get; init; }
-
-        public string LatestInternalReleaseNote { get; init; } = string.Empty;
-
-        public bool? NotifySubscribers { get; init; }
-
-        [JsonConverter(typeof(StringEnumConverter))]
-        public PublishMethod? PublishMethod { get; init; }
-
-        [DateTimeFormatValidator("yyyy-MM-dd")]
-        public string? PublishScheduled { get; init; }
-
-        public DateTime? PublishScheduledDate
-        {
-            get
-            {
-                if (PublishScheduled.IsNullOrEmpty())
-                {
-                    return null;
-                }
-
-                DateTime.TryParseExact(
-                    PublishScheduled,
-                    "yyyy-MM-dd",
-                    InvariantCulture,
-                    DateTimeStyles.None,
-                    out var dateTime
-                );
-                return dateTime.AsStartOfDayUtcForTimeZone();
-            }
-        }
-
-        [PartialDateValidator] public PartialDate? NextReleaseDate { get; init; }
-    }
-
     public class ReleaseSummaryViewModel
     {
         public Guid Id { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -61,7 +61,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public bool NotifySubscribers { get; set; }
 
-        public string LatestInternalReleaseNote { get; set; } = string.Empty;
+        public string? LatestInternalReleaseNote { get; set; }
 
         public bool Amendment { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
@@ -356,7 +356,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                     {
                         Publication = new Publication
                         {
-                            Published = DateTime.UtcNow
+                            LatestPublishedRelease = new Release()
                         },
                         Methodology = methodology
                     });
@@ -403,7 +403,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                     {
                         Publication = new Publication
                         {
-                            Published = DateTime.UtcNow
+                            LatestPublishedRelease = new Release()
                         },
                         Methodology = methodology
                     });
@@ -443,7 +443,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                     {
                         Publication = new Publication
                         {
-                            Published = DateTime.UtcNow
+                            LatestPublishedRelease = new Release()
                         },
                         Methodology = methodology
                     });
@@ -470,7 +470,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         {
             var nonLivePublication = new Publication
             {
-                Published = null
+                LatestPublishedRelease = null
             };
 
             var methodology = new Methodology
@@ -537,7 +537,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         {
             var publication = new Publication
             {
-                Published = DateTime.UtcNow
+                LatestPublishedRelease = new Release()
             };
 
             var methodology1 = new Methodology
@@ -650,7 +650,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         {
             var nonLivePublication = new Publication
             {
-                Published = null
+                LatestPublishedRelease = null
             };
 
             var methodology = new Methodology
@@ -704,7 +704,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         {
             var publication = new Publication
             {
-                Published = DateTime.UtcNow
+                LatestPublishedRelease = new Release()
             };
 
             var methodology1 = new Methodology
@@ -776,7 +776,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         {
             var publication = new Publication
             {
-                Published = DateTime.UtcNow
+                LatestPublishedRelease = new Release()
             };
 
             var methodology = new Methodology
@@ -843,7 +843,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         {
             var publication = new Publication
             {
-                Published = DateTime.UtcNow
+                LatestPublishedRelease = new Release()
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -885,7 +885,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 Publication = new Publication
                 {
-                    Published = DateTime.UtcNow
+                    LatestPublishedRelease = new Release()
                 },
                 Methodology = new Methodology
                 {
@@ -929,7 +929,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 Publication = new Publication
                 {
-                    Published = DateTime.UtcNow
+                    LatestPublishedRelease = new Release()
                 },
                 Methodology = new Methodology
                 {
@@ -967,7 +967,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 Publication = new Publication
                 {
-                    Published = DateTime.UtcNow
+                    LatestPublishedRelease = new Release()
                 },
                 Methodology = new Methodology
                 {
@@ -1011,7 +1011,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 Publication = new Publication
                 {
-                    Published = DateTime.UtcNow
+                    LatestPublishedRelease = new Release()
                 },
                 Methodology = new Methodology
                 {
@@ -1055,7 +1055,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 Publication = new Publication
                 {
-                    Published = DateTime.UtcNow
+                    LatestPublishedRelease = new Release()
                 },
                 Methodology = new Methodology
                 {
@@ -1114,7 +1114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 Publication = new Publication
                 {
-                    Published = DateTime.UtcNow
+                    LatestPublishedRelease = new Release()
                 },
                 Methodology = new Methodology
                 {
@@ -1181,7 +1181,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 Publication = new Publication
                 {
-                    Published = DateTime.UtcNow
+                    LatestPublishedRelease = new Release()
                 },
                 Methodology = new Methodology
                 {
@@ -1251,7 +1251,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 Publication = new Publication
                 {
-                    Published = DateTime.UtcNow
+                    LatestPublishedRelease = new Release()
                 },
                 Methodology = new Methodology
                 {
@@ -1326,7 +1326,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 Publication = new Publication
                 {
-                    Published = DateTime.UtcNow
+                    LatestPublishedRelease = new Release()
                 },
                 Methodology = new Methodology
                 {
@@ -1367,7 +1367,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 Publication = new Publication
                 {
-                    Published = null
+                    LatestPublishedRelease = null
                 },
                 Methodology = new Methodology
                 {
@@ -1405,7 +1405,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 Publication = new Publication
                 {
-                    Published = null
+                    LatestPublishedRelease = new Release()
                 },
                 Methodology = new Methodology
                 {
@@ -1654,7 +1654,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                     Publication = new Publication
                     {
                         Id = publicationId,
-                        Published = DateTime.UtcNow.AddDays(-1)
+                        LatestPublishedRelease = new Release()
                     },
                     Owner = true,
                     Methodology = new Methodology

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -213,12 +213,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .ToTable("ExternalMethodology");
 
             modelBuilder.Entity<Publication>()
-                .Property(n => n.Published)
-                .HasConversion(
-                    v => v,
-                    v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
-
-            modelBuilder.Entity<Publication>()
                 .Property(n => n.Updated)
                 .HasConversion(
                     v => v,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -263,6 +263,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     v => JsonConvert.DeserializeObject<List<Link>>(v));
 
             modelBuilder.Entity<Release>()
+                .Property(r => r.NotifiedOn)
+                .HasConversion(
+                    v => v,
+                    v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
+
+            modelBuilder.Entity<Release>()
                 .HasIndex(r => new {r.PreviousVersionId, r.Version});
 
             modelBuilder.Entity<Release>()
@@ -292,14 +298,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .HasOne(rs => rs.CreatedBy)
                 .WithMany()
                 .OnDelete(DeleteBehavior.NoAction);
-
-            modelBuilder.Entity<ReleaseStatus>()
-                .Property(rs => rs.NotifiedOn)
-                .HasConversion(
-                    v => v,
-                    v => v.HasValue
-                        ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
-                        : null);
 
             modelBuilder.Entity<ReleaseStatus>()
                 .Property(rs => rs.ApprovalStatus)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -25,6 +25,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<LegacyRelease> LegacyReleases { get; set; } = new();
 
+        // TODO EES-4058 Remove unused Published
         public DateTime? Published { get; set; }
 
         public Guid TopicId { get; set; }
@@ -41,7 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public DateTime? Updated { get; set; }
 
-        public bool Live => Published.HasValue && DateTime.Compare(DateTime.UtcNow, Published.Value) > 0;
+        public bool Live => LatestPublishedReleaseId.HasValue;
 
         public Guid? LatestPublishedReleaseId { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -245,6 +245,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<Link> RelatedInformation { get; set; } = new();
 
+        // TODO EES-4058 Remove unused DataLastPublished
         public DateTime? DataLastPublished { get; set; }
 
         public Release Clone()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -65,19 +65,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<ReleaseStatus> ReleaseStatuses { get; set; } = new();
 
-        public bool NotifySubscribers
-        {
-            get
-            {
-                var status = ReleaseStatuses
-                           .OrderBy(rs => rs.Created)
-                           .LastOrDefault();
-                return status != null
-                       && status.NotifySubscribers
-                       && status.NotifiedOn == null;
-            }
-        }
-
         public string? LatestInternalReleaseNote
         {
             get
@@ -98,6 +85,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public string PreReleaseAccessList { get; set; } = string.Empty;
 
         public string DataGuidance { get; set; } = string.Empty;
+
+        public bool NotifySubscribers { get; set; }
+
+        public DateTime? NotifiedOn { get; set; }
 
         public Release? PreviousVersion { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -78,7 +78,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             }
         }
 
-        public string LatestInternalReleaseNote
+        public string? LatestInternalReleaseNote
         {
             get
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
@@ -1,10 +1,11 @@
 #nullable enable
 
 using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
-    public class ReleaseStatus
+    public class ReleaseStatus : ICreatedTimestamp<DateTime?>
     {
         public Guid Id { get; set; }
 
@@ -14,8 +15,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string? InternalReleaseNote { get; set; }
 
+        // TODO EES-4058 Remove unused NotifySubscribers after EES-4056
         public bool NotifySubscribers { get; set; }
 
+        // TODO EES-4058 Remove unused NotifiedOn after EES-4056
         public DateTime? NotifiedOn { get; set; }
 
         public ReleaseApprovalStatus ApprovalStatus { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
@@ -12,10 +12,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Release Release { get; set; } = null!;
 
-        public string InternalReleaseNote { get; set; } = null!;
+        public string? InternalReleaseNote { get; set; }
 
         public bool NotifySubscribers { get; set; }
-        
+
         public DateTime? NotifiedOn { get; set; }
 
         public ReleaseApprovalStatus ApprovalStatus { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseServiceTests.cs
@@ -693,7 +693,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 TimePeriodCoverage = CalendarYear,
                 ReleaseName = "2020",
                 Published = new DateTime(2020, 1, 1),
-                DataLastPublished = new DateTime(2020, 1, 1),
                 NextReleaseDate = new PartialDate { Year = "2020" },
                 Type = ReleaseType.NationalStatistics
             };
@@ -703,7 +702,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 TimePeriodCoverage = CalendarYear,
                 ReleaseName = "2021",
                 Published = new DateTime(2021, 1, 1),
-                DataLastPublished = new DateTime(2021, 1, 1),
                 NextReleaseDate = new PartialDate { Year = "2021" },
                 Type = ReleaseType.NationalStatistics
             };
@@ -743,7 +741,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 Assert.Equal(release2.Published, releases[0].Published);
                 release2.NextReleaseDate.AssertDeepEqualTo(releases[0].NextReleaseDate);
                 Assert.Equal(release2.Type, releases[0].Type);
-                Assert.Equal(release2.DataLastPublished, releases[0].DataLastPublished);
                 Assert.True(releases[0].LatestRelease);
 
                 Assert.Equal(release1.Id, releases[1].Id);
@@ -755,7 +752,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 Assert.Equal(release1.Published, releases[1].Published);
                 release1.NextReleaseDate.AssertDeepEqualTo(releases[1].NextReleaseDate);
                 Assert.Equal(release1.Type, releases[1].Type);
-                Assert.Equal(release1.DataLastPublished, releases[1].DataLastPublished);
                 Assert.False(releases[1].LatestRelease);
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ReleaseSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ReleaseSummaryViewModel.cs
@@ -31,8 +31,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 
         public bool LatestRelease { get; }
 
-        public DateTime? DataLastPublished { get; }
-
         public PublicationSummaryViewModel? Publication { get; }
 
         public ReleaseSummaryViewModel(ReleaseCacheViewModel release, PublicationCacheViewModel publication)
@@ -47,7 +45,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
             NextReleaseDate = release.NextReleaseDate;
             Type = release.Type;
             LatestRelease = Id == publication.LatestReleaseId;
-            DataLastPublished = release.DataLastPublished;
             Publication = new PublicationSummaryViewModel(publication);
         }
 
@@ -63,7 +60,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
             NextReleaseDate = release.NextReleaseDate;
             Type = release.Type;
             LatestRelease = Id == release.Publication.LatestPublishedReleaseId;
-            DataLastPublished = release.DataLastPublished;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ReleaseViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ReleaseViewModel.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -54,8 +53,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 
         public List<LinkViewModel> RelatedInformation { get; }
 
-        public DateTime? DataLastPublished { get; }
-
         public PublicationViewModel Publication { get; }
 
         public ReleaseViewModel(
@@ -81,7 +78,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
             DownloadFiles = release.DownloadFiles;
             HasPreReleaseAccessList = !release.PreReleaseAccessList.IsNullOrEmpty();
             RelatedInformation = release.RelatedInformation;
-            DataLastPublished = release.DataLastPublished;
             Publication = publication;
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -17,7 +16,6 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentif
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
-using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.StatisticsDbUtils;
 using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
@@ -215,121 +213,48 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         [Fact]
         public async Task SetPublishedDates()
         {
-            var contentRelease = new Release
+            var release = new Release
             {
-                Id = Guid.NewGuid(),
                 PreviousVersionId = null,
                 Publication = new Publication(),
                 Version = 0
             };
 
-            var statisticsRelease = new Data.Model.Release
-            {
-                Id = contentRelease.Id
-            };
-
             var published = DateTime.UtcNow;
 
             var contentDbContextId = Guid.NewGuid().ToString();
-            var statisticsDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                await contentDbContext.Releases.AddAsync(contentRelease);
+                await contentDbContext.Releases.AddAsync(release);
                 await contentDbContext.SaveChangesAsync();
-
-                await statisticsDbContext.Release.AddAsync(statisticsRelease);
-                await statisticsDbContext.SaveChangesAsync();
             }
 
             var methodologyService = new Mock<IMethodologyService>(Strict);
 
             methodologyService.Setup(mock =>
-                    mock.SetPublishedDatesByPublication(contentRelease.PublicationId, published))
+                    mock.SetPublishedDatesByPublication(release.PublicationId, published))
                 .Returns(Task.CompletedTask);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 var service = BuildReleaseService(contentDbContext: contentDbContext,
-                    statisticsDbContext: statisticsDbContext,
                     methodologyService: methodologyService.Object);
 
-                await service.SetPublishedDates(contentRelease.Id, published);
+                await service.SetPublishedDates(release.Id, published);
 
                 VerifyAllMocks(methodologyService);
             }
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var actualContentRelease = await contentDbContext
+                var actualRelease = await contentDbContext
                     .Releases
                     .Include(r => r.Publication)
-                    .SingleAsync(r => r.Id == contentRelease.Id);
-                
-                Assert.Equal(published, actualContentRelease.Published);
-                Assert.Equal(published, actualContentRelease.Publication.Published);
+                    .SingleAsync(r => r.Id == release.Id);
 
-                Assert.True(actualContentRelease.DataLastPublished.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(actualContentRelease.DataLastPublished!.Value).Milliseconds, 0,
-                    1500);
-            }
-        }
-
-        [Fact]
-        public async Task SetPublishedDates_ReleaseHasNoStatisticsData()
-        {
-            var contentRelease = new Release
-            {
-                Id = Guid.NewGuid(),
-                PreviousVersionId = null,
-                Publication = new Publication(),
-                Version = 0
-            };
-
-            var published = DateTime.UtcNow;
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            {
-                await contentDbContext.Releases.AddAsync(contentRelease);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            var methodologyService = new Mock<IMethodologyService>(Strict);
-
-            methodologyService.Setup(mock =>
-                    mock.SetPublishedDatesByPublication(contentRelease.PublicationId, published))
-                .Returns(Task.CompletedTask);
-
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext())
-            {
-                var service = BuildReleaseService(contentDbContext: contentDbContext,
-                    statisticsDbContext: statisticsDbContext,
-                    methodologyService: methodologyService.Object);
-
-                await service.SetPublishedDates(contentRelease.Id, published);
-
-                VerifyAllMocks(methodologyService);
-            }
-
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            {
-                var actualContentRelease = await contentDbContext.Releases
-                    .Include(r => r.Publication)
-                    .SingleAsync(r => r.Id == contentRelease.Id);
-
-                Assert.NotNull(actualContentRelease);
-
-                Assert.Equal(published, actualContentRelease.Published);
-                Assert.Equal(published, actualContentRelease.Publication.Published);
-
-                Assert.True(actualContentRelease.DataLastPublished.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(actualContentRelease.DataLastPublished!.Value).Milliseconds, 0,
-                    1500);
+                Assert.Equal(published, actualRelease.Published);
+                Assert.Equal(published, actualRelease.Publication.Published);
             }
         }
 
@@ -338,7 +263,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         {
             var publication = new Publication();
 
-            var previousContentRelease = new Release
+            var previousRelease = new Release
             {
                 Id = Guid.NewGuid(),
                 Publication = publication,
@@ -347,75 +272,56 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Version = 0
             };
 
-            var contentRelease = new Release
+            var release = new Release
             {
-                Id = Guid.NewGuid(),
-                PreviousVersionId = previousContentRelease.Id,
+                PreviousVersionId = previousRelease.Id,
                 Publication = publication,
                 Version = 1
             };
 
-            var statisticsRelease = new Data.Model.Release
-            {
-                Id = contentRelease.Id
-            };
-
             var contentDbContextId = Guid.NewGuid().ToString();
-            var statisticsDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await contentDbContext.Publications.AddAsync(publication);
-                await contentDbContext.Releases.AddRangeAsync(previousContentRelease, contentRelease);
+                await contentDbContext.Releases.AddRangeAsync(previousRelease, release);
                 await contentDbContext.SaveChangesAsync();
-
-                await statisticsDbContext.Release.AddAsync(statisticsRelease);
-                await statisticsDbContext.SaveChangesAsync();
             }
 
             var methodologyService = new Mock<IMethodologyService>(Strict);
 
             methodologyService.Setup(mock =>
-                    mock.SetPublishedDatesByPublication(contentRelease.PublicationId, previousContentRelease.Published.Value))
+                    mock.SetPublishedDatesByPublication(release.PublicationId, previousRelease.Published.Value))
                 .Returns(Task.CompletedTask);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 var service = BuildReleaseService(contentDbContext: contentDbContext,
-                    statisticsDbContext: statisticsDbContext,
                     methodologyService: methodologyService.Object);
 
-                await service.SetPublishedDates(contentRelease.Id, DateTime.UtcNow);
+                await service.SetPublishedDates(release.Id, DateTime.UtcNow);
 
                 VerifyAllMocks(methodologyService);
             }
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var actualContentRelease = await contentDbContext
+                var actualRelease = await contentDbContext
                     .Releases
                     .Include(r => r.Publication)
-                    .SingleAsync(r => r.Id == contentRelease.Id);
-                
-                Assert.Equal(previousContentRelease.Published.Value, actualContentRelease.Published);
-                Assert.Equal(previousContentRelease.Published.Value, actualContentRelease.Publication.Published);
+                    .SingleAsync(r => r.Id == release.Id);
 
-                Assert.True(actualContentRelease.DataLastPublished.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(actualContentRelease.DataLastPublished!.Value).Milliseconds, 0,
-                    1500);
+                Assert.Equal(previousRelease.Published.Value, actualRelease.Published);
+                Assert.Equal(previousRelease.Published.Value, actualRelease.Publication.Published);
             }
         }
 
         private static ReleaseService BuildReleaseService(
             ContentDbContext? contentDbContext = null,
-            StatisticsDbContext? statisticsDbContext = null,
             IMethodologyService? methodologyService = null)
         {
             return new(
                 contentDbContext ?? Mock.Of<ContentDbContext>(),
-                statisticsDbContext ?? Mock.Of<StatisticsDbContext>(Strict),
                 methodologyService ?? Mock.Of<IMethodologyService>(Strict));
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -216,7 +216,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var release = new Release
             {
                 PreviousVersionId = null,
-                Publication = new Publication(),
                 Version = 0
             };
 
@@ -250,23 +249,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             {
                 var actualRelease = await contentDbContext
                     .Releases
-                    .Include(r => r.Publication)
                     .SingleAsync(r => r.Id == release.Id);
 
                 Assert.Equal(published, actualRelease.Published);
-                Assert.Equal(published, actualRelease.Publication.Published);
             }
         }
 
         [Fact]
         public async Task SetPublishedDates_AmendedReleaseHasPublishedDateOfPreviousVersion()
         {
-            var publication = new Publication();
-
             var previousRelease = new Release
             {
                 Id = Guid.NewGuid(),
-                Publication = publication,
                 Published = DateTime.UtcNow.AddDays(-1),
                 PreviousVersionId = null,
                 Version = 0
@@ -275,7 +269,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var release = new Release
             {
                 PreviousVersionId = previousRelease.Id,
-                Publication = publication,
                 Version = 1
             };
 
@@ -283,7 +276,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                await contentDbContext.Publications.AddAsync(publication);
                 await contentDbContext.Releases.AddRangeAsync(previousRelease, release);
                 await contentDbContext.SaveChangesAsync();
             }
@@ -308,11 +300,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             {
                 var actualRelease = await contentDbContext
                     .Releases
-                    .Include(r => r.Publication)
                     .SingleAsync(r => r.Id == release.Id);
 
                 Assert.Equal(previousRelease.Published.Value, actualRelease.Published);
-                Assert.Equal(previousRelease.Published.Value, actualRelease.Publication.Published);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -66,7 +66,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         public async Task SetPublishedDates(Guid id, DateTime published)
         {
             var release = await _contentDbContext.Releases
-                .Include(release => release.Publication)
                 .SingleOrDefaultAsync(r => r.Id == id);
 
             if (release == null)
@@ -90,9 +89,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
             _contentDbContext.Releases.Update(release);
             release.Published ??= published;
-
-            // Update the publication published date
-            release.Publication.Published = published;
 
             // Set the published date on any methodologies used by this publication that are now publicly accessible
             // as a result of this release being published

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Extensions.PublisherExtensions;
@@ -16,15 +15,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
     public class ReleaseService : IReleaseService
     {
         private readonly ContentDbContext _contentDbContext;
-        private readonly StatisticsDbContext _statisticsDbContext;
         private readonly IMethodologyService _methodologyService;
 
         public ReleaseService(ContentDbContext contentDbContext,
-            StatisticsDbContext statisticsDbContext,
             IMethodologyService methodologyService)
         {
             _contentDbContext = contentDbContext;
-            _statisticsDbContext = statisticsDbContext;
             _methodologyService = methodologyService;
         }
 
@@ -69,39 +65,38 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task SetPublishedDates(Guid id, DateTime published)
         {
-            var contentRelease = await _contentDbContext.Releases
+            var release = await _contentDbContext.Releases
                 .Include(release => release.Publication)
                 .SingleOrDefaultAsync(r => r.Id == id);
 
-            if (contentRelease == null)
+            if (release == null)
             {
                 throw new ArgumentException("Content Release does not exist", nameof(id));
             }
 
-            if (contentRelease.Amendment)
+            if (release.Amendment)
             {
                 var previousVersion = await _contentDbContext.Releases.AsNoTracking()
-                    .SingleOrDefaultAsync(r => r.Id == contentRelease.PreviousVersionId);
+                    .SingleOrDefaultAsync(r => r.Id == release.PreviousVersionId);
 
                 if (previousVersion?.Published == null)
                 {
                     throw new ArgumentException("Previous version of release does not exist or is not live",
-                        nameof(contentRelease.PreviousVersionId));
+                        nameof(release.PreviousVersionId));
                 }
 
                 published = previousVersion.Published.Value;
             }
 
-            _contentDbContext.Releases.Update(contentRelease);
-            contentRelease.Published ??= published;
-            contentRelease.DataLastPublished = DateTime.UtcNow;
+            _contentDbContext.Releases.Update(release);
+            release.Published ??= published;
 
             // Update the publication published date
-            contentRelease.Publication.Published = published;
+            release.Publication.Published = published;
 
             // Set the published date on any methodologies used by this publication that are now publicly accessible
             // as a result of this release being published
-            await _methodologyService.SetPublishedDatesByPublication(contentRelease.PublicationId, published);
+            await _methodologyService.SetPublishedDatesByPublication(release.PublicationId, published);
 
             await _contentDbContext.SaveChangesAsync();
         }

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testEditableRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testEditableRelease.ts
@@ -21,7 +21,6 @@ export const testEditableRelease: EditableRelease = {
   slug: '2020-21',
   publicationId: '8586c490-7027-4a8b-9df5-cf105c3e88ec',
   approvalStatus: 'Draft',
-  dataLastPublished: '',
   published: '',
   publication: {
     id: '8586c490-7027-4a8b-9df5-cf105c3e88ec',

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -44,7 +44,7 @@ export interface ReleaseStatusFormValues {
   nextReleaseDate?: PartialDate;
   approvalStatus: ReleaseApprovalStatus;
   notifySubscribers?: boolean;
-  latestInternalReleaseNote: string;
+  internalReleaseNote?: string;
 }
 
 export const formId = 'releaseStatusForm';
@@ -136,7 +136,7 @@ const ReleaseStatusForm = ({
       initialValues={{
         approvalStatus: release.approvalStatus,
         notifySubscribers: release.notifySubscribers,
-        latestInternalReleaseNote: release.latestInternalReleaseNote ?? '',
+        internalReleaseNote: release.latestInternalReleaseNote,
         publishMethod: release.publishScheduled ? 'Scheduled' : undefined,
         publishScheduled: release.publishScheduled
           ? parseISO(release.publishScheduled)
@@ -152,7 +152,7 @@ const ReleaseStatusForm = ({
           is: value => value === 'Approved',
           then: Yup.boolean().required(),
         }),
-        latestInternalReleaseNote: Yup.string().when('approvalStatus', {
+        internalReleaseNote: Yup.string().when('approvalStatus', {
           is: value => ['Approved', 'HigherLevelReview'].includes(value),
           then: Yup.string().required('Enter an internal note'),
         }),
@@ -230,7 +230,7 @@ const ReleaseStatusForm = ({
             />
 
             <FormFieldTextArea<ReleaseStatusFormValues>
-              name="latestInternalReleaseNote"
+              name="internalReleaseNote"
               className="govuk-!-width-one-half"
               label="Internal note"
               hint="Please include any relevant information"

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -233,7 +233,6 @@ describe('ReleaseStatusForm', () => {
       userEvent.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
-        latestInternalReleaseNote: '',
         approvalStatus: 'Draft',
       };
 
@@ -276,7 +275,7 @@ describe('ReleaseStatusForm', () => {
       userEvent.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
-        latestInternalReleaseNote: 'Test release note',
+        internalReleaseNote: 'Test release note',
         approvalStatus: 'HigherLevelReview',
         nextReleaseDate: {
           month: 5,
@@ -313,7 +312,7 @@ describe('ReleaseStatusForm', () => {
 
       expect(
         screen.getByRole('link', { name: 'Enter an internal note' }),
-      ).toHaveAttribute('href', '#releaseStatusForm-latestInternalReleaseNote');
+      ).toHaveAttribute('href', '#releaseStatusForm-internalReleaseNote');
     });
 
     test('fails to submit with invalid values', async () => {
@@ -377,7 +376,7 @@ describe('ReleaseStatusForm', () => {
       userEvent.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
-        latestInternalReleaseNote: 'Test release note',
+        internalReleaseNote: 'Test release note',
         approvalStatus: 'Draft',
         nextReleaseDate: {
           month: 5,
@@ -489,7 +488,7 @@ describe('ReleaseStatusForm', () => {
 
       expect(
         screen.getByRole('link', { name: 'Enter an internal note' }),
-      ).toHaveAttribute('href', '#releaseStatusForm-latestInternalReleaseNote');
+      ).toHaveAttribute('href', '#releaseStatusForm-internalReleaseNote');
     });
 
     test('shows error message when no publishing method selected', async () => {
@@ -676,7 +675,7 @@ describe('ReleaseStatusForm', () => {
       userEvent.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
-        latestInternalReleaseNote: 'Test release note',
+        internalReleaseNote: 'Test release note',
         approvalStatus: 'Draft',
         nextReleaseDate: {
           month: 5,
@@ -890,7 +889,7 @@ describe('ReleaseStatusForm', () => {
       userEvent.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
-        latestInternalReleaseNote: 'Test release note',
+        internalReleaseNote: 'Test release note',
         approvalStatus: 'Approved',
         notifySubscribers: true,
         publishScheduled: new Date(`${nextYear}-10-10`),
@@ -952,7 +951,7 @@ describe('ReleaseStatusForm', () => {
       userEvent.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
-        latestInternalReleaseNote: 'Test release note',
+        internalReleaseNote: 'Test release note',
         approvalStatus: 'Approved',
         notifySubscribers: true,
         publishMethod: 'Immediate',
@@ -1006,7 +1005,7 @@ describe('ReleaseStatusForm', () => {
       userEvent.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
-        latestInternalReleaseNote: 'Test release note',
+        internalReleaseNote: 'Test release note',
         approvalStatus: 'Approved',
         notifySubscribers: false,
         publishMethod: 'Immediate',

--- a/src/explore-education-statistics-admin/src/prototypes/data/tableToolData.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/data/tableToolData.tsx
@@ -654,7 +654,6 @@ export const summary: PublicationReleaseSummary = {
   },
   type: 'NationalStatistics',
   latestRelease: true,
-  dataLastPublished: '2021-10-28T08:30:03.5659378',
   publication: {
     id: '89869bba-0c00-40f7-b7d6-e28cb904ad37',
     title: 'Characteristics of children in need',

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -85,7 +85,7 @@ export interface UpdateReleaseRequest extends BaseReleaseRequest {
 
 export interface CreateReleaseStatusRequest {
   approvalStatus: ReleaseApprovalStatus;
-  latestInternalReleaseNote?: string;
+  internalReleaseNote?: string;
   publishMethod?: 'Scheduled' | 'Immediate';
   publishScheduled?: string;
   nextReleaseDate?: PartialDate;
@@ -179,7 +179,7 @@ export interface ReleaseStatus {
   approvalStatus: ReleaseApprovalStatus;
   notifySubscribers: boolean;
   created: string;
-  createdByEmail: string;
+  createdByEmail?: string;
   releaseVersion: number;
 }
 

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -89,6 +89,7 @@ export interface CreateReleaseStatusRequest {
   publishMethod?: 'Scheduled' | 'Immediate';
   publishScheduled?: string;
   nextReleaseDate?: PartialDate;
+  notifySubscribers?: boolean;
 }
 
 type PublishingStage =
@@ -177,7 +178,6 @@ export interface ReleaseStatus {
   releaseStatusId: string;
   internalReleaseNote: string;
   approvalStatus: ReleaseApprovalStatus;
-  notifySubscribers: boolean;
   created: string;
   createdByEmail?: string;
   releaseVersion: number;

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -143,7 +143,6 @@ export interface Release<
   updates: ReleaseNote[];
   content: ContentSection<ContentBlockType | DataBlockType | EmbedBlockType>[];
   downloadFiles: FileInfo[];
-  dataLastPublished: string;
   hasPreReleaseAccessList: boolean;
   hasDataGuidance: boolean;
 }
@@ -159,7 +158,6 @@ export interface ReleaseSummary {
   nextReleaseDate: PartialDate;
   type: ReleaseType;
   latestRelease: boolean;
-  dataLastPublished: string;
 }
 
 export interface PublicationReleaseSummary extends ReleaseSummary {

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testReleaseData.ts
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testReleaseData.ts
@@ -66,7 +66,6 @@ export const testRelease: Release = {
   },
   published: '2018-04-25T09:30:00',
   slug: '2016-17',
-  dataLastPublished: '',
   hasDataGuidance: true,
   hasPreReleaseAccessList: true,
   type: 'NationalStatistics',

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
@@ -303,7 +303,6 @@ export const testPublicationRelease: Release = {
   updates: [],
   content: [],
   downloadFiles: [],
-  dataLastPublished: '',
   hasPreReleaseAccessList: true,
   hasDataGuidance: true,
 };

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -82,7 +82,7 @@ Go to "Sign off" page
 
 Check publication owner can edit release status to "Ready for higher review"
     user clicks radio    Ready for higher review (this will notify approvers)
-    user enters text into element    id:releaseStatusForm-latestInternalReleaseNote
+    user enters text into element    id:releaseStatusForm-internalReleaseNote
     ...    ready for higher review (publication owner)
     user clicks button    Update status
     user waits until element is visible    id:CurrentReleaseStatus-Awaiting higher review

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -111,7 +111,7 @@ Approve release and wait for it to be Scheduled
 
     user clicks button    Edit release status
     user clicks radio    Approved for publication
-    user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Approved by prerelease UI tests
+    user enters text into element    id:releaseStatusForm-internalReleaseNote    Approved by prerelease UI tests
     user waits until page contains element    xpath://label[text()="On a specific date"]/../input
     user clicks radio    On a specific date
     user waits until page contains    Publish date

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -37,7 +37,7 @@ Go to release sign off page and verify initial release checklist
 
 Submit release for Higher Review
     user clicks radio    Ready for higher review (this will notify approvers)
-    user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Submitted for Higher Review
+    user enters text into element    id:releaseStatusForm-internalReleaseNote    Submitted for Higher Review
     user enters text into element    id:releaseStatusForm-nextReleaseDate-month    12
     user enters text into element    id:releaseStatusForm-nextReleaseDate-year    3001
     user clicks button    Update status
@@ -76,7 +76,7 @@ Verify release checklist has been updated
 
 Approve release
     user clicks radio    Approved for publication
-    user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Approved for release
+    user enters text into element    id:releaseStatusForm-internalReleaseNote    Approved for release
 
     user clicks radio    On a specific date
     user enters text into element    id:releaseStatusForm-publishScheduled-day    1

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -78,7 +78,7 @@ Approve release and wait for it to be Scheduled
 
     user clicks button    Edit release status
     user clicks radio    Approved for publication
-    user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Approved by UI tests
+    user enters text into element    id:releaseStatusForm-internalReleaseNote    Approved by UI tests
 
     user waits until page contains element    xpath://label[text()="On a specific date"]/../input    %{WAIT_SMALL}
     user clicks radio    On a specific date
@@ -120,7 +120,7 @@ Approve release for immediate publication but don't wait to finish
     user clicks button    Edit release status
     user waits until h2 is visible    Edit release status
     user clicks radio    Approved for publication
-    user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Approved by UI tests
+    user enters text into element    id:releaseStatusForm-internalReleaseNote    Approved by UI tests
     user clicks radio    Immediately
     user clicks button    Update status
     user waits until h2 is visible    Sign off

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -510,7 +510,7 @@ user approves release for immediate publication
     IF    '${release_type}' == 'amendment'
         user waits until page contains    Notify subscribers by email
     END
-    user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Approved by UI tests
+    user enters text into element    id:releaseStatusForm-internalReleaseNote    Approved by UI tests
     user clicks radio    Immediately
     user enters text into element    id:releaseStatusForm-nextReleaseDate-month    ${NEXT_RELEASE_MONTH}
     user enters text into element    id:releaseStatusForm-nextReleaseDate-year    ${NEXT_RELEASE_YEAR}
@@ -557,7 +557,7 @@ user puts release into draft
     user clicks button    Edit release status
     user waits until h2 is visible    Edit release status    %{WAIT_SMALL}
     user clicks radio    In draft
-    user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    ${release_note}
+    user enters text into element    id:releaseStatusForm-internalReleaseNote    ${release_note}
     IF    "${next_release_date_month}" != "${EMPTY}"
         user enters text into element    id:releaseStatusForm-nextReleaseDate-month    ${next_release_date_month}
     END
@@ -576,7 +576,7 @@ user puts release into higher level review
     user clicks button    Edit release status
     user waits until h2 is visible    Edit release status    %{WAIT_SMALL}
     user clicks radio    Ready for higher review (this will notify approvers)
-    user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Ready for higher review
+    user enters text into element    id:releaseStatusForm-internalReleaseNote    Ready for higher review
     user clicks button    Update status
     user waits until element is visible    id:CurrentReleaseStatus-Awaiting higher review    %{WAIT_SMALL}
 
@@ -596,7 +596,7 @@ user approves release for scheduled publication
     user waits until h2 is visible    Edit release status    %{WAIT_SMALL}
 
     user clicks radio    Approved for publication
-    user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Approved by UI tests
+    user enters text into element    id:releaseStatusForm-internalReleaseNote    Approved by UI tests
     user clicks radio    On a specific date
     user waits until page contains    Publish date
     user enters text into element    id:releaseStatusForm-publishScheduled-day    ${publish_date_day}


### PR DESCRIPTION
This PR is a tidy-up of code around approving releases in the Admin service, made ahead of raising a PR for [EES-4001](https://dfedigital.atlassian.net/browse/EES-4001) which will add a new option to allow updating the release published date on approval.

This PR should make for a clearer separation of the changes made specifically for EES-4001 and these changes which are not directly related but clean up code in the same area.

- Rename `ReleaseStatusCreateViewModel` to `ReleaseStatusCreateRequest`.
- Rename `LatestInternalReleaseNote` to `InternalReleaseNote` in the back-end `ReleaseStatusCreateRequest` and the front-end form component since `LatestInternalReleaseNote` doesn't make sense at the approval form and request level.
-  Allow `InternalReleaseNote` to be null since it's not a required field on all status transitions.
- Add `ICreatedTimestamp` interface to `ReleaseStatus` so that created date is set automatically.
- Remove unused `Release.DataLastPublished` to avoid any confusion about what dates need to be updated later on.
- Remove `Publication.Published` date also to avoid confusion about what dates need to be updated later. It's ambiguous what this date represented other than being used as a flag to indicate the publication has published releases.
- Migrate `NotifySubscribers` and `NotifiedOn` from the latest 'Approved' release status of the release if one exists, to new fields of `Release`.
- Other changes to make sure back-end / front-end are in agreement about nullability of fields.

Regarding the `NotifySubscribers` change, I can't see any need for this to be currently implemented in `ReleaseStatus` and require fetching all statuses and order them to get the latest in order to know what the effective values should be.

A migration is implemented to migrate values from the latest 'Approved' release status and at a later date we can drop those columns from `ReleaseStatus`.

### Future work to drop unused columns

The following can be dropped in future:

- ReleaseStatus.Approved
- ReleaseStatus.NotifiedOn
- Publication.Published
- Release.DataLastPublished

This work is described by [EES-4058](https://dfedigital.atlassian.net/browse/EES-4058).

### UI test report

![image](https://user-images.githubusercontent.com/4147126/215499896-3a96131f-91c4-4b6b-857b-5a271f2feb09.png)
