### PR TITLE
EES-4074, EES-4017 Update `BlobStorageService.StreamBlob` to use Azure.Storage.Blobs v12

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
@@ -33,8 +33,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             string expectedBlobPath,
             string filePathToStream)
         {
-            return service.Setup(s => s.StreamBlob(container, expectedBlobPath, null))
-                .ReturnsAsync(() => System.IO.File.OpenRead(filePathToStream));
+            return service.Setup(s => s.StreamBlob(container, expectedBlobPath, null, default))
+                .ReturnsAsync(() => File.OpenRead(filePathToStream));
         }
         
         public static IReturnsResult<IBlobStorageService> SetupListBlobs(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobStorageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobStorageServiceTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils.Interfaces;
@@ -19,6 +18,7 @@ using Xunit;
 using static Azure.Storage.Blobs.Models.BlobsModelFactory;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.IBlobStorageService;
+using static Moq.MockBehavior;
 using Capture = Moq.Capture;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
@@ -100,8 +100,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var json = @"{ ""Value"": ""test-value"" }";
 
-            blobClient.Setup(s => s.OpenReadAsync(0, null, null, default))
-                .ReturnsAsync(json.ToStream());
+            var response = new Mock<Response<BlobDownloadResult>>(Strict);
+
+            response.SetupGet(r => r.Value)
+                .Returns(BlobDownloadResult(BinaryData.FromString(json)));
+
+            blobClient.Setup(s => s.DownloadContentAsync())
+                .ReturnsAsync(response.Object);
 
             var blobContainerClient = MockBlobContainerClient(PublicReleaseFiles.Name, blobClient);
             var blobServiceClient = MockBlobServiceClient(blobContainerClient);
@@ -130,8 +135,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var json = @"{ ""Value"": ""test-value"" }";
 
-            blobClient.Setup(s => s.OpenReadAsync(0, null, null, default))
-                .ReturnsAsync(json.ToStream());
+            var response = new Mock<Response<BlobDownloadResult>>(Strict);
+
+            response.SetupGet(r => r.Value)
+                .Returns(BlobDownloadResult(BinaryData.FromString(json)));
+
+            blobClient.Setup(s => s.DownloadContentAsync())
+                .ReturnsAsync(response.Object);
 
             var blobContainerClient = MockBlobContainerClient(PublicReleaseFiles.Name, blobClient);
             var blobServiceClient = MockBlobServiceClient(blobContainerClient);
@@ -161,8 +171,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var json = "null";
 
-            blobClient.Setup(s => s.OpenReadAsync(0, null, null, default))
-                .ReturnsAsync(json.ToStream());
+            var response = new Mock<Response<BlobDownloadResult>>(Strict);
+
+            response.SetupGet(r => r.Value)
+                .Returns(BlobDownloadResult(BinaryData.FromString(json)));
+
+            blobClient.Setup(s => s.DownloadContentAsync())
+                .ReturnsAsync(response.Object);
 
             var blobContainerClient = MockBlobContainerClient(PublicReleaseFiles.Name, blobClient);
             var blobServiceClient = MockBlobServiceClient(blobContainerClient);
@@ -188,8 +203,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
                 metadata: new Dictionary<string, string>()
             );
 
-            blobClient.Setup(s => s.OpenReadAsync(0, null, null, default))
-                .ReturnsAsync(string.Empty.ToStream());
+
+            var response = new Mock<Response<BlobDownloadResult>>(Strict);
+
+            response.SetupGet(r => r.Value)
+                .Returns(BlobDownloadResult(BinaryData.FromString("")));
+
+            blobClient.Setup(s => s.DownloadContentAsync())
+                .ReturnsAsync(response.Object);
 
             var blobContainerClient = MockBlobContainerClient(PublicReleaseFiles.Name, blobClient);
             var blobServiceClient = MockBlobServiceClient(blobContainerClient);
@@ -533,7 +554,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         private static Mock<BlobServiceClient> MockBlobServiceClient(
             params Mock<BlobContainerClient>[] blobContainerClients)
         {
-            var blobServiceClient = new Mock<BlobServiceClient>(MockBehavior.Strict);
+            var blobServiceClient = new Mock<BlobServiceClient>(Strict);
 
             blobServiceClient.Setup(s => s.Uri)
                 .Returns(new Uri("https://data-storage:10001/devstoreaccount1;"));
@@ -551,7 +572,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             string containerName,
             params Mock<BlobClient>[] blobClients)
         {
-            var blobContainerClient = new Mock<BlobContainerClient>(MockBehavior.Strict);
+            var blobContainerClient = new Mock<BlobContainerClient>(Strict);
 
             blobContainerClient
                 .SetupGet(client => client.Name)
@@ -574,7 +595,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             IDictionary<string, string>? metadata = null,
             bool exists = true)
         {
-            var blobClient = new Mock<BlobClient>(MockBehavior.Strict);
+            var blobClient = new Mock<BlobClient>(Strict);
 
             blobClient.SetupGet(client => client.Name)
                 .Returns(name);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="AngleSharp" Version="1.0.0-alpha-844" />
         <PackageReference Include="AspectInjector" Version="2.7.3" PrivateAssets="all" />
         <PackageReference Include="AutoMapper" Version="9.0.0" />
-        <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+        <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
         <PackageReference Include="IsExternalInit" Version="1.0.2" PrivateAssets="all" />
         <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.14" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -350,27 +350,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return targetStream;
         }
 
-        public async Task<Stream> StreamBlob(IBlobContainer containerName, string path, int? bufferSize = null)
+        public async Task<Stream> StreamBlob(
+            IBlobContainer containerName,
+            string path,
+            int? bufferSize = null,
+            CancellationToken cancellationToken = default)
         {
-            // Azure SDK v12 isn't compatible with how we want to use file
-            // streams i.e. they need to be seekable. This is particularly
-            // a problem for MIME type validation.
-            // See: https://github.com/Azure/azure-sdk-for-net/pull/15032
-            // TODO: Change to v12 implementation when possible
-            var blobContainer = await GetCloudBlobContainer(containerName);
-            var blob = blobContainer.GetBlockBlobReference(path);
+            var blob = await GetBlobClient(containerName, path);
 
-            if (!await blob.ExistsAsync())
+            try
             {
-                throw new FileNotFoundException($"Could not find file at {containerName}/{path}");
+                return await blob.OpenReadAsync(bufferSize: bufferSize, cancellationToken: cancellationToken);
             }
-
-            if (bufferSize != null)
+            catch (RequestFailedException exception)
             {
-                blob.StreamMinimumReadSizeInBytes = (int) bufferSize;
-            }
+                if (exception.Status == 404)
+                {
+                    throw new FileNotFoundException($"Could not find file at {containerName}/{path}");
+                }
 
-            return await blob.OpenReadAsync();
+                throw;
+            }
         }
 
         public async Task<string> DownloadBlobText(IBlobContainer containerName, string path)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
@@ -79,11 +79,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
         /// differences in how the outputted stream behaves that you may or may not want.
         /// </para>
         /// </remarks>
-        /// <param name="containerName">name of the blob container</param>
-        /// <param name="path">path to the blob within the container</param>
-        /// <param name="bufferSize">size of the stream buffer</param>
-        /// <returns>the chunked blob stream</returns>
-        public Task<Stream> StreamBlob(IBlobContainer containerName, string path, int? bufferSize = null);
+        /// <param name="containerName">Name of the blob container</param>
+        /// <param name="path">Path to the blob within the container</param>
+        /// <param name="bufferSize">Size of the stream buffer</param>
+        /// <param name="cancellationToken">Token to cancel the request</param>
+        /// <returns>The chunked blob stream</returns>
+        public Task<Stream> StreamBlob(
+            IBlobContainer containerName,
+            string path,
+            int? bufferSize = null,
+            CancellationToken cancellationToken = default);
 
         public Task<string> DownloadBlobText(IBlobContainer containerName, string path);
 


### PR DESCRIPTION
This PR primarily updates the `BlobStorageService.StreamBlob` method to use the updated `Azure.Storage.Blobs` v12 SDK.

## Relevant changes

- Updating the Azure.Storage.Blobs to the latest resolves [EES-4017](https://dfedigital.atlassian.net/browse/EES-4017).
- Refactors `BlobStoragService.DownloadBlobText` to use the recommended `DownloadContentAsync` method to download the blob into memory. See [docs](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-download#download-to-a-string).

