### PR TITLE
EES-4050 - fixing a condition whereby adding a Methodology Note isn't awaited successfully

### DIFF
--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -405,7 +405,7 @@ user edits methodology note
     user enters text into element    label:Year    ${year}
     user enters text into element    label:Edit methodology note    ${note} - edited
     user clicks button    Update note
-    user waits until page contains    ${note} - edited
+    user waits until page contains button    Add note
 
 user creates public prerelease access list
     [Arguments]    ${content}


### PR DESCRIPTION
This PR:
- fixes a scenario whereby the saving of an Update note wasn't correctly being waited for

The current problem is that the post-save check is accidentally not relying on any save action, because it's waiting until text which is *already on the page* becomes available.

The fix is to wait for the previously hidden "Add note" button to reappear post-save.   