### PR TITLE
EES-4001 Add option 'Update published date' to Sign off tab when approving an amended release for publication

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
@@ -105,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var saved = await context.Releases
-                    .FirstAsync(r => r.Id == amendedRelease.Id);
+                    .SingleAsync(r => r.Id == amendedRelease.Id);
 
                 Assert.Equal("2030", saved.ReleaseName);
                 Assert.Equal(TimeIdentifier.CalendarYear, saved.TimePeriodCoverage);
@@ -115,27 +115,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task CreateReleaseStatus()
         {
-            var releaseId = Guid.NewGuid();
             var release = new Release
             {
-                Id = releaseId,
                 Type = ReleaseType.AdHocStatistics,
-                Publication = new Publication {Title = "Old publication"},
+                Publication = new Publication(),
                 ReleaseName = "2030",
                 TimePeriodCoverage = TimeIdentifier.March,
                 Slug = "2030-march",
+                ApprovalStatus = ReleaseApprovalStatus.Draft,
                 PublishScheduled = DateTime.UtcNow,
                 NextReleaseDate = new PartialDate {Day = "15", Month = "6", Year = "2039"},
                 PreReleaseAccessList = "Access list",
-                Version = 0,
-                PreviousVersionId = releaseId
             };
 
             var contextId = Guid.NewGuid().ToString();
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddRangeAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -155,14 +152,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 await releaseService
                     .CreateReleaseStatus(
-                        releaseId,
+                        release.Id,
                         new ReleaseStatusCreateRequest
                         {
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = nextReleaseDateEdited,
                             ApprovalStatus = ReleaseApprovalStatus.Draft,
-                            InternalReleaseNote = "Test internal note"
+                            InternalReleaseNote = "Test note"
                         }
                     );
 
@@ -173,15 +170,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var saved = await context.Releases
                     .Include(r => r.ReleaseStatuses)
-                    .FirstAsync(r => r.Id == releaseId);
+                    .SingleAsync(r => r.Id == release.Id);
 
                 Assert.Equal(release.Publication.Id, saved.PublicationId);
+                Assert.Equal(ReleaseApprovalStatus.Draft, saved.ApprovalStatus);
                 Assert.Equal(new DateTime(2051, 6, 29, 23, 0, 0, DateTimeKind.Utc),
                     saved.PublishScheduled);
                 Assert.Equal(nextReleaseDateEdited, saved.NextReleaseDate);
                 // NotifySubscribers should default to true for original releases
                 Assert.True(saved.NotifySubscribers);
-                Assert.Null(saved.NotifiedOn);
+                Assert.False(saved.UpdatePublishedDate);
                 Assert.Equal(ReleaseType.AdHocStatistics, saved.Type);
                 Assert.Equal("2030-march", saved.Slug);
                 Assert.Equal("2030", saved.ReleaseName);
@@ -192,7 +190,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release.Id, savedStatus.ReleaseId);
                 Assert.Equal(ReleaseApprovalStatus.Draft, savedStatus.ApprovalStatus);
                 Assert.Equal(_userId, savedStatus.CreatedById);
-                Assert.Equal("Test internal note", savedStatus.InternalReleaseNote);
+                Assert.Equal("Test note", savedStatus.InternalReleaseNote);
             }
         }
 
@@ -213,7 +211,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -274,7 +272,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -316,7 +314,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -358,7 +356,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -417,7 +415,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -477,7 +475,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -536,7 +534,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -596,7 +594,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -655,7 +653,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -718,7 +716,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -740,12 +738,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task CreateReleaseStatus_Approved_SendPreReleaseEmails()
+        public async Task CreateReleaseStatus_Approved()
         {
             var release = new Release
             {
+                ApprovalStatus = ReleaseApprovalStatus.Draft,
                 Type = ReleaseType.AdHocStatistics,
-                Publication = new Publication {Title = "Old publication"},
+                Publication = new Publication(),
                 ReleaseName = "2030",
                 Slug = "2030",
                 PublishScheduled = DateTime.UtcNow,
@@ -755,7 +754,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -764,31 +763,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var contentService = new Mock<IContentService>(MockBehavior.Strict);
             var preReleaseUserService = new Mock<IPreReleaseUserService>(MockBehavior.Strict);
 
+            releaseChecklistService
+                .Setup(s =>
+                    s.GetErrors(It.Is<Release>(r => r.Id == release.Id)))
+                .ReturnsAsync(
+                    new List<ReleaseChecklistIssue>()
+                );
+
+            publishingService
+                .Setup(s => s.ReleaseChanged(
+                    It.Is<Guid>(g => g == release.Id),
+                    It.IsAny<Guid>(),
+                    It.IsAny<bool>()
+                ))
+                .ReturnsAsync(Unit.Instance);
+
+            contentService.Setup(mock =>
+                    mock.GetContentBlocks<HtmlBlock>(release.Id))
+                .ReturnsAsync(new List<HtmlBlock>());
+
+            preReleaseUserService.Setup(mock =>
+                    mock.SendPreReleaseUserInviteEmails(release.Id))
+                .ReturnsAsync(Unit.Instance);
+
+            var nextReleaseDateEdited = new PartialDate { Month = "12", Year = "2000" };
+
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                releaseChecklistService
-                    .Setup(s =>
-                        s.GetErrors(It.Is<Release>(r => r.Id == release.Id)))
-                    .ReturnsAsync(
-                        new List<ReleaseChecklistIssue>()
-                    );
-
-                publishingService
-                    .Setup(s => s.ReleaseChanged(
-                        It.Is<Guid>(g => g == release.Id),
-                        It.IsAny<Guid>(),
-                        It.IsAny<bool>()
-                    ))
-                    .ReturnsAsync(Unit.Instance);
-
-                contentService.Setup(mock =>
-                        mock.GetContentBlocks<HtmlBlock>(release.Id))
-                    .ReturnsAsync(new List<HtmlBlock>());
-
-                preReleaseUserService.Setup(mock =>
-                        mock.SendPreReleaseUserInviteEmails(release.Id))
-                    .ReturnsAsync(Unit.Instance);
-
                 var releaseService = BuildService(contentDbContext: context,
                     releaseChecklistService: releaseChecklistService.Object,
                     publishingService: publishingService.Object,
@@ -804,7 +805,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             InternalReleaseNote = "Test note",
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
-                            NextReleaseDate = new PartialDate {Month="12", Year="2000"}
+                            NextReleaseDate = nextReleaseDateEdited
                         }
                     );
 
@@ -815,128 +816,61 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 result.AssertRight();
             }
-        }
-
-        [Fact]
-        public async Task CreateReleaseStatus_Approved_NotifySubscribers()
-        {
-            var release = new Release
-            {
-                Type = ReleaseType.AdHocStatistics,
-                Publication = new Publication {Title = "Old publication"},
-                ReleaseName = "2030",
-                Slug = "2030",
-                PublishScheduled = DateTime.UtcNow,
-                Version = 0,
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.AddAsync(release);
-                await context.SaveChangesAsync();
-            }
-
-            var releaseChecklistService = new Mock<IReleaseChecklistService>(MockBehavior.Strict);
-            var publishingService = new Mock<IPublishingService>(MockBehavior.Strict);
-            var contentService = new Mock<IContentService>(MockBehavior.Strict);
-            var preReleaseUserService = new Mock<IPreReleaseUserService>(MockBehavior.Strict);
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                releaseChecklistService
-                    .Setup(s =>
-                        s.GetErrors(It.Is<Release>(r => r.Id == release.Id)))
-                    .ReturnsAsync(
-                        new List<ReleaseChecklistIssue>()
-                    );
-
-                publishingService
-                    .Setup(s => s.ReleaseChanged(
-                        It.Is<Guid>(g => g == release.Id),
-                        It.IsAny<Guid>(),
-                        It.IsAny<bool>()
-                    ))
-                    .ReturnsAsync(Unit.Instance);
-
-                contentService.Setup(mock =>
-                        mock.GetContentBlocks<HtmlBlock>(release.Id))
-                    .ReturnsAsync(new List<HtmlBlock>());
-
-                preReleaseUserService.Setup(mock =>
-                        mock.SendPreReleaseUserInviteEmails(release.Id))
-                    .ReturnsAsync(Unit.Instance);
-
-                var releaseService = BuildService(contentDbContext: context,
-                    releaseChecklistService: releaseChecklistService.Object,
-                    publishingService: publishingService.Object,
-                    contentService: contentService.Object,
-                    preReleaseUserService: preReleaseUserService.Object);
-
-                var result = await releaseService
-                    .CreateReleaseStatus(
-                        release.Id,
-                        new ReleaseStatusCreateRequest
-                        {
-                            ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            InternalReleaseNote = "Test note",
-                            // No need to include NotifySubscribers - should default to true for original releases
-                            PublishMethod = PublishMethod.Scheduled,
-                            PublishScheduled = "2051-06-30",
-                            NextReleaseDate = new PartialDate { Month = "12", Year = "2000" }
-                        }
-                    );
-
-                VerifyAllMocks(releaseChecklistService, contentService);
-
-                result.AssertRight();
-            }
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var saved = await context.Releases
-                    .FirstAsync(r => r.Id == release.Id);
+                    .Include(r => r.ReleaseStatuses)
+                    .SingleAsync(r => r.Id == release.Id);
 
+                Assert.Equal(ReleaseApprovalStatus.Approved, saved.ApprovalStatus);
+                Assert.Equal(new DateTime(2051, 6, 29, 23, 0, 0, DateTimeKind.Utc),
+                    saved.PublishScheduled);
+                nextReleaseDateEdited.AssertDeepEqualTo(saved.NextReleaseDate);
+                // NotifySubscribers should default to true for original releases
                 Assert.True(saved.NotifySubscribers);
+                Assert.False(saved.UpdatePublishedDate);
+
+                var savedStatus = Assert.Single(saved.ReleaseStatuses);
+                Assert.Equal(release.Id, savedStatus.ReleaseId);
+                Assert.Equal(ReleaseApprovalStatus.Approved, savedStatus.ApprovalStatus);
+                Assert.Equal(_userId, savedStatus.CreatedById);
+                Assert.Equal("Test note", savedStatus.InternalReleaseNote);
             }
         }
 
         [Fact]
-        public async Task CreateReleaseStatus_Amendment_NotifySubscribers_False()
+        public async Task CreateReleaseStatus_Approved_Amendment()
         {
             var publication = new Publication();
 
-            var initialReleaseId = Guid.NewGuid();
             var initialRelease = new Release
             {
-                Id = initialReleaseId,
-                Type = ReleaseType.AdHocStatistics,
-                TimePeriodCoverage = TimeIdentifier.TaxYear,
-                Publication = publication,
-                ReleaseName = "2035",
-                Slug = "2035",
-                PublishScheduled = DateTime.UtcNow,
-                Version = 0,
-                PreviousVersionId = initialReleaseId
+                Id = Guid.NewGuid(),
+                Publication = publication
             };
 
             var amendedRelease = new Release
             {
+                ApprovalStatus = ReleaseApprovalStatus.Draft,
                 Type = ReleaseType.AdHocStatistics,
                 TimePeriodCoverage = TimeIdentifier.TaxYear,
                 Publication = publication,
                 ReleaseName = "2035",
                 Slug = "2035",
                 PublishScheduled = DateTime.UtcNow,
+                NotifySubscribers = true,
+                UpdatePublishedDate = false,
                 Version = 1,
-                PreviousVersionId = initialReleaseId
+                PreviousVersionId = initialRelease.Id
             };
 
             var contextId = Guid.NewGuid().ToString();
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddRangeAsync(amendedRelease, initialRelease);
+                await context.Publications.AddAsync(publication);
+                await context.Releases.AddRangeAsync(initialRelease, amendedRelease);
                 await context.SaveChangesAsync();
             }
 
@@ -977,14 +911,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     contentService: contentService.Object,
                     preReleaseUserService: preReleaseUserService.Object);
 
+                // Alter the approval status to Approved,
+                // toggling the values of NotifySubscribers and UpdatePublishedDate from their initial values
                 var result = await releaseService
                     .CreateReleaseStatus(
                         amendedRelease.Id,
                         new ReleaseStatusCreateRequest
                         {
-                            PublishScheduled = "2051-06-30",
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             NotifySubscribers = false,
+                            UpdatePublishedDate = true
                         }
                     );
 
@@ -999,112 +935,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var saved = await context.Releases
-                    .FirstAsync(r => r.Id == amendedRelease.Id);
+                    .SingleAsync(r => r.Id == amendedRelease.Id);
 
+                // Expect NotifySubscribers and UpdatePublishedDate to match the approval request values
                 Assert.False(saved.NotifySubscribers);
-            }
-        }
-
-        [Fact]
-        public async Task CreateReleaseStatus_Amendment_NotifySubscribers_True()
-        {
-            var publication = new Publication();
-
-            var initialReleaseId = Guid.NewGuid();
-            var initialRelease = new Release
-            {
-                Id = initialReleaseId,
-                Type = ReleaseType.AdHocStatistics,
-                TimePeriodCoverage = TimeIdentifier.TaxYear,
-                Publication = publication,
-                ReleaseName = "2035",
-                Slug = "2035",
-                PublishScheduled = DateTime.UtcNow,
-                Version = 0,
-                PreviousVersionId = initialReleaseId
-            };
-
-            var amendedRelease = new Release
-            {
-                Type = ReleaseType.AdHocStatistics,
-                TimePeriodCoverage = TimeIdentifier.TaxYear,
-                Publication = publication,
-                ReleaseName = "2035",
-                Slug = "2035",
-                PublishScheduled = DateTime.UtcNow,
-                Version = 1,
-                PreviousVersionId = initialReleaseId
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.AddRangeAsync(amendedRelease, initialRelease);
-                await context.SaveChangesAsync();
-            }
-
-            var releaseChecklistService = new Mock<IReleaseChecklistService>(MockBehavior.Strict);
-            var publishingService = new Mock<IPublishingService>(MockBehavior.Strict);
-            var contentService = new Mock<IContentService>(MockBehavior.Strict);
-            var preReleaseUserService = new Mock<IPreReleaseUserService>(MockBehavior.Strict);
-
-            releaseChecklistService
-                .Setup(s =>
-                    s.GetErrors(It.Is<Release>(r => r.Id == amendedRelease.Id)))
-                .ReturnsAsync(
-                    new List<ReleaseChecklistIssue>()
-                );
-
-            publishingService
-                .Setup(s => s.ReleaseChanged(
-                    It.Is<Guid>(g => g == amendedRelease.Id),
-                    It.IsAny<Guid>(),
-                    It.IsAny<bool>()
-                ))
-                .ReturnsAsync(Unit.Instance);
-
-            contentService.Setup(mock =>
-                    mock.GetContentBlocks<HtmlBlock>(amendedRelease.Id))
-                .ReturnsAsync(new List<HtmlBlock>());
-
-            preReleaseUserService.Setup(mock =>
-                    mock.SendPreReleaseUserInviteEmails(amendedRelease.Id))
-                .ReturnsAsync(Unit.Instance);
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var releaseService = BuildService(contentDbContext: context,
-                    releaseChecklistService: releaseChecklistService.Object,
-                    publishingService: publishingService.Object,
-                    contentService: contentService.Object,
-                    preReleaseUserService: preReleaseUserService.Object);
-
-                var result = await releaseService
-                    .CreateReleaseStatus(
-                        amendedRelease.Id,
-                        new ReleaseStatusCreateRequest
-                        {
-                            PublishScheduled = "2051-06-30",
-                            ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            NotifySubscribers = true,
-                        }
-                    );
-
-                VerifyAllMocks(contentService,
-                    preReleaseUserService,
-                    publishingService,
-                    releaseChecklistService);
-
-                result.AssertRight();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var saved = await context.Releases
-                    .FirstAsync(r => r.Id == amendedRelease.Id);
-
-                Assert.True(saved.NotifySubscribers);
+                Assert.True(saved.UpdatePublishedDate);
             }
         }
 
@@ -1123,7 +958,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -1611,7 +1446,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -1684,7 +1519,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(release);
+                await context.Releases.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
@@ -1766,7 +1601,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 contentService.Setup(mock => mock.GetContentBlocks<HtmlBlock>(release.Id))
                     .ReturnsAsync(new List<HtmlBlock>());
-
 
                 userReleaseRoleService.Setup(mock =>
                         mock.ListUserReleaseRolesByPublication(ReleaseRole.Approver, release.Publication.Id))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
@@ -113,6 +113,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 ApprovalStatus = releaseApprovalStatus,
                 NotifiedOn = DateTime.UtcNow,
                 NotifySubscribers = true,
+                UpdatePublishedDate = true,
                 Version = version,
                 PreviousVersionId = previousVersionReleaseId,
                 Created = createdDate,
@@ -498,6 +499,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(newReleaseId, amendment.Id);
                 Assert.Null(amendment.NotifiedOn);
                 Assert.False(amendment.NotifySubscribers);
+                Assert.False(amendment.UpdatePublishedDate);
                 Assert.Null(amendment.PublishScheduled);
                 Assert.Null(amendment.Published);
                 Assert.Equal(release.Version + 1, amendment.Version);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -75,7 +75,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 )).AssertRight();
 
                 Assert.Equal("Academic Year 2018/19", result.Title);
-                Assert.Equal(2018, result.Year);
                 Assert.Equal("2018/19", result.YearTitle);
                 Assert.Equal(TimeIdentifier.AcademicYear, result.TimePeriodCoverage);
                 Assert.Equal(ReleaseType.OfficialStatistics, result.Type);
@@ -230,7 +229,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         TemplateReleaseId = templateReleaseId,
                         Year = 2018,
                         TimePeriodCoverage = TimeIdentifier.AcademicYear,
-                        PublishScheduled = "2050-01-01",
                         Type = ReleaseType.OfficialStatistics
                     }
                 );
@@ -800,6 +798,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(viewModel.LatestRelease);
                 Assert.True(viewModel.Live);
                 Assert.False(viewModel.Amendment);
+                Assert.False(viewModel.NotifySubscribers);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -87,6 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Null(result.PublishScheduled);
                 Assert.Null(result.Published);
                 Assert.False(result.NotifySubscribers);
+                Assert.False(result.UpdatePublishedDate);
             }
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -106,6 +107,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Null(actual.NextReleaseDate);
                 Assert.Null(actual.NotifiedOn);
                 Assert.False(actual.NotifySubscribers);
+                Assert.False(actual.UpdatePublishedDate);
             }
         }
 
@@ -744,7 +746,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         InternalReleaseNote = "Release note 2 days ago",
                         Created = DateTime.UtcNow.Subtract(TimeSpan.FromDays(2))
                     }
-                }
+                },
+                NotifySubscribers = true,
+                UpdatePublishedDate = true
             };
 
             var publication = new Publication
@@ -798,7 +802,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(viewModel.LatestRelease);
                 Assert.True(viewModel.Live);
                 Assert.False(viewModel.Amendment);
-                Assert.False(viewModel.NotifySubscribers);
+                Assert.True(viewModel.NotifySubscribers);
+                Assert.True(viewModel.UpdatePublishedDate);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -56,12 +56,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                             ? model.PublishScheduled.Value.ConvertUtcToUkTimeZone()
                             : (DateTime?)null));
 
-            CreateMap<ReleaseCreateRequest, Release>()
-                .ForMember(dest => dest.PublishScheduled,
-                    m => m.MapFrom(model => model.PublishScheduledDate))
-                .ForMember(dest => dest.ReleaseName,
-                    m => m.MapFrom(r => r.Year.ToString()));
-
             CreateMap<Release, ReleaseSummaryViewModel>()
                 .ForMember(model => model.PublishScheduled,
                     m => m.MapFrom(model =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130142704_EES4001AddUpdatePublishedDateToRelease.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130142704_EES4001AddUpdatePublishedDateToRelease.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230130142704_EES4001AddUpdatePublishedDateToRelease")]
+    partial class EES4001AddUpdatePublishedDateToRelease
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -587,6 +589,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<Guid?>("LatestPublishedReleaseId")
                         .HasColumnType("uniqueidentifier");
 
+                    b.Property<DateTime?>("Published")
+                        .HasColumnType("datetime2");
+
                     b.Property<string>("Slug")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
@@ -660,6 +665,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.Property<string>("DataGuidance")
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTime?>("DataLastPublished")
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("NextReleaseDate")
                         .HasColumnType("nvarchar(max)");
@@ -805,6 +813,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.Property<string>("InternalReleaseNote")
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTime?>("NotifiedOn")
+                        .HasColumnType("datetime2");
+
+                    b.Property<bool>("NotifySubscribers")
+                        .HasColumnType("bit");
 
                     b.Property<Guid>("ReleaseId")
                         .HasColumnType("uniqueidentifier");

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130142704_EES4001AddUpdatePublishedDateToRelease.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230130142704_EES4001AddUpdatePublishedDateToRelease.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations;
+
+[ExcludeFromCodeCoverage]
+public partial class EES4001AddUpdatePublishedDateToRelease : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<bool>(
+            name: "UpdatePublishedDate",
+            table: "Releases",
+            type: "bit",
+            nullable: false,
+            defaultValue: false);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "UpdatePublishedDate",
+            table: "Releases");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseStatusCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseStatusCreateRequest.cs
@@ -47,4 +47,6 @@ public record ReleaseStatusCreateRequest
     }
 
     [PartialDateValidator] public PartialDate? NextReleaseDate { get; init; }
+
+    public bool? UpdatePublishedDate { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
@@ -129,7 +129,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     release.ApprovalStatus = request.ApprovalStatus;
                     release.NextReleaseDate = request.NextReleaseDate;
-                    release.NotifySubscribers = release.Version == 0 || request.NotifySubscribers == true;
+                    release.NotifySubscribers = release.Version == 0 || (request.NotifySubscribers ?? false);
+                    release.UpdatePublishedDate = request.UpdatePublishedDate ?? false;
                     release.PublishScheduled = request.PublishMethod == PublishMethod.Immediate
                         ? _dateTimeProvider.UtcNow
                         : request.PublishScheduledDate;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -116,9 +116,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(async _ => await ValidateReleaseSlugUniqueToPublication(releaseCreate.Slug, releaseCreate.PublicationId))
                 .OnSuccess(async () =>
                 {
-                    var release = _mapper.Map<Release>(releaseCreate);
-
-                    release.Id = _guidGenerator.NewGuid();
+                    var release = new Release
+                    {
+                        Id = _guidGenerator.NewGuid(),
+                        PublicationId =  releaseCreate.PublicationId,
+                        Slug = releaseCreate.Slug,
+                        TimePeriodCoverage = releaseCreate.TimePeriodCoverage,
+                        ReleaseName = releaseCreate.Year.ToString(),
+                        Type = releaseCreate.Type,
+                        ApprovalStatus = ReleaseApprovalStatus.Draft
+                    };
 
                     if (releaseCreate.TemplateReleaseId.HasValue)
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -64,6 +64,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public Guid? PreviousVersionId { get; set; }
 
         public ReleasePermissions? Permissions { get; set; }
+
+        public bool UpdatePublishedDate { get; set; }
     }
 
     public record ReleasePermissions

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -1,15 +1,11 @@
 #nullable enable
 using System;
 using System.ComponentModel.DataAnnotations;
-using System.Globalization;
-using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using static System.Globalization.CultureInfo;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.NamingUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.TimePeriodLabelFormatter;
 
@@ -92,31 +88,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         [Required]
         [JsonConverter(typeof(TimeIdentifierJsonConverter))]
         public TimeIdentifier TimePeriodCoverage { get; init; }
-
-        [DateTimeFormatValidator("yyyy-MM-dd")]
-        public string PublishScheduled { get; init; } = string.Empty;
-
-        public DateTime? PublishScheduledDate
-        {
-            get
-            {
-                if (PublishScheduled.IsNullOrEmpty())
-                {
-                    return null;
-                }
-
-                DateTime.TryParseExact(
-                    PublishScheduled,
-                    "yyyy-MM-dd",
-                    InvariantCulture,
-                    DateTimeStyles.None,
-                    out var dateTime
-                );
-                return dateTime.AsStartOfDayUtcForTimeZone();
-            }
-        }
-
-        [PartialDateValidator] public PartialDate? NextReleaseDate { get; set; } = null!;
 
         public string Slug => SlugFromTitle(Title);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseAmendmentExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseAmendmentExtensions.cs
@@ -22,6 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
             amendment.ApprovalStatus = ReleaseApprovalStatus.Draft;
             amendment.NotifiedOn = null;
             amendment.NotifySubscribers = false;
+            amendment.UpdatePublishedDate = false;
             amendment.Created = createdDate;
             amendment.CreatedById = createdByUserId;
             amendment.Version = release.Version + 1;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -90,6 +90,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public DateTime? NotifiedOn { get; set; }
 
+        public bool UpdatePublishedDate { get; set; }
+
         public Release? PreviousVersion { get; set; }
 
         public bool SoftDeleted { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseRepository.cs
@@ -8,6 +8,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 
 public interface IReleaseRepository
 {
+    Task<DateTime> GetPublishedDate(Guid releaseId,
+        DateTime actualPublishedDate);
+
     Task<Either<ActionResult, Release>> GetLatestPublishedRelease(Guid publicationId);
 
     Task<bool> IsLatestPublishedVersionOfRelease(Guid releaseId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
@@ -21,7 +21,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
         public async Task<List<Methodology>> GetByPublication(Guid publicationId)
         {
             return await _contentDbContext.PublicationMethodologies
-                .AsQueryable()
                 .Where(pm => pm.PublicationId == publicationId)
                 .Select(pm => pm.Methodology)
                 .ToListAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseRepository.cs
@@ -18,6 +18,39 @@ public class ReleaseRepository : IReleaseRepository
         _contentDbContext = contentDbContext;
     }
 
+    public async Task<DateTime> GetPublishedDate(Guid releaseId,
+        DateTime actualPublishedDate)
+    {
+        var release = await _contentDbContext.Releases
+            .SingleAsync(r => r.Id == releaseId);
+
+        // If the release is already published return the published date
+        if (release.Published.HasValue)
+        {
+            return release.Published.Value;
+        }
+
+        // For the first version of a release or if an update to the published date has been requested
+        // return the actual published date
+        if (release.Version == 0 || release.UpdatePublishedDate)
+        {
+            return actualPublishedDate;
+        }
+
+        // Otherwise, return the published date from the previous version
+        await _contentDbContext.Entry(release)
+            .Reference(r => r.PreviousVersion)
+            .LoadAsync();
+
+        if (!release.PreviousVersion!.Published.HasValue)
+        {
+            throw new ArgumentException(
+                $"Expected Release {release.PreviousVersionId} to have a Published date as the previous version of Release {release.Id}");
+        }
+
+        return release.PreviousVersion.Published.Value;
+    }
+
     public async Task<bool> IsLatestPublishedVersionOfRelease(Guid releaseId)
     {
         var release = await _contentDbContext.Releases

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -6,17 +6,14 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
-using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
-using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
-using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
-using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 {
@@ -211,7 +208,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         }
 
         [Fact]
-        public async Task SetPublishedDates()
+        public async Task SetPublishedDate_FirstVersion()
         {
             var release = new Release
             {
@@ -219,7 +216,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Version = 0
             };
 
-            var published = DateTime.UtcNow;
+            var actualPublishedDate = DateTime.UtcNow;
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
@@ -229,34 +226,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 await contentDbContext.SaveChangesAsync();
             }
 
-            var methodologyService = new Mock<IMethodologyService>(Strict);
-
-            methodologyService.Setup(mock =>
-                    mock.SetPublishedDatesByPublication(release.PublicationId, published))
-                .Returns(Task.CompletedTask);
-
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildReleaseService(contentDbContext: contentDbContext,
-                    methodologyService: methodologyService.Object);
-
-                await service.SetPublishedDates(release.Id, published);
-
-                VerifyAllMocks(methodologyService);
+                var service = BuildReleaseService(contentDbContext: contentDbContext);
+                await service.SetPublishedDate(release.Id, actualPublishedDate);
             }
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var actualRelease = await contentDbContext
+                var actual = await contentDbContext
                     .Releases
                     .SingleAsync(r => r.Id == release.Id);
 
-                Assert.Equal(published, actualRelease.Published);
+                // Expect the published date to have been updated with the actual published date
+                Assert.Equal(actualPublishedDate, actual.Published);
             }
         }
 
         [Fact]
-        public async Task SetPublishedDates_AmendedReleaseHasPublishedDateOfPreviousVersion()
+        public async Task SetPublishedDate_AmendedRelease()
         {
             var previousRelease = new Release
             {
@@ -280,39 +268,78 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 await contentDbContext.SaveChangesAsync();
             }
 
-            var methodologyService = new Mock<IMethodologyService>(Strict);
-
-            methodologyService.Setup(mock =>
-                    mock.SetPublishedDatesByPublication(release.PublicationId, previousRelease.Published.Value))
-                .Returns(Task.CompletedTask);
-
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildReleaseService(contentDbContext: contentDbContext,
-                    methodologyService: methodologyService.Object);
-
-                await service.SetPublishedDates(release.Id, DateTime.UtcNow);
-
-                VerifyAllMocks(methodologyService);
+                var service = BuildReleaseService(contentDbContext: contentDbContext);
+                await service.SetPublishedDate(release.Id, DateTime.UtcNow);
             }
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var actualRelease = await contentDbContext
+                var actual = await contentDbContext
                     .Releases
                     .SingleAsync(r => r.Id == release.Id);
 
-                Assert.Equal(previousRelease.Published.Value, actualRelease.Published);
+                // Expect the published date to have been copied from the previous version 
+                Assert.Equal(previousRelease.Published, actual.Published);
+            }
+        }
+
+        [Fact]
+        public async Task SetPublishedDate_AmendedReleaseAndUpdatePublishedDateIsTrue()
+        {
+            var previousRelease = new Release
+            {
+                Id = Guid.NewGuid(),
+                Published = DateTime.UtcNow.AddDays(-1),
+                PreviousVersionId = null,
+                Version = 0
+            };
+
+            var release = new Release
+            {
+                Published = null,
+                PreviousVersionId = previousRelease.Id,
+                Version = 1,
+                UpdatePublishedDate = true
+            };
+
+            var actualPublishedDate = DateTime.UtcNow;
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Releases.AddRangeAsync(previousRelease, release);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = BuildReleaseService(contentDbContext: contentDbContext);
+                await service.SetPublishedDate(release.Id, actualPublishedDate);
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var actual = await contentDbContext
+                    .Releases
+                    .SingleAsync(r => r.Id == release.Id);
+
+                // Expect the published date to have been updated with the actual published date
+                Assert.Equal(actualPublishedDate, actual.Published);
             }
         }
 
         private static ReleaseService BuildReleaseService(
-            ContentDbContext? contentDbContext = null,
-            IMethodologyService? methodologyService = null)
+            ContentDbContext? contentDbContext = null)
         {
+            contentDbContext ??= InMemoryContentDbContext();
+
             return new(
-                contentDbContext ?? Mock.Of<ContentDbContext>(),
-                methodologyService ?? Mock.Of<IMethodologyService>(Strict));
+                contentDbContext,
+                releaseRepository: new ReleaseRepository(contentDbContext)
+            );
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishImmediateReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishImmediateReleaseContentFunction.cs
@@ -39,7 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         /// <param name="executionContext"></param>
         /// <param name="logger"></param>
         /// <returns></returns>
-        [FunctionName("PublishReleaseContent")]
+        [FunctionName("PublishImmediateReleaseContent")]
         // ReSharper disable once UnusedMember.Global
         public async Task PublishImmediateReleaseContent(
             [QueueTrigger(PublishReleaseContentQueue)]

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
@@ -15,6 +15,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task<List<File>> GetFiles(Guid methodologyVersionId, params FileType[] types);
 
-        Task SetPublishedDatesByPublication(Guid publicationId, DateTime published);
+        Task SetPublishedDatesIfApplicable(Guid publicationId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseService.cs
@@ -19,6 +19,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task<Release> GetLatestRelease(Guid publicationId, IEnumerable<Guid> includedReleaseIds);
 
-        Task SetPublishedDates(Guid id, DateTime published);
+        Task SetPublishedDate(Guid releaseId, DateTime actualPublishedDate);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
@@ -45,14 +45,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .ToListAsync();
         }
 
-        public async Task SetPublishedDatesByPublication(Guid publicationId, DateTime published)
+        public async Task SetPublishedDatesIfApplicable(Guid publicationId)
         {
-            var methodologies = await _methodologyVersionRepository.GetLatestPublishedVersionByPublication(publicationId);
+            var methodologyVersions =
+                await _methodologyVersionRepository.GetLatestPublishedVersionByPublication(publicationId);
 
-            _context.UpdateRange(methodologies);
-
-            methodologies.ForEach(methodology => { methodology.Published ??= published; });
-
+            _context.MethodologyVersions.UpdateRange(methodologyVersions);
+            methodologyVersions.ForEach(methodology =>
+            {
+                methodology.Published ??= DateTime.UtcNow;
+            });
             await _context.SaveChangesAsync();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -17,6 +17,7 @@ public class PublishingCompletionService : IPublishingCompletionService
 {
     private readonly ContentDbContext _contentDbContext;
     private readonly IContentService _contentService;
+    private readonly IMethodologyService _methodologyService;
     private readonly INotificationsService _notificationsService;
     private readonly IReleasePublishingStatusService _releasePublishingStatusService;
     private readonly IPublicationRepository _publicationRepository;
@@ -25,6 +26,7 @@ public class PublishingCompletionService : IPublishingCompletionService
 
     public PublishingCompletionService(ContentDbContext contentDbContext,
         IContentService contentService,
+        IMethodologyService methodologyService,
         INotificationsService notificationsService,
         IReleasePublishingStatusService releasePublishingStatusService,
         IPublicationRepository publicationRepository,
@@ -33,6 +35,7 @@ public class PublishingCompletionService : IPublishingCompletionService
     {
         _contentDbContext = contentDbContext;
         _contentService = contentService;
+        _methodologyService = methodologyService;
         _notificationsService = notificationsService;
         _releasePublishingStatusService = releasePublishingStatusService;
         _publicationCacheService = publicationCacheService;
@@ -62,13 +65,13 @@ public class PublishingCompletionService : IPublishingCompletionService
         {
             return;
         }
-         
+
         await prePublishingStagesComplete
             .ToAsyncEnumerable()
             .ForEachAwaitAsync(status => _releasePublishingStatusService
                 .UpdatePublishingStageAsync(
-                    status.ReleaseId, 
-                    status.Id, 
+                    status.ReleaseId,
+                    status.Id,
                     ReleasePublishingStatusPublishingStage.Started));
 
         var releaseIdsToUpdate = prePublishingStagesComplete
@@ -77,7 +80,7 @@ public class PublishingCompletionService : IPublishingCompletionService
 
         await releaseIdsToUpdate
             .ToAsyncEnumerable()
-            .ForEachAwaitAsync(releaseId => _releaseService.SetPublishedDates(releaseId, DateTime.UtcNow));
+            .ForEachAwaitAsync(releaseId => _releaseService.SetPublishedDate(releaseId, DateTime.UtcNow));
 
         var publicationSlugs = prePublishingStagesComplete
             .Select(status => status.PublicationSlug)
@@ -88,20 +91,27 @@ public class PublishingCompletionService : IPublishingCompletionService
             .Where(p => publicationSlugs.Contains(p.Slug))
             .Select(p => p.Id)
             .ToListAsync();
-        
+
         await directlyRelatedPublicationIds
             .ToAsyncEnumerable()
             .ForEachAwaitAsync(_publicationRepository.UpdateLatestPublishedRelease);
-        
+
+        // Set the published date on any methodologies used by these publications that are now publicly accessible
+        // as a result of releases being published
+        await directlyRelatedPublicationIds
+            .ToAsyncEnumerable()
+            .ForEachAwaitAsync(publicationId =>
+                _methodologyService.SetPublishedDatesIfApplicable(publicationId));
+
         // Update the cached publication and any cached superseded publications.
         // If this is the first live release of the publication, the superseding is now enforced
         var publicationSlugsToUpdate = await _contentDbContext
             .Publications
-            .Where(p => directlyRelatedPublicationIds.Contains(p.Id) || 
+            .Where(p => directlyRelatedPublicationIds.Contains(p.Id) ||
                         (p.SupersededById != null && directlyRelatedPublicationIds.Contains(p.SupersededById.Value)))
             .Select(p => p.Slug)
             .ToListAsync();
-        
+
         await publicationSlugsToUpdate
             .ToAsyncEnumerable()
             .ForEachAwaitAsync(publicationSlug => _publicationCacheService.UpdatePublication(publicationSlug));
@@ -114,13 +124,13 @@ public class PublishingCompletionService : IPublishingCompletionService
         // Update the cached trees in case any methodologies/publications
         // are now accessible for the first time after publishing these releases
         await _contentService.UpdateCachedTaxonomyBlobs();
-        
+
         await prePublishingStagesComplete
             .ToAsyncEnumerable()
             .ForEachAwaitAsync(status => _releasePublishingStatusService
                 .UpdatePublishingStageAsync(
-                    status.ReleaseId, 
-                    status.Id, 
+                    status.ReleaseId,
+                    status.Id,
                     ReleasePublishingStatusPublishingStage.Complete));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -121,7 +121,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                 .AddScoped<IFootnoteRepository, FootnoteRepository>()
                 .AddScoped<IIndicatorRepository, IndicatorRepository>()
                 .AddScoped<IPublishingCompletionService, PublishingCompletionService>()
-                .AddScoped<IPublicationRepository, PublicationRepository>();
+                .AddScoped<IPublicationRepository, PublicationRepository>()
+                .AddScoped<IReleaseRepository, ReleaseRepository>();
 
             AddPersistenceHelper<ContentDbContext>(builder.Services);
             AddPersistenceHelper<StatisticsDbContext>(builder.Services);

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationManageReleaseContributorsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationManageReleaseContributorsPage.test.tsx
@@ -50,6 +50,7 @@ const testRelease: Release = {
   type: 'AdHocStatistics',
   year: 2000,
   yearTitle: '2000/01',
+  updatePublishedDate: false,
 };
 
 const testPublicationContributors: UserReleaseRole[] = [

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
@@ -25,4 +25,5 @@ export const testRelease: Release = {
   },
   previousVersionId: '',
   preReleaseAccessList: '',
+  updatePublishedDate: false,
 };

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
@@ -1,36 +1,10 @@
 import ReleaseStatusChecklist from '@admin/pages/release/components/ReleaseStatusChecklist';
-import { Release } from '@admin/services/releaseService';
+import { testRelease } from '@admin/pages/release/__data__/testRelease';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 describe('ReleaseStatusChecklist', () => {
-  const testRelease: Release = {
-    id: 'release-1',
-    slug: 'release-1-slug',
-    approvalStatus: 'Draft',
-    latestRelease: false,
-    live: false,
-    amendment: false,
-    year: 2021,
-    yearTitle: '2021/22',
-    publicationId: 'publication-1',
-    publicationTitle: 'Publication 1',
-    publicationSummary: 'Publication 1 summary',
-    publicationSlug: 'publication-1-slug',
-    timePeriodCoverage: { value: 'W51', label: 'Week 51' },
-    title: 'Release Title',
-    type: 'OfficialStatistics',
-    contact: {
-      teamName: 'Test name',
-      teamEmail: 'test@test.com',
-      contactName: 'Test contact name',
-      contactTelNo: '1111 1111 1111',
-    },
-    previousVersionId: '',
-    preReleaseAccessList: '',
-  };
-
   test('renders correctly with errors', () => {
     render(
       <MemoryRouter>

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -1,8 +1,6 @@
+import { testRelease } from '@admin/pages/release/__data__/testRelease';
 import { ReleaseStatusPermissions } from '@admin/services/permissionService';
-import {
-  Release,
-  ReleaseChecklistErrorCode,
-} from '@admin/services/releaseService';
+import { ReleaseChecklistErrorCode } from '@admin/services/releaseService';
 import { createServerValidationErrorMock } from '@common-test/createAxiosErrorMock';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { format } from 'date-fns';
@@ -14,32 +12,6 @@ import noop from 'lodash/noop';
 import userEvent from '@testing-library/user-event';
 
 describe('ReleaseStatusForm', () => {
-  const testRelease: Release = {
-    id: 'release-1',
-    slug: 'release-1-slug',
-    approvalStatus: 'Draft',
-    latestRelease: false,
-    live: false,
-    amendment: false,
-    year: 2021,
-    yearTitle: '2021/22',
-    publicationId: 'publication-1',
-    publicationTitle: 'Publication 1',
-    publicationSummary: 'Publication 1 summary',
-    publicationSlug: 'publication-1-slug',
-    timePeriodCoverage: { value: 'W51', label: 'Week 51' },
-    title: 'Release Title',
-    type: 'OfficialStatistics',
-    contact: {
-      teamName: 'Test name',
-      teamEmail: 'test@test.com',
-      contactName: 'Test contact name',
-      contactTelNo: '1111 1111 1111',
-    },
-    previousVersionId: '',
-    preReleaseAccessList: '',
-  };
-
   const testStatusPermissions: ReleaseStatusPermissions = {
     canMarkApproved: true,
     canMarkDraft: true,
@@ -694,7 +666,6 @@ describe('ReleaseStatusForm', () => {
           release={{
             ...testRelease,
             approvalStatus: 'Approved',
-            notifySubscribers: true,
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -785,7 +756,6 @@ describe('ReleaseStatusForm', () => {
           release={{
             ...testRelease,
             approvalStatus: 'Approved',
-            notifySubscribers: true,
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -849,7 +819,6 @@ describe('ReleaseStatusForm', () => {
           release={{
             ...testRelease,
             approvalStatus: 'Approved',
-            notifySubscribers: true,
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -891,7 +860,6 @@ describe('ReleaseStatusForm', () => {
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
         approvalStatus: 'Approved',
-        notifySubscribers: true,
         publishScheduled: new Date(`${nextYear}-10-10`),
         publishMethod: 'Scheduled',
         nextReleaseDate: {
@@ -924,7 +892,6 @@ describe('ReleaseStatusForm', () => {
           release={{
             ...testRelease,
             approvalStatus: 'Approved',
-            notifySubscribers: true,
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -953,7 +920,6 @@ describe('ReleaseStatusForm', () => {
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
         approvalStatus: 'Approved',
-        notifySubscribers: true,
         publishMethod: 'Immediate',
         nextReleaseDate: {
           month: 5,
@@ -966,53 +932,161 @@ describe('ReleaseStatusForm', () => {
       });
     });
 
-    test('amendment should have "Notify subscribers by email" checkbox', async () => {
-      const handleSubmit = jest.fn();
+    describe('amendments', () => {
+      test('renders with `notifySubscribers` and `updatePublishedDate` options', async () => {
+        const handleSubmit = jest.fn();
 
-      render(
-        <ReleaseStatusForm
-          release={{
-            ...testRelease,
-            approvalStatus: 'Approved',
-            amendment: true,
-            notifySubscribers: true,
-          }}
-          statusPermissions={testStatusPermissions}
-          onCancel={noop}
-          onSubmit={handleSubmit}
-        />,
-      );
+        render(
+          <ReleaseStatusForm
+            release={{
+              ...testRelease,
+              approvalStatus: 'Approved',
+              amendment: true,
+              notifySubscribers: true,
+              updatePublishedDate: true,
+            }}
+            statusPermissions={testStatusPermissions}
+            onCancel={noop}
+            onSubmit={handleSubmit}
+          />,
+        );
 
-      await userEvent.type(
-        screen.getByLabelText('Internal note'),
-        'Test release note',
-      );
+        await waitFor(() => {
+          expect(
+            screen.getByLabelText('Notify subscribers by email'),
+          ).toBeChecked();
+        });
 
-      expect(
-        screen.getByLabelText('Notify subscribers by email'),
-      ).toBeChecked();
+        expect(screen.getByLabelText('Update published date')).toBeChecked();
+      });
 
-      userEvent.click(screen.getByLabelText('Notify subscribers by email'));
+      test('renders default values for `notifySubscribers` and `updatePublishedDate` options when status is changed to Approved', async () => {
+        const handleSubmit = jest.fn();
 
-      expect(
-        screen.getByLabelText('Notify subscribers by email'),
-      ).not.toBeChecked();
+        render(
+          <ReleaseStatusForm
+            release={{
+              ...testRelease,
+              approvalStatus: 'Approved',
+              amendment: true,
+              notifySubscribers: false,
+              updatePublishedDate: true,
+            }}
+            statusPermissions={testStatusPermissions}
+            onCancel={noop}
+            onSubmit={handleSubmit}
+          />,
+        );
 
-      userEvent.click(screen.getByLabelText('Immediately'));
+        // Begin with checkboxes in opposite states to their default values
+        await waitFor(() => {
+          expect(
+            screen.getByLabelText('Notify subscribers by email'),
+          ).not.toBeChecked();
+        });
 
-      expect(handleSubmit).not.toHaveBeenCalled();
+        expect(screen.getByLabelText('Update published date')).toBeChecked();
 
-      userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+        // Toggle to Draft status and expect the options to not be rendered
+        userEvent.click(screen.getByLabelText('In draft'));
 
-      const expectedValues: ReleaseStatusFormValues = {
-        internalReleaseNote: 'Test release note',
-        approvalStatus: 'Approved',
-        notifySubscribers: false,
-        publishMethod: 'Immediate',
-      };
+        expect(
+          screen.queryByLabelText('Notify subscribers by email'),
+        ).not.toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(handleSubmit).toHaveBeenCalledWith(expectedValues);
+        expect(
+          screen.queryByLabelText('Update published date'),
+        ).not.toBeInTheDocument();
+
+        // Toggle back to Approved and expect the options have their default values
+        userEvent.click(screen.getByLabelText('Approved for publication'));
+
+        expect(
+          screen.getByLabelText('Notify subscribers by email'),
+        ).toBeChecked();
+
+        expect(
+          screen.getByLabelText('Update published date'),
+        ).not.toBeChecked();
+      });
+
+      test('shows warning message when `updatePublishedDate` is selected', async () => {
+        const handleSubmit = jest.fn();
+
+        render(
+          <ReleaseStatusForm
+            release={{
+              ...testRelease,
+              approvalStatus: 'Approved',
+              amendment: true,
+              notifySubscribers: false,
+              updatePublishedDate: false,
+            }}
+            statusPermissions={testStatusPermissions}
+            onCancel={noop}
+            onSubmit={handleSubmit}
+          />,
+        );
+
+        await waitFor(() => {
+          expect(
+            screen.getByLabelText('Update published date'),
+          ).not.toBeChecked();
+        });
+
+        userEvent.click(screen.getByLabelText('Update published date'));
+
+        expect(
+          screen.getByText(
+            "The release's published date in the public view will be updated once the publication is complete.",
+          ),
+        ).toBeInTheDocument();
+      });
+
+      test('submits successfully with updated values', async () => {
+        const handleSubmit = jest.fn();
+
+        render(
+          <ReleaseStatusForm
+            release={{
+              ...testRelease,
+              approvalStatus: 'Approved',
+              amendment: true,
+              notifySubscribers: true,
+              updatePublishedDate: false,
+            }}
+            statusPermissions={testStatusPermissions}
+            onCancel={noop}
+            onSubmit={handleSubmit}
+          />,
+        );
+
+        await userEvent.type(
+          screen.getByLabelText('Internal note'),
+          'Test release note',
+        );
+
+        userEvent.click(screen.getByLabelText('Notify subscribers by email'));
+
+        userEvent.click(screen.getByLabelText('Update published date'));
+
+        userEvent.click(screen.getByLabelText('Immediately'));
+
+        expect(handleSubmit).not.toHaveBeenCalled();
+
+        userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+        const expectedValues: ReleaseStatusFormValues = {
+          internalReleaseNote: 'Test release note',
+          approvalStatus: 'Approved',
+          publishMethod: 'Immediate',
+          notifySubscribers: false,
+          updatePublishedDate: true,
+        };
+
+        await waitFor(() => {
+          expect(handleSubmit).toHaveBeenCalledWith(expectedValues);
+        });
       });
     });
   });

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
@@ -1,7 +1,7 @@
 import { testRelease } from '@admin/pages/release/__data__/testRelease';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import _releaseService, { Release } from '@admin/services/releaseService';
+import _releaseService from '@admin/services/releaseService';
 import _permissionService from '@admin/services/permissionService';
 import _preReleaseUserService from '@admin/services/preReleaseUserService';
 import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
@@ -21,40 +21,9 @@ const preReleaseUserService = _preReleaseUserService as jest.Mocked<
   typeof _preReleaseUserService
 >;
 
-const releaseData: Release = {
-  id: 'release-1',
-  slug: 'release-1-slug',
-  approvalStatus: 'Draft',
-  latestRelease: false,
-  live: false,
-  amendment: false,
-  year: 2021,
-  yearTitle: '2021/22',
-  publicationId: 'publication-1',
-  publicationTitle: 'Publication 1',
-  publicationSummary: 'Publication 1 summary',
-  publicationSlug: 'publication-1-slug',
-  timePeriodCoverage: { value: 'W51', label: 'Week 51' },
-  title: 'Release Title',
-  type: 'OfficialStatistics',
-  contact: {
-    teamName: 'Test name',
-    teamEmail: 'test@test.com',
-    contactName: 'Test contact name',
-    contactTelNo: '1111 1111 1111',
-  },
-  nextReleaseDate: {
-    day: 1,
-    month: 1,
-    year: 2020,
-  },
-  previousVersionId: '',
-  preReleaseAccessList: '',
-};
-
 describe('ReleasePreReleaseAccessPage', () => {
   test('renders the pre-release users tab', async () => {
-    releaseService.getRelease.mockResolvedValue(releaseData);
+    releaseService.getRelease.mockResolvedValue(testRelease);
     permissionService.canUpdateRelease.mockResolvedValue(true);
     preReleaseUserService.getUsers.mockResolvedValue([]);
 
@@ -82,7 +51,7 @@ describe('ReleasePreReleaseAccessPage', () => {
   });
 
   test('renders pre-release page link correctly', async () => {
-    releaseService.getRelease.mockResolvedValue(releaseData);
+    releaseService.getRelease.mockResolvedValue(testRelease);
     permissionService.canUpdateRelease.mockResolvedValue(true);
 
     renderPage();
@@ -97,7 +66,7 @@ describe('ReleasePreReleaseAccessPage', () => {
   });
 
   test('only renders the public access list for amendments', async () => {
-    const amendmentRelease = { ...releaseData, amendment: true };
+    const amendmentRelease = { ...testRelease, amendment: true };
     releaseService.getRelease.mockResolvedValue(amendmentRelease);
     permissionService.canUpdateRelease.mockResolvedValue(true);
 
@@ -115,7 +84,7 @@ describe('ReleasePreReleaseAccessPage', () => {
   });
 
   test('renders the public access list tab', async () => {
-    releaseService.getRelease.mockResolvedValue(releaseData);
+    releaseService.getRelease.mockResolvedValue(testRelease);
     permissionService.canUpdateRelease.mockResolvedValue(true);
     preReleaseUserService.getUsers.mockResolvedValue([]);
 

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -18,6 +18,7 @@ export interface Release {
   slug: string;
   approvalStatus: ReleaseApprovalStatus;
   notifySubscribers?: boolean;
+  updatePublishedDate: boolean;
   latestRelease: boolean;
   live: boolean;
   amendment: boolean;
@@ -90,6 +91,7 @@ export interface CreateReleaseStatusRequest {
   publishScheduled?: string;
   nextReleaseDate?: PartialDate;
   notifySubscribers?: boolean;
+  updatePublishedDate?: boolean;
 }
 
 type PublishingStage =

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -587,6 +587,7 @@ user approves release for scheduled publication
     ...    ${publish_date_year}
     ...    ${next_release_month}=01
     ...    ${next_release_year}=2200
+    ...    ${update_amendment_published_date}=${False}
     user clicks link    Sign off
     user waits until page does not contain loading spinner
     user waits until h2 is visible    Sign off    %{WAIT_SMALL}
@@ -597,6 +598,10 @@ user approves release for scheduled publication
 
     user clicks radio    Approved for publication
     user enters text into element    id:releaseStatusForm-internalReleaseNote    Approved by UI tests
+    IF    ${update_amendment_published_date}
+        user waits until page contains    Update published date
+        user clicks checkbox    Update published date
+    END
     user clicks radio    On a specific date
     user waits until page contains    Publish date
     user enters text into element    id:releaseStatusForm-publishScheduled-day    ${publish_date_day}

--- a/tests/robot-tests/tests/libs/admin_api.py
+++ b/tests/robot-tests/tests/libs/admin_api.py
@@ -107,7 +107,6 @@ def user_creates_test_publication_via_api(publication_name: str, topic_id: str =
 
 
 def user_adds_user_invite_via_api(user_email: str, role_name: str, created_date: str = None):
-
     response = admin_client.post(
         f"/api/user-management/invites",
         {
@@ -122,7 +121,6 @@ def user_adds_user_invite_via_api(user_email: str, role_name: str, created_date:
 
 
 def user_adds_release_role_to_user_via_api(user_email: str, release_id: str, role_name: str = None):
-
     user_id = _get_user_details_via_api(user_email)["id"]
 
     response = admin_client.post(
@@ -138,7 +136,6 @@ def user_adds_release_role_to_user_via_api(user_email: str, release_id: str, rol
 
 
 def user_adds_publication_role_to_user_via_api(user_email: str, publication_id: str, role_name: str = None):
-
     user_id = _get_user_details_via_api(user_email)["id"]
 
     response = admin_client.post(
@@ -206,8 +203,14 @@ def user_creates_test_release_via_api(
     return response.json()["id"]
 
 
-def _get_user_details_via_api(user_email: str):
+def user_updates_release_published_date_via_api(release_id: str, published: datetime) -> None:
+    response = admin_client.patch(f"/api/releases/{release_id}/published", {"published": published.isoformat()})
+    assert (
+        response.status_code < 300
+    ), f"Updating release published date failed with {response.status_code} and {response.text}"
 
+
+def _get_user_details_via_api(user_email: str):
     users = admin_client.get("/api/user-management/users").json()
 
     matching_users = list(filter(lambda user: user["email"] == user_email, users))
@@ -218,7 +221,6 @@ def _get_user_details_via_api(user_email: str):
 
 
 def _get_prerelease_user_details_via_api(user_email: str):
-
     users = admin_client.get("/api/user-management/pre-release").json()
 
     matching_users = list(filter(lambda user: user["email"] == user_email, users))
@@ -229,7 +231,6 @@ def _get_prerelease_user_details_via_api(user_email: str):
 
 
 def _get_global_role_id(role_name: str):
-
     response = admin_client.get("/api/user-management/roles")
     assert (
         response.status_code < 300
@@ -244,7 +245,6 @@ def _get_global_role_id(role_name: str):
 
 
 def _get_user_invite(user_email: str):
-
     response = admin_client.get("/api/user-management/invites")
     assert response.status_code < 300, f"Getting list of invites failed with {response.status_code} and {response.text}"
 

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -19,6 +19,7 @@ ${timeout}=                             %{TIMEOUT}
 ${implicit_wait}=                       %{IMPLICIT_WAIT}
 ${prompt_to_continue_on_failure}=       0
 ${FAIL_TEST_SUITES_FAST}=               %{FAIL_TEST_SUITES_FAST}
+${DATE_FORMAT_MEDIUM}=                  %-d %B %Y
 
 
 *** Keywords ***

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -229,12 +229,14 @@ def format_uk_to_local_datetime(uk_local_datetime: str, strf: str) -> str:
 
 
 def get_current_datetime(strf: str, offset_days: int = 0) -> str:
-    now = datetime.datetime.now() + datetime.timedelta(days=offset_days)
+    return format_datetime(datetime.datetime.now() + datetime.timedelta(days=offset_days), strf)
 
+
+def format_datetime(datetime: datetime, strf: str) -> str:
     if os.name == "nt":
         strf = strf.replace("%-", "%#")
 
-    return now.strftime(strf)
+    return datetime.strftime(strf)
 
 
 def user_should_be_at_top_of_page():


### PR DESCRIPTION
⚠️ The UI tests of this change depend on [EES-4072](https://dfedigital.atlassian.net/browse/EES-4072) in https://github.com/dfe-analytical-services/explore-education-statistics/pull/3862 which adds a method which the UI tests can use to force a published date to a past date.

This PR adds a new checkbox 'Update published date' to the Admin Sign off tab when approving an **amendment** release for publication.

It allows the analysts to decide whether to update the published date to match the time the publishing process completes.

It applies to both immediate and scheduled publishing methods.

If not checked (default), the behaviour remains the same, i.e. an amendment is given the published date of the previous version.

![image](https://user-images.githubusercontent.com/4147126/216327529-ff486eed-8740-4ff3-b02d-4d3e329db60e.png)

A complication to doing this arises from the publishing process and the way we pre-cache release content for both immediate and scheduled publishing methods. Already, the code to fetch and cache release content has to expect that the release might not be published yet for this pre-caching, and in this case sets an expected date publish date in the view model based on logic around whether it's an amendment or not and when we expect publishing to complete (immediate=now, scheduled=future date).

This happens in separate Azure functions to the post publishing completion step which updates the published date of the release which makes it publicly accessible.

Both need to follow the same logic, i.e. `Content.Services.ReleaseService.GetRelease` used to pre-cache or pre-cache and stage the release, and `Publisher.Services.ReleaseService.SetPublishedDate` used in the post publishing completion step.

These are both tidied up now to use the same `ReleaseRepository.GetPublishedDate` method to resolve the published date based on version and `updatePublishedDate` flag.

However it feels like it would be much cleaner if pre-caching didn't exist, and also if the publish date fields were separated, one to control or audit when a release is published, and one for the display date which can be altered and set ahead of time.

### Other changes

- Remove unused `PublishScheduled` and `NextReleaseDate` from `ReleaseCreateRequest` and check fields of the saved Release in `ReleaseServiceTests` after creating a release. This change is tagged as EES-4056 in the commit history.

### UI test report

![image](https://user-images.githubusercontent.com/4147126/216641505-8b3e1926-8cb1-408b-a103-b832a460eb48.png)
