### PR TITLE
EES-4058 Drop unused database fields after EES-4056

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230202124813_EES4058DropUnusedFieldsAfterEES4056.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230202124813_EES4058DropUnusedFieldsAfterEES4056.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230202124813_EES4058DropUnusedFieldsAfterEES4056")]
+    partial class EES4058DropUnusedFieldsAfterEES4056
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230202124813_EES4058DropUnusedFieldsAfterEES4056.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230202124813_EES4058DropUnusedFieldsAfterEES4056.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations;
+
+[ExcludeFromCodeCoverage]
+public partial class EES4058DropUnusedFieldsAfterEES4056 : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "NotifiedOn",
+            table: "ReleaseStatus");
+
+        migrationBuilder.DropColumn(
+            name: "NotifySubscribers",
+            table: "ReleaseStatus");
+
+        migrationBuilder.DropColumn(
+            name: "DataLastPublished",
+            table: "Releases");
+
+        migrationBuilder.DropColumn(
+            name: "Published",
+            table: "Publications");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<DateTime>(
+            name: "NotifiedOn",
+            table: "ReleaseStatus",
+            type: "datetime2",
+            nullable: true);
+
+        migrationBuilder.AddColumn<bool>(
+            name: "NotifySubscribers",
+            table: "ReleaseStatus",
+            type: "bit",
+            nullable: false,
+            defaultValue: false);
+
+        migrationBuilder.AddColumn<DateTime>(
+            name: "DataLastPublished",
+            table: "Releases",
+            type: "datetime2",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTime>(
+            name: "Published",
+            table: "Publications",
+            type: "datetime2",
+            nullable: true);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -25,9 +25,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<LegacyRelease> LegacyReleases { get; set; } = new();
 
-        // TODO EES-4058 Remove unused Published
-        public DateTime? Published { get; set; }
-
         public Guid TopicId { get; set; }
 
         public Topic Topic { get; set; } = null!;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -236,9 +236,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<Link> RelatedInformation { get; set; } = new();
 
-        // TODO EES-4058 Remove unused DataLastPublished
-        public DateTime? DataLastPublished { get; set; }
-
         public Release Clone()
         {
             return MemberwiseClone() as Release;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
@@ -15,12 +15,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string? InternalReleaseNote { get; set; }
 
-        // TODO EES-4058 Remove unused NotifySubscribers after EES-4056
-        public bool NotifySubscribers { get; set; }
-
-        // TODO EES-4058 Remove unused NotifiedOn after EES-4056
-        public DateTime? NotifiedOn { get; set; }
-
         public ReleaseApprovalStatus ApprovalStatus { get; set; }
 
         public DateTime? Created { get; set; }


### PR DESCRIPTION
It's the tidy-up of the tidy-up. 🙂 

[EES-4056](https://dfedigital.atlassian.net/browse/EES-4056) in https://github.com/dfe-analytical-services/explore-education-statistics/pull/3821 removed all usages of four fields:

- `Publication.Published`
- `Release.DataLastPublished`
- `ReleaseStatus.NotifySubscribers`
- `ReleaseStatus.NotifiedOn`

This PR drops them from the content database.

⚠️ Not to be merged until EES-4056 has progressed through all environments.