### PR TITLE
Ees 3960 adding cache invalidation for publication and latest release json 2

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
@@ -224,9 +224,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var regex = Assert.IsType<Regex>(options.IncludeRegex);
             Assert.Matches(regex, "publications/publication-1/latest-release.json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/latest-release.json.bak");
             Assert.DoesNotMatch(regex, "something/publications/publication-1/latest-release.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/publication.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/publications/latest-release.json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/publications/releases");
         }
 
         [Fact]
@@ -251,7 +254,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                     Paths = new HashSet<string>
                     {
                         "latest-release.json",
-                        "publication.json"
+                        "publication.json",
+                        "releases"
                     }
                 });
 
@@ -262,6 +266,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var regex = Assert.IsType<Regex>(options.IncludeRegex);
             Assert.Matches(regex, "publications/publication-1/latest-release.json");
             Assert.Matches(regex, "publications/publication-1/publication.json");
+            Assert.Matches(regex, "publications/publication-1/releases");
+            Assert.DoesNotMatch(regex, "releases");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases2");
+            Assert.DoesNotMatch(regex, "publications/releases");
             Assert.DoesNotMatch(regex, "something/publications/publication-1/latest-release.json");
             Assert.DoesNotMatch(regex, "something/publications/publication-1/publication.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/publications/latest-release.json");

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
@@ -53,6 +53,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var regex = Assert.IsType<Regex>(options.IncludeRegex);
             Assert.Matches(regex, "releases/release-1/subject-meta/something");
+            Assert.DoesNotMatch(regex, "releases/subject-meta/something");
+            Assert.DoesNotMatch(regex, "release-1/subject-meta/something");
             Assert.DoesNotMatch(regex, "something/releases/release-1/subject-meta/something");
             Assert.DoesNotMatch(regex, "releases/release-1/data-blocks/something");
             Assert.DoesNotMatch(regex, "releases/release-1/invalid/something");
@@ -156,6 +158,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             Assert.Matches(regex, "publications/publication-1/something");
             Assert.Matches(regex, "publications/publication-1/releases/something");
             Assert.Matches(regex, "publications/publication-1/releases/release-1/something");
+            Assert.DoesNotMatch(regex, "publication-1/something");
             Assert.DoesNotMatch(regex, "publications/publication-2/something");
             Assert.DoesNotMatch(regex, "publications/publication-2/releases/something");
             Assert.DoesNotMatch(regex, "publications/publication-2/releases/release-1/something");
@@ -226,7 +229,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         }
 
         [Fact]
-        public async Task ClearPublicCachePublicationPaths_AllValidPaths()
+        public async Task ClearPublicCacheReleaseJson()
         {
             var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
 
@@ -250,9 +253,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var regex = Assert.IsType<Regex>(options.IncludeRegex);
             Assert.Matches(regex, "publications/publication-1/latest-release.json");
             Assert.Matches(regex, "publications/publication-1/releases/1234-56.json");
+            Assert.Matches(regex, "publications/publication-1/releases/1234-56-fy.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/latest-release_json");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/1234-56_json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/1234-56/data-block-id.json");
             Assert.DoesNotMatch(regex, "publications/latest-release.json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/1234-56.json");
+            Assert.DoesNotMatch(regex, "publications/1234-56.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/latest-release.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/12-56.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/latest-release.json.bak");
@@ -288,6 +295,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var regex = Assert.IsType<Regex>(options.IncludeRegex);
             Assert.Matches(regex, "publications/publication-1/releases/release-1/subject-meta/something");
+            Assert.DoesNotMatch(regex, "publications/releases/release-1/subject-meta/something");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/subject-meta/something");
             Assert.DoesNotMatch(regex,
                 "something/publications/publication-1/releases/release-1/subject-meta/something");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/release-1/data-blocks/something");

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
@@ -196,7 +196,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         }
 
         [Fact]
-        public async Task ClearPublicCachePublicationPaths_SingleValidPath()
+        public async Task ClearPublicCachePublicationJson()
         {
             var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
 
@@ -211,25 +211,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
 
-            var result = await controller.ClearPublicCachePublicationPaths(
-                new ClearPublicCachePublicationPathsViewModel
-                {
-                    Paths = SetOf("latest-release.json")
-                }
-            );
+            var result = await controller.ClearPublicCachePublicationJson();
 
             VerifyAllMocks(publicBlobStorageService);
 
             result.AssertNoContent();
 
             var regex = Assert.IsType<Regex>(options.IncludeRegex);
-            Assert.Matches(regex, "publications/publication-1/latest-release.json");
-            Assert.DoesNotMatch(regex, "publications/publication-1/latest-release.json.bak");
-            Assert.DoesNotMatch(regex, "something/publications/publication-1/latest-release.json");
-            Assert.DoesNotMatch(regex, "publications/publication-1/publication.json");
-            Assert.DoesNotMatch(regex, "publications/publication-1/releases/publications/latest-release.json");
-            Assert.DoesNotMatch(regex, "publications/publication-1/releases");
-            Assert.DoesNotMatch(regex, "publications/publication-1/releases/publications/releases");
+
+            Assert.Matches(regex, "publications/publication-1/publication.json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/publication_json");
+            Assert.DoesNotMatch(regex, "something/publications/publication-1/publication.json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/publications/publication.json");
         }
 
         [Fact]
@@ -248,16 +241,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
 
-            var result = await controller.ClearPublicCachePublicationPaths(
-                new ClearPublicCachePublicationPathsViewModel
-                {
-                    Paths = new HashSet<string>
-                    {
-                        "latest-release.json",
-                        "publication.json",
-                        "releases"
-                    }
-                });
+            var result = await controller.ClearPublicCacheReleaseJson();
 
             VerifyAllMocks(publicBlobStorageService);
 
@@ -265,15 +249,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var regex = Assert.IsType<Regex>(options.IncludeRegex);
             Assert.Matches(regex, "publications/publication-1/latest-release.json");
-            Assert.Matches(regex, "publications/publication-1/publication.json");
-            Assert.Matches(regex, "publications/publication-1/releases");
-            Assert.DoesNotMatch(regex, "releases");
-            Assert.DoesNotMatch(regex, "publications/publication-1/releases2");
-            Assert.DoesNotMatch(regex, "publications/releases");
-            Assert.DoesNotMatch(regex, "something/publications/publication-1/latest-release.json");
-            Assert.DoesNotMatch(regex, "something/publications/publication-1/publication.json");
-            Assert.DoesNotMatch(regex, "publications/publication-1/releases/publications/latest-release.json");
-            Assert.DoesNotMatch(regex, "publications/publication-1/releases/publications/publication.json");
+            Assert.Matches(regex, "publications/publication-1/releases/1234-56.json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/latest-release_json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/1234-56_json");
+            Assert.DoesNotMatch(regex, "publications/latest-release.json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/latest-release.json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/12-56.json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/latest-release.json.bak");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/1234-56.json.bak");
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
@@ -147,6 +147,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
             return NoContent();
         }
 
+        [HttpDelete("public-cache/publications")]
+        public async Task<ActionResult> ClearPublicCachePublicationPaths(
+            ClearPublicCachePublicationPathsViewModel request)
+        {
+            if (request.Paths.Any())
+            {
+                var pathString = request.Paths.JoinToString('|');
+
+                await _publicBlobStorageService.DeleteBlobs(
+                    BlobContainers.PublicContent,
+                    options: new DeleteBlobsOptions
+                    {
+                        IncludeRegex = new Regex($"^publications/[^/]*/({pathString})")
+                    }
+                );
+            }
+
+            return NoContent();
+        }
+
         public class UpdatePublicCacheTreePathsViewModel
         {
             public enum CacheEntry
@@ -172,6 +192,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
             {
                 FileStoragePathUtils.DataBlocksDirectory,
                 FileStoragePathUtils.SubjectMetaDirectory
+            };
+
+            [MinLength(1)]
+            [ContainsOnly(AllowedValuesProvider = nameof(AllowedPaths))]
+            public HashSet<string> Paths { get; set; } = new();
+        }
+
+        public class ClearPublicCachePublicationPathsViewModel
+        {
+            private static readonly HashSet<string> AllowedPaths = new()
+            {
+                FileStoragePathUtils.LatestReleaseFileName,
+                FileStoragePathUtils.PublicationFileName
             };
 
             [MinLength(1)]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
@@ -54,7 +54,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
                     BlobContainers.PrivateContent,
                     options: new DeleteBlobsOptions
                     {
-                        IncludeRegex = new Regex($"^releases/.*/({pathString})/")
+                        IncludeRegex = new Regex($"^releases/[^/]+/({pathString})/")
                     }
                 );
             }
@@ -111,7 +111,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
                     BlobContainers.PublicContent,
                     options: new DeleteBlobsOptions
                     {
-                        IncludeRegex = new Regex($"^publications/.*/releases/.*/({pathString})/")
+                        IncludeRegex = new Regex($"^publications/[^/]+/releases/[^/]+/({pathString})/")
                     }
                 );
             }
@@ -162,7 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
                 BlobContainers.PublicContent,
                 options: new DeleteBlobsOptions
                 {
-                    IncludeRegex = new Regex($"^publications/[^/]*/{publicationJsonFilenameRegex}$")
+                    IncludeRegex = new Regex($"^publications/[^/]+/{publicationJsonFilenameRegex}$")
                 });
 
             return NoContent();
@@ -184,7 +184,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
                 BlobContainers.PublicContent,
                 options: new DeleteBlobsOptions
                 {
-                    IncludeRegex = new Regex($"^publications/[^/]*/({latestReleaseJsonFilenameRegex}|releases/[0-9]{{4}}-.*\\.json)$")
+                    IncludeRegex = new Regex($"^publications/[^/]+/({latestReleaseJsonFilenameRegex}|releases/[0-9]{{4}}-[^/]+\\.json)$")
                 });
 
             return NoContent();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
@@ -147,7 +147,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
             return NoContent();
         }
 
-        [HttpDelete("public-cache/publications")]
+        [HttpDelete("public-cache/publications/paths")]
         public async Task<ActionResult> ClearPublicCachePublicationPaths(
             ClearPublicCachePublicationPathsViewModel request)
         {
@@ -159,7 +159,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
                     BlobContainers.PublicContent,
                     options: new DeleteBlobsOptions
                     {
-                        IncludeRegex = new Regex($"^publications/[^/]*/({pathString})")
+                        IncludeRegex = new Regex($"^publications/[^/]*/({pathString})$")
                     }
                 );
             }
@@ -204,7 +204,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
             private static readonly HashSet<string> AllowedPaths = new()
             {
                 FileStoragePathUtils.LatestReleaseFileName,
-                FileStoragePathUtils.PublicationFileName
+                FileStoragePathUtils.PublicationFileName,
+                FileStoragePathUtils.ReleasesDirectory,
             };
 
             [MinLength(1)]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -11,6 +11,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         public const string DataBlocksDirectory = "data-blocks";
         public const string ReleasesDirectory = "releases";
         public const string SubjectMetaDirectory = "subject-meta";
+        public const string LatestReleaseFileName = "latest-release.json";
+        public const string PublicationFileName = "publication.json";
 
         public static string PublicContentStagingPath() => "staging";
 
@@ -26,12 +28,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public static string PublicContentPublicationPath(string slug)
         {
-            return $"{PublicContentPublicationParentPath(slug)}/publication.json";
+            return $"{PublicContentPublicationParentPath(slug)}/{PublicationFileName}";
         }
 
         public static string PublicContentLatestReleasePath(string publicationSlug, bool staging = false)
         {
-            return $"{PublicContentPublicationParentPath(publicationSlug, staging)}/latest-release.json";
+            return $"{PublicContentPublicationParentPath(publicationSlug, staging)}/{LatestReleaseFileName}";
         }
 
         public static string PublicContentReleasePath(string publicationSlug, string releaseSlug, bool staging = false)


### PR DESCRIPTION
This PR:
- adds a new endpoint to clear down all `publication.json` files in the `public` cache for when the PublicationCacheViewModel becomes incompatible with the cached JSON 
- adds a new endpoint to clear down all `latest-release.json` and `releases/<year-timeidentifier>.json` files together for when the ReleaseCacheViewModel becomes incompatible with the cached JSON

These are requested via:

`DELETE /api/bau/public-cache/publications/publication-json`

and

`DELETE /api/bau/public-cache/publications/release-json`

respectively against the Admin API (with the appropriate Bearer tokens)