### PR TITLE
Fix `StatisticsDbContext` migrations

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
@@ -298,6 +298,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
                 .Property(r => r.TimeIdentifier)
                 .HasConversion(new EnumToEnumValueConverter<TimeIdentifier>())
                 .HasMaxLength(6);
+
+            // TODO EES-3763 - Read Replica cleanup - remove "PreviousVersionId" columns from
+            // statistics' "Release" table.
+            modelBuilder.Entity<Release>()
+                .HasIndex(data => data.PreviousVersionId);
         }
 
         private static void ConfigureReleaseSubject(ModelBuilder modelBuilder)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Release.cs
@@ -3,12 +3,9 @@ using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
-using static System.DateTime;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    // TODO EES-3763 - Read Replica cleanup - remove unused "Published" and "PreviousVersionId" columns from
-    // statistics' "Release" table. 
     public class Release
     {
         public Guid Id { get; set; }
@@ -17,6 +14,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public TimeIdentifier TimeIdentifier { get; set; }
         public int Year { get; set; }
         public ICollection<ReleaseFootnote> Footnotes { get; set; }
+
+        // TODO EES-3763 - Read Replica cleanup - remove unused "Published" and "PreviousVersionId" columns from
+        // statistics' "Release" table. 
+        public DateTime? Published { get; set; }
+        public Guid? PreviousVersionId { get; set; }
 
         public string Title =>
             TimePeriodLabelFormatter.Format(Year, TimeIdentifier, TimePeriodLabelFormat.FullLabelBeforeYear);


### PR DESCRIPTION
This PR temporarily adds back in unused fields `Release.Published` and `Release.PreviousVersionId` into the Statistics model as well as the configuration for the index on `Release.PreviousVersionId`.

Without these we can't generate a 'clean' migration currently.

They will be removed properly by the [EES-3763](https://dfedigital.atlassian.net/browse/EES-3763) Read-replica cleanup with a migration which will drop them from the database.