### PR TITLE
EES-4080 Add `IReleaseFileBlobService` and private/public implementations

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -37,6 +37,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
@@ -590,6 +592,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IUserRepository, UserRepository>();
             services.AddTransient<IUserInviteRepository, UserInviteRepository>();
             services.AddTransient<IFileUploadsValidatorService, FileUploadsValidatorService>();
+            services.AddTransient<IReleaseFileBlobService, PrivateReleaseFileBlobService>();
             services.AddTransient(provider => GetBlobStorageService(provider, "CoreStorage"));
             services.AddTransient<ITableStorageService, TableStorageService>(_ =>
                 new TableStorageService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
@@ -117,20 +117,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             this Mock<IBlobStorageService> service,
             IBlobContainer container,
             string path,
-            string blobText)
+            string blobText,
+            CancellationToken cancellationToken = default)
         {
             return service.Setup(s =>
-                    s.DownloadBlobText(container, path))
+                    s.DownloadBlobText(container, path, cancellationToken))
                 .ReturnsAsync(blobText);
         }
 
         public static IReturnsResult<IBlobStorageService> SetupDownloadBlobTextNotFound(
             this Mock<IBlobStorageService> service,
             IBlobContainer container,
-            string path)
+            string path,
+            CancellationToken cancellationToken = default)
         {
             return service.Setup(s =>
-                    s.DownloadBlobText(container, path))
+                    s.DownloadBlobText(container, path, cancellationToken))
                 .ThrowsAsync(new StorageException(new RequestResult
                 {
                     HttpStatusCode = (int) HttpStatusCode.NotFound

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
@@ -119,7 +119,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             string path,
             string blobText)
         {
-            return service.Setup(s => s.DownloadBlobText(container, path))
+            return service.Setup(s =>
+                    s.DownloadBlobText(container, path))
                 .ReturnsAsync(blobText);
         }
 
@@ -128,7 +129,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             IBlobContainer container,
             string path)
         {
-            return service.Setup(s => s.DownloadBlobText(container, path))
+            return service.Setup(s =>
+                    s.DownloadBlobText(container, path))
                 .ThrowsAsync(new StorageException(new RequestResult
                 {
                     HttpStatusCode = (int) HttpStatusCode.NotFound

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobCacheServiceTests.cs
@@ -84,7 +84,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
 
             blobStorageService.Setup(mock =>
-                    mock.GetDeserializedJson(PublicContent, cacheKey.Key, typeof(SampleClass)))
+                    mock.GetDeserializedJson(
+                        PublicContent, cacheKey.Key, typeof(SampleClass), default))
                 .ReturnsAsync(entity);
 
             var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
@@ -105,7 +106,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
 
             blobStorageService.Setup(mock =>
-                    mock.GetDeserializedJson(PublicContent, cacheKey.Key, typeof(SampleClass)))
+                    mock.GetDeserializedJson(
+                        PublicContent, cacheKey.Key, typeof(SampleClass), default))
                 .ThrowsAsync(new JsonException("Could not deserialize"));
 
 
@@ -130,7 +132,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
 
             blobStorageService.Setup(mock =>
-                    mock.GetDeserializedJson(PublicContent, cacheKey.Key, typeof(SampleClass)))
+                    mock.GetDeserializedJson(
+                        PublicContent, cacheKey.Key, typeof(SampleClass), default))
                 .ThrowsAsync(new FileNotFoundException());
 
             var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
@@ -150,7 +153,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
 
             blobStorageService.Setup(mock =>
-                    mock.GetDeserializedJson(PublicContent, cacheKey.Key, typeof(SampleClass)))
+                    mock.GetDeserializedJson(
+                        PublicContent, cacheKey.Key, typeof(SampleClass), default))
                 .ThrowsAsync(new Exception("Something went wrong"));
 
             var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobStorageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobStorageServiceTests.cs
@@ -105,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             response.SetupGet(r => r.Value)
                 .Returns(BlobDownloadResult(BinaryData.FromString(json)));
 
-            blobClient.Setup(s => s.DownloadContentAsync())
+            blobClient.Setup(s => s.DownloadContentAsync(default))
                 .ReturnsAsync(response.Object);
 
             var blobContainerClient = MockBlobContainerClient(PublicReleaseFiles.Name, blobClient);
@@ -140,7 +140,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             response.SetupGet(r => r.Value)
                 .Returns(BlobDownloadResult(BinaryData.FromString(json)));
 
-            blobClient.Setup(s => s.DownloadContentAsync())
+            blobClient.Setup(s => s.DownloadContentAsync(default))
                 .ReturnsAsync(response.Object);
 
             var blobContainerClient = MockBlobContainerClient(PublicReleaseFiles.Name, blobClient);
@@ -176,7 +176,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             response.SetupGet(r => r.Value)
                 .Returns(BlobDownloadResult(BinaryData.FromString(json)));
 
-            blobClient.Setup(s => s.DownloadContentAsync())
+            blobClient.Setup(s => s.DownloadContentAsync(default))
                 .ReturnsAsync(response.Object);
 
             var blobContainerClient = MockBlobContainerClient(PublicReleaseFiles.Name, blobClient);
@@ -209,7 +209,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             response.SetupGet(r => r.Value)
                 .Returns(BlobDownloadResult(BinaryData.FromString("")));
 
-            blobClient.Setup(s => s.DownloadContentAsync())
+            blobClient.Setup(s => s.DownloadContentAsync(default))
                 .ReturnsAsync(response.Object);
 
             var blobContainerClient = MockBlobContainerClient(PublicReleaseFiles.Name, blobClient);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -373,13 +373,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             }
         }
 
-        public async Task<string> DownloadBlobText(IBlobContainer containerName, string path)
+        public async Task<string> DownloadBlobText(
+            IBlobContainer containerName,
+            string path,
+            CancellationToken cancellationToken = default)
         {
             var blob = await GetBlobClient(containerName, path);
 
             try
             {
-                var response = await blob.DownloadContentAsync();
+                var response = await blob.DownloadContentAsync(cancellationToken);
                 return response.Value.Content.ToString();
             }
             catch (RequestFailedException exception)
@@ -393,9 +396,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             }
         }
 
-        public async Task<object?> GetDeserializedJson(IBlobContainer containerName, string path, Type type)
+        public async Task<object?> GetDeserializedJson(
+            IBlobContainer containerName,
+            string path,
+            Type type,
+            CancellationToken cancellationToken = default)
         {
-            var text = await DownloadBlobText(containerName, path);
+            var text = await DownloadBlobText(containerName, path, cancellationToken);
 
             if (string.IsNullOrWhiteSpace(text))
             {
@@ -409,10 +416,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             );
         }
 
-        public async Task<T?> GetDeserializedJson<T>(IBlobContainer containerName, string path)
+        public async Task<T?> GetDeserializedJson<T>(
+            IBlobContainer containerName,
+            string path,
+            CancellationToken cancellationToken = default)
             where T : class
         {
-            return (T?) await GetDeserializedJson(containerName, path, typeof(T));
+            return (T?) await GetDeserializedJson(containerName, path, typeof(T), cancellationToken);
         }
 
         public async Task<List<BlobInfo>> CopyDirectory(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
@@ -90,11 +90,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
             int? bufferSize = null,
             CancellationToken cancellationToken = default);
 
-        public Task<string> DownloadBlobText(IBlobContainer containerName, string path);
+        public Task<string> DownloadBlobText(
+            IBlobContainer containerName,
+            string path,
+            CancellationToken cancellationToken = default);
 
-        Task<object?> GetDeserializedJson(IBlobContainer containerName, string path, Type target);
+        Task<object?> GetDeserializedJson(
+            IBlobContainer containerName,
+            string path,
+            Type target,
+            CancellationToken cancellationToken = default);
 
-        Task<T?> GetDeserializedJson<T>(IBlobContainer containerName, string path)
+        Task<T?> GetDeserializedJson<T>(
+            IBlobContainer containerName,
+            string path,
+            CancellationToken cancellationToken = default)
             where T : class;
 
         public class CopyDirectoryOptions

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -13,6 +13,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
@@ -159,6 +161,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             services.AddTransient<IReleaseService, Services.ReleaseService>();
             services.AddTransient<IReleaseFileRepository, ReleaseFileRepository>();
             services.AddTransient<IReleaseFileService, ReleaseFileService>();
+            services.AddTransient<IReleaseFileBlobService, PublicReleaseFileBlobService>();
             services.AddTransient<IReleaseDataFileRepository, ReleaseDataFileRepository>();
             services.AddTransient<IDataGuidanceFileWriter, DataGuidanceFileWriter>();
             services.AddTransient<IGlossaryCacheService, GlossaryCacheService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/Interfaces/IReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/Interfaces/IReleaseFileBlobService.cs
@@ -1,0 +1,55 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
+
+public interface IReleaseFileBlobService
+{
+    Task<bool> CheckBlobExists(ReleaseFile releaseFile);
+
+    Task<BlobInfo> GetBlob(ReleaseFile releaseFile);
+
+    Task<BlobInfo?> FindBlob(ReleaseFile releaseFile);
+
+    Task DeleteFile(ReleaseFile releaseFile);
+
+    Task<bool> MoveBlob(ReleaseFile releaseFile, string destinationPath);
+
+    Task<Stream> StreamBlob(
+        ReleaseFile releaseFile,
+        int? bufferSize = null,
+        CancellationToken cancellationToken = default);
+
+    Task<string> DownloadBlobText(ReleaseFile releaseFile);
+
+    Task<Either<ActionResult, Stream>> DownloadToStream(
+        ReleaseFile releaseFile,
+        Stream stream,
+        CancellationToken? cancellationToken = null);
+
+    Task<object?> GetDeserializedJson(ReleaseFile releaseFile, Type target);
+
+    Task<T?> GetDeserializedJson<T>(ReleaseFile releaseFile) where T : class;
+
+    Task UploadFile(
+        ReleaseFile releaseFile,
+        IFormFile file);
+
+    Task UploadStream(
+        ReleaseFile releaseFile,
+        Stream stream,
+        string contentType);
+
+    Task UploadAsJson<T>(
+        ReleaseFile releaseFile,
+        T content,
+        JsonSerializerSettings? settings = null);
+
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/Interfaces/IReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/Interfaces/IReleaseFileBlobService.cs
@@ -27,7 +27,9 @@ public interface IReleaseFileBlobService
         int? bufferSize = null,
         CancellationToken cancellationToken = default);
 
-    Task<string> DownloadBlobText(ReleaseFile releaseFile);
+    Task<string> DownloadBlobText(
+        ReleaseFile releaseFile,
+        CancellationToken cancellationToken = default);
 
     Task<Either<ActionResult, Stream>> DownloadToStream(
         ReleaseFile releaseFile,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PrivateReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PrivateReleaseFileBlobService.cs
@@ -64,11 +64,14 @@ public class PrivateReleaseFileBlobService : IReleaseFileBlobService
         );
     }
 
-    public Task<string> DownloadBlobText(ReleaseFile releaseFile)
+    public Task<string> DownloadBlobText(
+        ReleaseFile releaseFile,
+        CancellationToken cancellationToken = default)
     {
         return _blobStorageService.DownloadBlobText(
             containerName: PrivateReleaseFiles,
-            path: releaseFile.Path()
+            path: releaseFile.Path(),
+            cancellationToken: cancellationToken
         );
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PrivateReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PrivateReleaseFileBlobService.cs
@@ -1,0 +1,130 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Services;
+
+public class PrivateReleaseFileBlobService : IReleaseFileBlobService
+{
+    private readonly IBlobStorageService _blobStorageService;
+
+    public PrivateReleaseFileBlobService(IBlobStorageService blobStorageService)
+    {
+        _blobStorageService = blobStorageService;
+    }
+
+    public Task<bool> CheckBlobExists(ReleaseFile releaseFile)
+    {
+        return _blobStorageService.CheckBlobExists(PrivateReleaseFiles, releaseFile.Path());
+    }
+
+    public Task<BlobInfo> GetBlob(ReleaseFile releaseFile)
+    {
+        return _blobStorageService.GetBlob(PrivateReleaseFiles, releaseFile.Path());
+    }
+
+    public Task<BlobInfo?> FindBlob(ReleaseFile releaseFile)
+    {
+        return _blobStorageService.FindBlob(PrivateReleaseFiles, releaseFile.Path());
+    }
+
+    public Task DeleteFile(ReleaseFile releaseFile)
+    {
+        return _blobStorageService.DeleteBlob(PrivateReleaseFiles, releaseFile.Path());
+    }
+
+    public Task<bool> MoveBlob(ReleaseFile releaseFile, string destinationPath)
+    {
+        return _blobStorageService.MoveBlob(
+            containerName: PrivateReleaseFiles,
+            sourcePath: releaseFile.Path(),
+            destinationPath: destinationPath
+        );
+    }
+
+    public Task<Stream> StreamBlob(
+        ReleaseFile releaseFile,
+        int? bufferSize = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _blobStorageService.StreamBlob(
+            containerName: PrivateReleaseFiles,
+            path: releaseFile.Path(),
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public Task<string> DownloadBlobText(ReleaseFile releaseFile)
+    {
+        return _blobStorageService.DownloadBlobText(
+            containerName: PrivateReleaseFiles,
+            path: releaseFile.Path()
+        );
+    }
+
+    public Task<Either<ActionResult, Stream>> DownloadToStream(
+        ReleaseFile releaseFile,
+        Stream stream,
+        CancellationToken? cancellationToken = null)
+    {
+        return _blobStorageService.DownloadToStream(
+            containerName: PrivateReleaseFiles,
+            path: releaseFile.Path(),
+            stream: stream,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public Task<object?> GetDeserializedJson(ReleaseFile releaseFile, Type target)
+    {
+        return _blobStorageService.GetDeserializedJson(
+            containerName: PrivateReleaseFiles,
+            path: releaseFile.Path(),
+            target: target
+        );
+    }
+
+    public Task<T?> GetDeserializedJson<T>(ReleaseFile releaseFile) where T : class
+    {
+        return _blobStorageService.GetDeserializedJson<T>(PrivateReleaseFiles, releaseFile.Path());
+    }
+
+    public Task UploadFile(ReleaseFile releaseFile, IFormFile file)
+    {
+        return _blobStorageService.UploadFile(
+            containerName: PrivateReleaseFiles,
+            path: releaseFile.Path(),
+            file: file
+        );
+    }
+
+    public Task UploadStream(ReleaseFile releaseFile, Stream stream, string contentType)
+    {
+        return _blobStorageService.UploadStream(
+            containerName: PrivateReleaseFiles,
+            path: releaseFile.Path(),
+            stream: stream,
+            contentType: contentType
+        );
+    }
+
+    public Task UploadAsJson<T>(ReleaseFile releaseFile, T content, JsonSerializerSettings? settings = null)
+    {
+        return _blobStorageService.UploadAsJson(
+            containerName: PrivateReleaseFiles,
+            path: releaseFile.Path(),
+            content: content,
+            settings: settings
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PublicReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PublicReleaseFileBlobService.cs
@@ -1,0 +1,125 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Services;
+
+public class PublicReleaseFileBlobService : IReleaseFileBlobService
+{
+    private readonly IBlobStorageService _blobStorageService;
+
+    public PublicReleaseFileBlobService(IBlobStorageService blobStorageService)
+    {
+        _blobStorageService = blobStorageService;
+    }
+
+    public Task<bool> CheckBlobExists(ReleaseFile releaseFile)
+    {
+        return _blobStorageService.CheckBlobExists(PublicReleaseFiles, releaseFile.PublicPath());
+    }
+
+    public Task<BlobInfo> GetBlob(ReleaseFile releaseFile)
+    {
+        return _blobStorageService.GetBlob(PublicReleaseFiles, releaseFile.PublicPath());
+    }
+
+    public Task<BlobInfo?> FindBlob(ReleaseFile releaseFile)
+    {
+        return _blobStorageService.FindBlob(PublicReleaseFiles, releaseFile.PublicPath());
+    }
+
+    public Task DeleteFile(ReleaseFile releaseFile)
+    {
+        return _blobStorageService.DeleteBlob(PublicReleaseFiles, releaseFile.PublicPath());
+    }
+
+    public Task<bool> MoveBlob(ReleaseFile releaseFile, string destinationPath)
+    {
+        return _blobStorageService.MoveBlob(
+            containerName: PublicReleaseFiles,
+            sourcePath: releaseFile.PublicPath(),
+            destinationPath: destinationPath);
+    }
+
+    public Task<Stream> StreamBlob(
+        ReleaseFile releaseFile,
+        int? bufferSize = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _blobStorageService.StreamBlob(
+            containerName: PublicReleaseFiles,
+            path: releaseFile.PublicPath(),
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public Task<string> DownloadBlobText(ReleaseFile releaseFile)
+    {
+        return _blobStorageService.DownloadBlobText(
+            containerName: PublicReleaseFiles,
+            path: releaseFile.PublicPath()
+        );
+    }
+
+    public Task<Either<ActionResult, Stream>> DownloadToStream(
+        ReleaseFile releaseFile,
+        Stream stream,
+        CancellationToken? cancellationToken = null)
+    {
+        return _blobStorageService.DownloadToStream(
+            containerName: PublicReleaseFiles,
+            path: releaseFile.PublicPath(),
+            stream: stream,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public Task<object?> GetDeserializedJson(ReleaseFile releaseFile, Type target)
+    {
+        return _blobStorageService.GetDeserializedJson(
+            containerName: PublicReleaseFiles,
+            path: releaseFile.PublicPath(),
+            target: target);
+    }
+
+    public Task<T?> GetDeserializedJson<T>(ReleaseFile releaseFile) where T : class
+    {
+        return _blobStorageService.GetDeserializedJson<T>(PublicReleaseFiles, releaseFile.PublicPath());
+    }
+
+    public Task UploadFile(ReleaseFile releaseFile, IFormFile file)
+    {
+        return _blobStorageService.UploadFile(
+            containerName: PublicReleaseFiles,
+            path: releaseFile.PublicPath(),
+            file: file);
+    }
+
+    public Task UploadStream(ReleaseFile releaseFile, Stream stream, string contentType)
+    {
+        return _blobStorageService.UploadStream(
+            containerName: PublicReleaseFiles,
+            path: releaseFile.PublicPath(),
+            stream: stream,
+            contentType: contentType);
+    }
+
+    public Task UploadAsJson<T>(ReleaseFile releaseFile, T content, JsonSerializerSettings? settings = null)
+    {
+        return _blobStorageService.UploadAsJson(
+            containerName: PublicReleaseFiles,
+            path: releaseFile.PublicPath(),
+            content: content,
+            settings: settings);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PublicReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PublicReleaseFileBlobService.cs
@@ -63,11 +63,14 @@ public class PublicReleaseFileBlobService : IReleaseFileBlobService
         );
     }
 
-    public Task<string> DownloadBlobText(ReleaseFile releaseFile)
+    public Task<string> DownloadBlobText(
+        ReleaseFile releaseFile,
+        CancellationToken cancellationToken = default)
     {
         return _blobStorageService.DownloadBlobText(
             containerName: PublicReleaseFiles,
-            path: releaseFile.PublicPath()
+            path: releaseFile.PublicPath(),
+            cancellationToken: cancellationToken
         );
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -16,6 +16,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Security;
@@ -143,6 +145,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
                         new BlobServiceClient(publicStorageConnectionString),
                         provider.GetRequiredService<ILogger<BlobStorageService>>(),
                         new StorageInstanceCreationUtil()));
+            services.AddTransient<IReleaseFileBlobService, PublicReleaseFileBlobService>();
             services.AddTransient<IFilterItemRepository, FilterItemRepository>();
             services.AddTransient<IFilterRepository, FilterRepository>();
             services.AddTransient<IFootnoteRepository, FootnoteRepository>();


### PR DESCRIPTION
This PR adds an `IReleaseFileBlobService` that wraps `IBlobStorageService` to provide methods for working with blobs using a `ReleaseFile` entity.

This removes potential errors from incorrectly calling `IBlobStorageService` methods e.g. with the wrong blob container name or calling `Path` instead of `PublicPath`, etc.

Importantly, this is also necessary for EES-3777 to allow us to create a re-usable `SubjectCsvMetaService` that can work in both the data API and the admin.

## Relevant changes

- Added cancellation token parameters to `DownloadBlobText` and `GetDeserializedJson` methods.