### PR TITLE
EES-4091 Change `ITimePeriodService` to use async

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -338,7 +338,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(new List<Location>());
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>());
 
             var contentDbContextId = Guid.NewGuid().ToString();
             var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -617,7 +617,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(new List<Location>());
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>());
 
             var contentDbContextId = Guid.NewGuid().ToString();
             var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -1039,7 +1039,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>
                 {
                     (2019, CalendarYear),
                     (2020, CalendarYear)
@@ -1271,7 +1271,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>
                 {
                     (2019, CalendarYear),
                     (2020, CalendarYear)
@@ -1528,7 +1528,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>
                 {
                     (2019, CalendarYear),
                     (2020, CalendarYear)
@@ -1761,7 +1761,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>
                 {
                     (2019, CalendarYear),
                     (2020, CalendarYear)
@@ -2158,7 +2158,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>
                 {
                     (2019, CalendarYear),
                     (2020, CalendarYear)
@@ -2548,7 +2548,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(new List<Location>());
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>());
 
             var contentDbContextId = Guid.NewGuid().ToString();
             var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -3001,7 +3001,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>
                 {
                     (2019, CalendarYear),
                     (2020, CalendarYear)
@@ -3417,7 +3417,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(new List<Location>());
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>());
 
             mocks.ReleaseService.Setup(service => service.RemoveDataFiles(
                 contentRelease.Id, originalFile.Id)).ReturnsAsync(Unit.Instance);
@@ -3632,7 +3632,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(new List<Location>());
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>());
 
             mocks.ReleaseService.Setup(service => service.RemoveDataFiles(
                 contentRelease.Id, originalFile.Id)).ReturnsAsync(Unit.Instance);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -178,7 +178,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             var locations = await _locationRepository.GetDistinctForSubject(subjectId);
 
-            var timePeriods = _timePeriodService.GetTimePeriods(subjectId);
+            var timePeriods = await _timePeriodService.GetTimePeriods(subjectId);
 
             return new ReplacementSubjectMeta
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
@@ -110,11 +110,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 timePeriodService
                     .Setup(s => s.GetTimePeriodLabels(releaseSubject1.SubjectId))
-                    .Returns(new TimePeriodLabels("2020/21", "2021/22"));
+                    .ReturnsAsync(new TimePeriodLabels("2020/21", "2021/22"));
 
                 timePeriodService
                     .Setup(s => s.GetTimePeriodLabels(releaseSubject2.SubjectId))
-                    .Returns(new TimePeriodLabels("2030", "2031"));
+                    .ReturnsAsync(new TimePeriodLabels("2030", "2031"));
 
                 dataGuidanceSubjectService
                     .Setup(s => s.GetGeographicLevels(releaseSubject1.SubjectId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
@@ -90,7 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             timePeriodService
                 .Setup(s => s.GetTimePeriods(releaseSubject.SubjectId))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>());
 
             locationRepository
                 .Setup(s => s.GetDistinctForSubject(releaseSubject.SubjectId))
@@ -218,7 +218,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             timePeriodService
                 .Setup(s => s.GetTimePeriods(releaseSubject.SubjectId))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>());
 
             locationRepository
                 .Setup(s => s.GetDistinctForSubject(releaseSubject.SubjectId))
@@ -356,7 +356,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             timePeriodService
                 .Setup(s => s.GetTimePeriods(It.IsAny<IQueryable<Observation>>()))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>());
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
@@ -423,7 +423,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             timePeriodService
                 .Setup(s => s.GetTimePeriods(It.IsAny<IQueryable<Observation>>()))
-                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>());
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
@@ -575,7 +575,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                             .ToList()
                             .Select(o => o.Id)
                             .SequenceEqual(observationsWihMatchingLocations.Select(m => m.Id)))))
-                    .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>
+                    .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>
                     {
                         (2012, TimeIdentifier.April),
                         (2012, TimeIdentifier.May),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodServiceTests.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using Xunit;
@@ -37,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 var service = new TimePeriodService(statisticsDbContext);
-                var result = service.GetTimePeriods(subject.Id).ToList();
+                var result = await service.GetTimePeriods(subject.Id);
 
                 Assert.Equal(5, result.Count);
                 Assert.Equal((2000, Week1), result[0]);
@@ -73,7 +72,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 var service = new TimePeriodService(statisticsDbContext);
-                var result = service.GetTimePeriods(subject.Id).ToList();
+                var result = await service.GetTimePeriods(subject.Id);
 
                 Assert.Equal(5, result.Count);
                 Assert.Equal((2000, February), result[0]);
@@ -104,7 +103,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 var service = new TimePeriodService(statisticsDbContext);
                 var queryableObservations = statisticsDbContext.Observation.AsQueryable();
-                var result = service.GetTimePeriods(queryableObservations).ToList();
+                var result = await service.GetTimePeriods(queryableObservations);
 
                 Assert.Equal(5, result.Count);
                 Assert.Equal((2000, Week1), result[0]);
@@ -168,7 +167,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 var service = new TimePeriodService(statisticsDbContext);
 
-                var result = service.GetTimePeriodLabels(subject.Id);
+                var result = await service.GetTimePeriodLabels(subject.Id);
 
                 Assert.Equal("2020/21 Q4", result.From);
                 Assert.Equal("2030/31 Q3", result.To);
@@ -227,7 +226,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 var service = new TimePeriodService(statisticsDbContext);
 
-                var result = service.GetTimePeriodLabels(subject.Id);
+                var result = await service.GetTimePeriodLabels(subject.Id);
 
                 Assert.Equal("2020 Week 8", result.From);
                 Assert.Equal("2020 Week 37", result.To);
@@ -262,7 +261,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 var service = new TimePeriodService(statisticsDbContext);
 
-                var result = service.GetTimePeriodLabels(subject.Id);
+                var result = await service.GetTimePeriodLabels(subject.Id);
 
                 Assert.Empty(result.From);
                 Assert.Empty(result.To);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/DataGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/DataGuidanceSubjectService.cs
@@ -96,9 +96,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         {
             return await _context
                 .Observation
-                .AsQueryable()
                 .AsNoTracking()
-                .Include(o => o.Location)
                 .Where(o => o.SubjectId == subjectId)
                 .Select(observation => observation.Location.GeographicLevel.GetEnumLabel())
                 .Distinct()

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/DataGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/DataGuidanceSubjectService.cs
@@ -139,7 +139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     releaseSubject.SubjectId);
 
             var geographicLevels = await GetGeographicLevels(subject.Id);
-            var timePeriods = _timePeriodService.GetTimePeriodLabels(subject.Id);
+            var timePeriods = await _timePeriodService.GetTimePeriodLabels(subject.Id);
             var variables = GetVariables(subject.Id);
             var footnotes = await GetFootnotes(releaseSubject.ReleaseId, subject.Id);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITimePeriodService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITimePeriodService.cs
@@ -2,21 +2,22 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
 {
     public interface ITimePeriodService
     {
-        IList<(int Year, TimeIdentifier TimeIdentifier)> GetTimePeriods(Guid subjectId);
+        Task<IList<(int Year, TimeIdentifier TimeIdentifier)>> GetTimePeriods(Guid subjectId);
 
-        IList<(int Year, TimeIdentifier TimeIdentifier)> GetTimePeriods(IQueryable<Observation> observations);
+        Task<IList<(int Year, TimeIdentifier TimeIdentifier)>>
+            GetTimePeriods(IQueryable<Observation> observationsQuery);
 
         IList<(int Year, TimeIdentifier TimeIdentifier)> GetTimePeriodRange(IList<Observation> observations);
 
-        TimePeriodLabels GetTimePeriodLabels(Guid subjectId);
+        Task<TimePeriodLabels> GetTimePeriodLabels(Guid subjectId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
@@ -86,7 +86,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                                 name: releaseFile.Name ?? string.Empty,
                                 order: releaseFile.Order,
                                 content: rs.DataGuidance ?? string.Empty,
-                                timePeriods: _timePeriodService.GetTimePeriodLabels(rs.SubjectId),
+                                timePeriods: await _timePeriodService.GetTimePeriodLabels(rs.SubjectId),
                                 geographicLevels: await _dataGuidanceSubjectService.GetGeographicLevels(rs.SubjectId),
                                 file: releaseFile.ToFileInfo()
                             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -153,7 +153,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     await InvalidateCachedReleaseSubjectMetadata(releaseId, subjectId);
                 });
         }
-        
+
         public async Task<ReleaseSubject?> GetReleaseSubjectForLatestPublishedVersion(Guid subjectId)
         {
             // Find all versions of a Release that this Subject is linked to.
@@ -183,7 +183,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             {
                 return null;
             }
-            
+
             // Finally, now that we have identified the latest Release version linked to this Subject, return the
             // appropriate ReleaseSubject record.
             return releaseSubjects
@@ -197,7 +197,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 Filters = await GetFilters(releaseSubject),
                 Indicators = await GetIndicators(releaseSubject),
                 Locations = await GetLocations(releaseSubject.SubjectId),
-                TimePeriod = GetTimePeriods(releaseSubject.SubjectId)
+                TimePeriod = await GetTimePeriods(releaseSubject.SubjectId)
             };
         }
 
@@ -229,7 +229,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                         .AsNoTracking()
                         .Where(o => o.SubjectId == query.SubjectId && query.LocationIds.Contains(o.LocationId));
 
-                    var timePeriods = GetTimePeriods(observations);
+                    var timePeriods = await GetTimePeriods(observations);
 
                     _logger.LogTrace("Got Time Periods in {Time} ms", stopwatch.Elapsed.TotalMilliseconds);
 
@@ -277,15 +277,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             return FiltersMetaViewModelBuilder.BuildFilters(filters, releaseSubject.FilterSequence);
         }
 
-        private TimePeriodsMetaViewModel GetTimePeriods(Guid subjectId)
+        private async Task<TimePeriodsMetaViewModel> GetTimePeriods(Guid subjectId)
         {
-            var timePeriods = _timePeriodService.GetTimePeriods(subjectId);
+            var timePeriods = await _timePeriodService.GetTimePeriods(subjectId);
             return BuildTimePeriodsViewModels(timePeriods);
         }
 
-        private TimePeriodsMetaViewModel GetTimePeriods(IQueryable<Observation> observations)
+        private async Task<TimePeriodsMetaViewModel> GetTimePeriods(IQueryable<Observation> observations)
         {
-            var timePeriods = _timePeriodService.GetTimePeriods(observations);
+            var timePeriods = await _timePeriodService.GetTimePeriods(observations);
             return BuildTimePeriodsViewModels(timePeriods);
         }
 


### PR DESCRIPTION
This PR changes `ITimePeriodService` to use async where possible.

It was a change made while investigating [EES-3945](https://dfedigital.atlassian.net/browse/EES-3945), looking at why Step 1 of the table builder can be slow, which I thought is worth raising as it's own PR.

There's some changes to make the code a little more concise:

`GetTimePeriodLabels(Guid subjectId)` is able to reuse `GetTimePeriods(subjectId)`.
`GetTimePeriods(Guid subjectId)` is able to reuse `GetDistinctObservationTimePeriods(IQueryable<Observation> observationsQuery)`.

All the methods which previously had ordering are refactored to use a common `OrderTimePeriods` method.

It also adds a little warning about the reason we order time periods in memory rather than in a database query.

I performance tested this change with caching _disabled_. There might be a very slight performance benefit but I used random subject id's and location id's (when filtering) so some slight variance was expected anyway.

 There wasn't any degradation in performance and in any case, these methods are lazily cached.

Areas performance tested were:

- Getting subject meta data
- Filtering subject meta data
- Listing subjects (since time periods are returned in `SubjectViewModel`).

