### PR TITLE
EES-4114 Move methods relating to `ReleaseSubject` into `ReleaseSubjectService`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -584,6 +584,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                 Content.Model.Repository.PublicationRepository>();
             services.AddTransient<ISubjectRepository, SubjectRepository>();
             services.AddTransient<ITimePeriodService, TimePeriodService>();
+            services.AddTransient<IReleaseSubjectService, ReleaseSubjectService>();
             services.AddTransient<ISubjectMetaService, SubjectMetaService>();
             services.AddTransient<IResultSubjectMetaService, ResultSubjectMetaService>();
             services.AddSingleton<DataServiceMemoryCache<BoundaryLevel>, DataServiceMemoryCache<BoundaryLevel>>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -138,6 +138,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
             services.AddTransient<IDataBlockService, DataBlockService>();
             services.AddTransient<IReleaseService, ReleaseService>();
             services.AddTransient<IResultSubjectMetaService, ResultSubjectMetaService>();
+            services.AddTransient<IReleaseSubjectService, ReleaseSubjectService>();
             services.AddTransient<ISubjectMetaService, SubjectMetaService>();
             services.AddSingleton<IBlobStorageService, BlobStorageService>(provider =>
                 new BlobStorageService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseSubjectServiceTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.StatisticsDbUtils;
+using ContentRelease = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests;
+
+public class ReleaseSubjectServiceTests
+{
+    [Fact]
+    public async Task Find_ReleaseId()
+    {
+        var releaseSubject = new ReleaseSubject
+        {
+            Subject = new Subject(),
+            Release = new Release()
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = BuildService(statisticsDbContext, contentDbContext);
+
+            var result = await service.Find(
+                subjectId: releaseSubject.SubjectId,
+                releaseId: releaseSubject.ReleaseId);
+
+            var actualReleaseSubject = result.AssertRight();
+            Assert.Equal(releaseSubject.ReleaseId, actualReleaseSubject.ReleaseId);
+            Assert.Equal(releaseSubject.SubjectId, actualReleaseSubject.SubjectId);
+        }
+    }
+
+    [Fact]
+    public async Task Find_NoReleaseId()
+    {
+        var subject = new Subject();
+
+        var previousReleaseVersion = new ContentRelease
+        {
+            Id = Guid.NewGuid(),
+            Published = DateTime.UtcNow.AddDays(-2),
+            Version = 0
+        };
+
+        var latestReleaseVersion = new ContentRelease
+        {
+            Id = Guid.NewGuid(),
+            Published = DateTime.UtcNow.AddDays(-1),
+            Version = 1
+        };
+
+        var futureReleaseVersion = new ContentRelease
+        {
+            Id = Guid.NewGuid(),
+            Published = DateTime.UtcNow.AddDays(1),
+            Version = 2
+        };
+
+        var releaseSubjectPreviousRelease = new ReleaseSubject
+        {
+            Subject = subject,
+            Release = new Release
+            {
+                Id = previousReleaseVersion.Id,
+            }
+        };
+
+        var releaseSubjectLatestRelease = new ReleaseSubject
+        {
+            Subject = subject,
+            Release = new Release
+            {
+                Id = latestReleaseVersion.Id
+            }
+        };
+
+        // Link the Subject to the next version of the Release with a future Published date/time
+        // that should not be considered Live
+        var releaseSubjectFutureRelease = new ReleaseSubject
+        {
+            Subject = subject,
+            Release = new Release
+            {
+                Id = futureReleaseVersion.Id
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await statisticsDbContext.Subject.AddAsync(subject);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(
+                releaseSubjectLatestRelease,
+                releaseSubjectFutureRelease,
+                releaseSubjectPreviousRelease);
+            await statisticsDbContext.SaveChangesAsync();
+
+            await contentDbContext.Releases.AddRangeAsync(
+                latestReleaseVersion,
+                futureReleaseVersion,
+                previousReleaseVersion);
+
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        {
+            var service = BuildService(statisticsDbContext, contentDbContext);
+
+            var result = await service.Find(subject.Id);
+
+            var actualReleaseSubject = result.AssertRight();
+            Assert.Equal(releaseSubjectLatestRelease.ReleaseId, actualReleaseSubject.ReleaseId);
+            Assert.Equal(releaseSubjectLatestRelease.SubjectId, actualReleaseSubject.SubjectId);
+        }
+    }
+
+    [Fact]
+    public async Task FindForLatestPublishedVersion()
+    {
+        var subject = new Subject();
+
+        var previousReleaseVersion = new ContentRelease
+        {
+            Id = Guid.NewGuid(),
+            Published = DateTime.UtcNow.AddDays(-2),
+            Version = 0
+        };
+
+        var latestReleaseVersion = new ContentRelease
+        {
+            Id = Guid.NewGuid(),
+            Published = DateTime.UtcNow.AddDays(-1),
+            Version = 1
+        };
+
+        var futureReleaseVersion = new ContentRelease
+        {
+            Id = Guid.NewGuid(),
+            Published = DateTime.UtcNow.AddDays(1),
+            Version = 2
+        };
+
+        var releaseSubjectPreviousRelease = new ReleaseSubject
+        {
+            Subject = subject,
+            Release = new Release
+            {
+                Id = previousReleaseVersion.Id,
+            }
+        };
+
+        var releaseSubjectLatestRelease = new ReleaseSubject
+        {
+            Subject = subject,
+            Release = new Release
+            {
+                Id = latestReleaseVersion.Id
+            }
+        };
+
+        // Link the Subject to the next version of the Release with a future Published date/time
+        // that should not be considered Live
+        var releaseSubjectFutureRelease = new ReleaseSubject
+        {
+            Subject = subject,
+            Release = new Release
+            {
+                Id = futureReleaseVersion.Id
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await statisticsDbContext.Subject.AddAsync(subject);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(
+                releaseSubjectLatestRelease,
+                releaseSubjectFutureRelease,
+                releaseSubjectPreviousRelease);
+            await statisticsDbContext.SaveChangesAsync();
+
+            await contentDbContext.Releases.AddRangeAsync(
+                latestReleaseVersion,
+                futureReleaseVersion,
+                previousReleaseVersion);
+
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        {
+            var service = BuildService(statisticsDbContext, contentDbContext);
+
+            var result = await service.FindForLatestPublishedVersion(subject.Id);
+
+            Assert.NotNull(result);
+            Assert.Equal(releaseSubjectLatestRelease.ReleaseId, result!.ReleaseId);
+            Assert.Equal(releaseSubjectLatestRelease.SubjectId, result.SubjectId);
+        }
+    }
+
+    [Fact]
+    public async Task FindForLatestPublishedVersion_NoReleases()
+    {
+        var subject = new Subject();
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await statisticsDbContext.Subject.AddAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        {
+            var service = BuildService(statisticsDbContext, contentDbContext);
+            Assert.Null(await service.FindForLatestPublishedVersion(subject.Id));
+        }
+    }
+
+    [Fact]
+    public async Task FindForLatestPublishedVersion_NoPublishedReleases()
+    {
+        var futureReleaseVersion = new ContentRelease
+        {
+            Id = Guid.NewGuid(),
+            Published = DateTime.UtcNow.AddDays(1)
+        };
+
+        // Link the Subject to a Release with a future Published date/time that should not be considered Live
+        var releaseSubjectFutureRelease = new ReleaseSubject
+        {
+            Subject = new Subject(),
+            Release = new Release
+            {
+                Id = futureReleaseVersion.Id
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubjectFutureRelease);
+            await statisticsDbContext.SaveChangesAsync();
+
+            await contentDbContext.Releases.AddRangeAsync(futureReleaseVersion);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        {
+            var service = BuildService(statisticsDbContext, contentDbContext);
+            Assert.Null(
+                await service.FindForLatestPublishedVersion(releaseSubjectFutureRelease.SubjectId));
+        }
+    }
+
+    private static ReleaseSubjectService BuildService(
+        StatisticsDbContext statisticsDbContext,
+        ContentDbContext contentDbContext)
+    {
+        return new ReleaseSubjectService(
+            statisticsDbContext: statisticsDbContext,
+            contentDbContext: contentDbContext
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
@@ -10,7 +10,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -2279,159 +2278,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Null(savedReleaseSubject.IndicatorSequence);
             }
         }
-        
-        [Fact]
-        public async Task GetReleaseSubjectForLatestPublishedVersion()
-        {
-            var subject = new Subject();
-            
-            var previousReleaseVersion = new ContentRelease
-            {
-                Id = Guid.NewGuid(),
-                Published = DateTime.UtcNow.AddDays(-2),
-                Version = 0
-            };
-
-            var latestReleaseVersion = new ContentRelease
-            {
-                Id = Guid.NewGuid(),
-                Published = DateTime.UtcNow.AddDays(-1),
-                Version = 1
-            };
-
-            var futureReleaseVersion = new ContentRelease
-            {
-                Id = Guid.NewGuid(),
-                Published = DateTime.UtcNow.AddDays(1),
-                Version = 2
-            };
-
-            var releaseSubjectPreviousRelease = new ReleaseSubject
-            {
-                Subject = subject,
-                Release = new Release
-                {
-                    Id = previousReleaseVersion.Id,
-                }
-            };
-
-            var releaseSubjectLatestRelease = new ReleaseSubject
-            {
-                Subject = subject,
-                Release = new Release
-                {
-                    Id = latestReleaseVersion.Id
-                }
-            };
-
-            // Link the Subject to the next version of the Release with a future Published date/time
-            // that should not be considered Live
-            var releaseSubjectFutureRelease = new ReleaseSubject
-            {
-                Subject = subject,
-                Release = new Release
-                {
-                    Id = futureReleaseVersion.Id
-                }
-            };
-
-            var statisticsDbContextId = Guid.NewGuid().ToString();
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-            {
-                await statisticsDbContext.Subject.AddAsync(subject);
-                await statisticsDbContext.ReleaseSubject.AddRangeAsync(
-                    releaseSubjectLatestRelease,
-                    releaseSubjectFutureRelease,
-                    releaseSubjectPreviousRelease);
-                await statisticsDbContext.SaveChangesAsync();
-            }
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            {
-                await contentDbContext.Releases.AddRangeAsync(
-                    latestReleaseVersion, 
-                    futureReleaseVersion,
-                    previousReleaseVersion);
-                
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            {
-                var service = BuildSubjectMetaService(statisticsDbContext, contentDbContext);
-
-                var result = await service.GetReleaseSubjectForLatestPublishedVersion(subject.Id);
-
-                Assert.NotNull(result);
-                Assert.Equal(releaseSubjectLatestRelease.ReleaseId, result!.ReleaseId);
-                Assert.Equal(releaseSubjectLatestRelease.SubjectId, result.SubjectId);
-            }
-        }
-
-        [Fact]
-        public async Task GetReleaseSubjectForLatestPublishedVersion_NoReleases()
-        {
-            var subject = new Subject();
-
-            var statisticsDbContextId = Guid.NewGuid().ToString();
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-            {
-                await statisticsDbContext.Subject.AddAsync(subject);
-                await statisticsDbContext.SaveChangesAsync();
-            }
-            
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            {
-                var service = BuildSubjectMetaService(statisticsDbContext, contentDbContext);
-                Assert.Null(await service.GetReleaseSubjectForLatestPublishedVersion(subject.Id));
-            }
-        }
-
-        [Fact]
-        public async Task GetReleaseSubjectForLatestPublishedVersion_NoPublishedReleases()
-        {
-            var futureReleaseVersion = new ContentRelease
-            {
-                Id = Guid.NewGuid(),
-                Published = DateTime.UtcNow.AddDays(1)
-            };
-            
-            // Link the Subject to a Release with a future Published date/time that should not be considered Live
-            var releaseSubjectFutureRelease = new ReleaseSubject
-            {
-                Subject = new Subject(),
-                Release = new Release
-                {
-                    Id = futureReleaseVersion.Id
-                }
-            };
-
-            var statisticsDbContextId = Guid.NewGuid().ToString();
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-            {
-                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubjectFutureRelease);
-                await statisticsDbContext.SaveChangesAsync();
-            }
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            {
-                await contentDbContext.Releases.AddRangeAsync(futureReleaseVersion);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            {
-                var service = BuildSubjectMetaService(statisticsDbContext, contentDbContext);
-                Assert.Null(
-                    await service.GetReleaseSubjectForLatestPublishedVersion(releaseSubjectFutureRelease.SubjectId));
-            }
-        }
 
         private static IOptions<LocationsOptions> DefaultLocationOptions()
         {
@@ -2471,21 +2317,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             StatisticsDbContext statisticsDbContext,
             ContentDbContext? contentDbContext = null,
             IBlobCacheService? cacheService = null,
+            IReleaseSubjectService? releaseSubjectService = null,
             IFilterRepository? filterRepository = null,
             IFilterItemRepository? filterItemRepository = null,
             IIndicatorGroupRepository? indicatorGroupRepository = null,
             ILocationRepository? locationRepository = null,
             IObservationService? observationService = null,
-            IPersistenceHelper<StatisticsDbContext>? statisticsPersistenceHelper = null,
             ITimePeriodService? timePeriodService = null,
             IUserService? userService = null,
             IOptions<LocationsOptions>? options = null)
         {
+            var contentDbContextInstance = contentDbContext ?? InMemoryContentDbContext();
+
             return new(
-                statisticsPersistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext),
                 statisticsDbContext,
-                contentDbContext ?? InMemoryContentDbContext(),
                 cacheService ?? Mock.Of<IBlobCacheService>(MockBehavior.Strict),
+                releaseSubjectService ?? new ReleaseSubjectService(statisticsDbContext, contentDbContextInstance),
                 filterRepository ?? Mock.Of<IFilterRepository>(MockBehavior.Strict),
                 filterItemRepository ?? Mock.Of<IFilterItemRepository>(MockBehavior.Strict),
                 indicatorGroupRepository ?? Mock.Of<IIndicatorGroupRepository>(MockBehavior.Strict),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IReleaseSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IReleaseSubjectService.cs
@@ -1,0 +1,15 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+
+public interface IReleaseSubjectService
+{
+    Task<Either<ActionResult, ReleaseSubject>> Find(Guid subjectId, Guid? releaseId = null);
+
+    Task<ReleaseSubject?> FindForLatestPublishedVersion(Guid subjectId);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ISubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ISubjectMetaService.cs
@@ -29,7 +29,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
         Task<Either<ActionResult, Unit>> UpdateSubjectIndicators(Guid releaseId,
             Guid subjectId,
             List<IndicatorGroupUpdateViewModel> request);
-
-        Task<ReleaseSubject?> GetReleaseSubjectForLatestPublishedVersion(Guid subjectId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseSubjectService.cs
@@ -1,0 +1,75 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services;
+
+public class ReleaseSubjectService : IReleaseSubjectService
+{
+    private readonly StatisticsDbContext _statisticsDbContext;
+    private readonly ContentDbContext _contentDbContext;
+
+    public ReleaseSubjectService(
+        StatisticsDbContext statisticsDbContext,
+        ContentDbContext contentDbContext)
+    {
+        _statisticsDbContext = statisticsDbContext;
+        _contentDbContext = contentDbContext;
+    }
+
+    public async Task<Either<ActionResult, ReleaseSubject>> Find(Guid subjectId, Guid? releaseId = null)
+    {
+        return await (
+                releaseId.HasValue
+                    ? _statisticsDbContext.ReleaseSubject.FirstOrDefaultAsync(
+                        rs => rs.ReleaseId == releaseId && rs.SubjectId == subjectId
+                    )
+                    : FindForLatestPublishedVersion(subjectId)
+            )
+            .OrNotFound();
+    }
+
+    public async Task<ReleaseSubject?> FindForLatestPublishedVersion(Guid subjectId)
+    {
+        // Find all versions of a Release that this Subject is linked to.
+        var releaseSubjects = await _statisticsDbContext
+            .ReleaseSubject
+            .AsNoTracking()
+            .Where(releaseSubject => releaseSubject.SubjectId == subjectId)
+            .ToListAsync();
+
+        var releaseIdsLinkedToSubject = releaseSubjects
+            .Select(releaseSubject => releaseSubject.ReleaseId)
+            .ToList();
+
+        // Find all versions of the Release that this Subject is linked to that are currently live
+        // or in the past have been live before being amended. Order them by Version to get the latest
+        // Live one at the end of the list.
+        var latestLiveReleaseVersionLinkedToSubject = _contentDbContext
+            .Releases
+            .AsNoTracking()
+            .Where(release => releaseIdsLinkedToSubject.Contains(release.Id))
+            .ToList()
+            .Where(release => release.Live)
+            .MaxBy(release => release.Version);
+
+        if (latestLiveReleaseVersionLinkedToSubject == null)
+        {
+            return null;
+        }
+
+        // Finally, now that we have identified the latest Release version linked to this Subject, return the
+        // appropriate ReleaseSubject record.
+        return releaseSubjects
+            .SingleOrDefault(releaseSubject => releaseSubject.ReleaseId == latestLiveReleaseVersionLinkedToSubject.Id);
+    }
+}


### PR DESCRIPTION
This PR moves methods relating to `ReleaseSubject` out of `SubjectMetaService` into a separate `ReleaseSubjectService`.

It didn't really make sense for `SubjectMetaService` to contain these methods, which obscures the fact they exist (making them less likely to be reused in other services).

This is a dependency of EES-3777.

## Relevant changes

- Renamed `CheckReleaseSubjectExists` method to less verbose `Find`
- Renamed `GetReleaseSubjectForLatestPublishedVersion` method to less verbose `FindForLatestPublishedVersion`