### PR TITLE
EES-2469 Add backend endpoints to support free text key stats

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/KeyStatisticServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/KeyStatisticServicePermissionTests.cs
@@ -72,6 +72,22 @@ public class KeyStatisticServicePermissionTests
     }
 
     [Fact]
+    public async Task UpdateKeyStatisticText()
+    {
+        await PolicyCheckBuilder<SecurityPolicies>()
+            .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            .AssertForbidden(
+                userService =>
+                {
+                    var service = SetupKeyStatisticService(userService: userService.Object);
+                    return service.CreateKeyStatisticText(
+                        _release.Id,
+                        new KeyStatisticTextCreateRequest());
+                }
+            );
+    }
+
+    [Fact]
     public async Task Delete()
     {
         await PolicyCheckBuilder<SecurityPolicies>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/KeyStatisticServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/KeyStatisticServicePermissionTests.cs
@@ -40,6 +40,22 @@ public class KeyStatisticServicePermissionTests
     }
 
     [Fact]
+    public async Task CreateKeyStatisticText()
+    {
+        await PolicyCheckBuilder<SecurityPolicies>()
+            .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            .AssertForbidden(
+                userService =>
+                {
+                    var service = SetupKeyStatisticService(userService: userService.Object);
+                    return service.CreateKeyStatisticText(
+                        _release.Id,
+                        new KeyStatisticTextCreateRequest());
+                }
+            );
+    }
+
+    [Fact]
     public async Task UpdateKeyStatisticDataBlock()
     {
         await PolicyCheckBuilder<SecurityPolicies>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/KeyStatisticServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/KeyStatisticServiceTests.cs
@@ -466,15 +466,8 @@ public class KeyStatisticServiceTests
 
             var viewModel = result.AssertRight();
 
-
             Assert.Equal("title", viewModel.Title);
-            Assert.Equal("Over 9000!", viewModel.Statistic);
-            Assert.Null(viewModel.Trend);
-            Assert.Null(viewModel.GuidanceTitle);
-            Assert.Null(viewModel.GuidanceText);
             Assert.Equal(3, viewModel.Order);
-            Assert.InRange(DateTime.UtcNow.Subtract(viewModel.Created).Milliseconds, 0, 1500);
-            Assert.Null(viewModel.Updated);
         }
 
         await using (var context = InMemoryContentDbContext(contextId))
@@ -489,18 +482,8 @@ public class KeyStatisticServiceTests
             Assert.Equal(2, keyStatistics[2].Order);
 
             var keyStatText = Assert.IsType<KeyStatisticText>(keyStatistics[3]);
-
             Assert.Equal("title", keyStatText.Title);
-            Assert.Equal("Over 9000!", keyStatText.Statistic);
-            Assert.Equal(release.Id, keyStatText.ReleaseId);
-            Assert.Null(keyStatText.Trend);
-            Assert.Null(keyStatText.GuidanceTitle);
-            Assert.Null(keyStatText.GuidanceText);
             Assert.Equal(3, keyStatText.Order);
-            Assert.Equal(_userId, keyStatText.CreatedById);
-            Assert.Null(keyStatText.UpdatedById);
-            Assert.InRange(DateTime.UtcNow.Subtract(keyStatText.Created).Milliseconds, 0, 1500);
-            Assert.Null(keyStatText.Updated);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/KeyStatisticController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/KeyStatisticController.cs
@@ -55,6 +55,17 @@ public class KeyStatisticController : ControllerBase
             .HandleFailuresOrOk();
     }
 
+    [HttpPut("release/{releaseId:guid}/key-statistic-text/{keyStatisticId:guid}")]
+    public async Task<ActionResult<KeyStatisticTextViewModel>> UpdateKeyStatisticText(
+        Guid releaseId,
+        Guid keyStatisticId,
+        KeyStatisticTextUpdateRequest request)
+    {
+        return await _keyStatisticService
+            .UpdateKeyStatisticText(releaseId, keyStatisticId, request)
+            .HandleFailuresOrOk();
+    }
+
     [HttpDelete("release/{releaseId:guid}/key-statistic/{keyStatisticId:guid}")]
     public async Task<ActionResult<Unit>> Delete(
         Guid releaseId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/KeyStatisticController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/KeyStatisticController.cs
@@ -34,6 +34,16 @@ public class KeyStatisticController : ControllerBase
             .HandleFailuresOrOk();
     }
 
+    [HttpPost("release/{releaseId:guid}/key-statistic-text")]
+    public async Task<ActionResult<KeyStatisticTextViewModel>> CreateKeyStatisticText(
+        Guid releaseId,
+        KeyStatisticTextCreateRequest request)
+    {
+        return await _keyStatisticService
+            .CreateKeyStatisticText(releaseId, request)
+            .HandleFailuresOrOk();
+    }
+
     [HttpPut("release/{releaseId:guid}/key-statistic-data-block/{keyStatisticId:guid}")]
     public async Task<ActionResult<KeyStatisticDataBlockViewModel>> UpdateKeyStatisticDataBlock(
         Guid releaseId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -98,6 +98,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                 .IncludeAllDerived();
 
             CreateMap<KeyStatisticDataBlockCreateRequest, KeyStatisticDataBlock>();
+            CreateMap<KeyStatisticTextCreateRequest, KeyStatisticText>();
 
             CreateMap<Release, Data.Model.Release>()
                 .ForMember(dest => dest.TimeIdentifier, m => m.MapFrom(r => r.TimePeriodCoverage));

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/KeyStatisticRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/KeyStatisticRequests.cs
@@ -14,6 +14,19 @@ public record KeyStatisticDataBlockCreateRequest
     public string? GuidanceText { get; set; }
 }
 
+public record KeyStatisticTextCreateRequest
+{
+    public string Title { get; set; } = string.Empty;
+
+    public string Statistic { get; set; } = string.Empty;
+
+    public string? Trend { get; set; }
+
+    public string? GuidanceTitle { get; set; }
+
+    public string? GuidanceText { get; set; }
+}
+
 public record KeyStatisticDataBlockUpdateRequest
 {
     public string? Trend { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/KeyStatisticRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/KeyStatisticRequests.cs
@@ -35,3 +35,16 @@ public record KeyStatisticDataBlockUpdateRequest
 
     public string? GuidanceText { get; set; }
 }
+
+public record KeyStatisticTextUpdateRequest
+{
+    public string Title { get; set; } = string.Empty;
+
+    public string Statistic { get; set; } = string.Empty;
+
+    public string? Trend { get; set; }
+
+    public string? GuidanceTitle { get; set; }
+
+    public string? GuidanceText { get; set; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IKeyStatisticService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IKeyStatisticService.cs
@@ -22,6 +22,11 @@ public interface IKeyStatisticService
         Guid keyStatisticId,
         KeyStatisticDataBlockUpdateRequest request);
 
+    Task<Either<ActionResult, KeyStatisticTextViewModel>> UpdateKeyStatisticText(
+        Guid releaseId,
+        Guid keyStatisticId,
+        KeyStatisticTextUpdateRequest request);
+
     Task<Either<ActionResult, Unit>> Delete(Guid releaseId, Guid keyStatisticId);
 
     Task DeleteAssociatedKeyStatisticDataBlock(Guid dataBlockId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IKeyStatisticService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IKeyStatisticService.cs
@@ -14,6 +14,9 @@ public interface IKeyStatisticService
     Task<Either<ActionResult, KeyStatisticDataBlockViewModel>> CreateKeyStatisticDataBlock(
         Guid releaseId, KeyStatisticDataBlockCreateRequest request);
 
+    Task<Either<ActionResult, KeyStatisticTextViewModel>> CreateKeyStatisticText(
+        Guid releaseId, KeyStatisticTextCreateRequest request);
+
     Task<Either<ActionResult, KeyStatisticDataBlockViewModel>> UpdateKeyStatisticDataBlock(
         Guid releaseId,
         Guid keyStatisticId,


### PR DESCRIPTION
This PR adds to backend endpoint that the frontend will use to create and update free text key stats.

Deleting and reordering key stats is covered by a generic method for all key stat types.