### PR TITLE
EES-3913 Add free text key stats to the frontend

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       { "argsIgnorePattern": "^_$" }
@@ -129,6 +130,7 @@
       "props": true,
       "ignorePropertyModificationsFor": ["draft", "acc"]
     }],
+    "no-shadow": "off",
     "no-use-before-define": "off",
     "no-useless-constructor": "off",
     "spaced-comment": ["warn", "always", { "markers": ["/"] }]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/KeyStatisticRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/KeyStatisticRequests.cs
@@ -14,19 +14,6 @@ public record KeyStatisticDataBlockCreateRequest
     public string? GuidanceText { get; set; }
 }
 
-public record KeyStatisticTextCreateRequest
-{
-    public string Title { get; set; } = string.Empty;
-
-    public string Statistic { get; set; } = string.Empty;
-
-    public string? Trend { get; set; }
-
-    public string? GuidanceTitle { get; set; }
-
-    public string? GuidanceText { get; set; }
-}
-
 public record KeyStatisticDataBlockUpdateRequest
 {
     public string? Trend { get; set; }
@@ -36,7 +23,7 @@ public record KeyStatisticDataBlockUpdateRequest
     public string? GuidanceText { get; set; }
 }
 
-public record KeyStatisticTextUpdateRequest
+public abstract record KeyStatisticTextSaveRequest
 {
     public string Title { get; set; } = string.Empty;
 
@@ -48,3 +35,6 @@ public record KeyStatisticTextUpdateRequest
 
     public string? GuidanceText { get; set; }
 }
+
+public record KeyStatisticTextCreateRequest : KeyStatisticTextSaveRequest;
+public record KeyStatisticTextUpdateRequest : KeyStatisticTextSaveRequest;

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/CancelAmendmentModal.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/CancelAmendmentModal.test.tsx
@@ -2,7 +2,7 @@ import { waitFor } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import CancelAmendmentModal from '@admin/pages/admin-dashboard/components/CancelAmendmentModal';
-import { noop } from 'lodash';
+import noop from 'lodash/noop';
 import userEvent from '@testing-library/user-event';
 
 describe('CancelAmendmentModal', () => {

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testEditableRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testEditableRelease.ts
@@ -1,8 +1,5 @@
 import { EditableRelease } from '@admin/services/releaseContentService';
-import {
-  KeyStatisticDataBlock,
-  KeyStatisticText,
-} from '@common/services/publicationService';
+import { KeyStatisticType } from '@common/services/publicationService';
 import { Table } from '@common/services/types/blocks';
 
 const emptyTable: Table = {
@@ -58,7 +55,7 @@ export const testEditableRelease: EditableRelease = {
   ],
   keyStatistics: [
     {
-      type: 'KeyStatisticDataBlock',
+      type: KeyStatisticType.DATABLOCK,
       id: 'keyStat-1',
       dataBlockId: 'dataBlock-1',
       trend: 'keyStat-1 trend',
@@ -66,7 +63,7 @@ export const testEditableRelease: EditableRelease = {
       created: '2023-01-01',
     },
     {
-      type: 'KeyStatisticText',
+      type: KeyStatisticType.TEXT,
       id: 'keyStat-2',
       title: 'KeyStat-2 title',
       statistic: 'KeyStat-2 value',
@@ -77,7 +74,7 @@ export const testEditableRelease: EditableRelease = {
       created: '2023-01-02',
     },
     {
-      type: 'KeyStatisticDataBlock',
+      type: KeyStatisticType.DATABLOCK,
       id: 'keyStat-3',
       dataBlockId: 'dataBlock-2',
       guidanceText: 'KeyStat-3 guidanceText',

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testEditableRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testEditableRelease.ts
@@ -1,5 +1,4 @@
 import { EditableRelease } from '@admin/services/releaseContentService';
-import { KeyStatisticType } from '@common/services/publicationService';
 import { Table } from '@common/services/types/blocks';
 
 const emptyTable: Table = {
@@ -55,7 +54,7 @@ export const testEditableRelease: EditableRelease = {
   ],
   keyStatistics: [
     {
-      type: KeyStatisticType.DATABLOCK,
+      type: 'KeyStatisticDataBlock',
       id: 'keyStat-1',
       dataBlockId: 'dataBlock-1',
       trend: 'keyStat-1 trend',
@@ -63,7 +62,7 @@ export const testEditableRelease: EditableRelease = {
       created: '2023-01-01',
     },
     {
-      type: KeyStatisticType.TEXT,
+      type: 'KeyStatisticText',
       id: 'keyStat-2',
       title: 'KeyStat-2 title',
       statistic: 'KeyStat-2 value',
@@ -74,7 +73,7 @@ export const testEditableRelease: EditableRelease = {
       created: '2023-01-02',
     },
     {
-      type: KeyStatisticType.DATABLOCK,
+      type: 'KeyStatisticDataBlock',
       id: 'keyStat-3',
       dataBlockId: 'dataBlock-2',
       guidanceText: 'KeyStat-3 guidanceText',

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/AddKeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/AddKeyStatistics.tsx
@@ -1,0 +1,95 @@
+import KeyStatDataBlockSelectForm from '@admin/pages/release/content/components/KeyStatDataBlockSelectForm';
+import styles from '@admin/pages/release/content/components/KeyStatistics.module.scss';
+import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
+import Button from '@common/components/Button';
+import WarningMessage from '@common/components/WarningMessage';
+import React, { useCallback, useState } from 'react';
+import { KeyStatisticType } from '@common/services/publicationService';
+import { KeyStatisticTextCreateRequest } from '@admin/services/keyStatisticService';
+import EditableKeyStatTextForm from '@admin/pages/release/content/components/EditableKeyStatTextForm';
+import ButtonGroup from '@common/components/ButtonGroup';
+import { KeyStatisticsProps } from '@admin/pages/release/content/components/KeyStatistics';
+
+const AddKeyStatistics = ({ release }: KeyStatisticsProps) => {
+  const [formType, setFormType] = useState<KeyStatisticType | undefined>(
+    undefined,
+  );
+  const {
+    updateUnattachedDataBlocks,
+    addKeyStatisticDataBlock,
+    addKeyStatisticText,
+  } = useReleaseContentActions();
+
+  const addKeyStatDataBlock = useCallback(
+    async (dataBlockId: string) => {
+      await addKeyStatisticDataBlock({ releaseId: release.id, dataBlockId });
+      await updateUnattachedDataBlocks({ releaseId: release.id });
+      setFormType(undefined);
+    },
+    [release.id, addKeyStatisticDataBlock, updateUnattachedDataBlocks],
+  );
+
+  const addKeyStatText = useCallback(
+    async (newKeyStatText: KeyStatisticTextCreateRequest) => {
+      await addKeyStatisticText({
+        releaseId: release.id,
+        keyStatisticText: newKeyStatText,
+      });
+      setFormType(undefined);
+    },
+    [release.id, addKeyStatisticText],
+  );
+
+  switch (formType) {
+    case 'KeyStatisticDataBlock':
+      return (
+        <div className={styles.dataBlockFormContainer}>
+          <WarningMessage>
+            In order to add a key statistic from a data block, you first need to
+            create a data block with just one value.
+            <br />
+            Any data blocks with more than one value cannot be selected as a key
+            statistic.
+          </WarningMessage>
+          <KeyStatDataBlockSelectForm
+            releaseId={release.id}
+            onSelect={addKeyStatDataBlock}
+            onCancel={() => setFormType(undefined)}
+          />
+        </div>
+      );
+    case 'KeyStatisticText':
+      return (
+        <div className={styles.textFormContainer}>
+          <EditableKeyStatTextForm
+            onSubmit={values => addKeyStatText(values)}
+            onCancel={() => setFormType(undefined)}
+            testId="keyStatText-createForm"
+          />
+        </div>
+      );
+    default:
+      return (
+        <ButtonGroup>
+          <Button
+            onClick={() => {
+              setFormType('KeyStatisticDataBlock');
+            }}
+            className="govuk-!-margin-bottom-2"
+          >
+            Add key statistic from data block
+          </Button>
+          <Button
+            onClick={() => {
+              setFormType('KeyStatisticText');
+            }}
+            className="govuk-!-margin-bottom-2"
+          >
+            Add free text key statistic
+          </Button>
+        </ButtonGroup>
+      );
+  }
+};
+
+export default AddKeyStatistics;

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStat.tsx
@@ -5,10 +5,7 @@ import {
   KeyStatisticDataBlockUpdateRequest,
   KeyStatisticTextUpdateRequest,
 } from '@admin/services/keyStatisticService';
-import {
-  KeyStatistic,
-  KeyStatisticType,
-} from '@common/services/publicationService';
+import { KeyStatistic } from '@common/services/publicationService';
 import React from 'react';
 
 interface EditableKeyStatProps {
@@ -34,7 +31,7 @@ const EditableKeyStat = ({
   } = useReleaseContentActions();
 
   switch (keyStat.type) {
-    case KeyStatisticType.DATABLOCK:
+    case 'KeyStatisticDataBlock':
       return (
         <EditableKeyStatDataBlock
           keyStat={keyStat}
@@ -53,9 +50,7 @@ const EditableKeyStat = ({
           }}
           onSubmit={async values => {
             const request: KeyStatisticDataBlockUpdateRequest = {
-              trend: values.trend,
-              guidanceTitle: values.guidanceTitle,
-              guidanceText: values.guidanceText,
+              ...values,
             };
 
             await updateKeyStatisticDataBlock({
@@ -66,7 +61,7 @@ const EditableKeyStat = ({
           }}
         />
       );
-    case KeyStatisticType.TEXT:
+    case 'KeyStatisticText':
       return (
         <EditableKeyStatText
           keyStat={keyStat}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStat.tsx
@@ -1,8 +1,14 @@
 import EditableKeyStatDataBlock from '@admin/pages/release/content/components/EditableKeyStatDataBlock';
 import EditableKeyStatText from '@admin/pages/release/content/components/EditableKeyStatText';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
-import { KeyStatisticDataBlockUpdateRequest } from '@admin/services/keyStatisticService';
-import { KeyStatistic } from '@common/services/publicationService';
+import {
+  KeyStatisticDataBlockUpdateRequest,
+  KeyStatisticTextUpdateRequest,
+} from '@admin/services/keyStatisticService';
+import {
+  KeyStatistic,
+  KeyStatisticType,
+} from '@common/services/publicationService';
 import React from 'react';
 
 interface EditableKeyStatProps {
@@ -24,64 +30,70 @@ const EditableKeyStat = ({
     deleteKeyStatistic,
     updateUnattachedDataBlocks,
     updateKeyStatisticDataBlock,
+    updateKeyStatisticText,
   } = useReleaseContentActions();
 
-  if (keyStat.type === 'KeyStatisticDataBlock') {
-    return (
-      <EditableKeyStatDataBlock
-        keyStat={keyStat}
-        releaseId={releaseId}
-        testId={testId}
-        isEditing={isEditing}
-        isReordering={isReordering}
-        onRemove={async () => {
-          await deleteKeyStatistic({
-            releaseId,
-            keyStatisticId: keyStat.id,
-          });
-          await updateUnattachedDataBlocks({
-            releaseId,
-          });
-        }}
-        onSubmit={async values => {
-          const request: KeyStatisticDataBlockUpdateRequest = {
-            trend: values.trend,
-            guidanceTitle: values.guidanceTitle,
-            guidanceText: values.guidanceText,
-          };
+  switch (keyStat.type) {
+    case KeyStatisticType.DATABLOCK:
+      return (
+        <EditableKeyStatDataBlock
+          keyStat={keyStat}
+          releaseId={releaseId}
+          testId={testId}
+          isEditing={isEditing}
+          isReordering={isReordering}
+          onRemove={async () => {
+            await deleteKeyStatistic({
+              releaseId,
+              keyStatisticId: keyStat.id,
+            });
+            await updateUnattachedDataBlocks({
+              releaseId,
+            });
+          }}
+          onSubmit={async values => {
+            const request: KeyStatisticDataBlockUpdateRequest = {
+              trend: values.trend,
+              guidanceTitle: values.guidanceTitle,
+              guidanceText: values.guidanceText,
+            };
 
-          await updateKeyStatisticDataBlock({
-            releaseId,
-            keyStatisticId: keyStat.id,
-            request,
-          });
-        }}
-      />
-    );
+            await updateKeyStatisticDataBlock({
+              releaseId,
+              keyStatisticId: keyStat.id,
+              request,
+            });
+          }}
+        />
+      );
+    case KeyStatisticType.TEXT:
+      return (
+        <EditableKeyStatText
+          keyStat={keyStat}
+          testId={testId}
+          isEditing={isEditing}
+          isReordering={isReordering}
+          onRemove={async () => {
+            await deleteKeyStatistic({
+              releaseId,
+              keyStatisticId: keyStat.id,
+            });
+          }}
+          onSubmit={async values => {
+            const request: KeyStatisticTextUpdateRequest = {
+              ...values,
+            };
+            await updateKeyStatisticText({
+              releaseId,
+              keyStatisticId: keyStat.id,
+              request,
+            });
+          }}
+        />
+      );
+    default:
+      return null;
   }
-
-  if (keyStat.type === 'KeyStatisticText') {
-    return (
-      <EditableKeyStatText
-        keyStat={keyStat}
-        testId={testId}
-        isEditing={isEditing}
-        isReordering={isReordering}
-        onRemove={async () => {
-          await deleteKeyStatistic({
-            releaseId,
-            keyStatisticId: keyStat.id,
-          });
-        }}
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        onSubmit={async values => {
-          // TODO: EES-3913
-        }}
-      />
-    );
-  }
-
-  return null;
 };
 
 export default EditableKeyStat;

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
@@ -23,7 +23,7 @@ export interface EditableKeyStatDataBlockFormProps {
   title: string;
   statistic: string;
   isReordering?: boolean;
-  testId?: string;
+  testId: string;
   onSubmit: (values: KeyStatDataBlockFormValues) => void;
   onCancel: () => void;
 }
@@ -33,7 +33,7 @@ const EditableKeyStatDataBlockForm = ({
   title,
   statistic,
   isReordering,
-  testId = 'keyStat',
+  testId,
   onSubmit,
   onCancel,
 }: EditableKeyStatDataBlockFormProps) => {
@@ -57,7 +57,7 @@ const EditableKeyStatDataBlockForm = ({
       onSubmit={handleSubmit}
     >
       {form => (
-        <Form id={`editableKeyStatForm-${keyStat.id}`}>
+        <Form id={`editableKeyStatDataBlockForm-${keyStat.id}`}>
           <KeyStatTile
             title={title}
             titleTag="h4"

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
@@ -7,10 +7,12 @@ import ButtonGroup from '@common/components/ButtonGroup';
 import { Form, FormFieldTextInput } from '@common/components/form';
 import useFormSubmit from '@common/hooks/useFormSubmit';
 import styles from '@common/modules/find-statistics/components/KeyStat.module.scss';
-import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile';
+import tileStyles from '@common/modules/find-statistics/components/KeyStatTile.module.scss';
 import { KeyStatisticText } from '@common/services/publicationService';
 import { Formik } from 'formik';
 import React from 'react';
+import classNames from 'classnames';
+import Yup from '@common/validation/yup';
 
 export interface KeyStatTextFormValues {
   title: string;
@@ -21,19 +23,19 @@ export interface KeyStatTextFormValues {
 }
 
 interface EditableKeyStatTextFormProps {
-  keyStat: KeyStatisticText;
-  isReordering?: boolean;
+  keyStat?: KeyStatisticText;
   onSubmit: (values: KeyStatTextFormValues) => void;
   onCancel: () => void;
-  testId?: string;
+  isReordering?: boolean;
+  testId: string;
 }
 
 export default function EditableKeyStatTextForm({
   keyStat,
-  isReordering,
-  testId = 'keyStat',
   onSubmit,
   onCancel,
+  isReordering,
+  testId,
 }: EditableKeyStatTextFormProps) {
   const handleSubmit = useFormSubmit<KeyStatTextFormValues>(async values => {
     await onSubmit({
@@ -44,62 +46,84 @@ export default function EditableKeyStatTextForm({
   });
 
   return (
-    <Formik<KeyStatTextFormValues>
-      initialValues={{
-        title: keyStat.title ?? '',
-        statistic: keyStat.statistic ?? '',
-        trend: keyStat.trend ?? '',
-        guidanceTitle: keyStat.guidanceTitle ?? 'Help',
-        guidanceText: keyStat.guidanceText ? toHtml(keyStat.guidanceText) : '',
-      }}
-      onSubmit={handleSubmit}
-    >
-      {form => (
-        <Form id={`editableKeyStatForm-${keyStat.id}`}>
-          <KeyStatTile
-            title={keyStat.title}
-            value={keyStat.statistic}
-            titleTag="h4"
-            testId={testId}
-            isReordering={isReordering}
+    <div data-testId={testId}>
+      <Formik<KeyStatTextFormValues>
+        initialValues={{
+          title: keyStat?.title ?? '',
+          statistic: keyStat?.statistic ?? '',
+          trend: keyStat?.trend ?? '',
+          guidanceTitle: keyStat?.guidanceTitle ?? 'Help',
+          guidanceText: keyStat?.guidanceText
+            ? toHtml(keyStat.guidanceText)
+            : '',
+        }}
+        validationSchema={Yup.object<KeyStatTextFormValues>({
+          title: Yup.string().required('Enter a title'),
+          statistic: Yup.string().required('Enter a statistic'),
+          trend: Yup.string(),
+          guidanceTitle: Yup.string(),
+          guidanceText: Yup.string(),
+        })}
+        onSubmit={handleSubmit}
+      >
+        {form => (
+          <Form
+            id={
+              keyStat
+                ? `editableKeyStatTextForm-${keyStat.id}`
+                : 'editableKeyStatTextForm-create'
+            }
           >
-            {/* TODO: EES-2469 Inputs for title/statistic have just been added with no testing / consideration for styling / user experience etc. */}
-            <FormFieldTextInput<KeyStatTextFormValues>
-              name="title"
-              label={<span className={styles.trendText}>Title</span>}
-            />
-            <FormFieldTextInput<KeyStatTextFormValues>
-              name="statistic"
-              label={<span className={styles.trendText}>Statistic</span>}
-            />
-            <FormFieldTextInput<KeyStatTextFormValues>
-              name="trend"
-              label={<span className={styles.trendText}>Trend</span>}
-            />
-          </KeyStatTile>
+            <div className={tileStyles.tile}>
+              <FormFieldTextInput<KeyStatTextFormValues>
+                name="title"
+                className={classNames(
+                  'govuk-!-margin-bottom-6',
+                  isReordering && 'govuk-!-width-one-third',
+                )}
+                label={<span className={styles.titleText}>Title</span>}
+              />
+              <FormFieldTextInput<KeyStatTextFormValues>
+                name="statistic"
+                className={classNames(
+                  'govuk-!-margin-bottom-6',
+                  isReordering && 'govuk-!-width-one-third',
+                )}
+                label={<span className={styles.statisticText}>Statistic</span>}
+              />
+              <FormFieldTextInput<KeyStatTextFormValues>
+                name="trend"
+                className={classNames(
+                  isReordering && 'govuk-!-width-one-third',
+                )}
+                label={<span className={styles.trendText}>Trend</span>}
+              />
+            </div>
 
-          <FormFieldTextInput<KeyStatTextFormValues>
-            formGroupClass="govuk-!-margin-top-2"
-            name="guidanceTitle"
-            label="Guidance title"
-          />
+            <FormFieldTextInput<KeyStatTextFormValues>
+              formGroupClass="govuk-!-margin-top-2"
+              name="guidanceTitle"
+              className={classNames(isReordering && 'govuk-!-width-one-third')}
+              label="Guidance title"
+            />
 
-          <FormFieldEditor<KeyStatTextFormValues>
-            name="guidanceText"
-            toolbarConfig={toolbarConfigs.simple}
-            label="Guidance text"
-          />
+            <FormFieldEditor<KeyStatTextFormValues>
+              name="guidanceText"
+              toolbarConfig={toolbarConfigs.simple}
+              label="Guidance text"
+            />
 
-          <ButtonGroup>
-            <Button disabled={form.isSubmitting} type="submit">
-              Save
-            </Button>
-            <Button variant="secondary" onClick={onCancel}>
-              Cancel
-            </Button>
-          </ButtonGroup>
-        </Form>
-      )}
-    </Formik>
+            <ButtonGroup>
+              <Button disabled={form.isSubmitting} type="submit">
+                Save
+              </Button>
+              <Button variant="secondary" onClick={onCancel}>
+                Cancel
+              </Button>
+            </ButtonGroup>
+          </Form>
+        )}
+      </Formik>
+    </div>
   );
 }

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
@@ -7,7 +7,6 @@ import ButtonGroup from '@common/components/ButtonGroup';
 import { Form, FormFieldTextInput } from '@common/components/form';
 import useFormSubmit from '@common/hooks/useFormSubmit';
 import styles from '@common/modules/find-statistics/components/KeyStat.module.scss';
-import tileStyles from '@common/modules/find-statistics/components/KeyStatTile.module.scss';
 import { KeyStatisticText } from '@common/services/publicationService';
 import { Formik } from 'formik';
 import React from 'react';
@@ -24,17 +23,17 @@ export interface KeyStatTextFormValues {
 
 interface EditableKeyStatTextFormProps {
   keyStat?: KeyStatisticText;
+  isReordering?: boolean;
   onSubmit: (values: KeyStatTextFormValues) => void;
   onCancel: () => void;
-  isReordering?: boolean;
   testId: string;
 }
 
 export default function EditableKeyStatTextForm({
   keyStat,
+  isReordering,
   onSubmit,
   onCancel,
-  isReordering,
   testId,
 }: EditableKeyStatTextFormProps) {
   const handleSubmit = useFormSubmit<KeyStatTextFormValues>(async values => {
@@ -46,7 +45,7 @@ export default function EditableKeyStatTextForm({
   });
 
   return (
-    <div data-testId={testId}>
+    <div data-testid={testId}>
       <Formik<KeyStatTextFormValues>
         initialValues={{
           title: keyStat?.title ?? '',
@@ -74,36 +73,36 @@ export default function EditableKeyStatTextForm({
                 : 'editableKeyStatTextForm-create'
             }
           >
-            <div className={tileStyles.tile}>
+            <div className={styles.textTile}>
               <FormFieldTextInput<KeyStatTextFormValues>
                 name="title"
-                className={classNames(
-                  'govuk-!-margin-bottom-6',
-                  isReordering && 'govuk-!-width-one-third',
-                )}
-                label={<span className={styles.titleText}>Title</span>}
+                className={classNames({
+                  'govuk-!-width-one-third': isReordering,
+                })}
+                label={<span>Title</span>}
               />
               <FormFieldTextInput<KeyStatTextFormValues>
                 name="statistic"
-                className={classNames(
-                  'govuk-!-margin-bottom-6',
-                  isReordering && 'govuk-!-width-one-third',
-                )}
-                label={<span className={styles.statisticText}>Statistic</span>}
+                className={classNames({
+                  'govuk-!-width-one-third': isReordering,
+                })}
+                label={<span>Statistic</span>}
               />
               <FormFieldTextInput<KeyStatTextFormValues>
                 name="trend"
-                className={classNames(
-                  isReordering && 'govuk-!-width-one-third',
-                )}
-                label={<span className={styles.trendText}>Trend</span>}
+                className={classNames({
+                  'govuk-!-width-one-third': isReordering,
+                })}
+                label={<span>Trend</span>}
               />
             </div>
 
             <FormFieldTextInput<KeyStatTextFormValues>
               formGroupClass="govuk-!-margin-top-2"
               name="guidanceTitle"
-              className={classNames(isReordering && 'govuk-!-width-one-third')}
+              className={classNames({
+                'govuk-!-width-one-third': isReordering,
+              })}
               label="Guidance title"
             />
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.module.scss
@@ -6,8 +6,12 @@
   }
 }
 
-.formContainer {
+.keyStatDataBlockFormContainer {
   width: 100%;
+}
+
+.keyStatTextFormContainer {
+  width: 33%;
 }
 
 .draggable {

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.module.scss
@@ -6,11 +6,11 @@
   }
 }
 
-.keyStatDataBlockFormContainer {
+.dataBlockFormContainer {
   width: 100%;
 }
 
-.keyStatTextFormContainer {
+.textFormContainer {
   width: 33%;
 }
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
@@ -1,11 +1,9 @@
 import BlockDroppable from '@admin/components/editable/BlockDroppable';
 import EditableKeyStat from '@admin/pages/release/content/components/EditableKeyStat';
-import KeyStatDataBlockSelectForm from '@admin/pages/release/content/components/KeyStatDataBlockSelectForm';
 import styles from '@admin/pages/release/content/components/KeyStatistics.module.scss';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
 import { EditableRelease } from '@admin/services/releaseContentService';
 import Button from '@common/components/Button';
-import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import { KeyStatContainer } from '@common/modules/find-statistics/components/KeyStat';
 import keyStatStyles from '@common/modules/find-statistics/components/KeyStat.module.scss';
@@ -13,9 +11,7 @@ import reorder from '@common/utils/reorder';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useState } from 'react';
 import { DragDropContext, Draggable, DropResult } from 'react-beautiful-dnd';
-import { KeyStatisticType } from '@common/services/publicationService';
-import { KeyStatisticTextCreateRequest } from '@admin/services/keyStatisticService';
-import EditableKeyStatTextForm from '@admin/pages/release/content/components/EditableKeyStatTextForm';
+import AddKeyStatistics from '@admin/pages/release/content/components/AddKeyStatistics';
 
 export interface KeyStatisticsProps {
   release: EditableRelease;
@@ -128,96 +124,6 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
       </DragDropContext>
     </>
   );
-};
-
-const AddKeyStatistics = ({ release }: KeyStatisticsProps) => {
-  const [formOpenForType, setFormOpenForType] = useState<
-    KeyStatisticType | undefined
-  >(undefined);
-  const {
-    updateUnattachedDataBlocks,
-    addKeyStatisticDataBlock,
-    addKeyStatisticText,
-  } = useReleaseContentActions();
-
-  const addKeyStatDataBlock = useCallback(
-    async (dataBlockId: string) => {
-      await addKeyStatisticDataBlock({ releaseId: release.id, dataBlockId });
-      await updateUnattachedDataBlocks({ releaseId: release.id });
-      setFormOpenForType(undefined);
-    },
-    [release.id, addKeyStatisticDataBlock, updateUnattachedDataBlocks],
-  );
-
-  const addKeyStatText = useCallback(
-    async (newKeyStatText: KeyStatisticTextCreateRequest) => {
-      await addKeyStatisticText({
-        releaseId: release.id,
-        keyStatisticText: newKeyStatText,
-      });
-      setFormOpenForType(undefined);
-    },
-    [release.id, addKeyStatisticText],
-  );
-
-  switch (formOpenForType) {
-    case KeyStatisticType.DATABLOCK:
-      return (
-        <div className={styles.keyStatDataBlockFormContainer}>
-          <WarningMessage>
-            In order to add a key statistic from a data block, you first need to
-            create a data block with just one value.
-            <br />
-            Any data blocks with more than one value cannot be selected as a key
-            statistic.
-          </WarningMessage>
-          <KeyStatDataBlockSelectForm
-            releaseId={release.id}
-            onSelect={addKeyStatDataBlock}
-            onCancel={() => setFormOpenForType(undefined)}
-          />
-        </div>
-      );
-    case KeyStatisticType.TEXT:
-      return (
-        <div className={styles.keyStatTextFormContainer}>
-          <EditableKeyStatTextForm
-            onSubmit={values =>
-              addKeyStatText(values as KeyStatisticTextCreateRequest)
-            }
-            onCancel={() => setFormOpenForType(undefined)}
-            testId="keyStatText-createForm"
-          />
-        </div>
-      );
-    default:
-      return (
-        <>
-          <ul className="govuk-list">
-            <li>
-              <Button
-                onClick={() => {
-                  setFormOpenForType(KeyStatisticType.DATABLOCK);
-                }}
-                className="govuk-!-margin-bottom-2"
-              >
-                Add key statistic from data block
-              </Button>
-            </li>
-            <li>
-              <Button
-                onClick={() => {
-                  setFormOpenForType(KeyStatisticType.TEXT);
-                }}
-                className="govuk-!-margin-bottom-2"
-              >
-                Add free text key statistic
-              </Button>
-            </li>
-          </ul>
-        </>
-      );
-  }
 };
 
 export default KeyStatistics;

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStat.test.tsx
@@ -6,7 +6,6 @@ import _keyStatisticService from '@admin/services/keyStatisticService';
 import {
   KeyStatisticDataBlock,
   KeyStatisticText,
-  KeyStatisticType,
 } from '@common/services/publicationService';
 import _tableBuilderService, {
   TableDataResponse,
@@ -38,7 +37,7 @@ const dataBlockService = _dataBlockService as jest.Mocked<
 describe('EditableKeyStat', () => {
   describe('for `KeyStatisticText` type', () => {
     const keyStatText: KeyStatisticText = {
-      type: KeyStatisticType.TEXT,
+      type: 'KeyStatisticText',
       id: 'keyStatDataBlock-1',
       title: 'Text title',
       statistic: 'Over 9000',
@@ -139,7 +138,7 @@ describe('EditableKeyStat', () => {
     };
 
     const keyStatDataBlock: KeyStatisticDataBlock = {
-      type: KeyStatisticType.DATABLOCK,
+      type: 'KeyStatisticDataBlock',
       id: 'keyStatDataBlock-1',
       trend: 'Trend',
       guidanceTitle: 'Guidance title',

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStat.test.tsx
@@ -61,7 +61,7 @@ describe('EditableKeyStat', () => {
           'Text title',
         );
 
-        expect(screen.getByTestId('keyStat-value')).toHaveTextContent(
+        expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
           'Over 9000',
         );
 
@@ -170,7 +170,7 @@ describe('EditableKeyStat', () => {
         expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
           'Indicator',
         );
-        expect(screen.getByTestId('keyStat-value')).toHaveTextContent(
+        expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
           '608,180',
         );
         expect(screen.getByTestId('keyStat-trend')).toHaveTextContent('Trend');

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStat.test.tsx
@@ -6,6 +6,7 @@ import _keyStatisticService from '@admin/services/keyStatisticService';
 import {
   KeyStatisticDataBlock,
   KeyStatisticText,
+  KeyStatisticType,
 } from '@common/services/publicationService';
 import _tableBuilderService, {
   TableDataResponse,
@@ -37,15 +38,15 @@ const dataBlockService = _dataBlockService as jest.Mocked<
 describe('EditableKeyStat', () => {
   describe('for `KeyStatisticText` type', () => {
     const keyStatText: KeyStatisticText = {
-      type: 'KeyStatisticText',
+      type: KeyStatisticType.TEXT,
       id: 'keyStatDataBlock-1',
+      title: 'Text title',
+      statistic: 'Over 9000',
       trend: 'Text trend',
       guidanceTitle: 'Text guidance title',
       guidanceText: 'Text guidance text',
       order: 0,
       created: '2023-01-01',
-      title: 'Text title',
-      statistic: 'Over 9000',
     };
 
     test('renders correctly', async () => {
@@ -138,7 +139,7 @@ describe('EditableKeyStat', () => {
     };
 
     const keyStatDataBlock: KeyStatisticDataBlock = {
-      type: 'KeyStatisticDataBlock',
+      type: KeyStatisticType.DATABLOCK,
       id: 'keyStatDataBlock-1',
       trend: 'Trend',
       guidanceTitle: 'Guidance title',

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
@@ -1,7 +1,10 @@
 import EditableKeyStatDataBlock from '@admin/pages/release/content/components/EditableKeyStatDataBlock';
 import { KeyStatDataBlockFormValues } from '@admin/pages/release/content/components/EditableKeyStatDataBlockForm';
 import _keyStatisticService from '@admin/services/keyStatisticService';
-import { KeyStatisticDataBlock } from '@common/services/publicationService';
+import {
+  KeyStatisticDataBlock,
+  KeyStatisticType,
+} from '@common/services/publicationService';
 import _tableBuilderService, {
   TableDataResponse,
 } from '@common/services/tableBuilderService';
@@ -70,7 +73,7 @@ describe('EditableKeyStatDataBlock', () => {
   };
 
   const keyStatDataBlock: KeyStatisticDataBlock = {
-    type: 'KeyStatisticDataBlock',
+    type: KeyStatisticType.DATABLOCK,
     id: 'keyStatDataBlock-1',
     trend: 'DataBlock trend',
     guidanceTitle: 'DataBlock guidance title',

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
@@ -1,16 +1,13 @@
 import EditableKeyStatDataBlock from '@admin/pages/release/content/components/EditableKeyStatDataBlock';
 import { KeyStatDataBlockFormValues } from '@admin/pages/release/content/components/EditableKeyStatDataBlockForm';
 import _keyStatisticService from '@admin/services/keyStatisticService';
-import {
-  KeyStatisticDataBlock,
-  KeyStatisticType,
-} from '@common/services/publicationService';
+import { KeyStatisticDataBlock } from '@common/services/publicationService';
 import _tableBuilderService, {
   TableDataResponse,
 } from '@common/services/tableBuilderService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { noop } from 'lodash';
+import noop from 'lodash/noop';
 import React from 'react';
 
 jest.mock('@admin/services/keyStatisticService');
@@ -73,7 +70,7 @@ describe('EditableKeyStatDataBlock', () => {
   };
 
   const keyStatDataBlock: KeyStatisticDataBlock = {
-    type: KeyStatisticType.DATABLOCK,
+    type: 'KeyStatisticDataBlock',
     id: 'keyStatDataBlock-1',
     trend: 'DataBlock trend',
     guidanceTitle: 'DataBlock guidance title',
@@ -100,13 +97,14 @@ describe('EditableKeyStatDataBlock', () => {
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'DataBlock indicator',
       );
-      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-        '608,180',
-      );
-      expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-        'DataBlock trend',
-      );
     });
+
+    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+      '608,180',
+    );
+    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
+      'DataBlock trend',
+    );
 
     expect(
       screen.getByRole('button', {
@@ -140,15 +138,15 @@ describe('EditableKeyStatDataBlock', () => {
       expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
         1,
       );
-
-      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-        'DataBlock indicator',
-      );
-      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-        '608,180',
-      );
-      expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
     });
+
+    expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
+      'DataBlock indicator',
+    );
+    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+      '608,180',
+    );
+    expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {
@@ -182,13 +180,14 @@ describe('EditableKeyStatDataBlock', () => {
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'DataBlock indicator',
       );
-      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-        '608,180',
-      );
-      expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-        'DataBlock trend',
-      );
     });
+
+    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+      '608,180',
+    );
+    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
+      'DataBlock trend',
+    );
 
     expect(
       screen.getByRole('button', {
@@ -222,13 +221,14 @@ describe('EditableKeyStatDataBlock', () => {
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'DataBlock indicator',
       );
-      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-        '608,180',
-      );
-      expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-        'DataBlock trend',
-      );
     });
+
+    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+      '608,180',
+    );
+    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
+      'DataBlock trend',
+    );
 
     expect(
       screen.queryByRole('button', {
@@ -293,32 +293,46 @@ describe('EditableKeyStatDataBlock', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-          'DataBlock indicator',
-        );
-        expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-          '608,180',
-        );
-        expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-          'DataBlock trend',
-        );
+        expect(screen.getByText(/Edit/)).toBeInTheDocument();
       });
 
-      expect(
-        screen.getByRole('button', {
-          name: 'DataBlock guidance title',
-        }),
-      ).toBeInTheDocument();
-
-      expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
-        'DataBlock guidance text',
-      );
-
-      expect(
+      userEvent.click(
         screen.getByRole('button', {
           name: 'Edit key statistic: DataBlock indicator',
         }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
+          'DataBlock indicator',
+        );
+      });
+
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
+
+      expect(screen.getByLabelText('Trend')).toHaveValue('DataBlock trend');
+
+      expect(screen.getByLabelText('Guidance title')).toHaveValue(
+        'DataBlock guidance title',
+      );
+
+      expect(screen.getByLabelText('Guidance text')).toHaveTextContent(
+        'DataBlock guidance text',
+      );
+
+      expect(screen.getByRole('button', { name: /Save/ })).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', { name: /Cancel/ }),
       ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', {
+          name: 'Edit key statistic: Text title',
+        }),
+      ).not.toBeInTheDocument();
 
       expect(
         screen.queryByRole('button', { name: /Remove/ }),
@@ -355,16 +369,16 @@ describe('EditableKeyStatDataBlock', () => {
         expect(screen.getByLabelText('Trend')).toBeInTheDocument();
       });
 
-      await userEvent.clear(screen.getByLabelText('Trend'));
+      userEvent.clear(screen.getByLabelText('Trend'));
       await userEvent.type(screen.getByLabelText('Trend'), 'New trend');
 
-      await userEvent.clear(screen.getByLabelText('Guidance title'));
+      userEvent.clear(screen.getByLabelText('Guidance title'));
       await userEvent.type(
         screen.getByLabelText('Guidance title'),
-        '  New guidance title  ', // Whitespace should be trimmed
+        'New guidance title',
       );
 
-      await userEvent.clear(screen.getByLabelText('Guidance text'));
+      userEvent.clear(screen.getByLabelText('Guidance text'));
       await userEvent.type(
         screen.getByLabelText('Guidance text'),
         'New guidance text',
@@ -373,10 +387,57 @@ describe('EditableKeyStatDataBlock', () => {
       userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
       await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledWith<[KeyStatDataBlockFormValues]>({
+        expect(onSubmit).toHaveBeenCalledWith<KeyStatDataBlockFormValues[]>({
           trend: 'New trend',
           guidanceTitle: 'New guidance title',
           guidanceText: 'New guidance text',
+        });
+      });
+    });
+
+    test('submitting edit form calls `onSubmit` handler with trimmed updated guidance title', async () => {
+      tableBuilderService.getDataBlockTableData.mockResolvedValue(
+        testTableDataResponse,
+      );
+
+      const onSubmit = jest.fn();
+
+      render(
+        <EditableKeyStatDataBlock
+          releaseId="release-1"
+          keyStat={keyStatDataBlock}
+          isEditing
+          onSubmit={onSubmit}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Edit/)).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Edit key statistic: DataBlock indicator',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Trend')).toBeInTheDocument();
+      });
+
+      userEvent.clear(screen.getByLabelText('Guidance title'));
+      await userEvent.type(
+        screen.getByLabelText('Guidance title'),
+        '  New guidance title  ',
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith<KeyStatDataBlockFormValues[]>({
+          trend: 'DataBlock trend',
+          guidanceTitle: 'New guidance title',
+          guidanceText: 'DataBlock guidance text',
         });
       });
     });
@@ -470,16 +531,14 @@ describe('EditableKeyStatDataBlock', () => {
         expect(
           screen.getByText('Could not load key statistic'),
         ).toBeInTheDocument();
-
-        expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
-        expect(
-          screen.queryByTestId('keyStat-statistic'),
-        ).not.toBeInTheDocument();
-        expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
-        expect(
-          screen.queryByTestId('keyStat-guidanceText'),
-        ).not.toBeInTheDocument();
       });
+
+      expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-statistic')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('keyStat-guidanceText'),
+      ).not.toBeInTheDocument();
 
       expect(
         screen.queryByRole('button', { name: 'Edit' }),

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
@@ -100,7 +100,9 @@ describe('EditableKeyStatDataBlock', () => {
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'DataBlock indicator',
       );
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
       expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
         'DataBlock trend',
       );
@@ -142,7 +144,9 @@ describe('EditableKeyStatDataBlock', () => {
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'DataBlock indicator',
       );
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
       expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
     });
 
@@ -178,7 +182,9 @@ describe('EditableKeyStatDataBlock', () => {
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'DataBlock indicator',
       );
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
       expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
         'DataBlock trend',
       );
@@ -216,7 +222,9 @@ describe('EditableKeyStatDataBlock', () => {
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'DataBlock indicator',
       );
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
       expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
         'DataBlock trend',
       );
@@ -288,7 +296,7 @@ describe('EditableKeyStatDataBlock', () => {
         expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
           'DataBlock indicator',
         );
-        expect(screen.getByTestId('keyStat-value')).toHaveTextContent(
+        expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
           '608,180',
         );
         expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
@@ -414,7 +422,9 @@ describe('EditableKeyStatDataBlock', () => {
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'DataBlock indicator',
       );
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
       expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
         'DataBlock trend',
       );
@@ -462,7 +472,9 @@ describe('EditableKeyStatDataBlock', () => {
         ).toBeInTheDocument();
 
         expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
-        expect(screen.queryByTestId('keyStat-value')).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId('keyStat-statistic'),
+        ).not.toBeInTheDocument();
         expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
         expect(
           screen.queryByTestId('keyStat-guidanceText'),

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
@@ -1,19 +1,23 @@
 import EditableKeyStatText from '@admin/pages/release/content/components/EditableKeyStatText';
-import { KeyStatisticText } from '@common/services/publicationService';
+import {
+  KeyStatisticText,
+  KeyStatisticType,
+} from '@common/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
 import { noop } from 'lodash';
 import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { KeyStatTextFormValues } from '@admin/pages/release/content/components/EditableKeyStatTextForm';
+import _keyStatisticService from '@admin/services/keyStatisticService';
+
+jest.mock('@admin/services/keyStatisticService');
+const keyStatisticService = _keyStatisticService as jest.Mocked<
+  typeof _keyStatisticService
+>;
 
 describe('EditableKeyStatText', () => {
-  // TODO: EES-2469 Write tests for EditableKeyStatText
-  // Text isEditing
-  // Text isEditing form
-  // Text isEditing form Cancel
-  // Text onSubmit
-  // Text onRemove
-
   const keyStatText: KeyStatisticText = {
-    type: 'KeyStatisticText',
+    type: KeyStatisticType.TEXT,
     id: 'keyStatDataBlock-1',
     trend: 'Text trend',
     guidanceTitle: 'Text guidance title',
@@ -166,5 +170,161 @@ describe('EditableKeyStatText', () => {
     expect(
       screen.queryByRole('button', { name: /Remove/ }),
     ).not.toBeInTheDocument();
+  });
+
+  describe('when editing', () => {
+    test('renders edit form correctly', async () => {
+      render(
+        <EditableKeyStatText keyStat={keyStatText} isEditing onSubmit={noop} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
+          'Text title',
+        );
+        expect(screen.getByTestId('keyStat-value')).toHaveTextContent(
+          'Over 9000',
+        );
+        expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
+          'Text trend',
+        );
+        expect(
+          screen.getByRole('button', {
+            name: 'Text guidance title',
+          }),
+        ).toBeInTheDocument();
+
+        expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
+          'Text guidance text',
+        );
+
+        expect(
+          screen.getByRole('button', {
+            name: 'Edit key statistic: Text title',
+          }),
+        ).toBeInTheDocument();
+
+        expect(
+          screen.queryByRole('button', { name: /Remove/ }),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    test('submitting edit form calls `onSubmit` handler with updated values', async () => {
+      const onSubmit = jest.fn();
+
+      render(
+        <EditableKeyStatText
+          keyStat={keyStatText}
+          isEditing
+          onSubmit={onSubmit}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Edit/)).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Edit key statistic: Text title',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Title')).toBeInTheDocument();
+      });
+
+      await userEvent.clear(screen.getByLabelText('Title'));
+      await userEvent.type(screen.getByLabelText('Title'), 'New title');
+
+      await userEvent.clear(screen.getByLabelText('Statistic'));
+      await userEvent.type(screen.getByLabelText('Statistic'), 'New statistic');
+
+      await userEvent.clear(screen.getByLabelText('Trend'));
+      await userEvent.type(screen.getByLabelText('Trend'), 'New trend');
+
+      await userEvent.clear(screen.getByLabelText('Guidance title'));
+      await userEvent.type(
+        screen.getByLabelText('Guidance title'),
+        '  New guidance title  ', // Whitespace should be trimmed
+      );
+
+      await userEvent.clear(screen.getByLabelText('Guidance text'));
+      await userEvent.type(
+        screen.getByLabelText('Guidance text'),
+        'New guidance text',
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith<[KeyStatTextFormValues]>({
+          title: 'New title',
+          statistic: 'New statistic',
+          trend: 'New trend',
+          guidanceTitle: 'New guidance title',
+          guidanceText: 'New guidance text',
+        });
+      });
+    });
+
+    test('clicking `Cancel` button toggles back to preview', async () => {
+      render(
+        <EditableKeyStatText keyStat={keyStatText} isEditing onSubmit={noop} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Edit/)).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Edit key statistic: Text title',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Cancel')).toBeInTheDocument();
+      });
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
+      });
+
+      expect(screen.queryByLabelText('Trend')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Guidance title')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Guidance text')).not.toBeInTheDocument();
+
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
+        'Text title',
+      );
+      expect(screen.getByTestId('keyStat-value')).toHaveTextContent(
+        'Over 9000',
+      );
+      expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
+        'Text trend',
+      );
+
+      expect(
+        screen.getByRole('button', {
+          name: 'Text guidance title',
+        }),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
+        'Text guidance text',
+      );
+
+      expect(
+        screen.queryByRole('button', { name: /Edit/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /Remove/ }),
+      ).not.toBeInTheDocument();
+
+      expect(keyStatisticService.updateKeyStatisticText).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
@@ -36,7 +36,7 @@ describe('EditableKeyStatText', () => {
         'Text title',
       );
 
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
         'Over 9000',
       );
 
@@ -76,7 +76,7 @@ describe('EditableKeyStatText', () => {
         'Text title',
       );
 
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
         'Over 9000',
       );
 
@@ -111,7 +111,7 @@ describe('EditableKeyStatText', () => {
         'Text title',
       );
 
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
         'Over 9000',
       );
 
@@ -148,7 +148,7 @@ describe('EditableKeyStatText', () => {
         'Text title',
       );
 
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
         'Over 9000',
       );
 
@@ -182,7 +182,7 @@ describe('EditableKeyStatText', () => {
         expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
           'Text title',
         );
-        expect(screen.getByTestId('keyStat-value')).toHaveTextContent(
+        expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
           'Over 9000',
         );
         expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
@@ -301,7 +301,7 @@ describe('EditableKeyStatText', () => {
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Text title',
       );
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
         'Over 9000',
       );
       expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
@@ -1,10 +1,7 @@
 import EditableKeyStatText from '@admin/pages/release/content/components/EditableKeyStatText';
-import {
-  KeyStatisticText,
-  KeyStatisticType,
-} from '@common/services/publicationService';
+import { KeyStatisticText } from '@common/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
-import { noop } from 'lodash';
+import noop from 'lodash/noop';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { KeyStatTextFormValues } from '@admin/pages/release/content/components/EditableKeyStatTextForm';
@@ -17,7 +14,7 @@ const keyStatisticService = _keyStatisticService as jest.Mocked<
 
 describe('EditableKeyStatText', () => {
   const keyStatText: KeyStatisticText = {
-    type: KeyStatisticType.TEXT,
+    type: 'KeyStatisticText',
     id: 'keyStatDataBlock-1',
     trend: 'Text trend',
     guidanceTitle: 'Text guidance title',
@@ -31,19 +28,13 @@ describe('EditableKeyStatText', () => {
   test('renders preview correctly', async () => {
     render(<EditableKeyStatText keyStat={keyStatText} onSubmit={noop} />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-        'Text title',
-      );
+    expect(screen.getByTestId('keyStat-title')).toHaveTextContent('Text title');
 
-      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-        'Over 9000',
-      );
+    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+      'Over 9000',
+    );
 
-      expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-        'Text trend',
-      );
-    });
+    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent('Text trend');
 
     expect(
       screen.getByRole('button', {
@@ -71,17 +62,13 @@ describe('EditableKeyStatText', () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-        'Text title',
-      );
+    expect(screen.getByTestId('keyStat-title')).toHaveTextContent('Text title');
 
-      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-        'Over 9000',
-      );
+    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+      'Over 9000',
+    );
 
-      expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {
@@ -106,19 +93,13 @@ describe('EditableKeyStatText', () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-        'Text title',
-      );
+    expect(screen.getByTestId('keyStat-title')).toHaveTextContent('Text title');
 
-      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-        'Over 9000',
-      );
+    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+      'Over 9000',
+    );
 
-      expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-        'Text trend',
-      );
-    });
+    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent('Text trend');
 
     expect(
       screen.getByRole('button', {
@@ -139,23 +120,18 @@ describe('EditableKeyStatText', () => {
     render(
       <EditableKeyStatText
         keyStat={{ ...keyStatText, guidanceText: undefined }}
+        onRemove={noop}
         onSubmit={noop}
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-        'Text title',
-      );
+    expect(screen.getByTestId('keyStat-title')).toHaveTextContent('Text title');
 
-      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-        'Over 9000',
-      );
+    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+      'Over 9000',
+    );
 
-      expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-        'Text trend',
-      );
-    });
+    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent('Text trend');
 
     expect(
       screen.queryByRole('button', {
@@ -165,6 +141,10 @@ describe('EditableKeyStatText', () => {
 
     expect(
       screen.queryByTestId('keyStat-guidanceText'),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: /Edit/ }),
     ).not.toBeInTheDocument();
 
     expect(
@@ -178,36 +158,43 @@ describe('EditableKeyStatText', () => {
         <EditableKeyStatText keyStat={keyStatText} isEditing onSubmit={noop} />,
       );
 
+      expect(screen.getByText(/Edit/)).toBeInTheDocument();
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Edit key statistic: Text title',
+        }),
+      );
+
       await waitFor(() => {
-        expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-          'Text title',
-        );
-        expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-          'Over 9000',
-        );
-        expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-          'Text trend',
-        );
-        expect(
-          screen.getByRole('button', {
-            name: 'Text guidance title',
-          }),
-        ).toBeInTheDocument();
-
-        expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
-          'Text guidance text',
-        );
-
-        expect(
-          screen.getByRole('button', {
-            name: 'Edit key statistic: Text title',
-          }),
-        ).toBeInTheDocument();
-
-        expect(
-          screen.queryByRole('button', { name: /Remove/ }),
-        ).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Title')).toHaveValue('Text title');
       });
+
+      expect(screen.getByLabelText('Statistic')).toHaveValue('Over 9000');
+      expect(screen.getByLabelText('Trend')).toHaveValue('Text trend');
+
+      expect(screen.getByLabelText('Guidance title')).toHaveValue(
+        'Text guidance title',
+      );
+
+      expect(screen.getByLabelText('Guidance text')).toHaveTextContent(
+        'Text guidance text',
+      );
+
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Cancel' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', {
+          name: 'Edit key statistic: Text title',
+        }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', { name: /Remove/ }),
+      ).not.toBeInTheDocument();
     });
 
     test('submitting edit form calls `onSubmit` handler with updated values', async () => {
@@ -221,9 +208,7 @@ describe('EditableKeyStatText', () => {
         />,
       );
 
-      await waitFor(() => {
-        expect(screen.getByText(/Edit/)).toBeInTheDocument();
-      });
+      expect(screen.getByText(/Edit/)).toBeInTheDocument();
 
       userEvent.click(
         screen.getByRole('button', {
@@ -235,22 +220,22 @@ describe('EditableKeyStatText', () => {
         expect(screen.getByLabelText('Title')).toBeInTheDocument();
       });
 
-      await userEvent.clear(screen.getByLabelText('Title'));
+      userEvent.clear(screen.getByLabelText('Title'));
       await userEvent.type(screen.getByLabelText('Title'), 'New title');
 
-      await userEvent.clear(screen.getByLabelText('Statistic'));
+      userEvent.clear(screen.getByLabelText('Statistic'));
       await userEvent.type(screen.getByLabelText('Statistic'), 'New statistic');
 
-      await userEvent.clear(screen.getByLabelText('Trend'));
+      userEvent.clear(screen.getByLabelText('Trend'));
       await userEvent.type(screen.getByLabelText('Trend'), 'New trend');
 
-      await userEvent.clear(screen.getByLabelText('Guidance title'));
+      userEvent.clear(screen.getByLabelText('Guidance title'));
       await userEvent.type(
         screen.getByLabelText('Guidance title'),
-        '  New guidance title  ', // Whitespace should be trimmed
+        'New guidance title',
       );
 
-      await userEvent.clear(screen.getByLabelText('Guidance text'));
+      userEvent.clear(screen.getByLabelText('Guidance text'));
       await userEvent.type(
         screen.getByLabelText('Guidance text'),
         'New guidance text',
@@ -259,7 +244,7 @@ describe('EditableKeyStatText', () => {
       userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
       await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledWith<[KeyStatTextFormValues]>({
+        expect(onSubmit).toHaveBeenCalledWith<KeyStatTextFormValues[]>({
           title: 'New title',
           statistic: 'New statistic',
           trend: 'New trend',
@@ -269,14 +254,52 @@ describe('EditableKeyStatText', () => {
       });
     });
 
+    test('submitting edit form calls `onSubmit` handler with trimmed updated guidance title', async () => {
+      const onSubmit = jest.fn();
+
+      render(
+        <EditableKeyStatText
+          keyStat={keyStatText}
+          isEditing
+          onSubmit={onSubmit}
+        />,
+      );
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Edit key statistic: Text title',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Title')).toBeInTheDocument();
+      });
+
+      userEvent.clear(screen.getByLabelText('Guidance title'));
+      await userEvent.type(
+        screen.getByLabelText('Guidance title'),
+        '   New guidance title  ',
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith<KeyStatTextFormValues[]>({
+          title: 'Text title',
+          statistic: 'Over 9000',
+          trend: 'Text trend',
+          guidanceTitle: 'New guidance title',
+          guidanceText: 'Text guidance text',
+        });
+      });
+    });
+
     test('clicking `Cancel` button toggles back to preview', async () => {
       render(
         <EditableKeyStatText keyStat={keyStatText} isEditing onSubmit={noop} />,
       );
 
-      await waitFor(() => {
-        expect(screen.getByText(/Edit/)).toBeInTheDocument();
-      });
+      expect(screen.getByText(/Edit/)).toBeInTheDocument();
 
       userEvent.click(
         screen.getByRole('button', {

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
@@ -13,7 +13,6 @@ import {
 import {
   ContentSection,
   KeyStatisticDataBlock,
-  KeyStatisticType,
 } from '@common/services/publicationService';
 import { DataBlock, Table } from '@common/services/types/blocks';
 import { produce } from 'immer';
@@ -632,7 +631,7 @@ describe('ReleaseContentContext', () => {
   test('ADD_KEY_STATISTIC adds a key statistic to release.keyStatistics array', () => {
     expect(testEditableRelease.keyStatistics).toHaveLength(3);
     const newKeyStat: KeyStatisticDataBlock = {
-      type: KeyStatisticType.DATABLOCK,
+      type: 'KeyStatisticDataBlock',
       id: 'keyStat-4',
       dataBlockId: 'dataBlock-0',
       trend: 'keyStat-4 trend',

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
@@ -13,6 +13,7 @@ import {
 import {
   ContentSection,
   KeyStatisticDataBlock,
+  KeyStatisticType,
 } from '@common/services/publicationService';
 import { DataBlock, Table } from '@common/services/types/blocks';
 import { produce } from 'immer';
@@ -631,7 +632,7 @@ describe('ReleaseContentContext', () => {
   test('ADD_KEY_STATISTIC adds a key statistic to release.keyStatistics array', () => {
     expect(testEditableRelease.keyStatistics).toHaveLength(3);
     const newKeyStat: KeyStatisticDataBlock = {
-      type: 'KeyStatisticDataBlock',
+      type: KeyStatisticType.DATABLOCK,
       id: 'keyStat-4',
       dataBlockId: 'dataBlock-0',
       trend: 'keyStat-4 trend',

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
@@ -16,6 +16,7 @@ import { Dictionary } from '@admin/types';
 import { useCallback, useMemo } from 'react';
 import keyStatisticService, {
   KeyStatisticDataBlockUpdateRequest,
+  KeyStatisticTextUpdateRequest,
 } from '@admin/services/keyStatisticService';
 import { KeyStatistic } from '@common/services/publicationService';
 import dataBlockService from '@admin/services/dataBlockService';
@@ -449,6 +450,20 @@ export default function useReleaseContentActions() {
     [dispatch],
   );
 
+  const addKeyStatisticText = useCallback(
+    async ({ releaseId, keyStatisticText }) => {
+      const createdKeyStatText = await keyStatisticService.createKeyStatisticText(
+        releaseId,
+        keyStatisticText,
+      );
+      dispatch({
+        type: 'ADD_KEY_STATISTIC',
+        payload: { keyStatistic: createdKeyStatText },
+      });
+    },
+    [dispatch],
+  );
+
   const updateKeyStatisticDataBlock = useCallback(
     async ({
       releaseId,
@@ -467,6 +482,29 @@ export default function useReleaseContentActions() {
       dispatch({
         type: 'UPDATE_KEY_STATISTIC',
         payload: { keyStatistic: updatedKeyStatisticDataBlock },
+      });
+    },
+    [dispatch],
+  );
+
+  const updateKeyStatisticText = useCallback(
+    async ({
+      releaseId,
+      keyStatisticId,
+      request,
+    }: {
+      releaseId: string;
+      keyStatisticId: string;
+      request: KeyStatisticTextUpdateRequest;
+    }) => {
+      const updatedKeyStatisticText = await keyStatisticService.updateKeyStatisticText(
+        releaseId,
+        keyStatisticId,
+        request,
+      );
+      dispatch({
+        type: 'UPDATE_KEY_STATISTIC',
+        payload: { keyStatistic: updatedKeyStatisticText },
       });
     },
     [dispatch],
@@ -518,6 +556,7 @@ export default function useReleaseContentActions() {
       addContentSectionBlock,
       addEmbedSectionBlock,
       addKeyStatisticDataBlock,
+      addKeyStatisticText,
       attachContentSectionBlock,
       deleteBlockComment,
       deleteContentSectionBlock,
@@ -533,6 +572,7 @@ export default function useReleaseContentActions() {
       updateEmbedSectionBlock,
       updateSectionBlockOrder,
       updateKeyStatisticDataBlock,
+      updateKeyStatisticText,
     }),
     [
       addBlockComment,
@@ -540,6 +580,7 @@ export default function useReleaseContentActions() {
       addContentSectionBlock,
       addEmbedSectionBlock,
       addKeyStatisticDataBlock,
+      addKeyStatisticText,
       attachContentSectionBlock,
       deleteBlockComment,
       deleteContentSectionBlock,
@@ -555,6 +596,7 @@ export default function useReleaseContentActions() {
       updateEmbedSectionBlock,
       updateSectionBlockOrder,
       updateKeyStatisticDataBlock,
+      updateKeyStatisticText,
     ],
   );
 }

--- a/src/explore-education-statistics-admin/src/services/keyStatisticService.ts
+++ b/src/explore-education-statistics-admin/src/services/keyStatisticService.ts
@@ -2,8 +2,8 @@ import client from '@admin/services/utils/service';
 import {
   KeyStatistic,
   KeyStatisticDataBlock,
+  KeyStatisticText,
 } from '@common/services/publicationService';
-import { Dictionary } from '@common/types';
 
 export interface KeyStatisticDataBlockCreateRequest {
   dataBlockId: string;
@@ -12,7 +12,23 @@ export interface KeyStatisticDataBlockCreateRequest {
   guidanceText?: string;
 }
 
+export interface KeyStatisticTextCreateRequest {
+  title: string;
+  statistic: string;
+  trend?: string;
+  guidanceTitle?: string;
+  guidanceText?: string;
+}
+
 export interface KeyStatisticDataBlockUpdateRequest {
+  trend?: string;
+  guidanceTitle?: string;
+  guidanceText?: string;
+}
+
+export interface KeyStatisticTextUpdateRequest {
+  title: string;
+  statistic: string;
   trend?: string;
   guidanceTitle?: string;
   guidanceText?: string;
@@ -29,6 +45,13 @@ const keyStatisticService = {
     );
   },
 
+  createKeyStatisticText(
+    releaseId: string,
+    request: KeyStatisticTextCreateRequest,
+  ): Promise<KeyStatisticText> {
+    return client.post(`/release/${releaseId}/key-statistic-text`, request);
+  },
+
   updateKeyStatisticDataBlock(
     releaseId: string,
     keyStatisticId: string,
@@ -36,6 +59,17 @@ const keyStatisticService = {
   ): Promise<KeyStatisticDataBlock> {
     return client.put(
       `/release/${releaseId}/key-statistic-data-block/${keyStatisticId}`,
+      request,
+    );
+  },
+
+  updateKeyStatisticText(
+    releaseId: string,
+    keyStatisticId: string,
+    request: KeyStatisticTextUpdateRequest,
+  ): Promise<KeyStatisticText> {
+    return client.put(
+      `/release/${releaseId}/key-statistic-text/${keyStatisticId}`,
       request,
     );
   },

--- a/src/explore-education-statistics-admin/src/services/keyStatisticService.ts
+++ b/src/explore-education-statistics-admin/src/services/keyStatisticService.ts
@@ -12,27 +12,22 @@ export interface KeyStatisticDataBlockCreateRequest {
   guidanceText?: string;
 }
 
-export interface KeyStatisticTextCreateRequest {
-  title: string;
-  statistic: string;
-  trend?: string;
-  guidanceTitle?: string;
-  guidanceText?: string;
-}
-
 export interface KeyStatisticDataBlockUpdateRequest {
   trend?: string;
   guidanceTitle?: string;
   guidanceText?: string;
 }
 
-export interface KeyStatisticTextUpdateRequest {
+interface KeyStatisticTextSaveRequest {
   title: string;
   statistic: string;
   trend?: string;
   guidanceTitle?: string;
   guidanceText?: string;
 }
+
+export type KeyStatisticTextCreateRequest = KeyStatisticTextSaveRequest;
+export type KeyStatisticTextUpdateRequest = KeyStatisticTextSaveRequest;
 
 const keyStatisticService = {
   createKeyStatisticDataBlock(

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
@@ -258,9 +258,9 @@ describe('MapBlockInternal', () => {
     expect(tile.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
       'Authorised absence rate (2016/17)',
     );
-    expect(tile.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
-      '3.5%',
-    );
+    expect(
+      tile.getByTestId('mapBlock-indicatorTile-statistic'),
+    ).toHaveTextContent('3.5%');
   });
 
   test('renders location indicator tiles correctly with custom decimal places', async () => {
@@ -299,9 +299,9 @@ describe('MapBlockInternal', () => {
     expect(tile1.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
       'Authorised absence rate (2016/17)',
     );
-    expect(tile1.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
-      '3.51%',
-    );
+    expect(
+      tile1.getByTestId('mapBlock-indicatorTile-statistic'),
+    ).toHaveTextContent('3.51%');
 
     userEvent.selectOptions(select, group1Options[1]);
 
@@ -309,9 +309,9 @@ describe('MapBlockInternal', () => {
     expect(tile2.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
       'Authorised absence rate (2016/17)',
     );
-    expect(tile2.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
-      '3.01%',
-    );
+    expect(
+      tile2.getByTestId('mapBlock-indicatorTile-statistic'),
+    ).toHaveTextContent('3.01%');
 
     userEvent.selectOptions(select, group1Options[2]);
 
@@ -319,9 +319,9 @@ describe('MapBlockInternal', () => {
     expect(tile3.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
       'Authorised absence rate (2016/17)',
     );
-    expect(tile3.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
-      '4.01%',
-    );
+    expect(
+      tile3.getByTestId('mapBlock-indicatorTile-statistic'),
+    ).toHaveTextContent('4.01%');
   });
 
   test('resetting the map when select None Selected', async () => {

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.module.scss
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.module.scss
@@ -41,12 +41,10 @@
   }
 }
 
-.titleText {
-  color: govuk-colour('white');
-}
-
-.statisticText {
-  color: govuk-colour('white');
+.textTile {
+  background: govuk-colour('light-grey');
+  border: 3px solid govuk-colour('blue');
+  padding: govuk-spacing(3);
 }
 
 .trendText {

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.module.scss
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.module.scss
@@ -41,6 +41,14 @@
   }
 }
 
+.titleText {
+  color: govuk-colour('white');
+}
+
+.statisticText {
+  color: govuk-colour('white');
+}
+
 .trendText {
   color: govuk-colour('white');
 }

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.tsx
@@ -30,7 +30,7 @@ const KeyStatTile = ({
         {title}
       </TitleElement>
 
-      <p className="govuk-heading-xl" data-testid={`${testId}-value`}>
+      <p className="govuk-heading-xl" data-testid={`${testId}-statistic`}>
         {formatPretty(value)}
       </p>
 

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
@@ -19,7 +19,9 @@ describe('KeyStat', () => {
         'Number of applications received',
       );
 
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
 
       expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
         'Down from 620,330 in 2017',
@@ -53,7 +55,9 @@ describe('KeyStat', () => {
         'Number of applications received',
       );
 
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
 
       expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
         'Down from 620,330 in 2017',
@@ -85,7 +89,9 @@ describe('KeyStat', () => {
         'Number of applications received',
       );
 
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
 
       expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
       expect(screen.queryByRole('button')).not.toBeInTheDocument();

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStatDataBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStatDataBlock.test.tsx
@@ -95,7 +95,9 @@ describe('KeyStatDataBlock', () => {
         'Number of applications received',
       );
 
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
 
       expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
         'Down from 620,330 in 2017',
@@ -137,7 +139,9 @@ describe('KeyStatDataBlock', () => {
         'Number of applications received',
       );
 
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
 
       expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
         'Down from 620,330 in 2017',
@@ -177,7 +181,9 @@ describe('KeyStatDataBlock', () => {
         'Number of applications received',
       );
 
-      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+        '608,180',
+      );
 
       expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
     });
@@ -209,7 +215,7 @@ describe('KeyStatDataBlock', () => {
         1,
       );
       expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('keyStat-value')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-statistic')).not.toBeInTheDocument();
       expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
     });
 
@@ -251,7 +257,7 @@ describe('KeyStatDataBlock', () => {
         1,
       );
       expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('keyStat-value')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-statistic')).not.toBeInTheDocument();
       expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
     });
 

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -84,6 +84,7 @@ export interface ReleaseNote {
 }
 
 export interface KeyStatisticBase {
+  type: KeyStatisticType;
   id: string;
   trend?: string;
   guidanceTitle?: string;
@@ -93,19 +94,20 @@ export interface KeyStatisticBase {
   updated?: string;
 }
 
-// eslint-disable-next-line no-shadow
-export enum KeyStatisticType {
-  DATABLOCK = 'KeyStatisticDataBlock',
-  TEXT = 'KeyStatisticText',
-}
+export const KeyStatisticTypes = {
+  DataBlock: 'KeyStatisticDataBlock',
+  Text: 'KeyStatisticText',
+} as const;
+
+export type KeyStatisticType = typeof KeyStatisticTypes[keyof typeof KeyStatisticTypes];
 
 export interface KeyStatisticDataBlock extends KeyStatisticBase {
-  type: KeyStatisticType.DATABLOCK;
+  type: 'KeyStatisticDataBlock';
   dataBlockId: string;
 }
 
 export interface KeyStatisticText extends KeyStatisticBase {
-  type: KeyStatisticType.TEXT;
+  type: 'KeyStatisticText';
   title: string;
   statistic: string;
 }

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -93,13 +93,19 @@ export interface KeyStatisticBase {
   updated?: string;
 }
 
+// eslint-disable-next-line no-shadow
+export enum KeyStatisticType {
+  DATABLOCK = 'KeyStatisticDataBlock',
+  TEXT = 'KeyStatisticText',
+}
+
 export interface KeyStatisticDataBlock extends KeyStatisticBase {
-  type: 'KeyStatisticDataBlock';
+  type: KeyStatisticType.DATABLOCK;
   dataBlockId: string;
 }
 
 export interface KeyStatisticText extends KeyStatisticBase {
-  type: 'KeyStatisticText';
+  type: KeyStatisticType.TEXT;
   title: string;
   statistic: string;
 }

--- a/src/explore-education-statistics-common/src/types/util.ts
+++ b/src/explore-education-statistics-common/src/types/util.ts
@@ -2,7 +2,6 @@
  * Enumerates the typical comparison
  * integers of 1, 0 and -1.
  */
-// eslint-disable-next-line no-shadow
 export enum Comparison {
   GreaterThan = 1,
   EqualTo = 0,

--- a/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
@@ -109,15 +109,15 @@ Validate Analyst1 can see 'Content' page key stats
     user waits until page does not contain loading spinner
     user scrolls to element    id:releaseHeadlines
     user checks key stat contents    1    Overall absence rate    4.7%    Up from 4.6% in 2015/16    90
-    user checks key stat definition    1    What is overall absence?
+    user checks key stat guidance    1    What is overall absence?
     ...    Total number of all authorised and unauthorised absences from possible school sessions for all pupils.
 
     user checks key stat contents    2    Authorised absence rate    3.4%    Similar to previous years
-    user checks key stat definition    2    What is authorized absence rate?
+    user checks key stat guidance    2    What is authorized absence rate?
     ...    Number of authorised absences as a percentage of the overall school population.
 
     user checks key stat contents    3    Unauthorised absence rate    1.3%    Up from 1.1% in 2015/16
-    user checks key stat definition    3    What is unauthorized absence rate?
+    user checks key stat guidance    3    What is unauthorized absence rate?
     ...    Number of unauthorised absences as a percentage of the overall school population.
 
     user checks element count is x    css:[data-testid="keyStat"]    3

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -170,7 +170,7 @@ Remove newly added key statistics data block tile
 Add free text key stat
     user adds free text key stat    Free text key stat title    9001%    Trend    Guidance title    Guidance text
 
-    User Checks Element Count Is X    testid:keyStat    2
+    user checks element count is x    testid:keyStat    2
     user checks key stat contents    1    Proportion of settings open    1%    Down from last year
     user checks key stat guidance    1    Learn more about open settings    Some information about about open settings
     user checks key stat contents    2    Free text key stat title    9001%    Trend
@@ -180,7 +180,7 @@ Update free text key stat
     user updates free text key stat    2    Updated title    9002%    Updated trend    Updated guidance title
     ...    Updated guidance text
 
-    User Checks Element Count Is X    testid:keyStat    2
+    user checks element count is x    testid:keyStat    2
     user checks key stat contents    1    Proportion of settings open    1%    Down from last year
     user checks key stat guidance    1    Learn more about open settings    Some information about about open settings
     user checks key stat contents    2    Updated title    9002%    Updated trend
@@ -190,7 +190,7 @@ Remove free text key stat
     user removes key stat    2
     user waits until page does not contain    Updated title
 
-    User Checks Element Count Is X    testid:keyStat    1
+    user checks element count is x    testid:keyStat    1
     user checks key stat contents    1    Proportion of settings open    1%    Down from last year
     user checks key stat guidance    1    Learn more about open settings    Some information about about open settings
 

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -121,8 +121,8 @@ Remove secondary statistics
     user checks page does not contain button    Remove secondary stats
     user checks page contains button    Add secondary stats
 
-Add a key statistics tile
-    user clicks button    Add key statistic
+Add a key statistics data block tile
+    user clicks button    Add key statistic from data block
     user waits until page contains element    name:selectedDataBlock    %{WAIT_MEDIUM}
     user checks select contains x options    name:selectedDataBlock    3
     user checks select contains option    name:selectedDataBlock    Select a data block
@@ -149,8 +149,8 @@ Check the guidance information for the key statistics tile
     user opens details dropdown    Learn more about open settings
     user checks page contains    Some information about about open settings
 
-Add another key statistics tile
-    user clicks button    Add another key statistic
+Add another key statistics data block tile
+    user clicks button    Add key statistic from data block
     user waits until page contains element    name:selectedDataBlock    %{WAIT_MEDIUM}
     user checks select contains x options    name:selectedDataBlock    2
     user checks select contains option    name:selectedDataBlock    Select a data block
@@ -159,13 +159,40 @@ Add another key statistics tile
     user checks page contains    Number of open settings
     user checks page contains    22,900
 
-Remove a key statistics tile
-    # Remove the second tile
+Remove newly added key statistics data block tile
     user clicks the nth key stats tile button    2    Remove
     user waits until page does not contain    Number of open settings    %{WAIT_MEDIUM}
     user checks page does not contain    22,900
+
     # Make sure the first key stat tile is still there
     user checks page contains    Proportion of settings open
+
+Add free text key stat
+    user adds free text key stat    Free text key stat title    9001%    Trend    Guidance title    Guidance text
+
+    User Checks Element Count Is X    testid:keyStat    2
+    user checks key stat contents    1    Proportion of settings open    1%    Down from last year
+    user checks key stat guidance    1    Learn more about open settings    Some information about about open settings
+    user checks key stat contents    2    Free text key stat title    9001%    Trend
+    user checks key stat guidance    2    Guidance title    Guidance text
+
+Update free text key stat
+    user updates free text key stat    2    Updated title    9002%    Updated trend    Updated guidance title
+    ...    Updated guidance text
+
+    User Checks Element Count Is X    testid:keyStat    2
+    user checks key stat contents    1    Proportion of settings open    1%    Down from last year
+    user checks key stat guidance    1    Learn more about open settings    Some information about about open settings
+    user checks key stat contents    2    Updated title    9002%    Updated trend
+    user checks key stat guidance    2    Updated guidance title    Updated guidance text
+
+Remove free text key stat
+    user removes key stat    2
+    user waits until page does not contain    Updated title
+
+    User Checks Element Count Is X    testid:keyStat    1
+    user checks key stat contents    1    Proportion of settings open    1%    Down from last year
+    user checks key stat guidance    1    Learn more about open settings    Some information about about open settings
 
 Add key statistics summary content to release
     user adds headlines text block

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -124,6 +124,13 @@ Navigate to 'Content' page
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user waits until page contains button    Add a summary text block    %{WAIT_SMALL}
 
+Add free text key stat
+    user adds free text key stat    Free text key stat title    9001%    Trend    Guidance title    Guidance text
+
+    User Checks Element Count Is X    testid:keyStat    1
+    user checks key stat contents    1    Free text key stat title    9001%    Trend
+    user checks key stat guidance    1    Guidance title    Guidance text
+
 Add three accordion sections to release
     user waits for page to finish loading
     user waits until page does not contain loading spinner
@@ -366,8 +373,14 @@ Verify public pre-release access list
     user waits until page contains    Published ${EXPECTED_PUBLISHED_DATE}
     user waits until page contains    Test public access list
 
-Verify accordions are correct
+Verify free text key stat is correct
     user goes to release page via breadcrumb    ${PUBLICATION_NAME}    ${RELEASE_NAME}
+
+    User Checks Element Count Is X    testid:keyStat    1
+    user checks key stat contents    1    Free text key stat title    9001%    Trend
+    user checks key stat guidance    1    Guidance title    Guidance text
+
+Verify accordions are correct
     user checks there are x accordion sections    1    id:data-accordion
     user checks accordion is in position    Explore data and files    1    id:data-accordion
 
@@ -624,6 +637,14 @@ Navigate to 'Content' page for amendment
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user waits until page contains button    Add a summary text block
 
+Update free text key stat
+    user updates free text key stat    1    Updated title    Updated statistic    Updated trend
+    ...    Updated guidance title    Updated guidance text
+
+    User Checks Element Count Is X    testid:keyStat    1
+    user checks key stat contents    1    Updated title    Updated statistic    Updated trend
+    user checks key stat guidance    1    Updated guidance title    Updated guidance text
+
 Verify amended Dates data block table has footnotes
     ${accordion}=    user opens accordion section    Dates data block    id:releaseMainContent
     ${data_block_table}=    user gets data block table from parent    ${DATABLOCK_NAME}    ${accordion}
@@ -729,6 +750,11 @@ Verify amendment is displayed as the latest release
 Verify amendment is published
     user checks summary list contains    Published    ${EXPECTED_PUBLISHED_DATE}
     user checks summary list contains    Next update    December 3001
+
+Verify amendment free text key stat is updated
+    User Checks Element Count Is X    testid:keyStat    1
+    user checks key stat contents    1    Updated title    Updated statistic    Updated trend
+    user checks key stat guidance    1    Updated guidance title    Updated guidance text
 
 Verify amendment files
     user opens accordion section    Explore data and files

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -127,7 +127,7 @@ Navigate to 'Content' page
 Add free text key stat
     user adds free text key stat    Free text key stat title    9001%    Trend    Guidance title    Guidance text
 
-    User Checks Element Count Is X    testid:keyStat    1
+    user checks element count is x    testid:keyStat    1
     user checks key stat contents    1    Free text key stat title    9001%    Trend
     user checks key stat guidance    1    Guidance title    Guidance text
 
@@ -376,7 +376,7 @@ Verify public pre-release access list
 Verify free text key stat is correct
     user goes to release page via breadcrumb    ${PUBLICATION_NAME}    ${RELEASE_NAME}
 
-    User Checks Element Count Is X    testid:keyStat    1
+    user checks element count is x    testid:keyStat    1
     user checks key stat contents    1    Free text key stat title    9001%    Trend
     user checks key stat guidance    1    Guidance title    Guidance text
 
@@ -641,7 +641,7 @@ Update free text key stat
     user updates free text key stat    1    Updated title    Updated statistic    Updated trend
     ...    Updated guidance title    Updated guidance text
 
-    User Checks Element Count Is X    testid:keyStat    1
+    user checks element count is x    testid:keyStat    1
     user checks key stat contents    1    Updated title    Updated statistic    Updated trend
     user checks key stat guidance    1    Updated guidance title    Updated guidance text
 
@@ -752,7 +752,7 @@ Verify amendment is published
     user checks summary list contains    Next update    December 3001
 
 Verify amendment free text key stat is updated
-    User Checks Element Count Is X    testid:keyStat    1
+    user checks element count is x    testid:keyStat    1
     user checks key stat contents    1    Updated title    Updated statistic    Updated trend
     user checks key stat guidance    1    Updated guidance title    Updated guidance text
 

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -105,15 +105,15 @@ Validate headlines -- Summary tab key stats
     user scrolls to element    xpath://h2[contains(text(), "Headline facts and figures")]
 
     user checks key stat contents    1    Overall absence rate    4.7%    Up from 4.6% in 2015/16    %{WAIT_MEDIUM}
-    user checks key stat definition    1    What is overall absence?
+    user checks key stat guidance    1    What is overall absence?
     ...    Total number of all authorised and unauthorised absences from possible school sessions for all pupils.
 
     user checks key stat contents    2    Authorised absence rate    3.4%    Similar to previous years
-    user checks key stat definition    2    What is authorized absence rate?
+    user checks key stat guidance    2    What is authorized absence rate?
     ...    Number of authorised absences as a percentage of the overall school population.
 
     user checks key stat contents    3    Unauthorised absence rate    1.3%    Up from 1.1% in 2015/16
-    user checks key stat definition    3    What is unauthorized absence rate?
+    user checks key stat guidance    3    What is unauthorized absence rate?
     ...    Number of unauthorised absences as a percentage of the overall school population.
 
 Validate headlines -- Summary tab content

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -813,3 +813,46 @@ get release id from url
     ...    release\/([0-9A-Fa-f]{8}[-]?[0-9A-Fa-f]{4}[-]?[0-9A-Fa-f]{4}[-]?[0-9A-Fa-f]{4}[-]?[0-9A-Fa-f]{12})    1
     ${release_id}=    Get From List    ${release_id_match}    0
     [Return]    ${release_id}
+
+user adds free text key stat
+    [Arguments]    ${title}    ${value}    ${trend}    ${guidance_title}    ${guidance_text}
+    user clicks button    Add free text key statistic
+    user waits until page contains element    id:editableKeyStatTextForm-create-title
+
+    user enters text into element    id:editableKeyStatTextForm-create-title    ${title}
+    user enters text into element    id:editableKeyStatTextForm-create-statistic    ${value}
+    user enters text into element    id:editableKeyStatTextForm-create-trend    ${trend}
+    user enters text into element    id:editableKeyStatTextForm-create-guidanceTitle    ${guidance_title}
+
+    user clicks element    id:editableKeyStatTextForm-create-guidanceText
+    user presses keys    ${guidance_text}
+
+    user clicks button    Save
+    user waits until page does not contain button    Save
+
+user updates free text key stat
+    [Arguments]    ${tile_num}    ${title}    ${statistic}    ${trend}    ${guidance_title}    ${guidance_text}
+    user waits until page contains element    xpath://*[@data-testid="keyStat"][${tile_num}]
+
+    user clicks element    xpath://*[@data-testid="keyStat"][${tile_num}]//button[contains(text(), "Edit")]
+
+    user waits until page contains button    Save
+
+    user enters text into element    xpath://*[@data-testid="keyStat"][${tile_num}]//input[@name="title"]    ${title}
+    user enters text into element    xpath://*[@data-testid="keyStat"][${tile_num}]//input[@name="statistic"]
+    ...    ${statistic}
+    user enters text into element    xpath://*[@data-testid="keyStat"][${tile_num}]//input[@name="trend"]    ${trend}
+    user enters text into element    xpath://*[@data-testid="keyStat"][${tile_num}]//input[@name="guidanceTitle"]
+    ...    ${guidance_title}
+
+    user clicks element    xpath://*[@data-testid="keyStat"][${tile_num}]//*[contains(@class, "ck-content")]
+    user presses keys    CTRL+a+BACKSPACE
+    user presses keys    ${guidance_text}
+
+    user clicks button    Save
+    user waits until page does not contain button    Save
+
+user removes key stat
+    [Arguments]    ${tile_num}
+    user waits until page contains element    xpath://*[@data-testid="keyStat"][${tile_num}]
+    user clicks element    xpath://*[@data-testid="keyStat"][${tile_num}]//button[contains(text(), "Remove")]

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -815,12 +815,12 @@ get release id from url
     [Return]    ${release_id}
 
 user adds free text key stat
-    [Arguments]    ${title}    ${value}    ${trend}    ${guidance_title}    ${guidance_text}
+    [Arguments]    ${title}    ${statistic}    ${trend}    ${guidance_title}    ${guidance_text}
     user clicks button    Add free text key statistic
     user waits until page contains element    id:editableKeyStatTextForm-create-title
 
     user enters text into element    id:editableKeyStatTextForm-create-title    ${title}
-    user enters text into element    id:editableKeyStatTextForm-create-statistic    ${value}
+    user enters text into element    id:editableKeyStatTextForm-create-statistic    ${statistic}
     user enters text into element    id:editableKeyStatTextForm-create-trend    ${trend}
     user enters text into element    id:editableKeyStatTextForm-create-guidanceTitle    ${guidance_title}
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -845,8 +845,7 @@ user updates free text key stat
     user enters text into element    xpath://*[@data-testid="keyStat"][${tile_num}]//input[@name="guidanceTitle"]
     ...    ${guidance_title}
 
-    user clicks element    xpath://*[@data-testid="keyStat"][${tile_num}]//*[contains(@class, "ck-content")]
-    user presses keys    CTRL+a+BACKSPACE
+    user clears element text    xpath://*[@data-testid="keyStat"][${tile_num}]//*[contains(@class, "ck-content")]
     user presses keys    ${guidance_text}
 
     user clicks button    Save

--- a/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
+++ b/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
@@ -29,7 +29,8 @@ user cannot see edit controls for release content
     user waits until page does not contain button    Add note
     user waits until page does not contain button    Add related page link
     user waits until page does not contain button    Add secondary stats
-    user waits until page does not contain button    Add key statistic
+    user waits until page does not contain button    Add key statistic from data block
+    user waits until page does not contain button    Add free text key statistic
     user waits until page does not contain button    Add a headlines text block
     user waits until page does not contain button    Add new section
 

--- a/tests/robot-tests/tests/libs/charts.robot
+++ b/tests/robot-tests/tests/libs/charts.robot
@@ -158,7 +158,7 @@ user checks map tooltip item contains
     user waits until element contains    ${element}    ${text}
 
 user checks map chart indicator tile contains
-    [Arguments]    ${locator}    ${title}    ${value}
+    [Arguments]    ${locator}    ${title}    ${statistic}
     user waits until parent contains element    ${locator}
     ...    testid:mapBlock-indicator
     ${indicator}=    get child element    ${locator}    testid:mapBlock-indicator
@@ -167,9 +167,9 @@ user checks map chart indicator tile contains
     user waits until element is visible    ${indicator_title}
     user waits until element contains    ${indicator_title}    ${title}
 
-    ${indicator_value}=    get child element    ${indicator}    testid:mapBlock-indicatorTile-value
-    user waits until element is visible    ${indicator_value}
-    user waits until element contains    ${indicator_value}    ${value}
+    ${indicator_stat}=    get child element    ${indicator}    testid:mapBlock-indicatorTile-statistic
+    user waits until element is visible    ${indicator_stat}
+    user waits until element contains    ${indicator_stat}    ${statistic}
 
 user checks infographic chart contains alt
     [Arguments]    ${locator}    ${text}

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -760,13 +760,16 @@ user checks key stat contents
     user waits until element contains
     ...    css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-trend"]    ${trend}
 
-user checks key stat definition
+user checks key stat guidance
     [Arguments]    ${tile}    ${guidance_title}    ${guidance_text}
     user opens details dropdown    ${guidance_title}    css:[data-testid="keyStat"]:nth-of-type(${tile})
     user waits until element is visible
     ...    css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-guidanceText"]
     user checks element should contain
     ...    css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-guidanceText"]    ${guidance_text}
+
+    # The guidance text dropdown can hide the key stat Edit and Remove buttons
+    user closes details dropdown    ${guidance_title}    css:[data-testid="keyStat"]:nth-of-type(${tile})
 
 user checks page contains radio
     [Arguments]    ${label}

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -750,13 +750,13 @@ user checks publication bullet does not contain link
     ...    xpath://details[@open]//*[text()="${publication}"]/..//a[text()="${link}"]
 
 user checks key stat contents
-    [Arguments]    ${tile}    ${title}    ${value}    ${trend}    ${wait}=${timeout}
+    [Arguments]    ${tile}    ${title}    ${statistic}    ${trend}    ${wait}=${timeout}
     user waits until element is visible
     ...    css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-title"]    ${wait}
     user waits until element contains    css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-title"]
     ...    ${title}
-    user waits until element contains    css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-value"]
-    ...    ${value}
+    user waits until element contains
+    ...    css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-statistic"]    ${statistic}
     user waits until element contains
     ...    css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-trend"]    ${trend}
 

--- a/tests/robot-tests/tests/visual_testing/tables_and_charts.robot
+++ b/tests/robot-tests/tests/visual_testing/tables_and_charts.robot
@@ -136,7 +136,7 @@ Check Key Stats Table
     user waits until page contains element
     ...    xpath://div[@data-testid="keyStat"][${content_block.content_block_position}]
     user waits until parent contains element
-    ...    xpath://div[@data-testid="keyStat"][${content_block.content_block_position}]    testid:keyStat-value
+    ...    xpath://div[@data-testid="keyStat"][${content_block.content_block_position}]    testid:keyStat-statistic
     ${filepath}=    user takes screenshot of element
     ...    xpath://div[@data-testid="keyStat"][${content_block.content_block_position}]
     ...    ${SNAPSHOT_FOLDER}/${content_block.release_id}/${KEY_STATS_FOLDER}/${content_block.content_block_id}-table.png


### PR DESCRIPTION
This PR adds free text key stat tiles to the frontend. This includes some UI layout changes to key stats on the Admin content page - credit to Marv - visually separating the adding key stat functionality from the existing key stat / editing functionality.

I've made this PR as a draft, as I've not been able to run the UI tests - ~~I'm waiting for [EES-2469](https://github.com/dfe-analytical-services/explore-education-statistics/pull/3897) to be merged~~. Once that is merged, I'll fix the UI tests I've added, which inevitably will be failing. Edit: Oops - accidentally didn't create it as a draft - anyway I will fix regardless

### Other changes:
- Introduced `KeyStatisticType` enum - hopefully makes some key stat code clearer and less error prone.
- Made naming/labelling of key stat "statistic" consistent across the codebase - This is actually a problem of my own creation. The key stat "statistic" was originally named "value", but with the new key stat work I used  "statistic". With hindsight, I would have made my naming consistent with prior naming and used "value", but since it was 50/50 when I realised the issue, I've decided to go with "statistic".