### PR TITLE
EES-4119 - increase max table cells on dev

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -100,6 +100,9 @@
     },
     "immediatePublicationOfScheduledReleasesEnabled": {
       "value": true
+    },
+    "tableBuilderMaxTableCellsAllowed": {
+      "value": 6000000
     }
   }
 }


### PR DESCRIPTION
This PR:
* Increases the max table cells allowed on dev in order to support the performance testing of large permalinks for the potential migration to app service containers (see https://dfedigital.atlassian.net/browse/EES-4081)