### PR TITLE
EES-4092 Scale down Dev/Test/Pre-prod databases

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -89,11 +89,32 @@
     "branch": {
        "value": "dev"
     },
+    "skuContentDb": {
+      "value": "Standard"
+    },
+    "tierContentDb": {
+      "value": "Standard"
+    },
+    "capacityContentDb": {
+      "value": 50
+    },
+    "skuStatisticsDb": {
+      "value": "GP_S_Gen5"
+    },
+    "tierStatisticsDb": {
+      "value": "GeneralPurpose"
+    },
+    "capacityStatisticsDb": {
+      "value": 4
+    },
+    "minCapacityStatisticsDb": {
+      "value": "0.5"
+    },
     "maxContentDbSizeBytes": {
       "value": 1073741824
     },
     "maxStatsDbSizeBytes": {
-      "value": 322122547200
+      "value": 268435456000
     },
     "dataFactoryConcurrency": {
       "value": 10

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -56,6 +56,27 @@
     "tableBuilderMaxTableCellsAllowed": {
       "value": 1000000
     },
+    "skuContentDb": {
+      "value": "Standard"
+    },
+    "tierContentDb": {
+      "value": "Standard"
+    },
+    "capacityContentDb": {
+      "value": 50
+    },
+    "skuStatisticsDb": {
+      "value": "GP_S_Gen5"
+    },
+    "tierStatisticsDb": {
+      "value": "GeneralPurpose"
+    },
+    "capacityStatisticsDb": {
+      "value": 4
+    },
+    "minCapacityStatisticsDb": {
+      "value": "0.5"
+    },
     "maxContentDbSizeBytes": {
       "value": 1073741824
     },

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -56,23 +56,29 @@
     "storageAccountPrefix": {
       "value": "sa"
     },
-    "minCapacityStatisticsDb": {
-      "value": "4"
+    "skuContentDb": {
+      "value": "GP_S_Gen5"
     },
-    "maxCapacityStatisticsDb": {
-      "value": 10
+    "tierContentDb": {
+      "value": "GeneralPurpose"
     },
-    "autoPauseDelayStatisticsDb": {
-      "value": -1
+    "capacityContentDb": {
+      "value": 6
     },
     "minCapacityContentDb": {
       "value": "2"
     },
-    "maxCapacityContentDb": {
-      "value": 6
+    "skuStatisticsDb": {
+      "value": "GP_S_Gen5"
     },
-    "autoPauseDelayContentDb": {
-      "value": -1
+    "tierStatisticsDb": {
+      "value": "GeneralPurpose"
+    },
+    "capacityStatisticsDb": {
+      "value": 10
+    },
+    "minCapacityStatisticsDb": {
+      "value": "4"
     },
     "enableAlerts": {
       "value": true

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -71,6 +71,24 @@
     "tableBuilderMaxTableCellsAllowed": {
       "value": 1000000
     },
+    "skuContentDb": {
+      "value": "Standard"
+    },
+    "tierContentDb": {
+      "value": "Standard"
+    },
+    "capacityContentDb": {
+      "value": 10
+    },
+    "skuStatisticsDb": {
+      "value": "Standard"
+    },
+    "tierStatisticsDb": {
+      "value": "Standard"
+    },
+    "capacityStatisticsDb": {
+      "value": 50
+    },
     "maxContentDbSizeBytes": {
       "value": 1073741824
     },

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -638,29 +638,59 @@
         "dev"
       ]
     },
-    "minCapacityStatisticsDb": {
+    "skuContentDb": {
       "type": "string",
-      "defaultValue": "0.75"
+      "allowedValues": [
+        "Free",
+        "Basic",
+        "Standard",
+        "Premium",
+        "GP_S_Gen5"
+      ]
     },
-    "maxCapacityStatisticsDb": {
-      "type": "int",
-      "defaultValue": 1
+    "skuStatisticsDb": {
+      "type": "string",
+      "allowedValues": [
+        "Free",
+        "Basic",
+        "Standard",
+        "Premium",
+        "GP_S_Gen5"
+      ]
     },
-    "autoPauseDelayStatisticsDb": {
-      "type": "int",
-      "defaultValue": -1
+    "tierContentDb": {
+      "type": "string",
+      "allowedValues": [
+        "Free",
+        "Basic",
+        "Standard",
+        "Premium",
+        "GeneralPurpose"
+      ]
+    },
+    "tierStatisticsDb": {
+      "type": "string",
+      "allowedValues": [
+        "Free",
+        "Basic",
+        "Standard",
+        "Premium",
+        "GeneralPurpose"
+      ]
     },
     "minCapacityContentDb": {
       "type": "string",
-      "defaultValue": "0.75"
+      "defaultValue": null
     },
-    "maxCapacityContentDb": {
-      "type": "int",
-      "defaultValue": 1
+    "capacityContentDb": {
+      "type": "int"
     },
-    "autoPauseDelayContentDb": {
-      "type": "int",
-      "defaultValue": -1
+    "minCapacityStatisticsDb": {
+      "type": "string",
+      "defaultValue": null
+    },
+    "capacityStatisticsDb": {
+      "type": "int"
     },
     "deploySlotName": {
       "type": "string",
@@ -2108,7 +2138,7 @@
     {
       "name": "[variables('coreSqlServerName')]",
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2019-06-01-preview",
+      "apiVersion": "2022-05-01-preview",
       "location": "[resourceGroup().location]",
       "properties": {
         "administratorLogin": "[parameters('sqlAdministratorLogin')]",
@@ -2118,6 +2148,7 @@
       "resources": [
         {
           "type": "databases",
+          "apiVersion": "2022-05-01-preview",
           "name": "[variables('statisticsDbName')]",
           "location": "[resourceGroup().location]",
           "tags": {
@@ -2133,31 +2164,28 @@
             "DeploymentRepo": "[parameters('deploymentRepo')]",
             "DeploymentScript": "[parameters('deploymentScript')]"
           },
-          "apiVersion": "2020-08-01-preview",
           "dependsOn": [
             "[variables('coreSqlServerName')]"
           ],
           "sku": {
-            "name": "GP_S_Gen5",
-            "tier": "GeneralPurpose",
-            "family": "Gen5",
-            "capacity": "[parameters('maxCapacityStatisticsDb')]"
+            "name": "[parameters('skuStatisticsDb')]",
+            "tier": "[parameters('tierStatisticsDb')]",
+            "capacity": "[parameters('capacityStatisticsDb')]"
           },
-          "kind": "v12.0,user,vcore,serverless",
           "properties": {
             "collation": "SQL_Latin1_General_CP1_CI_AS",
             "maxSizeBytes": "[parameters('maxStatsDbSizeBytes')]",
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,
             "readScale": "Disabled",
-            "autoPauseDelay": "[parameters('autoPauseDelayStatisticsDb')]",
             "storageAccountType": "GRS",
             "minCapacity": "[parameters('minCapacityStatisticsDb')]"
           }
         },
         {
-          "name": "[variables('contentDbName')]",
           "type": "databases",
+          "apiVersion": "2022-05-01-preview",
+          "name": "[variables('contentDbName')]",
           "location": "[resourceGroup().location]",
           "tags": {
             "Department": "[parameters('departmentName')]",
@@ -2172,24 +2200,20 @@
             "DeploymentRepo": "[parameters('deploymentRepo')]",
             "DeploymentScript": "[parameters('deploymentScript')]"
           },
-          "apiVersion": "2020-08-01-preview",
           "dependsOn": [
             "[variables('coreSqlServerName')]"
           ],
           "sku": {
-            "name": "GP_S_Gen5",
-            "tier": "GeneralPurpose",
-            "family": "Gen5",
-            "capacity": "[parameters('maxCapacityContentDb')]"
+            "name": "[parameters('skuContentDb')]",
+            "tier": "[parameters('tierContentDb')]",
+            "capacity": "[parameters('capacityContentDb')]"
           },
-          "kind": "v12.0,user,vcore,serverless",
           "properties": {
             "collation": "SQL_Latin1_General_CP1_CI_AS",
             "maxSizeBytes": "[parameters('maxContentDbSizeBytes')]",
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,
             "readScale": "Disabled",
-            "autoPauseDelay": "[parameters('autoPauseDelayContentDb')]",
             "storageAccountType": "GRS",
             "minCapacity": "[parameters('minCapacityContentDb')]"
           }
@@ -2357,7 +2381,7 @@
     {
       "name": "[variables('publicSqlServerName')]",
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2019-06-01-preview",
+      "apiVersion": "2022-05-01-preview",
       "location": "[resourceGroup().location]",
       "properties": {
         "administratorLogin": "[parameters('sqlAdministratorLogin')]",
@@ -2367,6 +2391,7 @@
       "resources": [
         {
           "type": "databases",
+          "apiVersion": "2022-05-01-preview",
           "name": "[variables('statisticsReplicaDbName')]",
           "location": "[resourceGroup().location]",
           "tags": {
@@ -2382,25 +2407,21 @@
             "DeploymentRepo": "[parameters('deploymentRepo')]",
             "DeploymentScript": "[parameters('deploymentScript')]"
           },
-          "apiVersion": "2020-08-01-preview",
           "dependsOn": [
             "[variables('publicSqlServerName')]",
             "[resourceId('Microsoft.Sql/servers/databases', variables('coreSqlServerName'), variables('statisticsDbName'))]"
           ],
           "sku": {
-            "name": "GP_S_Gen5",
-            "tier": "GeneralPurpose",
-            "family": "Gen5",
-            "capacity": "[parameters('maxCapacityStatisticsDb')]"
+            "name": "[parameters('skuStatisticsDb')]",
+            "tier": "[parameters('tierStatisticsDb')]",
+            "capacity": "[parameters('capacityStatisticsDb')]"
           },
-          "kind": "v12.0,user,vcore,serverless",
           "properties": {
             "collation": "SQL_Latin1_General_CP1_CI_AS",
             "maxSizeBytes": "[parameters('maxStatsDbSizeBytes')]",
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,
             "readScale": "Disabled",
-            "autoPauseDelay": "[parameters('autoPauseDelayStatisticsDb')]",
             "storageAccountType": "GRS",
             "minCapacity": "[parameters('minCapacityStatisticsDb')]",
             "createMode": "OnlineSecondary",


### PR DESCRIPTION
Changes in this PR:

- Change Dev/Pre-Prod content databases to use DTU purchasing model, capacity 50 DTU's.
- Change Test content database to use DTU purchasing model, capacity 10 DTU's.
- Change Test statistics databases to use DTU purchasing model, capacity 50 DTU's.
- Change Min-max vCores of Dev/Pre-prod statistics databases from 0.75-1 to 0.5-4.
- Reduce Dev statistics database size from 300Gb to 250Gb.

There's a significant annual cost saving to be made just by making these changes to Dev/Test/Pre-prod.

The investigation behind this change considered auto-pause, and swapping away from serverless to use provisioned databases including with reservations. See the writeup [EES-4092](https://dfedigital.atlassian.net/browse/EES-4092).
