### PR TITLE
EES-4092 Fix deployment error caused by null default values

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -680,14 +680,14 @@
     },
     "minCapacityContentDb": {
       "type": "string",
-      "defaultValue": null
+      "defaultValue": ""
     },
     "capacityContentDb": {
       "type": "int"
     },
     "minCapacityStatisticsDb": {
       "type": "string",
-      "defaultValue": null
+      "defaultValue": ""
     },
     "capacityStatisticsDb": {
       "type": "int"
@@ -2179,7 +2179,7 @@
             "zoneRedundant": false,
             "readScale": "Disabled",
             "storageAccountType": "GRS",
-            "minCapacity": "[parameters('minCapacityStatisticsDb')]"
+            "minCapacity": "[if(not(empty(parameters('minCapacityStatisticsDb'))), parameters('minCapacityStatisticsDb'), json('null'))]"
           }
         },
         {
@@ -2215,7 +2215,7 @@
             "zoneRedundant": false,
             "readScale": "Disabled",
             "storageAccountType": "GRS",
-            "minCapacity": "[parameters('minCapacityContentDb')]"
+            "minCapacity": "[if(not(empty(parameters('minCapacityContentDb'))), parameters('minCapacityContentDb'), json('null'))]"
           }
         },
         {
@@ -2423,7 +2423,7 @@
             "zoneRedundant": false,
             "readScale": "Disabled",
             "storageAccountType": "GRS",
-            "minCapacity": "[parameters('minCapacityStatisticsDb')]",
+            "minCapacity": "[if(not(empty(parameters('minCapacityStatisticsDb'))), parameters('minCapacityStatisticsDb'), json('null'))]",
             "createMode": "OnlineSecondary",
             "sourceDatabaseId": "[resourceId('Microsoft.Sql/servers/databases', variables('coreSqlServerName'), variables('statisticsDbName'))]",
             "secondaryType": "Geo"


### PR DESCRIPTION
This PR should fix the arm template validation/deployment failure seen in DevOps currently which is caused by https://github.com/dfe-analytical-services/explore-education-statistics/pull/3909 attempting to create optional parameters which default to `null` which is not allowed.

We've run into this issue previously, see attempts in [here](https://github.com/dfe-analytical-services/explore-education-statistics/pull/3446/files) and [here](https://github.com/dfe-analytical-services/explore-education-statistics/pull/3447/files#diff-df68079c12e13e39423a2e795f489815684f257e5c884a2c15f38cde357671e8) and it looks like there's no other way around it as the parameter values are non-nullable. It appears to be impossible to have an optional parameter with a null value.