### PR TITLE
EES-4140 - decrease maxTableCells allowed on dev

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -121,9 +121,6 @@
     },
     "immediatePublicationOfScheduledReleasesEnabled": {
       "value": true
-    },
-    "tableBuilderMaxTableCellsAllowed": {
-      "value": 6000000
     }
   }
 }


### PR DESCRIPTION
This PR: 
* reverts the maxTableCellsAllowed back to its default value of 25000 on development environments (due to the conclusion of recent performance testing)