### PR TITLE
EES-4059 move related dashboards link up

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -198,17 +198,17 @@ const ReleaseContent = () => {
                     </Button>
                   </li>
                 )}
+                {!!release.relatedDashboardsSection?.content.length && (
+                  <li>
+                    <a href="#related-dashboards">View related dashboard(s)</a>
+                  </li>
+                )}
                 <li>
                   <a href="#releaseMainContent">Release contents</a>
                 </li>
                 <li>
                   <a href="#explore-data-and-files">Explore data</a>
                 </li>
-                {!!release.relatedDashboardsSection?.content.length && (
-                  <li>
-                    <a href="#related-dashboards">View related dashboard(s)</a>
-                  </li>
-                )}
                 <li>
                   <a href="#help-and-support">Help and support</a>
                 </li>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -254,6 +254,11 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                     </ButtonLink>
                   </li>
                 )}
+                {!!release.relatedDashboardsSection?.content.length && (
+                  <li>
+                    <a href="#related-dashboards">View related dashboard(s)</a>
+                  </li>
+                )}
                 <li>
                   <a
                     href="#content"
@@ -282,11 +287,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                     Explore data
                   </a>
                 </li>
-                {!!release.relatedDashboardsSection?.content.length && (
-                  <li>
-                    <a href="#related-dashboards">View related dashboard(s)</a>
-                  </li>
-                )}
+
                 <li>
                   <a
                     href="#help-and-support"

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
@@ -155,14 +155,14 @@ describe('PublicationReleasePage', () => {
 
     expect(quickLinks).toHaveLength(4);
 
-    expect(quickLinks[0]).toHaveTextContent('Release contents');
-    expect(quickLinks[0]).toHaveAttribute('href', '#content');
+    expect(quickLinks[0]).toHaveTextContent('View related dashboard(s)');
+    expect(quickLinks[0]).toHaveAttribute('href', '#related-dashboards');
 
-    expect(quickLinks[1]).toHaveTextContent('Explore data');
-    expect(quickLinks[1]).toHaveAttribute('href', '#explore-data-and-files');
+    expect(quickLinks[1]).toHaveTextContent('Release contents');
+    expect(quickLinks[1]).toHaveAttribute('href', '#content');
 
-    expect(quickLinks[2]).toHaveTextContent('View related dashboard(s)');
-    expect(quickLinks[2]).toHaveAttribute('href', '#related-dashboards');
+    expect(quickLinks[2]).toHaveTextContent('Explore data');
+    expect(quickLinks[2]).toHaveAttribute('href', '#explore-data-and-files');
 
     expect(quickLinks[3]).toHaveTextContent('Help and support');
     expect(quickLinks[3]).toHaveAttribute('href', '#help-and-support');


### PR DESCRIPTION
Moves the 'View related dashboards' link up to just below the Download all data button.