### PR TITLE
🐛 EES-4092 Disable auto-pause

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2178,6 +2178,7 @@
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,
             "readScale": "Disabled",
+            "autoPauseDelay": -1,
             "storageAccountType": "GRS",
             "minCapacity": "[if(not(empty(parameters('minCapacityStatisticsDb'))), parameters('minCapacityStatisticsDb'), json('null'))]"
           }
@@ -2214,6 +2215,7 @@
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,
             "readScale": "Disabled",
+            "autoPauseDelay": -1,
             "storageAccountType": "GRS",
             "minCapacity": "[if(not(empty(parameters('minCapacityContentDb'))), parameters('minCapacityContentDb'), json('null'))]"
           }
@@ -2422,6 +2424,7 @@
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,
             "readScale": "Disabled",
+            "autoPauseDelay": -1,
             "storageAccountType": "GRS",
             "minCapacity": "[if(not(empty(parameters('minCapacityStatisticsDb'))), parameters('minCapacityStatisticsDb'), json('null'))]",
             "createMode": "OnlineSecondary",


### PR DESCRIPTION
This PR disables auto-pause for databases using vCore serverless settings.

#3915 made a change which mistakenly enabled it, after assuming `autoPauseDelay` has a default value of `-1` which is not the case, see [Microsoft.Sql servers/databases](https://learn.microsoft.com/en-us/azure/templates/microsoft.sql/servers/databases?pivots=deployment-language-arm-template).

Without this alteration auto-pause would be enabled for all databases using vCore serverless config, i.e. the statistics and statistics geo-replica in all environments and the content database in Prod which we don't want right now, especially since auto pausing is not compatible with geo replication.

