### PR TITLE
EES-3913 Add input length validation and fix KeyStatisticDataBlock cascade delete bug

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230228123640_EES3913RemoveCascadeDeleteOnKeyStatDataBlockTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230228123640_EES3913RemoveCascadeDeleteOnKeyStatDataBlockTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230228123640_EES3913RemoveCascadeDeleteOnKeyStatDataBlockTable")]
+    partial class EES3913RemoveCascadeDeleteOnKeyStatDataBlockTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230228123640_EES3913RemoveCascadeDeleteOnKeyStatDataBlockTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230228123640_EES3913RemoveCascadeDeleteOnKeyStatDataBlockTable.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES3913RemoveCascadeDeleteOnKeyStatDataBlockTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_KeyStatisticsDataBlock_ContentBlock_DataBlockId",
+                table: "KeyStatisticsDataBlock");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_KeyStatisticsDataBlock_ContentBlock_DataBlockId",
+                table: "KeyStatisticsDataBlock",
+                column: "DataBlockId",
+                principalTable: "ContentBlock",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_KeyStatisticsDataBlock_ContentBlock_DataBlockId",
+                table: "KeyStatisticsDataBlock");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_KeyStatisticsDataBlock_ContentBlock_DataBlockId",
+                table: "KeyStatisticsDataBlock",
+                column: "DataBlockId",
+                principalTable: "ContentBlock",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/KeyStatisticRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/KeyStatisticRequests.cs
@@ -1,5 +1,7 @@
 #nullable enable
 using System;
+using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
@@ -7,8 +9,10 @@ public record KeyStatisticDataBlockCreateRequest
 {
     public Guid DataBlockId { get; set; }
 
+    [MaxLength(KeyStatistic.TrendMaxLength)]
     public string? Trend { get; set; }
 
+    [MaxLength(KeyStatistic.GuidanceTitleMaxLength)]
     public string? GuidanceTitle { get; set; }
 
     public string? GuidanceText { get; set; }
@@ -16,8 +20,10 @@ public record KeyStatisticDataBlockCreateRequest
 
 public record KeyStatisticDataBlockUpdateRequest
 {
+    [MaxLength(KeyStatistic.TrendMaxLength)]
     public string? Trend { get; set; }
 
+    [MaxLength(KeyStatistic.GuidanceTitleMaxLength)]
     public string? GuidanceTitle { get; set; }
 
     public string? GuidanceText { get; set; }
@@ -25,12 +31,16 @@ public record KeyStatisticDataBlockUpdateRequest
 
 public abstract record KeyStatisticTextSaveRequest
 {
+    [MaxLength(KeyStatistic.TitleMaxLength)]
     public string Title { get; set; } = string.Empty;
 
+    [MaxLength(KeyStatistic.StatisticMaxLength)]
     public string Statistic { get; set; } = string.Empty;
 
+    [MaxLength(KeyStatistic.TrendMaxLength)]
     public string? Trend { get; set; }
 
+    [MaxLength(KeyStatistic.GuidanceTitleMaxLength)]
     public string? GuidanceTitle { get; set; }
 
     public string? GuidanceText { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -90,7 +90,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public Task<Either<ActionResult, Unit>> DeleteDataBlocks(DeleteDataBlockPlan deletePlan)
         {
             return InvalidateDataBlockCaches(deletePlan)
-                .OnSuccess(() => DeleteDependentDataBlocks(deletePlan))
                 .OnSuccessVoid(async () =>
                 {
                     var dataBlockIds = deletePlan.DependentDataBlocks
@@ -102,7 +101,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     await _context.SaveChangesAsync();
 
                     await RemoveChartFileReleaseLinks(deletePlan);
-                });
+                })
+                .OnSuccess(() => DeleteDependentDataBlocks(deletePlan));
         }
 
         public async Task<Either<ActionResult, Unit>> RemoveChartFile(Guid releaseId, Guid id)
@@ -403,11 +403,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<bool> IsUnattachedDataBlock(Guid releaseId, DataBlock dataBlock)
         {
-                return dataBlock.ContentSectionId == null
-                       && await _context.KeyStatisticsDataBlock
-                           .Where(ks =>ks.ReleaseId == releaseId)
-                           .AllAsync(ks =>
-                               ks.DataBlockId != dataBlock.Id);
+            return dataBlock.ContentSectionId == null
+                   && await _context.KeyStatisticsDataBlock
+                       .Where(ks =>ks.ReleaseId == releaseId)
+                       .AllAsync(ks =>
+                           ks.DataBlockId != dataBlock.Id);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -539,9 +539,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
             modelBuilder.Entity<KeyStatisticDataBlock>()
                 .HasOne<DataBlock>(ks => ks.DataBlock)
                 .WithMany()
-                // WARN: This is necessary - otherwise a cascade delete occurs when an associated data block is removed.
-                // This cascade delete _only_ removes the KeyStatisticsDataBlock entry, leaving a KeyStatistics table
-                // entry.
+                // WARN: This is necessary - otherwise an automatically generated cascade delete is added for when an
+                // associated data block is removed. That cascade delete _only_ removes the KeyStatisticsDataBlock
+                // entry, leaving a KeyStatistics table entry, which should never happen.
                 .OnDelete(DeleteBehavior.NoAction);
 
             modelBuilder.Entity<KeyStatisticText>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -535,6 +535,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
 
             modelBuilder.Entity<KeyStatisticDataBlock>()
                 .ToTable("KeyStatisticsDataBlock");
+
+            modelBuilder.Entity<KeyStatisticDataBlock>()
+                .HasOne<DataBlock>(ks => ks.DataBlock)
+                .WithMany()
+                // WARN: This is necessary - otherwise a cascade delete occurs when an associated data block is removed.
+                // This cascade delete _only_ removes the KeyStatisticsDataBlock entry, leaving a KeyStatistics table
+                // entry.
+                .OnDelete(DeleteBehavior.NoAction);
+
             modelBuilder.Entity<KeyStatisticText>()
                 .ToTable("KeyStatisticsText");
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/KeyStatistic.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/KeyStatistic.cs
@@ -6,6 +6,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 public abstract class KeyStatistic : ICreatedUpdatedTimestamps<DateTime, DateTime?>
 {
+    public const int TitleMaxLength = 24;
+    public const int StatisticMaxLength = 11;
+    public const int TrendMaxLength = 229;
+    public const int GuidanceTitleMaxLength = 65;
+
     public Guid Id { get; set; }
 
     public Guid ReleaseId { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/KeyStatistic.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/KeyStatistic.cs
@@ -6,9 +6,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 public abstract class KeyStatistic : ICreatedUpdatedTimestamps<DateTime, DateTime?>
 {
-    public const int TitleMaxLength = 24;
-    public const int StatisticMaxLength = 11;
-    public const int TrendMaxLength = 229;
+    public const int TitleMaxLength = 25;
+    public const int StatisticMaxLength = 12;
+    public const int TrendMaxLength = 230;
     public const int GuidanceTitleMaxLength = 65;
 
     public Guid Id { get; set; }

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
@@ -57,7 +57,7 @@ const EditableKeyStatDataBlockForm = ({
         guidanceText: keyStat.guidanceText ? toHtml(keyStat.guidanceText) : '',
       }}
       validationSchema={Yup.object<KeyStatDataBlockFormValues>({
-        trend: Yup.string().max(229),
+        trend: Yup.string().max(230),
         guidanceTitle: Yup.string().max(65),
         guidanceText: Yup.string(),
       })}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
@@ -11,6 +11,8 @@ import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile'
 import { KeyStatisticDataBlock } from '@common/services/publicationService';
 import { Formik } from 'formik';
 import React from 'react';
+import Yup from '@common/validation/yup';
+import { KeyStatTextFormValues } from '@admin/pages/release/content/components/EditableKeyStatTextForm';
 
 export interface KeyStatDataBlockFormValues {
   trend: string;
@@ -54,6 +56,11 @@ const EditableKeyStatDataBlockForm = ({
         guidanceTitle: keyStat.guidanceTitle ?? 'Help',
         guidanceText: keyStat.guidanceText ? toHtml(keyStat.guidanceText) : '',
       }}
+      validationSchema={Yup.object<KeyStatDataBlockFormValues>({
+        trend: Yup.string().max(229),
+        guidanceTitle: Yup.string().max(65),
+        guidanceText: Yup.string(),
+      })}
       onSubmit={handleSubmit}
     >
       {form => (

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
@@ -57,9 +57,9 @@ export default function EditableKeyStatTextForm({
             : '',
         }}
         validationSchema={Yup.object<KeyStatTextFormValues>({
-          title: Yup.string().required('Enter a title').max(24),
-          statistic: Yup.string().required('Enter a statistic').max(11),
-          trend: Yup.string().max(229),
+          title: Yup.string().required('Enter a title').max(25),
+          statistic: Yup.string().required('Enter a statistic').max(12),
+          trend: Yup.string().max(230),
           guidanceTitle: Yup.string().max(65),
           guidanceText: Yup.string(),
         })}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
@@ -57,10 +57,10 @@ export default function EditableKeyStatTextForm({
             : '',
         }}
         validationSchema={Yup.object<KeyStatTextFormValues>({
-          title: Yup.string().required('Enter a title'),
-          statistic: Yup.string().required('Enter a statistic'),
-          trend: Yup.string(),
-          guidanceTitle: Yup.string(),
+          title: Yup.string().required('Enter a title').max(24),
+          statistic: Yup.string().required('Enter a statistic').max(11),
+          trend: Yup.string().max(229),
+          guidanceTitle: Yup.string().max(65),
           guidanceText: Yup.string(),
         })}
         onSubmit={handleSubmit}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
@@ -224,7 +224,7 @@ describe('EditableKeyStatText', () => {
       await userEvent.type(screen.getByLabelText('Title'), 'New title');
 
       userEvent.clear(screen.getByLabelText('Statistic'));
-      await userEvent.type(screen.getByLabelText('Statistic'), 'New statistic');
+      await userEvent.type(screen.getByLabelText('Statistic'), 'New stat');
 
       userEvent.clear(screen.getByLabelText('Trend'));
       await userEvent.type(screen.getByLabelText('Trend'), 'New trend');
@@ -246,7 +246,7 @@ describe('EditableKeyStatText', () => {
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith<KeyStatTextFormValues[]>({
           title: 'New title',
-          statistic: 'New statistic',
+          statistic: 'New stat',
           trend: 'New trend',
           guidanceTitle: 'New guidance title',
           guidanceText: 'New guidance text',

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -638,11 +638,11 @@ Navigate to 'Content' page for amendment
     user waits until page contains button    Add a summary text block
 
 Update free text key stat
-    user updates free text key stat    1    Updated title    Updated statistic    Updated trend
+    user updates free text key stat    1    Updated title    New stat    Updated trend
     ...    Updated guidance title    Updated guidance text
 
     user checks element count is x    testid:keyStat    1
-    user checks key stat contents    1    Updated title    Updated statistic    Updated trend
+    user checks key stat contents    1    Updated title    New stat    Updated trend
     user checks key stat guidance    1    Updated guidance title    Updated guidance text
 
 Verify amended Dates data block table has footnotes
@@ -753,7 +753,7 @@ Verify amendment is published
 
 Verify amendment free text key stat is updated
     user checks element count is x    testid:keyStat    1
-    user checks key stat contents    1    Updated title    Updated statistic    Updated trend
+    user checks key stat contents    1    Updated title    New stat    Updated trend
     user checks key stat guidance    1    Updated guidance title    Updated guidance text
 
 Verify amendment files


### PR DESCRIPTION
This PR makes two changes:

### Adds input length validation for key stats. 

Specifically for the title, statistic, trend, and guidance title field. Lengths have been chosen based on a combination of what is currently the max length in use on production and what fits the UI. These values have been run past Cam.

On the backend, the lengths are stored as consts in the `KeyStatistic` class. This was done because originally we intended add these contraints to the database, which means they were reused more times. This is also why I haven't made a similar change on the frontend - it doesn't seem worth creating a central location for them given they only get used two places at most. But obviously happy to change that if others want that.

### Fixes KeyStatisticDataBlock cascade delete bug

Nusrath found a bug where entries from `KeyStatisticsDataBlock` table were being removed without the associated `KeyStatistics` table entry being removed. This was happening due to this code:
```
            modelBuilder.Entity<KeyStatisticDataBlock>()
                .ToTable("KeyStatisticsDataBlock");
```
This code was adding a cascade delete on the `DataBlockId`, if the associated entry in the `ContentBlock` table was removed. Credit to Ben to working out what to add to `ContentDbContext` to remove this cascade delete. This change also meant that a `KeyStatisticDataBlock` must be removed before its associated `DataBlock` object can be removed.