### PR TITLE
EES-4059 link to help and support heading not accordion

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHelpAndSupportSection.tsx
@@ -46,11 +46,12 @@ const ReleaseHelpAndSupportSection = ({
       <h2
         className="govuk-heading-m govuk-!-margin-top-9"
         data-testid="extra-information"
+        id="help-and-support"
       >
         Help and support
       </h2>
 
-      <Accordion id="helpAndSupport">
+      <Accordion id="help-and-support-accordion">
         <AccordionSection
           heading="Methodology"
           caption="Find out how and why we collect, process and publish these statistics"

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
@@ -18,7 +18,6 @@ import ManagementInformationSection from '@common/modules/find-statistics/compon
 
 interface Props {
   includeAnalytics?: boolean;
-  accordionId: string;
   publicationTitle: string;
   methodologies: MethodologySummary[];
   externalMethodology?: ExternalMethodology;
@@ -27,7 +26,6 @@ interface Props {
 }
 
 const PublicationReleaseHelpAndSupportSection = ({
-  accordionId,
   includeAnalytics = false,
   publicationTitle,
   methodologies,
@@ -40,11 +38,12 @@ const PublicationReleaseHelpAndSupportSection = ({
       <h2
         className="govuk-heading-m govuk-!-margin-top-9"
         data-testid="extra-information"
+        id="help-and-support"
       >
         Help and support
       </h2>
       <AccordionComponent
-        accordionId={accordionId}
+        accordionId="help-and-support-accordion"
         includeAnalytics={includeAnalytics}
         publicationTitle={publicationTitle}
       >

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -571,7 +571,6 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
       )}
 
       <PublicationReleaseHelpAndSupportSection
-        accordionId="help-and-support"
         publicationTitle={release.publication.title}
         methodologies={release.publication.methodologies}
         externalMethodology={release.publication.externalMethodology}

--- a/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
@@ -133,7 +133,7 @@ Validate Analyst1 can see 'Content' page accordion sections
     user checks accordion is in position    Pupil referral unit absence    8    id:releaseMainContent
     user checks accordion is in position    Regional and local authority (LA) breakdown    9    id:releaseMainContent
     user checks there are x accordion sections    9    id:releaseMainContent
-    user checks accordion is in position    Methodology    1    id:helpAndSupport
-    user checks accordion is in position    Official statistics    2    id:helpAndSupport
-    user checks accordion is in position    Contact us    3    id:helpAndSupport
-    user checks there are x accordion sections    3    id:helpAndSupport
+    user checks accordion is in position    Methodology    1    id:help-and-support-accordion
+    user checks accordion is in position    Official statistics    2    id:help-and-support-accordion
+    user checks accordion is in position    Contact us    3    id:help-and-support-accordion
+    user checks there are x accordion sections    3    id:help-and-support-accordion

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
@@ -78,7 +78,7 @@ Go to public release page
     user waits until h1 is visible    ${PUBLICATION_NAME_UPDATED}    %{WAIT_MEDIUM}
 
 Validate publication details are updated on public page
-    ${section}=    user opens accordion section    Contact us    css:#help-and-support
+    ${section}=    user opens accordion section    Contact us    css:#help-and-support-accordion
     user checks element contains    ${section}    Team name updated
     user checks element contains    ${section}    email_updated@test.com
     user checks element contains    ${section}    Contact name updated

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -389,9 +389,9 @@ Verify accordions are correct
     user checks accordion is in position    Test text    2    id:content
     user checks accordion is in position    Test embedded dashboard section    3    id:content
 
-    user checks there are x accordion sections    2    id:help-and-support
-    user checks accordion is in position    National statistics    1    id:help-and-support
-    user checks accordion is in position    Contact us    2    id:help-and-support
+    user checks there are x accordion sections    2    id:help-and-support-accordion
+    user checks accordion is in position    National statistics    1    id:help-and-support-accordion
+    user checks accordion is in position    Contact us    2    id:help-and-support-accordion
 
 Verify Dates data block accordion section
     user opens accordion section    Dates data block    id:content
@@ -846,8 +846,8 @@ Verify amendment accordions are correct
     user checks accordion is in position    Dates data block    1    id:content
     user checks accordion is in position    Test text    2    id:content
     user checks accordion is in position    Test embedded dashboard section    3    id:content
-    user checks accordion is in position    Experimental statistics    1    id:help-and-support
-    user checks accordion is in position    Contact us    2    id:help-and-support
+    user checks accordion is in position    Experimental statistics    1    id:help-and-support-accordion
+    user checks accordion is in position    Contact us    2    id:help-and-support-accordion
 
 Verify amendment Dates data block accordion section
     user opens accordion section    Dates data block    id:content

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -241,11 +241,11 @@ Validate accordion sections order
 
     user checks there are x accordion sections    9    id:content
 
-    user checks accordion is in position    Methodology    1    id:help-and-support
-    user checks accordion is in position    Official statistics    2    id:help-and-support
-    user checks accordion is in position    Contact us    3    id:help-and-support
+    user checks accordion is in position    Methodology    1    id:help-and-support-accordion
+    user checks accordion is in position    Official statistics    2    id:help-and-support-accordion
+    user checks accordion is in position    Contact us    3    id:help-and-support-accordion
 
-    user checks there are x accordion sections    3    id:help-and-support
+    user checks there are x accordion sections    3    id:help-and-support-accordion
 
 Check explore data link opens accordion section
     user verifies accordion is closed    Explore data and files


### PR DESCRIPTION
Changes the Help and Support quick link on release pages to link to the Help and Support heading instead of the accordion.