### PR TITLE
EES-4156 Alter Prod serverless content db configuration

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -63,10 +63,10 @@
       "value": "GeneralPurpose"
     },
     "capacityContentDb": {
-      "value": 6
+      "value": 4
     },
     "minCapacityContentDb": {
-      "value": "2"
+      "value": "0.5"
     },
     "skuStatisticsDb": {
       "value": "GP_S_Gen5"


### PR DESCRIPTION
This PR alters the configuration of the Prod serverless content database.

It changes the capacity from 6 vCores to 4 vCores and the minimum capacity from 2 vCores to 0.5 vCores.

We are making this change because we've seen that the database has very low utilisation at the current config.

![image (25)](https://user-images.githubusercontent.com/4147126/222517439-d708b789-18a0-4bdc-9509-f3bd7b6cc5b8.png)
