### PR TITLE
EES-3763 Remove Azure Data Factory config for public statistics database

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -47,28 +47,6 @@
       ]
     },
     {
-      "name": "[concat(parameters('factoryName'), '/ls_sql_public_statistics')]",
-      "type": "Microsoft.DataFactory/factories/linkedServices",
-      "apiVersion": "2018-06-01",
-      "properties": {
-        "annotations": [],
-        "type": "AzureSqlDatabase",
-        "typeProperties": {
-          "connectionString": {
-            "type": "AzureKeyVaultSecret",
-            "store": {
-              "referenceName": "AzureKeyVault",
-              "type": "LinkedServiceReference"
-            },
-            "secretName": "ees-sql-public-datafactory-connectionstring"
-          }
-        }
-      },
-      "dependsOn": [
-        "[concat(variables('factoryId'), '/linkedServices/AzureKeyVault')]"
-      ]
-    },
-    {
       "name": "[concat(parameters('factoryName'), '/AzureKeyVault')]",
       "type": "Microsoft.DataFactory/factories/linkedServices",
       "apiVersion": "2018-06-01",
@@ -139,136 +117,6 @@
       },
       "dependsOn": [
         "[concat(variables('factoryId'), '/linkedServices/ls_sql_statistics')]"
-      ]
-    },
-    {
-      "name": "[concat(parameters('factoryName'), '/pl_rebuild_public_statistics_indexes')]",
-      "type": "Microsoft.DataFactory/factories/pipelines",
-      "apiVersion": "2018-06-01",
-      "properties": {
-        "activities": [
-          {
-            "name": "sp_rebuild_indexes",
-            "type": "SqlServerStoredProcedure",
-            "dependsOn": [],
-            "policy": {
-              "timeout": "0.12:00:00",
-              "retry": 0,
-              "retryIntervalInSeconds": 30,
-              "secureOutput": false,
-              "secureInput": false
-            },
-            "userProperties": [],
-            "typeProperties": {
-              "storedProcedureName": "[[dbo].[RebuildIndexes]",
-              "storedProcedureParameters": {
-                "Percent": {
-                  "value": {
-                    "value": "@pipeline().parameters.Percentage",
-                    "type": "Expression"
-                  },
-                  "type": "Int32"
-                },
-                "Tables": {
-                  "value": {
-                    "value": "@pipeline().parameters.Tables",
-                    "type": "Expression"
-                  },
-                  "type": "String"
-                }
-              }
-            },
-            "linkedServiceName": {
-              "referenceName": "ls_sql_public_statistics",
-              "type": "LinkedServiceReference"
-            }
-          }
-        ],
-        "parameters": {
-          "Percentage": {
-            "type": "int",
-            "defaultValue": 70
-          },
-          "Tables": {
-            "type": "string",
-            "defaultValue": "Observation,ObservationFilterItem"
-          }
-        },
-        "annotations": [],
-        "lastPublishTime": "2020-09-14T16:47:15Z"
-      },
-      "dependsOn": [
-        "[concat(variables('factoryId'), '/linkedServices/ls_sql_public_statistics')]"
-      ]
-    },
-    {
-      "name": "[concat(parameters('factoryName'), '/pl_purge_subjects_public_statistics')]",
-      "type": "Microsoft.DataFactory/factories/pipelines",
-      "apiVersion": "2018-06-01",
-      "properties": {
-        "activities": [
-          {
-            "name": "sp_remove_soft_deleted_subjects",
-            "type": "SqlServerStoredProcedure",
-            "dependsOn": [],
-            "policy": {
-              "timeout": "0.12:00:00",
-              "retry": 0,
-              "retryIntervalInSeconds": 30,
-              "secureOutput": false,
-              "secureInput": false
-            },
-            "userProperties": [],
-            "typeProperties": {
-              "storedProcedureName": "[[dbo].[RemoveSoftDeletedSubjects]",
-              "storedProcedureParameters": {
-                "TotalObservationLimit": {
-                  "value": {
-                    "value": "@pipeline().parameters.TotalObservationLimit",
-                    "type": "Expression"
-                  },
-                  "type": "Int32"
-                },
-                "ObservationCommitBatchSize": {
-                  "value": {
-                    "value": "@pipeline().parameters.ObservationCommitBatchSize",
-                    "type": "Expression"
-                  },
-                  "type": "Int32"
-                },
-                "ObservationFilterItemCommitBatchSize": {
-                  "value": {
-                    "value": "@pipeline().parameters.ObservationFilterItemCommitBatchSize",
-                    "type": "Expression"
-                  },
-                  "type": "Int32"
-                }
-              }
-            },
-            "linkedServiceName": {
-              "referenceName": "ls_sql_public_statistics",
-              "type": "LinkedServiceReference"
-            }
-          }
-        ],
-        "parameters": {
-          "TotalObservationLimit": {
-            "type": "int",
-            "defaultValue": 20000000
-          },
-          "ObservationCommitBatchSize": {
-            "type": "int",
-            "defaultValue": 1000
-          },
-          "ObservationFilterItemCommitBatchSize": {
-            "type": "int",
-            "defaultValue": 20000
-          }
-        },
-        "annotations": []
-      },
-      "dependsOn": [
-        "[concat(variables('factoryId'), '/linkedServices/ls_sql_public_statistics')]"
       ]
     },
     {
@@ -354,13 +202,6 @@
               "referenceName": "pl_purge_subjects_statistics",
               "type": "PipelineReference"
             },
-            "parameters": {}
-          },
-          {
-            "pipelineReference": {
-              "referenceName": "pl_purge_subjects_public_statistics",
-              "type": "PipelineReference"
-            },
             "parameters": {
               "TotalObservationLimit": "[variables('removeSoftDeletedSubjectsObservationLimit')]",
               "ObservationCommitBatchSize": "[variables('removeSoftDeletedSubjectsObservationCommitBatchSize')]",
@@ -384,8 +225,7 @@
         }
       },
       "dependsOn": [
-        "[concat(variables('factoryId'), '/pipelines/pl_purge_subjects_statistics')]",
-        "[concat(variables('factoryId'), '/pipelines/pl_purge_subjects_public_statistics')]"
+        "[concat(variables('factoryId'), '/pipelines/pl_purge_subjects_statistics')]"
       ]
     },
     {
@@ -399,16 +239,6 @@
           {
             "pipelineReference": {
               "referenceName": "pl_rebuild_statistics_indexes",
-              "type": "PipelineReference"
-            },
-            "parameters": {
-              "Percentage": "[variables('fragmentationPercentage')]",
-              "Tables": "[variables('fragmentationTables')]"
-            }
-          },
-          {
-            "pipelineReference": {
-              "referenceName": "pl_rebuild_public_statistics_indexes",
               "type": "PipelineReference"
             },
             "parameters": {
@@ -433,8 +263,7 @@
         }
       },
       "dependsOn": [
-        "[concat(variables('factoryId'), '/pipelines/pl_rebuild_statistics_indexes')]",
-        "[concat(variables('factoryId'), '/pipelines/pl_rebuild_public_statistics_indexes')]"
+        "[concat(variables('factoryId'), '/pipelines/pl_rebuild_statistics_indexes')]"
       ]
     }
   ]


### PR DESCRIPTION
This PR removes pipelines `pl_purge_subjects_public_statistics` and `pl_rebuild_public_statistics_indexes` from Azure Data Factory config in the db-maintenance ARM template.

It also removes linked service `ls_sql_public_statistics` from the same template since it's now unused.