### PR TITLE
EES-4094 Alter Prod statistics databases to use provisioned rather than serverless compute tier

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -69,16 +69,13 @@
       "value": "0.5"
     },
     "skuStatisticsDb": {
-      "value": "GP_S_Gen5"
+      "value": "GP_Gen5"
     },
     "tierStatisticsDb": {
       "value": "GeneralPurpose"
     },
     "capacityStatisticsDb": {
-      "value": 10
-    },
-    "minCapacityStatisticsDb": {
-      "value": "4"
+      "value": 6
     },
     "enableAlerts": {
       "value": true

--- a/useful-scripts/get_data_block_responses/get_data_block_responses.py
+++ b/useful-scripts/get_data_block_responses/get_data_block_responses.py
@@ -17,12 +17,15 @@ SELECT ContentBlock.Id                              AS ContentBlockId,
 FROM ContentBlock
 JOIN ReleaseContentBlocks ON ContentBlock.Id = ReleaseContentBlocks.ContentBlockId
 JOIN Releases ON ReleaseContentBlocks.ReleaseId = Releases.Id
+LEFT JOIN KeyStatisticsDataBlock ON ContentBlock.Id = KeyStatisticsDataBlock.DataBlockId
 WHERE ContentBlock.Type = 'DataBlock'
   AND Releases.Published IS NOT NULL
   AND Releases.SoftDeleted = 0
   AND (
     -- Include DataBlocks that are linked to Content Sections
     ContentSectionId IS NOT NULL
+    -- Include DataBlocks that are Key Statistics
+    OR KeyStatisticsDataBlock.DataBlockId IS NOT NULL
     -- Include DataBlocks that are Featured Tables
     OR (DataBlock_HighlightName IS NOT NULL
         AND DataBlock_HighlightName <> ''))


### PR DESCRIPTION
This PR alters the configuration of the Prod statistics databases to use provisioned rather than serverless compute tier.

The previous configuration was min capacity 4 vCores, scaling up to an overall capacity of 10 vCores.

That meant a minimum of 4 vCores continuously available independent of usage, but a downside of this was cost with the serverless tier being more expensive especially without us taking advantage of auto-pause.

Here we provision 6 vCores to be continuously available, which despite having more resources made continuously available, makes a significant annual cost saving over the previous config using serverless.

The `GP_Gen5_6` provisioned compute option also has 31.1Gb memory continuously available, compared to the `GP_S_Gen5_10` serverless compute option where minimum capacity 4 vCores will only have a minimum of 12Gb continuously available. Memory scale-down in serverless is triggered during low or idle usage periods, unlike provisioned compute. This memory is used by caches like the buffer pool for data pages and precompiled query plans. With the serverless option having less memory continuously available it's likely that more queries need to read data from storage which is slower.

After this change we should review the metrics again to see what difference has been made.