### PR TITLE
Ees 4160 stop prerelease emails on immediate publishing

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseService.cs
@@ -33,6 +33,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public PreReleaseWindowStatus GetPreReleaseWindowStatus(Release release, DateTime referenceTime)
         {
+            if (release.Live)
+            {
+                return new PreReleaseWindowStatus
+                {
+                    Access = PreReleaseAccess.After
+                };             
+            }
+            
             if (!release.PublishScheduled.HasValue)
             {
                 return new PreReleaseWindowStatus

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
@@ -165,7 +165,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             switch (request.ApprovalStatus)
                             {
                                 case ReleaseApprovalStatus.Approved:
-                                    await _preReleaseUserService.SendPreReleaseUserInviteEmails(release.Id);
+                                    if (request.PublishMethod == PublishMethod.Scheduled)
+                                    {
+                                        await _preReleaseUserService.SendPreReleaseUserInviteEmails(release.Id);
+                                    }
                                     break;
 
                                 case ReleaseApprovalStatus.HigherLevelReview:

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/BasicReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/BasicReleaseSummary.tsx
@@ -55,10 +55,11 @@ const BasicReleaseSummary = ({ release }: Props) => {
 
       <SummaryList>
         <SummaryListItem term="Published">
-          {releaseDate && (
+          {releaseDate ? (
             <FormattedDate>{parseISO(releaseDate)}</FormattedDate>
+          ) : (
+            <p>TBA</p>
           )}
-          {!releaseDate && <p>TBA</p>}
         </SummaryListItem>
         {isValidPartialDate(release.nextReleaseDate) && (
           <SummaryListItem term="Next update">

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/BasicReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/BasicReleaseSummary.tsx
@@ -33,6 +33,7 @@ interface Props {
 }
 
 const BasicReleaseSummary = ({ release }: Props) => {
+  const releaseDate = release.published ?? release.publishScheduled;
   return (
     <>
       <div className="dfe-flex dfe-align-items--center dfe-justify-content--space-between govuk-!-margin-bottom-3">
@@ -53,12 +54,11 @@ const BasicReleaseSummary = ({ release }: Props) => {
       </div>
 
       <SummaryList>
-        <SummaryListItem term="Publish date">
-          {release.publishScheduled ? (
-            <FormattedDate>{parseISO(release.publishScheduled)}</FormattedDate>
-          ) : (
-            <p>TBA</p>
+        <SummaryListItem term="Published">
+          {releaseDate && (
+            <FormattedDate>{parseISO(releaseDate)}</FormattedDate>
           )}
+          {!releaseDate && <p>TBA</p>}
         </SummaryListItem>
         {isValidPartialDate(release.nextReleaseDate) && (
           <SummaryListItem term="Next update">


### PR DESCRIPTION
This hotfix PR:
- stops pre-release invite emails from being sent out when a Release is published Immediately
- shows the real Published date on the Release Content (preview) page in Admin if it has already gone live - this is to prevent confusion around Releases that might have had their Published dates manually amended, or for scheduled Releases that have been forced out immediately using the "Immediate" Publisher HTTP function triggers
- adds a guard to prevent access to Pre-release Window if the Release is already live (and its Published date differs from its Publish Scheduled date, as for Releases that might have had their Published dates manually amended, or for scheduled Releases that have been forced out immediately using the "Immediate" Publisher HTTP function triggers)
- Changes "Publish date" label on the Admin Release Content page to be "Published", to match its live counterpart label on the public site Release page

![image](https://user-images.githubusercontent.com/12444316/223349929-a172ea7b-345a-4c2b-ab9a-2e3b5b55396a.png)
