### PR TITLE
EES-3993 Increase statistics database size in Dev from 250Gb to 350Gb

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -114,7 +114,7 @@
       "value": 1073741824
     },
     "maxStatsDbSizeBytes": {
-      "value": 268435456000
+      "value": 375809638400
     },
     "dataFactoryConcurrency": {
       "value": 10


### PR DESCRIPTION
This PR makes an ARM template parameter change to `dev.parameters.json` to increase the capacity of the statistics database in the Dev environment from 250Gb to 350Gb.

It was recently 300Gb but https://github.com/dfe-analytical-services/explore-education-statistics/pull/3909 decided to reduce it down to 250Gb after seeing the allocated space was under 250Gb.

After recent performance testing the space used has now increased and after rebuilding indexes the allocated space is close to 300Gb.