### PR TITLE
🐛 EES-4094 Allow General purpose - provisioned compute

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -655,6 +655,7 @@
         "Basic",
         "Standard",
         "Premium",
+        "GP_Gen5",
         "GP_S_Gen5"
       ]
     },


### PR DESCRIPTION
Add `GP_Gen5` to allowed list of values to allow specifying General Purpose Provisioned Compute tier databases.