### PR TITLE
🐛 EES-3993 Remove Percent parameter from stored procedure in Azure Data Factory ARM template config

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -79,13 +79,6 @@
             "typeProperties": {
               "storedProcedureName": "[[dbo].[RebuildIndexes]",
               "storedProcedureParameters": {
-                "Percent": {
-                  "value": {
-                    "value": "@pipeline().parameters.Percentage",
-                    "type": "Expression"
-                  },
-                  "type": "Int32"
-                },
                 "Tables": {
                   "value": {
                     "value": "@pipeline().parameters.Tables",


### PR DESCRIPTION
This is a bugfix for https://github.com/dfe-analytical-services/explore-education-statistics/pull/3928 which is currently failing at the Development infrastructure deploy stage.

It removes a parameter which should have been removed in the original change.