### PR TITLE
EES-4092 Change statistics database and geo-replica from Serverless to Provisioned in Dev and Pre-Prod.

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -99,16 +99,13 @@
       "value": 50
     },
     "skuStatisticsDb": {
-      "value": "GP_S_Gen5"
+      "value": "GP_Gen5"
     },
     "tierStatisticsDb": {
       "value": "GeneralPurpose"
     },
     "capacityStatisticsDb": {
-      "value": 4
-    },
-    "minCapacityStatisticsDb": {
-      "value": "0.5"
+      "value": 2
     },
     "maxContentDbSizeBytes": {
       "value": 1073741824

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -66,16 +66,13 @@
       "value": 50
     },
     "skuStatisticsDb": {
-      "value": "GP_S_Gen5"
+      "value": "GP_Gen5"
     },
     "tierStatisticsDb": {
       "value": "GeneralPurpose"
     },
     "capacityStatisticsDb": {
-      "value": 4
-    },
-    "minCapacityStatisticsDb": {
-      "value": "0.5"
+      "value": 2
     },
     "maxContentDbSizeBytes": {
       "value": 1073741824


### PR DESCRIPTION
This PR changes the statistics database and its geo-replica from using the vCore Serverless compute tier to the vCore Provisioned compute tier in Dev and Pre-Prod.

This revisits #3909 and is made after analysing the cost savings originally estimated.

Originally the serverless config was minimum capacity 0.75 vCore, overall capacity 1 vCore.
The change recently made by  #3909 altered it to minimum capacity 0.5 vCore, overall capacity 4 vCore but this hasn't provided the expected cost saving.

The new setting will move away from Serverless to the Provisioned compute tier with a compute size of 2 vCores.

Over the original serverless config that we had, this new config provides higher resource limits in every aspect compared, for a lower cost.

<html>


<body>


  | Serverless 0.75-1 vCores | Provisioned 2 vCores
-- | -- | --
Memory Gb | 2.25 - 3 | 10.4
Max data size Gb | 512 | 1024
Max data IOPS | 320 | 640
Max log rate /MBps | 4.5 | 9


</body>

</html>




Compared to the config we’ve recently applied (0.5-4), the benefit of moving to provisioned except for known cost and that the resources are continuously available is not as clear because there's a lower max IOPS and log rate which could show as a difference during importing. However given that we've only run with that for a few weeks there shouldn't be a problem. The old setting had been our established config in Dev/Test/Pre-Prod for a long period of time.


See the writeup in the comment dated 8th March on [EES-4092](https://dfedigital.atlassian.net/browse/EES-4092) for more info on why this change is being made.