### PR TITLE
EES-4044 remove find stats page banner

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
@@ -163,22 +163,6 @@ const FindStatisticsPage: NextPage = () => {
           : undefined
       }
     >
-      <InsetText>
-        <p className="govuk-heading-m">This page has changed</p>
-        <p>
-          Following user feedback we’ve made some changes to this page to make
-          our publications easier to find. If you have any comments on the new
-          design please let us know via the{' '}
-          <Link
-            to="https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-XMiKzsnr8xJoWM_DeGwIu9UNDJHOEJDRklTNVA1SDdLOFJITEwyWU1OQS4u"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            survey
-          </Link>
-          .
-        </p>
-      </InsetText>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <p className="govuk-body-l">


### PR DESCRIPTION
Removes the temporary banner on the Find Statistics page.