### PR TITLE
EES-4177 Add Grafana remote image rendering service to performance test project

### DIFF
--- a/tests/performance-tests/docker-compose.yml
+++ b/tests/performance-tests/docker-compose.yml
@@ -8,7 +8,10 @@ services:
       - INFLUXDB_DB=k6
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:9.3.2
+    depends_on:
+      - influxdb
+      - renderer
     networks:
       - k6_performance_test_network
     links:
@@ -19,17 +22,26 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_BASIC_ENABLED=false
+      - GF_RENDERING_SERVER_URL=http://renderer:8081/render
+      - GF_RENDERING_CALLBACK_URL=http://grafana:3005/
+      - GF_LOG_FILTERS=rendering:debug
     volumes:
       - ./dashboards:/var/lib/grafana/dashboards
       - ./grafana-dashboard.yml:/etc/grafana/provisioning/dashboards/dashboard.yml
       - ./grafana-datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
       - "./grafana.ini:/etc/grafana/grafana.ini"
 
+  renderer:
+    image: grafana/grafana-image-renderer:latest
+    networks:
+      - k6_performance_test_network
+    ports:
+      - 8081
+
   k6:
     image: loadimpact/k6:latest
     depends_on:
       - influxdb
-      - grafana
     # Add the host IP address to the k6 container to allow it to connect to the host 
     # when running and developing performance tests locally.
     extra_hosts:


### PR DESCRIPTION
This PR adds the Grafana remote image rendering service to the Docker setup in the performance test project to allow rendering panels and dashboards as PNG's which can be downloaded.

The Grafana image plugin is not compatible with the current Grafana Docker image, so we run the plugin in a remote rendering HTTP service within Docker instead.

See [Grafana Image Renderer](https://grafana.com/grafana/plugins/grafana-image-renderer/).

> Grafana renders an image by making an HTTP request to the remote rendering service, which in turn renders the image and returns it back in the HTTP response to Grafana.

### Other changes

Pin Grafana version to `9.3.2` rather than `latest` because the InfluxDB data source configuration in `grafana-datasource.yml` seems to be incompatible with the latest version. If we query the configured InfluxDB data source through the Grafana API there's no database name (`"database": ""`) and it's leading to the error in all dashboards/panels `InfluxDB Error: database name required`.

