### PR TITLE
EES-2431 - add user testing invite banner

### DIFF
--- a/src/explore-education-statistics-admin/src/components/PageHeader.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageHeader.tsx
@@ -59,7 +59,7 @@ const PageHeader = ({ wide }: Props) => {
                   src={logo}
                   className="govuk-header__logotype-crown-fallback-image"
                 />
-                <span className="govuk-header__logotype-text"> GOV.UK</span>
+                <span className="govuk-header__logotype-text">GOV.UK</span>
               </span>
             </a>
           </div>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
@@ -12,7 +12,6 @@ import { KeyStatisticDataBlock } from '@common/services/publicationService';
 import { Formik } from 'formik';
 import React from 'react';
 import Yup from '@common/validation/yup';
-import { KeyStatTextFormValues } from '@admin/pages/release/content/components/EditableKeyStatTextForm';
 
 export interface KeyStatDataBlockFormValues {
   trend: string;

--- a/src/explore-education-statistics-frontend/src/components/Page.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Page.tsx
@@ -9,6 +9,7 @@ import PageHeader from './PageHeader';
 import PageMeta, { PageMetaProps } from './PageMeta';
 import PageTitle from './PageTitle';
 import TemporaryNotice from './TemporaryNotice';
+import UserTestingBanner from './UserTestingBanner';
 
 type Props = {
   title: string;
@@ -46,7 +47,7 @@ const Page = ({
         {...pageMeta}
       />
       <PageHeader />
-
+      <UserTestingBanner />
       {router.asPath.includes(
         'find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-outbreak',
       ) && (

--- a/src/explore-education-statistics-frontend/src/components/PageHeader.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageHeader.tsx
@@ -7,7 +7,7 @@ const PageHeader = () => (
       Skip to main content
     </a>
 
-    <header className="govuk-header " role="banner" data-module="header">
+    <header className="govuk-header" role="banner" data-module="header">
       <div className="govuk-header__container">
         <div className="govuk-width-container">
           <div className="govuk-header__logo">

--- a/src/explore-education-statistics-frontend/src/components/UserTestingBanner.module.scss
+++ b/src/explore-education-statistics-frontend/src/components/UserTestingBanner.module.scss
@@ -1,0 +1,24 @@
+@import '~govuk-frontend/govuk/base';
+
+.container {
+  background: govuk-colour('blue');
+}
+
+.heading {
+  color: govuk-colour('white');
+  font-weight: $govuk-font-weight-bold;
+  margin-bottom: govuk-spacing(0);
+}
+
+.link {
+  color: govuk-colour('white') !important;
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:focus {
+    @include govuk-focused-text;
+    color: govuk-colour('black') !important;
+  }
+}

--- a/src/explore-education-statistics-frontend/src/components/UserTestingBanner.tsx
+++ b/src/explore-education-statistics-frontend/src/components/UserTestingBanner.tsx
@@ -1,0 +1,50 @@
+import useMounted from '@common/hooks/useMounted';
+import { useCookies } from '@frontend/hooks/useCookies';
+import React from 'react';
+import ButtonText from '@common/components/ButtonText';
+import classNames from 'classnames';
+import styles from './UserTestingBanner.module.scss';
+import Link from './Link';
+
+const UserTestingBanner = () => {
+  const { getCookie, setUserTestingBannerSeenCookie } = useCookies();
+  const isUserTestingBannerSeen = getCookie('userTestingBannerSeen') === 'true';
+  const { isMounted } = useMounted();
+
+  if (isMounted && !isUserTestingBannerSeen) {
+    return (
+      <div className={styles.container}>
+        <div className="govuk-width-container">
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-three-quarters">
+              <p className={styles.heading}>
+                Help develop Explore education Statistics
+              </p>
+              <p>
+                <Link
+                  className={styles.link}
+                  to="https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-XMiKzsnr8xJoWM_DeGwIu9UQVNYVkxZSEJVVjhPOURXSjJVMjhZRTdYMi4u"
+                >
+                  Get involved in making this service better
+                </Link>
+              </p>
+            </div>
+            <div className="govuk-grid-column-one-quarter dfe-align--right">
+              <ButtonText
+                className={classNames(styles.link, 'govuk-!-margin-bottom-2')}
+                onClick={() => {
+                  setUserTestingBannerSeenCookie(true);
+                }}
+              >
+                Close
+              </ButtonText>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};
+export default UserTestingBanner;

--- a/src/explore-education-statistics-frontend/src/hooks/useCookies.ts
+++ b/src/explore-education-statistics-frontend/src/hooks/useCookies.ts
@@ -25,6 +25,7 @@ interface Cookie {
 interface AllowedCookies {
   bannerSeen: Cookie;
   disableGA: Cookie;
+  userTestingBannerSeen: Cookie;
 }
 
 export const allowedCookies: AllowedCookies = {
@@ -40,6 +41,13 @@ export const allowedCookies: AllowedCookies = {
     duration: '10 years',
     options: {
       expires: addYears(new Date(), 10),
+    },
+  },
+  userTestingBannerSeen: {
+    name: 'ees_user_testing_banner_seen',
+    duration: '1 year',
+    options: {
+      expires: addYears(new Date(), 1),
     },
   },
 };
@@ -86,6 +94,15 @@ export function useCookies(initialCookies?: Dictionary<string>) {
         allowedCookies.bannerSeen.name,
         value,
         allowedCookies.bannerSeen.options,
+      );
+    },
+    setUserTestingBannerSeenCookie(isSeen: boolean) {
+      const value = isSeen ? 'true' : 'false';
+
+      setCookie(
+        allowedCookies.userTestingBannerSeen.name,
+        value,
+        allowedCookies.userTestingBannerSeen.options,
       );
     },
     setGADisabledCookie(isDisabled: boolean) {

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
@@ -32,7 +32,6 @@ import compact from 'lodash/compact';
 import omit from 'lodash/omit';
 import { useRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
-import InsetText from '@common/components/InsetText';
 
 export interface FindStatisticsPageQuery {
   page?: number;

--- a/src/explore-education-statistics-frontend/src/pages/cookies/details.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/cookies/details.tsx
@@ -2,8 +2,9 @@ import Page from '@frontend/components/Page';
 import React from 'react';
 import { allowedCookies } from '@frontend/hooks/useCookies';
 import Link from '@frontend/components/Link';
+import { NextPage } from 'next';
 
-function CookiesPage() {
+const CookiesPage: NextPage = () => {
   return (
     <Page
       title="Details about cookies"
@@ -64,43 +65,37 @@ function CookiesPage() {
         </p>
         <p>We don’t allow Google to use or share our analytics data.</p>
         <p>Google Analytics sets the following cookies:</p>
-        <table className="govuk-table">
-          <thead className="govuk-table__head">
-            <tr className="govuk-table__row">
-              <th className="govuk-table__header" scope="col">
-                Name
-              </th>
-              <th className="govuk-table__header" scope="col">
-                Purpose
-              </th>
-              <th className="govuk-table__header" scope="col">
-                Expires
-              </th>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Purpose</th>
+              <th scope="col">Expires</th>
             </tr>
           </thead>
-          <tbody className="govuk-table__body">
-            <tr className="govuk-table__row">
-              <td className="govuk-table__cell">_ga</td>
-              <td className="govuk-table__cell">
+          <tbody>
+            <tr>
+              <td>_ga</td>
+              <td>
                 This helps us count how many people visit GOV.UK by tracking if
                 you’ve visited before
               </td>
-              <td className="govuk-table__cell">2 years</td>
+              <td>2 years</td>
             </tr>
-            <tr className="govuk-table__row">
-              <td className="govuk-table__cell">_gid</td>
-              <td className="govuk-table__cell">
+            <tr>
+              <td>_gid</td>
+              <td>
                 This helps us count how many people visit GOV.UK by tracking if
                 you’ve visited before
               </td>
-              <td className="govuk-table__cell">24 hours</td>
+              <td>24 hours</td>
             </tr>
-            <tr className="govuk-table__row">
-              <td className="govuk-table__cell">_gat</td>
-              <td className="govuk-table__cell">
+            <tr>
+              <td>_gat</td>
+              <td>
                 Used to manage the rate at which page view requests are made
               </td>
-              <td className="govuk-table__cell">1 minute</td>
+              <td>1 minute</td>
             </tr>
           </tbody>
         </table>
@@ -121,32 +116,32 @@ function CookiesPage() {
           knows not to show it again.
         </p>
 
-        <table className="govuk-table">
-          <thead className="govuk-table__head">
-            <tr className="govuk-table__row">
-              <th className="govuk-table__header" scope="col">
-                Name
-              </th>
-              <th className="govuk-table__header" scope="col">
-                Purpose
-              </th>
-              <th className="govuk-table__header" scope="col">
-                Expires
-              </th>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Purpose</th>
+              <th scope="col">Expires</th>
             </tr>
           </thead>
-          <tbody className="govuk-table__body">
-            <tr className="govuk-table__row">
-              <td className="govuk-table__cell">
-                {allowedCookies.bannerSeen.name}
-              </td>
-              <td className="govuk-table__cell">
+          <tbody>
+            <tr>
+              <td>{allowedCookies.bannerSeen.name}</td>
+              <td>
                 Saves a message to let us know that you’ve seen our cookie
                 message
               </td>
-              <td className="govuk-table__cell">
-                {allowedCookies.bannerSeen.duration}
+              <td>{allowedCookies.bannerSeen.duration}</td>
+            </tr>
+          </tbody>
+          <tbody>
+            <tr>
+              <td>{allowedCookies.userTestingBannerSeen.name}</td>
+              <td>
+                Saves a message to let us know that you’ve seen our user testing
+                invite message
               </td>
+              <td>{allowedCookies.userTestingBannerSeen.duration}</td>
             </tr>
           </tbody>
         </table>
@@ -158,31 +153,20 @@ function CookiesPage() {
           you return to GOV.UK: Explore education statistics.
         </p>
 
-        <table className="govuk-table">
-          <thead className="govuk-table__head">
-            <tr className="govuk-table__row">
-              <th className="govuk-table__header" scope="col">
-                Name
-              </th>
-              <th className="govuk-table__header" scope="col">
-                Purpose
-              </th>
-              <th className="govuk-table__header" scope="col">
-                Expires
-              </th>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Purpose</th>
+              <th scope="col">Expires</th>
             </tr>
           </thead>
-          <tbody className="govuk-table__body">
-            <tr className="govuk-table__row">
-              <td className="govuk-table__cell">
-                {allowedCookies.disableGA.name}
-              </td>
-              <td className="govuk-table__cell">
-                Disables Google Analytics tracking
-              </td>
-              <td className="govuk-table__cell">
-                {allowedCookies.disableGA.duration}
-              </td>
+
+          <tbody>
+            <tr>
+              <td>{allowedCookies.disableGA.name}</td>
+              <td>Disables Google Analytics tracking</td>
+              <td>{allowedCookies.disableGA.duration}</td>
             </tr>
           </tbody>
         </table>
@@ -199,40 +183,30 @@ function CookiesPage() {
         <h3>Microsoft Application Insights</h3>
         <p>Microsoft Application Insights collects telemetry information.</p>
 
-        <table className="govuk-table">
-          <thead className="govuk-table__head">
-            <tr className="govuk-table__row">
-              <th className="govuk-table__header" scope="col">
-                Name
-              </th>
-              <th className="govuk-table__header" scope="col">
-                Purpose
-              </th>
-              <th className="govuk-table__header" scope="col">
-                Expires
-              </th>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Purpose</th>
+              <th scope="col">Expires</th>
             </tr>
           </thead>
-          <tbody className="govuk-table__body">
-            <tr className="govuk-table__row">
-              <td className="govuk-table__cell">ai_user</td>
-              <td className="govuk-table__cell">
-                Used to identify returning users
-              </td>
-              <td className="govuk-table__cell">1 year</td>
+          <tbody>
+            <tr>
+              <td>ai_user</td>
+              <td>Used to identify returning users</td>
+              <td>1 year</td>
             </tr>
-            <tr className="govuk-table__row">
-              <td className="govuk-table__cell">ai_session</td>
-              <td className="govuk-table__cell">
-                Anonymous session identifer to group a user's activities
-              </td>
-              <td className="govuk-table__cell">15 minutes</td>
+            <tr>
+              <td>ai_session</td>
+              <td>Anonymous session identifer to group a user's activities</td>
+              <td>15 minutes</td>
             </tr>
           </tbody>
         </table>
       </section>
     </Page>
   );
-}
+};
 
 export default CookiesPage;


### PR DESCRIPTION
This PR adds a user-testing invite banner to the home page.

![Screenshot 2023-03-23 at 09 27 42](https://user-images.githubusercontent.com/55030296/227160184-5211b007-0643-4c1a-afc0-7db3245ae8fc.png)

## Relevant changes
* Adds a cookie to support the display of the banner: `ees_user_testing_banner_seen` 
* Updates cookie page to reflect new cookies that have been added

## Other changes:
* Cleans up lint warnings
