### PR TITLE
EES-4168 change past releases text

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -264,12 +264,12 @@ const ReleaseContent = () => {
             {!!releaseCount && (
               <>
                 <h3 className="govuk-heading-s" id="past-releases">
-                  Past releases
+                  Releases in this series
                 </h3>
 
                 <Details
                   className="govuk-!-margin-bottom-4"
-                  summary={`View previous releases (${releaseCount})`}
+                  summary={`View releases (${releaseCount})`}
                 >
                   <ScrollableContainer maxHeight={300}>
                     <ul className="govuk-list">

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -339,12 +339,12 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
             {!!otherReleasesCount && (
               <>
                 <h3 className="govuk-heading-s" id="past-releases">
-                  Past releases
+                  Releases in this series
                 </h3>
 
                 <Details
                   className="govuk-!-margin-bottom-4"
-                  summary={`View previous releases (${otherReleasesCount})`}
+                  summary={`View releases (${otherReleasesCount})`}
                   hiddenText={`for ${release.publication.title}`}
                   onToggle={open =>
                     open &&

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
@@ -174,15 +174,14 @@ describe('PublicationReleasePage', () => {
     const usefulInfo = within(screen.getByRole('complementary'));
 
     expect(
-      usefulInfo.getByRole('heading', { name: 'Past releases' }),
+      usefulInfo.getByRole('heading', { name: 'Releases in this series' }),
     ).toBeInTheDocument();
 
     const details = within(usefulInfo.getByRole('group'));
 
     userEvent.click(
       details.getByRole('button', {
-        name:
-          'View previous releases (5) for Pupil absence in schools in England',
+        name: 'View releases (5) for Pupil absence in schools in England',
       }),
     );
 

--- a/tests/robot-tests/tests/admin_and_public/bau/legacy_releases.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/legacy_releases.robot
@@ -58,9 +58,9 @@ Approve release
 
 Check legacy release appears on public frontend
     user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
-    user opens details dropdown    View previous releases (1)
+    user opens details dropdown    View releases (1)
 
-    ${other_releases}=    user gets details content element    View previous releases (1)
+    ${other_releases}=    user gets details content element    View releases (1)
 
     user checks list has x items    css:ul    1    ${other_releases}
 
@@ -94,9 +94,9 @@ Validate updated legacy release
 Validate public frontend shows changes made to legacy release after saving publication
     user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
 
-    user opens details dropdown    View previous releases (1)
+    user opens details dropdown    View releases (1)
 
-    ${other_releases}=    user gets details content element    View previous releases (1)
+    ${other_releases}=    user gets details content element    View releases (1)
 
     user checks list has x items    css:ul    1    ${other_releases}
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -442,9 +442,9 @@ Navigate to published release page
 Check latest release is correct
     user waits until page contains title caption    ${RELEASE_2_NAME}    %{WAIT_MEDIUM}
     user checks page contains    This is the latest data
-    user checks page contains    View previous releases (1)
+    user checks page contains    View releases (1)
 
-    user opens details dropdown    View previous releases (1)
+    user opens details dropdown    View releases (1)
     user waits until page contains other release    ${RELEASE_1_NAME}
     user checks page does not contain other release    ${RELEASE_2_NAME}
 
@@ -454,7 +454,7 @@ Check other release is correct
     user waits until page contains title caption    ${RELEASE_1_NAME}
 
     user waits until page contains link    View latest data: ${RELEASE_2_NAME}
-    user checks page contains    View previous releases (1)
+    user checks page contains    View releases (1)
     user waits until page contains other release    ${RELEASE_2_NAME}
     user checks page does not contain other release    ${RELEASE_1_NAME}
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -747,7 +747,7 @@ Navigate to amendment release page
 
 Verify amendment is displayed as the latest release
     user checks page does not contain    View latest data:
-    user checks page does not contain    View previous releases (1)
+    user checks page does not contain    View releases (1)
 
 Verify amendment is published
     user checks summary list contains    Published    ${EXPECTED_PUBLISHED_DATE}

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -45,14 +45,14 @@ Validate Email alerts link
 
 Validate "About these statistics" -- Number of other releases
     user checks number of other releases is correct    6
-    user opens details dropdown    View previous releases (6)
+    user opens details dropdown    View releases (6)
     user checks other release is shown in position    Academic year 2014/15    1
     user checks other release is shown in position    Academic year 2013/14    2
     user checks other release is shown in position    Academic year 2012/13    3
     user checks other release is shown in position    Academic year 2011/12    4
     user checks other release is shown in position    Academic year 2010/11    5
     user checks other release is shown in position    Academic year 2009/10    6
-    user closes details dropdown    View previous releases (6)
+    user closes details dropdown    View releases (6)
 
 Validate "About these statistics" -- "Last updated"
     user checks summary list contains    Last updated    22 August 2022


### PR DESCRIPTION
Updates the text for the other releases section on release pages.

<img width="165" alt="pastreleases" src="https://user-images.githubusercontent.com/81572860/226925239-7f0a1b05-bd8d-421c-aac5-deb40dcd95e4.PNG">
