### PR TITLE
EES-4087 collapse all filters by default

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxGroupsMenu.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxGroupsMenu.tsx
@@ -4,7 +4,7 @@ import RHFFormFieldCheckboxSearchSubGroups, {
 } from '@common/components/form/rhf/RHFFormFieldCheckboxSearchSubGroups';
 import RHFFormCheckboxSelectedCount from '@common/components/form/rhf/RHFFormCheckboxSelectedCount';
 import { OmitStrict } from '@common/types';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { FieldValues, useFormContext } from 'react-hook-form';
 import get from 'lodash/get';
 
@@ -16,16 +16,26 @@ interface Props<TFormValues extends FieldValues>
   hiddenText?: string;
   legend: string;
   open?: boolean;
+  onToggle?: (isOpen: boolean) => void;
 }
 
 export default function RHFFormFieldCheckboxGroupsMenu<
   TFormValues extends FieldValues
 >(props: Props<TFormValues>) {
-  const { hiddenText, legend, name, open = false } = props;
+  const { hiddenText, legend, name, open = false, onToggle } = props;
 
   const {
     formState: { errors },
   } = useFormContext();
+
+  // Groups with an error are opened, so add them to the list of open
+  // filters to prevent the group collapsing as soon as you select
+  // an option in the group.
+  useEffect(() => {
+    if (!open && get(errors, name)) {
+      onToggle?.(true);
+    }
+  }, [errors, name, open, onToggle]);
 
   return (
     <DetailsMenu
@@ -35,6 +45,7 @@ export default function RHFFormFieldCheckboxGroupsMenu<
       preventToggle={!!get(errors, name)}
       summary={legend}
       summaryAfter={<RHFFormCheckboxSelectedCount name={name} />}
+      onToggle={onToggle}
     >
       <RHFFormFieldCheckboxSearchSubGroups {...props} legendHidden />
     </DetailsMenu>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -1,3 +1,5 @@
+import ButtonText from '@common/components/ButtonText';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 import CollapsibleList from '@common/components/CollapsibleList';
 import { FormFieldset } from '@common/components/form';
 import FormProvider from '@common/components/form/rhf/FormProvider';
@@ -77,6 +79,7 @@ const FiltersForm = ({
 
   const [tableQueryError, setTableQueryError] = useState<TableQueryErrorCode>();
   const [previousValues, setPreviousValues] = useState<FormValues>();
+  const [openFilterGroups, setOpenFilterGroups] = useState<string[]>([]);
 
   const initialFormValues = useMemo(() => {
     // Automatically select indicator when one indicator group with one option
@@ -155,6 +158,8 @@ const FiltersForm = ({
     ([_, value]) => value.order,
   );
 
+  const allFilterKeys = orderedFilters.map(([filterKey]) => filterKey);
+
   const orderedIndicators = orderBy(
     Object.values(subjectMeta.indicators),
     'order',
@@ -232,7 +237,31 @@ const FiltersForm = ({
                   {orderedFilters.length > 0 && (
                     <FormFieldset
                       error={getError('filters')}
-                      hint="Select at least one option from all categories"
+                      hint={
+                        <div className="dfe-flex dfe-justify-content--space-between dfe-flex-wrap">
+                          <span className="govuk-!-margin-bottom-2">
+                            Select at least one option from all categories
+                          </span>
+                          {orderedFilters.length > 1 && (
+                            <ButtonText
+                              className="govuk-!-margin-bottom-2"
+                              onClick={() => {
+                                setOpenFilterGroups(
+                                  openFilterGroups.length !==
+                                    allFilterKeys.length
+                                    ? allFilterKeys
+                                    : [],
+                                );
+                              }}
+                            >
+                              {openFilterGroups.length !== allFilterKeys.length
+                                ? 'Expand all'
+                                : 'Collapse all'}
+                              <VisuallyHidden> categories</VisuallyHidden>
+                            </ButtonText>
+                          )}
+                        </div>
+                      }
                       id="filters"
                       legend="Categories"
                       legendSize="m"
@@ -251,12 +280,19 @@ const FiltersForm = ({
                             key={filterKey}
                             legend={filterGroup.legend}
                             name={filterName}
-                            open={orderedFilterGroupOptions.length === 1}
+                            open={openFilterGroups.includes(filterKey)}
                             options={orderedFilterGroupOptions.map(group => ({
                               legend: group.label,
                               options: group.options,
                             }))}
                             order={[]}
+                            onToggle={isOpen => {
+                              setOpenFilterGroups(groups =>
+                                isOpen
+                                  ? [...groups, filterKey]
+                                  : groups.filter(group => group !== filterKey),
+                              );
+                            }}
                           />
                         );
                       })}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FiltersForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FiltersForm.test.tsx
@@ -802,4 +802,213 @@ describe('FiltersForm', () => {
       screen.getByRole('group', { name: 'Absence by reason', hidden: true }),
     );
   });
+
+  test('all filter groups are collapsed by default', () => {
+    render(
+      <FiltersForm
+        {...testWizardStepProps}
+        subject={testSubject}
+        subjectMeta={testSubjectMeta}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(
+      screen.getByRole('group', {
+        name: 'School type',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Ethnic group major',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Gender',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Total',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+  });
+
+  test('shows the expand all button if there are multiple filter groups', () => {
+    render(
+      <FiltersForm
+        {...testWizardStepProps}
+        subject={testSubject}
+        subjectMeta={testSubjectMeta}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Expand all categories' }),
+    ).toBeInTheDocument();
+  });
+
+  test('does not show the expand all button if there is only one filter group', () => {
+    render(
+      <FiltersForm
+        {...testWizardStepProps}
+        subject={testSubject}
+        subjectMeta={{
+          ...testSubjectMeta,
+          filters: {
+            SchoolType: {
+              id: 'school-type',
+              totalValue: '',
+              hint: 'Filter by school type',
+              legend: 'School type',
+              options: {
+                Default: {
+                  id: 'default',
+                  label: 'Default',
+                  options: [
+                    {
+                      label: 'State-funded secondary',
+                      value: 'state-funded-secondary',
+                    },
+                    {
+                      label: 'Special',
+                      value: 'special',
+                    },
+                  ],
+                  order: 0,
+                },
+              },
+              name: 'school_type',
+              order: 0,
+            },
+          },
+        }}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Expand all categories' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('toggles expanding and collapsing all filter groups when click the button', async () => {
+    render(
+      <FiltersForm
+        {...testWizardStepProps}
+        subject={testSubject}
+        subjectMeta={testSubjectMeta}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(
+      screen.getByRole('group', {
+        name: 'School type',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Ethnic group major',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Gender',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Total',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Expand all categories' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Collapse all/)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('group', {
+        name: 'School type',
+        hidden: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Ethnic group major',
+        hidden: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Gender',
+        hidden: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Total',
+        hidden: true,
+      }),
+    ).toBeVisible();
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Collapse all categories' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Expand all/)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('group', {
+        name: 'School type',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Ethnic group major',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Gender',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Total',
+        hidden: true,
+      }),
+    ).not.toBeVisible();
+  });
 });

--- a/tests/robot-tests/tests/admin/bau/delete_subject.robot
+++ b/tests/robot-tests/tests/admin/bau/delete_subject.robot
@@ -115,6 +115,7 @@ Select time period
     user waits until table tool wizard step is available    4    Choose your filters
 
 Select categories
+    user opens details dropdown    Random Filter
     user clicks checkbox    Blue
     user clicks checkbox    Orange
 


### PR DESCRIPTION
Collapse all table tool filters by default and add a collapse / expand all button to toggle them.

![collapsed](https://user-images.githubusercontent.com/81572860/227276904-0cc7a23b-1a00-431f-a57f-737e5cdf9da1.PNG)

![expanded](https://user-images.githubusercontent.com/81572860/227276923-49dc0cc5-749a-4a6f-8481-a6f0d62656ae.PNG)
