### PR TITLE
EES-4187 Use UniversalWrapper with caching code

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
@@ -190,7 +190,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             SetupCall(mocks.persistenceHelper, releaseContentBlock);
 
             mocks.cacheService
-                .Setup(s => s.GetItem(
+                .Setup(s => s.GetItemAsync(
                     ItIs.DeepEqualTo(new DataBlockTableResultCacheKey(releaseContentBlock)),
                     typeof(TableBuilderResultViewModel)))
                 .ReturnsAsync(null);
@@ -209,7 +209,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 .ReturnsAsync(_tableBuilderResults);
 
             mocks.cacheService
-                .Setup(s => s.SetItem<object>(
+                .Setup(s => s.SetItemAsync<object>(
                     ItIs.DeepEqualTo(new DataBlockTableResultCacheKey(releaseContentBlock)),
                     _tableBuilderResults))
                 .Returns(Task.CompletedTask);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
@@ -751,7 +751,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var cacheService = new Mock<IBlobCacheService>(Strict);
 
                 cacheService
-                    .Setup(s => s.DeleteItem(dataBlockCacheKey))
+                    .Setup(s => s.DeleteItemAsync(dataBlockCacheKey))
                     .Returns(Task.CompletedTask);
 
                 var service = BuildDataBlockService(
@@ -1115,7 +1115,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var cacheService = new Mock<IBlobCacheService>(Strict);
 
                 cacheService
-                    .Setup(s => s.DeleteItem(dataBlockCacheKey))
+                    .Setup(s => s.DeleteItemAsync(dataBlockCacheKey))
                     .Returns(Task.CompletedTask);
 
                 var service = BuildDataBlockService(
@@ -1224,7 +1224,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var cacheService = new Mock<IBlobCacheService>(Strict);
 
                 cacheService
-                    .Setup(s => s.DeleteItem(dataBlockCacheKey))
+                    .Setup(s => s.DeleteItemAsync(dataBlockCacheKey))
                     .Returns(Task.CompletedTask);
 
                 var service = BuildDataBlockService(
@@ -1352,7 +1352,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var cacheService = new Mock<IBlobCacheService>(Strict);
 
                 cacheService
-                    .Setup(s => s.DeleteItem(dataBlockCacheKey))
+                    .Setup(s => s.DeleteItemAsync(dataBlockCacheKey))
                     .Returns(Task.CompletedTask);
 
                 var service = BuildDataBlockService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -296,7 +296,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var releaseSubjectRepository = new Mock<IReleaseSubjectRepository>(Strict);
 
             cacheService
-                .Setup(service => service.DeleteItem(new PrivateSubjectMetaCacheKey(release.Id, subject.Id)))
+                .Setup(service => service.DeleteItemAsync(new PrivateSubjectMetaCacheKey(release.Id, subject.Id)))
                 .Returns(Task.CompletedTask);
 
             dataBlockService.Setup(service => service.GetDeletePlan(release.Id, subject))
@@ -450,10 +450,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var releaseDataFileService = new Mock<IReleaseDataFileService>(Strict);
             var releaseSubjectRepository = new Mock<IReleaseSubjectRepository>(Strict);
 
-            cacheService.Setup(service => service.DeleteItem(new PrivateSubjectMetaCacheKey(release.Id, subject.Id)))
+            cacheService.Setup(service => service.DeleteItemAsync(new PrivateSubjectMetaCacheKey(release.Id, subject.Id)))
                 .Returns(Task.CompletedTask);
             cacheService.Setup(service =>
-                    service.DeleteItem(new PrivateSubjectMetaCacheKey(release.Id, replacementSubject.Id)))
+                    service.DeleteItemAsync(new PrivateSubjectMetaCacheKey(release.Id, replacementSubject.Id)))
                 .Returns(Task.CompletedTask);
 
             dataBlockService.Setup(service =>
@@ -1217,7 +1217,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 mock.SoftDeleteAllReleaseSubjects(release.Id)).Returns(Task.CompletedTask);
 
             cacheService
-                .Setup(mock => mock.DeleteCacheFolder(
+                .Setup(mock => mock.DeleteCacheFolderAsync(
                     ItIs.DeepEqualTo(new PrivateReleaseContentFolderCacheKey(release.Id))))
                 .Returns(Task.CompletedTask);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -3047,7 +3047,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(cacheKey);
 
             mocks.cacheService
-                .Setup(service => service.DeleteItem(cacheKey))
+                .Setup(service => service.DeleteItemAsync(cacheKey))
                 .Returns(Task.CompletedTask);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
@@ -434,7 +434,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 cacheService
                     .Setup(s =>
-                        s.DeleteCacheFolder(
+                        s.DeleteCacheFolderAsync(
                             ItIs.DeepEqualTo(new PrivateReleaseContentFolderCacheKey(releaseId))))
                     .Returns(Task.CompletedTask);
 
@@ -585,7 +585,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     cacheService
                         .InSequence(releaseCacheInvalidationSequence)
                         .Setup(s =>
-                            s.DeleteCacheFolder(
+                            s.DeleteCacheFolderAsync(
                                 ItIs.DeepEqualTo(new PrivateReleaseContentFolderCacheKey(releaseId))))
                         .Returns(Task.CompletedTask));
 
@@ -873,7 +873,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 cacheService
                     .Setup(s =>
-                        s.DeleteCacheFolder(
+                        s.DeleteCacheFolderAsync(
                             ItIs.DeepEqualTo(new PrivateReleaseContentFolderCacheKey(releaseId))))
                     .Returns(Task.CompletedTask);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -377,7 +377,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             return _cacheKeyService
                 .CreateCacheKeyForDataBlock(releaseId, dataBlockId)
-                .OnSuccessVoid(_cacheService.DeleteItem);
+                .OnSuccessVoid(_cacheService.DeleteItemAsync);
         }
 
         public async Task<Either<ActionResult, List<DataBlockViewModel>>> GetUnattachedDataBlocks(Guid releaseId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -196,7 +196,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return _persistenceHelper
                 .CheckEntityExists<Release>(releaseId)
                 .OnSuccess(_userService.CheckCanDeleteRelease)
-                .OnSuccessDo(async release => await _cacheService.DeleteCacheFolder(
+                .OnSuccessDo(async release => await _cacheService.DeleteCacheFolderAsync(
                     new PrivateReleaseContentFolderCacheKey(release.Id)))
                 .OnSuccessDo(async () => await _releaseDataFileService.DeleteAll(releaseId))
                 .OnSuccessDo(async () => await _releaseFileService.DeleteAll(releaseId))
@@ -560,7 +560,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccessVoid(async deletePlan =>
                 {
                     await _releaseSubjectRepository.SoftDeleteReleaseSubject(releaseId, deletePlan.SubjectId);
-                    await _cacheService.DeleteItem(new PrivateSubjectMetaCacheKey(releaseId, deletePlan.SubjectId));
+                    await _cacheService.DeleteItemAsync(new PrivateSubjectMetaCacheKey(releaseId, deletePlan.SubjectId));
                 })
                 .OnSuccess(() => _releaseDataFileService.Delete(releaseId, fileId));
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -1108,7 +1108,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             return _cacheKeyService
                 .CreateCacheKeyForDataBlock(releaseId, plan.Id)
-                .OnSuccessVoid(_cacheService.DeleteItem);
+                .OnSuccessVoid(_cacheService.DeleteItemAsync);
         }
 
         private static Guid ReplacementPlanOriginalId(TargetableReplacementViewModel plan)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
@@ -257,7 +257,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         private Task DeleteCachedReleaseContent(Guid releaseId)
         {
-            return _cacheService.DeleteCacheFolder(new PrivateReleaseContentFolderCacheKey(releaseId));
+            return _cacheService.DeleteCacheFolderAsync(new PrivateReleaseContentFolderCacheKey(releaseId));
         }
 
         private async Task DeleteSoftDeletedContentDbRelease(Guid releaseId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/CacheAspectTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/CacheAspectTests.cs
@@ -178,14 +178,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
             {
             }
 
-            public override async Task<object?> Get(ICacheKey cacheKey, Type returnType)
+            public override object? Get(ICacheKey cacheKey, Type returnType)
             {
-                return await CacheService.Object.GetItem(cacheKey, returnType);
+                return CacheService.Object.GetItem(cacheKey, returnType);
             }
 
-            public override async Task Set(ICacheKey cacheKey, object value)
+            public override async Task<object?> GetAsync(ICacheKey cacheKey, Type returnType)
             {
-                await CacheService.Object.SetItem(cacheKey, value);
+                return await CacheService.Object.GetItemAsync(cacheKey, returnType);
+            }
+
+            public override void Set(ICacheKey cacheKey, object value)
+            {
+                CacheService.Object.SetItem(cacheKey, value);
+            }
+
+            public override async Task SetAsync(ICacheKey cacheKey, object value)
+            {
+                await CacheService.Object.SetItemAsync(cacheKey, value);
             }
         }
 
@@ -227,9 +237,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
             }
 
             [TestCache(typeof(TestCacheKey))]
-            public static Task<TestValue> NoParams_Task()
+            public static async Task<TestValue> NoParams_Task()
             {
-                return Task.FromResult(new TestValue());
+                return new TestValue();
             }
 
             [TestCache(typeof(TestCacheKey))]
@@ -374,8 +384,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
 
             [TestCache(typeof(TestCacheKeyWithTwoStrings))]
             public static TestValue TwoParamsOfSameType_KeyWithTwoParamsOfSameType_BothParamAttributes_SingleAmbiguous(
-                    [CacheKeyParam] string param1,
-                    [CacheKeyParam] string key2)
+                [CacheKeyParam] string param1,
+                [CacheKeyParam] string key2)
             {
                 return new();
             }
@@ -545,20 +555,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
                 return new();
             }
 
-            [TestCache(typeof(TestCacheKeyWithString))]
-            [TestCache(typeof(TestCacheKeyWithInt))]
-            public static TestValue TwoCaches(string param1, int param2)
-            {
-                return new();
-            }
-
-            [TestCache(typeof(TestCacheKeyWithString))]
-            [TestCache(typeof(TestCacheKeyWithInt), Priority = 100)]
-            public static TestValue TwoCaches_CustomOrder(string param1, int param2)
-            {
-                return new();
-            }
-
             [TestCache(null!)]
             public static TestValue NullKeyType()
             {
@@ -637,7 +633,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
 
             CacheService
                 .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
-                .ReturnsAsync(null);
+                .Returns(null);
 
             TestMethods.NoParams_ActionResult_NotFound().AssertNotFoundResult();
 
@@ -645,11 +641,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
         }
 
         [Fact]
-        public void NoParams_Task_CacheMiss()
+        public async Task NoParams_Task_CacheMiss()
         {
             var cacheKey = new TestCacheKey();
 
-            AssertCacheMiss(cacheKey, () => TestMethods.NoParams_Task().Result);
+            CacheService
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TestValue)))
+                .ReturnsAsync(null);
+
+            var args = new List<object>();
+
+            CacheService
+                .Setup(s => s.SetItemAsync(cacheKey, Capture.In(args)))
+                .Returns(Task.CompletedTask);
+
+
+            var result = await TestMethods.NoParams_Task();
+
+            VerifyAllMocks(CacheService);
+            Assert.Equal(args[0], result);
         }
 
         [Fact]
@@ -658,7 +668,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
             var cacheKey = new TestCacheKey();
 
             CacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TestValue)))
                 .ReturnsAsync(null);
 
             var exception = await Assert.ThrowsAsync<Exception>(TestMethods.NoParams_Task_Failure);
@@ -669,20 +679,44 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
         }
 
         [Fact]
-        public void NoParams_TaskEither_CacheHit()
+        public async Task NoParams_TaskEither_CacheHit()
         {
             var cacheKey = new TestCacheKey();
             var expected = new TestValue();
 
-            AssertCacheHit(cacheKey, expected, () => TestMethods.NoParams_TaskEither().Result.Right);
+            CacheService
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TestValue)))
+                .ReturnsAsync(expected);
+
+            var resultEither = await TestMethods.NoParams_TaskEither();
+            var result = resultEither.Right;
+
+            Assert.Equal(expected, result);
+
+            VerifyAllMocks(CacheService);
         }
 
         [Fact]
-        public void NoParams_TaskEither_CacheMiss()
+        public async Task NoParams_TaskEither_CacheMiss()
         {
             var cacheKey = new TestCacheKey();
 
-            AssertCacheMiss(cacheKey, () => TestMethods.NoParams_TaskEither().Result.Right);
+            CacheService
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TestValue)))
+                .ReturnsAsync(null);
+
+            var args = new List<object>();
+
+            CacheService
+                .Setup(s => s.SetItemAsync(cacheKey, Capture.In(args)))
+                .Returns(Task.CompletedTask);
+
+            var resultEither = await TestMethods.NoParams_TaskEither();
+            var result = resultEither.Right;
+
+            VerifyAllMocks(CacheService);
+
+            Assert.Equal(args[0], result);
         }
 
         [Fact]
@@ -691,7 +725,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
             var cacheKey = new TestCacheKey();
 
             CacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TestValue)))
                 .ReturnsAsync(null);
 
             var exception = await Assert.ThrowsAsync<Exception>(TestMethods.NoParams_TaskEither_Failure);
@@ -707,7 +741,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
             var cacheKey = new TestCacheKey();
 
             CacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TestValue)))
                 .ReturnsAsync(null);
 
             var result = await TestMethods.NoParams_TaskEither_Left();
@@ -722,7 +756,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
         {
             var cacheKey = new TestCacheKey();
 
-            AssertCacheMiss(cacheKey, () => TestMethods.NoParams_TaskActionResult().Result.Value);
+            AssertCacheMissAsync(cacheKey, TestMethods.NoParams_TaskActionResult);
         }
 
         [Fact]
@@ -731,7 +765,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
             var cacheKey = new TestCacheKey();
 
             CacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TestValue)))
                 .ReturnsAsync(null);
 
             var result = await TestMethods.NoParams_TaskActionResult_NotFound();
@@ -742,11 +776,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
         }
 
         [Fact]
-        private void NoParams_NestedTaskEither()
+        private async Task NoParams_NestedTaskEither()
         {
             var cacheKey = new TestCacheKey();
 
-            AssertCacheMiss(cacheKey, () => TestMethods.NoParams_NestedTaskEither().Result.Right.Result);
+            AssertCacheMissAsync(cacheKey, TestMethods.NoParams_NestedTaskEither);
         }
 
         [Fact]
@@ -1208,150 +1242,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
         }
 
         [Fact]
-        public void TwoCaches_CacheHitOnFirst()
-        {
-            var cacheKey1 = new TestCacheKeyWithString("test");
-
-            var expected = new TestValue();
-
-            CacheService
-                .Setup(s => s.GetItem(cacheKey1, typeof(TestValue)))
-                .ReturnsAsync(expected);
-
-            var result = TestMethods.TwoCaches("test", 10);
-
-            Assert.Equal(expected, result);
-
-            VerifyAllMocks(CacheService);
-        }
-
-        [Fact]
-        public void TwoCaches_CacheHitOnSecond()
-        {
-            var cacheKey1 = new TestCacheKeyWithString("test");
-            var cacheKey2 = new TestCacheKeyWithInt(10);
-
-            var expected = new TestValue();
-
-            CacheService
-                .Setup(s => s.GetItem(cacheKey1, typeof(TestValue)))
-                .ReturnsAsync(null);
-            CacheService
-                .Setup(s => s.GetItem(cacheKey2, typeof(TestValue)))
-                .ReturnsAsync(expected);
-
-            var result = TestMethods.TwoCaches("test", 10);
-
-            Assert.Equal(expected, result);
-
-            VerifyAllMocks(CacheService);
-        }
-
-        [Fact]
-        public void TwoCaches_CacheMissAll()
-        {
-            var cacheKey1 = new TestCacheKeyWithString("test");
-            var cacheKey2 = new TestCacheKeyWithInt(10);
-
-            CacheService
-                .Setup(s => s.GetItem(cacheKey1, typeof(TestValue)))
-                .ReturnsAsync(null);
-            CacheService
-                .Setup(s => s.GetItem(cacheKey2, typeof(TestValue)))
-                .ReturnsAsync(null);
-
-            var args = new List<object>();
-
-            CacheService
-                .Setup(s => s.SetItem(cacheKey1, Capture.In(args)))
-                .Returns(Task.CompletedTask);
-            CacheService
-                .Setup(s => s.SetItem(cacheKey2, Capture.In(args)))
-                .Returns(Task.CompletedTask);
-
-            var result = TestMethods.TwoCaches("test", 10);
-
-            Assert.Equal(args[0], result);
-            Assert.Equal(args[1], result);
-
-            VerifyAllMocks(CacheService);
-        }
-
-        [Fact]
-        public void TwoCaches_CustomOrder_CacheHitOnFirst()
-        {
-            // Due to the custom cache order, we are
-            // using the second cache first.
-            var cacheKey = new TestCacheKeyWithInt(10);
-
-            var expected = new TestValue();
-
-            CacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
-                .ReturnsAsync(expected);
-
-            var result = TestMethods.TwoCaches_CustomOrder("test", 10);
-
-            Assert.Equal(expected, result);
-
-            VerifyAllMocks(CacheService);
-        }
-
-        [Fact]
-        public void TwoCaches_CustomOrder_CacheHitOnSecond()
-        {
-            // Due to the custom cache order, we are
-            // using the first cache last.
-            var cacheKey1 = new TestCacheKeyWithInt(10);
-            var cacheKey2 = new TestCacheKeyWithString("test");
-
-            var expected = new TestValue();
-
-            CacheService
-                .Setup(s => s.GetItem(cacheKey1, typeof(TestValue)))
-                .ReturnsAsync(null);
-            CacheService
-                .Setup(s => s.GetItem(cacheKey2, typeof(TestValue)))
-                .ReturnsAsync(expected);
-
-            var result = TestMethods.TwoCaches_CustomOrder("test", 10);
-
-            Assert.Equal(expected, result);
-
-            VerifyAllMocks(CacheService);
-        }
-
-        [Fact]
-        public void TwoCaches_CustomOrder_CacheMissAll()
-        {
-            var cacheKey1 = new TestCacheKeyWithString("test");
-            var cacheKey2 = new TestCacheKeyWithInt(10);
-
-            CacheService
-                .Setup(s => s.GetItem(cacheKey1, typeof(TestValue)))
-                .ReturnsAsync(null);
-            CacheService
-                .Setup(s => s.GetItem(cacheKey2, typeof(TestValue)))
-                .ReturnsAsync(null);
-
-            var args = new List<object>();
-
-            CacheService
-                .Setup(s => s.SetItem(cacheKey1, Capture.In(args)))
-                .Returns(Task.CompletedTask);
-            CacheService
-                .Setup(s => s.SetItem(cacheKey2, Capture.In(args)))
-                .Returns(Task.CompletedTask);
-
-            var result = TestMethods.TwoCaches_CustomOrder("test", 10);
-
-            Assert.Equal(args[0], result);
-            Assert.Equal(args[1], result);
-
-            VerifyAllMocks(CacheService);
-        }
-
-        [Fact]
         public void NullCacheKeyType()
         {
             var exception = Assert.Throws<ArgumentException>(TestMethods.NullKeyType);
@@ -1381,8 +1271,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
             // This means that we're only ever getting fresh values for the item and then setting or updating the cached
             // entry with that new value rather than ever attempting to retrieve it.
             CacheService
-                .Setup(s => s.SetItem(cacheKey, Capture.In(args)))
-                .Returns(Task.CompletedTask);
+                .Setup(s => s.SetItem(cacheKey, Capture.In(args)));
 
             var returnedItem = TestMethods.ForceUpdate();
 
@@ -1396,9 +1285,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
         {
             CacheService
                 .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
-                .ReturnsAsync(expectedResult);
+                .Returns(expectedResult);
 
             var result = run();
+
+            Assert.Equal(expectedResult, result);
+
+            VerifyAllMocks(CacheService);
+        }
+
+        private static async Task AssertCacheHit(ICacheKey cacheKey, object expectedResult, Func<Task<TestValue>> run)
+        {
+            CacheService
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TestValue)))
+                .ReturnsAsync(expectedResult);
+
+            var result = await run();
 
             Assert.Equal(expectedResult, result);
 
@@ -1410,17 +1312,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
             AssertCacheMiss(cacheKey, typeof(TestValue), run);
         }
 
+        private static async Task AssertCacheMissAsync(ICacheKey cacheKey, object result)
+        {
+            await AssertCacheMissAsync(cacheKey, typeof(TestValue), result);
+        }
+
         private static void AssertCacheMiss(ICacheKey cacheKey, Type returnType, Func<object> run)
         {
             CacheService
                 .Setup(s => s.GetItem(cacheKey, returnType))
-                .ReturnsAsync(null);
+                .Returns(null);
 
             var args = new List<object>();
 
             CacheService
-                .Setup(s => s.SetItem(cacheKey, Capture.In(args)))
-                .Returns(Task.CompletedTask);
+                .Setup(s => s.SetItem(cacheKey, Capture.In(args)));
 
             var result = run();
 
@@ -1429,7 +1335,43 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
             VerifyAllMocks(CacheService);
         }
 
-        private static MissingMemberException AssertNoMatchingConstructorException(
+        private static async Task AssertCacheMissAsync(ICacheKey cacheKey, Type returnType, object result)
+        {
+            CacheService
+                .Setup(s => s.GetItemAsync(cacheKey, returnType))
+                .ReturnsAsync(null);
+
+            var args = new List<object>();
+
+            CacheService
+                .Setup(s => s.SetItemAsync(cacheKey, Capture.In(args)))
+                .Returns(Task.CompletedTask);
+
+            Assert.Equal(args[0], result);
+
+            VerifyAllMocks(CacheService);
+        }
+
+        private static async Task AssertCacheMiss(ICacheKey cacheKey, Type returnType, Func<Task<object>> run)
+        {
+            CacheService
+                .Setup(s => s.GetItemAsync(cacheKey, returnType))
+                .ReturnsAsync(null);
+
+            var args = new List<object>();
+
+            CacheService
+                .Setup(s => s.SetItemAsync(cacheKey, Capture.In(args)))
+                .Returns(Task.CompletedTask);
+
+            var result = await run();
+
+            Assert.Equal(args[0], result);
+
+            VerifyAllMocks(CacheService);
+        }
+
+        private static void AssertNoMatchingConstructorException(
             Type cacheKeyType,
             Func<object> run)
         {
@@ -1439,8 +1381,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
                 $"No matching constructor for cache key {cacheKeyType.GetPrettyFullName()}",
                 exception.Message
             );
-
-            return exception;
         }
 
         private static AmbiguousMatchException AssertNoUnambiguousMatchException(Type cacheKeyType, Func<TestValue> run)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/MemoryCacheAttributeTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/MemoryCacheAttributeTests.cs
@@ -71,6 +71,12 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
         {
             return new();
         }
+
+        [MemoryCache(typeof(TestMemoryCacheKey), expiryScheduleCron: HourlyExpirySchedule, durationInSeconds: 45)]
+        public static async Task<TestValue> SingleParamAsync(string param)
+        {
+            return new();
+        }
     }
     // ReSharper enable UnusedParameter.Local
 
@@ -82,7 +88,7 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         _memoryCacheService
             .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
-            .ReturnsAsync(expectedResult);
+            .Returns(expectedResult);
 
         var result = TestMethods.SingleParam("test");
 
@@ -90,7 +96,7 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
         Assert.Equal(expectedResult, result);
 
         _memoryCacheService.Verify(
-            s => s.GetItem(cacheKey, typeof(TestValue)), 
+            s => s.GetItem(cacheKey, typeof(TestValue)),
             Times.Once);
     }
 
@@ -101,19 +107,18 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         _memoryCacheService
             .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
-            .ReturnsAsync(null);
+            .Returns(null);
 
         var args = new List<object>();
 
         var expectedCacheConfiguration = new MemoryCacheConfiguration(45, CrontabSchedule.Parse(HourlyExpirySchedule));
-            
+
         _memoryCacheService
             .Setup(s => s.SetItem(
-                cacheKey, 
-                Capture.In(args), 
-                ItIs.DeepEqualTo(expectedCacheConfiguration), 
-                null))
-            .Returns(Task.CompletedTask);
+                cacheKey,
+                Capture.In(args),
+                ItIs.DeepEqualTo(expectedCacheConfiguration),
+                null));
 
         var result = TestMethods.SingleParam("test");
 
@@ -121,7 +126,7 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
         Assert.Equal(args[0], result);
 
         _memoryCacheService.Verify(
-            s => s.GetItem(cacheKey, typeof(TestValue)), 
+            s => s.GetItem(cacheKey, typeof(TestValue)),
             Times.Once);
 
         _memoryCacheService
@@ -129,8 +134,8 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
                     cacheKey, 
                     Capture.In(args), 
                     ItIs.DeepEqualTo(expectedCacheConfiguration), 
-                    null), 
-            Times.Once);
+                    null),
+                Times.Once);
     }
 
     [Fact]
@@ -140,15 +145,14 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         _memoryCacheService
             .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
-            .ReturnsAsync(null);
+            .Returns(null);
 
         var args = new List<object>();
 
         var expectedDefaultCacheConfiguration = new MemoryCacheConfiguration(135);
-            
+
         _memoryCacheService
-            .Setup(s => s.SetItem(cacheKey, Capture.In(args), expectedDefaultCacheConfiguration, null))
-            .Returns(Task.CompletedTask);
+            .Setup(s => s.SetItem(cacheKey, Capture.In(args), expectedDefaultCacheConfiguration, null));
 
         var result = TestMethods.DefaultCacheConfig("test");
 
@@ -156,11 +160,11 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
         Assert.Equal(args[0], result);
 
         _memoryCacheService.Verify(
-            s => s.GetItem(cacheKey, typeof(TestValue)), 
+            s => s.GetItem(cacheKey, typeof(TestValue)),
             Times.Once);
 
         _memoryCacheService.Verify(
-            s => s.SetItem(cacheKey, Capture.In(args), expectedDefaultCacheConfiguration, null), 
+            s => s.SetItem(cacheKey, Capture.In(args), expectedDefaultCacheConfiguration, null),
             Times.Once);
     }
 
@@ -175,20 +179,19 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         targetMemoryCacheService
             .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
-            .ReturnsAsync(null);
+            .Returns(null);
 
         var args = new List<object>();
 
         var expectedCacheConfiguration = new MemoryCacheConfiguration(45, CrontabSchedule.Parse(HourlyExpirySchedule));
-            
+
         targetMemoryCacheService
-            .Setup(s => 
+            .Setup(s =>
                 s.SetItem(
-                    cacheKey, 
-                    Capture.In(args), 
-                    ItIs.DeepEqualTo(expectedCacheConfiguration), 
-                    null))
-            .Returns(Task.CompletedTask);
+                    cacheKey,
+                    Capture.In(args),
+                    ItIs.DeepEqualTo(expectedCacheConfiguration),
+                    null));
 
         var result = TestMethods.SpecificCacheService("test");
 
@@ -204,14 +207,14 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
         var configuration = CreateMockConfigurationSection(
             TupleOf("DurationInSeconds", "456"),
             TupleOf("ExpirySchedule", HalfHourlyExpirySchedule));
-        
+
         MemoryCacheAttribute.SetOverrideConfiguration(configuration.Object);
-        
+
         var cacheKey = new TestMemoryCacheKey("test");
 
         _memoryCacheService
             .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
-            .ReturnsAsync(null);
+            .Returns(null);
 
         var args = new List<object>();
 
@@ -219,14 +222,13 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
         // and the ExpirySchedule are different from those on the `TestMethods.SingleParam` method's cache attribute
         // itself, so we know they've both been overridden.
         var expectedCacheConfiguration = new MemoryCacheConfiguration(456, CrontabSchedule.Parse(HalfHourlyExpirySchedule));
-            
+
         _memoryCacheService
-            .Setup(s => 
-                s.SetItem(cacheKey, 
-                    Capture.In(args), 
-                    ItIs.DeepEqualTo(expectedCacheConfiguration), 
-                    null))
-            .Returns(Task.CompletedTask);
+            .Setup(s =>
+                s.SetItem(cacheKey,
+                    Capture.In(args),
+                    ItIs.DeepEqualTo(expectedCacheConfiguration),
+                    null));
 
         var result = TestMethods.SingleParam("test");
 
@@ -242,14 +244,14 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
         var configuration = CreateMockConfigurationSection(
             TupleOf("DurationInSeconds", (string) null),
             TupleOf("ExpirySchedule", (string) null));
-        
+
         MemoryCacheAttribute.SetOverrideConfiguration(configuration.Object);
-        
+
         var cacheKey = new TestMemoryCacheKey("test");
 
         _memoryCacheService
             .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
-            .ReturnsAsync(null);
+            .Returns(null);
 
         var args = new List<object>();
 
@@ -257,15 +259,14 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
         // values have been specified for either override parameter, then the `TestMethods.SingleParam` cache
         // attribute's config values should still be used.
         var expectedCacheConfiguration = new MemoryCacheConfiguration(45, CrontabSchedule.Parse(HourlyExpirySchedule));
-            
+
         _memoryCacheService
-            .Setup(s => 
+            .Setup(s =>
                 s.SetItem(
-                    cacheKey, 
+                    cacheKey,
                     Capture.In(args),
-                    ItIs.DeepEqualTo(expectedCacheConfiguration), 
-                    null))
-            .Returns(Task.CompletedTask);
+                    ItIs.DeepEqualTo(expectedCacheConfiguration),
+                    null));
 
         var result = TestMethods.SingleParam("test");
 
@@ -279,18 +280,18 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
     public void OverrideConfigSectionSpecifiedButEmptyValues()
     {
         // We don't have the ability to provide "null" default values in the ARM templates for "string" and
-        // "int" parameter types, so we represent them as being not set with empty strings and -1. 
+        // "int" parameter types, so we represent them as being not set with empty strings and -1.
         var configuration = CreateMockConfigurationSection(
             TupleOf("DurationInSeconds", "-1"),
             TupleOf("ExpirySchedule", ""));
-        
+
         MemoryCacheAttribute.SetOverrideConfiguration(configuration.Object);
-        
+
         var cacheKey = new TestMemoryCacheKey("test");
 
         _memoryCacheService
             .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
-            .ReturnsAsync(null);
+            .Returns(null);
 
         var args = new List<object>();
 
@@ -298,15 +299,14 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
         // values have been specified for either override parameter, then the `TestMethods.SingleParam` cache
         // attribute's config values should still be used.
         var expectedCacheConfiguration = new MemoryCacheConfiguration(45, CrontabSchedule.Parse(HourlyExpirySchedule));
-            
+
         _memoryCacheService
-            .Setup(s => 
+            .Setup(s =>
                 s.SetItem(
-                    cacheKey, 
+                    cacheKey,
                     Capture.In(args),
-                    ItIs.DeepEqualTo(expectedCacheConfiguration), 
-                    null))
-            .Returns(Task.CompletedTask);
+                    ItIs.DeepEqualTo(expectedCacheConfiguration),
+                    null));
 
         var result = TestMethods.SingleParam("test");
 
@@ -347,4 +347,67 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
         );
     }
 
+    [Fact]
+    public async Task CacheHitAsync()
+    {
+        var cacheKey = new TestMemoryCacheKey("test");
+        var expectedResult = new TestValue();
+
+        // MemoryCache calls aren't async, so we can call sync `GetItem`
+        // in MemoryCacheAttribute#GetAsync
+        _memoryCacheService
+            .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
+            .Returns(expectedResult);
+
+        var result = await TestMethods.SingleParamAsync("test");
+
+        Assert.IsType<TestValue>(result);
+        Assert.Equal(expectedResult, result);
+
+        _memoryCacheService.Verify(
+            s => s.GetItem(cacheKey, typeof(TestValue)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CacheMissAsync()
+    {
+        var cacheKey = new TestMemoryCacheKey("test");
+
+        // MemoryCache calls aren't async, so we call sync `GetItem`
+        // in MemoryCacheAttribute#GetAsync
+        _memoryCacheService
+            .Setup(s => s.GetItem(cacheKey, typeof(TestValue)))
+            .Returns(null);
+
+        var args = new List<object>();
+
+        var expectedCacheConfiguration = new MemoryCacheConfiguration(45, CrontabSchedule.Parse(HourlyExpirySchedule));
+
+        // MemoryCache calls aren't async, so we call sync `SetItem`
+        // in MemoryCacheAttribute#SetAsync
+        _memoryCacheService
+            .Setup(s => s.SetItem(
+                cacheKey,
+                Capture.In(args),
+                ItIs.DeepEqualTo(expectedCacheConfiguration),
+                null));
+
+        var result = await TestMethods.SingleParamAsync("test");
+
+        Assert.IsType<TestValue>(result);
+        Assert.Equal(args[0], result);
+
+        _memoryCacheService.Verify(
+            s => s.GetItem(cacheKey, typeof(TestValue)),
+            Times.Once);
+
+        _memoryCacheService
+            .Verify(s => s.SetItem(
+                    cacheKey,
+                    Capture.In(args),
+                    ItIs.DeepEqualTo(expectedCacheConfiguration),
+                    null),
+                Times.Once);
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/MemoryCacheAttributeTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/MemoryCacheAttributeTests.cs
@@ -92,7 +92,6 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         var result = TestMethods.SingleParam("test");
 
-        Assert.IsType<TestValue>(result);
         Assert.Equal(expectedResult, result);
 
         _memoryCacheService.Verify(
@@ -122,7 +121,6 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         var result = TestMethods.SingleParam("test");
 
-        Assert.IsType<TestValue>(result);
         Assert.Equal(args[0], result);
 
         _memoryCacheService.Verify(
@@ -156,7 +154,6 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         var result = TestMethods.DefaultCacheConfig("test");
 
-        Assert.IsType<TestValue>(result);
         Assert.Equal(args[0], result);
 
         _memoryCacheService.Verify(
@@ -197,7 +194,6 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         VerifyAllMocks(_memoryCacheService, targetMemoryCacheService);
 
-        Assert.IsType<TestValue>(result);
         Assert.Equal(args[0], result);
     }
 
@@ -234,7 +230,6 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         VerifyAllMocks(_memoryCacheService);
 
-        Assert.IsType<TestValue>(result);
         Assert.Equal(args[0], result);
     }
 
@@ -272,7 +267,6 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         VerifyAllMocks(_memoryCacheService);
 
-        Assert.IsType<TestValue>(result);
         Assert.Equal(args[0], result);
     }
 
@@ -312,7 +306,6 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         VerifyAllMocks(_memoryCacheService);
 
-        Assert.IsType<TestValue>(result);
         Assert.Equal(args[0], result);
     }
 
@@ -361,7 +354,6 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         var result = await TestMethods.SingleParamAsync("test");
 
-        Assert.IsType<TestValue>(result);
         Assert.Equal(expectedResult, result);
 
         _memoryCacheService.Verify(
@@ -395,7 +387,6 @@ public class MemoryCacheAttributeTests : IClassFixture<CacheTestFixture>, IDispo
 
         var result = await TestMethods.SingleParamAsync("test");
 
-        Assert.IsType<TestValue>(result);
         Assert.Equal(args[0], result);
 
         _memoryCacheService.Verify(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ReflectionExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ReflectionExtensionsTests.cs
@@ -305,8 +305,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             [Fact]
             public void Task()
             {
-                Exception e = Assert.Throws<ArgumentException>(() => TestString.TryBoxToResult(typeof(Task<string>), out var boxed));
-                Assert.Equal("Should never need to box a Task", e.Message);
+                Assert.True(TestString.TryBoxToResult(typeof(Task<string>), out var boxed));
+
+                var value = Assert.IsType<Task<string>>(boxed);
+                Assert.Equal(TestString, value.Result);
             }
 
             [Fact]
@@ -317,12 +319,94 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             }
 
             [Fact]
+            public void Task_List()
+            {
+                var list = ListOf("test");
+
+                Assert.True(list.TryBoxToResult(typeof(Task<List<string>>), out var boxed));
+
+                var value = Assert.IsType<Task<List<string>>>(boxed);
+                Assert.Equal(list, value.Result);
+            }
+
+            [Fact]
+            public void Task_List_Interface()
+            {
+                var list = ListOf("test");
+
+                Assert.True(list.TryBoxToResult(typeof(Task<IList<string>>), out var boxed));
+
+                var value = Assert.IsType<Task<IList<string>>>(boxed);
+                Assert.Equal(list, value.Result);
+            }
+
+            [Fact]
+            public void Task_List_Collection()
+            {
+                var list = ListOf("test");
+
+                Assert.True(list.TryBoxToResult(typeof(Task<ICollection<string>>), out var boxed));
+
+                var value = Assert.IsType<Task<ICollection<string>>>(boxed);
+                Assert.Equal(list, value.Result);
+            }
+
+            [Fact]
+            public void Task_List_Enumerable()
+            {
+                var list = ListOf("test");
+
+                Assert.True(list.TryBoxToResult(typeof(Task<IEnumerable<string>>), out var boxed));
+
+                var value = Assert.IsType<Task<IEnumerable<string>>>(boxed);
+                Assert.Equal(list, value.Result);
+            }
+
+            [Fact]
+            public void Task_List_Task()
+            {
+                var list = ListOf(FromResult("test"));
+
+                Assert.True(list.TryBoxToResult(typeof(Task<List<Task<string>>>), out var boxed));
+
+                var value = Assert.IsType<Task<List<Task<string>>>>(boxed);
+                Assert.Equal(list, value.Result);
+            }
+
+            [Fact]
             public void Task_List_Task_Void()
             {
                 var list = ListOf("test");
 
                 Assert.False(list.TryBoxToResult(typeof(Task<List<Task>>), out var boxed));
                 Assert.Equal(list, boxed);
+            }
+
+            [Fact]
+            public void Task_Either()
+            {
+                Assert.True(TestString.TryBoxToResult(typeof(Task<Either<Unit, string>>), out var boxed));
+
+                var value = Assert.IsType<Task<Either<Unit, string>>>(boxed);
+                Assert.Equal(TestString, value.Result.Right);
+            }
+
+            [Fact]
+            public void Task_Either_ActionResult()
+            {
+                Assert.True(TestString.TryBoxToResult(typeof(Task<Either<Unit, ActionResult<string>>>), out var boxed));
+
+                var value = Assert.IsType<Task<Either<Unit, ActionResult<string>>>>(boxed);
+                Assert.Equal(TestString, value.Result.Right.Value);
+            }
+
+            [Fact]
+            public void Task_Task()
+            {
+                Assert.True(TestString.TryBoxToResult(typeof(Task<Task<string>>), out var boxed));
+
+                var value = Assert.IsType<Task<Task<string>>>(boxed);
+                Assert.Equal(TestString, value.Result.Result);
             }
 
             [Fact]
@@ -400,6 +484,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             }
 
             [Fact]
+            public void Task_ActionResult()
+            {
+                Assert.True(TestString.TryBoxToResult(typeof(Task<ActionResult<string>>), out var boxed));
+
+                var value = Assert.IsType<Task<ActionResult<string>>>(boxed);
+                Assert.Equal(TestString, value.Result.Value);
+            }
+
+            [Fact]
             public void Task_Task_Void_DoesNotBox()
             {
                 Assert.False(TestString.TryBoxToResult(typeof(Task<Task>), out var boxed));
@@ -416,8 +509,77 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             [Fact]
             public void Either_Task()
             {
-                var exception = Assert.Throws<ArgumentException>(() => TestString.TryBoxToResult(typeof(Either<Unit, Task<string>>), out var boxed));
-                Assert.Equal("Should never need to box a Task", exception.Message);
+                Assert.True(TestString.TryBoxToResult(typeof(Either<Unit, Task<string>>), out var boxed));
+
+                var value = Assert.IsType<Either<Unit, Task<string>>>(boxed);
+                Assert.Equal(TestString, value.Right.Result);
+            }
+
+            [Fact]
+            public void Either_Task_ActionResult()
+            {
+                Assert.True(TestString.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<string>>>), out var boxed));
+
+                var value = Assert.IsType<Either<Unit, Task<ActionResult<string>>>>(boxed);
+                Assert.Equal(TestString, value.Right.Result.Value);
+            }
+
+            [Fact]
+            public void Either_Task_ActionResult_List()
+            {
+                var list = ListOf("test");
+
+                Assert.True(list.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<List<string>>>>), out var boxed));
+
+                var value = Assert.IsType<Either<Unit, Task<ActionResult<List<string>>>>>(boxed);
+                Assert.Equal(list, value.Right.Result.Value);
+            }
+
+            [Fact]
+            public void Either_Task_ActionResult_List_Interface()
+            {
+                var list = ListOf("test");
+
+                Assert.True(list.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<IList<string>>>>), out var boxed));
+
+                var value = Assert.IsType<Either<Unit, Task<ActionResult<IList<string>>>>>(boxed);
+                Assert.Equal(list, value.Right.Result.Value);
+            }
+
+            [Fact]
+            public void Either_Task_ActionResult_List_Collection()
+            {
+                var list = ListOf("test");
+
+                Assert.True(list.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<ICollection<string>>>>), out var boxed));
+
+                var value = Assert.IsType<Either<Unit, Task<ActionResult<ICollection<string>>>>>(boxed);
+                Assert.Equal(list, value.Right.Result.Value);
+            }
+
+            [Fact]
+            public void Either_Task_ActionResult_List_Enumerable()
+            {
+                var list = ListOf("test");
+
+                Assert.True(list.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<IEnumerable<string>>>>), out var boxed));
+
+                var value = Assert.IsType<Either<Unit, Task<ActionResult<IEnumerable<string>>>>>(boxed);
+                Assert.Equal(list, value.Right.Result.Value);
+            }
+
+            [Fact]
+            public void Either_Task_ActionResult_DoesNotBox()
+            {
+                Assert.False(TestString.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<List<string>>>>), out var boxed));
+                Assert.Equal(TestString, boxed);
+            }
+
+            [Fact]
+            public void Either_Task_ActionResult_Void_DoesNotBox()
+            {
+                Assert.False(TestString.TryBoxToResult(typeof(Either<Unit, Task<ActionResult>>), out var boxed));
+                Assert.Equal(TestString, boxed);
             }
 
             [Fact]
@@ -468,10 +630,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             }
 
             [Fact]
-            public void List_Tasks_Void() // TryUnboxResult doesn't inspect elements of Lists, so this passes
+            public void List_Tasks_Void()
             {
                 var list = ListOf(CompletedTask, CompletedTask);
 
+                // TryUnboxResult doesn't inspect elements of Lists, so this test passes
                 Assert.True(list.TryUnboxResult(out var unboxed));
                 Assert.Equal(list, unboxed);
             }
@@ -606,7 +769,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
                 var boxed = FromResult(TestString);
 
                 var exception = Assert.Throws<ArgumentException>(() => boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal("Should never need to unbox a Task", exception.Message);
+                Assert.Equal("Cannot unbox Tasks as this may cause thread exhaustion. Consider awaiting the result first.", exception.Message);
             }
 
             [Fact]
@@ -615,7 +778,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
                 var boxed = CompletedTask;
 
                 var exception = Assert.Throws<ArgumentException>(() => boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal("Should never need to unbox a Task", exception.Message);
+                Assert.Equal("Cannot unbox Tasks as this may cause thread exhaustion. Consider awaiting the result first.", exception.Message);
             }
 
             [Fact]
@@ -652,7 +815,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
                 var boxed = new Either<Unit, Task<string>>(FromResult(TestString));
 
                 var exception = Assert.Throws<ArgumentException>(() => boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal("Should never need to unbox a Task", exception.Message);
+                Assert.Equal("Cannot unbox Tasks as this may cause thread exhaustion. Consider awaiting the result first.", exception.Message);
             }
 
             [Fact]
@@ -661,7 +824,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
                 var boxed = new Either<Unit, Task>(CompletedTask);
 
                 var exception = Assert.Throws<ArgumentException>(() => boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal("Should never need to unbox a Task", exception.Message);
+                Assert.Equal("Cannot unbox Tasks as this may cause thread exhaustion. Consider awaiting the result first.", exception.Message);
             }
 
             [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ReflectionExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ReflectionExtensionsTests.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -304,10 +305,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             [Fact]
             public void Task()
             {
-                Assert.True(TestString.TryBoxToResult(typeof(Task<string>), out var boxed));
-
-                var value = Assert.IsType<Task<string>>(boxed);
-                Assert.Equal(TestString, value.Result);
+                Exception e = Assert.Throws<ArgumentException>(() => TestString.TryBoxToResult(typeof(Task<string>), out var boxed));
+                Assert.Equal("Should never need to box a Task", e.Message);
             }
 
             [Fact]
@@ -315,61 +314,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             {
                 Assert.False(TestString.TryBoxToResult(typeof(Task), out var boxed));
                 Assert.Equal(TestString, boxed);
-            }
-
-            [Fact]
-            public void Task_List()
-            {
-                var list = ListOf("test");
-
-                Assert.True(list.TryBoxToResult(typeof(Task<List<string>>), out var boxed));
-
-                var value = Assert.IsType<Task<List<string>>>(boxed);
-                Assert.Equal(list, value.Result);
-            }
-
-            [Fact]
-            public void Task_List_Interface()
-            {
-                var list = ListOf("test");
-
-                Assert.True(list.TryBoxToResult(typeof(Task<IList<string>>), out var boxed));
-
-                var value = Assert.IsType<Task<IList<string>>>(boxed);
-                Assert.Equal(list, value.Result);
-            }
-
-            [Fact]
-            public void Task_List_Collection()
-            {
-                var list = ListOf("test");
-
-                Assert.True(list.TryBoxToResult(typeof(Task<ICollection<string>>), out var boxed));
-
-                var value = Assert.IsType<Task<ICollection<string>>>(boxed);
-                Assert.Equal(list, value.Result);
-            }
-
-            [Fact]
-            public void Task_List_Enumerable()
-            {
-                var list = ListOf("test");
-
-                Assert.True(list.TryBoxToResult(typeof(Task<IEnumerable<string>>), out var boxed));
-
-                var value = Assert.IsType<Task<IEnumerable<string>>>(boxed);
-                Assert.Equal(list, value.Result);
-            }
-
-            [Fact]
-            public void Task_List_Task()
-            {
-                var list = ListOf(FromResult("test"));
-
-                Assert.True(list.TryBoxToResult(typeof(Task<List<Task<string>>>), out var boxed));
-
-                var value = Assert.IsType<Task<List<Task<string>>>>(boxed);
-                Assert.Equal(list, value.Result);
             }
 
             [Fact]
@@ -456,46 +400,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             }
 
             [Fact]
-            public void Task_Either()
-            {
-                Assert.True(TestString.TryBoxToResult(typeof(Task<Either<Unit, string>>), out var boxed));
-
-                var value = Assert.IsType<Task<Either<Unit, string>>>(boxed);
-                Assert.Equal(TestString, value.Result.Right);
-            }
-
-            [Fact]
-            public void Task_Either_ActionResult()
-            {
-                Assert.True(TestString.TryBoxToResult(typeof(Task<Either<Unit, ActionResult<string>>>), out var boxed));
-
-                var value = Assert.IsType<Task<Either<Unit, ActionResult<string>>>>(boxed);
-                Assert.Equal(TestString, value.Result.Right.Value);
-            }
-
-            [Fact]
-            public void Task_Task()
-            {
-                Assert.True(TestString.TryBoxToResult(typeof(Task<Task<string>>), out var boxed));
-
-                var value = Assert.IsType<Task<Task<string>>>(boxed);
-                Assert.Equal(TestString, value.Result.Result);
-            }
-
-            [Fact]
             public void Task_Task_Void_DoesNotBox()
             {
                 Assert.False(TestString.TryBoxToResult(typeof(Task<Task>), out var boxed));
                 Assert.Equal(TestString, boxed);
-            }
-
-            [Fact]
-            public void Task_ActionResult()
-            {
-                Assert.True(TestString.TryBoxToResult(typeof(Task<ActionResult<string>>), out var boxed));
-
-                var value = Assert.IsType<Task<ActionResult<string>>>(boxed);
-                Assert.Equal(TestString, value.Result.Value);
             }
 
             [Fact]
@@ -508,77 +416,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             [Fact]
             public void Either_Task()
             {
-                Assert.True(TestString.TryBoxToResult(typeof(Either<Unit, Task<string>>), out var boxed));
-
-                var value = Assert.IsType<Either<Unit, Task<string>>>(boxed);
-                Assert.Equal(TestString, value.Right.Result);
-            }
-
-            [Fact]
-            public void Either_Task_ActionResult()
-            {
-                Assert.True(TestString.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<string>>>), out var boxed));
-
-                var value = Assert.IsType<Either<Unit, Task<ActionResult<string>>>>(boxed);
-                Assert.Equal(TestString, value.Right.Result.Value);
-            }
-
-            [Fact]
-            public void Either_Task_ActionResult_List()
-            {
-                var list = ListOf("test");
-
-                Assert.True(list.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<List<string>>>>), out var boxed));
-
-                var value = Assert.IsType<Either<Unit, Task<ActionResult<List<string>>>>>(boxed);
-                Assert.Equal(list, value.Right.Result.Value);
-            }
-
-            [Fact]
-            public void Either_Task_ActionResult_List_Interface()
-            {
-                var list = ListOf("test");
-
-                Assert.True(list.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<IList<string>>>>), out var boxed));
-
-                var value = Assert.IsType<Either<Unit, Task<ActionResult<IList<string>>>>>(boxed);
-                Assert.Equal(list, value.Right.Result.Value);
-            }
-
-            [Fact]
-            public void Either_Task_ActionResult_List_Collection()
-            {
-                var list = ListOf("test");
-
-                Assert.True(list.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<ICollection<string>>>>), out var boxed));
-
-                var value = Assert.IsType<Either<Unit, Task<ActionResult<ICollection<string>>>>>(boxed);
-                Assert.Equal(list, value.Right.Result.Value);
-            }
-
-            [Fact]
-            public void Either_Task_ActionResult_List_Enumerable()
-            {
-                var list = ListOf("test");
-
-                Assert.True(list.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<IEnumerable<string>>>>), out var boxed));
-
-                var value = Assert.IsType<Either<Unit, Task<ActionResult<IEnumerable<string>>>>>(boxed);
-                Assert.Equal(list, value.Right.Result.Value);
-            }
-
-            [Fact]
-            public void Either_Task_ActionResult_DoesNotBox()
-            {
-                Assert.False(TestString.TryBoxToResult(typeof(Either<Unit, Task<ActionResult<List<string>>>>), out var boxed));
-                Assert.Equal(TestString, boxed);
-            }
-
-            [Fact]
-            public void Either_Task_ActionResult_Void_DoesNotBox()
-            {
-                Assert.False(TestString.TryBoxToResult(typeof(Either<Unit, Task<ActionResult>>), out var boxed));
-                Assert.Equal(TestString, boxed);
+                var exception = Assert.Throws<ArgumentException>(() => TestString.TryBoxToResult(typeof(Either<Unit, Task<string>>), out var boxed));
+                Assert.Equal("Should never need to box a Task", exception.Message);
             }
 
             [Fact]
@@ -629,7 +468,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             }
 
             [Fact]
-            public void List_Tasks_Void()
+            public void List_Tasks_Void() // TryUnboxResult doesn't inspect elements of Lists, so this passes
             {
                 var list = ListOf(CompletedTask, CompletedTask);
 
@@ -766,8 +605,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             {
                 var boxed = FromResult(TestString);
 
-                Assert.True(boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal(TestString, unboxed);
+                var exception = Assert.Throws<ArgumentException>(() => boxed.TryUnboxResult(out var unboxed));
+                Assert.Equal("Should never need to unbox a Task", exception.Message);
             }
 
             [Fact]
@@ -775,39 +614,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             {
                 var boxed = CompletedTask;
 
-                Assert.False(boxed.TryUnboxResult(out var unboxed));
-                Assert.Null(unboxed);
-
-            }
-
-            [Fact]
-            public void Task_List()
-            {
-                var list = ListOf("test");
-                var boxed = FromResult(list);
-
-                Assert.True(boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal(list, unboxed);
-            }
-
-            [Fact]
-            public void Task_List_Tasks()
-            {
-                var list = ListOf(FromResult("test1"), FromResult("test2"));
-                var boxed = FromResult(list);
-
-                Assert.True(boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal(list, unboxed);
-            }
-
-            [Fact]
-            public void Task_List_Tasks_Void()
-            {
-                var list = ListOf(CompletedTask, CompletedTask);
-                var boxed = FromResult(list);
-
-                Assert.True(boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal(list, unboxed);
+                var exception = Assert.Throws<ArgumentException>(() => boxed.TryUnboxResult(out var unboxed));
+                Assert.Equal("Should never need to unbox a Task", exception.Message);
             }
 
             [Fact]
@@ -839,39 +647,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             }
 
             [Fact]
-            public void Task_Either()
-            {
-                var boxed = FromResult(new Either<Unit, string>(TestString));
-
-                Assert.True(boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal(TestString, unboxed);
-            }
-
-            [Fact]
-            public void Task_Either_ActionResult()
-            {
-                var boxed = FromResult(new Either<Unit, ActionResult<string>>(TestString));
-
-                Assert.True(boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal(TestString, unboxed);
-            }
-
-            [Fact]
-            public void Task_Task()
-            {
-                var boxed = FromResult(FromResult(TestString));
-
-                Assert.True(boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal(TestString, unboxed);
-            }
-
-            [Fact]
             public void Either_Task()
             {
                 var boxed = new Either<Unit, Task<string>>(FromResult(TestString));
 
-                Assert.True(boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal(TestString, unboxed);
+                var exception = Assert.Throws<ArgumentException>(() => boxed.TryUnboxResult(out var unboxed));
+                Assert.Equal("Should never need to unbox a Task", exception.Message);
             }
 
             [Fact]
@@ -879,31 +660,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             {
                 var boxed = new Either<Unit, Task>(CompletedTask);
 
-                Assert.False(boxed.TryUnboxResult(out var unboxed));
-                Assert.Null(unboxed);
-            }
-
-            [Fact]
-            public void Either_Task_ActionResult()
-            {
-                var boxed = new Either<Unit, Task<ActionResult<string>>>(
-                    FromResult(new ActionResult<string>(TestString))
-                );
-
-                Assert.True(boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal(TestString, unboxed);
-            }
-
-            [Fact]
-            public void Either_Task_ActionResult_Void()
-            {
-                var result = new OkResult();
-                var boxed = new Either<Unit, Task<ActionResult>>(
-                    FromResult<ActionResult>(result)
-                );
-
-                Assert.True(boxed.TryUnboxResult(out var unboxed));
-                Assert.Equal(result, unboxed);
+                var exception = Assert.Throws<ArgumentException>(() => boxed.TryUnboxResult(out var unboxed));
+                Assert.Equal("Should never need to unbox a Task", exception.Message);
             }
 
             [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobCacheServiceTests.cs
@@ -39,7 +39,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         }
 
         [Fact]
-        public async Task SetItem()
+        public void SetItem()
+        {
+            var entity = new SampleClass();
+
+            var cacheKey = new SampleCacheKey(PublicContent, entity.Id);
+
+            var service = SetupBlobStorageCacheService();
+
+            Assert.Throws<NotImplementedException>(() => service.SetItem(cacheKey, typeof(SampleClass)));
+        }
+
+        [Fact]
+        public async Task SetItemAsync()
         {
             var cacheKey = new SampleCacheKey(PublicContent, Guid.NewGuid());
 
@@ -51,13 +63,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
 
-            await service.SetItem(cacheKey, "test item");
+            await service.SetItemAsync(cacheKey, "test item");
 
             VerifyAllMocks(blobStorageService);
         }
 
         [Fact]
-        public async Task DeleteItem()
+        public async Task DeleteItemAsync()
         {
             var cacheKey = new SampleCacheKey(PublicContent, Guid.NewGuid());
 
@@ -69,13 +81,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
 
-            await service.DeleteItem(cacheKey);
+            await service.DeleteItemAsync(cacheKey);
 
             VerifyAllMocks(blobStorageService);
         }
 
         [Fact]
-        public async Task GetItem()
+        public void GetItem()
+        {
+            var entity = new SampleClass();
+
+            var cacheKey = new SampleCacheKey(PublicContent, entity.Id);
+
+            var service = SetupBlobStorageCacheService();
+
+            Assert.Throws<NotImplementedException>(() => service.GetItem(cacheKey, typeof(SampleClass)));
+        }
+
+        [Fact]
+        public async Task GetItemAsync()
         {
             var entity = new SampleClass();
 
@@ -90,7 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
 
-            var result = await service.GetItem(cacheKey, typeof(SampleClass));
+            var result = await service.GetItemAsync(cacheKey, typeof(SampleClass));
             var typedResult = Assert.IsType<SampleClass>(result);
 
             Assert.Equal(entity, typedResult);
@@ -99,7 +123,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         }
 
         [Fact]
-        public async Task GetItem_NullIfErrorDeserializingCachedEntity()
+        public async Task GetItemAsync_NullIfErrorDeserializingCachedEntity()
         {
             var cacheKey = new SampleCacheKey(PublicContent, Guid.NewGuid());
 
@@ -117,7 +141,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
 
-            var result = await service.GetItem(cacheKey, typeof(SampleClass));
+            var result = await service.GetItemAsync(cacheKey, typeof(SampleClass));
 
             Assert.Null(result);
 
@@ -125,7 +149,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         }
 
         [Fact]
-        public async Task GetItem_NullIfNoFileFoundException()
+        public async Task GetItemAsync_NullIfNoFileFoundException()
         {
             var cacheKey = new SampleCacheKey(PublicContent, Guid.NewGuid());
 
@@ -138,7 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
 
-            var result = await service.GetItem(cacheKey, typeof(SampleClass));
+            var result = await service.GetItemAsync(cacheKey, typeof(SampleClass));
 
             Assert.Null(result);
 
@@ -146,7 +170,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         }
 
         [Fact]
-        public async Task GetItem_NullIfException()
+        public async Task GetItemAsync_NullIfException()
         {
             var cacheKey = new SampleCacheKey(PublicContent, Guid.NewGuid());
 
@@ -159,7 +183,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
 
-            var result = await service.GetItem(cacheKey, typeof(SampleClass));
+            var result = await service.GetItemAsync(cacheKey, typeof(SampleClass));
 
             Assert.Null(result);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/MemoryCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/MemoryCacheServiceTests.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
@@ -33,7 +32,7 @@ public class MemoryCacheServiceTests
     private readonly SampleCacheKey _cacheKey = new("Key");
 
     [Fact]
-    public async Task SetItem()
+    public void SetItem()
     {
         // The requested ExpirySchedule is hourly, meaning that cached items will have their 
         // expiry times truncated if the requested cache duration would carry over into a new
@@ -47,11 +46,11 @@ public class MemoryCacheServiceTests
         // This should not be truncated as it does not carry over into the next hour.
         var expectedCacheExpiry = now.AddSeconds(45);
 
-        await SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
+        SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
     }
         
     [Fact]
-    public async Task SetItem_ExpiryTimeTruncated_Hourly()
+    public void SetItem_ExpiryTimeTruncated_Hourly()
     {
         // The requested ExpirySchedule is hourly, meaning that cached items will have their 
         // expiry times truncated if the requested cache duration would carry over into a new
@@ -65,11 +64,11 @@ public class MemoryCacheServiceTests
         // This should be truncated as it carries 15 seconds over into the next hour.
         var expectedCacheExpiry = now.AddSeconds(45 - 15);
 
-        await SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
+        SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
     }
         
     [Fact]
-    public async Task SetItem_ExpiryTimeTruncated_Hourly_LastHourOfDay()
+    public void SetItem_ExpiryTimeTruncated_Hourly_LastHourOfDay()
     {
         // The requested ExpirySchedule is hourly, meaning that cached items will have their 
         // expiry times truncated if the requested cache duration would carry over into a new
@@ -84,11 +83,11 @@ public class MemoryCacheServiceTests
         // This should be truncated as it carries 15 seconds over into the next hour.
         var expectedCacheExpiry = now.AddSeconds(45 - 15);
 
-        await SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
+        SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
     }
         
     [Fact]
-    public async Task SetItem_ExpiryTimeNotTruncated_HalfHourly()
+    public void SetItem_ExpiryTimeNotTruncated_HalfHourly()
     {
         // The requested ExpirySchedule is half-hourly, meaning that cached items will have
         // their expiry times truncated if the requested cache duration would carry over into
@@ -102,11 +101,11 @@ public class MemoryCacheServiceTests
         // This should not be truncated as it does not carry over into the next half hour.
         var expectedCacheExpiry = now.AddSeconds(15);
 
-        await SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
+        SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
     }
         
     [Fact]
-    public async Task SetItem_ExpiryTimeTruncated_HalfHourly()
+    public void SetItem_ExpiryTimeTruncated_HalfHourly()
     {
         // The requested ExpirySchedule is hourly, meaning that cached items will have their 
         // expiry times truncated if the requested cache duration would carry over into a new
@@ -120,11 +119,11 @@ public class MemoryCacheServiceTests
         // This should be truncated as it carries 15 seconds over into the next half hour.
         var expectedCacheExpiry = now.AddSeconds(45 - 15);
 
-        await SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
+        SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
     }
         
     [Fact]
-    public async Task SetItem_ExpiryTimeTruncated_HalfHourly_LastHalfHourOfDay()
+    public void SetItem_ExpiryTimeTruncated_HalfHourly_LastHalfHourOfDay()
     {
         // The requested ExpirySchedule is hourly, meaning that cached items will have their 
         // expiry times truncated if the requested cache duration would carry over into a new
@@ -139,11 +138,11 @@ public class MemoryCacheServiceTests
         // This should be truncated as it carries 15 seconds over into the next half hour.
         var expectedCacheExpiry = now.AddSeconds(45 - 15);
 
-        await SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
+        SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
     }
         
     [Fact]
-    public async Task SetItem_ExpiryTimeNotTruncated_NoExpirySchedule()
+    public void SetItem_ExpiryTimeNotTruncated_NoExpirySchedule()
     {
         // The requested ExpirySchedule is hourly, meaning that cached items will have their 
         // expiry times truncated if the requested cache duration would carry over into a new
@@ -156,11 +155,11 @@ public class MemoryCacheServiceTests
         // schedule, the requested cache duration will be honoured.
         var expectedCacheExpiry = now.AddSeconds(6000);
 
-        await SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
+        SetItemAndAssertExpiryTime(now, cacheConfiguration, expectedCacheExpiry);
     }
         
     [Fact]
-    public async Task SetItem_ExceptionHandledGracefullyWhenCachingItem()
+    public void SetItem_ExceptionHandledGracefullyWhenCachingItem()
     {
         var cacheConfiguration = new MemoryCacheConfiguration(6000);
 
@@ -171,12 +170,12 @@ public class MemoryCacheServiceTests
             .Throws(new Exception("Exception during \"SetItem\" call should have been handled gracefully"));
 
         var service = SetupService(memoryCache.Object);
-        await service.SetItem(_cacheKey, "test item", cacheConfiguration, DateTime.UtcNow);
+        service.SetItem(_cacheKey, "test item", cacheConfiguration, DateTime.UtcNow);
         VerifyAllMocks(memoryCache);
     }
 
     [Fact]
-    public async Task GetItem()
+    public void GetItem()
     {
         object entity = new SampleClass();
 
@@ -186,13 +185,13 @@ public class MemoryCacheServiceTests
 
         var service = SetupService(memoryCache);
 
-        var result = await service.GetItem(_cacheKey, typeof(SampleClass));
+        var result = service.GetItem(_cacheKey, typeof(SampleClass));
 
         Assert.Equal(entity, result);
     }
 
     [Fact]
-    public async Task GetItem_MoreSpecificSubtypeReturnsOk()
+    public void GetItem_MoreSpecificSubtypeReturnsOk()
     {
         object entity = new SampleClassSubtype();
 
@@ -202,13 +201,13 @@ public class MemoryCacheServiceTests
 
         var service = SetupService(memoryCache);
 
-        var result = await service.GetItem(_cacheKey, typeof(SampleClass));
+        var result = service.GetItem(_cacheKey, typeof(SampleClass));
 
         Assert.Equal(entity, result);
     }
 
     [Fact]
-    public async Task GetItem_NullIfLessSpecificSupertype()
+    public void GetItem_NullIfLessSpecificSupertype()
     {
         object entity = new SampleClassSuperclass();
         
@@ -218,23 +217,23 @@ public class MemoryCacheServiceTests
 
         var service = SetupService(memoryCache);
 
-        var result = await service.GetItem(_cacheKey, typeof(SampleClass));
+        var result = service.GetItem(_cacheKey, typeof(SampleClass));
 
         Assert.Null(result);
     }
 
     [Fact]
-    public async Task GetItem_NullIfCacheMiss()
+    public void GetItem_NullIfCacheMiss()
     {
         var service = SetupService();
 
-        var result = await service.GetItem(_cacheKey, typeof(SampleClass));
+        var result = service.GetItem(_cacheKey, typeof(SampleClass));
 
         Assert.Null(result);
     }
 
     [Fact]
-    public async Task GetItem_NullIfException()
+    public void GetItem_NullIfException()
     {
         var key = new SampleCacheKey("");
 
@@ -247,14 +246,14 @@ public class MemoryCacheServiceTests
 
         var service = SetupService(memoryCache.Object);
 
-        var result = await service.GetItem(key, typeof(SampleClass));
+        var result = service.GetItem(key, typeof(SampleClass));
         VerifyAllMocks(memoryCache);
 
         Assert.Null(result);
     }
 
     [Fact]
-    public async Task GetItem_NullIfIncorrectType()
+    public void GetItem_NullIfIncorrectType()
     {
         object entityOfIncorrectType = new SampleClass();
 
@@ -268,13 +267,13 @@ public class MemoryCacheServiceTests
 
         var service = SetupService(memoryCache.Object);
 
-        var result = await service.GetItem(key, typeof(string));
+        var result = service.GetItem(key, typeof(string));
         VerifyAllMocks(memoryCache);
 
         Assert.Null(result);
     }
 
-    private async Task SetItemAndAssertExpiryTime(
+    private void SetItemAndAssertExpiryTime(
         DateTime now,
         MemoryCacheConfiguration cacheConfiguration,
         DateTime expectedCacheExpiry)
@@ -289,7 +288,7 @@ public class MemoryCacheServiceTests
             .Returns(cacheEntry);
 
         var service = SetupService(memoryCache.Object);
-        await service.SetItem(_cacheKey, valueToCache, cacheConfiguration, now);
+        service.SetItem(_cacheKey, valueToCache, cacheConfiguration, now);
         VerifyAllMocks(memoryCache);
         
         Assert.Equal($"\"{valueToCache}\"".Length, cacheEntry.Size);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/BlobCacheAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/BlobCacheAttribute.cs
@@ -39,7 +39,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
             Services.Clear();
         }
 
-        public override async Task<object?> Get(ICacheKey cacheKey, Type returnType)
+        public override object? Get(ICacheKey cacheKey, Type returnType)
+        {
+            // Blob cache requires an async call to blob storage, so allowing use of `Get` would inject async code into
+            // the sync attributed method.
+            throw new ArgumentException("The BlobCache attribute cannot be applied to sync methods");
+        }
+
+        public override void Set(ICacheKey cacheKey, object value)
+        {
+            // Blob cache requires an async call to blob storage, so allowing use of `Set` would inject async code into
+            // the sync attributed method.
+            throw new ArgumentException("The BlobCache attribute cannot be applied to sync methods");
+        }
+
+        public override async Task<object?> GetAsync(ICacheKey cacheKey, Type returnType)
         {
             if (cacheKey is IBlobCacheKey key)
             {
@@ -56,7 +70,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
             throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
         }
 
-        public override async Task Set(ICacheKey cacheKey, object value)
+        public override async Task SetAsync(ICacheKey cacheKey, object value)
         {
             if (cacheKey is IBlobCacheKey key)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheAspect.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheAspect.cs
@@ -1,17 +1,14 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using AspectInjector.Broker;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Aspects.Universal.Aspects;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
 {
     [Aspect(Scope.Global)]
-    public class CacheAspect
+    public class CacheAspect : BaseUniversalWrapperAspect
     {
         private const BindingFlags ConstructorBindingFlags =
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance |
@@ -30,9 +27,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
 
         [Advice(Kind.Around)]
         public object Handle(
-            [Argument(Source.Target)] Func<object[], object> target,
-            [Argument(Source.Arguments)] object[] args,
+            [Argument(Source.Instance)] object instance,
+            [Argument(Source.Type)] Type type,
             [Argument(Source.Metadata)] MethodBase method,
+            [Argument(Source.Target)] Func<object[], object> target,
+            [Argument(Source.Name)] string name,
+            [Argument(Source.Arguments)] object[] args,
             [Argument(Source.ReturnType)] Type returnType,
             [Argument(Source.Triggers)] Attribute[] triggers)
         {
@@ -46,342 +46,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
                 throw new ArgumentException("Method return type cannot be void");
             }
 
-            var cacheTriggers = triggers
-                .OfType<CacheAttribute>()
-                .Distinct()
-                .OrderByDescending(c => c.Priority)
-                .ToList();
-
-            // Keep track of the the cache keys so that we
-            // don't need to recalculate them later on
-            // (this could be expensive due to reflection).
-            var cacheKeys = new Dictionary<Type, ICacheKey>();
-
-            object? cachedResult = null;
-
-            // May be using boxed types, and these may be nested, so we
-            // recursively go through all the types to get the real
-            // return type that we're interested in caching.
-            var cachedReturnType = returnType.GetUnboxedResultTypePath().Last();
-
-            foreach (var cacheTrigger in cacheTriggers)
+            if (typeof(Task).IsAssignableFrom(returnType) && !returnType.IsConstructedGenericType)
             {
-                // Don't attempt to get a cached value from any triggers that are requesting that the cached value be
-                // updated rather than fetched from the cache. 
-                if (cacheTrigger.ForceUpdate)
-                {
-                    continue;
-                }
-                
-                var cacheKey = cacheKeys.GetOrSet(
-                    cacheTrigger.Key,
-                    () => GetCacheKey(cacheTrigger.Key, args, method)
-                );
-
-                var triggerResult = cacheTrigger.Get(cacheKey, cachedReturnType).Result;
-
-                if (triggerResult is null)
-                {
-                    continue;
-                }
-
-                cachedResult = triggerResult;
-                break;
+                throw new ArgumentException("Method return type cannot be Task. Consider using Task<TResult>");
             }
 
-            if (cachedResult?.TryBoxToResult(returnType, out cachedResult) == true)
-            {
-                return cachedResult;
-            }
-
-            // If no cached result could be found, then we run the real
-            // method and get its result so that we can cache it.
-            var result = target(args);
-
-            if (!result.TryUnboxResult(out cachedResult) || cachedResult is null)
-            {
-                return result;
-            }
-
-            Task.WaitAll(
-                cacheTriggers.Select(
-                        cacheTrigger =>
-                        {
-                            var cacheKey = cacheKeys.GetOrSet(
-                                cacheTrigger.Key,
-                                () => GetCacheKey(cacheTrigger.Key, args, method)
-                            );
-
-                            return cacheTrigger.Set(cacheKey, cachedResult);
-                        }
-                    )
-                    .ToArray()
-            );
-
-            return result;
+            return BaseHandle(instance, type, method, target, name, args, returnType, triggers);
         }
-
-        private ICacheKey GetCacheKey(Type cacheKeyType, object[] methodArgs, MethodBase method)
-        {
-            // Order constructors from most parameters to least so that we can
-            // try and find the constructor with the most matching arguments first.
-            var constructors = cacheKeyType.GetConstructors()
-                .OrderByDescending(constructor => constructor.GetParameters().Length)
-                .ToList();
-
-            if (constructors.Count == 0)
-            {
-                throw new MissingMethodException(
-                    $"Cache key {cacheKeyType.GetPrettyFullName()} must have at least one constructor"
-                );
-            }
-
-            var parameters = GetMatchingParams(constructors, method, cacheKeyType);
-
-            var invokeArgs = parameters
-                .Select(param =>
-                    {
-                        if (param.Param is not null)
-                        {
-                            return methodArgs[param.Param.Position];
-                        }
-
-                        return param.HasDefaultValue ? Type.Missing : null;
-                    }
-                )
-                .ToList();
-
-            // For some reason, invoking with only missing values
-            // will lead to an exception being thrown.
-            if (invokeArgs.All(arg => arg == Type.Missing))
-            {
-                invokeArgs.Clear();
-            }
-
-            var keyInstance = Activator.CreateInstance(
-                cacheKeyType,
-                bindingAttr: ConstructorBindingFlags,
-                args: invokeArgs.ToArray(),
-                binder: null,
-                culture: null
-            );
-
-            if (keyInstance is ICacheKey key)
-            {
-                return key;
-            }
-
-            throw new InvalidOperationException(
-                $"Constructor returned null when it should instantiate {cacheKeyType.GetPrettyFullName()}"
-            );
-        }
-
-        private static List<ParameterInfoScore> GetMatchingParams(
-            List<ConstructorInfo> constructors,
-            MethodBase method,
-            Type cacheKeyType)
-        {
-            var methodParams = method.GetParameters();
-
-            var cacheKeyParams = methodParams
-                .Select(
-                    param =>
-                    {
-                        var attribute = param.GetCustomAttribute<CacheKeyParamAttribute>();
-
-                        return attribute is not null ? new CacheKeyParamInfo(param, attribute) : null;
-                    }
-                )
-                .WhereNotNull()
-                .ToList();
-
-            List<string> matchErrors = new();
-
-            foreach (var constructor in constructors)
-            {
-                var constructorParams = constructor.GetParameters();
-
-                var constructorParamMatches = cacheKeyParams.Count > 0
-                    ? MatchConstructorToCacheKeyParams(constructorParams, cacheKeyParams)
-                    : MatchConstructorToMethodParams(constructorParams, methodParams);
-
-                // Not enough arguments match the constructor's
-                // parameters, so we should move onto the next one.
-                if (constructorParamMatches.Count != constructorParams.Length)
-                {
-                    continue;
-                }
-
-                if (!constructorParamMatches.All(HasUnambiguousMatch))
-                {
-                    matchErrors.Add(GetMultipleMatchesError(constructorParams, constructorParamMatches));
-
-                    continue;
-                }
-
-                // The final param candidates that we select
-                // to invoke the cache key constructor with.
-                var selectedParams = constructorParamMatches
-                    .Select(matches => matches[0])
-                    .ToList();
-
-                var nonNullParams = selectedParams
-                    .Select(param => param.Param)
-                    .WhereNotNull()
-                    .ToList();
-
-                var distinctNonNullParams = nonNullParams.Distinct().ToList();
-
-                if (nonNullParams.Count != distinctNonNullParams.Count)
-                {
-                    matchErrors.Add(GetCandidateParametersError(constructorParams, distinctNonNullParams));
-
-                    continue;
-                }
-
-                return selectedParams;
-            }
-
-            if (matchErrors.Any())
-            {
-                throw new AmbiguousMatchException(
-                    $"No constructor for cache key {cacheKeyType.GetPrettyFullName()} could be unambiguously matched. Found the following problems: \n- " +
-                    matchErrors.JoinToString("\n- ")
-                );
-            }
-
-            throw new MissingMemberException(
-                $"No matching constructor for cache key {cacheKeyType.GetPrettyFullName()} using parameters from method: {method}"
-            );
-        }
-
-        private static string GetMultipleMatchesError(
-            ParameterInfo[] constructorParams,
-            List<List<ParameterInfoScore>> constructorParamMatches)
-        {
-            var positions = constructorParamMatches
-                .Select((matches, index) => !HasUnambiguousMatch(matches) ? index.ToString() : "")
-                .Where(position => !position.IsNullOrEmpty())
-                .JoinToString(", ");
-
-            var constructorString = constructorParams
-                .Select(param => param.ToShortString())
-                .JoinToString(", ");
-
-            return $"Constructor ({constructorString}) has multiple matches at position(s): {positions}";
-        }
-
-        private static string GetCandidateParametersError(
-            IEnumerable<ParameterInfo> constructorParams,
-            IEnumerable<ParameterInfo> selectedParams)
-        {
-            var constructorString = constructorParams
-                .Select(param => param.ToShortString())
-                .JoinToString(", ");
-
-            var paramsString = selectedParams
-                .Select(param => param.ToShortString())
-                .JoinToString(", ");
-
-            return
-                $"Constructor ({constructorString}) has candidate parameters ({paramsString}) that could not be unambiguously matched";
-        }
-
-        private static bool HasUnambiguousMatch(List<ParameterInfoScore> matches)
-        {
-            return matches.Count > 1
-                ? matches[0].Score > matches[1].Score
-                : matches.Count == 1;
-        }
-
-        private static List<List<ParameterInfoScore>> MatchConstructorToCacheKeyParams(
-            ParameterInfo[] constructorParams,
-            List<CacheKeyParamInfo> cacheKeyParams)
-        {
-            return MatchConstructorToParams(
-                constructorParams,
-                constructorParam =>  cacheKeyParams
-                    .Where(param => constructorParam.ParameterType.IsAssignableFrom(param.Info.ParameterType))
-                    .Select(param => ScoreCacheKeyParam(param, constructorParam))
-                    .OrderByDescending(param => param.Score)
-                    .ToList()
-            );
-        }
-
-        private static List<List<ParameterInfoScore>> MatchConstructorToMethodParams(
-            ParameterInfo[] constructorParams,
-            ParameterInfo[] methodParams)
-        {
-            return MatchConstructorToParams(
-                constructorParams,
-                constructorParam => methodParams
-                    .Where(param => constructorParam.ParameterType.IsAssignableFrom(param.ParameterType))
-                    .Select(param => ScoreParam(param, constructorParam))
-                    .OrderByDescending(param => param.Score)
-                    .ToList()
-            );
-        }
-
-        private static List<List<ParameterInfoScore>> MatchConstructorToParams(
-            ParameterInfo[] constructorParams,
-            Func<ParameterInfo, List<ParameterInfoScore>> matcher)
-        {
-            return constructorParams.Select(
-                    constructorParam =>
-                    {
-                        var matches = matcher(constructorParam);
-
-                        if (!matches.Any() && (constructorParam.IsNullable() || constructorParam.HasDefaultValue))
-                        {
-                            matches.Add(new ParameterInfoScore(null, 0, constructorParam.HasDefaultValue));
-                        }
-
-                        return matches;
-                    }
-                )
-                .Where(paramMatches => paramMatches.Any())
-                .ToList();
-        }
-
-        private static ParameterInfoScore ScoreCacheKeyParam(
-            CacheKeyParamInfo cacheKeyParam,
-            ParameterInfo constructorParam)
-        {
-            var (cacheKeyParamInfo, cacheKeyParamAttribute) = cacheKeyParam;
-
-            var score = 0;
-
-            if (cacheKeyParamAttribute.Name is not null
-                && cacheKeyParamAttribute.Name == constructorParam.Name)
-            {
-                score += 1;
-            }
-            else if (constructorParam.Name is not null 
-                     && constructorParam.Name.Equals(cacheKeyParamInfo.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                score += 1;
-            }
-
-            return new ParameterInfoScore(cacheKeyParam.Info, score, constructorParam.HasDefaultValue);
-        }
-
-        private static ParameterInfoScore ScoreParam(
-            ParameterInfo methodParam,
-            ParameterInfo constructorParam)
-        {
-            var score = 0;
-
-            if (constructorParam.Name is not null 
-                && constructorParam.Name.Equals(methodParam.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                score += 1;
-            }
-
-            return new ParameterInfoScore(methodParam, score, constructorParam.HasDefaultValue);
-        }
-
-        private record CacheKeyParamInfo(ParameterInfo Info, CacheKeyParamAttribute Attribute);
-
-        private record ParameterInfoScore(ParameterInfo? Param, int Score, bool HasDefaultValue = false);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheAttribute.cs
@@ -1,7 +1,12 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using AspectInjector.Broker;
+using Aspects.Universal.Attributes;
+using Aspects.Universal.Events;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
@@ -11,21 +16,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
     /// Base caching attribute that should be extended with specific
     /// caching implementations e.g. blob storage, memory, Redis, etc.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method)]
     [Injection(typeof(CacheAspect), Inherited = true)]
-    public abstract class CacheAttribute : Attribute
+    public abstract class CacheAttribute : BaseUniversalWrapperAttribute
     {
+        private const BindingFlags ConstructorBindingFlags =
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance |
+            BindingFlags.OptionalParamBinding;
+
         /// <summary>
         /// The base type of the cache key to use.
         /// The <see cref="Key"/> must be assignable to this.
         /// </summary>
         protected virtual Type BaseKey => typeof(ICacheKey);
-
-        /// <summary>
-        /// Cache with highest priority is checked first.
-        /// 0 - Lowest, 255 - Highest.
-        /// </summary>
-        public byte Priority { get; init; } = 0;
 
         /// <summary>
         /// The explicit type of the caching key to use. It must be assignable
@@ -74,8 +77,348 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
             }
         }
 
-        public abstract Task<object?> Get(ICacheKey cacheKey, Type returnType);
+        protected override T WrapSync<T>(Func<object[], T> target, object[] args, AspectEventArgs eventArgs)
+        {
+            var unboxedResultType = typeof(T).GetUnboxedResultTypePath().Last();
 
-        public abstract Task Set(ICacheKey cacheKey, object value);
+            var cacheKey = GetCacheKey(Key, args, eventArgs.Method);
+
+            object? cachedResult = null;
+            if (!ForceUpdate)
+            {
+                cachedResult = Get(cacheKey, unboxedResultType);
+            }
+
+            if (cachedResult?.TryBoxToResult(typeof(T), out cachedResult) == true)
+            {
+                return (T)cachedResult;
+            }
+
+            try
+            {
+                var result = target(args);
+
+                if (!result.TryUnboxResult(out cachedResult) || cachedResult is null)
+                {
+                    return result;
+                }
+
+                Set(cacheKey, cachedResult);
+
+                return result;
+            }
+            catch (Exception exception)
+            {
+                return OnException<T>(eventArgs, exception);
+            }
+        }
+
+        protected override async Task<T> WrapAsync<T>(Func<object[], Task<T>> target, object[] args, AspectEventArgs eventArgs)
+        {
+            var unboxedResultType = typeof(T).GetUnboxedResultTypePath().Last();
+
+            var cacheKey = GetCacheKey(Key, args, eventArgs.Method);
+
+            object? cachedResult = null;
+            if (!ForceUpdate)
+            {
+                cachedResult = await GetAsync(cacheKey, unboxedResultType);
+            }
+
+            if (cachedResult?.TryBoxToResult(typeof(T), out cachedResult) == true)
+            {
+                return (T)cachedResult;
+            }
+
+            try
+            {
+                var result = await target(args);
+
+                if (!result.TryUnboxResult(out cachedResult) || cachedResult is null)
+                {
+                    return result;
+                }
+
+                await SetAsync(cacheKey, cachedResult);
+
+                return result;
+            }
+            catch (Exception exception)
+            {
+                return OnException<T>(eventArgs, exception);
+            }
+        }
+
+        public abstract object? Get(ICacheKey cacheKey, Type returnType);
+
+        public abstract void Set(ICacheKey cacheKey, object value);
+
+        public abstract Task<object?> GetAsync(ICacheKey cacheKey, Type returnType);
+
+        public abstract Task SetAsync(ICacheKey cacheKey, object value);
+
+        protected virtual T OnException<T>(AspectEventArgs eventArgs, Exception exception) => throw exception;
+
+        public ICacheKey GetCacheKey(Type cacheKeyType, object[] methodArgs, MethodBase method)
+        {
+            // Order constructors from most parameters to least so that we can
+            // try and find the constructor with the most matching arguments first.
+            var constructors = cacheKeyType.GetConstructors()
+                .OrderByDescending(constructor => constructor.GetParameters().Length)
+                .ToList();
+
+            if (constructors.Count == 0)
+            {
+                throw new MissingMethodException(
+                    $"Cache key {cacheKeyType.GetPrettyFullName()} must have at least one constructor"
+                );
+            }
+
+            var parameters = GetMatchingParams(constructors, method, cacheKeyType);
+
+            var invokeArgs = parameters
+                .Select(param =>
+                    {
+                        if (param.Param is not null)
+                        {
+                            return methodArgs[param.Param.Position];
+                        }
+
+                        return param.HasDefaultValue ? Type.Missing : null;
+                    }
+                )
+                .ToList();
+
+            // For some reason, invoking with only missing values
+            // will lead to an exception being thrown.
+            if (invokeArgs.All(arg => arg == Type.Missing))
+            {
+                invokeArgs.Clear();
+            }
+
+            var keyInstance = Activator.CreateInstance(
+                cacheKeyType,
+                bindingAttr: ConstructorBindingFlags,
+                args: invokeArgs.ToArray(),
+                binder: null,
+                culture: null
+            );
+
+            if (keyInstance is ICacheKey key)
+            {
+                return key;
+            }
+
+            throw new InvalidOperationException(
+                $"Constructor returned null when it should instantiate {cacheKeyType.GetPrettyFullName()}"
+            );
+        }
+        private static List<ParameterInfoScore> GetMatchingParams(
+            List<ConstructorInfo> constructors,
+            MethodBase method,
+            Type cacheKeyType)
+        {
+            var methodParams = method.GetParameters();
+
+            var cacheKeyParams = methodParams
+                .Select(
+                    param =>
+                    {
+                        var attribute = param.GetCustomAttribute<CacheKeyParamAttribute>();
+
+                        return attribute is not null ? new CacheKeyParamInfo(param, attribute) : null;
+                    }
+                )
+                .WhereNotNull()
+                .ToList();
+
+            List<string> matchErrors = new();
+
+            foreach (var constructor in constructors)
+            {
+                var constructorParams = constructor.GetParameters();
+
+                var constructorParamMatches = cacheKeyParams.Count > 0
+                    ? MatchConstructorToCacheKeyParams(constructorParams, cacheKeyParams)
+                    : MatchConstructorToMethodParams(constructorParams, methodParams);
+
+                // Not enough arguments match the constructor's
+                // parameters, so we should move onto the next one.
+                if (constructorParamMatches.Count != constructorParams.Length)
+                {
+                    continue;
+                }
+
+                if (!constructorParamMatches.All(HasUnambiguousMatch))
+                {
+                    matchErrors.Add(GetMultipleMatchesError(constructorParams, constructorParamMatches));
+
+                    continue;
+                }
+
+                // The final param candidates that we select
+                // to invoke the cache key constructor with.
+                var selectedParams = constructorParamMatches
+                    .Select(matches => matches[0])
+                    .ToList();
+
+                var nonNullParams = selectedParams
+                    .Select(param => param.Param)
+                    .WhereNotNull()
+                    .ToList();
+
+                var distinctNonNullParams = nonNullParams.Distinct().ToList();
+
+                if (nonNullParams.Count != distinctNonNullParams.Count)
+                {
+                    matchErrors.Add(GetCandidateParametersError(constructorParams, distinctNonNullParams));
+
+                    continue;
+                }
+
+                return selectedParams;
+            }
+
+            if (matchErrors.Any())
+            {
+                throw new AmbiguousMatchException(
+                    $"No constructor for cache key {cacheKeyType.GetPrettyFullName()} could be unambiguously matched. Found the following problems: \n- " +
+                    matchErrors.JoinToString("\n- ")
+                );
+            }
+
+            throw new MissingMemberException(
+                $"No matching constructor for cache key {cacheKeyType.GetPrettyFullName()} using parameters from method: {method}"
+            );
+        }
+
+        private static string GetMultipleMatchesError(
+            ParameterInfo[] constructorParams,
+            List<List<ParameterInfoScore>> constructorParamMatches)
+        {
+            var positions = constructorParamMatches
+                .Select((matches, index) => !HasUnambiguousMatch(matches) ? index.ToString() : "")
+                .Where(position => !position.IsNullOrEmpty())
+                .JoinToString(", ");
+
+            var constructorString = constructorParams
+                .Select(param => param.ToShortString())
+                .JoinToString(", ");
+
+            return $"Constructor ({constructorString}) has multiple matches at position(s): {positions}";
+        }
+
+        private static string GetCandidateParametersError(
+            IEnumerable<ParameterInfo> constructorParams,
+            IEnumerable<ParameterInfo> selectedParams)
+        {
+            var constructorString = constructorParams
+                .Select(param => param.ToShortString())
+                .JoinToString(", ");
+
+            var paramsString = selectedParams
+                .Select(param => param.ToShortString())
+                .JoinToString(", ");
+
+            return
+                $"Constructor ({constructorString}) has candidate parameters ({paramsString}) that could not be unambiguously matched";
+        }
+
+        private static bool HasUnambiguousMatch(List<ParameterInfoScore> matches)
+        {
+            return matches.Count > 1
+                ? matches[0].Score > matches[1].Score
+                : matches.Count == 1;
+        }
+
+        private static List<List<ParameterInfoScore>> MatchConstructorToCacheKeyParams(
+            ParameterInfo[] constructorParams,
+            List<CacheKeyParamInfo> cacheKeyParams)
+        {
+            return MatchConstructorToParams(
+                constructorParams,
+                constructorParam =>  cacheKeyParams
+                    .Where(param => constructorParam.ParameterType.IsAssignableFrom(param.Info.ParameterType))
+                    .Select(param => ScoreCacheKeyParam(param, constructorParam))
+                    .OrderByDescending(param => param.Score)
+                    .ToList()
+            );
+        }
+
+        private static List<List<ParameterInfoScore>> MatchConstructorToMethodParams(
+            ParameterInfo[] constructorParams,
+            ParameterInfo[] methodParams)
+        {
+            return MatchConstructorToParams(
+                constructorParams,
+                constructorParam => methodParams
+                    .Where(param => constructorParam.ParameterType.IsAssignableFrom(param.ParameterType))
+                    .Select(param => ScoreParam(param, constructorParam))
+                    .OrderByDescending(param => param.Score)
+                    .ToList()
+            );
+        }
+
+        private static List<List<ParameterInfoScore>> MatchConstructorToParams(
+            ParameterInfo[] constructorParams,
+            Func<ParameterInfo, List<ParameterInfoScore>> matcher)
+        {
+            return constructorParams.Select(
+                    constructorParam =>
+                    {
+                        var matches = matcher(constructorParam);
+
+                        if (!matches.Any() && (constructorParam.IsNullable() || constructorParam.HasDefaultValue))
+                        {
+                            matches.Add(new ParameterInfoScore(null, 0, constructorParam.HasDefaultValue));
+                        }
+
+                        return matches;
+                    }
+                )
+                .Where(paramMatches => paramMatches.Any())
+                .ToList();
+        }
+
+        private static ParameterInfoScore ScoreCacheKeyParam(
+            CacheKeyParamInfo cacheKeyParam,
+            ParameterInfo constructorParam)
+        {
+            var (cacheKeyParamInfo, cacheKeyParamAttribute) = cacheKeyParam;
+
+            var score = 0;
+
+            if (cacheKeyParamAttribute.Name is not null
+                && cacheKeyParamAttribute.Name == constructorParam.Name)
+            {
+                score += 1;
+            }
+            else if (constructorParam.Name is not null
+                     && constructorParam.Name.Equals(cacheKeyParamInfo.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                score += 1;
+            }
+
+            return new ParameterInfoScore(cacheKeyParam.Info, score, constructorParam.HasDefaultValue);
+        }
+
+        private static ParameterInfoScore ScoreParam(
+            ParameterInfo methodParam,
+            ParameterInfo constructorParam)
+        {
+            var score = 0;
+
+            if (constructorParam.Name is not null
+                && constructorParam.Name.Equals(methodParam.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                score += 1;
+            }
+
+            return new ParameterInfoScore(methodParam, score, constructorParam.HasDefaultValue);
+        }
+
+        private record CacheKeyParamInfo(ParameterInfo Info, CacheKeyParamAttribute Attribute);
+
+        private record ParameterInfoScore(ParameterInfo? Param, int Score, bool HasDefaultValue = false);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ReflectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ReflectionExtensions.cs
@@ -58,7 +58,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
                         break;
 
                     case "Task":
-                        throw new ArgumentException("Should never need to box a Task");
+                        var task = typeof(Task).GetMethod("FromResult")
+                            ?.MakeGenericMethod(boxType.GenericTypeArguments)
+                            .Invoke(null, new[] { boxedValue });
+
+                        boxedValue = task;
+                        break;
 
                     case "Either":
                         var eitherType = typeof(Either<,>).MakeGenericType(boxType.GenericTypeArguments);
@@ -95,7 +100,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 
                 if (result is Task)
                 {
-                    throw new ArgumentException("Should never need to unbox a Task");
+                    // TODO: EES-4268 Create async variant of this method
+                    throw new ArgumentException("Cannot unbox Tasks as this may cause thread exhaustion. Consider awaiting the result first.");
                 }
 
                 var resultType = result.GetType();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ReflectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ReflectionExtensions.cs
@@ -58,12 +58,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
                         break;
 
                     case "Task":
-                        var task = typeof(Task).GetMethod("FromResult")
-                            ?.MakeGenericMethod(boxType.GenericTypeArguments)
-                            .Invoke(null, new[] { boxedValue });
-
-                        boxedValue = task;
-                        break;
+                        throw new ArgumentException("Should never need to box a Task");
 
                     case "Either":
                         var eitherType = typeof(Either<,>).MakeGenericType(boxType.GenericTypeArguments);
@@ -98,6 +93,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
                     return true;
                 }
 
+                if (result is Task)
+                {
+                    throw new ArgumentException("Should never need to unbox a Task");
+                }
+
                 var resultType = result.GetType();
 
                 // Stop at the first non-generic result type type.
@@ -111,23 +111,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
                 {
                     result = null;
                     return false;
-                }
-
-                if (result is Task task)
-                {
-                    try
-                    {
-                        task.Wait();
-
-                    }
-                    catch (AggregateException)
-                    {
-                        result = null;
-                        return false;
-                    }
-
-                    result = result.GetType().GetProperty("Result")?.GetValue(task);
-                    continue;
                 }
 
                 // Potentially unsafe to use just the name for this,

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -8,6 +8,7 @@
     <ItemGroup>
         <PackageReference Include="AngleSharp" Version="1.0.0-alpha-844" />
         <PackageReference Include="AspectInjector" Version="2.7.3" PrivateAssets="all" />
+        <PackageReference Include="Aspects.Universal" Version="1.0.1" />
         <PackageReference Include="AutoMapper" Version="9.0.0" />
         <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
         <PackageReference Include="CsvHelper" Version="30.0.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobCacheService.cs
@@ -21,7 +21,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             _logger = logger;
         }
 
-        public async Task<object?> GetItem(IBlobCacheKey cacheKey, Type targetType)
+        public object? GetItem(IBlobCacheKey cacheKey, Type targetType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<object?> GetItemAsync(IBlobCacheKey cacheKey, Type targetType)
         {
             var blobContainer = cacheKey.Container;
             var key = cacheKey.Key;
@@ -31,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             {
                 var result = await _blobStorageService.GetDeserializedJson(cacheKey.Container, cacheKey.Key, targetType);
 
-                _logger.LogDebug("Blob cache {HitOrMiss} - for key {CacheKey}", 
+                _logger.LogDebug("Blob cache {HitOrMiss} - for key {CacheKey}",
                     result != null ? "hit" : "miss", key);
 
                 return result;
@@ -41,7 +46,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
                 // If there's an error deserializing the blob, we should
                 // assume it's not salvageable and delete it so that it's re-built.
                 _logger.LogWarning(e, $"Error deserializing JSON for blobContainer {blobContainer} and cache " +
-                                   $"key {key} - deleting cached JSON");
+                                      $"key {key} - deleting cached JSON");
                 await _blobStorageService.DeleteBlob(blobContainer, key);
             }
             catch (FileNotFoundException)
@@ -56,7 +61,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return default;
         }
 
-        public async Task SetItem<TItem>(
+        public void SetItem<TItem>(
+            IBlobCacheKey cacheKey,
+            TItem item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task SetItemAsync<TItem>(
             IBlobCacheKey cacheKey,
             TItem item)
         {
@@ -65,15 +77,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
             _logger.LogDebug("Blob cache set - for key {CacheKey}", cacheKey.Key);
         }
-        
-        public async Task DeleteItem(IBlobCacheKey cacheKey)
+
+        public async Task DeleteItemAsync(IBlobCacheKey cacheKey)
         {
             await _blobStorageService.DeleteBlob(cacheKey.Container, cacheKey.Key);
 
             _logger.LogDebug("Blob cache delete - for key {CacheKey}", cacheKey.Key);
         }
 
-        public async Task DeleteCacheFolder(IBlobCacheKey cacheFolderKey)
+        public async Task DeleteCacheFolderAsync(IBlobCacheKey cacheFolderKey)
         {
             await _blobStorageService.DeleteBlobs(cacheFolderKey.Container, cacheFolderKey.Key);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobCacheService.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobCacheService.cs
@@ -1,18 +1,13 @@
 ﻿#nullable enable
-using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 {
-    public interface IBlobCacheService
+    public interface IBlobCacheService : ICacheService<IBlobCacheKey>
     {
-        Task<object?> GetItem(IBlobCacheKey cacheKey, Type targetType);
-
-        Task SetItem<TItem>(IBlobCacheKey cacheKey, TItem item);
-
-        Task DeleteItem(IBlobCacheKey cacheKey);
+        Task DeleteItemAsync(IBlobCacheKey cacheKey);
         
-        Task DeleteCacheFolder(IBlobCacheKey cacheFolderKey);
+        Task DeleteCacheFolderAsync(IBlobCacheKey cacheFolderKey);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
@@ -2,35 +2,17 @@
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 {
     public interface ICacheService<in TKey> where TKey : ICacheKey
     {
-        Task<TItem?> GetItem<TItem>(TKey cacheKey)
-            where TItem : class;
+        object? GetItem(TKey cacheKey, Type targetType);
 
-        Task<object?> GetItem(TKey cacheKey, Type targetType);
+        Task<object?> GetItemAsync(TKey cacheKey, Type targetType);
 
-        Task SetItem<TItem>(TKey cacheKey, TItem item);
+        void SetItem<TItem>(TKey cacheKey, TItem item);
 
-        Task DeleteItem(TKey cacheKey);
-        
-        Task<TItem> GetItem<TItem>(
-            TKey cacheKey,
-            Func<TItem> itemSupplier)
-            where TItem : class;
-
-        Task<TItem> GetItem<TItem>(
-            TKey cacheKey,
-            Func<Task<TItem>> itemSupplier)
-            where TItem : class;
-
-        Task<Either<ActionResult, TItem>> GetItem<TItem>(
-            TKey cacheKey,
-            Func<Task<Either<ActionResult, TItem>>> itemSupplier)
-            where TItem : class;
+        Task SetItemAsync<TItem>(TKey cacheKey, TItem item);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IMemoryCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IMemoryCacheService.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 using System;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 
@@ -22,11 +21,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 /// </summary>
 public interface IMemoryCacheService
 {
-    Task<object?> GetItem(IMemoryCacheKey cacheKey, Type targetType);
+    object? GetItem(IMemoryCacheKey cacheKey, Type targetType);
 
-    Task SetItem<TItem>(
-        IMemoryCacheKey cacheKey, 
-        TItem item, 
+    void SetItem<TItem>(
+        IMemoryCacheKey cacheKey,
+        TItem item,
         MemoryCacheConfiguration configuration,
         DateTime? nowUtc = null);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/MemoryCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/MemoryCacheService.cs
@@ -32,7 +32,7 @@ public class MemoryCacheService : IMemoryCacheService
         _logger = logger;
     }
 
-    public Task<object?> GetItem(IMemoryCacheKey cacheKey, Type targetType)
+    public object? GetItem(IMemoryCacheKey cacheKey, Type targetType)
     {
         object? cachedItem;
 
@@ -43,40 +43,40 @@ public class MemoryCacheService : IMemoryCacheService
         catch (Exception e)
         {
             _logger.LogError(
-                e, 
-                "Error whilst retrieving cached item for key {CacheKey} - returning null", 
+                e,
+                "Error whilst retrieving cached item for key {CacheKey} - returning null",
                 GetCacheKeyDescription(cacheKey));
-            return Task.FromResult((object?) null);
+            return null;
         }
 
         if (cachedItem == null)
         {
             _logger.LogInformation(
-                "Cache miss for cache key {CacheKeyDescription}", 
+                "Cache miss for cache key {CacheKeyDescription}",
                 GetCacheKeyDescription(cacheKey));
-            return Task.FromResult((object?) null);
+            return null;
         }
-        
+
         if (!targetType.IsInstanceOfType(cachedItem))
         {
             _logger.LogError(
                 "Cached type {CachedItemType} is not an instance of " +
                 "{TargetType} for cache key {CacheKey} - returning null",
-                cachedItem.GetType(), 
-                nameof(targetType), 
+                cachedItem.GetType(),
+                nameof(targetType),
                 GetCacheKeyDescription(cacheKey));
 
-            return Task.FromResult((object?) null);
+            return null;
         }
 
         _logger.LogInformation(
             "Returning cached result for cache key {CacheKeyDescription}",
             GetCacheKeyDescription(cacheKey));
 
-        return Task.FromResult(cachedItem)!;
+        return cachedItem;
     }
 
-    public Task SetItem<TItem>(
+    public void SetItem<TItem>(
         IMemoryCacheKey cacheKey,
         TItem item,
         MemoryCacheConfiguration configuration,
@@ -96,7 +96,7 @@ public class MemoryCacheService : IMemoryCacheService
             else
             {
                 var nextExpiryTime = configuration.ExpirySchedule.GetNextOccurrence(now);
-                
+
                 absoluteExpiryTime = targetAbsoluteExpiryDateTime < nextExpiryTime
                     ? targetAbsoluteExpiryDateTime
                     : nextExpiryTime;
@@ -118,14 +118,12 @@ public class MemoryCacheService : IMemoryCacheService
             _logger.LogInformation("Setting cached item with cache key {CacheKeyDescription}, " +
                                    "approx size {Size} bytes, expiry time {ExpiryTime}",
                 GetCacheKeyDescription(cacheKey), approximateSizeInBytes, expiryTime);
-            return Task.CompletedTask;
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Exception thrown when caching item with cache key {CacheKeyDescription}.  " +
-                                "Returning gracefully.", 
+                                "Returning gracefully.",
                 GetCacheKeyDescription(cacheKey));
-            return Task.CompletedTask;
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerCachingTests.cs
@@ -37,7 +37,7 @@ public class ReleaseControllerCachingTests : CacheServiceTestFixture
             .Setup(s => s.GetItem(
                 new GetLatestReleaseCacheKey(PublicationSlug),
                 typeof(ReleaseViewModel)))
-            .ReturnsAsync(null);
+            .Returns(null);
 
         var methodologySummaries = new List<MethodologyVersionSummaryViewModel>();
         var publicationCacheViewModel = new PublicationCacheViewModel
@@ -63,8 +63,7 @@ public class ReleaseControllerCachingTests : CacheServiceTestFixture
                 new GetLatestReleaseCacheKey(PublicationSlug),
                 It.IsAny<ReleaseViewModel>(),
                 ItIs.DeepEqualTo(expectedCacheConfiguration),
-                null))
-            .Returns(Task.CompletedTask);
+                null));
 
         var controller = BuildReleaseController(
             methodologyCacheService: methodologyCacheService.Object,
@@ -91,7 +90,7 @@ public class ReleaseControllerCachingTests : CacheServiceTestFixture
             .Setup(s => s.GetItem(
                 new GetLatestReleaseCacheKey(PublicationSlug),
                 typeof(ReleaseViewModel)))
-            .ReturnsAsync(releaseViewModel);
+            .Returns(releaseViewModel);
 
         var controller = BuildReleaseController();
 
@@ -112,7 +111,7 @@ public class ReleaseControllerCachingTests : CacheServiceTestFixture
             .Setup(s => s.GetItem(
                 new GetReleaseCacheKey(PublicationSlug, ReleaseSlug),
                 typeof(ReleaseViewModel)))
-            .ReturnsAsync(null);
+            .Returns(null);
 
         var methodologySummaries = new List<MethodologyVersionSummaryViewModel>();
         var publicationCacheViewModel = new PublicationCacheViewModel
@@ -138,8 +137,7 @@ public class ReleaseControllerCachingTests : CacheServiceTestFixture
                 new GetReleaseCacheKey(PublicationSlug, ReleaseSlug),
                 It.IsAny<ReleaseViewModel>(),
                 ItIs.DeepEqualTo(expectedCacheConfiguration),
-                null))
-            .Returns(Task.CompletedTask);
+                null));
 
         var controller = BuildReleaseController(
             methodologyCacheService: methodologyCacheService.Object,
@@ -166,7 +164,7 @@ public class ReleaseControllerCachingTests : CacheServiceTestFixture
             .Setup(s => s.GetItem(
                 new GetReleaseCacheKey(PublicationSlug, ReleaseSlug),
                 typeof(ReleaseViewModel)))
-            .ReturnsAsync(releaseViewModel);
+            .Returns(releaseViewModel);
 
         var controller = BuildReleaseController();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
@@ -28,15 +28,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
             MemoryCacheService
                 .Setup(s => s.GetItem(
                     It.IsAny<IMemoryCacheKey>(), typeof(ReleaseViewModel)))
-                .ReturnsAsync(null);
+                .Returns(null);
 
             MemoryCacheService
                 .Setup(s => s.SetItem<object>(
                     It.IsAny<IMemoryCacheKey>(),
                     It.IsAny<ReleaseViewModel>(),
                     It.IsAny<MemoryCacheConfiguration>(),
-                    null))
-                .Returns(Task.CompletedTask);
+                    null));
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
@@ -28,11 +28,11 @@ public class GlossaryCacheServiceTests : CacheServiceTestFixture
         var cacheKey = new GlossaryCacheKey();
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(cacheKey, typeof(List<GlossaryCategoryViewModel>)))
+            .Setup(s => s.GetItemAsync(cacheKey, typeof(List<GlossaryCategoryViewModel>)))
             .ReturnsAsync(null);
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(cacheKey, _glossary))
+            .Setup(s => s.SetItemAsync<object>(cacheKey, _glossary))
             .Returns(Task.CompletedTask);
 
         var glossaryService = new Mock<IGlossaryService>(Strict);
@@ -54,7 +54,7 @@ public class GlossaryCacheServiceTests : CacheServiceTestFixture
     public async Task GetGlossary_CachedGlossary()
     {
         PublicBlobCacheService
-            .Setup(s => s.GetItem(new GlossaryCacheKey(), typeof(List<GlossaryCategoryViewModel>)))
+            .Setup(s => s.GetItemAsync(new GlossaryCacheKey(), typeof(List<GlossaryCategoryViewModel>)))
             .ReturnsAsync(_glossary);
 
         var service = BuildService();
@@ -76,7 +76,7 @@ public class GlossaryCacheServiceTests : CacheServiceTestFixture
             .ReturnsAsync(_glossary);
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(new GlossaryCacheKey(), _glossary))
+            .Setup(s => s.SetItemAsync<object>(new GlossaryCacheKey(), _glossary))
             .Returns(Task.CompletedTask);
 
         var service = BuildService(glossaryService: glossaryService.Object);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/MethodologyCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/MethodologyCacheServiceTests.cs
@@ -62,7 +62,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
     public async Task GetSummariesTree_NoCachedTreeExists()
     {
         PublicBlobCacheService
-            .Setup(s => s.GetItem(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
+            .Setup(s => s.GetItemAsync(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
             .ReturnsAsync(null);
 
         var methodologyService = new Mock<IMethodologyService>(Strict);
@@ -72,7 +72,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
             .ReturnsAsync(new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(_methodologyTree));
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(new AllMethodologiesCacheKey(), _methodologyTree))
+            .Setup(s => s.SetItemAsync<object>(new AllMethodologiesCacheKey(), _methodologyTree))
             .Returns(Task.CompletedTask);
 
         var service = SetupService(methodologyService: methodologyService.Object);
@@ -88,7 +88,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
     public async Task GetSummariesTree_CachedTreeExists()
     {
         PublicBlobCacheService
-            .Setup(s => s.GetItem(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
+            .Setup(s => s.GetItemAsync(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
             .ReturnsAsync(_methodologyTree);
 
         var service = SetupService();
@@ -106,7 +106,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
         var publicationId = _methodologyTree[1].Topics[0].Publications[0].Id;
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
+            .Setup(s => s.GetItemAsync(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
             .ReturnsAsync(null);
 
         var methodologyService = new Mock<IMethodologyService>(Strict);
@@ -116,7 +116,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
             .ReturnsAsync(new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(_methodologyTree));
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(new AllMethodologiesCacheKey(), _methodologyTree))
+            .Setup(s => s.SetItemAsync<object>(new AllMethodologiesCacheKey(), _methodologyTree))
             .Returns(Task.CompletedTask);
 
         var service = SetupService(methodologyService: methodologyService.Object);
@@ -143,7 +143,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
         // We should not see any attempt to "get" the cached tree, but rather only see a fresh fetching
         // of the latest tree and then it being cached.
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(new AllMethodologiesCacheKey(), _methodologyTree))
+            .Setup(s => s.SetItemAsync<object>(new AllMethodologiesCacheKey(), _methodologyTree))
             .Returns(Task.CompletedTask);
 
         var service = SetupService(methodologyService: methodologyService.Object);
@@ -161,7 +161,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
         var publicationId = _methodologyTree[1].Topics[0].Publications[0].Id;
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
+            .Setup(s => s.GetItemAsync(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
             .ReturnsAsync(_methodologyTree);
 
         var service = SetupService();
@@ -182,7 +182,7 @@ public class MethodologyCacheServiceTests : CacheServiceTestFixture
         var publicationId = Guid.NewGuid();
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
+            .Setup(s => s.GetItemAsync(new AllMethodologiesCacheKey(), typeof(List<AllMethodologiesThemeViewModel>)))
             .ReturnsAsync(_methodologyTree);
 
         var service = SetupService();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -75,11 +75,11 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
         var cacheKey = new PublicationCacheKey(PublicationSlug);
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(cacheKey, typeof(PublicationCacheViewModel)))
+            .Setup(s => s.GetItemAsync(cacheKey, typeof(PublicationCacheViewModel)))
             .ReturnsAsync(null);
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(cacheKey, _publicationViewModel))
+            .Setup(s => s.SetItemAsync<object>(cacheKey, _publicationViewModel))
             .Returns(Task.CompletedTask);
 
         var publicationService = new Mock<IPublicationService>(Strict);
@@ -103,7 +103,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
         var cacheKey = new PublicationCacheKey(PublicationSlug);
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(cacheKey, typeof(PublicationCacheViewModel)))
+            .Setup(s => s.GetItemAsync(cacheKey, typeof(PublicationCacheViewModel)))
             .ReturnsAsync(_publicationViewModel);
 
         var service = BuildService();
@@ -121,7 +121,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
         var cacheKey = new PublicationCacheKey(PublicationSlug);
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(cacheKey, typeof(PublicationCacheViewModel)))
+            .Setup(s => s.GetItemAsync(cacheKey, typeof(PublicationCacheViewModel)))
             .ReturnsAsync(null);
 
         var publicationService = new Mock<IPublicationService>(Strict);
@@ -160,7 +160,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
         });
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(
+            .Setup(s => s.GetItemAsync(
                 new PublicationTreeCacheKey(), typeof(IList<PublicationTreeThemeViewModel>)))
             .ReturnsAsync(null);
 
@@ -171,7 +171,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
             .ReturnsAsync(publicationTree);
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(
+            .Setup(s => s.SetItemAsync<object>(
                 new PublicationTreeCacheKey(), publicationTree))
             .Returns(Task.CompletedTask);
 
@@ -206,7 +206,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
         };
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(
+            .Setup(s => s.GetItemAsync(
                 new PublicationTreeCacheKey(), typeof(IList<PublicationTreeThemeViewModel>)))
             .ReturnsAsync(ListOf(publicationTree));
 
@@ -396,7 +396,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
             .ReturnsAsync(_publicationViewModel);
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(cacheKey, _publicationViewModel))
+            .Setup(s => s.SetItemAsync<object>(cacheKey, _publicationViewModel))
             .Returns(Task.CompletedTask);
 
         var service = BuildService(publicationService: publicationService.Object);
@@ -427,7 +427,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
         // We should not see any attempt to "get" the cached tree, but rather only see a fresh fetching
         // of the latest tree and then it being cached.
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(
+            .Setup(s => s.SetItemAsync<object>(
                 new PublicationTreeCacheKey(), publicationTree))
             .Returns(Task.CompletedTask);
 
@@ -473,7 +473,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
         PublicationTreeFilter filter)
     {
         PublicBlobCacheService
-            .Setup(s => s.GetItem(
+            .Setup(s => s.GetItemAsync(
                 new PublicationTreeCacheKey(), typeof(IList<PublicationTreeThemeViewModel>)))
             .ReturnsAsync(ListOf(publicationTree));
 
@@ -492,7 +492,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
         PublicationTreeFilter filter)
     {
         PublicBlobCacheService
-            .Setup(s => s.GetItem(
+            .Setup(s => s.GetItemAsync(
                 new PublicationTreeCacheKey(), typeof(IList<PublicationTreeThemeViewModel>)))
             .ReturnsAsync(ListOf(publicationTree));
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/ReleaseCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/ReleaseCacheServiceTests.cs
@@ -97,11 +97,11 @@ public class ReleaseCacheServiceTests : CacheServiceTestFixture
         var cacheKey = new ReleaseCacheKey(PublicationSlug, ReleaseSlug);
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(cacheKey, typeof(ReleaseCacheViewModel)))
+            .Setup(s => s.GetItemAsync(cacheKey, typeof(ReleaseCacheViewModel)))
             .ReturnsAsync(null);
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(cacheKey, _releaseViewModel))
+            .Setup(s => s.SetItemAsync<object>(cacheKey, _releaseViewModel))
             .Returns(Task.CompletedTask);
 
         var releaseService = new Mock<IReleaseService>(Strict);
@@ -124,7 +124,7 @@ public class ReleaseCacheServiceTests : CacheServiceTestFixture
         var cacheKey = new ReleaseCacheKey(PublicationSlug, ReleaseSlug);
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(cacheKey, typeof(ReleaseCacheViewModel)))
+            .Setup(s => s.GetItemAsync(cacheKey, typeof(ReleaseCacheViewModel)))
             .ReturnsAsync(_releaseViewModel);
 
         var service = BuildService();
@@ -142,7 +142,7 @@ public class ReleaseCacheServiceTests : CacheServiceTestFixture
         var cacheKey = new ReleaseCacheKey(PublicationSlug, ReleaseSlug);
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(cacheKey, typeof(ReleaseCacheViewModel)))
+            .Setup(s => s.GetItemAsync(cacheKey, typeof(ReleaseCacheViewModel)))
             .ReturnsAsync(null);
 
         var releaseService = new Mock<IReleaseService>(Strict);
@@ -165,11 +165,11 @@ public class ReleaseCacheServiceTests : CacheServiceTestFixture
         var cacheKey = new ReleaseCacheKey(PublicationSlug);
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(cacheKey, typeof(ReleaseCacheViewModel)))
+            .Setup(s => s.GetItemAsync(cacheKey, typeof(ReleaseCacheViewModel)))
             .ReturnsAsync(null);
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(cacheKey, _releaseViewModel))
+            .Setup(s => s.SetItemAsync<object>(cacheKey, _releaseViewModel))
             .Returns(Task.CompletedTask);
 
         var releaseService = new Mock<IReleaseService>(Strict);
@@ -192,7 +192,7 @@ public class ReleaseCacheServiceTests : CacheServiceTestFixture
         var cacheKey = new ReleaseCacheKey(PublicationSlug);
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(cacheKey, typeof(ReleaseCacheViewModel)))
+            .Setup(s => s.GetItemAsync(cacheKey, typeof(ReleaseCacheViewModel)))
             .ReturnsAsync(_releaseViewModel);
 
         var service = BuildService();
@@ -210,7 +210,7 @@ public class ReleaseCacheServiceTests : CacheServiceTestFixture
         var cacheKey = new ReleaseCacheKey(PublicationSlug);
 
         PublicBlobCacheService
-            .Setup(s => s.GetItem(cacheKey, typeof(ReleaseCacheViewModel)))
+            .Setup(s => s.GetItemAsync(cacheKey, typeof(ReleaseCacheViewModel)))
             .ReturnsAsync(null);
 
         var releaseService = new Mock<IReleaseService>(Strict);
@@ -239,7 +239,7 @@ public class ReleaseCacheServiceTests : CacheServiceTestFixture
             .ReturnsAsync(_releaseViewModel);
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(cacheKey, _releaseViewModel))
+            .Setup(s => s.SetItemAsync<object>(cacheKey, _releaseViewModel))
             .Returns(Task.CompletedTask);
 
         var service = BuildService(releaseService: releaseService.Object);
@@ -268,7 +268,7 @@ public class ReleaseCacheServiceTests : CacheServiceTestFixture
             .ReturnsAsync(_releaseViewModel);
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(cacheKey, _releaseViewModel))
+            .Setup(s => s.SetItemAsync<object>(cacheKey, _releaseViewModel))
             .Returns(Task.CompletedTask);
 
         var service = BuildService(releaseService: releaseService.Object);
@@ -297,7 +297,7 @@ public class ReleaseCacheServiceTests : CacheServiceTestFixture
             .ReturnsAsync(_releaseViewModel);
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(cacheKey, _releaseViewModel))
+            .Setup(s => s.SetItemAsync<object>(cacheKey, _releaseViewModel))
             .Returns(Task.CompletedTask);
 
         var service = BuildService(releaseService: releaseService.Object);
@@ -328,7 +328,7 @@ public class ReleaseCacheServiceTests : CacheServiceTestFixture
             .ReturnsAsync(_releaseViewModel);
 
         PublicBlobCacheService
-            .Setup(s => s.SetItem<object>(cacheKey, _releaseViewModel))
+            .Setup(s => s.SetItemAsync<object>(cacheKey, _releaseViewModel))
             .Returns(Task.CompletedTask);
 
         var service = BuildService(releaseService: releaseService.Object);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -50,7 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                 .ReturnsAsync(cacheKey);
 
             mocks.cacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(List<SubjectViewModel>)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(List<SubjectViewModel>)))
                 .ReturnsAsync(null);
 
             mocks
@@ -59,7 +59,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                 .ReturnsAsync(subjects);
 
             mocks.cacheService
-                .Setup(s => s.SetItem<object>(cacheKey, subjects))
+                .Setup(s => s.SetItemAsync<object>(cacheKey, subjects))
                 .Returns(Task.CompletedTask);
 
             var result = await controller.ListLatestReleaseSubjects(publication.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
@@ -253,11 +253,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var cacheKey = new DataBlockTableResultCacheKey(Release.Publication.Slug, Release.Slug, DataBlockId);
 
             BlobCacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(TableBuilderResultViewModel)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TableBuilderResultViewModel)))
                 .ReturnsAsync(null);
 
             BlobCacheService
-                .Setup(s => s.SetItem<object>(cacheKey, _tableBuilderResults))
+                .Setup(s => s.SetItemAsync<object>(cacheKey, _tableBuilderResults))
                 .Returns(Task.CompletedTask);
 
             var dataBlockService = new Mock<IDataBlockService>();
@@ -320,11 +320,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var cacheKey = new DataBlockTableResultCacheKey(Release.Publication.Slug, Release.Slug, DataBlockId);
 
             BlobCacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(TableBuilderResultViewModel)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TableBuilderResultViewModel)))
                 .ReturnsAsync(null);
 
             BlobCacheService
-                .Setup(s => s.SetItem<object>(cacheKey, _tableBuilderResults))
+                .Setup(s => s.SetItemAsync<object>(cacheKey, _tableBuilderResults))
                 .Returns(Task.CompletedTask);
 
             var dataBlockService = new Mock<IDataBlockService>(Strict);
@@ -363,11 +363,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var cacheKey = new DataBlockTableResultCacheKey(Release.Publication.Slug, Release.Slug, DataBlockId);
 
             BlobCacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(TableBuilderResultViewModel)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TableBuilderResultViewModel)))
                 .ReturnsAsync(null);
 
             BlobCacheService
-                .Setup(s => s.SetItem<object>(cacheKey, _tableBuilderResults))
+                .Setup(s => s.SetItemAsync<object>(cacheKey, _tableBuilderResults))
                 .Returns(Task.CompletedTask);
 
             var dataBlockService = new Mock<IDataBlockService>(Strict);
@@ -413,11 +413,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var cacheKey = new DataBlockTableResultCacheKey(Release.Publication.Slug, Release.Slug, DataBlockId);
 
             BlobCacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(TableBuilderResultViewModel)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TableBuilderResultViewModel)))
                 .ReturnsAsync(null);
 
             BlobCacheService
-                .Setup(s => s.SetItem<object>(cacheKey, _tableBuilderResults))
+                .Setup(s => s.SetItemAsync<object>(cacheKey, _tableBuilderResults))
                 .Returns(Task.CompletedTask);
 
             var dataBlockService = new Mock<IDataBlockService>(Strict);
@@ -499,11 +499,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var cacheKey = new DataBlockTableResultCacheKey(Release.Publication.Slug, Release.Slug, DataBlockId);
 
             BlobCacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(TableBuilderResultViewModel)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(TableBuilderResultViewModel)))
                 .ReturnsAsync(null);
 
             BlobCacheService
-                .Setup(s => s.SetItem<object>(cacheKey, _tableBuilderResults))
+                .Setup(s => s.SetItemAsync<object>(cacheKey, _tableBuilderResults))
                 .Returns(Task.CompletedTask);
 
             var dataBlockService = new Mock<IDataBlockService>(Strict);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderMetaControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderMetaControllerTests.cs
@@ -63,11 +63,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             SetupCall(mocks.contentPersistenceHelper, ReleaseId, contentRelease);
 
             mocks.cacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(SubjectMetaViewModel)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(SubjectMetaViewModel)))
                 .ReturnsAsync(null);
 
             mocks.cacheService
-                .Setup(s => s.SetItem<object>(cacheKey, subjectMetaViewModel))
+                .Setup(s => s.SetItemAsync<object>(cacheKey, subjectMetaViewModel))
                 .Returns(Task.CompletedTask);
 
             mocks.releaseSubjectService
@@ -112,11 +112,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             SetupCall(mocks.contentPersistenceHelper, ReleaseId, contentRelease);
 
             mocks.cacheService
-                .Setup(s => s.GetItem(cacheKey, typeof(SubjectMetaViewModel)))
+                .Setup(s => s.GetItemAsync(cacheKey, typeof(SubjectMetaViewModel)))
                 .ReturnsAsync(null);
 
             mocks.cacheService
-                .Setup(s => s.SetItem<object>(cacheKey, subjectMetaViewModel))
+                .Setup(s => s.SetItemAsync<object>(cacheKey, subjectMetaViewModel))
                 .Returns(Task.CompletedTask);
 
             mocks.releaseSubjectService

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
@@ -973,7 +973,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
 
             cacheService
-                .Setup(service => service.DeleteItem(new PrivateSubjectMetaCacheKey(releaseSubject.ReleaseId,
+                .Setup(service => service.DeleteItemAsync(new PrivateSubjectMetaCacheKey(releaseSubject.ReleaseId,
                     releaseSubject.SubjectId)))
                 .Returns(Task.CompletedTask);
 
@@ -1799,7 +1799,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var indicatorGroupRepository = new Mock<IIndicatorGroupRepository>(MockBehavior.Strict);
 
             cacheService
-                .Setup(service => service.DeleteItem(new PrivateSubjectMetaCacheKey(releaseSubject.ReleaseId,
+                .Setup(service => service.DeleteItemAsync(new PrivateSubjectMetaCacheKey(releaseSubject.ReleaseId,
                     releaseSubject.SubjectId)))
                 .Returns(Task.CompletedTask);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -287,7 +287,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         private Task InvalidateCachedReleaseSubjectMetadata(Guid releaseId, Guid subjectId)
         {
-            return _cacheService.DeleteItem(new PrivateSubjectMetaCacheKey(releaseId, subjectId));
+            return _cacheService.DeleteItemAsync(new PrivateSubjectMetaCacheKey(releaseId, subjectId));
         }
 
         private async Task<Either<ActionResult, Unit>> ValidateFiltersForSubject(

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -71,11 +71,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         private async Task DeleteLazilyCachedReleaseResults(Guid releaseId, string publicationSlug, string releaseSlug)
         {
-            await _privateBlobCacheService.DeleteCacheFolder(new PrivateReleaseContentFolderCacheKey(releaseId));
+            await _privateBlobCacheService.DeleteCacheFolderAsync(new PrivateReleaseContentFolderCacheKey(releaseId));
 
-            await _publicBlobCacheService.DeleteCacheFolder(new ReleaseDataBlockResultsFolderCacheKey(publicationSlug, releaseSlug));
-            await _publicBlobCacheService.DeleteItem(new ReleaseSubjectsCacheKey(publicationSlug, releaseSlug));
-            await _publicBlobCacheService.DeleteCacheFolder(new ReleaseSubjectMetaFolderCacheKey(publicationSlug, releaseSlug));
+            await _publicBlobCacheService.DeleteCacheFolderAsync(new ReleaseDataBlockResultsFolderCacheKey(publicationSlug, releaseSlug));
+            await _publicBlobCacheService.DeleteItemAsync(new ReleaseSubjectsCacheKey(publicationSlug, releaseSlug));
+            await _publicBlobCacheService.DeleteCacheFolderAsync(new ReleaseSubjectMetaFolderCacheKey(publicationSlug, releaseSlug));
         }
 
         public async Task DeletePreviousVersionsDownloadFiles(params Guid[] releaseIds)

--- a/tests/performance-tests/src/tests/public/getReleasePageCacheMiss.test.ts
+++ b/tests/performance-tests/src/tests/public/getReleasePageCacheMiss.test.ts
@@ -1,0 +1,81 @@
+/* eslint-disable no-console */
+import { Counter, Rate, Trend } from 'k6/metrics';
+import { Options } from 'k6/options';
+import http from 'k6/http';
+import { check, fail } from 'k6';
+import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js';
+import getEnvironmentAndUsersFromFile from '../../utils/environmentAndUsers';
+import loggingUtils from '../../utils/loggingUtils';
+
+export const options: Options = {
+  stages: [
+    {
+      duration: '30s',
+      target: 2000,
+    },
+  ],
+  vus: 2000,
+  vusMax: 2000,
+  noConnectionReuse: true,
+  insecureSkipTLSVerify: true,
+};
+
+export const errorRate = new Rate('ees_errors');
+export const getReleaseSuccessCount = new Counter('ees_get_release_success');
+export const getReleaseFailureCount = new Counter('ees_get_release_failure');
+export const getReleaseRequestDuration = new Trend(
+  'ees_get_release_duration',
+  true,
+);
+
+const environmentAndUsers = getEnvironmentAndUsersFromFile(
+  __ENV.TEST_ENVIRONMENT,
+);
+
+export function setup() {
+  loggingUtils.logDashboardUrls();
+}
+
+const performTest = () => {
+  const startTime = Date.now();
+  let response;
+  try {
+    response = http.get(
+      `${environmentAndUsers.environment.publicUrl}/find-statistics/pupil-absence-in-schools-in-england/2016-17`,
+      {
+        timeout: '120s',
+      },
+    );
+  } catch (e) {
+    getReleaseFailureCount.add(1);
+    errorRate.add(1);
+    fail(`Failure to get Release page - ${JSON.stringify(e)}`);
+  }
+
+  if (
+    check(response, {
+      'response code was 200': ({ status }) => status === 200,
+      'response should have contained body': ({ body }) => body != null,
+      'response contains expected title': res =>
+        res.html().text().includes('Pupil absence in schools in England'),
+      'response contains expected content': res =>
+        res.html().text().includes('pupils missed on average 8.2 school days'),
+    })
+  ) {
+    console.log('SUCCESS!');
+    getReleaseSuccessCount.add(1);
+    getReleaseRequestDuration.add(Date.now() - startTime);
+  } else {
+    console.log(`FAILURE! Got ${response.status} response code`);
+    getReleaseFailureCount.add(1);
+    getReleaseRequestDuration.add(Date.now() - startTime);
+    errorRate.add(1);
+    fail('Failure to Get Release page');
+  }
+};
+export function handleSummary(data: unknown) {
+  return {
+    'getReleasePageCacheMiss.html': htmlReport(data),
+  };
+}
+export default performTest;


### PR DESCRIPTION
This PR adds the ability to run async code without blocking threads when using caching - specifically caching code in and around `CacheAspect`/`CacheAttribute`. We were having thread exhaustion / deadlock issues when there was a large number of simultaneous cache misses. See Jira comments for EES-4177 and other related tickets for a more detailed investigation, recreation, and breakdown of the issue.

UniversalWrapper allows us to define `WrapSync` and `WrapAsync` methods for cache attributes. I believe the code in these methods is injected into the attributed method - with the `WrapSync` code being injected if the attributed method is synchronous, and the `WrapAsync` code being injected if the attributed method is async. To take advantage of this, we've moved most code that was previously in `CacheAspect` to `CacheAttribute`. It has also meant that `MemoryCacheAttribute` and `BlobCacheAttribute` now have separate `Get/GetAsync` and `Set/SetAsync` methods.

`MemoryCacheService`'s calls to get and set cached values are not async, therefore we can still support adding the `MemoryCache` attribute to sync and async methods. 

BlobCache, however, requires async calls to blob storage, so we cannot allow the BlobCache attribute to be applied to sync methods without blocking threads.

With async code now being handled in `WrapAsync`, there is no longer any need to manage `Task`s in `ReflectionExtensions#TryBoxToResult` and `TryUnboxResult`.

A few other changes have been made:

### Removal of `CacheAttribute`'s `Priority` and `AllowMultiple`

`BaseUniversalWrapperAspect#BaseHandle` doesn't provide support for allowing multiple cache triggers to be supplied with differing priorities. I believe to make this work we'd need to pull `BaseHandle` into our codebase. Fixing this seems nontrivial, and we haven't actually used this priority functionality, so I removed it.

### Failing unit test related to MemoryCache's `OverrideDurationInSeconds` and `OverrideExpirySchedule`

A unit test - `MemoryCacheAttributeTests#OverrideDurationInSecondsAndExpirySchedule` - to test the ability to override a memory cache's configuration was failing when run alongside all other unit tests, but passing when run by itself. We determined that this is because it was reusing an instance of `MemoryCacheAttribute` and therefore the constructor wasn't being called - the constructor previously set `DurationInSections` and `ExpirySchedule` to the value of the static override variables, if they weren't null. So now instead we check whether we should use the static override values whenever we call `service.SetItem`.

I also renamed the private static override variables because Rider told me to.

### Local testing

I created a performance test `getReleasePageCacheMiss.test.ts`. This is a copy of `getReleasePage.test.ts`, but of shorter duration with more virtual users, which caused thread exhaustion before this PR's changes. I used this locally alongside `dotnet-counters` to prove the issue had been solved.

### What this PR doesn't do

If a lot of cache misses happen all at once, the code will still generate and write the cache file multiple times.

### Credit

Most of this was worked out by Ben - you can see his test project projects to recreate the issue and then prove that universal wrapper solves the issue here:
- https://github.com/benoutram/cache-aspect-test
- https://github.com/benoutram/cache-aspect-universal-wrapper