### PR TITLE
EES-4191 - added missing newBatchThreshold setting for Importer funct…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/host.json
@@ -13,7 +13,8 @@
   "extensions": {
     "queues": {
       "batchSize": 6,
-      "maxDequeueCount": 3
+      "maxDequeueCount": 3,
+      "newBatchThreshold": 1
     }
   }
 }


### PR DESCRIPTION
During the investigation of importer deadlocks in `EES-4180`, we found that without the “newBatchThreshold” setting having a provided value, around 54 importer Functions were being executed in parallel, rather than the 6 we would expect.

This appears to be a bug in the host.json, as the documentation states that without a specified value, this value should default to “batchSize / 2”, which would be “3” in our case.  This is definitely not happening!

This PR adds a value of "1", which means that when the Importer reaches 1 remaining ongoing job, it'll look to spawn the next batch of 6 jobs.

![image](https://user-images.githubusercontent.com/12444316/227587583-f29c789f-269e-4417-a5f3-f4cb7f9af99d.png)
