### PR TITLE
EES-4188 increase key stat title character limit

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/KeyStatistic.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/KeyStatistic.cs
@@ -6,7 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 public abstract class KeyStatistic : ICreatedUpdatedTimestamps<DateTime, DateTime?>
 {
-    public const int TitleMaxLength = 25;
+    public const int TitleMaxLength = 60;
     public const int StatisticMaxLength = 12;
     public const int TrendMaxLength = 230;
     public const int GuidanceTitleMaxLength = 65;

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
@@ -57,7 +57,7 @@ export default function EditableKeyStatTextForm({
             : '',
         }}
         validationSchema={Yup.object<KeyStatTextFormValues>({
-          title: Yup.string().required('Enter a title').max(25),
+          title: Yup.string().required('Enter a title').max(60),
           statistic: Yup.string().required('Enter a statistic').max(12),
           trend: Yup.string().max(230),
           guidanceTitle: Yup.string().max(65),


### PR DESCRIPTION
Increases the character limit on Key Statistic titles to 60.