### PR TITLE
EES-4193 - automate snapshot pull requests

### DIFF
--- a/.github/workflows/validate-snapshots.yml
+++ b/.github/workflows/validate-snapshots.yml
@@ -1,0 +1,66 @@
+name: Validate snapshots
+on:
+  workflow_dispatch:
+  schedule: 
+    - cron: '35 9,12,16 * * 1-5'
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  PYTHON_VERSION: 3.10.10
+
+jobs:
+  test:
+    name: Validate snapshots
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Install moreutils
+        run: sudo apt install moreutils
+
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off            
+
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pipenv'
+
+      - name: Install pipenv
+        run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
+
+      - name: pipenv install
+        run: pipenv install
+
+      - name: Validate snapshots
+        working-directory: tests/robot-tests
+        run: pipenv run python scripts/create_snapshots.py --validate --slack-webhook-url ${{ env.SLACK_WEBHOOK_URL }}
+
+      - name: Set output variables
+        id: vars
+        run: |
+          pr_title="chore(tests): Update test snapshots $(date +%d-%m-%Y)"
+          pr_body="This PR was auto-generated on $(date +%d-%m-%Y) \
+            by [create-pull-request](https://github.com/peter-evans/create-pull-request) \
+            due to visual differences identified"
+          echo "pr_title=$pr_title" >> $GITHUB_OUTPUT
+          echo "pr_body=$pr_body" >> $GITHUB_OUTPUT
+
+      - name: Create pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ env.GH_TOKEN }}
+          commit-message: 'chore(tests): update test snapshots - ${{ env.DATE }}'
+          committer: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          branch: chore/update-test-snapshots
+          add-paths: |
+            tests/robot-tests/tests/snapshots
+          reviewers: rmbielby, lauraselby, cjrace, chfoster, twilliams24
+          title: ${{ steps.vars.outputs.pr_title }}
+          body: ${{ steps.vars.outputs.pr_body }}          
+          draft: false


### PR DESCRIPTION
This PR:
* Automates the creation of snapshot pull requests. Previously, we'd get an alert at 9:30 AM in the `#alerts` channel notifying us that `create_snapshots.py` has detected differences. We'd then have to manually create a branch, push, create a PR, assign the team as reviewers and then notify the `#alerts` channel about it. Now, pull requests will automatically be raised by the `dfe-sdt` bot user. The Action `peter-evans/create-pull-request@v4` will look for changed files inside the `tests/robot-tests/tests/snapshots` directory and if there are changed files, it will raise a pull request targeting dev.


### Relevant changes: 
* Added a fine-grained personal access token `GH_TOKEN` as an action secret to allow the workflow to raise pull requests on behalf of the `dfe-sdt` user
* Added `SLACK_WEBBHOOK_URL` as an action secret
* Set the workflow to run at `9:30AM` every day Monday to Friday (and on workflow dispatch so we can run it at other times if necessary)
* Added dependency caching to reduce wasted time installing python dependencies