### PR TITLE
EES-4088 remove go back warning on table tool for later steps

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -374,6 +374,10 @@ const TableToolWizard = ({
     state.response?.tableHeaders,
   ]);
 
+  const showChangeWarningForSteps = hidePublicationSelectionStage
+    ? [1]
+    : [1, 2];
+
   return (
     <ConfirmContextProvider>
       {({ askConfirm }) => (
@@ -383,7 +387,10 @@ const TableToolWizard = ({
             initialStep={state.initialStep}
             id="tableToolWizard"
             onStepChange={async (nextStep, previousStep) => {
-              if (nextStep < previousStep) {
+              if (
+                nextStep < previousStep &&
+                showChangeWarningForSteps.includes(nextStep)
+              ) {
                 const confirmed = await askConfirm();
                 return confirmed ? nextStep : previousStep;
               }

--- a/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
@@ -530,8 +530,6 @@ Validate table cells
 
 Go back to locations step
     user clicks button    Edit locations
-    user waits until page contains element    xpath://h2[text()="Go back to previous step"]
-    user clicks button    Confirm
     user waits until table tool wizard step is available    3    Choose locations
 
 Select provider 1

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
@@ -100,8 +100,9 @@ Check latest release contains glossary info icon
 
 Click glossary info icon and verify entry is correct
     user clicks button    Absence
+    ${modal}=    user waits until modal is visible    Absence
     user waits until h2 is visible    Absence
     user checks page contains    When a pupil misses (or is absent from) at least 1 possible school session.
-    user clicks button    Close
+    user clicks button    Close    ${modal}
     user waits until page does not contain element    xpath://h2[text()="Absence"]
     user checks page does not contain    When a pupil misses (or is absent from) at least 1 possible school session.

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -273,7 +273,6 @@ Edit data block for amendment
     user waits until h2 is visible    Data block details
 
     user clicks element    testid:wizardStep-4-goToButton
-    user clicks button    Confirm
 
     user opens details dropdown    Date
     user clicks category checkbox    Date    24/03/2020

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -585,7 +585,6 @@ Edit data block for amendment
     user waits until h2 is visible    Data block details
 
     user clicks element    testid:wizardStep-4-goToButton
-    user clicks button    Confirm
 
     user opens details dropdown    Date
     user clicks category checkbox    Date    24/03/2020

--- a/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
@@ -74,8 +74,7 @@ Validate Number of schools row results
 
 Go back to Locations step
     user clicks element    xpath://button[contains(text(), "Edit locations")]
-    user waits until page contains element    xpath://h2[text()="Go back to previous step"]
-    user clicks element    xpath://button[text()="Confirm"]
+    user waits until table tool wizard step is available    3    Choose locations
 
 Unselect England as a location
     [Documentation]    DFE-1142    EES-231

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -90,8 +90,7 @@ Validate the query could exceed the maximum allowable table size
 
 Go back to Locations step
     user clicks button    Edit locations
-    user waits until page contains element    xpath://h2[text()="Go back to previous step"]
-    user clicks button    Confirm
+    user waits until table tool wizard step is available    3    Choose locations
 
 Unselect all LA Locations
     user opens details dropdown    Local authority


### PR DESCRIPTION
Changes the table tool to only show the warning modal when you go back to the publication and subject steps.

Also, fixes an unrelated failing test in `publish_content.robot`.