### PR TITLE
EES-2465 back button behaviour on table tool

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
@@ -90,7 +90,7 @@ const ReleasePreviewTableTool = ({ releaseId, publication }: Props) => {
 
           <TableToolWizard
             themeMeta={[]}
-            hidePublicationSelectionStage
+            hidePublicationStep
             initialState={initialState}
             onSubjectStepBack={() => setHighlightId(undefined)}
             renderFeaturedTable={highlight => (

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -129,7 +129,7 @@ const DataBlockSourceWizard = ({
 
       <TableToolWizard
         themeMeta={[]}
-        hidePublicationSelectionStage
+        hidePublicationStep
         initialState={tableToolState}
         showTableQueryErrorDownload={false}
         finalStep={({ query, table, tableHeaders, onReorder }) => (

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
@@ -107,7 +107,7 @@ const PreReleaseTableToolPage = ({
         {tableToolState && (
           <TableToolWizard
             themeMeta={[]}
-            hidePublicationSelectionStage
+            hidePublicationStep
             scrollOnMount
             initialState={tableToolState}
             renderFeaturedTable={highlight => (

--- a/src/explore-education-statistics-admin/src/prototypes/components/PrototypeTableToolWizard.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/components/PrototypeTableToolWizard.tsx
@@ -73,7 +73,7 @@ export interface FinalStepRenderProps {
 export interface PrototypeTableToolWizardProps {
   themeMeta?: Theme[];
   initialState?: Partial<InitialTableToolState>;
-  hidePublicationSelectionStage?: boolean;
+  hidePublicationStep?: boolean;
   finalStep?: (props: FinalStepRenderProps) => ReactElement;
   loadingFastTrack?: boolean;
   renderFeaturedTable?: (featuredTable: FeaturedTable) => ReactNode;
@@ -92,7 +92,7 @@ const PrototypeTableToolWizard = ({
   themeMeta = [],
   initialState = {},
   scrollOnMount,
-  hidePublicationSelectionStage,
+  hidePublicationStep,
   renderFeaturedTable,
   finalStep,
   showTableQueryErrorDownload = true,
@@ -377,7 +377,7 @@ const PrototypeTableToolWizard = ({
               return nextStep;
             }}
           >
-            {!hidePublicationSelectionStage && (
+            {!hidePublicationStep && (
               <WizardStep onBack={handlePublicationStepBack}>
                 {stepProps => (
                   <PrototypePublicationForm

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -218,7 +218,7 @@ const FiltersForm = ({
               {stepHeading}
 
               <div className="govuk-grid-row">
-                <div className="govuk-grid-column-one-half-from-desktop">
+                <div className="govuk-grid-column-one-half-from-desktop govuk-!-margin-bottom-6">
                   <RHFFormFieldCheckboxSearchSubGroups
                     disabled={formState.isSubmitting}
                     hint="Select at least one indicator below"

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectStep.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectStep.tsx
@@ -75,7 +75,7 @@ const SubjectStep = ({
       <>
         {stepHeading}
 
-        <Tabs id={subjectTabsId}>
+        <Tabs id={subjectTabsId} modifyHash={false}>
           <TabsSection
             title="Featured tables"
             id={subjectTabIds.featuredTables}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -23,7 +23,10 @@ import applyTableHeadersOrder from '@common/modules/table-tool/utils/applyTableH
 import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/getDefaultTableHeadersConfig';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import parseYearCodeTuple from '@common/modules/table-tool/utils/parseYearCodeTuple';
-import publicationService, { Theme } from '@common/services/publicationService';
+import publicationService, {
+  PublicationTreeSummary,
+  Theme,
+} from '@common/services/publicationService';
 import tableBuilderService, {
   FeaturedTable,
   ReleaseTableDataQuery,
@@ -64,35 +67,47 @@ export interface FinalStepRenderProps {
 }
 
 export interface TableToolWizardProps {
-  themeMeta?: Theme[];
-  initialState?: Partial<InitialTableToolState>;
-  hidePublicationSelectionStage?: boolean;
   finalStep?: (props: FinalStepRenderProps) => ReactElement;
+  hidePublicationStep?: boolean;
+  initialState?: Partial<InitialTableToolState>;
   loadingFastTrack?: boolean;
   renderFeaturedTable?: (featuredTable: FeaturedTable) => ReactNode;
   scrollOnMount?: boolean;
+  showTableQueryErrorDownload?: boolean;
+  themeMeta?: Theme[];
+  currentStep?: number;
+  onPublicationFormSubmit?: (publication: PublicationTreeSummary) => void;
+  onStepChange?: (nextStep: number, previousStep: number) => void;
+  onSubjectFormSubmit?(params: {
+    publication: SelectedPublication;
+    release: SelectedPublication['selectedRelease'];
+    subjectId: string;
+  }): void;
+  onSubjectStepBack?: (publication?: SelectedPublication) => void;
+  onSubmit?: (table: FullTable) => void;
   onTableQueryError?: (
     errorCode: TableQueryErrorCode,
     publicationTitle: string,
     subjectName: string,
   ) => void;
-  showTableQueryErrorDownload?: boolean;
-  onSubmit?: (table: FullTable) => void;
-  onSubjectStepBack?: () => void;
 }
 
 const TableToolWizard = ({
-  themeMeta = [],
-  initialState = {},
-  scrollOnMount,
-  hidePublicationSelectionStage,
-  renderFeaturedTable,
   finalStep,
-  showTableQueryErrorDownload = true,
-  onSubmit,
-  onSubjectStepBack,
-  onTableQueryError,
+  hidePublicationStep,
+  initialState = {},
   loadingFastTrack = false,
+  renderFeaturedTable,
+  scrollOnMount,
+  showTableQueryErrorDownload = true,
+  themeMeta = [],
+  currentStep,
+  onPublicationFormSubmit,
+  onStepChange,
+  onSubjectFormSubmit,
+  onSubjectStepBack,
+  onSubmit,
+  onTableQueryError,
 }: TableToolWizardProps) => {
   const router = useRouter();
   const [state, updateState] = useImmer<TableToolState>({
@@ -128,6 +143,8 @@ const TableToolWizard = ({
   const handlePublicationFormSubmit: PublicationFormSubmitHandler = async ({
     publication,
   }) => {
+    onPublicationFormSubmit?.(publication);
+
     const [subjects, featuredTables] = await Promise.all([
       tableBuilderService.listLatestReleaseSubjects(publication.id),
       tableBuilderService.listLatestReleaseFeaturedTables(publication.id),
@@ -140,7 +157,7 @@ const TableToolWizard = ({
     updateState(draft => {
       draft.subjects = subjects;
       draft.featuredTables = featuredTables;
-
+      draft.query.releaseId = undefined;
       draft.query.publicationId = publication.id;
       draft.selectedPublication = {
         id: publication.id,
@@ -161,13 +178,21 @@ const TableToolWizard = ({
 
   const handleSubjectStepBack = () => {
     if (onSubjectStepBack) {
-      onSubjectStepBack();
+      onSubjectStepBack(state.selectedPublication);
     }
   };
 
   const handleSubjectFormSubmit: SubjectFormSubmitHandler = async ({
     subjectId: selectedSubjectId,
   }) => {
+    if (state.selectedPublication) {
+      onSubjectFormSubmit?.({
+        publication: state.selectedPublication,
+        release: state.selectedPublication.selectedRelease,
+        subjectId: selectedSubjectId,
+      });
+    }
+
     const nextSubjectMeta = await tableBuilderService.getSubjectMeta(
       selectedSubjectId,
       state.query.releaseId,
@@ -374,9 +399,7 @@ const TableToolWizard = ({
     state.response?.tableHeaders,
   ]);
 
-  const showChangeWarningForSteps = hidePublicationSelectionStage
-    ? [1]
-    : [1, 2];
+  const showChangeWarningForSteps = hidePublicationStep ? [1] : [1, 2];
 
   return (
     <ConfirmContextProvider>
@@ -386,7 +409,9 @@ const TableToolWizard = ({
             scrollOnMount={scrollOnMount}
             initialStep={state.initialStep}
             id="tableToolWizard"
+            currentStep={currentStep}
             onStepChange={async (nextStep, previousStep) => {
+              onStepChange?.(nextStep, previousStep);
               if (
                 nextStep < previousStep &&
                 showChangeWarningForSteps.includes(nextStep)
@@ -398,7 +423,7 @@ const TableToolWizard = ({
               return nextStep;
             }}
           >
-            {!hidePublicationSelectionStage && (
+            {!hidePublicationStep && (
               <WizardStep onBack={handlePublicationStepBack}>
                 {stepProps => (
                   <PublicationForm

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -215,7 +215,7 @@ describe('TableToolWizard', () => {
   test('does not render publication step if instructed to hide it', async () => {
     render(
       <TableToolWizard
-        hidePublicationSelectionStage
+        hidePublicationStep
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 1,

--- a/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
@@ -27,11 +27,21 @@ Validate "Absence by characteristic" subject details
     ...    ${details}
     user checks summary list contains    Time period    2012/13 to 2016/17    ${details}
 
+Validate back takes you to step 1
+    user goes back
+    user waits until table tool wizard step is available    1    Choose a publication
+    user clicks element    id:publicationForm-submit
+
 Select subject "Absence by characteristic"
     user clicks radio    Absence by characteristic
     user clicks element    id:publicationSubjectForm-submit
     user waits until table tool wizard step is available    3    Choose locations
     user checks previous table tool step contains    2    Subject    Absence by characteristic
+
+Validate back takes you to step 2
+    user goes back
+    user waits until table tool wizard step is available    2    Choose a subject
+    user clicks element    id:publicationSubjectForm-submit
 
 Select Location Country, England
     user opens details dropdown    National


### PR DESCRIPTION
Changes the behaviour when you click the browser back button while using  the table tool.

When I click the back button from:

- a featured table
  - if got there from step 2 > go back to step 2
  - if followed a direct link to the table > normal back button behaviour
- step 2 (subject)
  - if publication step was the initial step > go back to publication step
  - if subject step was the initial step (i.e. came from release page) > normal back button behaviour
- steps 3, 4, 5 & 6 (location, time, filters and final) > go back to step 2

## Notes:
- I ended up with a combination of the two approaches suggested on the ticket - it updates the url when you choose a publication and subject, and intercepts the back click using `beforePopState` to activate the correct step. I initially tried just using `beforePopState` but was ended up with various scenarios where it didn't quite work which adding the publication and subject to the url fixed.
- Currently when you choose a featured table and then go back to step 2 the featured table you chose isn't in the list any more. I've changed this to always show all featured tables after checking with Cam that it wasn't expected behaviour.
- I've removed the hash change on the subject tabs as it was causing problems and doesn't seem necessary.
- This only effects the table tool in the public frontend, not the admin.
- I wasn't sure of the best way to test this so have tagged a couple of basic tests on to an existing UI test. Better ideas are welcome.

## Bonus bug fix

Fixes [EES-4204](https://dfedigital.atlassian.net/browse/EES-4204) as I kept hitting it and it was simple to sort out.