### PR TITLE
EES-4203 fix table performance

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/createTableCartesian.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/createTableCartesian.ts
@@ -41,6 +41,13 @@ export default function createTableCartesian({
   // as we want to remove empty ones later.
   const columnsWithText = columnHeadersCartesian.map(() => false);
 
+  // Group measures by their respective combination of filters
+  // allowing lookups later on to be MUCH faster.
+  const measuresByFilterCombination = groupResultMeasuresByCombination(
+    results,
+    excludedFilterIds,
+  );
+
   const tableCartesian = rowHeadersCartesian.map(rowFilterCombination => {
     return columnHeadersCartesian.map(
       (columnFilterCombination, columnIndex) => {
@@ -79,13 +86,6 @@ export default function createTableCartesian({
         if (!dataSet.indicator) {
           throw new Error('No indicator for filter combination');
         }
-
-        // Group measures by their respective combination of filters
-        // allowing lookups later on to be MUCH faster.
-        const measuresByFilterCombination = groupResultMeasuresByCombination(
-          results,
-          excludedFilterIds,
-        );
 
         const text = getCellText(
           measuresByFilterCombination,


### PR DESCRIPTION
Fixes the table rendering performance problem caused by the refactoring when we moved to the universal table format. The cause was calling `groupResultMeasuresByCombination` inside the loop to create `tableCartesian` when it only needs to be called once.

This reduced the time to generate a largish table locally from 16s to 274ms.

Before:
![current-perf](https://user-images.githubusercontent.com/81572860/229497676-ad2d9341-544a-492b-81ce-6f34233446a8.PNG)

After:
![new-perf](https://user-images.githubusercontent.com/81572860/229497670-33b9f18e-df70-46e7-9c0a-4a61d8c19e36.PNG)
