### PR TITLE
EES-4213 Add endpoint to reproduce 502 Bad Gateway error

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BadGatewayTestController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BadGatewayTestController.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+/// <summary>
+/// TODO EES-4218 Temporary controller intended to test the timeout duration between IIS and Kestrel
+/// in Azure App Service environments. Remove after testing is completed.
+/// </summary>
+[Route("api")]
+[ApiController]
+[Authorize(Roles = GlobalRoles.RoleNames.BauUser)]
+public class BadGatewayTestController
+{
+    [HttpGet("bau/delay")]
+    public async Task<ActionResult> Delay([FromQuery] [Range(1, 600)] [Required] int durationSeconds)
+    {
+        await Task.Delay(TimeSpan.FromSeconds(durationSeconds));
+        return new OkResult();
+    }
+}


### PR DESCRIPTION
This PR adds a new temporary Admin API endpoint which produces a delayed response dependent on the `durationSeconds` parameter.

This is being added to reliably demonstrate the timeout causing the 502 Bad Gateway error, believed to be occur at 2 minutes.

We are deploying the Admin application to an Azure App Service running IIS with the ASP .Net Core module configured to use the out-of-process hosting model:

![ancm-outofprocess](https://user-images.githubusercontent.com/4147126/229731512-8c609c56-9bfa-4c40-9caf-07393b537413.png)

According to the IIS documentation the ANCM module will wait for a default of 2 minutes for a response from the process listening to the .Net Core application. After this duration the request is terminated and IIS responds with status 502.3 Bad Gateway.

We should be able to reproduce this consistently using the new test endpoint with a duration of 120 seconds.

### Usage

```
GET https://{adminUrl}/api/bau/delay?durationSeconds=120 HTTP/1.1
Authorization: Bearer {authToken}
```
`durationSeconds` must be in the range 1-600 seconds.