### PR TITLE
EES-4218 Increase Admin's request timeout from `00:02:00` to `00:05:00` and tidy up `web.config`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -6,7 +6,6 @@
     <UserSecretsId>aspnet-GovUk.Education.ExploreEducationStatistics.Admin-27177B65-FE3A-416B-97FE-420DF4EFF8BF</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
-    <AspNetCoreModuleName>AspNetCoreModule</AspNetCoreModuleName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.webServer>
+    <aspNetCore requestTimeout="00:05:00" />
     <httpProtocol>
       <customHeaders>
         <remove name="X-Powered-By" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <configuration>
-  <system.web>
-     <httpRuntime maxRequestLength="104857600" executionTimeout="240" /> 
-  </system.web>
   <system.webServer>
     <httpProtocol>
       <customHeaders>
@@ -15,49 +11,8 @@
         <requestLimits maxAllowedContentLength="104857600" />
       </requestFiltering>
     </security>
-
     <applicationInitialization doAppInitAfterRestart="true">
       <add initializationPage="/api/health" />
     </applicationInitialization>
-    <rewrite>
-      <rules>
-        <rule name="Redirect azure to govuk - dev" patternSyntax="Wildcard" stopProcessing="true">
-          <match url="*" />
-          <conditions>
-            <add input="{HTTP_HOST}" pattern="s101d01-as-ees-admin.azurewebsites.net" />
-          </conditions>
-          <action type="Redirect" url="https://admin.dev.explore-education-statistics.service.gov.uk/{R:0}" />
-        </rule>
-        <rule name="Redirect hive to govuk  - dev" patternSyntax="Wildcard" stopProcessing="true">
-          <match url="*" />
-          <conditions>
-            <add input="{HTTP_HOST}" pattern="admin.dev.ees.hiveit.cloud" />
-          </conditions>
-          <action type="Redirect" url="https://admin.dev.explore-education-statistics.service.gov.uk/{R:0}" />
-        </rule>
-        <rule name="Redirect azure to govuk - test" patternSyntax="Wildcard" stopProcessing="true">
-          <match url="*" />
-          <conditions>
-            <add input="{HTTP_HOST}" pattern="s101t01-as-ees-admin.azurewebsites.net" />
-          </conditions>
-          <action type="Redirect" url="https://admin.test.explore-education-statistics.service.gov.uk/{R:0}" />
-        </rule>
-        <rule name="Redirect hive to govuk  - test" patternSyntax="Wildcard" stopProcessing="true">
-          <match url="*" />
-          <conditions>
-            <add input="{HTTP_HOST}" pattern="admin.test.ees.hiveit.cloud" />
-          </conditions>
-          <action type="Redirect" url="https://admin.test.explore-education-statistics.service.gov.uk/{R:0}" />
-        </rule>
-
-        <rule name="Redirect azure to admin.ees.hiveit.cloud" patternSyntax="Wildcard" stopProcessing="true">
-          <match url="*" />
-          <conditions>
-            <add input="{HTTP_HOST}" pattern="s101p02-as-ees-admin.azurewebsites.net" />
-          </conditions>
-          <action type="Redirect" url="https://admin.test.ees.hiveit.cloud/{R:0}" />
-        </rule>
-      </rules>
-    </rewrite>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
This PR increases the Admin application request timeout from `00:02:00` to `00:05:00`.

```
<aspNetCore requestTimeout="00:05:00" />
```

According to the IIS documentation the ANCM module will wait for a default of 2 minutes for a response from the process listening to the .Net Core application where it's deployed using out-of-process hosting.

After this duration the request is terminated and IIS responds with status 502.3 Bad Gateway.

The temporary endpoint added by https://github.com/dfe-analytical-services/explore-education-statistics/pull/3989 can be used to test this change. Here we can see an existing request that's been configured to take longer than 2 minutes getting terminated:

![image](https://user-images.githubusercontent.com/4147126/229765064-68977550-3472-4bef-9b46-6f0e0a26410e.png)

The .Net `publish` build target will transform the `web.config` file so the output will end up like this:

```
<handlers>
      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
</handlers>
<aspNetCore requestTimeout="00:05:00" processPath="dotnet" arguments=".\GovUk.Education.ExploreEducationStatistics.Admin.exe" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="OutOfProcess" />
```

See [web.config](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/web-config?view=aspnetcore-6.0) for more information.

### Other changes

- Remove `<system.web>` element from `web.config`. This appears to be related only to .Net Framework applications rather than .Net Core, and applies to early versions of IIS.
- Remove a set of rewrite rules from `web.config`. I don't _think_ these are being used, but they are being included and unnecessarily processed with every request.
- Remove the `<AspNetCoreModuleName>AspNetCoreModule</AspNetCoreModuleName>` directive from `Admin.csproj`. This value is forcing IIS to use AspNetCoreModule v1 which was discontinued in 2019. AspNetCoreModule v2 supports .Net Core applications since 2.0 (we target .Net Core 6.0). It's been recommedned to switch to AspNetCoreModule v2 since 3.0.