### PR TITLE
Reduce statistics database connection timeout to 5 minutes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
@@ -61,7 +61,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
             // are what get used in real application scenarios.
         }
 
-        public StatisticsDbContext(DbContextOptions<StatisticsDbContext> options) : this(options, int.MaxValue)
+        public StatisticsDbContext(DbContextOptions<StatisticsDbContext> options) : this(options, timeout: 300)
         {
         }
 


### PR DESCRIPTION
This PR makes a small change reducing the _statistics_ database `CommandTimeout` to 5 minutes.

If this isn't set in the connection string or configured separately then the default `CommandTimeout` of the SqlClient is 30 seconds. We see this in logging of _content_ database queries where we haven't overridden it:

`Executing DbCommand [Parameters=[], CommandType='Text', CommandTimeout='30']`

However for the _statistics_ database we've currently set this to `int.MaxValue`

`Executing DbCommand [], CommandType='Text', CommandTimeout='2147483647']`

That's 68 years.

Timeouts such as the [Azure App Service Load Balancer timeout of 4 minutes](https://learn.microsoft.com/en-us/troubleshoot/azure/app-service/web-apps-performance-faqs#why-does-my-request-time-out-after-230-seconds) are going to occur before this, but requests can continue executing on the target server.

We reduce this timeout to prevent a build-up of long running database queries.