### PR TITLE
EES-4225 Fix exceptions streaming data file blob in `GetCsvStream` methods

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
@@ -101,10 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
         [Fact]
         public void PublicPath()
         {
-            var release = new Release
-            {
-                Id = Guid.NewGuid()
-            };
+            var releaseId = Guid.NewGuid();
 
             var ancillaryFile = new File
             {
@@ -138,27 +135,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                 Type = Image
             };
 
-            Assert.Equal($"{release.Id}/ancillary/{ancillaryFile.Id}",
-                ancillaryFile.PublicPath(release));
+            Assert.Equal($"{releaseId}/ancillary/{ancillaryFile.Id}",
+                ancillaryFile.PublicPath(releaseId: releaseId));
 
-            Assert.Equal($"{release.Id}/chart/{chartFile.Id}",
-                chartFile.PublicPath(release));
+            Assert.Equal($"{releaseId}/chart/{chartFile.Id}",
+                chartFile.PublicPath(releaseId: releaseId));
 
-            Assert.Equal($"{release.Id}/data/{dataFile.Id}",
-                dataFile.PublicPath(release));
+            Assert.Equal($"{releaseId}/data/{dataFile.Id}",
+                dataFile.PublicPath(releaseId: releaseId));
 
-            Assert.Equal($"{release.Id}/image/{imageFile.Id}",
-                imageFile.PublicPath(release));
+            Assert.Equal($"{releaseId}/image/{imageFile.Id}",
+                imageFile.PublicPath(releaseId: releaseId));
         }
 
         [Fact]
         public void PublicPath_FileTypeIsNotAPublicFileType()
         {
-            var release = new Release
-            {
-                Id = Guid.NewGuid()
-            };
-
             EnumUtil.GetEnumValues<FileType>().ForEach(type =>
             {
                 if (!PublicFileTypes.Contains(type))
@@ -167,7 +159,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                     {
                         Type = type
                     };
-                    Assert.Throws<ArgumentOutOfRangeException>(() => file.PublicPath(release));
+                    Assert.Throws<ArgumentOutOfRangeException>(() => file.PublicPath(releaseId: Guid.NewGuid()));
                 }
             });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseFileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseFileExtensionTests.cs
@@ -45,14 +45,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
         [Fact]
         public void PublicPath()
         {
-            var release = new Release
-            {
-                Id = Guid.NewGuid()
-            };
-
             var releaseFile = new ReleaseFile
             {
-                Release = release,
+                ReleaseId = Guid.NewGuid(),
                 File = new File
                 {
                     Id = Guid.NewGuid(),
@@ -62,7 +57,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                 }
             };
 
-            Assert.Equal(releaseFile.File.PublicPath(release), releaseFile.PublicPath());
+            Assert.Equal($"{releaseFile.ReleaseId}/ancillary/{releaseFile.File.Id}", releaseFile.PublicPath());
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseFileExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseFileExtensions.cs
@@ -17,7 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
 
         public static string PublicPath(this ReleaseFile releaseFile)
         {
-            return releaseFile.File.PublicPath(releaseFile.Release);
+            return releaseFile.File.PublicPath(releaseFile.ReleaseId);
         }
 
         public static FileInfo ToPublicFileInfo(this ReleaseFile releaseFile)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkCsvMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkCsvMetaService.cs
@@ -94,6 +94,7 @@ public class PermalinkCsvMetaService : IPermalinkCsvMetaService
                 .SingleAsync(
                     predicate: rf =>
                         rf.File.SubjectId == releaseSubject.SubjectId
+                        && rf.File.Type == FileType.Data
                         && rf.ReleaseId == releaseSubject.ReleaseId,
                     cancellationToken: cancellationToken
                 );
@@ -105,7 +106,7 @@ public class PermalinkCsvMetaService : IPermalinkCsvMetaService
             _logger.LogError(
                 exception,
                 message: "Could not get file for release subject (ReleaseId = {ReleaseId}, SubjectId = {SubjectId})",
-                releaseSubject.ReleaseId, releaseSubject.Subject);
+                releaseSubject.ReleaseId, releaseSubject.SubjectId);
 
             return null;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectCsvMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectCsvMetaService.cs
@@ -89,6 +89,7 @@ public class SubjectCsvMetaService : ISubjectCsvMetaService
                 .SingleAsync(
                     predicate: rf =>
                         rf.File.SubjectId == releaseSubject.SubjectId
+                        && rf.File.Type == FileType.Data
                         && rf.ReleaseId == releaseSubject.ReleaseId,
                     cancellationToken: cancellationToken
                 );
@@ -100,7 +101,7 @@ public class SubjectCsvMetaService : ISubjectCsvMetaService
             _logger.LogError(
                 exception,
                 message: "Could not get file for release subject (ReleaseId = {ReleaseId}, SubjectId = {SubjectId})",
-                releaseSubject.ReleaseId, releaseSubject.Subject);
+                releaseSubject.ReleaseId, releaseSubject.SubjectId);
 
             return null;
         }


### PR DESCRIPTION
This PR fixes exceptions occurring streaming the data file blob in `SubjectCsvMetaService` and `PermalinkCsvMetaService` where within the `GetCsvStream` methods the `ReleaseFile` predicate was not constrained by type `FileType.Data`.

This led to the exception `Sequence contains more than one element.` due to the existence of the other `ReleaseFile` of type `FileType.Metadata`.

There was also an exception occurring streaming the blob using `releaseFile.PublicPath()` due to its reliance on the `releaseFile.Release` being loaded. This is changed to only rely on `releaseFile.ReleaseId`.

### Other changes

- Fix exception logging which was missing the `SubjectId`