### PR TITLE
EES-4229 - permalink naming changes in support of EES-3753 (#3966)

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PermalinkControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PermalinkControllerTests.cs
@@ -42,7 +42,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
         var permalinkService = new Mock<IPermalinkService>(Strict);
 
         permalinkService
-            .Setup(s => s.Get(id, It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetLegacy(id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(permalink);
 
         var client = SetupApp(permalinkService: permalinkService.Object)
@@ -64,11 +64,11 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
 
         permalinkService
             .Setup(s => s
-                .DownloadCsvToStream(id, It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+                .LegacyDownloadCsvToStream(id, It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Unit.Instance)
             .Callback<Guid, Stream, CancellationToken>(
                 (_, stream, _) => { stream.WriteText("Test csv"); }
-            );;
+            );
 
         var client = SetupApp(permalinkService: permalinkService.Object)
             .CreateClient();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
@@ -80,7 +80,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var service = BuildService(releaseRepository: releaseRepository.Object,
                 subjectRepository: subjectRepository.Object);
 
-            var result = await service.Create(request);
+            var result = await service.CreateLegacy(request);
 
             MockUtils.VerifyAllMocks(
                 releaseRepository,
@@ -200,7 +200,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     subjectRepository: subjectRepository.Object,
                     tableBuilderService: tableBuilderService.Object);
 
-                var result = (await service.Create(request)).AssertRight();
+                var result = (await service.CreateLegacy(request)).AssertRight();
 
                 MockUtils.VerifyAllMocks(
                     blobStorageService,
@@ -310,7 +310,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     blobStorageService: blobStorageService.Object,
                     tableBuilderService: tableBuilderService.Object);
 
-                var result = (await service.Create(release.Id, request)).AssertRight();
+                var result = (await service.CreateLegacy(release.Id, request)).AssertRight();
 
                 MockUtils.VerifyAllMocks(
                     blobStorageService,
@@ -541,7 +541,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     subjectRepository: subjectRepository.Object,
                     tableBuilderService: tableBuilderService.Object);
 
-                var result = await service.Create(request);
+                var result = await service.CreateLegacy(request);
                 result.AssertRight();
 
                 MockUtils.VerifyAllMocks(
@@ -640,7 +640,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = (await service.Get(permalink.Id)).AssertRight();
+                var result = (await service.GetLegacy(permalink.Id)).AssertRight();
 
                 MockUtils.VerifyAllMocks(blobStorageService);
 
@@ -736,7 +736,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = (await service.Get(permalink.Id)).AssertRight();
+                var result = (await service.GetLegacy(permalink.Id)).AssertRight();
 
                 MockUtils.VerifyAllMocks(blobStorageService);
 
@@ -777,7 +777,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 path: permalinkId.ToString());
 
             var service = BuildService(blobStorageService: blobStorageService.Object);
-            var result = await service.Get(permalinkId);
+            var result = await service.GetLegacy(permalinkId);
 
             MockUtils.VerifyAllMocks(
                 blobStorageService);
@@ -815,7 +815,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = (await service.Get(permalink.Id)).AssertRight();
+                var result = (await service.GetLegacy(permalink.Id)).AssertRight();
 
                 MockUtils.VerifyAllMocks(blobStorageService);
 
@@ -909,7 +909,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = (await service.Get(permalink.Id)).AssertRight();
+                var result = (await service.GetLegacy(permalink.Id)).AssertRight();
 
                 MockUtils.VerifyAllMocks(blobStorageService);
 
@@ -992,7 +992,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = (await service.Get(permalink.Id)).AssertRight();
+                var result = (await service.GetLegacy(permalink.Id)).AssertRight();
 
                 MockUtils.VerifyAllMocks(blobStorageService);
 
@@ -1075,7 +1075,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = (await service.Get(permalink.Id)).AssertRight();
+                var result = (await service.GetLegacy(permalink.Id)).AssertRight();
 
                 MockUtils.VerifyAllMocks(blobStorageService);
 
@@ -1160,7 +1160,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = (await service.Get(permalink.Id)).AssertRight();
+                var result = (await service.GetLegacy(permalink.Id)).AssertRight();
 
                 MockUtils.VerifyAllMocks(blobStorageService);
 
@@ -1238,7 +1238,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = (await service.Get(permalink.Id)).AssertRight();
+                var result = (await service.GetLegacy(permalink.Id)).AssertRight();
 
                 MockUtils.VerifyAllMocks(blobStorageService);
 
@@ -1368,7 +1368,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             using var stream = new MemoryStream();
 
-            var result = await service.DownloadCsvToStream(permalink.Id, stream);
+            var result = await service.LegacyDownloadCsvToStream(permalink.Id, stream);
 
             MockUtils.VerifyAllMocks(blobStorageService, permalinkCsvMetaService);
 
@@ -1392,7 +1392,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 path: permalinkId.ToString());
 
             var service = BuildService(blobStorageService: blobStorageService.Object);
-            var result = await service.DownloadCsvToStream(permalinkId, new MemoryStream());
+            var result = await service.LegacyDownloadCsvToStream(permalinkId, new MemoryStream());
 
             MockUtils.VerifyAllMocks(blobStorageService);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PermalinkController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PermalinkController.cs
@@ -23,7 +23,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
 
         [HttpGet("permalink/{id:guid}")]
         [Produces("application/json", "text/csv")]
-        public async Task Get(
+        public async Task GetLegacyPermalink(
             Guid id,
             CancellationToken cancellationToken)
         {
@@ -33,29 +33,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
                     contentType: "text/csv",
                     filename: $"permalink-{id}.csv");
 
-                await _permalinkService.DownloadCsvToStream(id, Response.BodyWriter.AsStream(), cancellationToken);
+                await _permalinkService.LegacyDownloadCsvToStream(id, Response.BodyWriter.AsStream(), cancellationToken);
 
                 return;
             }
 
             var result = await _permalinkService
-                .Get(id, cancellationToken)
+                .GetLegacy(id, cancellationToken)
                 .HandleFailuresOr(Ok);
 
             await result.ExecuteResultAsync(ControllerContext);
         }
 
         [HttpPost]
-        public async Task<ActionResult<LegacyPermalinkViewModel>> Create([FromBody] PermalinkCreateRequest request)
+        public async Task<ActionResult<LegacyPermalinkViewModel>> CreateLegacyPermalink([FromBody] PermalinkCreateRequest request)
         {
-            return await _permalinkService.Create(request).HandleFailuresOrOk();
+            return await _permalinkService.CreateLegacy(request).HandleFailuresOrOk();
         }
 
         [HttpPost("permalink/release/{releaseId:guid}")]
-        public async Task<ActionResult<LegacyPermalinkViewModel>> Create(Guid releaseId,
+        public async Task<ActionResult<LegacyPermalinkViewModel>> CreateLegacyPermalink(Guid releaseId,
             [FromBody] PermalinkCreateRequest request)
         {
-            return await _permalinkService.Create(releaseId, request).HandleFailuresOrOk();
+            return await _permalinkService.CreateLegacy(releaseId, request).HandleFailuresOrOk();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IPermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IPermalinkService.cs
@@ -12,14 +12,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interface
 
 public interface IPermalinkService
 {
-    Task<Either<ActionResult, LegacyPermalinkViewModel>> Get(Guid id, CancellationToken cancellationToken = default);
+    Task<Either<ActionResult, LegacyPermalinkViewModel>> GetLegacy(Guid id, CancellationToken cancellationToken = default);
 
-    Task<Either<ActionResult, Unit>> DownloadCsvToStream(
+    Task<Either<ActionResult, Unit>> LegacyDownloadCsvToStream(
         Guid id,
         Stream stream,
         CancellationToken cancellationToken = default);
 
-    Task<Either<ActionResult, LegacyPermalinkViewModel>> Create(PermalinkCreateRequest request);
+    Task<Either<ActionResult, LegacyPermalinkViewModel>> CreateLegacy(PermalinkCreateRequest request);
 
-    Task<Either<ActionResult, LegacyPermalinkViewModel>> Create(Guid releaseId, PermalinkCreateRequest request);
+    Task<Either<ActionResult, LegacyPermalinkViewModel>> CreateLegacy(Guid releaseId, PermalinkCreateRequest request);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -69,19 +69,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             _mapper = mapper;
         }
 
-        public async Task<Either<ActionResult, LegacyPermalinkViewModel>> Get(
+        // TODO EES-3755 Remove after Permalink snapshot work is complete
+        public async Task<Either<ActionResult, LegacyPermalinkViewModel>> GetLegacy(
             Guid id,
             CancellationToken cancellationToken = default)
         {
-            return await Find(id, cancellationToken).OnSuccess(BuildViewModel);
+            return await FindLegacy(id, cancellationToken).OnSuccess(BuildLegacyViewModel);
         }
 
-        public async Task<Either<ActionResult, Unit>> DownloadCsvToStream(
+        // TODO EES-3755 Remove after Permalink snapshot work is complete
+        public async Task<Either<ActionResult, Unit>> LegacyDownloadCsvToStream(
             Guid id,
             Stream stream,
             CancellationToken cancellationToken = default)
         {
-            return await Find(id, cancellationToken)
+            return await FindLegacy(id, cancellationToken)
                 .OnSuccessCombineWith(permalink => _permalinkCsvMetaService.GetCsvMeta(permalink, cancellationToken))
                 .OnSuccessVoid(
                     async tuple =>
@@ -206,7 +208,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             return string.Empty;
         }
 
-        private async Task<Either<ActionResult, LegacyPermalink>> Find(
+        // TODO EES-3755 Remove after Permalink snapshot work is complete
+        private async Task<Either<ActionResult, LegacyPermalink>> FindLegacy(
             Guid id,
             CancellationToken cancellationToken)
         {
@@ -227,15 +230,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             }
         }
 
-        public async Task<Either<ActionResult, LegacyPermalinkViewModel>> Create(PermalinkCreateRequest request)
+        // TODO EES-3755 Remove after Permalink snapshot work is complete
+        public async Task<Either<ActionResult, LegacyPermalinkViewModel>> CreateLegacy(PermalinkCreateRequest request)
         {
             return await _subjectRepository.FindPublicationIdForSubject(request.Query.SubjectId)
                 .OrNotFound()
                 .OnSuccess(publicationId => _releaseRepository.GetLatestPublishedRelease(publicationId))
-                .OnSuccess(release => Create(release.Id, request));
+                .OnSuccess(release => CreateLegacy(release.Id, request));
         }
 
-        public async Task<Either<ActionResult, LegacyPermalinkViewModel>> Create(Guid releaseId,
+        // TODO EES-3755 Remove after Permalink snapshot work is complete
+        public async Task<Either<ActionResult, LegacyPermalinkViewModel>> CreateLegacy(Guid releaseId,
             PermalinkCreateRequest request)
         {
             return await _tableBuilderService.Query(releaseId, request.Query)
@@ -281,7 +286,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
 
                     await _contentDbContext.SaveChangesAsync();
 
-                    return await BuildViewModel(legacyPermalink);
+                    return await BuildLegacyViewModel(legacyPermalink);
                 });
         }
 
@@ -303,7 +308,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
 
         private static int CountLocations(IEnumerable<LocationAttributeViewModel> locationAttributes)
         {
-            return locationAttributes.Sum(attribute => attribute.Options is null ? 1 : CountLocations(attribute.Options));
+            return locationAttributes.Sum(
+                attribute => attribute.Options is null ? 1 : CountLocations(attribute.Options));
         }
 
         private static JsonSerializerSettings BuildJsonSerializerSettings()
@@ -315,7 +321,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             };
         }
 
-        private async Task<LegacyPermalinkViewModel> BuildViewModel(LegacyPermalink permalink)
+        // TODO EES-3755 Remove after Permalink snapshot work is complete
+        private async Task<LegacyPermalinkViewModel> BuildLegacyViewModel(LegacyPermalink permalink)
         {
             var viewModel = _mapper.Map<LegacyPermalinkViewModel>(permalink);
 


### PR DESCRIPTION
This PR: 
* Renames existing permalink services, controllers, interfaces, etc. to have a prefix of 'Legacy'. This is to support the work in EES-3753 when moving to permalink snapshots. We've found that a lot of code is being shared from the existing `permalinkService` so the plan going forward is to merge the separate permalink snapshot service into the existing `permalinkService`. To distinguish what methods are legacy and what methods relate to the new snapshot view model, we are now prefixing existing permalink related stuff with 'Legacy'