### PR TITLE
EES-4240 Add Permalink migration fields and check Permalink exists

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230406082108_EES3753AddMigrationFields.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230406082108_EES3753AddMigrationFields.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230406082108_EES3753AddMigrationFields")]
+    partial class EES3753AddMigrationFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230406082108_EES3753AddMigrationFields.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230406082108_EES3753AddMigrationFields.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations;
+
+[ExcludeFromCodeCoverage]
+public partial class EES3753AddMigrationFields : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // Add temporary columns to assist with the migration to Permalinks snapshots
+
+        migrationBuilder.AddColumn<bool>(
+            name: "Legacy",
+            table: "Permalinks",
+            type: "bit",
+            nullable: false,
+            defaultValue: false);
+
+        migrationBuilder.AddColumn<bool>(
+            name: "LegacyHasSnapshot",
+            table: "Permalinks",
+            type: "bit",
+            nullable: true);
+
+        // Set the Legacy flag to true for all existing Permalinks so we can differentiate
+        // between legacy Permalinks and Permalinks snapshots while both routes exist
+        migrationBuilder.Sql("UPDATE Permalinks SET Legacy = 1");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Legacy",
+            table: "Permalinks");
+
+        migrationBuilder.DropColumn(
+            name: "LegacyHasSnapshot",
+            table: "Permalinks");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Permalink.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Permalink.cs
@@ -29,6 +29,16 @@ public class Permalink : ICreatedTimestamp<DateTime>
     public int CountTimePeriods { get; set; }
 
     /// <summary>
+    /// True if this is a legacy Permalink
+    /// </summary>
+    public bool Legacy { get; set; }
+
+    /// <summary>
+    /// True if the legacy Permalink snapshot (Universal table and CSV) has been generated
+    /// </summary>
+    public bool? LegacyHasSnapshot { get; set; }
+
+    /// <summary>
     /// Content length in bytes of the legacy Permalink in blob storage 
     /// </summary>
     public long? LegacyContentLength { get; set; }


### PR DESCRIPTION
This PR sets up a couple of fields relevant to the future work to implement Permalink snapshots and the work to migrate all existing Permalinks to snapshot format.

`Permalink.Legacy`
`Permalink.LegacyHasSnapshot`

As soon as [EES-3753 - BE work required to support new Permalinks with table snapshots](https://dfedigital.atlassian.net/browse/EES-3753) is completed, there will for a time being, exist two sets of routes for creating and accessing Permalinks:

- Creating and fetching a Permalink or Permalink CSV _with_ a table snapshot (new)
- Creating and fetching a Permalink or Permalink CSV _without_ a table snapshot (legacy)

Until the legacy routes are removed, they should only allow access to Permalinks which exist in legacy format.

The new routes will be designed to only allow access to Permalinks created with table snapshot, or legacy Permalinks where the table snapshot has been generated through a migration which will be developed separately.

These temporary flags will be dropped at the same time the legacy routes are removed.

### Other changes

- Rename some unit test methods to reflect their target method name