### PR TITLE
Added support for providing arbitrary IdP configuration that will be …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,7 @@ remote-profile
 
 .DS_Store
 
+src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Idp.json
+
 ## IdentityServer Developer Signing key
 **/*/tempkey.rsa

--- a/README.md
+++ b/README.md
@@ -209,9 +209,9 @@ and contains a number of users for different roles. The [appsettings.Keycloak.js
 src/GovUk.Education.ExploreEducationStatistics.Admin\appsettings.Keycloak.json) configuration file contains the details for 
 connecting Admin to this IdP.
 
-Alternatively, you can provide your own OpenID Connect configuration in the gitignored [appsettings.Idp.json](
-src/GovUk.Education.ExploreEducationStatistics.Admin\appsettings.Idp.json) file (you can use the Keycloak equivalent as a
-template as to how the configuration in the file should be structured).
+Alternatively, you can provide your own OpenID Connect configuration in the [appsettings.Idp.json](
+src/GovUk.Education.ExploreEducationStatistics.Admin\appsettings.Idp.json) file that is ignored from Git. You can use the 
+Keycloak equivalent as a template as to how the configuration in the file should be structured.
 
 #### Using Keycloak
 
@@ -252,9 +252,10 @@ docker-compose up --build --force-recreate idp
 
 #### Using a different Identity Provider
 
-If you have your own OpenID Connect IdP set up, you can provide its configuration in the gitignored 
-[appsettings.Idp.json](src/GovUk.Education.ExploreEducationStatistics.Admin\appsettings.Idp.json) file (you can 
-use the Keycloak equivalent as a template as to how the configuration in the file should be structured).
+If you have your own OpenID Connect IdP set up, you can provide its configuration in the 
+[appsettings.Idp.json](src/GovUk.Education.ExploreEducationStatistics.Admin\appsettings.Idp.json) file that is 
+ignored from Git. You can use the Keycloak equivalent as a template as to how the configuration in the file should
+be structured.
 
 > Note that it must have Implicit Flow enabled and be using the OpenID Connect protocol. It must be set to issue 
 ID Tokens.
@@ -289,7 +290,7 @@ IdpProviderConfiguration={NameOfYourIdentityProvider}
 BootstrapUsersConfiguration={NameOfYourIdentityProvider}BootstrapUsers
 ```
 
-and start up Admin wih these environment variables set. This allows you to more easily switch between different IdP 
+and start up Admin wih these environment variables set. This allows you to easily switch between different IdP 
 configurations if you have need of more than one for easy reference.
 
 ### Running the backend

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Program.cs
@@ -18,8 +18,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((ctx, builder) =>
                 {
-                    builder.AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("IdpProviderConfiguration")}.json", true, true);
-                    builder.AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("BootstrapUsersConfiguration")}.json", true, true);
+                    var idpConfiguration = 
+                        Environment.GetEnvironmentVariable("IdpProviderConfiguration") ?? "Idp";
+                    
+                    builder.AddJsonFile(
+                        $"appsettings.{idpConfiguration}.json", 
+                        optional: false, 
+                        reloadOnChange: true);
+                    
+                    builder.AddJsonFile(
+                        $"appsettings.{Environment.GetEnvironmentVariable("BootstrapUsersConfiguration")}.json", 
+                        optional: true, 
+                        reloadOnChange: true);
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Program.cs
@@ -18,12 +18,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((ctx, builder) =>
                 {
+                    var idpConfigFileRequired = ctx.HostingEnvironment.IsDevelopment();
+                    
                     var idpConfiguration = 
                         Environment.GetEnvironmentVariable("IdpProviderConfiguration") ?? "Idp";
                     
                     builder.AddJsonFile(
                         $"appsettings.{idpConfiguration}.json", 
-                        optional: false, 
+                        optional: !idpConfigFileRequired, 
                         reloadOnChange: true);
                     
                     builder.AddJsonFile(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserInviteRepository.cs
@@ -37,7 +37,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             if (createdDate != null && createdDate > DateTime.UtcNow)
             {
-                throw new ArgumentException($"{nameof(UserInvite)} created date cannot be a future date");
+                throw new ArgumentException($"{nameof(UserInvite)} created date cannot be a future date " +
+                                            $"- {createdDate} is more than {DateTime.UtcNow}");
             }
             
             var existingInvite = await _usersAndRolesDbContext

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Keycloak.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Keycloak.json
@@ -3,11 +3,6 @@
     "ClientId": "ees-admin-client",
     "ClientSecret": "eaa4cc70-e80b-4a7e-a20f-2856d97f470d",
     "Authority": "http://ees.local:5030/auth/realms/ees-realm",
-    "RequireHttpsMetadata": false,
-    "CallbackPath": "/signin-oidc",
-    "SignedOutRedirectUri": "/signed-out",
-    "ResponseType": "code id_token",
-    "TokenValidationParameters.NameClaimType": "name",
-    "TokenValidationParameters.RoleClaimType": "role"
+    "RequireHttpsMetadata": false
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
@@ -24,9 +24,6 @@
     "RefreshTokenExpiration": "Absolute"
   },
   "OpenIdConnect": {
-    "ClientId": "97d25f91-bd4b-4b82-843b-2583b8194800",
-    "ClientSecret": "C@R3I_k42?3=15W5-KzV=Nbpg.eBq/:4",
-    "Authority": "https://login.microsoftonline.com/6ada462c-eda9-40c7-ba09-df3df9f51d6b/",
     "CallbackPath": "/signin-oidc",
     "SignedOutRedirectUri": "/signed-out",
     "ResponseType": "code id_token",

--- a/tests/robot-tests/tests/libs/admin_api.py
+++ b/tests/robot-tests/tests/libs/admin_api.py
@@ -112,7 +112,7 @@ def user_adds_user_invite_via_api(user_email: str, role_name: str, created_date:
         {
             "email": user_email,
             "roleId": _get_global_role_id(role_name),
-            "createdDate": created_date or datetime.today().strftime("%Y-%m-%d %H:%M:%S"),
+            "createdDate": created_date or datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
         },
     )
     assert (


### PR DESCRIPTION
This PR:
- removes the App Registration to Hive's main AD from the codebase
- adds in the ability to drop in any IdP configuration into a .gitignored file `appsettings.Idp.json` so that we can provide configuration away from source control to connect to our new DfE Development AD App Registration

There is also a fix to the Expired Invite UI test where a BST time was being provided to an endpoint that was expecting UTC.

## New config file

The configuration file to connect to the new Azure DfE Development App Registration can be found alongside the other shared passwords under the title "Azure AD IdP configuration".  Its contents can be dropped into a new `appsettings.Idp.json` file in Admin.  Keycloak continues to operate as per usual.

## Tasks after this work has gone in

After everybody has moved to the new AD, the App Registration can be removed from the old AD, the test users removed, and security defaults enabled.

## Future changes and simplifications

Now that we can drop an arbitrary set of IdP configuration into `appsettings.Idp.json`, it's perfectly possible to drop in the Keycloak config into that file as well as the DfE Development Azure config.  Therefore it might no longer be necessary to maintain a `./run.js adminKeycloak`, in favour of just dropping Keycloak config into that file.  This being the case, we could then also do away with the `IdpProviderConfiguration` environment variable and the `BootstrapUsersConfiguration` environment variable too (in favour of another .gitignored file maybe like `users.Idp.json`). 

