### PR TITLE
EES-4231 Backend work to support new featured tables

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
@@ -98,6 +98,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                                 content: "Test content",
                                 timePeriods: new TimePeriodLabels(),
                                 geographicLevels: new List<string>(),
+                                filters: new List<string>(),
+                                indicators: new Dictionary<string, List<string>>(),
                                 file: new FileInfo
                                 {
                                     Id = Guid.NewGuid(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
@@ -99,7 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                                 timePeriods: new TimePeriodLabels(),
                                 geographicLevels: new List<string>(),
                                 filters: new List<string>(),
-                                indicators: new Dictionary<string, List<string>>(),
+                                indicators: new List<string>(),
                                 file: new FileInfo
                                 {
                                     Id = Guid.NewGuid(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -100,7 +100,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 
             var featuredTables = new List<FeaturedTableViewModel>
             {
-                new FeaturedTableViewModel { Id = Guid.NewGuid(), Name = "name", Description = "description", }, // @MarkFix Add SubjectId?
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "name",
+                    Description = "description",
+                    SubjectId = Guid.NewGuid(),
+                },
             };
 
             var (controller, mocks) = BuildControllerAndMocks();
@@ -149,9 +155,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                     From = "2020",
                     To = "2022"
                 },
-                new List<string>
+                new List<string> { "level1" },
+                new List<string> { "filter1", },
+
+                new Dictionary<string, List<string>>
                 {
-                    "level1"
+                    { "indicatorGroup1", new List<string> { "indicator1", "indicator2" } },
+                    { "indicatorGroup2", new List<string> { "indicator3", "indicator4" } },
                 },
                 new FileInfo
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -100,13 +100,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 
             var featuredTables = new List<FeaturedTableViewModel>
             {
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    Name = "name",
-                    Description = "description",
-                    SubjectId = Guid.NewGuid(),
-                },
+                new
+                (
+                    Id: Guid.NewGuid(),
+                    Name: "name",
+                    Description: "description",
+                    SubjectId: Guid.NewGuid()
+                ),
             };
 
             var (controller, mocks) = BuildControllerAndMocks();
@@ -158,10 +158,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                 new List<string> { "level1" },
                 new List<string> { "filter1", },
 
-                new Dictionary<string, List<string>>
+                new List<string>
                 {
-                    { "indicatorGroup1", new List<string> { "indicator1", "indicator2" } },
-                    { "indicatorGroup2", new List<string> { "indicator3", "indicator4" } },
+                    "indicator1", "indicator2", "indicator3", "indicator4",
                 },
                 new FileInfo
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -100,7 +100,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 
             var featuredTables = new List<FeaturedTableViewModel>
             {
-                new(Guid.NewGuid(), "name", "description")
+                new FeaturedTableViewModel { Id = Guid.NewGuid(), Name = "name", Description = "description", }, // @MarkFix Add SubjectId?
             };
 
             var (controller, mocks) = BuildControllerAndMocks();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
@@ -44,10 +45,65 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 DataGuidance = "Guidance 2"
             };
 
+            var subject1Filter1 = new Filter
+            {
+                Subject = releaseSubject1.Subject,
+                Label = "subject 1 filter 1",
+            };
+
+            var subject1Filter2 = new Filter
+            {
+                Subject = releaseSubject1.Subject,
+                Label = "subject 1 filter 2",
+            };
+
+            var subject1IndicatorGroup1 = new IndicatorGroup
+            {
+                Subject = releaseSubject1.Subject,
+                Label = "subject 1 indicator group 1",
+                Indicators = new List<Indicator>
+                {
+                    new Indicator { Label = "subject 1 indicator group 1 indicator 1" },
+                    new Indicator { Label = "subject 1 indicator group 1 indicator 2" },
+                    new Indicator { Label = "subject 1 indicator group 1 indicator 3" },
+                }
+            };
+
+            var subject1IndicatorGroup2 = new IndicatorGroup
+            {
+                Subject = releaseSubject1.Subject,
+                Label = "subject 1 indicator group 2",
+                Indicators = new List<Indicator>
+                {
+                    new Indicator { Label = "subject 1 indicator group 2 indicator 1" },
+                    new Indicator { Label = "subject 1 indicator group 2 indicator 2" },
+                }
+            };
+
+            var subject2Filter1 = new Filter
+            {
+                Subject = releaseSubject2.Subject,
+                Label = "subject 2 filter 1",
+            };
+
+            var subject2IndicatorGroup1 = new IndicatorGroup
+            {
+                Subject = releaseSubject2.Subject,
+                Label = "subject 2 indicator group 1",
+                Indicators = new List<Indicator>
+                {
+                    new Indicator { Label = "subject 2 indicator group 1 indicator 1" },
+                }
+            };
+
             var statisticsDbContextId = Guid.NewGuid().ToString();
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await statisticsDbContext.Filter.AddRangeAsync(
+                    subject1Filter1, subject1Filter2, subject2Filter1);
+                await statisticsDbContext.IndicatorGroup.AddRangeAsync(
+                    subject1IndicatorGroup1, subject1IndicatorGroup2, subject2IndicatorGroup1);
                 await statisticsDbContext.SaveChangesAsync();
             }
 
@@ -155,6 +211,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal("Local Authority", subjects[0].GeographicLevels[0]);
                 Assert.Equal("Local Authority District", subjects[0].GeographicLevels[1]);
 
+                Assert.Equal(2, subjects[0].Filters.Count);
+                Assert.Equal("subject 1 filter 1", subjects[0].Filters[0]);
+                Assert.Equal("subject 1 filter 2", subjects[0].Filters[1]);
+
+                Assert.Equal(2, subjects[0].Indicators.Keys.Count);
+                Assert.Equal(3, subjects[0].Indicators["subject 1 indicator group 1"].Count);
+                Assert.Equal("subject 1 indicator group 1 indicator 1", subjects[0].Indicators["subject 1 indicator group 1"][0]);
+                Assert.Equal("subject 1 indicator group 1 indicator 2", subjects[0].Indicators["subject 1 indicator group 1"][1]);
+                Assert.Equal("subject 1 indicator group 1 indicator 3", subjects[0].Indicators["subject 1 indicator group 1"][2]);
+                Assert.Equal(2, subjects[0].Indicators["subject 1 indicator group 2"].Count);
+                Assert.Equal("subject 1 indicator group 2 indicator 1", subjects[0].Indicators["subject 1 indicator group 2"][0]);
+                Assert.Equal("subject 1 indicator group 2 indicator 2", subjects[0].Indicators["subject 1 indicator group 2"][1]);
+
                 Assert.Equal(releaseSubject2.Subject.Id, subjects[1].Id);
                 Assert.Equal(releaseFile2.Name, subjects[1].Name);
                 Assert.Equal(releaseFile2.File.Id, subjects[1].File.Id);
@@ -168,6 +237,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 Assert.Single(subjects[1].GeographicLevels);
                 Assert.Equal("National", subjects[1].GeographicLevels[0]);
+
+                Assert.Single(subjects[1].Filters);
+                Assert.Equal("subject 2 filter 1", subjects[1].Filters[0]);
+
+                Assert.Single(subjects[1].Indicators.Keys);
+                Assert.Single(subjects[1].Indicators["subject 2 indicator group 1"]);
+                Assert.Equal("subject 2 indicator group 1 indicator 1", subjects[1].Indicators["subject 2 indicator group 1"][0]);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
@@ -496,17 +496,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         public async Task ListFeaturedTables()
         {
             var releaseId = Guid.NewGuid();
-            var release = new Release
-            {
-                Id = releaseId
-            };
+            var release = new Release { Id = releaseId };
+            var statRelease = new Data.Model.Release { Id = releaseId };
 
             var releaseSubject1 = new ReleaseSubject
             {
-                Release = new Data.Model.Release
-                {
-                    Id = releaseId
-                },
+                Release = statRelease,
                 Subject = new Subject
                 {
                     Id = Guid.NewGuid()
@@ -514,10 +509,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
             var releaseSubject2 = new ReleaseSubject
             {
-                Release = new Data.Model.Release
-                {
-                    Id = releaseId
-                },
+                Release = statRelease,
                 Subject = new Subject
                 {
                     Id = Guid.NewGuid()
@@ -575,7 +567,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 HighlightDescription = "Test highlight description 2",
                 Query = new ObservationQueryContext
                 {
-                    SubjectId = releaseSubject1.Subject.Id,
+                    SubjectId = releaseSubject2.Subject.Id,
                 }
             };
 
@@ -605,7 +597,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                await statisticsDbContext.AddAsync(releaseSubject1);
+                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
                 await statisticsDbContext.SaveChangesAsync();
             }
 
@@ -626,10 +618,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal(dataBlock1.Id, featuredTables[0].Id);
                 Assert.Equal(dataBlock1.HighlightName, featuredTables[0].Name);
                 Assert.Equal(dataBlock1.HighlightDescription, featuredTables[0].Description);
+                Assert.Equal(releaseSubject1.SubjectId, featuredTables[0].SubjectId);
 
                 Assert.Equal(dataBlock2.Id, featuredTables[1].Id);
                 Assert.Equal(dataBlock2.HighlightName, featuredTables[1].Name);
                 Assert.Equal(dataBlock2.HighlightDescription, featuredTables[1].Description);
+                Assert.Equal(releaseSubject2.SubjectId, featuredTables[1].SubjectId);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
@@ -11,11 +11,13 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 {
@@ -88,8 +90,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                                 content: rs.DataGuidance ?? string.Empty,
                                 timePeriods: await _timePeriodService.GetTimePeriodLabels(rs.SubjectId),
                                 geographicLevels: await _dataGuidanceSubjectService.GetGeographicLevels(rs.SubjectId),
-                                filters: await GetFilters(rs.SubjectId),
-                                indicators: await GetIndicators(rs.SubjectId),
+                                filters: await GetFilters(rs.SubjectId, rs.FilterSequence),
+                                indicators: await GetIndicators(rs.SubjectId, rs.IndicatorSequence),
                                 file: releaseFile.ToFileInfo()
                             );
                         }
@@ -99,27 +101,56 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 .ToList();
         }
 
-        private async Task<List<string>> GetFilters(Guid subjectId)
+        private async Task<List<string>> GetFilters(Guid subjectId, List<FilterSequenceEntry>? filterSequence)
         {
-            return await _statisticsDbContext.Filter
+            var unorderedFilterList = await _statisticsDbContext.Filter
                 .Where(filter => filter.SubjectId == subjectId)
-                .Select(filter => filter.Label)
-                .OrderBy(filterLabel => filterLabel)
                 .ToListAsync();
+
+            if (filterSequence == null)
+            {
+                return unorderedFilterList
+                    .Select(filter => filter.Label)
+                    .OrderBy(label => label)
+                    .ToList();
+            }
+
+            var filterIdSequence = filterSequence
+                .Select(filter => filter.Id)
+                .ToList();
+
+            return unorderedFilterList
+                .OrderBy(filter => filterIdSequence.IndexOf(filter.Id))
+                .Select(filter => filter.Label)
+                .ToList();
         }
 
-        private async Task<Dictionary<string, List<string>>> GetIndicators(Guid subjectId)
+        private async Task<List<string>> GetIndicators(
+            Guid subjectId,
+            List<IndicatorGroupSequenceEntry>? indicatorGroupSequence)
         {
-            return await _statisticsDbContext.IndicatorGroup
-                .Include(ig => ig.Indicators)
-                .Where(indicatorGroup => indicatorGroup.SubjectId == subjectId)
-                .ToDictionaryAsync(
-                    indicatorGroup => indicatorGroup.Label,
-                    indicatorGroup => indicatorGroup.Indicators
-                        .Select(indicator => indicator.Label)
-                        .OrderBy(indicatorLabel => indicatorLabel)
-                        .ToList());
+            var unorderedIndicators= await _statisticsDbContext.Indicator
+                .Where(indicator => indicator.IndicatorGroup.SubjectId == subjectId)
+                .ToListAsync();
+
+            if (indicatorGroupSequence == null)
+            {
+                return unorderedIndicators
+                    .Select(indicator => indicator.Label)
+                    .OrderBy(label => label)
+                    .ToList();
+            }
+
+            var indicatorIdSequence = indicatorGroupSequence
+                .SelectMany(indicatorGroup => indicatorGroup.ChildSequence)
+                .ToList();
+
+            return unorderedIndicators
+                .OrderBy(indicator => indicatorIdSequence.IndexOf(indicator.Id))
+                .Select(indicator => indicator.Label)
+                .ToList();
         }
+
 
         public async Task<Either<ActionResult, List<FeaturedTableViewModel>>> ListFeaturedTables(Guid releaseId)
         {
@@ -138,12 +169,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 .Where(dataBlock => subjectsToInclude.Contains(dataBlock.Query.SubjectId))
                 .Select(
                     dataBlock => new FeaturedTableViewModel
-                    {
-                        Id = dataBlock.Id,
-                        Name =  dataBlock.HighlightName ?? string.Empty,
-                        Description = dataBlock.HighlightDescription ?? string.Empty,
-                        SubjectId = dataBlock.Query.SubjectId,
-                    }
+                    (
+                        dataBlock.Id,
+                        dataBlock.HighlightName ?? string.Empty,
+                        dataBlock.HighlightDescription ?? string.Empty,
+                        dataBlock.Query.SubjectId
+                    )
                 )
                 .OrderBy(featuredTable => featuredTable.Name)
                 .ToList();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
@@ -113,11 +113,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             return releaseContentBlocks
                 .Where(dataBlock => subjectsToInclude.Contains(dataBlock.Query.SubjectId))
                 .Select(
-                    dataBlock => new FeaturedTableViewModel(
-                        id: dataBlock.Id,
-                        name: dataBlock.HighlightName ?? string.Empty,
-                        description: dataBlock.HighlightDescription ?? string.Empty
-                    )
+                    dataBlock => new FeaturedTableViewModel
+                    {
+                        Id = dataBlock.Id,
+                        Name =  dataBlock.HighlightName ?? string.Empty,
+                        Description = dataBlock.HighlightDescription ?? string.Empty,
+                        SubjectId = dataBlock.Query.SubjectId,
+                    }
                 )
                 .OrderBy(featuredTable => featuredTable.Name)
                 .ToList();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/FeaturedTableViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/FeaturedTableViewModel.cs
@@ -5,17 +5,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
 {
     public record FeaturedTableViewModel
     {
-        public Guid Id { get; }
+        public Guid Id { get; set; }
 
-        public string Name { get; }
+        public string Name { get; set; }
 
-        public string Description { get; }
+        public string Description { get; set; }
 
-        public FeaturedTableViewModel(Guid id, string name, string description = "")
-        {
-            Id = id;
-            Name = name;
-            Description = description;
-        }
+        public Guid SubjectId { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/FeaturedTableViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/FeaturedTableViewModel.cs
@@ -3,14 +3,5 @@ using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
 {
-    public record FeaturedTableViewModel
-    {
-        public Guid Id { get; set; }
-
-        public string Name { get; set; }
-
-        public string Description { get; set; }
-
-        public Guid SubjectId { get; set; }
-    }
+    public record FeaturedTableViewModel(Guid Id, string Name, string Description, Guid SubjectId);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/SubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/SubjectViewModel.cs
@@ -19,6 +19,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
 
         public List<string> GeographicLevels { get; }
 
+        public List<string> Filters { get; }
+
+        public Dictionary<string, List<string>> Indicators { get; }
+
         public FileInfo File { get; }
 
         public SubjectViewModel(
@@ -28,6 +32,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
             string content,
             TimePeriodLabels timePeriods,
             List<string> geographicLevels,
+            List<string> filters,
+            Dictionary<string, List<string>> indicators,
             FileInfo file)
         {
             Id = id;
@@ -36,6 +42,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
             Content = content;
             TimePeriods = timePeriods;
             GeographicLevels = geographicLevels;
+            Filters = filters;
+            Indicators = indicators;
             File = file;
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/SubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/SubjectViewModel.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
 
         public List<string> Filters { get; }
 
-        public Dictionary<string, List<string>> Indicators { get; }
+        public List<string> Indicators { get; }
 
         public FileInfo File { get; }
 
@@ -33,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
             TimePeriodLabels timePeriods,
             List<string> geographicLevels,
             List<string> filters,
-            Dictionary<string, List<string>> indicators,
+            List<string> indicators,
             FileInfo file)
         {
             Id = id;


### PR DESCRIPTION
This PR provides changes to give the frontend the information it needs to render the new featured tables design.

It seems this requires just two changes:
- Return the `subjectId` alongside featured tables.
- Return filter and indicator labels alongside subjects.

:rotating_light: After this is merged, we will need to clear the public cache `subject.json` files. I'll create a faffy deploy ticket to track this. (Edit: EES-4266) :rotating_light:

I'll also put do not merge on this ticket. In theory, we could merge it immediately - it doesn't affect existing functionality - but it might make sense for these changes to go in alongside the frontend changes for featured tables in EES-4048.