### PR TITLE
EES-4277 Trim leading and trailing spaces for featured table names and descriptions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -66,6 +66,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     var dataBlock = _mapper.Map<DataBlock>(dataBlockCreate);
                     dataBlock.Created = DateTime.UtcNow;
+                    dataBlock.HighlightName = dataBlock.HighlightName?.Trim();
+                    dataBlock.HighlightDescription = dataBlock.HighlightDescription?.Trim();
 
                     var added = (await _context.DataBlocks.AddAsync(dataBlock)).Entity;
 
@@ -176,6 +178,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             }
 
                             _mapper.Map(dataBlockUpdate, dataBlock);
+                            dataBlock.HighlightName = dataBlock.HighlightName?.Trim();
+                            dataBlock.HighlightDescription = dataBlock.HighlightDescription?.Trim();
 
                             _context.DataBlocks.Update(dataBlock);
                             await _context.SaveChangesAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -66,8 +66,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     var dataBlock = _mapper.Map<DataBlock>(dataBlockCreate);
                     dataBlock.Created = DateTime.UtcNow;
-                    dataBlock.HighlightName = dataBlock.HighlightName?.Trim();
-                    dataBlock.HighlightDescription = dataBlock.HighlightDescription?.Trim();
 
                     var added = (await _context.DataBlocks.AddAsync(dataBlock)).Entity;
 
@@ -178,8 +176,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             }
 
                             _mapper.Map(dataBlockUpdate, dataBlock);
-                            dataBlock.HighlightName = dataBlock.HighlightName?.Trim();
-                            dataBlock.HighlightDescription = dataBlock.HighlightDescription?.Trim();
 
                             _context.DataBlocks.Update(dataBlock);
                             await _context.SaveChangesAsync();

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
@@ -47,8 +47,8 @@ const DataBlockDetailsForm = ({
     ({ highlightName, highlightDescription, isHighlight, ...values }) => {
       onSubmit({
         ...values,
-        highlightName: isHighlight ? highlightName : '',
-        highlightDescription: isHighlight ? highlightDescription : '',
+        highlightName: isHighlight ? highlightName.trim() : '',
+        highlightDescription: isHighlight ? highlightDescription.trim() : '',
       });
     },
     [],
@@ -65,11 +65,13 @@ const DataBlockDetailsForm = ({
         isHighlight: Yup.boolean(),
         highlightName: Yup.string().when('isHighlight', {
           is: true,
-          then: Yup.string().required('Enter a featured table name'),
+          then: Yup.string().trim().required('Enter a featured table name'),
         }),
         highlightDescription: Yup.string().when('isHighlight', {
           is: true,
-          then: Yup.string().required('Enter a featured table description'),
+          then: Yup.string()
+            .trim()
+            .required('Enter a featured table description'),
         }),
         heading: Yup.string().required('Enter a table title'),
         source: Yup.string(),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockDetailsForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockDetailsForm.test.tsx
@@ -77,7 +77,7 @@ describe('DataBlockDetailsForm', () => {
     });
   });
 
-  test('shows validation error if has whitespace featured table name', async () => {
+  test('shows validation error if featured table name is entirely a whitespace string', async () => {
     render(
       <DataBlockDetailsForm
         initialValues={{


### PR DESCRIPTION
This prevents a bug where by allowing a whitespace featured table name, potentially a featured table with no title could appear on be published and appear on the public site.

This work is done in preparation for splitting featured tables details out of the ContentBlocks table and into their own entity.