### PR TITLE
EES-4274 Switch Admin App Service from out-of-process hosting model to in-process

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -5,7 +5,6 @@
     <LangVersion>10.0</LangVersion>
     <UserSecretsId>aspnet-GovUk.Education.ExploreEducationStatistics.Admin-27177B65-FE3A-416B-97FE-420DF4EFF8BF</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
-    <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.webServer>
-    <aspNetCore requestTimeout="00:05:00" />
     <httpProtocol>
       <customHeaders>
         <remove name="X-Powered-By" />


### PR DESCRIPTION
This PR attempts to switch the Admin App service from the out-out-process hosting model using IIS and Kestrel to in-process hosting using just IIS.

In-process has been the default hosting model for new App Services since ASP .Net Core 3.0 and we use it for the Data API and Content API.

In the out-of-process hosting model, IIS (w3wp.exe) running ANCM proxies HTTP requests to Kestrel (Admin.exe) which is a separate dotnet process.

We’d like to switch Admin to using in-process because it’s more performant - there’s no network communication between two servers and it should be less resource intensive.

> In-process hosting runs an ASP.NET Core app in the same process as its IIS worker process. In-process hosting provides improved performance over out-of-process hosting because requests aren't proxied over the loopback adapter, a network interface that returns outgoing network traffic back to the same machine.

There's also other benefits to switching to the in-process hosting model:

> Client disconnects are detected. The [HttpContext.RequestAborted](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httpcontext.requestaborted) cancellation token is cancelled when the client disconnects.

An advantage to remaining with out-of-process would be that the Admin server is Kestrel, identical to our local environments. In-process changes this to IIS. However, we’ve already established running in-process should work ok for us, since it’s the hosting model used by both the Data API and the Content API.

If it doesn't work I think it's likely to be around differences in how authentication is set up. In this case we can quickly revert it but at least we'll be able to document other problems that making this change will encounter.

See [In-process hosting](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/in-process-hosting?view=aspnetcore-7.0) for further information.

### Other changes

- Remove the `requestTimeout` attribute because it's not applicable to the in-process hosting model. See [web.config](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/web-config?view=aspnetcore-7.0).
