### PR TITLE
EES-3754 Add support for Basic Authorization header to frontend `HttpClient`

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1276,7 +1276,10 @@
         "WEBSITE_RUN_FROM_PACKAGE": "1",
         "PublicStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public'), '2018-02-14').secretUriWithVersion, ')')]",
         "enableSwagger": "[parameters('enableSwagger')]",
-        "PublicAppUrl": "[variables('publicAppUrl')]",
+        "PublicApp:Url": "[variables('publicAppUrl')]",
+        "PublicApp:BasicAuth": "[parameters('publicAppBasicAuth')]",
+        "PublicApp:BasicAuthUsername": "[parameters('publicAppBasicAuthUsername')]",
+        "PublicApp:BasicAuthPassword": "[parameters('publicAppBasicAuthPassword')]",
         "RequestTimeouts:TableBuilderQuery": "[parameters('requestTimeoutsTableBuilderQuery')]",
         "TableBuilder:MaxTableCellsAllowed": "[parameters('tableBuilderMaxTableCellsAllowed')]"
       }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.Development.json
@@ -13,5 +13,10 @@
       "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
   },
-  "PublicAppUrl": "http://localhost:3000"
+  "PublicApp": {
+    "Url": "http://localhost:3000",
+    "BasicAuth": false,
+    "BasicAuthUsername": "",
+    "BasicAuthPassword": ""
+  }
 }


### PR DESCRIPTION
This PR allows adding a Basic auth header by default to all requests made by the HttpClient used in the `FrontendService`.

This will be added when basic auth is enabled for the Public app service in the environment, controlled by environment properties.

The environment properties already exist in the infrastructure and are applied to the Data API with a slight tweak to `template.json`.

To be clear, this change isn't adding Basic auth to the Data API service. It's allowing the `FrontendService` to make HTTP requests to the Public App service if the Public App service is protected by Basic auth.