### PR TITLE
EES-4291 rename to json and caption in the permalink endpoint

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/api/permalink/__tests__/createPermalinkTable.test.ts
+++ b/src/explore-education-statistics-frontend/src/modules/api/permalink/__tests__/createPermalinkTable.test.ts
@@ -49,7 +49,7 @@ describe('permalink api route', () => {
     expect(res.statusCode).toBe(500);
   });
 
-  test('returns the table json and title when a valid request is sent', async () => {
+  test('returns the table json and caption when a valid request is sent', async () => {
     const { req, res } = createApiMocks({
       method: 'POST',
       body: {
@@ -210,8 +210,8 @@ describe('permalink api route', () => {
     expect(res.statusCode).toBe(200);
     // eslint-disable-next-line no-underscore-dangle
     expect(res._getData()).toEqual({
-      table: expectedTable,
-      title:
+      json: expectedTable,
+      caption:
         "Number of fixed period exclusions for 'Duration of fixed exclusions' in England for 2006/07",
     });
   });

--- a/src/explore-education-statistics-frontend/src/modules/api/permalink/createPermalinkTable.ts
+++ b/src/explore-education-statistics-frontend/src/modules/api/permalink/createPermalinkTable.ts
@@ -11,8 +11,8 @@ import { UnmappedTableHeadersConfig } from '@common/services/permalinkService';
 import { TableDataResponse } from '@common/services/tableBuilderService';
 
 interface SuccessBody {
-  table: TableJson;
-  title: string;
+  json: TableJson;
+  caption: string;
 }
 
 /**
@@ -55,10 +55,10 @@ export default async function createPermalinkTable(
       results: fullTable.results,
     });
 
-    const title = generateTableTitle(fullTable.subjectMeta);
+    const caption = generateTableTitle(fullTable.subjectMeta);
 
-    if (tableJson && title) {
-      return res.status(200).send({ table: tableJson, title });
+    if (tableJson && caption) {
+      return res.status(200).send({ json: tableJson, caption });
     }
     return res.status(500).send({ message: 'Cannot build table', status: 500 });
   } catch (error) {


### PR DESCRIPTION
Rename `table` to `json` and `title` to `caption` in the response from the Next.js permalink endpoint.