### PR TITLE
EES-3792 Add `DataSetTitle` and `PublicationTitle` to `PermalinkViewModel` for new Permalink page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
@@ -374,6 +374,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
                 Assert.Equal(expectedPermalinkId, result.Id);
                 Assert.InRange(DateTime.UtcNow.Subtract(result.Created).Milliseconds, 0, 1500);
+                Assert.Equal("Test data set", result.DataSetTitle);
+                Assert.Equal("Test publication", result.PublicationTitle);
                 Assert.Equal(PermalinkStatus.Current, result.Status);
                 Assert.Equal("{}", result.Table.ToString());
             }
@@ -667,6 +669,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
                 Assert.Equal(expectedPermalinkId, result.Id);
                 Assert.InRange(DateTime.UtcNow.Subtract(result.Created).Milliseconds, 0, 1500);
+                Assert.Equal("Test data set", result.DataSetTitle);
+                Assert.Equal("Test publication", result.PublicationTitle);
                 Assert.Equal(PermalinkStatus.Current, result.Status);
                 Assert.Equal("{}", result.Table.ToString());
             }
@@ -720,6 +724,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             {
                 Id = Guid.NewGuid(),
                 Created = DateTime.UtcNow,
+                DataSetTitle = "Test data set",
+                PublicationTitle = "Test publication",
                 SubjectId = Guid.NewGuid()
             };
 
@@ -754,6 +760,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
                 Assert.Equal(permalink.Id, result.Id);
                 Assert.Equal(permalink.Created, result.Created);
+                Assert.Equal("Test data set", result.DataSetTitle);
+                Assert.Equal("Test publication", result.PublicationTitle);
                 Assert.Equal(PermalinkStatus.Current, result.Status);
                 Assert.Equal("{}", result.Table.ToString());
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -472,6 +472,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             {
                 Id = permalink.Id,
                 Created = permalink.Created,
+                DataSetTitle = permalink.DataSetTitle,
+                PublicationTitle = permalink.PublicationTitle,
                 Status = status,
                 Table = universalTable
             };

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/PermalinkViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/PermalinkViewModel.cs
@@ -12,6 +12,10 @@ public record PermalinkViewModel
 
     public DateTime Created { get; init; }
 
+    public string DataSetTitle { get; init; } = string.Empty;
+
+    public string PublicationTitle { get; init; } = string.Empty;
+
     [JsonConverter(typeof(StringEnumConverter))]
     public PermalinkStatus Status { get; init; }
 


### PR DESCRIPTION
This PR adds `DataSetTitle` and `PublicationTitle` to `PermalinkViewModel` for the new Permalink page.

They will be used in the page title and navigation:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/4147126/618c44fe-2a62-49c9-9710-3ba43bd388b5)

and also in the source label:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/4147126/85ede2f5-cb55-4d6d-9f05-0fa21064d574)
