### PR TITLE
EES-3792 new permalink snapshots under feature flag

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DataTableCaption.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DataTableCaption.tsx
@@ -5,12 +5,12 @@ import React, { useMemo } from 'react';
 interface Props {
   id?: string;
   title?: string;
-  meta: FullTableMeta;
+  meta?: FullTableMeta;
 }
 
 const DataTableCaption = ({ id, title, meta }: Props) => {
   const generatedTitle = useMemo<string>(
-    () => (title ? '' : generateTableTitle(meta)),
+    () => (!title && meta ? generateTableTitle(meta) : ''),
     [meta, title],
   );
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
@@ -4,6 +4,7 @@ import ButtonGroup from '@common/components/ButtonGroup';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import downloadTableOdsFile from '@common/modules/table-tool/components/utils/downloadTableOdsFile';
 import generateTableTitle from '@common/modules/table-tool/utils/generateTableTitle';
+import { Footnote } from '@common/services/types/footnotes';
 import downloadFile from '@common/utils/file/downloadFile';
 import Yup from '@common/validation/yup';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -18,31 +19,41 @@ interface FormValues {
 
 interface Props {
   fileName: string;
-  fullTable: FullTable;
+  footnotes?: Footnote[];
+  fullTable?: FullTable;
   headingTag?: 'h2' | 'h3' | 'h4';
   headingSize?: 's' | 'm' | 'l';
   tableRef: RefObject<HTMLElement>;
+  tableTitle?: string;
   onCsvDownload: () => Blob | Promise<Blob>;
   onSubmit?: (type: FileFormat) => void;
 }
 
 const DownloadTable = ({
   fileName,
+  footnotes = [],
   fullTable,
   headingTag = 'h3',
   headingSize = 's',
   tableRef,
+  tableTitle = '',
   onCsvDownload,
   onSubmit,
 }: Props) => {
+  const tableFootnotes = fullTable
+    ? fullTable.subjectMeta.footnotes
+    : footnotes;
   const handleCsvDownload = async () => {
     const csv = await onCsvDownload();
     downloadFile(csv, fileName);
   };
 
   const handleOdsDownload = () => {
-    const title = generateTableTitle(fullTable.subjectMeta);
-    downloadTableOdsFile(fileName, fullTable.subjectMeta, tableRef, title);
+    const title = fullTable
+      ? generateTableTitle(fullTable.subjectMeta)
+      : tableTitle;
+
+    downloadTableOdsFile(fileName, tableFootnotes, tableRef, title);
   };
 
   return (

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/downloadTableOdsFile.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/downloadTableOdsFile.ts
@@ -1,4 +1,5 @@
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
+import { Footnote } from '@common/services/types/footnotes';
 import { Dictionary } from '@common/types';
 import last from 'lodash/last';
 import sum from 'lodash/sum';
@@ -134,12 +135,10 @@ export function appendFootnotes(
 
 export default function downloadTableOdsFile(
   fileName: string,
-  subjectMeta: FullTableMeta,
+  footnotes: Footnote[],
   tableRef: RefObject<HTMLElement>,
   title: string,
 ): void {
-  const { footnotes } = subjectMeta;
-
   let tableEl: HTMLTableElement | null = null;
 
   if (tableRef.current) {

--- a/src/explore-education-statistics-common/src/services/permalinkSnapshotService.ts
+++ b/src/explore-education-statistics-common/src/services/permalinkSnapshotService.ts
@@ -1,0 +1,53 @@
+import { TableJson } from '@common/modules/table-tool/utils/mapTableToJson';
+import { dataApi } from '@common/services/api';
+import { TableDataQuery } from '@common/services/tableBuilderService';
+import { Footnote } from '@common/services/types/footnotes';
+import { UnmappedTableHeadersConfig } from '@common/services/permalinkService';
+
+export interface PermalinkSnapshot {
+  created: string;
+  dataSetTitle: string;
+  id: string;
+  publicationTitle: string;
+  status:
+    | 'Current'
+    | 'SubjectRemoved'
+    | 'SubjectReplacedOrRemoved'
+    | 'NotForLatestRelease'
+    | 'PublicationSuperseded';
+  table: {
+    caption: string;
+    footnotes: Footnote[];
+    json: TableJson;
+  };
+}
+
+interface CreatePermalink {
+  query: TableDataQuery;
+  configuration: {
+    tableHeaders: UnmappedTableHeadersConfig;
+  };
+}
+
+const permalinkSnapshotService = {
+  createPermalink(query: CreatePermalink): Promise<PermalinkSnapshot> {
+    return dataApi.post(`/permalink-snapshot`, query);
+  },
+  async getPermalink(id: string): Promise<PermalinkSnapshot> {
+    return dataApi.get(`/permalink-snapshot/${id}`, {
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+  },
+  async getPermalinkCsv(id: string): Promise<Blob> {
+    return dataApi.get(`/permalink-snapshot/${id}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+      responseType: 'blob',
+    });
+  },
+};
+
+export default permalinkSnapshotService;

--- a/src/explore-education-statistics-frontend/src/modules/permalink/__data__/testPermalinkData.ts
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/__data__/testPermalinkData.ts
@@ -1,4 +1,136 @@
 import { Permalink } from '@common/services/permalinkService';
+import { PermalinkSnapshot } from '@common/services/permalinkSnapshotService';
+
+export const testPermalinkSnapshot: PermalinkSnapshot = {
+  created: '2020-10-07T12:00:00.00Z',
+  dataSetTitle: 'Data Set 1',
+  id: 'permalink-1',
+  publicationTitle: 'Publication 1',
+  status: 'Current',
+  table: {
+    caption: 'Test table caption 1',
+    footnotes: [
+      { id: 'footnote-1', label: 'Footnote 1' },
+      { id: 'footnote-2', label: 'Footnote 2' },
+    ],
+    json: {
+      thead: [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            tag: 'td',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: '2014/15 Autumn term',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: '2015/16 Autumn term',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: '2016/17 Autumn term',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: '2017/18 Autumn term',
+            tag: 'th',
+          },
+        ],
+      ],
+      tbody: [
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: 'State-funded primary',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '420,194',
+          },
+          {
+            tag: 'td',
+            text: '385,676',
+          },
+          {
+            tag: 'td',
+            text: '403,409',
+          },
+          {
+            tag: 'td',
+            text: '402,755',
+          },
+        ],
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: 'State-funded primary and secondary',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '567,279',
+          },
+          {
+            tag: 'td',
+            text: '516,897',
+          },
+          {
+            tag: 'td',
+            text: '543,325',
+          },
+          {
+            tag: 'td',
+            text: '540,135',
+          },
+        ],
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: 'State-funded secondary',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '147,085',
+          },
+          {
+            tag: 'td',
+            text: '131,221',
+          },
+          {
+            tag: 'td',
+            text: '139,916',
+          },
+          {
+            tag: 'td',
+            text: '137,380',
+          },
+        ],
+      ],
+    },
+  },
+};
 
 export const testPermalink: Permalink = {
   id: 'permalink-1',

--- a/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/PermalinkPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/PermalinkPage.test.tsx
@@ -3,287 +3,453 @@ import {
   testPermalinkWithHierarchicalLocations,
   testPermalinkWithLocationCodes,
   testPermalinkWithResultLocationIds,
+  testPermalinkSnapshot,
 } from '@frontend/modules/permalink/__data__/testPermalinkData';
 import PermalinkPage from '@frontend/modules/permalink/PermalinkPage';
 import { render, screen, within } from '@testing-library/react';
 import React from 'react';
 
 describe('PermalinkPage', () => {
-  test('renders correctly with permalink', () => {
-    render(<PermalinkPage data={testPermalink} />);
+  // TO DO - EES-4259 remove without newPermalinks version tests and test data
+  describe('with newPermalinks', () => {
+    test('renders correctly with permalink', () => {
+      render(<PermalinkPage newPermalinks data={testPermalinkSnapshot} />);
 
-    expect(
-      screen.getByText("'Subject 1' from 'Test publication'", {
-        selector: 'h1',
-      }),
-    ).toBeInTheDocument();
+      expect(
+        screen.getByText("'Data Set 1' from 'Publication 1'", {
+          selector: 'h1',
+        }),
+      ).toBeInTheDocument();
 
-    expect(screen.getByTestId('created-date')).toHaveTextContent(
-      '7 October 2020',
-    );
+      expect(screen.getByTestId('created-date')).toHaveTextContent(
+        '7 October 2020',
+      );
 
-    expect(screen.getByRole('figure')).toHaveTextContent(
-      "Number of authorised absence sessions for 'Subject 1' for Gender female in Barnet for 2020/21",
-    );
+      expect(screen.getByRole('figure')).toHaveTextContent(
+        'Test table caption 1',
+      );
 
-    expect(screen.getByRole('table')).toBeInTheDocument();
+      const table = screen.getByRole('table');
 
-    const rows = screen.getAllByRole('row');
+      expect(table.querySelectorAll('thead tr')).toHaveLength(1);
+      expect(table.querySelectorAll('thead th')).toHaveLength(4);
 
-    expect(rows).toHaveLength(2);
-    expect(within(rows[0]).getByRole('columnheader')).toHaveTextContent(
-      '2020/21',
-    );
-    expect(within(rows[1]).getByRole('rowheader')).toHaveTextContent('Barnet');
-    expect(within(rows[1]).getByRole('cell')).toHaveTextContent('123');
+      expect(table.querySelectorAll('tbody tr')).toHaveLength(3);
+      expect(table.querySelectorAll('tbody th')).toHaveLength(3);
+      expect(table.querySelectorAll('tbody td')).toHaveLength(12);
 
-    expect(
-      screen.getByText('Source: Test publication, Subject 1'),
-    ).toBeInTheDocument();
+      expect(table).toMatchSnapshot();
+
+      const footnotes = within(screen.getByTestId('footnotes')).getAllByRole(
+        'listitem',
+      );
+      expect(footnotes).toHaveLength(2);
+      expect(footnotes[0]).toHaveTextContent('Footnote 1');
+      expect(footnotes[1]).toHaveTextContent('Footnote 2');
+    });
+
+    test('renders no warning message with permalink status Current', () => {
+      render(<PermalinkPage newPermalinks data={testPermalinkSnapshot} />);
+
+      expect(screen.queryByText(/WARNING/)).not.toBeInTheDocument();
+
+      // Table still renders
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(4);
+    });
+
+    test('renders warning message with permalink status SubjectRemoved', () => {
+      render(
+        <PermalinkPage
+          newPermalinks
+          data={{
+            ...testPermalinkSnapshot,
+            status: 'SubjectRemoved',
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          'WARNING - The data used in this table is no longer valid.',
+        ),
+      ).toBeInTheDocument();
+
+      // Table still renders
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(4);
+    });
+
+    test('renders warning message with permalink status SubjectReplacedOrRemoved', () => {
+      render(
+        <PermalinkPage
+          newPermalinks
+          data={{
+            ...testPermalinkSnapshot,
+            status: 'SubjectReplacedOrRemoved',
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          'WARNING - The data used in this table may be invalid as the subject file has been amended or removed since its creation.',
+        ),
+      ).toBeInTheDocument();
+
+      // Table still renders
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(4);
+    });
+
+    test('renders warning message with permalink status NotForLatestRelease', () => {
+      render(
+        <PermalinkPage
+          newPermalinks
+          data={{
+            ...testPermalinkSnapshot,
+            status: 'NotForLatestRelease',
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          'WARNING - The data used in this table may now be out-of-date as a new release has been published since its creation.',
+        ),
+      ).toBeInTheDocument();
+
+      // Table still renders
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(4);
+    });
+
+    test('renders warning message with permalink status PublicationSuperseded', () => {
+      render(
+        <PermalinkPage
+          newPermalinks
+          data={{
+            ...testPermalinkSnapshot,
+            status: 'PublicationSuperseded',
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          'WARNING - The data used in this table may now be out-of-date as a new release has been published since its creation.',
+        ),
+      ).toBeInTheDocument();
+
+      // Table still renders
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(4);
+    });
   });
 
-  test('renders correctly with hierarchical locations', () => {
-    render(<PermalinkPage data={testPermalinkWithHierarchicalLocations} />);
+  describe('without newPermalinks', () => {
+    test('renders correctly with permalink', () => {
+      render(<PermalinkPage newPermalinks={false} data={testPermalink} />);
 
-    expect(
-      screen.getByText("'Subject 1' from 'Test publication'", {
-        selector: 'h1',
-      }),
-    ).toBeInTheDocument();
+      expect(
+        screen.getByText("'Subject 1' from 'Test publication'", {
+          selector: 'h1',
+        }),
+      ).toBeInTheDocument();
 
-    expect(screen.getByTestId('created-date')).toHaveTextContent(
-      '7 October 2020',
-    );
+      expect(screen.getByTestId('created-date')).toHaveTextContent(
+        '7 October 2020',
+      );
 
-    expect(screen.getByRole('figure')).toHaveTextContent(
-      "Number of authorised absence sessions for 'Subject 1' for Gender female in Barnet and Bolton for 2020/21",
-    );
+      expect(screen.getByRole('figure')).toHaveTextContent(
+        "Number of authorised absence sessions for 'Subject 1' for Gender female in Barnet for 2020/21",
+      );
 
-    expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getByRole('table')).toBeInTheDocument();
 
-    const table = screen.getByRole('table');
+      const rows = screen.getAllByRole('row');
 
-    expect(table.querySelectorAll('thead tr')).toHaveLength(1);
-    expect(table.querySelectorAll('thead th')).toHaveLength(1);
-    expect(table.querySelectorAll('thead th[scope="colgroup"]')).toHaveLength(
-      0,
-    );
-    expect(table.querySelectorAll('thead th[scope="col"]')).toHaveLength(1);
-    expect(table.querySelector('thead th[scope="col"]')).toHaveTextContent(
-      '2020/21',
-    );
+      expect(rows).toHaveLength(2);
+      expect(within(rows[0]).getByRole('columnheader')).toHaveTextContent(
+        '2020/21',
+      );
+      expect(within(rows[1]).getByRole('rowheader')).toHaveTextContent(
+        'Barnet',
+      );
+      expect(within(rows[1]).getByRole('cell')).toHaveTextContent('123');
 
-    const rows = table.querySelectorAll('tbody tr');
+      expect(
+        screen.getByText('Source: Test publication, Subject 1'),
+      ).toBeInTheDocument();
+    });
 
-    expect(rows).toHaveLength(2);
+    test('renders correctly with hierarchical locations', () => {
+      render(
+        <PermalinkPage
+          newPermalinks={false}
+          data={testPermalinkWithHierarchicalLocations}
+        />,
+      );
 
-    // Row 1
+      expect(
+        screen.getByText("'Subject 1' from 'Test publication'", {
+          selector: 'h1',
+        }),
+      ).toBeInTheDocument();
 
-    const row1Headers = rows[0].querySelectorAll('th');
-    const row1Cells = rows[0].querySelectorAll('td');
+      expect(screen.getByTestId('created-date')).toHaveTextContent(
+        '7 October 2020',
+      );
 
-    expect(row1Headers).toHaveLength(2);
+      expect(screen.getByRole('figure')).toHaveTextContent(
+        "Number of authorised absence sessions for 'Subject 1' for Gender female in Barnet and Bolton for 2020/21",
+      );
 
-    expect(row1Headers[0]).toHaveAttribute('scope', 'rowgroup');
-    expect(row1Headers[0]).toHaveAttribute('colspan', '1');
-    expect(row1Headers[0]).toHaveTextContent('Outer London');
+      expect(screen.getByRole('table')).toBeInTheDocument();
 
-    expect(row1Headers[1]).toHaveAttribute('scope', 'row');
-    expect(row1Headers[1]).toHaveAttribute('colspan', '1');
-    expect(row1Headers[1]).toHaveTextContent('Barnet');
+      const table = screen.getByRole('table');
 
-    expect(row1Cells).toHaveLength(1);
-    expect(row1Cells[0]).toHaveTextContent('123');
+      expect(table.querySelectorAll('thead tr')).toHaveLength(1);
+      expect(table.querySelectorAll('thead th')).toHaveLength(1);
+      expect(table.querySelectorAll('thead th[scope="colgroup"]')).toHaveLength(
+        0,
+      );
+      expect(table.querySelectorAll('thead th[scope="col"]')).toHaveLength(1);
+      expect(table.querySelector('thead th[scope="col"]')).toHaveTextContent(
+        '2020/21',
+      );
 
-    // Row 2
+      const rows = table.querySelectorAll('tbody tr');
 
-    const row2Headers = rows[1].querySelectorAll('th');
-    const row2Cells = rows[1].querySelectorAll('td');
+      expect(rows).toHaveLength(2);
 
-    expect(row2Headers).toHaveLength(2);
+      // Row 1
 
-    expect(row2Headers[0]).toHaveAttribute('scope', 'rowgroup');
-    expect(row2Headers[0]).toHaveAttribute('colspan', '1');
-    expect(row2Headers[0]).toHaveTextContent('North West');
+      const row1Headers = rows[0].querySelectorAll('th');
+      const row1Cells = rows[0].querySelectorAll('td');
 
-    expect(row2Headers[1]).toHaveAttribute('scope', 'row');
-    expect(row2Headers[1]).toHaveAttribute('colspan', '1');
-    expect(row2Headers[1]).toHaveTextContent('Bolton');
+      expect(row1Headers).toHaveLength(2);
 
-    expect(row2Cells).toHaveLength(1);
-    expect(row2Cells[0]).toHaveTextContent('456');
+      expect(row1Headers[0]).toHaveAttribute('scope', 'rowgroup');
+      expect(row1Headers[0]).toHaveAttribute('colspan', '1');
+      expect(row1Headers[0]).toHaveTextContent('Outer London');
 
-    expect(
-      screen.getByText('Source: Test publication, Subject 1'),
-    ).toBeInTheDocument();
-  });
+      expect(row1Headers[1]).toHaveAttribute('scope', 'row');
+      expect(row1Headers[1]).toHaveAttribute('colspan', '1');
+      expect(row1Headers[1]).toHaveTextContent('Barnet');
 
-  test("renders correctly with a permalink created prior to the switchover from Location codes to id's", () => {
-    render(<PermalinkPage data={testPermalinkWithLocationCodes} />);
+      expect(row1Cells).toHaveLength(1);
+      expect(row1Cells[0]).toHaveTextContent('123');
 
-    expect(
-      screen.getByText("'Subject 1' from 'Test publication'", {
-        selector: 'h1',
-      }),
-    ).toBeInTheDocument();
+      // Row 2
 
-    expect(screen.getByTestId('created-date')).toHaveTextContent(
-      '7 October 2020',
-    );
+      const row2Headers = rows[1].querySelectorAll('th');
+      const row2Cells = rows[1].querySelectorAll('td');
 
-    expect(screen.getByRole('figure')).toHaveTextContent(
-      "Number of authorised absence sessions for 'Subject 1' for Gender female in Barnet for 2020/21",
-    );
+      expect(row2Headers).toHaveLength(2);
 
-    expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(row2Headers[0]).toHaveAttribute('scope', 'rowgroup');
+      expect(row2Headers[0]).toHaveAttribute('colspan', '1');
+      expect(row2Headers[0]).toHaveTextContent('North West');
 
-    const rows = screen.getAllByRole('row');
+      expect(row2Headers[1]).toHaveAttribute('scope', 'row');
+      expect(row2Headers[1]).toHaveAttribute('colspan', '1');
+      expect(row2Headers[1]).toHaveTextContent('Bolton');
 
-    expect(rows).toHaveLength(2);
-    expect(within(rows[0]).getByRole('columnheader')).toHaveTextContent(
-      '2020/21',
-    );
-    expect(within(rows[1]).getByRole('rowheader')).toHaveTextContent('Barnet');
-    expect(within(rows[1]).getByRole('cell')).toHaveTextContent('123');
+      expect(row2Cells).toHaveLength(1);
+      expect(row2Cells[0]).toHaveTextContent('456');
 
-    expect(
-      screen.getByText('Source: Test publication, Subject 1'),
-    ).toBeInTheDocument();
-  });
+      expect(
+        screen.getByText('Source: Test publication, Subject 1'),
+      ).toBeInTheDocument();
+    });
 
-  // Test a special case where a Permalink has 'locationId' in each result but still uses location codes.
-  // This was a possible state after EES-3203.
-  test("renders correctly with a permalink that has location id's in results", () => {
-    render(<PermalinkPage data={testPermalinkWithResultLocationIds} />);
+    test("renders correctly with a permalink created prior to the switchover from Location codes to id's", () => {
+      render(
+        <PermalinkPage
+          newPermalinks={false}
+          data={testPermalinkWithLocationCodes}
+        />,
+      );
 
-    expect(
-      screen.getByText("'Subject 1' from 'Test publication'", {
-        selector: 'h1',
-      }),
-    ).toBeInTheDocument();
+      expect(
+        screen.getByText("'Subject 1' from 'Test publication'", {
+          selector: 'h1',
+        }),
+      ).toBeInTheDocument();
 
-    expect(screen.getByTestId('created-date')).toHaveTextContent(
-      '7 October 2020',
-    );
+      expect(screen.getByTestId('created-date')).toHaveTextContent(
+        '7 October 2020',
+      );
 
-    expect(screen.getByRole('figure')).toHaveTextContent(
-      "Number of authorised absence sessions for 'Subject 1' for Gender female in Barnet for 2020/21",
-    );
+      expect(screen.getByRole('figure')).toHaveTextContent(
+        "Number of authorised absence sessions for 'Subject 1' for Gender female in Barnet for 2020/21",
+      );
 
-    expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getByRole('table')).toBeInTheDocument();
 
-    const rows = screen.getAllByRole('row');
+      const rows = screen.getAllByRole('row');
 
-    expect(rows).toHaveLength(2);
-    expect(within(rows[0]).getByRole('columnheader')).toHaveTextContent(
-      '2020/21',
-    );
-    expect(within(rows[1]).getByRole('rowheader')).toHaveTextContent('Barnet');
-    expect(within(rows[1]).getByRole('cell')).toHaveTextContent('123');
+      expect(rows).toHaveLength(2);
+      expect(within(rows[0]).getByRole('columnheader')).toHaveTextContent(
+        '2020/21',
+      );
+      expect(within(rows[1]).getByRole('rowheader')).toHaveTextContent(
+        'Barnet',
+      );
+      expect(within(rows[1]).getByRole('cell')).toHaveTextContent('123');
 
-    expect(
-      screen.getByText('Source: Test publication, Subject 1'),
-    ).toBeInTheDocument();
-  });
+      expect(
+        screen.getByText('Source: Test publication, Subject 1'),
+      ).toBeInTheDocument();
+    });
 
-  test('renders no warning message with permalink status Current', () => {
-    render(
-      <PermalinkPage
-        data={{
-          ...testPermalink,
-          status: 'Current',
-        }}
-      />,
-    );
+    // Test a special case where a Permalink has 'locationId' in each result but still uses location codes.
+    // This was a possible state after EES-3203.
+    test("renders correctly with a permalink that has location id's in results", () => {
+      render(
+        <PermalinkPage
+          newPermalinks={false}
+          data={testPermalinkWithResultLocationIds}
+        />,
+      );
 
-    expect(screen.queryByText(/WARNING/)).not.toBeInTheDocument();
+      expect(
+        screen.getByText("'Subject 1' from 'Test publication'", {
+          selector: 'h1',
+        }),
+      ).toBeInTheDocument();
 
-    // Table still renders
-    expect(screen.getByRole('table')).toBeInTheDocument();
-    expect(screen.getAllByRole('row')).toHaveLength(2);
-  });
+      expect(screen.getByTestId('created-date')).toHaveTextContent(
+        '7 October 2020',
+      );
 
-  test('renders warning message with permalink status SubjectRemoved', () => {
-    render(
-      <PermalinkPage
-        data={{
-          ...testPermalink,
-          status: 'SubjectRemoved',
-        }}
-      />,
-    );
+      expect(screen.getByRole('figure')).toHaveTextContent(
+        "Number of authorised absence sessions for 'Subject 1' for Gender female in Barnet for 2020/21",
+      );
 
-    expect(
-      screen.getByText(
-        'WARNING - The data used in this table is no longer valid.',
-      ),
-    ).toBeInTheDocument();
+      expect(screen.getByRole('table')).toBeInTheDocument();
 
-    // Table still renders
-    expect(screen.getByRole('table')).toBeInTheDocument();
-    expect(screen.getAllByRole('row')).toHaveLength(2);
-  });
+      const rows = screen.getAllByRole('row');
 
-  test('renders warning message with permalink status SubjectReplacedOrRemoved', () => {
-    render(
-      <PermalinkPage
-        data={{
-          ...testPermalink,
-          status: 'SubjectReplacedOrRemoved',
-        }}
-      />,
-    );
+      expect(rows).toHaveLength(2);
+      expect(within(rows[0]).getByRole('columnheader')).toHaveTextContent(
+        '2020/21',
+      );
+      expect(within(rows[1]).getByRole('rowheader')).toHaveTextContent(
+        'Barnet',
+      );
+      expect(within(rows[1]).getByRole('cell')).toHaveTextContent('123');
 
-    expect(
-      screen.getByText(
-        'WARNING - The data used in this table may be invalid as the subject file has been amended or removed since its creation.',
-      ),
-    ).toBeInTheDocument();
+      expect(
+        screen.getByText('Source: Test publication, Subject 1'),
+      ).toBeInTheDocument();
+    });
 
-    // Table still renders
-    expect(screen.getByRole('table')).toBeInTheDocument();
-    expect(screen.getAllByRole('row')).toHaveLength(2);
-  });
+    test('renders no warning message with permalink status Current', () => {
+      render(
+        <PermalinkPage
+          newPermalinks={false}
+          data={{
+            ...testPermalink,
+            status: 'Current',
+          }}
+        />,
+      );
 
-  test('renders warning message with permalink status NotForLatestRelease', () => {
-    render(
-      <PermalinkPage
-        data={{
-          ...testPermalink,
-          status: 'NotForLatestRelease',
-        }}
-      />,
-    );
+      expect(screen.queryByText(/WARNING/)).not.toBeInTheDocument();
 
-    expect(
-      screen.getByText(
-        'WARNING - The data used in this table may now be out-of-date as a new release has been published since its creation.',
-      ),
-    ).toBeInTheDocument();
+      // Table still renders
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(2);
+    });
 
-    // Table still renders
-    expect(screen.getByRole('table')).toBeInTheDocument();
-    expect(screen.getAllByRole('row')).toHaveLength(2);
-  });
+    test('renders warning message with permalink status SubjectRemoved', () => {
+      render(
+        <PermalinkPage
+          newPermalinks={false}
+          data={{
+            ...testPermalink,
+            status: 'SubjectRemoved',
+          }}
+        />,
+      );
 
-  test('renders warning message with permalink status PublicationSuperseded', () => {
-    render(
-      <PermalinkPage
-        data={{
-          ...testPermalink,
-          status: 'PublicationSuperseded',
-        }}
-      />,
-    );
+      expect(
+        screen.getByText(
+          'WARNING - The data used in this table is no longer valid.',
+        ),
+      ).toBeInTheDocument();
 
-    expect(
-      screen.getByText(
-        'WARNING - The data used in this table may now be out-of-date as a new release has been published since its creation.',
-      ),
-    ).toBeInTheDocument();
+      // Table still renders
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(2);
+    });
 
-    // Table still renders
-    expect(screen.getByRole('table')).toBeInTheDocument();
-    expect(screen.getAllByRole('row')).toHaveLength(2);
+    test('renders warning message with permalink status SubjectReplacedOrRemoved', () => {
+      render(
+        <PermalinkPage
+          newPermalinks={false}
+          data={{
+            ...testPermalink,
+            status: 'SubjectReplacedOrRemoved',
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          'WARNING - The data used in this table may be invalid as the subject file has been amended or removed since its creation.',
+        ),
+      ).toBeInTheDocument();
+
+      // Table still renders
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(2);
+    });
+
+    test('renders warning message with permalink status NotForLatestRelease', () => {
+      render(
+        <PermalinkPage
+          newPermalinks={false}
+          data={{
+            ...testPermalink,
+            status: 'NotForLatestRelease',
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          'WARNING - The data used in this table may now be out-of-date as a new release has been published since its creation.',
+        ),
+      ).toBeInTheDocument();
+
+      // Table still renders
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(2);
+    });
+
+    test('renders warning message with permalink status PublicationSuperseded', () => {
+      render(
+        <PermalinkPage
+          newPermalinks={false}
+          data={{
+            ...testPermalink,
+            status: 'PublicationSuperseded',
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          'WARNING - The data used in this table may now be out-of-date as a new release has been published since its creation.',
+        ),
+      ).toBeInTheDocument();
+
+      // Table still renders
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(2);
+    });
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/__snapshots__/PermalinkPage.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/__snapshots__/PermalinkPage.test.tsx.snap
@@ -1,0 +1,140 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PermalinkPage with newPermalinks renders correctly with permalink 1`] = `
+<table
+  aria-labelledby="dataTableCaption"
+  class="govuk-table table"
+  data-testid="dataTableCaption-table"
+>
+  <thead
+    class="tableHead"
+  >
+    <tr>
+      <td
+        colspan="1"
+        rowspan="1"
+      />
+      <th
+        colspan="1"
+        rowspan="1"
+        scope="col"
+      >
+        2014/15 Autumn term
+      </th>
+      <th
+        colspan="1"
+        rowspan="1"
+        scope="col"
+      >
+        2015/16 Autumn term
+      </th>
+      <th
+        colspan="1"
+        rowspan="1"
+        scope="col"
+      >
+        2016/17 Autumn term
+      </th>
+      <th
+        colspan="1"
+        rowspan="1"
+        scope="col"
+      >
+        2017/18 Autumn term
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th
+        class=""
+        colspan="1"
+        rowspan="1"
+        scope="row"
+      >
+        State-funded primary
+      </th>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        420,194
+      </td>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        385,676
+      </td>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        403,409
+      </td>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        402,755
+      </td>
+    </tr>
+    <tr>
+      <th
+        class=""
+        colspan="1"
+        rowspan="1"
+        scope="row"
+      >
+        State-funded primary and secondary
+      </th>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        567,279
+      </td>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        516,897
+      </td>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        543,325
+      </td>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        540,135
+      </td>
+    </tr>
+    <tr>
+      <th
+        class=""
+        colspan="1"
+        rowspan="1"
+        scope="row"
+      >
+        State-funded secondary
+      </th>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        147,085
+      </td>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        131,221
+      </td>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        139,916
+      </td>
+      <td
+        class="govuk-table__cell--numeric"
+      >
+        137,380
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -33,6 +33,7 @@ export interface TableToolPageProps {
   subjects?: Subject[];
   subjectMeta?: SubjectMeta;
   themeMeta: Theme[];
+  newPermalinks?: boolean; // TO DO - EES-4259 remove `newPermalinks` param and tidy up
 }
 
 const TableToolPage: NextPage<TableToolPageProps> = ({
@@ -42,6 +43,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
   subjects,
   subjectMeta,
   themeMeta,
+  newPermalinks,
 }) => {
   const router = useRouter();
   const [loadingFastTrack, setLoadingFastTrack] = useState(false);
@@ -170,6 +172,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
                         table={table}
                         tableHeaders={tableHeaders}
                         onReorderTableHeaders={onReorder}
+                        newPermalinks={newPermalinks}
                       />
                     )}
                 </>
@@ -178,15 +181,27 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
           );
         }}
         onPublicationFormSubmit={publication => {
-          router.push(`/data-tables/${publication.slug}`, undefined, {
-            shallow: true,
-            scroll: false,
-          });
+          router.push(
+            {
+              pathname: `/data-tables/${publication.slug}`,
+              query: newPermalinks ? { newPermalinks } : undefined,
+            },
+            undefined,
+            {
+              shallow: true,
+              scroll: false,
+            },
+          );
         }}
         onStepChange={() => setCurrentStep(undefined)}
         onSubjectFormSubmit={({ publication, release, subjectId }) => {
           router.push(
-            `/data-tables/${publication.slug}/${release.slug}?subjectId=${subjectId}`,
+            {
+              pathname: `/data-tables/${publication.slug}/${release.slug}`,
+              query: newPermalinks
+                ? { subjectId, newPermalinks }
+                : { subjectId },
+            },
             undefined,
             {
               shallow: true,
@@ -195,10 +210,17 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
           );
         }}
         onSubjectStepBack={publication => {
-          router.push(`/data-tables/${publication?.slug}`, undefined, {
-            shallow: true,
-            scroll: false,
-          });
+          router.push(
+            {
+              pathname: `/data-tables/${publication?.slug}`,
+              query: newPermalinks ? { newPermalinks } : undefined,
+            },
+            undefined,
+            {
+              shallow: true,
+              scroll: false,
+            },
+          );
         }}
         onSubmit={table => {
           logEvent({
@@ -242,9 +264,13 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
 export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async ({
   query,
 }) => {
-  const { publicationSlug = '', releaseSlug = '' } = query as Dictionary<
-    string
-  >;
+  const {
+    publicationSlug = '',
+    releaseSlug = '',
+    newPermalinks,
+  } = query as Dictionary<string>;
+
+  console.log('query', query, newPermalinks);
 
   const themeMeta = await publicationService.getPublicationTree({
     publicationFilter: 'DataTables',
@@ -259,6 +285,7 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
     return {
       props: {
         themeMeta,
+        newPermalinks: !!newPermalinks,
       },
     };
   }
@@ -299,6 +326,7 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
       },
       subjects,
       featuredTables,
+      newPermalinks: !!newPermalinks,
     },
   };
 };

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
@@ -22,6 +22,7 @@ interface TableToolFinalStepProps {
   table: FullTable;
   tableHeaders: TableHeadersConfig;
   selectedPublication: SelectedPublication;
+  newPermalinks?: boolean; // TO DO - EES-4259 remove `newPermalinks` param and tidy up
   onReorderTableHeaders: (reorderedTableHeaders: TableHeadersConfig) => void;
 }
 
@@ -30,6 +31,7 @@ const TableToolFinalStep = ({
   tableHeaders,
   query,
   selectedPublication,
+  newPermalinks,
   onReorderTableHeaders,
 }: TableToolFinalStepProps) => {
   const dataTableRef = useRef<HTMLElement>(null);
@@ -138,6 +140,7 @@ const TableToolFinalStep = ({
               tableHeaders={tableHeaders}
               query={query}
               selectedPublication={selectedPublication}
+              newPermalinks={newPermalinks}
             />
           </div>
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
@@ -64,7 +64,7 @@ describe('TableToolShare', () => {
     const urlInput = screen.getByTestId('permalink-generated-url');
     expect(urlInput).toBeInTheDocument();
     expect(urlInput).toHaveValue(
-      'http://localhost/data-tables/permalink/permalink-id',
+      'http://localhost:3000/data-tables/permalink/permalink-id',
     );
 
     expect(
@@ -110,7 +110,7 @@ describe('TableToolShare', () => {
     );
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      'http://localhost/data-tables/permalink/permalink-id',
+      'http://localhost:3000/data-tables/permalink/permalink-id',
     );
   });
 });


### PR DESCRIPTION
Adds the new permalink creation process and permalink page under a feature flag.

Add the query param `newPermalinks=true` to see the new version:
- to create new permalinks `/data-tables?newPermalinks=true`
- to view new permalinks `/data-tables/permalink<id>?newPermalinks=true`
