### PR TITLE
EES-4295 - remove success notification for snapshots

### DIFF
--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -262,10 +262,7 @@ class SnapshotService:
             ) if self.slack_webhook_url else print("Snapshot script complete. Snapshots do not match")
 
         else:
-            # All snapshots match so send a success message to slack (so we know the workflow has actually ran)
-            self._send_slack_notification(
-                f"Snapshot test workflow successfully completed for {self.public_url} :white_check_mark:"
-            ) if self.slack_webhook_url else print("Snapshot script complete. No differences found.")
+            print("Snapshot script complete. No differences found.")
 
     def write_snapshots_to_file(self) -> None:
         for name in self.snapshots:


### PR DESCRIPTION
This PR:
* Removes the success slack notification from `create_snapshots.py` in order to reduce spam of the channel & to enable us to run this workflow more frequently