### PR TITLE
EES-4212 wrap text in key stats

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.module.scss
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.module.scss
@@ -6,6 +6,7 @@
   flex-direction: column;
   flex-grow: 1;
   justify-content: space-evenly;
+  overflow-wrap: break-word;
   padding: 0.7rem 1rem;
 
   @include govuk-media-query($until: tablet) {


### PR DESCRIPTION
Makes sure that all text in key stat blocks will wrap rather than overflow the block.