### PR TITLE
EES-4275 Add support to compress and decompress blobs. Confgure Permalink snapshots to use compression

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
@@ -1753,11 +1753,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .Single(f => f.Filename == metaFileName);
 
                 Assert.Equal(10240, dataFile.ContentLength);
-                Assert.Equal("text/csv", dataFile.ContentType);
+                Assert.Equal(ContentTypes.Csv, dataFile.ContentType);
                 Assert.Equal(FileType.Data, dataFile.Type);
 
                 Assert.Equal(10240, metaFile.ContentLength);
-                Assert.Equal("text/csv", metaFile.ContentType);
+                Assert.Equal(ContentTypes.Csv, metaFile.ContentType);
                 Assert.Equal(Metadata, metaFile.Type);
 
                 var releaseFiles = contentDbContext.ReleaseFiles.ToList();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
@@ -1403,10 +1403,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var blobStorageService = new Mock<IBlobStorageService>(Strict);
 
-            blobStorageService.Setup(mock =>
-                    mock.DownloadToStream(PrivateReleaseFiles, releaseFile.Path(),
-                        It.IsAny<MemoryStream>(), null))
-                .ReturnsAsync(new MemoryStream());
+            blobStorageService
+                .SetupDownloadToStream(PrivateReleaseFiles, releaseFile.Path(), "Test file content");
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
@@ -1417,17 +1415,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 MockUtils.VerifyAllMocks(blobStorageService);
 
-                Assert.True(result.IsRight);
+                var fileStreamResult = result.AssertRight();
 
-                blobStorageService.Verify(
-                    mock =>
-                        mock.DownloadToStream(PrivateReleaseFiles, releaseFile.Path(),
-                        It.IsAny<MemoryStream>(), null),
-                    Times.Once());
-
-                Assert.Equal("application/pdf", result.Right.ContentType);
-                Assert.Equal("ancillary.pdf", result.Right.FileDownloadName);
-                Assert.IsType<MemoryStream>(result.Right.FileStream);
+                Assert.Equal("application/pdf", fileStreamResult.ContentType);
+                Assert.Equal("ancillary.pdf", fileStreamResult.FileDownloadName);
+                Assert.Equal("Test file content", fileStreamResult.FileStream.ReadToEnd());
             }
         }
 
@@ -1459,10 +1451,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var blobStorageService = new Mock<IBlobStorageService>(Strict);
 
-            blobStorageService.Setup(mock =>
-                    mock.DownloadToStream(PrivateReleaseFiles, releaseFile.Path(),
-                        It.IsAny<MemoryStream>(), null))
-                .ReturnsAsync(new MemoryStream());
+            blobStorageService
+                .SetupDownloadToStream(PrivateReleaseFiles, releaseFile.Path(), "Test file content");
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
@@ -1473,17 +1463,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 MockUtils.VerifyAllMocks(blobStorageService);
 
-                Assert.True(result.IsRight);
+                var fileStreamResult = result.AssertRight();
 
-                blobStorageService.Verify(
-                    mock =>
-                        mock.DownloadToStream(PrivateReleaseFiles, releaseFile.Path(),
-                        It.IsAny<MemoryStream>(), null),
-                    Times.Once());
-
-                Assert.Equal("application/pdf", result.Right.ContentType);
-                Assert.Equal("Ancillary 1.pdf", result.Right.FileDownloadName);
-                Assert.IsType<MemoryStream>(result.Right.FileStream);
+                Assert.Equal("application/pdf", fileStreamResult.ContentType);
+                Assert.Equal("Ancillary 1.pdf", fileStreamResult.FileDownloadName);
+                Assert.Equal("Test file content", fileStreamResult.FileStream.ReadToEnd());
             }
         }
 
@@ -2271,7 +2255,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .SetupDownloadToStream(
                     container: PrivateReleaseFiles,
                     path: releaseFile1.Path(),
-                    blobText: "Test ancillary blob",
+                    content: "Test ancillary blob",
                     cancellationToken: tokenSource.Token)
                 .Callback(() => tokenSource.Cancel());
 
@@ -2613,7 +2597,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
 
                 Assert.NotNull(releaseFile);
-                var file = releaseFile!.File;
+                var file = releaseFile.File;
 
                 Assert.Equal(10240, file.ContentLength);
                 Assert.Equal("application/pdf", file.ContentType);
@@ -2693,7 +2677,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     );
 
                 Assert.NotNull(releaseFile);
-                var file = releaseFile!.File;
+                var file = releaseFile.File;
 
                 Assert.Equal(10240, file.ContentLength);
                 Assert.Equal("image/png", file.ContentType);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileService.cs
@@ -40,7 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             Guid releaseId,
             Stream outputStream,
             IEnumerable<Guid>? fileIds = null,
-            CancellationToken? cancellationToken = null);
+            CancellationToken cancellationToken = default);
 
         Task<Either<ActionResult, Unit>> Update(Guid releaseId, Guid fileId, ReleaseFileUpdateViewModel update);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
@@ -190,7 +190,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             Guid releaseId,
             Stream outputStream,
             IEnumerable<Guid>? fileIds = null,
-            CancellationToken? cancellationToken = null)
+            CancellationToken cancellationToken = default)
         {
             return await _persistenceHelper.CheckEntityExists<Release>(
                     releaseId,
@@ -220,14 +220,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             List<ReleaseFile> releaseFiles,
             Release release,
             Stream outputStream,
-            CancellationToken? cancellationToken)
+            CancellationToken cancellationToken)
         {
             using var archive = new ZipArchive(outputStream, ZipArchiveMode.Create);
 
             foreach (var releaseFile in releaseFiles)
             {
                 // Stop immediately if we receive a cancellation request
-                if (cancellationToken?.IsCancellationRequested == true)
+                if (cancellationToken.IsCancellationRequested)
                 {
                     return;
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobClientExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobClientExtensions.cs
@@ -1,0 +1,70 @@
+﻿#nullable enable
+using System;
+using System.Threading;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Moq;
+using Moq.Language.Flow;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class MockBlobClientExtensions
+{
+    public static IReturnsResult<BlobClient> SetupDownloadContentAsync(
+        this Mock<BlobClient> blobClient,
+        string content,
+        string? contentEncoding = null,
+        CancellationToken cancellationToken = default)
+    {
+        var downloadDetails = BlobsModelFactory.BlobDownloadDetails(
+            lastModified: default,
+            metadata: default,
+            contentRange: default,
+            contentEncoding: contentEncoding,
+            cacheControl: default,
+            contentDisposition: default,
+            contentLanguage: default,
+            blobSequenceNumber: default,
+            copyCompletedOn: default,
+            copyStatusDescription: default,
+            copyId: default,
+            copyProgress: default,
+            copySource: default,
+            copyStatus: default,
+            leaseDuration: default,
+            leaseState: default,
+            leaseStatus: default,
+            acceptRanges: default,
+            blobCommittedBlockCount: default,
+            isServerEncrypted: default,
+            encryptionKeySha256: default,
+            encryptionScope: default,
+            blobContentHash: default,
+            tagCount: default,
+            versionId: default,
+            isSealed: default,
+            objectReplicationSourceProperties: default,
+            objectReplicationDestinationPolicy: default
+        );
+
+        var blobDownloadResult = BlobsModelFactory.BlobDownloadResult(
+            content: BinaryData.FromString(content),
+            details: downloadDetails);
+
+        var response = new Mock<Response<BlobDownloadResult>>(MockBehavior.Strict);
+        response.SetupGet(r => r.Value)
+            .Returns(blobDownloadResult);
+
+        return blobClient.Setup(s => s.DownloadContentAsync(cancellationToken))
+            .ReturnsAsync(response.Object);
+    }
+
+    public static IReturnsResult<BlobClient> SetupDownloadContentAsyncNotFound(
+        this Mock<BlobClient> blobClient,
+        CancellationToken cancellationToken = default)
+    {
+        return blobClient.Setup(s => s.DownloadContentAsync(cancellationToken))
+            .ThrowsAsync(new RequestFailedException(status: 404, message: "Blob not found"));
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
@@ -220,5 +220,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
                     s.GetDeserializedJson(container, path, type, settings, cancellationToken))
                 .ThrowsAsync(exception);
         }
+
+        public static IReturnsResult<IBlobStorageService> SetupUploadAsJson<T>(
+            this Mock<IBlobStorageService> service,
+            IBlobContainer container,
+            string path,
+            T content,
+            string? contentEncoding = null,
+            JsonSerializerSettings? settings = null,
+            CancellationToken cancellationToken = default)
+        {
+            return service.Setup(s =>
+                    s.UploadAsJson(container, path, content, contentEncoding, settings, cancellationToken))
+                .Returns(Task.CompletedTask);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobCacheServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
@@ -50,14 +49,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
 
-            blobStorageService.Setup(mock => mock.UploadAsJson(
-                    PublicContent,
-                    cacheKey.Key,
-                    "test item",
-                    null,
-                    null,
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
+            blobStorageService.SetupUploadAsJson(
+                container: PublicContent,
+                path: cacheKey.Key,
+                content: "test item");
 
             var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/CompressionUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/CompressionUtilsTests.cs
@@ -1,0 +1,173 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Xunit;
+using ZstdSharp;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+
+public class CompressionUtilsTests
+{
+    private const string Content = "Test content";
+
+    [Fact]
+    public async Task CompressToStream_UnsupportedContentEncoding()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await CompressionUtils.CompressToStream(
+                stream: Content.ToStream(),
+                targetStream: new MemoryStream(),
+                contentEncoding: "other"));
+    }
+
+    [Fact]
+    public async Task CompressToStream_Gzip()
+    {
+        // Compress some content to a stream using the method under test
+        await using var compressedStream = new MemoryStream();
+        await CompressionUtils.CompressToStream(
+            stream: Content.ToStream(),
+            targetStream: compressedStream,
+            contentEncoding: ContentEncodings.Gzip);
+
+        Assert.Equal(0, compressedStream.Position);
+        Assert.True(compressedStream.Length > 0);
+
+        // Decompress the stream using the compression class directly and assert it contains the original content
+        await using var decompressedStream = new MemoryStream();
+        await using (var decompressor = new GZipStream(compressedStream, CompressionMode.Decompress))
+        {
+            await decompressor.CopyToAsync(decompressedStream);
+        }
+
+        decompressedStream.SeekToBeginning();
+        Assert.Equal(Content, decompressedStream.ReadToEnd());
+    }
+
+    [Fact]
+    public async Task CompressToStream_Zstandard()
+    {
+        // Compress some content to a stream using the method under test
+        await using var compressedStream = new MemoryStream();
+        await CompressionUtils.CompressToStream(
+            stream: Content.ToStream(),
+            targetStream: compressedStream,
+            contentEncoding: ContentEncodings.Zstd);
+
+        Assert.Equal(0, compressedStream.Position);
+        Assert.True(compressedStream.Length > 0);
+
+        // Decompress the stream using the compression class directly and assert it contains the original content
+        await using var decompressedStream = new MemoryStream();
+        await using (var decompressor = new DecompressionStream(compressedStream))
+        {
+            await decompressor.CopyToAsync(decompressedStream);
+        }
+
+        decompressedStream.SeekToBeginning();
+        Assert.Equal(Content, decompressedStream.ReadToEnd());
+    }
+
+    [Fact]
+    public async Task DecompressToStream_UnsupportedContentEncoding()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await CompressionUtils.DecompressToStream(
+                stream: Content.ToStream(),
+                targetStream: new MemoryStream(),
+                contentEncoding: "other"));
+    }
+
+    [Fact]
+    public async Task DecompressToStream_Gzip()
+    {
+        // Compress some content to a stream using the compression class directly
+        await using var compressedStream = new MemoryStream();
+        await using (var compressor = new GZipStream(compressedStream, CompressionMode.Compress, leaveOpen: true))
+        {
+            compressor.WriteText(Content);
+        }
+
+        // Decompress the stream using the method under test and assert it contains the original content
+        await using var decompressedStream = new MemoryStream();
+        await CompressionUtils.DecompressToStream(
+            stream: compressedStream,
+            targetStream: decompressedStream,
+            contentEncoding: ContentEncodings.Gzip);
+
+        Assert.Equal(0, decompressedStream.Position);
+        Assert.Equal(Content, decompressedStream.ReadToEnd());
+    }
+
+    [Fact]
+    public async Task DecompressToStream_Zstandard()
+    {
+        // Compress some content to a stream using the compression class directly
+        await using var compressedStream = new MemoryStream();
+        await using (var compressor = new CompressionStream(compressedStream, level: 11, leaveOpen: true))
+        {
+            compressor.WriteText(Content);
+        }
+
+        // Decompress the stream using the method under test and assert it contains the original content
+        await using var decompressedStream = new MemoryStream();
+        await CompressionUtils.DecompressToStream(
+            stream: compressedStream,
+            targetStream: decompressedStream,
+            contentEncoding: ContentEncodings.Zstd);
+
+        Assert.Equal(0, decompressedStream.Position);
+        Assert.Equal(Content, decompressedStream.ReadToEnd());
+    }
+
+    [Fact]
+    public async Task DecompressToString_UnsupportedContentEncoding()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await CompressionUtils.DecompressToString(
+                bytes: Encoding.UTF8.GetBytes(Content),
+                contentEncoding: "other"));
+    }
+
+    [Fact]
+    public async Task DecompressToString_Gzip()
+    {
+        // Compress some content to a byte array using the compression class directly
+        await using var compressedStream = new MemoryStream();
+        await using (var compressor = new GZipStream(compressedStream, CompressionMode.Compress, leaveOpen: true))
+        {
+            compressor.WriteText(Content);
+        }
+
+        // Decompress the byte array using the method under test
+        var result = await CompressionUtils.DecompressToString(
+            bytes: compressedStream.ToArray(),
+            contentEncoding: ContentEncodings.Gzip);
+
+        Assert.Equal(Content, result);
+    }
+
+    [Fact]
+    public async Task DecompressToString_Zstandard()
+    {
+        // Compress some content to a byte array using the compression class directly
+        await using var compressedStream = new MemoryStream();
+        await using (var compressor = new CompressionStream(compressedStream, level: 11, leaveOpen: true))
+        {
+            compressor.WriteText(Content);
+        }
+
+        // Decompress the byte array using the method under test
+        var result = await CompressionUtils.DecompressToString(
+            bytes: compressedStream.ToArray(),
+            contentEncoding: ContentEncodings.Zstd);
+
+        Assert.Equal(Content, result);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/CompressionUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/CompressionUtilsTests.cs
@@ -38,6 +38,7 @@ public class CompressionUtilsTests
 
         Assert.Equal(0, compressedStream.Position);
         Assert.True(compressedStream.Length > 0);
+        Assert.NotEqual(Content.ToStream(), compressedStream);
 
         // Decompress the stream using the compression class directly and assert it contains the original content
         await using var decompressedStream = new MemoryStream();
@@ -62,6 +63,7 @@ public class CompressionUtilsTests
 
         Assert.Equal(0, compressedStream.Position);
         Assert.True(compressedStream.Length > 0);
+        Assert.NotEqual(Content.ToStream(), compressedStream);
 
         // Decompress the stream using the compression class directly and assert it contains the original content
         await using var decompressedStream = new MemoryStream();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StreamExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StreamExtensions.cs
@@ -14,9 +14,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             writer.Flush();
         }
 
-        public static string ReadToEnd(this Stream stream)
+        public static byte[] ReadFully(this Stream stream)
         {
-            using var reader = new StreamReader(stream, leaveOpen: true);
+            using var memoryStream = new MemoryStream();
+            stream.CopyTo(memoryStream);
+            return memoryStream.ToArray();
+        }
+
+        public static string ReadToEnd(this Stream stream, bool leaveOpen = false)
+        {
+            using var reader = new StreamReader(stream, leaveOpen);
             return reader.ReadToEnd();
         }
 
@@ -33,6 +40,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return BitConverter.ToString(hash)
                 .Replace("-", string.Empty)
                 .ToLowerInvariant();
+        }
+
+        public static void SeekToBeginning(this Stream stream)
+        {
+            if (stream.CanSeek)
+            {
+                stream.Seek(offset: 0, origin: SeekOrigin.Begin);
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -33,6 +33,7 @@
         <PackageReference Include="Mime" Version="3.1.0" />
         <PackageReference Include="Mime-Detective" Version="0.0.6-beta5" />
         <PackageReference Include="Thinktecture.EntityFrameworkCore.BulkOperations" Version="4.1.0" />
+        <PackageReference Include="ZstdSharp.Port" Version="0.7.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ContentEncodings.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ContentEncodings.cs
@@ -1,0 +1,15 @@
+﻿#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public static class ContentEncodings
+{
+    /// <summary>
+    /// A stream of bytes compressed using the Gzip file format
+    /// </summary>
+    public const string Gzip = "gzip";
+
+    /// <summary>
+    /// A stream of bytes compressed using the Zstandard protocol
+    /// </summary>
+    public const string Zstd = "zstd";
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ContentTypes.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ContentTypes.cs
@@ -1,0 +1,7 @@
+﻿#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public static class ContentTypes
+{
+    public const string Csv = "text/csv";
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobCacheService.cs
@@ -1,8 +1,8 @@
 ﻿#nullable enable
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -34,7 +34,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             // Attempt to read blob from the storage container
             try
             {
-                var result = await _blobStorageService.GetDeserializedJson(cacheKey.Container, cacheKey.Key, targetType);
+                var result = await _blobStorageService.GetDeserializedJson(cacheKey.Container, cacheKey.Key, targetType)
+                    .OrElse(() => (object?) null);
 
                 _logger.LogDebug("Blob cache {HitOrMiss} - for key {CacheKey}",
                     result != null ? "hit" : "miss", key);
@@ -48,10 +49,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
                 _logger.LogWarning(e, $"Error deserializing JSON for blobContainer {blobContainer} and cache " +
                                       $"key {key} - deleting cached JSON");
                 await _blobStorageService.DeleteBlob(blobContainer, key);
-            }
-            catch (FileNotFoundException)
-            {
-                // Do nothing as the blob just doesn't exist
             }
             catch (Exception e)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Mime;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
@@ -106,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         public async Task<BlobInfo> GetBlob(IBlobContainer containerName, string path)
         {
             var blob = await GetBlobClient(containerName, path);
-            var properties = (await blob.GetPropertiesAsync()).Value;
+            BlobProperties properties = await blob.GetPropertiesAsync();
 
             return new BlobInfo(
                 path: blob.Name,
@@ -143,7 +142,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
             var blobContainer = await GetBlobContainer(containerName);
 
-            _logger.LogInformation($"Deleting blobs from {blobContainer.Name}/{directoryPath}");
+            _logger.LogInformation("Deleting blobs from {containerName}/{path}", blobContainer.Name, directoryPath);
 
             string? continuationToken = null;
 
@@ -168,11 +167,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
                         if (excluded || !included)
                         {
-                            _logger.LogInformation($"Ignoring blob {blobContainer.Name}/{blob.Name}");
+                            _logger.LogInformation("Ignoring blob {containerName}/{path}", blobContainer.Name, blob.Name);
                             continue;
                         }
 
-                        _logger.LogInformation($"Deleting blob {blobContainer.Name}/{blob.Name}");
+                        _logger.LogInformation("Deleting blob {containerName}/{path}", blobContainer.Name, blob.Name);
 
                         deleteTasks.Add(blobContainer.DeleteBlobIfExistsAsync(blob.Name));
                     }
@@ -188,7 +187,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         {
             var blob = await GetBlobClient(containerName, path);
 
-            _logger.LogInformation($"Deleting blob {containerName}/{path}");
+            _logger.LogInformation("Deleting blob {containerName}/{path}", containerName, path);
 
             await blob.DeleteIfExistsAsync();
         }
@@ -202,7 +201,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
             var tempFilePath = await UploadToTemporaryFile(file);
 
-            _logger.LogInformation($"Uploading file to blob {containerName}/{path}");
+            _logger.LogInformation("Uploading file to blob {containerName}/{path}", containerName, path);
 
             await blob.UploadAsync(
                 path: tempFilePath,
@@ -289,67 +288,106 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             string path,
             Stream stream,
             string contentType,
+            string? contentEncoding = null,
             CancellationToken cancellationToken = default)
         {
-            var blobContainer = await GetBlobContainer(containerName);
-            var blob = blobContainer.GetBlockBlobClient(path);
+            var blob = await GetBlobClient(containerName, path);
 
-            _logger.LogInformation($"Uploading {containerName}/{path}");
+            _logger.LogInformation("Uploading text to blob {containerName}/{path}", containerName, path);
 
-            if (stream.CanSeek)
+            var httpHeaders = new BlobHttpHeaders
             {
-                stream.Seek(0, SeekOrigin.Begin);
-            }
+                ContentEncoding = contentEncoding,
+                ContentType = contentType
+            };
 
-            await blob.UploadAsync(
-                content: stream,
-                httpHeaders: new BlobHttpHeaders
-                {
-                    ContentType = contentType,
-                },
-                cancellationToken: cancellationToken
-            );
+            var compress = contentEncoding != null;
+            if (compress)
+            {
+                await using var targetStream = new MemoryStream();
+                await CompressionUtils.CompressToStream(
+                    stream: stream,
+                    targetStream: targetStream,
+                    contentEncoding: contentEncoding!,
+                    cancellationToken: cancellationToken);
+                await blob.UploadAsync(
+                    content: targetStream,
+                    httpHeaders: httpHeaders,
+                    cancellationToken: cancellationToken
+                );
+            }
+            else
+            {
+                stream.SeekToBeginning();
+                await blob.UploadAsync(
+                    content: stream,
+                    httpHeaders: httpHeaders,
+                    cancellationToken: cancellationToken
+                );
+            }
         }
 
         public async Task UploadAsJson<T>(
             IBlobContainer containerName,
             string path,
             T content,
-            JsonSerializerSettings? settings)
+            string? contentEncoding = null,
+            JsonSerializerSettings? settings = null,
+            CancellationToken cancellationToken = default)
         {
-            var json = JsonConvert.SerializeObject(content, null, settings);
+            await using var stream = new MemoryStream();
+            await using var jsonWriter = new JsonTextWriter(new StreamWriter(stream, leaveOpen: true));
+            JsonSerializer.CreateDefault(settings).Serialize(jsonWriter, content, typeof(T));
+            await jsonWriter.FlushAsync(cancellationToken);
 
-            await UploadText(
+            await UploadStream(
                 containerName: containerName,
                 path: path,
-                content: json,
-                contentType: MediaTypeNames.Application.Json
-            );
+                stream: stream,
+                contentEncoding: contentEncoding,
+                contentType: MediaTypeNames.Application.Json,
+                cancellationToken: cancellationToken);
         }
 
         public async Task<Either<ActionResult, Stream>> DownloadToStream(
             IBlobContainer containerName,
             string path,
             Stream targetStream,
-            CancellationToken? cancellationToken = null)
+            bool decompress = true,
+            CancellationToken cancellationToken = default)
         {
-            var blobContainer = await GetBlobContainer(containerName);
-            var blob = blobContainer.GetBlobClient(path);
+            return await GetBlobClientOrNotFound(containerName, path)
+                .OnSuccess(async blob =>
+                {
+                    if (decompress)
+                    {
+                        BlobProperties blobProperties =
+                            await blob.GetPropertiesAsync(cancellationToken: cancellationToken);
 
-            if (!await blob.ExistsAsync())
-            {
-                _logger.LogWarning($"Could not find file at {containerName}/{path}");
-                return new NotFoundResult();
-            }
+                        // Check the ContentEncoding property to determine if the blob
+                        // is compressed and only decompress if necessary.
+                        if (blobProperties.ContentEncoding.IsNullOrEmpty())
+                        {
+                            await blob.DownloadToAsync(targetStream, cancellationToken);
+                        }
+                        else
+                        {
+                            var blobStream = await blob.OpenReadAsync(cancellationToken: cancellationToken);
+                            await CompressionUtils.DecompressToStream(
+                                stream: blobStream,
+                                targetStream: targetStream,
+                                contentEncoding: blobProperties.ContentEncoding,
+                                cancellationToken: cancellationToken);
+                        }
+                    }
+                    else
+                    {
+                        await blob.DownloadToAsync(targetStream, cancellationToken);
+                        targetStream.SeekToBeginning();
+                    }
 
-            await blob.DownloadToAsync(targetStream, cancellationToken ?? CancellationToken.None);
-
-            if (targetStream.CanSeek)
-            {
-                targetStream.Seek(0, SeekOrigin.Begin);
-            }
-
-            return targetStream;
+                    return targetStream;
+                });
         }
 
         public async Task<Stream> StreamBlob(
@@ -375,7 +413,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             }
         }
 
-        public async Task<string> DownloadBlobText(
+        public async Task<Either<ActionResult, string>> DownloadBlobText(
             IBlobContainer containerName,
             string path,
             CancellationToken cancellationToken = default)
@@ -384,47 +422,61 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
             try
             {
-                var response = await blob.DownloadContentAsync(cancellationToken);
-                return response.Value.Content.ToString();
-            }
-            catch (RequestFailedException exception)
-            {
-                if (exception.Status == 404)
+                BlobDownloadResult response = await blob.DownloadContentAsync(cancellationToken);
+
+                // Check the ContentEncoding property to determine if the blob
+                // is compressed and only decompress if necessary.
+                var contentEncoding = response.Details.ContentEncoding;
+                if (contentEncoding.IsNullOrEmpty())
                 {
-                    ThrowFileNotFoundException(containerName, path);
+                    return response.Content.ToString();
                 }
 
-                throw;
+                return await CompressionUtils.DecompressToString(
+                    bytes: response.Content.ToArray(),
+                    contentEncoding: contentEncoding,
+                    cancellationToken: cancellationToken);
+            }
+            catch (RequestFailedException exception)
+                when (exception.Status == 404)
+            {
+                return new NotFoundResult();
             }
         }
 
-        public async Task<object?> GetDeserializedJson(
+        public async Task<Either<ActionResult, object?>> GetDeserializedJson(
             IBlobContainer containerName,
             string path,
             Type type,
+            JsonSerializerSettings? settings = null,
             CancellationToken cancellationToken = default)
         {
-            var text = await DownloadBlobText(containerName, path, cancellationToken);
+            return await DownloadBlobText(containerName, path, cancellationToken)
+                .OnSuccess(text =>
+                {
+                    if (string.IsNullOrWhiteSpace(text))
+                    {
+                        throw new JsonException(
+                            $"Found empty file when trying to deserialize JSON for path: {path}");
+                    }
 
-            if (string.IsNullOrWhiteSpace(text))
-            {
-                throw new JsonException(
-                    $"Found empty file when trying to deserialize JSON for path: {path}");
-            }
-
-            return JsonConvert.DeserializeObject(
-                text,
-                type
-            );
+                    return JsonConvert.DeserializeObject(
+                        value: text,
+                        type,
+                        settings
+                    );
+                });
         }
 
-        public async Task<T?> GetDeserializedJson<T>(
+        public async Task<Either<ActionResult, T?>> GetDeserializedJson<T>(
             IBlobContainer containerName,
             string path,
+            JsonSerializerSettings? settings = null,
             CancellationToken cancellationToken = default)
             where T : class
         {
-            return (T?) await GetDeserializedJson(containerName, path, typeof(T), cancellationToken);
+            return (await GetDeserializedJson(containerName, path, typeof(T), settings, cancellationToken))
+                .OnSuccess(deserialized => deserialized as T);
         }
 
         public async Task<List<BlobInfo>> CopyDirectory(
@@ -435,7 +487,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             IBlobStorageService.CopyDirectoryOptions? options = null)
         {
             _logger.LogInformation(
-                "Copying directory from {0}/{1} to {2}/{3}",
+                "Copying directory from {sourceContainer}/{sourcePath} to {destinationContainer}/{destinationPath}",
                 sourceContainerName,
                 sourceDirectoryPath,
                 destinationContainerName,
@@ -502,28 +554,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             await DeleteBlobs(sourceContainerName, sourceDirectoryPath);
         }
 
-        private async Task UploadText(
-            IBlobContainer containerName,
-            string path,
-            string content,
-            string contentType)
-        {
-            var blobContainer = await GetBlobContainer(containerName);
-            var blob = blobContainer.GetBlockBlobClient(path);
-
-            _logger.LogInformation($"Uploading text to blob {containerName}/{path}");
-
-            await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
-
-            await blob.UploadAsync(
-                content: stream,
-                httpHeaders: new BlobHttpHeaders
-                {
-                    ContentType = contentType,
-                }
-            );
-        }
-
         private void FileTransferredCallback(
             object sender,
             TransferEventArgs e,
@@ -544,7 +574,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             );
 
             _logger.LogInformation(
-                "Transferred {0}/{1} -> {2}/{3}",
+                "Transferred {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}",
                 source.Container.Name,
                 source.Name,
                 destination.Container.Name,
@@ -558,7 +588,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var destination = (CloudBlockBlob) e.Destination;
 
             _logger.LogInformation(
-                "Failed to transfer {0}/{1} -> {2}/{3}. Error message: {4}",
+                "Failed to transfer {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}. Error message: {errorMessage}",
                 source.Container.Name,
                 source.Name,
                 destination.Container.Name,
@@ -573,7 +603,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var destination = (CloudBlockBlob) e.Destination;
 
             _logger.LogInformation(
-                "Skipped transfer {0}/{1} -> {2}/{3}",
+                "Skipped transfer {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}",
                 source.Container.Name,
                 source.Name,
                 destination.Container.Name,
@@ -585,6 +615,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         {
             var blobContainer = await GetBlobContainer(containerName);
             return blobContainer.GetBlobClient(path);
+        }
+
+        private async Task<Either<ActionResult, BlobClient>> GetBlobClientOrNotFound(IBlobContainer containerName,
+            string path)
+        {
+            var blobClient = await GetBlobClient(containerName, path);
+            if (await blobClient.ExistsAsync())
+            {
+                return blobClient;
+            }
+
+            _logger.LogWarning("Could not find blob {containerName}/{path}", containerName, path);
+            return new NotFoundResult();
         }
 
         /**
@@ -601,7 +644,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var blobClient = storageAccount.CreateCloudBlobClient();
 
             var containerName = IsDevelopmentStorageAccount(blobClient) ? container.EmulatedName : container.Name;
-            
+
             var containerClient = blobClient.GetContainerReference(containerName);
 
             await _storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
@@ -616,7 +659,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         private async Task<BlobContainerClient> GetBlobContainer(IBlobContainer container)
         {
             var containerName = IsDevelopmentStorageAccount(_client) ? container.EmulatedName : container.Name;
-            
+
             var containerClient = _client.GetBlobContainerClient(containerName);
 
             await _storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
@@ -48,13 +48,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
             string path,
             Stream stream,
             string contentType,
+            string? contentEncoding = null,
             CancellationToken cancellationToken = default);
 
         public Task UploadAsJson<T>(
             IBlobContainer containerName,
             string path,
             T content,
-            JsonSerializerSettings? settings = null);
+            string? contentEncoding = null,
+            JsonSerializerSettings? settings = null,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Download the entirety of a blob to a target stream.
@@ -62,13 +65,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
         /// <param name="containerName">name of the blob container</param>
         /// <param name="path">path to the blob within the container</param>
         /// <param name="stream">stream to output blob to</param>
+        /// <param name="decompress">if true, checks the content encoding and decompresses the blob if necessary</param>
         /// <param name="cancellationToken">used to cancel the download</param>
         /// <returns>the stream that the blob has been output to</returns>
         public Task<Either<ActionResult, Stream>> DownloadToStream(
             IBlobContainer containerName,
             string path,
             Stream stream,
-            CancellationToken? cancellationToken = null);
+            bool decompress = true,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Stream a blob in chunks.
@@ -91,20 +96,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
             int? bufferSize = null,
             CancellationToken cancellationToken = default);
 
-        public Task<string> DownloadBlobText(
+        public Task<Either<ActionResult, string>> DownloadBlobText(
             IBlobContainer containerName,
             string path,
             CancellationToken cancellationToken = default);
 
-        Task<object?> GetDeserializedJson(
+        Task<Either<ActionResult, object?>> GetDeserializedJson(
             IBlobContainer containerName,
             string path,
-            Type target,
+            Type type,
+            JsonSerializerSettings? settings = null,
             CancellationToken cancellationToken = default);
 
-        Task<T?> GetDeserializedJson<T>(
+        Task<Either<ActionResult, T?>> GetDeserializedJson<T>(
             IBlobContainer containerName,
             string path,
+            JsonSerializerSettings? settings = null,
             CancellationToken cancellationToken = default)
             where T : class;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/CompressionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/CompressionUtils.cs
@@ -1,0 +1,97 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using ZstdSharp;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public static class CompressionUtils
+{
+    public static async Task CompressToStream(
+        Stream stream,
+        Stream targetStream,
+        string contentEncoding,
+        CancellationToken cancellationToken = default)
+    {
+        stream.SeekToBeginning();
+
+        switch (contentEncoding)
+        {
+            case ContentEncodings.Gzip:
+            {
+                await using var compressor = new GZipStream(targetStream, CompressionMode.Compress, leaveOpen: true);
+                await stream.CopyToAsync(compressor, cancellationToken);
+                break;
+            }
+            case ContentEncodings.Zstd:
+            {
+                await using var compressor = new CompressionStream(targetStream, level: 11, leaveOpen: true);
+                await stream.CopyToAsync(compressor, cancellationToken);
+                break;
+            }
+            default:
+                throw new NotSupportedException($"Content encoding {contentEncoding} is not supported");
+        }
+
+        targetStream.SeekToBeginning();
+    }
+
+    public static async Task DecompressToStream(
+        Stream stream,
+        Stream targetStream,
+        string contentEncoding,
+        CancellationToken cancellationToken = default)
+    {
+        stream.SeekToBeginning();
+
+        switch (contentEncoding)
+        {
+            case ContentEncodings.Gzip:
+            {
+                await using var decompressor = new GZipStream(stream, CompressionMode.Decompress);
+                await decompressor.CopyToAsync(targetStream, cancellationToken);
+                break;
+            }
+            case ContentEncodings.Zstd:
+            {
+                await using var decompressor = new DecompressionStream(stream);
+                await decompressor.CopyToAsync(targetStream, cancellationToken);
+                break;
+            }
+            default:
+                throw new NotSupportedException($"Content encoding {contentEncoding} is not supported");
+        }
+
+        targetStream.SeekToBeginning();
+    }
+
+    public static async Task<string> DecompressToString(
+        byte[] bytes,
+        string contentEncoding,
+        CancellationToken cancellationToken = default)
+    {
+        switch (contentEncoding)
+        {
+            case ContentEncodings.Gzip:
+            {
+                await using var stream = new MemoryStream(bytes);
+                await using var targetStream = new MemoryStream();
+                await DecompressToStream(stream, targetStream, contentEncoding, cancellationToken);
+                return targetStream.ReadToEnd();
+            }
+            case ContentEncodings.Zstd:
+            {
+                using var decompressor = new Decompressor();
+                return Encoding.UTF8.GetString(decompressor.Unwrap(bytes));
+            }
+            default:
+                throw new NotSupportedException($"Content encoding {contentEncoding} is not supported");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerTests.cs
@@ -83,7 +83,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
                         It.IsAny<Stream>(),
                         It.Is<IEnumerable<Guid>>(
                             ids => ids.SequenceEqual(ListOf(fileId1, fileId2))),
-                        It.IsAny<CancellationToken?>()
+                        It.IsAny<CancellationToken>()
                     )
                 )
                 .ReturnsAsync(Unit.Instance)
@@ -114,7 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
                         _release.Id,
                         It.IsAny<Stream>(),
                         null,
-                        It.IsAny<CancellationToken?>()
+                        It.IsAny<CancellationToken>()
                     )
                 )
                 .ReturnsAsync(Unit.Instance)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/Interfaces/IReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/Interfaces/IReleaseFileBlobService.cs
@@ -27,18 +27,18 @@ public interface IReleaseFileBlobService
         int? bufferSize = null,
         CancellationToken cancellationToken = default);
 
-    Task<string> DownloadBlobText(
+    Task<Either<ActionResult, string>> DownloadBlobText(
         ReleaseFile releaseFile,
         CancellationToken cancellationToken = default);
 
     Task<Either<ActionResult, Stream>> DownloadToStream(
         ReleaseFile releaseFile,
         Stream stream,
-        CancellationToken? cancellationToken = null);
+        CancellationToken cancellationToken = default);
 
-    Task<object?> GetDeserializedJson(ReleaseFile releaseFile, Type target);
+    Task<Either<ActionResult, object?>> GetDeserializedJson(ReleaseFile releaseFile, Type type);
 
-    Task<T?> GetDeserializedJson<T>(ReleaseFile releaseFile) where T : class;
+    Task<Either<ActionResult, T?>> GetDeserializedJson<T>(ReleaseFile releaseFile) where T : class;
 
     Task UploadFile(
         ReleaseFile releaseFile,
@@ -53,5 +53,4 @@ public interface IReleaseFileBlobService
         ReleaseFile releaseFile,
         T content,
         JsonSerializerSettings? settings = null);
-
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PrivateReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PrivateReleaseFileBlobService.cs
@@ -64,7 +64,7 @@ public class PrivateReleaseFileBlobService : IReleaseFileBlobService
         );
     }
 
-    public Task<string> DownloadBlobText(
+    public Task<Either<ActionResult, string>> DownloadBlobText(
         ReleaseFile releaseFile,
         CancellationToken cancellationToken = default)
     {
@@ -78,7 +78,7 @@ public class PrivateReleaseFileBlobService : IReleaseFileBlobService
     public Task<Either<ActionResult, Stream>> DownloadToStream(
         ReleaseFile releaseFile,
         Stream stream,
-        CancellationToken? cancellationToken = null)
+        CancellationToken cancellationToken = default)
     {
         return _blobStorageService.DownloadToStream(
             containerName: PrivateReleaseFiles,
@@ -88,16 +88,16 @@ public class PrivateReleaseFileBlobService : IReleaseFileBlobService
         );
     }
 
-    public Task<object?> GetDeserializedJson(ReleaseFile releaseFile, Type target)
+    public Task<Either<ActionResult, object?>> GetDeserializedJson(ReleaseFile releaseFile, Type type)
     {
         return _blobStorageService.GetDeserializedJson(
             containerName: PrivateReleaseFiles,
             path: releaseFile.Path(),
-            target: target
+            type: type
         );
     }
 
-    public Task<T?> GetDeserializedJson<T>(ReleaseFile releaseFile) where T : class
+    public Task<Either<ActionResult, T?>> GetDeserializedJson<T>(ReleaseFile releaseFile) where T : class
     {
         return _blobStorageService.GetDeserializedJson<T>(PrivateReleaseFiles, releaseFile.Path());
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PublicReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PublicReleaseFileBlobService.cs
@@ -63,7 +63,7 @@ public class PublicReleaseFileBlobService : IReleaseFileBlobService
         );
     }
 
-    public Task<string> DownloadBlobText(
+    public Task<Either<ActionResult, string>> DownloadBlobText(
         ReleaseFile releaseFile,
         CancellationToken cancellationToken = default)
     {
@@ -77,7 +77,7 @@ public class PublicReleaseFileBlobService : IReleaseFileBlobService
     public Task<Either<ActionResult, Stream>> DownloadToStream(
         ReleaseFile releaseFile,
         Stream stream,
-        CancellationToken? cancellationToken = null)
+        CancellationToken cancellationToken = default)
     {
         return _blobStorageService.DownloadToStream(
             containerName: PublicReleaseFiles,
@@ -87,15 +87,15 @@ public class PublicReleaseFileBlobService : IReleaseFileBlobService
         );
     }
 
-    public Task<object?> GetDeserializedJson(ReleaseFile releaseFile, Type target)
+    public Task<Either<ActionResult, object?>> GetDeserializedJson(ReleaseFile releaseFile, Type type)
     {
         return _blobStorageService.GetDeserializedJson(
             containerName: PublicReleaseFiles,
             path: releaseFile.PublicPath(),
-            target: target);
+            type: type);
     }
 
-    public Task<T?> GetDeserializedJson<T>(ReleaseFile releaseFile) where T : class
+    public Task<Either<ActionResult, T?>> GetDeserializedJson<T>(ReleaseFile releaseFile) where T : class
     {
         return _blobStorageService.GetDeserializedJson<T>(PublicReleaseFiles, releaseFile.PublicPath());
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -4,9 +4,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Net.Mime;
 using System.Threading;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -18,7 +18,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
-using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
@@ -878,11 +877,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             // to prevent the next file from being fetched.
             blobStorageService
                 .SetupCheckBlobExists(PublicReleaseFiles, releaseFile1.PublicPath(), true);
+
             blobStorageService
                 .SetupDownloadToStream(
                     container: PublicReleaseFiles,
                     path: releaseFile1.PublicPath(),
-                    blobText: "Test ancillary blob",
+                    content: "Test ancillary blob",
                     cancellationToken: tokenSource.Token)
                 .Callback(() => tokenSource.Cancel());
 
@@ -983,7 +983,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                             PublicReleaseFiles,
                             allFilesZipPath,
                             It.IsAny<Stream>(),
-                            "application/zip",
+                            MediaTypeNames.Application.Zip,
+                            null,
                             It.IsAny<CancellationToken>()
                         )
                 )
@@ -1043,7 +1044,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 // Data guidance is generated if there is at least one data file
                 Assert.Equal("data-guidance/data-guidance.txt", zip.Entries[2].FullName);
                 Assert.Equal("Test data guidance blob", zip.Entries[2].Open().ReadToEnd());
-
             }
         }
 
@@ -1085,21 +1085,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 );
 
             blobStorageService
-                .Setup(
-                    s =>
-                        s.DownloadToStream(
-                            PublicReleaseFiles,
-                            allFilesZipPath,
-                            It.IsAny<FileStream>(),
-                            null
-                        )
-                )
-                .Returns<IBlobContainer, string, Stream, CancellationToken?>(
-                    (_, _, stream, _) => Task.FromResult(new Either<ActionResult, Stream>(stream))
-                )
-                .Callback<IBlobContainer, string, Stream, CancellationToken?>(
-                    (_, _, stream, _) => { stream.WriteText("Test cached all files zip"); }
-                );
+                .SetupDownloadToStream(PublicReleaseFiles, allFilesZipPath, "Test cached all files zip");
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
@@ -1188,7 +1174,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                             PublicReleaseFiles,
                             allFilesZipPath,
                             It.IsAny<Stream>(),
-                            "application/zip",
+                            MediaTypeNames.Application.Zip,
+                            null,
                             It.IsAny<CancellationToken>()
                         )
                 )

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseFileService.cs
@@ -25,6 +25,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces
             Guid releaseId,
             Stream outputStream,
             IEnumerable<Guid>? fileIds = null,
-            CancellationToken? cancellationToken = null);
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -81,7 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             Guid releaseId,
             Stream outputStream,
             IEnumerable<Guid>? fileIds = null,
-            CancellationToken? cancellationToken = null)
+            CancellationToken cancellationToken = default)
         {
             return await _persistenceHelper.CheckEntityExists<Release>(
                     releaseId,
@@ -118,7 +118,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
         private async Task<bool> TryStreamCachedAllFilesZip(
             Release release,
             Stream outputStream,
-            CancellationToken? cancellationToken = null)
+            CancellationToken cancellationToken)
         {
             var path = release.AllFilesZipPath();
             var allFilesZip = await _blobStorageService.FindBlob(PublicReleaseFiles, path);
@@ -148,7 +148,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
         private async Task ZipAllFilesToStream(
             Release release,
             Stream outputStream,
-            CancellationToken? cancellationToken = null)
+            CancellationToken cancellationToken)
         {
             var releaseFiles = (await QueryReleaseFiles(release.Id).ToListAsync())
                 .OrderBy(rf => rf.File.ZipFileEntryName())
@@ -181,14 +181,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             List<ReleaseFile> releaseFiles,
             Release release,
             Stream outputStream,
-            CancellationToken? cancellationToken)
+            CancellationToken cancellationToken)
         {
             using var archive = new ZipArchive(outputStream, ZipArchiveMode.Create);
 
             foreach (var releaseFile in releaseFiles)
             {
                 // Stop immediately if we receive a cancellation request
-                if (cancellationToken?.IsCancellationRequested == true)
+                if (cancellationToken.IsCancellationRequested)
                 {
                     return;
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PermalinkControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PermalinkControllerTests.cs
@@ -274,7 +274,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
             uri: $"/api/permalink/{permalinkId}",
             headers: new Dictionary<string, string>
             {
-                { HeaderNames.Accept, "text/csv" }
+                { HeaderNames.Accept, ContentTypes.Csv }
             }
         );
 
@@ -304,7 +304,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
             uri: $"/api/permalink-snapshot/{permalinkId}",
             headers: new Dictionary<string, string>
             {
-                { HeaderNames.Accept, "text/csv" }
+                { HeaderNames.Accept, ContentTypes.Csv }
             }
         );
 
@@ -333,7 +333,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
             uri: $"/api/permalink/{permalinkId}",
             headers: new Dictionary<string, string>
             {
-                { HeaderNames.Accept, "text/csv" }
+                { HeaderNames.Accept, ContentTypes.Csv }
             }
         );
 
@@ -361,7 +361,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
             uri: $"/api/permalink-snapshot/{permalinkId}",
             headers: new Dictionary<string, string>
             {
-                { HeaderNames.Accept, "text/csv" }
+                { HeaderNames.Accept, ContentTypes.Csv }
             }
         );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
@@ -173,7 +173,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                     content: new JsonNetContent(ObservationQueryContext),
                     headers: new Dictionary<string, string>
                     {
-                        { HeaderNames.Accept, "text/csv" }
+                        { HeaderNames.Accept, ContentTypes.Csv }
                     }
                 );
 
@@ -237,7 +237,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                     content: new JsonNetContent(ObservationQueryContext),
                     headers: new Dictionary<string, string>
                     {
-                        { HeaderNames.Accept, "text/csv" }
+                        { HeaderNames.Accept, ContentTypes.Csv }
                     }
                 );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PermalinkController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PermalinkController.cs
@@ -33,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
             if (Request.AcceptsCsv(exact: true))
             {
                 Response.ContentDispositionAttachment(
-                    contentType: "text/csv",
+                    contentType: ContentTypes.Csv,
                     filename: $"permalink-{permalinkId}.csv");
 
                 var csvResult = await _permalinkService.LegacyDownloadCsvToStream(
@@ -84,7 +84,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
             if (Request.AcceptsCsv(exact: true))
             {
                 Response.ContentDispositionAttachment(
-                    contentType: "text/csv",
+                    contentType: ContentTypes.Csv,
                     filename: $"permalink-{permalinkId}.csv");
 
                 var csvResult = await _permalinkService.DownloadCsvToStream(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
@@ -16,7 +16,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Data.Api.Cancellation.RequestTimeoutConfigurationKeys;
@@ -57,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
         {
             if (Request.AcceptsCsv(exact: true))
             {
-                Response.ContentDispositionAttachment("text/csv");
+                Response.ContentDispositionAttachment(ContentTypes.Csv);
 
                 await _tableBuilderService.QueryToCsvStream(query, Response.BodyWriter.AsStream(), cancellationToken);
 
@@ -82,7 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
             if (Request.AcceptsCsv(exact: true))
             {
                 Response.ContentDispositionAttachment(
-                    contentType: "text/csv",
+                    contentType: ContentTypes.Csv,
                     filename: $"{releaseId}.csv");
 
                 await _tableBuilderService.QueryToCsvStream(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataArchiveService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataArchiveService.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.IO.Compression;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
@@ -36,7 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     containerName: PrivateReleaseFiles,
                     path: import.File.Path(),
                     stream: stream,
-                    contentType: "text/csv");
+                    contentType: ContentTypes.Csv);
             }
 
             await using (var stream = metadataFile.Open())
@@ -45,7 +46,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     containerName: PrivateReleaseFiles,
                     path: import.MetaFile.Path(),
                     stream: stream,
-                    contentType: "text/csv");
+                    contentType: ContentTypes.Csv);
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
@@ -935,7 +935,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 result.AssertRight();
 
-                stream.Seek(0L, SeekOrigin.Begin);
+                stream.SeekToBeginning();
 
                 Snapshot.Match(stream.ReadToEnd());
             }
@@ -1251,7 +1251,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 result.AssertRight();
 
-                stream.Seek(0L, SeekOrigin.Begin);
+                stream.SeekToBeginning();
 
                 Snapshot.Match(stream.ReadToEnd());
             }
@@ -1373,7 +1373,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 result.AssertRight();
 
-                stream.Seek(0L, SeekOrigin.Begin);
+                stream.SeekToBeginning();
 
                 Snapshot.Match(stream.ReadToEnd());
             }


### PR DESCRIPTION
This PR adds support to `BlobStorageService` to compress and decompress blobs, providing two available algorithms, [Gzip](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.gzipstream?view=net-7.0) or [ZStandard](http://facebook.github.io/zstd/).

Currently this uses the ZstdSharp port of ZStandard to С# but it should be trivial to swap it out for one of the ZStandard C# alternatives.

Methods `BlobStorageService.UploadAsJson` and `BlobStorageService.UploadStream` now take an optional `contentEncoding` parameter. If this is specified (using one of the supported encodings, either `ContentEncodings.Gzip` or `ContentEncodings.Json`) then the content will be compressed on upload.

Methods `BlobStorageService.DownloadBlobText`, `BlobStorageService.DownloadToStream` and `BlobStorageService.GetDeserializedJson` are changed to be aware of compressed blobs. If a blob has property `ContentEncoding` equal to one of the supported encodings, it will be automatically be decompressed.

Method `BlobStorageService.DownloadToStream` is given a `decompress` flag which can be used to ignore compression if there's a reason to stream a blob untouched. In case a blob is known to never be compressed the same flag can be used to avoid the internal API call which occurs to get the blob properties. This extra call is required to find the content encoding.

This PR changes the new permalink snapshot feature to use ZStandard compression using this new feature.
It also alters the migration of all legacy permalinks to use ZStandard compression.

# Other changes
- `BlobStorageService` methods `DownloadBlobText`, `GetDeserializedJson` and `GetDeserializedJson<T>` are changed to return `NotFoundResult` when the blob is not found rather than throwing an exception.
- `BlobStorageService` methods `GetDeserializedJson`, `GetDeserializedJson<T>`, and `UploadAsJson` are changed to accept optional `JsonSerializerSettings`.
- Improve coverage of methods supporting `CancellationToken`.
- Replace occurrences of `CancellationToken? cancellationToken = null` with `CancellationToken cancellationToken = default` , since `CancellationToken` is a value type which can't be null.
