### PR TITLE
EES-3792 FE - Suffix value of PUBLIC_URL with '/' to match the value set in Azure environments

### DIFF
--- a/src/explore-education-statistics-frontend/.env
+++ b/src/explore-education-statistics-frontend/.env
@@ -2,4 +2,4 @@ CONTENT_API_BASE_URL=http://localhost:5010/api
 DATA_API_BASE_URL=http://localhost:5000/api
 NOTIFICATION_API_BASE_URL=http://localhost:7073/api
 GA_TRACKING_ID=
-PUBLIC_URL=http://localhost:3000
+PUBLIC_URL=http://localhost:3000/

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -270,8 +270,6 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
     newPermalinks,
   } = query as Dictionary<string>;
 
-  console.log('query', query, newPermalinks);
-
   const themeMeta = await publicationService.getPublicationTree({
     publicationFilter: 'DataTables',
   });

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
@@ -69,8 +69,8 @@ const TableToolShare = ({
     }
 
     const url = newPermalinks
-      ? `${process.env.PUBLIC_URL}/data-tables/permalink/${id}?newPermalinks=true`
-      : `${process.env.PUBLIC_URL}/data-tables/permalink/${id}`;
+      ? `${process.env.PUBLIC_URL}data-tables/permalink/${id}?newPermalinks=true`
+      : `${process.env.PUBLIC_URL}data-tables/permalink/${id}`;
 
     setPermalinkUrl(url);
     setPermalinkLoading(false);


### PR DESCRIPTION
This PR makes a frontend change to suffix the value of `PUBLIC_URL` with '/' to match the value set in Azure environments where the public url is suffixed.

This fixes a bug with the generated Permalink url seen below, highlighted by a failing UI test 

>Generated permalink "dev.explore-education-statistics.service.gov.uk//data-tables/permalink/21e47af1-1171-4ceb-b618-08db55cac306" is invalid! Should start with "dev.explore-education-statistics.service.gov.uk/data-tables/permalink/"

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/4147126/f7c84569-d718-4159-86bd-9cbc5027e2d9)

This code had been recently changed from `${window.location.origin}/data-tables/permalink...` to `${process.env.PUBLIC_URL}/data-tables/permalink...` in #4035.

### Other changes

- Remove console logging in `TableToolPage.tsx`.