### PR TITLE
EES-4245 Fix bug returning combined table results for deduplicated locations

### DIFF
--- a/src/explore-education-statistics-common/src/services/util/__tests__/combineMeasuresWithDuplicateLocationCodes.test.ts
+++ b/src/explore-education-statistics-common/src/services/util/__tests__/combineMeasuresWithDuplicateLocationCodes.test.ts
@@ -22,7 +22,7 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
       .join(' / ');
   };
 
-  test('does not affect results that do not contain locations with duplicate levels and codes', () => {
+  test('does not affect results that only contain locations without duplicate levels and codes', () => {
     const tableDataResult: TableDataResult[] = [
       {
         filters: ['filter-1', 'filter-2'],
@@ -143,7 +143,7 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
         },
         location: {
           provider: {
-            code: 'duplicate-provider-code',
+            code: 'duplicate-provider-code-1',
             name: 'Provider 1',
           },
         },
@@ -159,7 +159,7 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
         },
         location: {
           provider: {
-            code: 'duplicate-provider-code',
+            code: 'duplicate-provider-code-1',
             name: 'Provider 2',
           },
         },
@@ -180,12 +180,81 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
           },
         },
       },
+      {
+        filters: ['filter-1', 'filter-2'],
+        geographicLevel: 'provider',
+        timePeriod: '',
+        measures: {
+          'indicator-1': '100',
+          'indicator-2': '110',
+          'indicator-3': '120',
+        },
+        location: {
+          provider: {
+            code: 'duplicate-provider-code-2',
+            name: 'Provider 3',
+          },
+        },
+      },
+      {
+        filters: ['filter-1', 'filter-2'],
+        geographicLevel: 'provider',
+        timePeriod: '',
+        measures: {
+          'indicator-1': '130',
+          'indicator-2': '140',
+          'indicator-3': '150',
+        },
+        location: {
+          provider: {
+            code: 'duplicate-provider-code-2',
+            name: 'Provider 4',
+          },
+        },
+      },
+      {
+        filters: ['filter-1', 'filter-2'],
+        geographicLevel: 'provider',
+        timePeriod: '',
+        measures: {
+          'indicator-1': '160',
+          'indicator-2': '170',
+          'indicator-3': '180',
+        },
+        location: {
+          provider: {
+            code: 'provider-5',
+            name: 'Provider 5',
+          },
+        },
+      },
+      {
+        filters: ['filter-1', 'filter-2'],
+        geographicLevel: 'provider',
+        timePeriod: '',
+        measures: {
+          'indicator-1': '190',
+          'indicator-2': '200',
+          'indicator-3': '210',
+        },
+        location: {
+          provider: {
+            code: 'provider-6',
+            name: 'Provider 6',
+          },
+        },
+      },
     ];
 
     const deduplicatedLocations: LocationFilter[] = [
       new LocationFilter({
-        value: 'duplicate-provider-code',
+        value: 'duplicate-provider-code-1',
         label: 'Provider 1 / Provider 2',
+        level: 'provider',
+      }),
+      new LocationFilter({
+        value: 'duplicate-provider-code-2',
+        label: 'Provider 3 / Provider 4',
         level: 'provider',
       }),
     ];
@@ -212,14 +281,62 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
         geographicLevel: 'provider',
         timePeriod: '',
         measures: {
+          'indicator-1': '160',
+          'indicator-2': '170',
+          'indicator-3': '180',
+        },
+        location: {
+          provider: {
+            code: 'provider-5',
+            name: 'Provider 5',
+          },
+        },
+      },
+      {
+        filters: ['filter-1', 'filter-2'],
+        geographicLevel: 'provider',
+        timePeriod: '',
+        measures: {
+          'indicator-1': '190',
+          'indicator-2': '200',
+          'indicator-3': '210',
+        },
+        location: {
+          provider: {
+            code: 'provider-6',
+            name: 'Provider 6',
+          },
+        },
+      },
+      {
+        filters: ['filter-1', 'filter-2'],
+        geographicLevel: 'provider',
+        timePeriod: '',
+        measures: {
           'indicator-1': '10 / 40',
           'indicator-2': '20 / 50',
           'indicator-3': '30 / 60',
         },
         location: {
           provider: {
-            code: 'duplicate-provider-code',
+            code: 'duplicate-provider-code-1',
             name: 'Provider 1 / Provider 2',
+          },
+        },
+      },
+      {
+        filters: ['filter-1', 'filter-2'],
+        geographicLevel: 'provider',
+        timePeriod: '',
+        measures: {
+          'indicator-1': '100 / 130',
+          'indicator-2': '110 / 140',
+          'indicator-3': '120 / 150',
+        },
+        location: {
+          provider: {
+            code: 'duplicate-provider-code-2',
+            name: 'Provider 3 / Provider 4',
           },
         },
       },
@@ -340,7 +457,7 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
           },
           location: {
             provider: {
-              code: 'duplicate-provider-code',
+              code: 'duplicate-provider-code-1',
               name: 'Provider 1',
             },
           },
@@ -356,8 +473,104 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
           },
           location: {
             provider: {
-              code: 'duplicate-provider-code',
+              code: 'duplicate-provider-code-1',
               name: 'Provider 2',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-1',
+          measures: {
+            'indicator-1': '70',
+            'indicator-2': '80',
+            'indicator-3': '90',
+          },
+          location: {
+            provider: {
+              code: 'duplicate-provider-code-2',
+              name: 'Provider 3',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-2',
+          measures: {
+            'indicator-1': '100',
+            'indicator-2': '110',
+            'indicator-3': '120',
+          },
+          location: {
+            provider: {
+              code: 'duplicate-provider-code-2',
+              name: 'Provider 4',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-1',
+          measures: {
+            'indicator-1': '130',
+            'indicator-2': '140',
+            'indicator-3': '150',
+          },
+          location: {
+            provider: {
+              code: 'provider-5',
+              name: 'Provider 5',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-2',
+          measures: {
+            'indicator-1': '160',
+            'indicator-2': '170',
+            'indicator-3': '180',
+          },
+          location: {
+            provider: {
+              code: 'provider-5',
+              name: 'Provider 5',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-1',
+          measures: {
+            'indicator-1': '190',
+            'indicator-2': '200',
+            'indicator-3': '210',
+          },
+          location: {
+            provider: {
+              code: 'provider-6',
+              name: 'Provider 6',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-2',
+          measures: {
+            'indicator-1': '220',
+            'indicator-2': '230',
+            'indicator-3': '240',
+          },
+          location: {
+            provider: {
+              code: 'provider-6',
+              name: 'Provider 6',
             },
           },
         },
@@ -365,13 +578,82 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
 
       const deduplicatedLocations: LocationFilter[] = [
         new LocationFilter({
-          value: 'duplicate-provider-code',
+          value: 'duplicate-provider-code-1',
           label: 'Provider 1 / Provider 2',
+          level: 'provider',
+        }),
+        new LocationFilter({
+          value: 'duplicate-provider-code-2',
+          label: 'Provider 3 / Provider 4',
           level: 'provider',
         }),
       ];
 
       const expectedMergedResults = [
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-1',
+          measures: {
+            'indicator-1': '130',
+            'indicator-2': '140',
+            'indicator-3': '150',
+          },
+          location: {
+            provider: {
+              code: 'provider-5',
+              name: 'Provider 5',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-2',
+          measures: {
+            'indicator-1': '160',
+            'indicator-2': '170',
+            'indicator-3': '180',
+          },
+          location: {
+            provider: {
+              code: 'provider-5',
+              name: 'Provider 5',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-1',
+          measures: {
+            'indicator-1': '190',
+            'indicator-2': '200',
+            'indicator-3': '210',
+          },
+          location: {
+            provider: {
+              code: 'provider-6',
+              name: 'Provider 6',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-2',
+          measures: {
+            'indicator-1': '220',
+            'indicator-2': '230',
+            'indicator-3': '240',
+          },
+          location: {
+            provider: {
+              code: 'provider-6',
+              name: 'Provider 6',
+            },
+          },
+        },
         {
           filters: ['filter-1', 'filter-2'],
           geographicLevel: 'provider',
@@ -383,7 +665,7 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
           },
           location: {
             provider: {
-              code: 'duplicate-provider-code',
+              code: 'duplicate-provider-code-1',
               name: 'Provider 1 / Provider 2',
             },
           },
@@ -399,8 +681,40 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
           },
           location: {
             provider: {
-              code: 'duplicate-provider-code',
+              code: 'duplicate-provider-code-1',
               name: 'Provider 1 / Provider 2',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-1',
+          measures: {
+            'indicator-1': '70 / 0',
+            'indicator-2': '80 / 0',
+            'indicator-3': '90 / 0',
+          },
+          location: {
+            provider: {
+              code: 'duplicate-provider-code-2',
+              name: 'Provider 3 / Provider 4',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: 'time-period-2',
+          measures: {
+            'indicator-1': '0 / 100',
+            'indicator-2': '0 / 110',
+            'indicator-3': '0 / 120',
+          },
+          location: {
+            provider: {
+              code: 'duplicate-provider-code-2',
+              name: 'Provider 3 / Provider 4',
             },
           },
         },
@@ -423,7 +737,7 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
         {
           filters: ['filter-1', 'filter-2'],
           geographicLevel: 'provider',
-          timePeriod: 'time-period-1',
+          timePeriod: '',
           measures: {
             'indicator-1': '10',
             'indicator-2': '20',
@@ -431,7 +745,7 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
           },
           location: {
             provider: {
-              code: 'duplicate-provider-code',
+              code: 'duplicate-provider-code-1',
               name: 'Provider 1',
             },
           },
@@ -439,7 +753,7 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
         {
           filters: ['filter-2', 'filter-3'],
           geographicLevel: 'provider',
-          timePeriod: 'time-period-2',
+          timePeriod: '',
           measures: {
             'indicator-1': '40',
             'indicator-2': '50',
@@ -447,8 +761,104 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
           },
           location: {
             provider: {
-              code: 'duplicate-provider-code',
+              code: 'duplicate-provider-code-1',
               name: 'Provider 2',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '70',
+            'indicator-2': '80',
+            'indicator-3': '90',
+          },
+          location: {
+            provider: {
+              code: 'duplicate-provider-code-2',
+              name: 'Provider 3',
+            },
+          },
+        },
+        {
+          filters: ['filter-2', 'filter-3'],
+          geographicLevel: 'provider',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '100',
+            'indicator-2': '110',
+            'indicator-3': '120',
+          },
+          location: {
+            provider: {
+              code: 'duplicate-provider-code-2',
+              name: 'Provider 4',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '130',
+            'indicator-2': '140',
+            'indicator-3': '150',
+          },
+          location: {
+            provider: {
+              code: 'provider-5',
+              name: 'Provider 5',
+            },
+          },
+        },
+        {
+          filters: ['filter-2', 'filter-3'],
+          geographicLevel: 'provider',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '160',
+            'indicator-2': '170',
+            'indicator-3': '180',
+          },
+          location: {
+            provider: {
+              code: 'provider-5',
+              name: 'Provider 5',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '190',
+            'indicator-2': '200',
+            'indicator-3': '210',
+          },
+          location: {
+            provider: {
+              code: 'provider-6',
+              name: 'Provider 6',
+            },
+          },
+        },
+        {
+          filters: ['filter-2', 'filter-3'],
+          geographicLevel: 'provider',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '220',
+            'indicator-2': '230',
+            'indicator-3': '240',
+          },
+          location: {
+            provider: {
+              code: 'provider-6',
+              name: 'Provider 6',
             },
           },
         },
@@ -456,8 +866,13 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
 
       const deduplicatedLocations: LocationFilter[] = [
         new LocationFilter({
-          value: 'duplicate-provider-code',
+          value: 'duplicate-provider-code-1',
           label: 'Provider 1 / Provider 2',
+          level: 'provider',
+        }),
+        new LocationFilter({
+          value: 'duplicate-provider-code-2',
+          label: 'Provider 3 / Provider 4',
           level: 'provider',
         }),
       ];
@@ -466,7 +881,71 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
         {
           filters: ['filter-1', 'filter-2'],
           geographicLevel: 'provider',
-          timePeriod: 'time-period-1',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '130',
+            'indicator-2': '140',
+            'indicator-3': '150',
+          },
+          location: {
+            provider: {
+              code: 'provider-5',
+              name: 'Provider 5',
+            },
+          },
+        },
+        {
+          filters: ['filter-2', 'filter-3'],
+          geographicLevel: 'provider',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '160',
+            'indicator-2': '170',
+            'indicator-3': '180',
+          },
+          location: {
+            provider: {
+              code: 'provider-5',
+              name: 'Provider 5',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '190',
+            'indicator-2': '200',
+            'indicator-3': '210',
+          },
+          location: {
+            provider: {
+              code: 'provider-6',
+              name: 'Provider 6',
+            },
+          },
+        },
+        {
+          filters: ['filter-2', 'filter-3'],
+          geographicLevel: 'provider',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '220',
+            'indicator-2': '230',
+            'indicator-3': '240',
+          },
+          location: {
+            provider: {
+              code: 'provider-6',
+              name: 'Provider 6',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: '',
           measures: {
             'indicator-1': '10 / 0',
             'indicator-2': '20 / 0',
@@ -474,7 +953,7 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
           },
           location: {
             provider: {
-              code: 'duplicate-provider-code',
+              code: 'duplicate-provider-code-1',
               name: 'Provider 1 / Provider 2',
             },
           },
@@ -482,7 +961,7 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
         {
           filters: ['filter-2', 'filter-3'],
           geographicLevel: 'provider',
-          timePeriod: 'time-period-2',
+          timePeriod: '',
           measures: {
             'indicator-1': '0 / 40',
             'indicator-2': '0 / 50',
@@ -490,8 +969,40 @@ describe('combineMeasuresWithDuplicateLocationCodes', () => {
           },
           location: {
             provider: {
-              code: 'duplicate-provider-code',
+              code: 'duplicate-provider-code-1',
               name: 'Provider 1 / Provider 2',
+            },
+          },
+        },
+        {
+          filters: ['filter-1', 'filter-2'],
+          geographicLevel: 'provider',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '70 / 0',
+            'indicator-2': '80 / 0',
+            'indicator-3': '90 / 0',
+          },
+          location: {
+            provider: {
+              code: 'duplicate-provider-code-2',
+              name: 'Provider 3 / Provider 4',
+            },
+          },
+        },
+        {
+          filters: ['filter-2', 'filter-3'],
+          geographicLevel: 'provider',
+          timePeriod: '',
+          measures: {
+            'indicator-1': '0 / 100',
+            'indicator-2': '0 / 110',
+            'indicator-3': '0 / 120',
+          },
+          location: {
+            provider: {
+              code: 'duplicate-provider-code-2',
+              name: 'Provider 3 / Provider 4',
             },
           },
         },

--- a/src/explore-education-statistics-common/src/services/util/combineMeasuresWithDuplicateLocationCodes.ts
+++ b/src/explore-education-statistics-common/src/services/util/combineMeasuresWithDuplicateLocationCodes.ts
@@ -86,126 +86,122 @@ export default function combineMeasuresWithDuplicateLocationCodes(
       }),
   );
 
-  return Object.entries(resultsGroupedByLocationCodeAndLevel).flatMap(
-    ([key, resultsForLocation]) => {
-      const { level, code }: LocationGroupingKey = JSON.parse(key);
-      const resultsGroupedByLocationName = groupBy(
-        resultsForLocation,
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        r => r.location![level].name,
-      );
+  const deduplicatedResults = Object.entries(
+    resultsGroupedByLocationCodeAndLevel,
+  ).flatMap(([key, resultsForLocation]) => {
+    const { level, code }: LocationGroupingKey = JSON.parse(key);
+    const resultsGroupedByLocationName = groupBy(
+      resultsForLocation,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      r => r.location![level].name,
+    );
 
-      // If there is only a single unique Location name for this combination of Level and Code, no combining of result
-      // sets needs to be done.
-      if (Object.keys(resultsGroupedByLocationName).length === 1) {
-        return resultsForLocation;
-      }
+    // If there is only a single unique Location name for this combination of Level and Code, no combining of result
+    // sets needs to be done.
+    if (Object.keys(resultsGroupedByLocationName).length === 1) {
+      return resultsForLocation;
+    }
 
-      // Get the label for the combined Location row.
-      const combinedLocation = deduplicatedLocations.find(
-        l => l.level === level && l.value === code,
+    // Get the label for the combined Location row.
+    const combinedLocation = deduplicatedLocations.find(
+      l => l.level === level && l.value === code,
+    );
+    if (!combinedLocation) {
+      throw new Error(
+        `No available Location exists with level ${level} and code ${code}`,
       );
-      if (!combinedLocation) {
-        throw new Error(
-          `No available Location exists with level ${level} and code ${code}`,
+    }
+
+    const allAvailableTimePeriods = uniq(
+      resultsForLocation.flatMap(result => result.timePeriod),
+    );
+
+    // Generate a set of result rows that will cover every Time Period / Filter combination that is present in
+    // this set of data.  These combinations will be used to gather values from each Location name's data sets
+    // against every measurement that is captured in this data.  The values will be kept in order of their Location
+    // name so that the order of combined measurement values will match the order of the combined Location names in the
+    // table row label e.g. ("Provider 1 / Provider 2" - Achievements: "20 / 35"), where "20" is the "Achievements" value
+    // for Provider 1, and "35" is the "Achievements" value for Provider 2.
+    const timePeriodFilterCombinations: TableDataResult[] = allAvailableTimePeriods.flatMap(
+      timePeriod => {
+        const rowsForTimePeriod = resultsForLocation.filter(
+          r => r.timePeriod === timePeriod,
         );
-      }
-
-      const allAvailableTimePeriods = uniq(
-        resultsForLocation.flatMap(result => result.timePeriod),
-      );
-
-      // Generate a set of result rows that will cover every Time Period / Filter combination that is present in
-      // this set of data.  These combinations will be used to gather values from each Location name's data sets
-      // against every measurement that is captured in this data.  The values will be kept in order of their Location
-      // name so that the order of combined measurement values will match the order of the combined Location names in the
-      // table row label e.g. ("Provider 1 / Provider 2" - Achievements: "20 / 35"), where "20" is the "Achievements" value
-      // for Provider 1, and "35" is the "Achievements" value for Provider 2.
-      const timePeriodFilterCombinations: TableDataResult[] = allAvailableTimePeriods.flatMap(
-        timePeriod => {
-          const rowsForTimePeriod = resultsForLocation.filter(
-            r => r.timePeriod === timePeriod,
-          );
-          const allAvailableFilterCombinations = uniqWith(
-            rowsForTimePeriod.map(result => result.filters.sort()),
-            (filters, filtersOther) => isEqual(filters, filtersOther),
-          );
-          const allAvailableMeasures = uniq(
-            rowsForTimePeriod.flatMap(result => Object.keys(result.measures)),
-          );
-          return allAvailableFilterCombinations.flatMap(filters => {
-            return {
-              timePeriod,
-              filters,
-              geographicLevel: level,
-              location: {
-                [level]: {
-                  name: combinedLocation.label,
-                  code,
-                },
-              },
-              measures: allAvailableMeasures.reduce(
-                (acc, measure) => ({
-                  ...acc,
-                  [measure]: '',
-                }),
-                {},
-              ),
-            };
-          });
-        },
-      );
-
-      const allAvailableLocationNames = Object.keys(
-        resultsGroupedByLocationName,
-      ).sort();
-
-      // Now for each combination of Time Period and Filters, produce a single combined row of data that merges
-      // the duplicate rows from each Location into one, using a strategy to merge a set of data for each measurement
-      // into a single value.
-      const deduplicatedResults = timePeriodFilterCombinations.flatMap(
-        combination => {
-          // For each measure, collect the value for that measure from each Location's results for this Time Period and
-          // Filter combination, or undefined if a Location does not have a value that matches this criteria.
-          const measureValuesForEachLocation = Object.keys(
-            combination.measures,
-          ).reduce((acc, measure) => {
-            const measureValues = allAvailableLocationNames.map(
-              locationName => {
-                const resultForLocationName = resultsGroupedByLocationName[
-                  locationName
-                ].find(
-                  result =>
-                    result.timePeriod === combination.timePeriod &&
-                    isEqual(combination.filters, result.filters),
-                );
-                return resultForLocationName?.measures[measure];
-              },
-            );
-            return {
-              ...acc,
-              [measure]: measureValues,
-            };
-          }, {});
-
-          // Now for each measure, combine the values gathered from all of the Locations into a single value per measure.
-          const mergedMeasurements = mapValues(
-            measureValuesForEachLocation,
-            measurementsMergeStrategy,
-          );
-
-          // Return the Time Period / Filter combination, now with the merged measurement values from all of the
-          // Locations
+        const allAvailableFilterCombinations = uniqWith(
+          rowsForTimePeriod.map(result => result.filters.sort()),
+          (filters, filtersOther) => isEqual(filters, filtersOther),
+        );
+        const allAvailableMeasures = uniq(
+          rowsForTimePeriod.flatMap(result => Object.keys(result.measures)),
+        );
+        return allAvailableFilterCombinations.flatMap(filters => {
           return {
-            ...combination,
-            measures: mergedMeasurements,
+            timePeriod,
+            filters,
+            geographicLevel: level,
+            location: {
+              [level]: {
+                name: combinedLocation.label,
+                code,
+              },
+            },
+            measures: allAvailableMeasures.reduce(
+              (acc, measure) => ({
+                ...acc,
+                [measure]: '',
+              }),
+              {},
+            ),
           };
-        },
+        });
+      },
+    );
+
+    const allAvailableLocationNames = Object.keys(
+      resultsGroupedByLocationName,
+    ).sort();
+
+    // Now for each combination of Time Period and Filters, produce a single combined row of data that merges
+    // the duplicate rows from each Location into one, using a strategy to merge a set of data for each measurement
+    // into a single value.
+    return timePeriodFilterCombinations.flatMap(combination => {
+      // For each measure, collect the value for that measure from each Location's results for this Time Period and
+      // Filter combination, or undefined if a Location does not have a value that matches this criteria.
+      const measureValuesForEachLocation = Object.keys(
+        combination.measures,
+      ).reduce((acc, measure) => {
+        const measureValues = allAvailableLocationNames.map(locationName => {
+          const resultForLocationName = resultsGroupedByLocationName[
+            locationName
+          ].find(
+            result =>
+              result.timePeriod === combination.timePeriod &&
+              isEqual(combination.filters, result.filters),
+          );
+          return resultForLocationName?.measures[measure];
+        });
+        return {
+          ...acc,
+          [measure]: measureValues,
+        };
+      }, {});
+
+      // Now for each measure, combine the values gathered from all of the Locations into a single value per measure.
+      const mergedMeasurements = mapValues(
+        measureValuesForEachLocation,
+        measurementsMergeStrategy,
       );
 
-      return [...unaffectedResults, ...deduplicatedResults];
-    },
-  );
+      // Return the Time Period / Filter combination, now with the merged measurement values from all of the
+      // Locations
+      return {
+        ...combination,
+        measures: mergedMeasurements,
+      };
+    });
+  });
+
+  return [...unaffectedResults, ...deduplicatedResults];
 }
 
 /**

--- a/src/explore-education-statistics-common/src/services/util/combineMeasuresWithDuplicateLocationCodes.ts
+++ b/src/explore-education-statistics-common/src/services/util/combineMeasuresWithDuplicateLocationCodes.ts
@@ -128,7 +128,7 @@ export default function combineMeasuresWithDuplicateLocationCodes(
           );
           const allAvailableFilterCombinations = uniqWith(
             rowsForTimePeriod.map(result => result.filters.sort()),
-            (a1, a2) => isEqual(a1, a2),
+            (filters, filtersOther) => isEqual(filters, filtersOther),
           );
           const allAvailableMeasures = uniq(
             rowsForTimePeriod.flatMap(result => Object.keys(result.measures)),
@@ -151,7 +151,7 @@ export default function combineMeasuresWithDuplicateLocationCodes(
                 }),
                 {},
               ),
-            } as TableDataResult;
+            };
           });
         },
       );


### PR DESCRIPTION
This PR fixes a frontend bug returning combined table results for locations that have been deduplicated.

After deduplicating the locations and then merging table results of the affected locations we should always expect less table rows in the returned result, but in the case of 6 permalinks found which contain multiple duplicate provider codes (codes for which one or more different provider names exist) we can see the number of table results after deduplication far exceeds the original number of results.

The bug occurs while processing the table results that are affected by every deduplicated location.
For each deduplicated location, instead of returning the deduplicated table results, the function was returning the deduplicated table results combined with the array of unaffected results.

The unaffected results only need to be combined when all the deduplicated table results are worked out for all locations.

This bug meant the returned number of table results was inflated above what it should be by (_number of deduplicated locations -1 * number of unaffected table results_).

In the case of only one deduplicated location, this made no difference to the result, and is why it wasn't caught by the current unit test.

It can be seen by adapting one of the unit tests for the `combineMeasuresWithDuplicateLocationCodes` function.

Let's set up this set of table results with two duplicate location codes `duplicate-provider-code-1` used by `Provider 1` and `Provider 2`, and `duplicate-provider-code-2` used by `Provider 3` and `Provider 4`:

```
[
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "10",
      "indicator-2": "20",
      "indicator-3": "30"
    },
    "location": {
      "provider": { "code": "duplicate-provider-code-1", "name": "Provider 1" }
    }
  },
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "40",
      "indicator-2": "50",
      "indicator-3": "60"
    },
    "location": {
      "provider": { "code": "duplicate-provider-code-1", "name": "Provider 2" }
    }
  },
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "100",
      "indicator-2": "110",
      "indicator-3": "120"
    },
    "location": {
      "provider": { "code": "duplicate-provider-code-2", "name": "Provider 3" }
    }
  },
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "130",
      "indicator-2": "140",
      "indicator-3": "150"
    },
    "location": {
      "provider": { "code": "duplicate-provider-code-2", "name": "Provider 4" }
    }
  },
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "160",
      "indicator-2": "170",
      "indicator-3": "180"
    },
    "location": { "provider": { "code": "provider-5", "name": "Provider 5" } }
  },
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "190",
      "indicator-2": "200",
      "indicator-3": "210"
    },
    "location": { "provider": { "code": "provider-6", "name": "Provider 6" } }
  }
]

```
Now let's pass it to the function along with this reference data for the deduplicated locations:

```
[
  new LocationFilter({
    value: 'duplicate-provider-code-1',
    label: 'Provider 1 / Provider 2',
    level: 'provider',
  }),
  new LocationFilter({
    value: 'duplicate-provider-code-2',
    label: 'Provider 3 / Provider 4',
    level: 'provider',
  })
]
```

We should expect the 2 table results for `Provider 1` and `Provider 2` to be combined, and the 2 results for `Provider 3 and Provider 4` to be combined, leaving 2 unaffected results. In total 6 results in the input should become 4 in the result.

❎ **Result without fix**  2 combined results as expected but the 2 unaffected results are included twice giving 6 results in total:

```
[
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "160",
      "indicator-2": "170",
      "indicator-3": "180"
    },
    "location": { "provider": { "code": "provider-5", "name": "Provider 5" } }
  },
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "190",
      "indicator-2": "200",
      "indicator-3": "210"
    },
    "location": { "provider": { "code": "provider-6", "name": "Provider 6" } }
  },
  {
    "timePeriod": "",
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "location": {
      "provider": {
        "name": "Provider 1 / Provider 2",
        "code": "duplicate-provider-code-1"
      }
    },
    "measures": {
      "indicator-1": "10 / 40",
      "indicator-2": "20 / 50",
      "indicator-3": "30 / 60"
    }
  },
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "160",
      "indicator-2": "170",
      "indicator-3": "180"
    },
    "location": { "provider": { "code": "provider-5", "name": "Provider 5" } }
  },
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "190",
      "indicator-2": "200",
      "indicator-3": "210"
    },
    "location": { "provider": { "code": "provider-6", "name": "Provider 6" } }
  },
  {
    "timePeriod": "",
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "location": {
      "provider": {
        "name": "Provider 3 / Provider 4",
        "code": "duplicate-provider-code-2"
      }
    },
    "measures": {
      "indicator-1": "100 / 130",
      "indicator-2": "110 / 140",
      "indicator-3": "120 / 150"
    }
  }
]
```

✅ **Result with fix** 4 results as expected consisting of 2 combined results and 2 unaffected results :

```
[
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "160",
      "indicator-2": "170",
      "indicator-3": "180"
    },
    "location": { "provider": { "code": "provider-5", "name": "Provider 5" } }
  },
  {
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "timePeriod": "",
    "measures": {
      "indicator-1": "190",
      "indicator-2": "200",
      "indicator-3": "210"
    },
    "location": { "provider": { "code": "provider-6", "name": "Provider 6" } }
  },
  {
    "timePeriod": "",
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "location": {
      "provider": {
        "name": "Provider 1 / Provider 2",
        "code": "duplicate-provider-code-1"
      }
    },
    "measures": {
      "indicator-1": "10 / 40",
      "indicator-2": "20 / 50",
      "indicator-3": "30 / 60"
    }
  },
  {
    "timePeriod": "",
    "filters": ["filter-1", "filter-2"],
    "geographicLevel": "provider",
    "location": {
      "provider": {
        "name": "Provider 3 / Provider 4",
        "code": "duplicate-provider-code-2"
      }
    },
    "measures": {
      "indicator-1": "100 / 130",
      "indicator-2": "110 / 140",
      "indicator-3": "120 / 150"
    }
  }
]
```

Here's the impact seen on the 6 permalinks contain duplicate provider locations:

<html>
<head>
</head>
<body>


Permalink ending | Deduplicated locations | Table results | Unaffected results | Affected results | Table results after deduplicating (without fix) | Table results difference (without fix) | Table results after deduplicating (with fix) | Table results difference (with fix)
-- | -- | -- | -- | -- | -- | -- | -- | --
b95cfa030cfc | 96 | 8355 | 7873 | 482 | 756290 | +747935 | 8355 | 0
6d48c01570d3 | 79 | 5924 | 5485 | 439 | 433754 | +427830 | 5924 | 0
348dcf837ab4 | 119 | 7754 | 7167 | 587 | 853460 |+845706 | 7754 | 0
8df77639ef5c | 102 | 5837 | 5328 | 509 | 543965 | +538128 | 5837 | 0
d320cb9e2a41 | 119 | 7754 | 7167 | 587 | 853460 | +845706 | 7754 | 0
d10e2242013f | 96 | 8355 | 7873 | 482 | 756290 | +747935 | 8355 | 0


</body>

</html>

The reason why we see 0's for the difference in the number of table results after deduplicating (with the fix!) is because of the nature of the observation data in the Permalinks. Where there are duplicate locations in the results, those results have none-overlapping time periods. Each of those results now gets the deduplicated location label but the overall number of results remains the same. This is just one of the types of scenarios that the deduplicating code handles.

This and the other scenarios are  covered by unit tests which are adjusted by this PR to add data that would cause failures without this fix.
