### PR TITLE
EES-4246, EES-3408 Fix filter groups with duplicate labels not being inserted into optimised filters

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/Header.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/Header.ts
@@ -41,12 +41,9 @@ export default class Header {
     while (child) {
       if (child.text === this.text && child.span === this.span) {
         crossSpan += 1;
-      }
-
-      if (child.children.length === 1) {
         child = child.getFirstChild();
       } else {
-        child = undefined;
+        break;
       }
     }
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableData.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableData.ts
@@ -7,44 +7,68 @@ import {
 import { FullTable } from '../../types/fullTable';
 import { TableHeadersConfig } from '../../types/tableHeaders';
 
-const category1Filter1 = new CategoryFilter({
+const category1GroupTotalFilter1 = new CategoryFilter({
   value: 'category-1-filter-1',
   label: 'Total',
   group: 'Total',
   isTotal: true,
-  category: 'Category1',
+  category: 'Category 1',
 });
 
-const category1Filter2 = new CategoryFilter({
+const category1Group1Filter2 = new CategoryFilter({
   value: 'category-1-filter-2',
   label: 'Category 1 Filter 2',
   group: 'Group 1',
   isTotal: false,
-  category: 'Category1',
+  category: 'Category 1',
 });
 
-const category1Filter3 = new CategoryFilter({
+const category1Group1Filter3 = new CategoryFilter({
   value: 'category-1-filter-3',
   label: 'Category 1 Filter 3',
   group: 'Group 1',
   isTotal: false,
-  category: 'Category1',
+  category: 'Category 1',
 });
 
-const category2Filter1 = new CategoryFilter({
+const category1Group2Filter4 = new CategoryFilter({
+  value: 'category-1-filter-4',
+  label: 'Category 1 Filter 4',
+  group: 'Group 2',
+  isTotal: false,
+  category: 'Category 1',
+});
+
+const category2GroupDefaultFilter1 = new CategoryFilter({
   value: 'category-2-filter-1',
   label: 'Category 2 Filter 1',
   group: 'Default',
   isTotal: false,
-  category: 'Category2',
+  category: 'Category 2',
 });
 
-const category2Filter2 = new CategoryFilter({
+const category2GroupDefaultFilter2 = new CategoryFilter({
   value: 'category-2-filter-2',
   label: 'Category 2 Filter 2',
   group: 'Default',
   isTotal: false,
-  category: 'Category2',
+  category: 'Category 2',
+});
+
+const category3Group1Filter1 = new CategoryFilter({
+  value: 'category-3-filter-1',
+  label: 'Category 3 Filter 1',
+  group: 'Group 1',
+  isTotal: false,
+  category: 'Category 3',
+});
+
+const category3Group2Filter2 = new CategoryFilter({
+  value: 'category-3-filter-2',
+  label: 'Category 3 Filter 2',
+  group: 'Group 2',
+  isTotal: false,
+  category: 'Category 3',
 });
 
 const indicator1 = new Indicator({
@@ -128,12 +152,12 @@ const testSubjectMeta1: FullTable['subjectMeta'] = {
   filters: {
     Category1: {
       name: 'category_1',
-      options: [category1Filter1],
+      options: [category1GroupTotalFilter1],
       order: 0,
     },
     Category2: {
       name: 'category_1',
-      options: [category2Filter1, category2Filter2],
+      options: [category2GroupDefaultFilter1, category2GroupDefaultFilter2],
       order: 1,
     },
   },
@@ -146,7 +170,7 @@ export const testTableWithOneLevelOfRowAndColHeaders: FullTable = {
   subjectMeta: testSubjectMeta1,
   results: [
     {
-      filters: [category2Filter1.id, category1Filter1.id],
+      filters: [category2GroupDefaultFilter1.id, category1GroupTotalFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -155,7 +179,7 @@ export const testTableWithOneLevelOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter1.id],
+      filters: [category2GroupDefaultFilter1.id, category1GroupTotalFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -188,7 +212,7 @@ export const testTableWithTwoLevelsOfRowAndOneLevelOfColHeadersConfig: TableHead
   rowGroups: [[indicator1]],
 };
 
-export const testTableWithOneLevelOfRowsAndTwoLevelsofColHeadersConfig: TableHeadersConfig = {
+export const testTableWithOneLevelOfRowsAndTwoLevelsOfColHeadersConfig: TableHeadersConfig = {
   columns: [location1, location2],
   columnGroups: [[timePeriod1]],
   rows: [indicator1],
@@ -199,7 +223,7 @@ export const testTableWithTwoLevelsOfRowAndColHeaders: FullTable = {
   subjectMeta: testSubjectMeta1,
   results: [
     {
-      filters: [category2Filter1.id, category1Filter1.id],
+      filters: [category2GroupDefaultFilter1.id, category1GroupTotalFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -209,7 +233,7 @@ export const testTableWithTwoLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter2.id, category1Filter1.id],
+      filters: [category2GroupDefaultFilter2.id, category1GroupTotalFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -219,7 +243,7 @@ export const testTableWithTwoLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category2Filter2.id, category1Filter1.id],
+      filters: [category2GroupDefaultFilter2.id, category1GroupTotalFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -229,7 +253,7 @@ export const testTableWithTwoLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter1.id],
+      filters: [category2GroupDefaultFilter1.id, category1GroupTotalFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -239,7 +263,7 @@ export const testTableWithTwoLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category2Filter2.id, category1Filter1.id],
+      filters: [category2GroupDefaultFilter2.id, category1GroupTotalFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -249,7 +273,7 @@ export const testTableWithTwoLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter2.id, category1Filter1.id],
+      filters: [category2GroupDefaultFilter2.id, category1GroupTotalFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -259,7 +283,7 @@ export const testTableWithTwoLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter1.id],
+      filters: [category2GroupDefaultFilter1.id, category1GroupTotalFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -269,7 +293,7 @@ export const testTableWithTwoLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter1.id],
+      filters: [category2GroupDefaultFilter1.id, category1GroupTotalFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -283,7 +307,7 @@ export const testTableWithTwoLevelsOfRowAndColHeaders: FullTable = {
 
 export const testTableWithTwoLevelsOfRowAndColHeadersConfig: TableHeadersConfig = {
   columnGroups: [[location1, location2]],
-  rowGroups: [[category2Filter1, category2Filter2]],
+  rowGroups: [[category2GroupDefaultFilter1, category2GroupDefaultFilter2]],
   columns: [timePeriod1, timePeriod2],
   rows: [indicator1, indicator2],
 };
@@ -294,12 +318,12 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
     filters: {
       Category1: {
         name: 'category_1',
-        options: [category1Filter2, category1Filter3],
+        options: [category1Group1Filter2, category1Group1Filter3],
         order: 0,
       },
       Category2: {
         name: 'category_2',
-        options: [category2Filter1, category2Filter2],
+        options: [category2GroupDefaultFilter1, category2GroupDefaultFilter2],
         order: 1,
       },
     },
@@ -309,7 +333,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
   },
   results: [
     {
-      filters: [category2Filter2.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter2.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -319,7 +343,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter1.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location3.value,
       measures: {
@@ -329,7 +353,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter1.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -339,7 +363,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter2.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter2.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -349,7 +373,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter2.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter2.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -359,7 +383,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter2.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter2.id],
       geographicLevel: 'localAuthority',
       locationId: location4.value,
       measures: {
@@ -369,7 +393,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter2.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter2.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location4.value,
       measures: {
@@ -379,7 +403,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter2.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter2.id],
       geographicLevel: 'localAuthority',
       locationId: location3.value,
       measures: {
@@ -389,7 +413,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter2.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter2.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -399,7 +423,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter1.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location3.value,
       measures: {
@@ -409,7 +433,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter1.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -419,7 +443,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter2.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter2.id],
       geographicLevel: 'localAuthority',
       locationId: location3.value,
       measures: {
@@ -429,7 +453,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter1.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -439,7 +463,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter1.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -449,7 +473,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter2.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter2.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -459,7 +483,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter1.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location3.value,
       measures: {
@@ -469,7 +493,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter1.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location4.value,
       measures: {
@@ -479,7 +503,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter1.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -489,7 +513,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter2.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter2.id],
       geographicLevel: 'localAuthority',
       locationId: location4.value,
       measures: {
@@ -499,7 +523,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter2.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter2.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -509,7 +533,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter2.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter2.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location4.value,
       measures: {
@@ -519,7 +543,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter1.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location4.value,
       measures: {
@@ -529,7 +553,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter2.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter2.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -539,7 +563,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter1.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -549,7 +573,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter2.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter2.id],
       geographicLevel: 'localAuthority',
       locationId: location1.value,
       measures: {
@@ -559,7 +583,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter1.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location4.value,
       measures: {
@@ -569,7 +593,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter1.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location3.value,
       measures: {
@@ -579,7 +603,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category2Filter1.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter1.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -589,7 +613,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter1.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location4.value,
       measures: {
@@ -599,7 +623,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category2Filter2.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter2.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location3.value,
       measures: {
@@ -609,7 +633,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod2.id,
     },
     {
-      filters: [category2Filter2.id, category1Filter2.id],
+      filters: [category2GroupDefaultFilter2.id, category1Group1Filter2.id],
       geographicLevel: 'localAuthority',
       locationId: location3.value,
       measures: {
@@ -619,7 +643,7 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
       timePeriod: timePeriod1.id,
     },
     {
-      filters: [category1Filter3.id, category2Filter1.id],
+      filters: [category1Group1Filter3.id, category2GroupDefaultFilter1.id],
       geographicLevel: 'localAuthority',
       locationId: location2.value,
       measures: {
@@ -634,9 +658,114 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
 export const testTableWithThreeLevelsOfRowAndColHeadersConfig: TableHeadersConfig = {
   columns: [timePeriod1, timePeriod2],
   columnGroups: [
-    [category2Filter1, category2Filter2],
-    [category1Filter2, category1Filter3],
+    [category2GroupDefaultFilter1, category2GroupDefaultFilter2],
+    [category1Group1Filter2, category1Group1Filter3],
   ],
   rows: [indicator1, indicator2],
   rowGroups: [[location1, location2, location3, location4]],
+};
+
+export const testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabels: FullTable = {
+  subjectMeta: {
+    ...initialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [category1Group1Filter2, category1Group2Filter4],
+        order: 0,
+      },
+      Category3: {
+        name: 'category_3',
+        options: [category3Group1Filter1, category3Group2Filter2],
+        order: 1,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1, timePeriod2],
+  },
+  results: [
+    {
+      filters: [category1Group1Filter2.id, category3Group1Filter1.id],
+      geographicLevel: 'localAuthority',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '20',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group1Filter2.id, category3Group1Filter1.id],
+      geographicLevel: 'localAuthority',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '7163',
+      },
+      timePeriod: timePeriod2.id,
+    },
+    {
+      filters: [category1Group1Filter2.id, category3Group2Filter2.id],
+      geographicLevel: 'localAuthority',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '44',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group1Filter2.id, category3Group2Filter2.id],
+      geographicLevel: 'localAuthority',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '32',
+      },
+      timePeriod: timePeriod2.id,
+    },
+    {
+      filters: [category1Group2Filter4.id, category3Group1Filter1.id],
+      geographicLevel: 'localAuthority',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '767',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter4.id, category3Group1Filter1.id],
+      geographicLevel: 'localAuthority',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '19340',
+      },
+      timePeriod: timePeriod2.id,
+    },
+    {
+      filters: [category1Group2Filter4.id, category3Group2Filter2.id],
+      geographicLevel: 'localAuthority',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '331',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter4.id, category3Group2Filter2.id],
+      geographicLevel: 'localAuthority',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '2458',
+      },
+      timePeriod: timePeriod2.id,
+    },
+  ],
+};
+
+export const testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabelsConfig: TableHeadersConfig = {
+  columnGroups: [
+    [category3Group1Filter1, category3Group2Filter2],
+    [category1Group1Filter2, category1Group2Filter4],
+  ],
+  columns: [timePeriod1, timePeriod2],
+  rowGroups: [[location1]],
+  rows: [indicator1],
 };

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/Header.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/Header.test.ts
@@ -80,6 +80,22 @@ describe('Header', () => {
 
       expect(header.crossSpan).toBe(1);
     });
+
+    test('returns 1 if non-identical child and identical grandchild', () => {
+      const header = new Header('1', '1').addChild(
+        new Header('2', '2').addChild(new Header('1', '1')),
+      );
+
+      expect(header.crossSpan).toBe(1);
+    });
+
+    test('returns 2 if identical child and non-identical grandchild', () => {
+      const header = new Header('1', '1').addChild(
+        new Header('1', '1').addChild(new Header('2', '2')),
+      );
+
+      expect(header.crossSpan).toBe(2);
+    });
   });
 
   describe('addChild', () => {

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableToJson.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableToJson.test.ts
@@ -6,8 +6,10 @@ import {
   testTableWithOneLevelOfRowAndColHeaders,
   testTableWithOneLevelOfRowAndColHeadersConfig,
   testTableWithTwoLevelsOfRowAndOneLevelOfColHeadersConfig,
-  testTableWithOneLevelOfRowsAndTwoLevelsofColHeadersConfig,
+  testTableWithOneLevelOfRowsAndTwoLevelsOfColHeadersConfig,
   testTableWithMissingTimePeriod,
+  testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabelsConfig,
+  testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabels,
 } from '@common/modules/table-tool/utils/__data__/testTableData';
 import mapTableToJson, {
   TableCellJson,
@@ -120,7 +122,7 @@ describe('mapTableToJson', () => {
 
   test('returns the correct JSON for  a table with two levels of col headers and one level of row headers', () => {
     const result = mapTableToJson({
-      tableHeadersConfig: testTableWithOneLevelOfRowsAndTwoLevelsofColHeadersConfig,
+      tableHeadersConfig: testTableWithOneLevelOfRowsAndTwoLevelsOfColHeadersConfig,
       subjectMeta: testTableWithOneLevelOfRowAndColHeaders.subjectMeta,
       results: testTableWithOneLevelOfRowAndColHeaders.results,
     }).tableJson;
@@ -513,6 +515,136 @@ describe('mapTableToJson', () => {
     ]);
   });
 
+  test('correctly adds groups across three levels of column headers with same labels', () => {
+    const result = mapTableToJson({
+      tableHeadersConfig: testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabelsConfig,
+      subjectMeta:
+        testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabels.subjectMeta,
+      results:
+        testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabels.results,
+    }).tableJson;
+
+    expect(result.thead).toEqual<TableCellJson[][]>([
+      [
+        { colSpan: 1, rowSpan: 5, tag: 'td' },
+        {
+          colSpan: 4,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Group 1',
+        },
+        {
+          colSpan: 4,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Group 2',
+        },
+      ],
+      [
+        {
+          colSpan: 4,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Category 3 Filter 1',
+        },
+        {
+          colSpan: 4,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Category 3 Filter 2',
+        },
+      ],
+      [
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Group 1',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Group 2',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Group 1',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Group 2',
+        },
+      ],
+      [
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Category 1 Filter 2',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Category 1 Filter 4',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Category 1 Filter 2',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'Category 1 Filter 4',
+        },
+      ],
+      [
+        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2012/13' },
+        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2013/14' },
+        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2012/13' },
+        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2013/14' },
+        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2012/13' },
+        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2013/14' },
+        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2012/13' },
+        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2013/14' },
+      ],
+    ]);
+
+    expect(result.tbody).toEqual<TableCellJson[][]>([
+      [
+        { colSpan: 1, rowSpan: 1, scope: 'row', tag: 'th', text: 'LA 1' },
+        { tag: 'td', text: '20' },
+        { tag: 'td', text: '7,163' },
+        { tag: 'td', text: '767' },
+        { tag: 'td', text: '19,340' },
+        { tag: 'td', text: '44' },
+        { tag: 'td', text: '32' },
+        { tag: 'td', text: '331' },
+        { tag: 'td', text: '2,458' },
+      ],
+    ]);
+  });
+
   describe('hasMissingRowsOrColumns', () => {
     const testQuery: ReleaseTableDataQuery = {
       subjectId: 'subject-1-id',
@@ -530,6 +662,7 @@ describe('mapTableToJson', () => {
       indicators: ['indicator-1', 'indicator-2'],
       locationIds: ['la-1', 'la-2'],
     };
+
     test('is false when no rows or columns are excluded', () => {
       const result = mapTableToJson({
         tableHeadersConfig: testTableWithOneLevelOfRowAndColHeadersConfig,

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/optimizeFilters.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/optimizeFilters.test.ts
@@ -44,29 +44,47 @@ const testTimePeriod2 = new TimePeriodFilter({
   code: 'AY',
   order: 1,
 });
-const testCategoryFilter1 = new CategoryFilter({
-  value: 'category-filter-1',
+const testCategory1Group1Filter1 = new CategoryFilter({
+  value: 'filter-1',
   label: 'Filter 1',
   group: 'Filter Group 1',
-  category: 'Category1',
+  category: 'Category 1',
 });
-const testCategoryFilter2 = new CategoryFilter({
-  value: 'category-filter-2',
+const testCategory1Group1Filter2 = new CategoryFilter({
+  value: 'filter-2',
   label: 'Filter 2',
   group: 'Filter Group 1',
-  category: 'Category1',
+  category: 'Category 1',
 });
-const testCategoryFilter3 = new CategoryFilter({
-  value: 'category-filter-3',
+const testCategory1Group2Filter3 = new CategoryFilter({
+  value: 'filter-3',
   label: 'Filter 3',
-  group: 'FilterGroup 2',
-  category: 'Category2',
+  group: 'Filter Group 2',
+  category: 'Category 1',
 });
-const testCategoryFilter4 = new CategoryFilter({
-  value: 'category-filter-4',
+const testCategory2GroupDefaultFilter4 = new CategoryFilter({
+  value: 'filter-4',
   label: 'Filter 4',
   group: 'Default',
-  category: 'Category3',
+  category: 'Category 2',
+});
+const testCategory3Group1Filter5 = new CategoryFilter({
+  value: 'filter-5',
+  label: 'Filter 5',
+  group: 'Filter Group 1',
+  category: 'Category 3',
+});
+const testCategory3Group2Filter6 = new CategoryFilter({
+  value: 'filter-6',
+  label: 'Filter 6',
+  group: 'Filter Group 2',
+  category: 'Category 3',
+});
+const testCategory3Group2Filter7 = new CategoryFilter({
+  value: 'filter-7',
+  label: 'Filter 7',
+  group: 'Filter Group 2',
+  category: 'Category 3',
 });
 
 describe('optimizeFilters', () => {
@@ -76,6 +94,7 @@ describe('optimizeFilters', () => {
       [testLocationFilter1, testLocationFilter2],
       [testTimePeriod1, testTimePeriod2],
     ];
+
     const result = optimizeFilters(testFilters, testHeaderConfig);
     expect(result).toEqual(testFilters);
   });
@@ -86,6 +105,7 @@ describe('optimizeFilters', () => {
       [testLocationFilter1, testLocationFilter2],
       [],
     ];
+
     const result = optimizeFilters(testFilters, testHeaderConfig);
     expect(result).toEqual([testLocationFilter1]);
   });
@@ -96,40 +116,206 @@ describe('optimizeFilters', () => {
       [testLocationFilter1, testLocationFilter2],
       [testTimePeriod1],
     ];
+
     const result = optimizeFilters(testFilters, testHeaderConfig);
     expect(result).toEqual([testLocationFilter1]);
   });
 
-  test('adds a filter group when there are multiple subgroups and the group is not `Default`', () => {
-    const testFilters: Filter[] = [testCategoryFilter1, testTimePeriod1];
+  test('adds FilterGroup when groups with different labels in 1 level are not `Default`', () => {
+    const testFilters: Filter[] = [testCategory1Group1Filter1, testTimePeriod1];
     const testHeaderConfig: Filter[][] = [
-      [testCategoryFilter1, testCategoryFilter2, testCategoryFilter3],
+      // Belong to different groups
+      [
+        testCategory1Group1Filter1,
+        testCategory1Group1Filter2,
+        testCategory1Group2Filter3,
+      ],
       [testTimePeriod1, testTimePeriod2],
     ];
+
     const result = optimizeFilters(testFilters, testHeaderConfig);
     expect(result).toEqual([
-      new FilterGroup('Filter Group 1'),
-      testCategoryFilter1,
+      new FilterGroup('Filter Group 1', 0),
+      testCategory1Group1Filter1,
       testTimePeriod1,
     ]);
   });
 
-  test('does not add a filter group when there are multiple subgroups and the group is `Default`', () => {
-    const testFilters: Filter[] = [testCategoryFilter4, testTimePeriod1];
-    const testHeaderConfig: Filter[][] = [
-      [testCategoryFilter3, testCategoryFilter4],
-      [testTimePeriod1, testTimePeriod2],
+  test('adds FilterGroups for groups across 2 non-adjacent levels with different labels that are not `Default`', () => {
+    const testFilters: Filter[] = [
+      testCategory1Group1Filter1,
+      testTimePeriod1,
+      testCategory3Group1Filter5,
     ];
+    const testHeaderConfig: Filter[][] = [
+      // Belong to different groups
+      [
+        testCategory1Group1Filter1,
+        testCategory1Group1Filter2,
+        testCategory1Group2Filter3,
+      ],
+      [testTimePeriod1, testTimePeriod2],
+      // Belong to different groups
+      [testCategory3Group1Filter5, testCategory3Group2Filter6],
+    ];
+
     const result = optimizeFilters(testFilters, testHeaderConfig);
-    expect(result).toEqual([testCategoryFilter4, testTimePeriod1]);
+    expect(result).toEqual([
+      new FilterGroup('Filter Group 1', 0),
+      testCategory1Group1Filter1,
+      testTimePeriod1,
+      new FilterGroup('Filter Group 1', 2),
+      testCategory3Group1Filter5,
+    ]);
   });
 
-  test('does not add a filter group when there are multiple subgroups and the group is undefined', () => {
+  test('adds FilterGroups for groups across 2 adjacent levels with different labels that are not `Default`', () => {
+    const testFilters: Filter[] = [
+      testCategory1Group1Filter2,
+      testCategory3Group2Filter6,
+      testTimePeriod2,
+    ];
+    const testHeaderConfig: Filter[][] = [
+      // Belong to different groups
+      [
+        testCategory1Group1Filter1,
+        testCategory1Group1Filter2,
+        testCategory1Group2Filter3,
+      ],
+      // Belong to different groups
+      [testCategory3Group1Filter5, testCategory3Group2Filter6],
+      [testTimePeriod1, testTimePeriod2],
+    ];
+
+    const result = optimizeFilters(testFilters, testHeaderConfig);
+    expect(result).toEqual([
+      new FilterGroup('Filter Group 1', 0),
+      testCategory1Group1Filter2,
+      new FilterGroup('Filter Group 2', 1),
+      testCategory3Group2Filter6,
+      testTimePeriod2,
+    ]);
+  });
+
+  test('only adds FilterGroup for group that is not `Default`', () => {
+    const testFilters: Filter[] = [
+      testCategory1Group1Filter1,
+      testTimePeriod1,
+      testCategory2GroupDefaultFilter4,
+    ];
+    const testHeaderConfig: Filter[][] = [
+      // Belong to different groups
+      [
+        testCategory1Group1Filter1,
+        testCategory1Group1Filter2,
+        testCategory1Group2Filter3,
+      ],
+      [testTimePeriod1, testTimePeriod2],
+      // A filter belongs to Default group, so no FilterGroup added
+      [testCategory2GroupDefaultFilter4, testCategory3Group1Filter5],
+    ];
+
+    const result = optimizeFilters(testFilters, testHeaderConfig);
+    expect(result).toEqual([
+      new FilterGroup('Filter Group 1', 0),
+      testCategory1Group1Filter1,
+      testTimePeriod1,
+      testCategory2GroupDefaultFilter4,
+    ]);
+  });
+
+  test('does not add a FilterGroup when group is `Default`', () => {
+    const testFilters: Filter[] = [
+      testCategory2GroupDefaultFilter4,
+      testTimePeriod1,
+    ];
+    const testHeaderConfig: Filter[][] = [
+      // Belong to different groups, but filter
+      // being optimized belongs to Default group
+      [testCategory2GroupDefaultFilter4, testCategory1Group2Filter3],
+      [testTimePeriod1, testTimePeriod2],
+    ];
+
+    const result = optimizeFilters(testFilters, testHeaderConfig);
+    expect(result).toEqual([testCategory2GroupDefaultFilter4, testTimePeriod1]);
+  });
+
+  test('does not add a FilterGroup when one group that is not `Default`', () => {
+    const testFilters: Filter[] = [testCategory1Group1Filter1, testTimePeriod1];
+    const testHeaderConfig: Filter[][] = [
+      // Belong to same group
+      [testCategory1Group1Filter1, testCategory1Group1Filter2],
+      [testTimePeriod1, testTimePeriod2],
+    ];
+
+    const result = optimizeFilters(testFilters, testHeaderConfig);
+    expect(result).toEqual([testCategory1Group1Filter1, testTimePeriod1]);
+  });
+
+  test('does not add FilterGroups when groups across 1 level have same labels that are not `Default`', () => {
+    const testFilters: Filter[] = [testCategory1Group1Filter1, testTimePeriod1];
+    const testHeaderConfig: Filter[][] = [
+      // Belong to same group
+      [testCategory1Group1Filter1, testCategory1Group1Filter2],
+      [testTimePeriod1, testTimePeriod2],
+    ];
+
+    const result = optimizeFilters(testFilters, testHeaderConfig);
+    expect(result).toEqual([testCategory1Group1Filter1, testTimePeriod1]);
+  });
+
+  test('does not add FilterGroups when groups across 2 adjacent levels have same labels that are not `Default`', () => {
+    const testFilters: Filter[] = [
+      testCategory1Group1Filter2,
+      testCategory3Group2Filter7,
+      testTimePeriod2,
+    ];
+    const testHeaderConfig: Filter[][] = [
+      // Belong to same group
+      [testCategory1Group1Filter1, testCategory1Group1Filter2],
+      // Belong to same group
+      [testCategory3Group2Filter6, testCategory3Group2Filter7],
+      [testTimePeriod1, testTimePeriod2],
+    ];
+
+    const result = optimizeFilters(testFilters, testHeaderConfig);
+    expect(result).toEqual([
+      testCategory1Group1Filter2,
+      testCategory3Group2Filter7,
+      testTimePeriod2,
+    ]);
+  });
+
+  test('does not add FilterGroups when groups across 2 non-adjacent levels have same labels that are not `Default`', () => {
+    const testFilters: Filter[] = [
+      testCategory1Group1Filter1,
+      testTimePeriod1,
+      testCategory3Group1Filter5,
+    ];
+    const testHeaderConfig: Filter[][] = [
+      // Belong to same group
+      [testCategory1Group1Filter1, testCategory1Group1Filter2],
+      [testTimePeriod1, testTimePeriod2],
+      // Belong to same group
+      [testCategory3Group2Filter6, testCategory3Group2Filter7],
+    ];
+
+    const result = optimizeFilters(testFilters, testHeaderConfig);
+    expect(result).toEqual([
+      testCategory1Group1Filter1,
+      testTimePeriod1,
+      testCategory3Group1Filter5,
+    ]);
+  });
+
+  test('does not add a FilterGroup when there are no groups', () => {
     const testFilters: Filter[] = [testLocationFilter5, testTimePeriod1];
     const testHeaderConfig: Filter[][] = [
+      // None of these are grouped
       [testLocationFilter3, testLocationFilter5],
       [testTimePeriod1, testTimePeriod2],
     ];
+
     const result = optimizeFilters(testFilters, testHeaderConfig);
     expect(result).toEqual([testLocationFilter5, testTimePeriod1]);
   });

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/optimizeFilters.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/optimizeFilters.ts
@@ -2,10 +2,10 @@ import { Filter } from '@common/modules/table-tool/types/filters';
 import last from 'lodash/last';
 
 export class FilterGroup extends Filter {
-  constructor(label: string) {
+  constructor(label: string, level: number) {
     super({
       label,
-      value: label,
+      value: `${label} (level: ${level})`,
     });
   }
 }
@@ -13,7 +13,7 @@ export class FilterGroup extends Filter {
 /**
  * Optimize a set of filters for the best viewing experience.
  *
- * Typically we add or remove filters depending on whether they are
+ * Typically, we add or remove filters depending on whether they are
  * actually needed for the user to understand the table.
  */
 export default function optimizeFilters(
@@ -33,24 +33,18 @@ export default function optimizeFilters(
     optimizedFilters = filters.length > 1 ? filters.slice(0, -1) : filters;
   }
 
-  return (
-    optimizedFilters
-      // Add additional filter sub groups
-      // to our filters if required.
-      .flatMap((filter, index) => {
-        const firstSubGroup = headerConfig[index][0].group;
+  // Add additional filter groups to our filters if required.
+  return optimizedFilters.flatMap((filter, index) => {
+    const firstSubGroup = headerConfig[index][0].group;
 
-        // Don't bother showing a single subgroup as this adds
-        // additional groups to a potentially crowded table.
-        const hasMultipleSubGroups = headerConfig[index].some(
-          header => header.group !== firstSubGroup,
-        );
+    // Don't bother showing a single group as this adds
+    // additional groups to a potentially crowded table.
+    const hasMultipleGroups = headerConfig[index].some(
+      header => header.group !== firstSubGroup,
+    );
 
-        return hasMultipleSubGroups &&
-          filter.group &&
-          filter.group !== 'Default'
-          ? [new FilterGroup(filter.group), filter]
-          : filter;
-      })
-  );
+    return filter.group && filter.group !== 'Default' && hasMultipleGroups
+      ? [new FilterGroup(filter.group, index), filter]
+      : filter;
+  });
 }


### PR DESCRIPTION
This fixes a bug in EES-4246 where filter groups with duplicate labels (e.g. 'Total') are not being inserted into the filters from the `optimizeFilters` function. This was preventing the entire table from rendering as the table header tree would not be correctly constructed in `mapTableToJson`, consequently throwing a null pointer.

Various tests have been also been added to test this more thoroughly.

## Alignment issues in EES-3408

This change also fixes an issue highlighted by a test data set from EES-3408 where there previously alignment issues due to incorrect cross spans being calculated. 

Using the `EES-3408.csv` data set, we can get a table like this:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/9917868/df4c516f-762d-47a4-83d5-6c40c967dcab)

This has now been fixed so the table looks like:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/9917868/efc14e2d-ff7a-4e2f-bd44-f1e9551eda42)

This has also been tested with the `grouped-filters-and-indicators.csv` data set which seems fine:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/9917868/1bd2a2dd-b591-45e7-a81b-68340cc652f0)
