### PR TITLE
EES-4157 Fix window overflow when many filter options in table tool

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.module.scss
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.module.scss
@@ -4,6 +4,10 @@
   margin: govuk-spacing(4) 0 govuk-spacing(1);
   overflow-y: auto;
   padding: govuk-spacing(2);
+  // Need this to prevent child elements with absolute positioning
+  // (e.g. visually hidden text) from causing the entire browser
+  // window to overflow and have more height than is necessary.
+  position: relative;
 
   @media (max-height: 720px) {
     max-height: 70vh;


### PR DESCRIPTION
This fix prevents the entire browser window from overflowing when there are many filter options in any of table tool's checkbox groups. 

This was primarily being caused by the the checkbox groups containing visually hidden text. Visually hidden elements are absolutely positioned and for some reason, this causes height calculations to break out of the nearest overflow context (i.e. the checkbox group) and target the entire browser window.

Interestingly, the issue was only present in Chromium browsers (not Firefox) so there may be a bug here or divergence in how the browsers calculate height. Either way, this can just be fixed by adding `position: relative` to the checkbox group container.