### PR TITLE
EES-4048 Tweak font sizes and remove unneeded grid columns from data set step

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/AllFeaturedTables.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/AllFeaturedTables.tsx
@@ -35,77 +35,71 @@ export default function AllFeaturedTables({
 
   return (
     <>
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-three-quarters-from-desktop">
-          <h3>All featured tables for this publication</h3>
-          <p>
-            View featured tables from across all data sets for this publication.
-            If you can't find what you are looking for please select a specific
-            data set, and then you can create your own table.
-          </p>
+      <h3>All featured tables for this publication</h3>
 
-          <FormSearchBar
-            className="govuk-!-margin-bottom-5"
-            id="featuredTables-search"
-            label="Search featured tables"
-            labelSize="s"
-            name="search"
-            onReset={() => setFilteredFeaturedTables(featuredTables)}
-            onSubmit={handleSearch}
-          />
-        </div>
-      </div>
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-full">
-          {filteredFeaturedTables.length > 0 ? (
+      <p>
+        View featured tables from across all data sets for this publication. If
+        you can't find what you are looking for please select a specific data
+        set, and then you can create your own table.
+      </p>
+
+      <FormSearchBar
+        className="govuk-!-margin-bottom-5"
+        id="featuredTables-search"
+        label="Search featured tables"
+        labelSize="s"
+        name="search"
+        onReset={() => setFilteredFeaturedTables(featuredTables)}
+        onSubmit={handleSearch}
+      />
+
+      {filteredFeaturedTables.length > 0 ? (
+        <>
+          <VisuallyHidden>
+            <p aria-live="polite" aria-atomic>
+              {`Showing ${filteredFeaturedTables.length} featured table${
+                filteredFeaturedTables.length > 1 ? 's' : ''
+              }`}
+            </p>
+          </VisuallyHidden>
+
+          {!isMobileMedia && (
             <>
-              <VisuallyHidden>
-                <p aria-live="polite" aria-atomic>
-                  {`Showing ${filteredFeaturedTables.length} featured table${
-                    filteredFeaturedTables.length > 1 ? 's' : ''
-                  }`}
+              {listView ? (
+                <p>
+                  Showing list view.{' '}
+                  <ButtonText onClick={toggleListView.off}>
+                    View as grid
+                  </ButtonText>
                 </p>
-              </VisuallyHidden>
-
-              {!isMobileMedia && (
-                <>
-                  {listView ? (
-                    <p>
-                      Showing list view.{' '}
-                      <ButtonText onClick={toggleListView.off}>
-                        View as grid
-                      </ButtonText>
-                    </p>
-                  ) : (
-                    <p>
-                      Showing grid view.{' '}
-                      <ButtonText onClick={toggleListView.on}>
-                        View as list
-                      </ButtonText>
-                    </p>
-                  )}
-                </>
+              ) : (
+                <p>
+                  Showing grid view.{' '}
+                  <ButtonText onClick={toggleListView.on}>
+                    View as list
+                  </ButtonText>
+                </p>
               )}
-              <ChevronGrid testId="featuredTables">
-                {filteredFeaturedTables.map(table => {
-                  return (
-                    <ChevronCard
-                      as="li"
-                      cardSize={listView ? 'l' : 's'}
-                      description={table.description ?? ''}
-                      key={table.id}
-                      link={renderFeaturedTableLink?.(table)}
-                      noBorder
-                    />
-                  );
-                })}
-              </ChevronGrid>
             </>
-          ) : (
-            <p>No featured tables found.</p>
           )}
-        </div>
-      </div>
+          <ChevronGrid testId="featuredTables">
+            {filteredFeaturedTables.map(table => {
+              return (
+                <ChevronCard
+                  as="li"
+                  cardSize={listView ? 'l' : 's'}
+                  description={table.description ?? ''}
+                  key={table.id}
+                  link={renderFeaturedTableLink?.(table)}
+                  noBorder
+                />
+              );
+            })}
+          </ChevronGrid>
+        </>
+      ) : (
+        <p>No featured tables found.</p>
+      )}
     </>
   );
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DataSetStepContent.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DataSetStepContent.tsx
@@ -68,7 +68,7 @@ export default function DataSetStepContent({
         </>
       ) : (
         <>
-          <p className="govuk-body-l">
+          <p>
             {`Please select a data set, you will then be able to see a summary of
             the data, create your own tables,${
               featuredTables.length > 0 ? ' view featured tables,' : ''
@@ -77,7 +77,7 @@ export default function DataSetStepContent({
           </p>
           {featuredTables.length > 0 && (
             <>
-              <p className="govuk-body-l">
+              <p>
                 Alternatively you can browse{' '}
                 <ButtonText
                   onClick={() => setValue('subjectId', 'all-featured')}


### PR DESCRIPTION
This PR removes the large fonts used for guidance text across the data set step. This now looks like:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/9917868/57281487-94f1-4e81-956a-4078ab0c39ff)

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/9917868/4e1f2dae-6389-486c-baf4-3bd2481b07f2)

We have also removed the unneeded grid column styling from `AllFeaturedTables` as this has been replaced by the `govuk-width-container` applied to the `DataSetContent` container div.