### PR TITLE
EES-4236 Increase the body size limit of the FE CreatePermalinkTable endpoint

### DIFF
--- a/src/explore-education-statistics-frontend/src/pages/api/permalink.ts
+++ b/src/explore-education-statistics-frontend/src/pages/api/permalink.ts
@@ -1,6 +1,14 @@
 import createPermalinkTable from '@frontend/modules/api/permalink/createPermalinkTable';
 import withMethods from '@frontend/middleware/withMethods';
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '20mb',
+    },
+  },
+};
+
 export default withMethods({
   post: createPermalinkTable,
 });


### PR DESCRIPTION
This PR increases the body size limit of the frontend `CreatePermalinkTable` endpoint.

See [Custom config](https://nextjs.org/docs/pages/building-your-application/routing/api-routes#custom-config).

[EES-4247](https://dfedigital.atlassian.net/browse/EES-4247) will establish if this limit needs to be any higher, and if we should compress the request between the backend and the frontend, but for now to attempt creating Permalink snapshots where the table request is any bigger than 1mb we need to increase this limit.