### PR TITLE
EES-4318 Fix table CSV generation for Permalinks created before EES-613

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkCsvMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkCsvMetaService.cs
@@ -49,6 +49,7 @@ public class PermalinkCsvMetaService : IPermalinkCsvMetaService
         _releaseFileBlobService = releaseFileBlobService;
     }
 
+    // TODO EES-3755 Remove after Permalink snapshot work is complete
     public async Task<Either<ActionResult, PermalinkCsvMetaViewModel>> GetCsvMeta(
         LegacyPermalink permalink,
         CancellationToken cancellationToken = default)
@@ -105,12 +106,12 @@ public class PermalinkCsvMetaService : IPermalinkCsvMetaService
         var locationCols = GetLocationsColumns(permalink.FullTable.Results);
 
         var csvFilters = tableResultMeta.Filters.Values.ToDictionary(
-            filter => filter.Name,
+            filter => filter.Name ?? filter.Legend.SnakeCase(),
             filter => new FilterCsvMetaViewModel(filter)
         );
 
         var csvIndicators = tableResultMeta.Indicators.ToDictionary(
-            indicator => indicator.Name,
+            indicator => indicator.Name ?? indicator.Label.SnakeCase(),
             indicator => new IndicatorCsvMetaViewModel(indicator)
         );
 
@@ -143,12 +144,14 @@ public class PermalinkCsvMetaService : IPermalinkCsvMetaService
         var locations = await GetLocations(tableResultMeta.Locations);
 
         var csvFilters = tableResultMeta.Filters.Values.ToDictionary(
-            filter => filter.Name,
+            // TODO EES-3755 Remove fallback after Permalink snapshot work is complete
+            filter => filter.Name ?? filter.Legend.SnakeCase(),
             filter => new FilterCsvMetaViewModel(filter)
         );
 
         var csvIndicators = tableResultMeta.Indicators.ToDictionary(
-            indicator => indicator.Name,
+            // TODO EES-3755 Remove fallback after Permalink snapshot work is complete
+            indicator => indicator.Name ?? indicator.Label.SnakeCase(),
             indicator => new IndicatorCsvMetaViewModel(indicator)
         );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/FilterCsvMetaViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/FilterCsvMetaViewModels.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
@@ -32,7 +33,8 @@ public record FilterCsvMetaViewModel
     public FilterCsvMetaViewModel(FilterMetaViewModel filter)
     {
         Id = filter.Id;
-        Name = filter.Name;
+        // TODO EES-3755 Remove fallback after Permalink snapshot work is complete
+        Name = filter.Name ?? filter.Legend.SnakeCase();
         Items = filter.Options
             .SelectMany(filterGroup => filterGroup.Value.Options)
             .Select(filterItem => new FilterItemCsvMetaViewModel(filterItem))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/FilterMetaViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/FilterMetaViewModels.cs
@@ -9,9 +9,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Me
     {
         public Guid Id { get; init; }
         public string? Hint { get; init; }
-        public string? Legend { get; init; }
+        public string Legend { get; init; } = string.Empty;
         public Dictionary<string, FilterGroupMetaViewModel> Options { get; init; } = new();
-        public string Name { get; init; } = string.Empty;
+        // TODO EES-3755 Change Name to not be nullable after Permalink snapshot work is complete.
+        // This type within Permalinks created before EES-613 has no Name.
+        public string? Name { get; init; } = string.Empty;
         public Guid? TotalValue { get; init; }
         public int Order { get; init; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/IndicatorCsvMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/IndicatorCsvMetaViewModel.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using Newtonsoft.Json;
 
@@ -37,7 +38,8 @@ public record IndicatorCsvMetaViewModel
         Id = indicator.Value;
         DecimalPlaces = indicator.DecimalPlaces;
         Label = indicator.Label;
-        Name = indicator.Name;
+        // TODO EES-3755 Remove fallback after Permalink snapshot work is complete
+        Name = indicator.Name ?? indicator.Label.SnakeCase();
         Unit = indicator.Unit;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/IndicatorMetaViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/IndicatorMetaViewModels.cs
@@ -35,7 +35,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Me
 
         public Guid Value { get; init; }
 
-        public string Name { get; init; } = string.Empty;
+        // TODO EES-3755 Change Name to not be nullable after Permalink snapshot work is complete.
+        // This type within Permalinks created before EES-613 has no Name.
+        public string? Name { get; init; } = string.Empty;
 
         public int? DecimalPlaces { get; init; }
 


### PR DESCRIPTION
This PR fixes table CSV generation for Permalinks created before EES-613 change #1572  was deployed.

This bug affects early permalinks - approximately the first month of permalinks created in Prod after the service went live.

Prior to EES-613, `FilterMetaViewModel` and `IndicatorMetaViewModel` had no `Name` property which is used by CSV generation for the filter/indicator column names.

These early permalinks currently fail with server error 500 when selecting the Download table ‘Table in CSV format’ option.

We add a fallback for the filter and indicator view model names to use snake case of the label instead.

### Other changes

- Change `FilterMetaViewModel.Legend` to be not nullable.