### PR TITLE
EES-4192 Fix `ContentDbContextModelSnapshot` for nullable `LastProcessedRowIndex`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
@@ -176,7 +176,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<int>("ImportedRows")
                         .HasColumnType("int");
 
-                    b.Property<int>("LastProcessedRowIndex")
+                    b.Property<int?>("LastProcessedRowIndex")
                         .HasColumnType("int");
 
                     b.Property<Guid>("MetaFileId")


### PR DESCRIPTION
Corrects the type of `LastProcessedRowIndex` in `ContentDbContextModelSnapshot`.