### PR TITLE
EES-4288 fix map custom groups rounding bug

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/__tests__/generateLegendDataGroups.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/__tests__/generateLegendDataGroups.test.ts
@@ -1606,5 +1606,53 @@ describe('generateLegendDataGroups', () => {
         },
       ]);
     });
+
+    test('handles custom groups with a mixture of integer and non-integer groups', () => {
+      const dataClasses = generateLegendDataGroups({
+        colour: 'rgba(0, 0, 0, 1)',
+        dataGrouping: {
+          customGroups: [
+            { min: 0, max: 1 },
+            {
+              min: 1.01,
+              max: 1.2,
+            },
+          ],
+
+          type: 'Custom',
+        },
+        unit: '%',
+        decimalPlaces: 2,
+        values: [
+          1.13516,
+          1.0764,
+          1.20243,
+          0.9777,
+          1.07861,
+          0.9045,
+          0.83771,
+          0.8458,
+        ],
+      });
+
+      expect(dataClasses).toEqual<LegendDataGroup[]>([
+        {
+          colour: 'rgba(128, 128, 128, 1)',
+          decimalPlaces: 2,
+          min: '0%',
+          max: '1%',
+          minRaw: -0.005,
+          maxRaw: 1.004,
+        },
+        {
+          colour: 'rgba(0, 0, 0, 1)',
+          decimalPlaces: 2,
+          min: '1.01%',
+          max: '1.2%',
+          minRaw: 1.005,
+          maxRaw: 1.204,
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
With certain custom groups the rounding was wrong causing locations to be assigned to the wrong group (see [ticket ](https://dfedigital.atlassian.net/browse/EES-4288) for an example). 

This was caused by using the highest number of decimal places per group to set the raw values, these have now been set to be the highest number of decimal places from all custom groups.