### PR TITLE
EES-4310 Preview featured tables trying to get data block via feature…

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
@@ -20,7 +20,7 @@ interface Props {
   publication: Publication | ContentPublication;
 }
 const ReleasePreviewTableTool = ({ releaseId, publication }: Props) => {
-  const [featuredTableId, setFeaturedTableId] = useState<string>();
+  const [dataBlockId, setDataBlockId] = useState<string>();
 
   const { value: initialState, isLoading } = useAsyncHandledRetry<
     InitialTableToolState | undefined
@@ -30,14 +30,8 @@ const ReleasePreviewTableTool = ({ releaseId, publication }: Props) => {
       tableBuilderService.listReleaseSubjects(releaseId),
     ]);
 
-    const filteredFeaturedTables = featuredTables.filter(
-      table => table.id !== featuredTableId,
-    );
-
-    if (featuredTableId) {
-      const { table, query } = await dataBlockService.getDataBlock(
-        featuredTableId,
-      );
+    if (dataBlockId) {
+      const { table, query } = await dataBlockService.getDataBlock(dataBlockId);
 
       const [subjectMeta, tableData] = await Promise.all([
         tableBuilderService.getSubjectMeta(query.subjectId, releaseId),
@@ -53,7 +47,7 @@ const ReleasePreviewTableTool = ({ releaseId, publication }: Props) => {
       return {
         initialStep: 5,
         subjects,
-        featuredTables: filteredFeaturedTables,
+        featuredTables,
         query: {
           ...query,
           publicationId: publication.id,
@@ -70,7 +64,7 @@ const ReleasePreviewTableTool = ({ releaseId, publication }: Props) => {
     return {
       initialStep: 1,
       subjects,
-      featuredTables: filteredFeaturedTables,
+      featuredTables,
       query: {
         publicationId: publication.id,
         releaseId,
@@ -80,7 +74,7 @@ const ReleasePreviewTableTool = ({ releaseId, publication }: Props) => {
         locationIds: [],
       },
     };
-  }, [releaseId, featuredTableId]);
+  }, [releaseId, dataBlockId]);
 
   return (
     <LoadingSpinner loading={isLoading}>
@@ -92,11 +86,11 @@ const ReleasePreviewTableTool = ({ releaseId, publication }: Props) => {
             themeMeta={[]}
             hidePublicationStep
             initialState={initialState}
-            onSubjectStepBack={() => setFeaturedTableId(undefined)}
+            onSubjectStepBack={() => setDataBlockId(undefined)}
             renderFeaturedTableLink={featuredTable => (
               <ButtonText
                 onClick={() => {
-                  setFeaturedTableId(featuredTable.id);
+                  setDataBlockId(featuredTable.dataBlockId);
                 }}
               >
                 {featuredTable.name}

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
@@ -39,10 +39,6 @@ const PreReleaseTableToolPage = ({
       tableBuilderService.listReleaseSubjects(releaseId),
     ]);
 
-    const filteredFeaturedTables = featuredTables.filter(
-      highlight => highlight.dataBlockId !== dataBlockId,
-    );
-
     if (dataBlockId) {
       const { table, query } = await dataBlockService.getDataBlock(dataBlockId);
 
@@ -60,7 +56,7 @@ const PreReleaseTableToolPage = ({
       return {
         initialStep: 5,
         subjects,
-        featuredTables: filteredFeaturedTables,
+        featuredTables,
         query: {
           ...query,
           publicationId,
@@ -77,7 +73,7 @@ const PreReleaseTableToolPage = ({
     return {
       initialStep: 1,
       subjects,
-      featuredTables: filteredFeaturedTables,
+      featuredTables,
       query: {
         publicationId,
         releaseId,


### PR DESCRIPTION
…dTableId instead of dataBlockId

This PR fixes a bug where in Admin, on a release's Content page, if you click `Preview table tool` and then click a featured table look, you'd get an error. This is because it was trying to fetch the data block via the featuredTableId instead of the dataBlockId.

I also noticed there was a `filteredFeaturedTables` variable, and I wasn't sure what it was being used for. I ran this past Amy and ended up removing it from `ReleasePreviewTableTool.tsx` - and I also removed the same named variable from `PreReleaseTableToolPage.tsx` as well.