### PR TITLE
EES-3940 restrict chart y axis width on mobile

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -1,3 +1,4 @@
+import { useMobileMedia } from '@common/hooks/useMedia';
 import ChartContainer from '@common/modules/charts/components/ChartContainer';
 import CustomTooltip from '@common/modules/charts/components/CustomTooltip';
 import useLegend from '@common/modules/charts/components/hooks/useLegend';
@@ -58,6 +59,7 @@ const HorizontalBarBlock = ({
   dataLabelPosition,
 }: HorizontalBarProps) => {
   const [legendProps, renderLegend] = useLegend();
+  const { isMedia: isMobileMedia } = useMobileMedia();
 
   if (
     axes === undefined ||
@@ -81,7 +83,13 @@ const HorizontalBarBlock = ({
   const minorDomainTicks = getMinorAxisDomainTicks(chartData, axes.minor);
   const majorDomainTicks = getMajorAxisDomainTicks(chartData, axes.major);
 
-  const yAxisWidth = parseNumber(axes.major.size);
+  // Enforce a max y axis width on mobile as large widths cause
+  // the chart to not be visible.
+  const maxMobileYAxisWidth = 160;
+  const yAxisWidth =
+    isMobileMedia && axes.major.size && axes.major.size > maxMobileYAxisWidth
+      ? maxMobileYAxisWidth
+      : parseNumber(axes.major.size);
   const xAxisHeight = parseNumber(axes.minor.size);
 
   const dataSetCategoryConfigs = getDataSetCategoryConfigs({
@@ -153,6 +161,7 @@ const HorizontalBarBlock = ({
                 dataSetCategoryConfigs={dataSetCategoryConfigs}
               />
             }
+            position={isMobileMedia ? { x: 0 } : undefined}
             wrapperStyle={{ zIndex: 1000 }}
           />
 


### PR DESCRIPTION
Fixes the bug rendering horizontal charts on mobile by:
- restricting the y axis width so there's always space for the chart
- positioning tooltips on the left

**Before:**
![before](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/52e95a43-98c6-43a9-8995-60a98a511878)

**After:**
![now1](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/34b049ae-60d7-4e3f-a6f6-3c0f8bea6986)
![now2](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/f7e16d96-ff38-4409-9690-5c830ff90bc5)
