### PR TITLE
EES-4327 Fix data replacements for data block with map chart with nul…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -835,16 +835,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         );
                     }
 
-                    if (dataSet.Location != null
-                        && locationTargets.TryGetValue(dataSet.Location.Value, out var targetLocationId))
+                    if (dataSet.Location != null)
                     {
-                        dataSet.Location.Value = targetLocationId;
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException(
-                            $"Expected target replacement value for dataBlock {dataBlock.Id} chart data set config location: {dataSet.Location?.Value}"
-                        );
+                        if (locationTargets.TryGetValue(dataSet.Location.Value, out var targetLocationId))
+                        {
+                            dataSet.Location.Value = targetLocationId;
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException(
+                                $"Expected target replacement value for dataBlock {dataBlock.Id} chart data set config location: {dataSet.Location?.Value}"
+                            );
+                        }
                     }
                 });
         }


### PR DESCRIPTION
…l location in config

This PR fixes a bug where a data replacement will fail if a data block has a map chart attached that has a dataSetConfig that has a dataSet that has a null location.