### PR TITLE
EES-3251 force text wrapping on map key

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -468,7 +468,7 @@ export default function MapBlockInternal({
         </div>
         {selectedDataSetConfig && (
           <div className="govuk-grid-column-one-third">
-            <h3 className="govuk-heading-s">
+            <h3 className="govuk-heading-s dfe-word-break--break-word">
               Key to {selectedDataSetConfig?.config?.label}
             </h3>
             <ul className="govuk-list" data-testid="mapBlock-legend">

--- a/src/explore-education-statistics-common/src/styles/utils/_text.scss
+++ b/src/explore-education-statistics-common/src/styles/utils/_text.scss
@@ -1,3 +1,7 @@
 .dfe-white-space--pre-wrap {
   white-space: pre-wrap;
 }
+
+.dfe-word-break--break-word {
+  word-break: break-word;
+}


### PR DESCRIPTION
Adds a util class for `word-break: break-word` and applies it to the key heading on maps to prevent text overflowing.