### PR TITLE
EES-4320 fix permalinks bug and add dedupe code to api

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/mapTableToJson.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/mapTableToJson.ts
@@ -243,16 +243,21 @@ function mapTableBody(
       }),
     );
 
-    rowsJson.push(...rowsHeaderJson);
+    // TO DO - EES-4259 Can remove this check once the permalinks migration is done.
+    // Check for rowsHeaderJson because of some old permalinks with duplicate
+    // locations in the table headers - EES-4320.
+    if (rowsHeaderJson) {
+      rowsJson.push(...rowsHeaderJson);
 
-    rowsJson.push(
-      ...row.map<TableCellJson>(cell => {
-        return {
-          tag: 'td',
-          text: cell,
-        };
-      }),
-    );
+      rowsJson.push(
+        ...row.map<TableCellJson>(cell => {
+          return {
+            tag: 'td',
+            text: cell,
+          };
+        }),
+      );
+    }
 
     return rowsJson;
   });

--- a/src/explore-education-statistics-common/src/services/permalinkService.ts
+++ b/src/explore-education-statistics-common/src/services/permalinkService.ts
@@ -49,7 +49,11 @@ export default {
     return dataApi.post(`/permalink`, query);
   },
   async getPermalink(id: string): Promise<Permalink> {
-    return deduplicatePermalinkLocations(await dataApi.get(`/permalink/${id}`));
+    const permalink: Permalink = await dataApi.get(`/permalink/${id}`);
+    return {
+      ...permalink,
+      fullTable: deduplicatePermalinkLocations(permalink.fullTable),
+    };
   },
   async getPermalinkCsv(id: string): Promise<Blob> {
     return dataApi.get(`/permalink/${id}`, {

--- a/src/explore-education-statistics-common/src/services/util/permalinkServiceUtils.ts
+++ b/src/explore-education-statistics-common/src/services/util/permalinkServiceUtils.ts
@@ -1,7 +1,7 @@
-import { Permalink } from '@common/services/permalinkService';
 import {
   FilterOption,
   LocationOption,
+  TableDataResponse,
 } from '@common/services/tableBuilderService';
 import combineMeasuresWithDuplicateLocationCodes from '@common/services/util/combineMeasuresWithDuplicateLocationCodes';
 import groupBy from 'lodash/groupBy';
@@ -26,17 +26,17 @@ import uniq from 'lodash/uniq';
  * by Location id without returning other results for different Locations that share the
  * same geographic level and code.
  */
-function deduplicatePermalinkLocations(permalink: Permalink): Permalink {
-  const { fullTable: tableData } = permalink;
-
+function deduplicatePermalinkLocations(
+  tableData: TableDataResponse,
+): TableDataResponse {
   if (!tableData.subjectMeta || tableData.results.length === 0) {
-    return permalink;
+    return tableData;
   }
 
   // Absence of the 'location' field in the first result tells that this isn't a
   // a historical Permalink which needs deduplication.
   if (!tableData.results[0].location) {
-    return permalink;
+    return tableData;
   }
 
   const { subjectMeta } = tableData;
@@ -93,15 +93,12 @@ function deduplicatePermalinkLocations(permalink: Permalink): Permalink {
   );
 
   return {
-    ...permalink,
-    fullTable: {
-      ...tableData,
-      subjectMeta: {
-        ...subjectMeta,
-        locations: mergedLocations,
-      },
-      results: mergedResults,
+    ...tableData,
+    subjectMeta: {
+      ...subjectMeta,
+      locations: mergedLocations,
     },
+    results: mergedResults,
   };
 }
 

--- a/src/explore-education-statistics-frontend/src/modules/api/permalink/createPermalinkTable.ts
+++ b/src/explore-education-statistics-frontend/src/modules/api/permalink/createPermalinkTable.ts
@@ -9,6 +9,7 @@ import { ErrorBody } from '@frontend/modules/api/types/error';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { UnmappedTableHeadersConfig } from '@common/services/permalinkService';
 import { TableDataResponse } from '@common/services/tableBuilderService';
+import deduplicatePermalinkLocations from '@common/services/util/permalinkServiceUtils';
 
 interface SuccessBody {
   json: TableJson;
@@ -43,7 +44,13 @@ export default async function createPermalinkTable(
   }
 
   try {
-    const fullTable = mapFullTable(unmappedFullTable);
+    // TO DO - EES-4259
+    // For old permalinks with duplicate locations.
+    // Can be removed once the permalinks migration is done.
+    const dedupedUnmappedFullTable = deduplicatePermalinkLocations(
+      unmappedFullTable,
+    );
+    const fullTable = mapFullTable(dedupedUnmappedFullTable);
     const tableHeadersConfig = mapTableHeadersConfig(
       configuration.tableHeaders,
       fullTable,


### PR DESCRIPTION
Does two things:

1. Fixes the broken permalinks reported in EES-4320. This was caused by these permalinks having duplicate locations in `tableHeadersConfig` as well as `fullTable` - most of the old permalinks with duplicate locations don't have this problem so it's not accounted for in the deduplication code and presumably didn't cause an error with the old way of rendering the table.

2. Adds `deduplicatePermalinkLocations` to the `createPermalinkTable` endpoint as I realised this would need to be there for when old permalinks with duplicate locations are migrated.