### PR TITLE
EES-4236 Increase the body size limit of the FE CreatePermalinkTable endpoint

### DIFF
--- a/src/explore-education-statistics-frontend/src/pages/api/permalink.ts
+++ b/src/explore-education-statistics-frontend/src/pages/api/permalink.ts
@@ -4,7 +4,7 @@ import withMethods from '@frontend/middleware/withMethods';
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: '20mb',
+      sizeLimit: '75mb',
     },
   },
 };


### PR DESCRIPTION
This PR increases the body size limit of the frontend CreatePermalinkTable endpoint from 20mb to 75mb.

It doesn't follow that the request is the same size as the permalink json file size since the types get transformed from `LegacyPermalink` to `TableCreateRequest`.

Inspecting the size of the `TableCreateRequest` sent to the frontend service while migrating them we find that the largest one is currently `77963116 bytes`, just under the new limit set here.






















