### PR TITLE
EES-4340 add locations dedupe code to createPermalinkTable endpoint

### DIFF
--- a/src/explore-education-statistics-common/src/services/permalinkService.ts
+++ b/src/explore-education-statistics-common/src/services/permalinkService.ts
@@ -49,7 +49,11 @@ export default {
     return dataApi.post(`/permalink`, query);
   },
   async getPermalink(id: string): Promise<Permalink> {
-    return deduplicatePermalinkLocations(await dataApi.get(`/permalink/${id}`));
+    const permalink: Permalink = await dataApi.get(`/permalink/${id}`);
+    return {
+      ...permalink,
+      fullTable: deduplicatePermalinkLocations(permalink.fullTable),
+    };
   },
   async getPermalinkCsv(id: string): Promise<Blob> {
     return dataApi.get(`/permalink/${id}`, {

--- a/src/explore-education-statistics-common/src/services/util/permalinkServiceUtils.ts
+++ b/src/explore-education-statistics-common/src/services/util/permalinkServiceUtils.ts
@@ -1,7 +1,7 @@
-import { Permalink } from '@common/services/permalinkService';
 import {
   FilterOption,
   LocationOption,
+  TableDataResponse,
 } from '@common/services/tableBuilderService';
 import combineMeasuresWithDuplicateLocationCodes from '@common/services/util/combineMeasuresWithDuplicateLocationCodes';
 import groupBy from 'lodash/groupBy';
@@ -26,17 +26,17 @@ import uniq from 'lodash/uniq';
  * by Location id without returning other results for different Locations that share the
  * same geographic level and code.
  */
-function deduplicatePermalinkLocations(permalink: Permalink): Permalink {
-  const { fullTable: tableData } = permalink;
-
+function deduplicatePermalinkLocations(
+  tableData: TableDataResponse,
+): TableDataResponse {
   if (!tableData.subjectMeta || tableData.results.length === 0) {
-    return permalink;
+    return tableData;
   }
 
   // Absence of the 'location' field in the first result tells that this isn't a
   // a historical Permalink which needs deduplication.
   if (!tableData.results[0].location) {
-    return permalink;
+    return tableData;
   }
 
   const { subjectMeta } = tableData;
@@ -93,15 +93,12 @@ function deduplicatePermalinkLocations(permalink: Permalink): Permalink {
   );
 
   return {
-    ...permalink,
-    fullTable: {
-      ...tableData,
-      subjectMeta: {
-        ...subjectMeta,
-        locations: mergedLocations,
-      },
-      results: mergedResults,
+    ...tableData,
+    subjectMeta: {
+      ...subjectMeta,
+      locations: mergedLocations,
     },
+    results: mergedResults,
   };
 }
 

--- a/src/explore-education-statistics-frontend/src/modules/api/permalink/createPermalinkTable.ts
+++ b/src/explore-education-statistics-frontend/src/modules/api/permalink/createPermalinkTable.ts
@@ -8,6 +8,7 @@ import logger from '@common/services/logger';
 import { ErrorBody } from '@frontend/modules/api/types/error';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { UnmappedTableHeadersConfig } from '@common/services/permalinkService';
+import deduplicatePermalinkLocations from '@common/services/util/permalinkServiceUtils';
 import { TableDataResponse } from '@common/services/tableBuilderService';
 
 interface SuccessBody {
@@ -43,7 +44,13 @@ export default async function createPermalinkTable(
   }
 
   try {
-    const fullTable = mapFullTable(unmappedFullTable);
+    // TO DO - EES-4259
+    // For old permalinks with duplicate locations.
+    // Can be removed once the permalinks migration is done.
+    const dedupedUnmappedFullTable = deduplicatePermalinkLocations(
+      unmappedFullTable,
+    );
+    const fullTable = mapFullTable(dedupedUnmappedFullTable);
     const tableHeadersConfig = mapTableHeadersConfig(
       configuration.tableHeaders,
       fullTable,


### PR DESCRIPTION
When the create permalink table api endpoint was added we didn’t include the code to deduplicate locations for old permalinks. This adds it so the old permalinks with duplicate locations will display correctly.