### PR TITLE
EES-4169 Update help and support page

### DIFF
--- a/src/explore-education-statistics-frontend/src/pages/help-support.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/help-support.tsx
@@ -35,11 +35,11 @@ function HelpSupportPage() {
           </section>
           <section className="govuk-section-break--xl">
             <h2 className="govuk-heading-m">Find statistics and data</h2>
-            The service contains all of DfE's published official
-            statistics.
+            The service contains all of DfE's published official statistics.
             <p>
               To find specific sets of statistics currently published via the
-              service, browse our <a href="/find-statistics">Find statistics and data</a> section.
+              service, browse our{' '}
+              <a href="/find-statistics">Find statistics and data</a> section.
             </p>
             <p>
               To find out about the methodology behind the specific statistics
@@ -60,10 +60,8 @@ function HelpSupportPage() {
             </h2>
             <p>
               To create your own tables and explore the data we have available
-              via the service use the table tool
-              available in our{' '}
-              <a href="/data-tables">Create your own tables</a>{' '}
-              section.
+              via the service use the table tool available in our{' '}
+              <a href="/data-tables">Create your own tables</a> section.
             </p>
             <p>
               You can use our table tool to choose the data and area of
@@ -72,12 +70,12 @@ function HelpSupportPage() {
             </p>
             <p>
               Once you've created your table, you can download the data it
-              contains for your own offline analysis, or share a permanement 
+              contains for your own offline analysis, or share a permanement
               webpage of the created table.
             </p>
             <p>
-              You can also download full data files of those statistics currently
-              published via the service through our{' '}
+              You can also download full data files of those statistics
+              currently published via the service through our{' '}
               <a href="/data-catalogue">Data catalogue</a>.
             </p>
             <p>
@@ -94,8 +92,7 @@ function HelpSupportPage() {
             <p>
               Sign up by selecting the 'Sign up for email alerts' link found at
               the top of the pages found under{' '}
-              <a href="/find-statistics">Find statistics and data</a>
-              .
+              <a href="/find-statistics">Find statistics and data</a>.
             </p>
             <p>
               You'll then be sent an email alert with a link to the latest

--- a/src/explore-education-statistics-frontend/src/pages/help-support.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/help-support.tsx
@@ -21,12 +21,6 @@ function HelpSupportPage() {
               the range of education-related statistics and data it provides.
             </p>
             <p>
-              We will be adding and publishing more of the official statistics
-              and data DfE collects on schools, further and higher education and
-              children and young people to the service as and when they are
-              officially released by DfE.
-            </p>
-            <p>
               All the statistics and data published this service are produced in
               line with the UK Statistical Authority's{' '}
               <a href="https://www.statisticsauthority.gov.uk/code-of-practice/">
@@ -41,34 +35,11 @@ function HelpSupportPage() {
           </section>
           <section className="govuk-section-break--xl">
             <h2 className="govuk-heading-m">Find statistics and data</h2>
-            The service does not currently contain all of DfE's official
-            statistics and data and more will be added as and when they are
-            officially released by DfE.
+            The service contains all of DfE's published official
+            statistics.
             <p>
               To find specific sets of statistics currently published via the
-              service and links to those which can still be found on the{' '}
-              <a href="https://www.gov.uk/government/organisations/department-for-education/about/statistics">
-                Statistics at DfE
-              </a>{' '}
-              pages GOV.UK browse our{' '}
-              <a href="/find-statistics">Find statistics and data</a> section.
-            </p>
-            <p>
-              You can also download data files of those statistics currently
-              published via the service through our{' '}
-              <a href="/data-catalogue">Data catalogue</a> section.
-            </p>
-            <p>
-              These files are currently only available in csv format but other
-              formats will be made available in the future.
-            </p>
-            <p>
-              However, to download data files of those statistics not yet
-              currently available through the service you'll need to visit the{' '}
-              <a href="https://www.gov.uk/government/organisations/department-for-education/about/statistics">
-                Statistics at DfE
-              </a>{' '}
-              pages GOV.UK.
+              service, browse our <a href="/find-statistics">Find statistics and data</a> section.
             </p>
             <p>
               To find out about the methodology behind the specific statistics
@@ -88,9 +59,10 @@ function HelpSupportPage() {
               Creating and downloading data tables
             </h2>
             <p>
-              To create your own tables and explore the national and regional
-              data we have available via the service use the table tool
-              available in our <a href="/data-tables">Create your own tables</a>{' '}
+              To create your own tables and explore the data we have available
+              via the service use the table tool
+              available in our{' '}
+              <a href="/data-tables">Create your own tables</a>{' '}
               section.
             </p>
             <p>
@@ -100,19 +72,30 @@ function HelpSupportPage() {
             </p>
             <p>
               Once you've created your table, you can download the data it
-              contains for your own offline analysis.
+              contains for your own offline analysis, or share a permanement 
+              webpage of the created table.
+            </p>
+            <p>
+              You can also download full data files of those statistics currently
+              published via the service through our{' '}
+              <a href="/data-catalogue">Data catalogue</a>.
+            </p>
+            <p>
+              These files are currently only available in CSV format but other
+              formats will be made available in the future.
             </p>
           </section>
           <section className="govuk-section-break--xl">
             <h2 className="govuk-heading-m">Sign up for email alerts</h2>
             <p>
               You can sign up to receive emails when new statistics and data are
-              released and published through our service.
+              published through our service.
             </p>
             <p>
               Sign up by selecting the 'Sign up for email alerts' link found at
               the top of the pages found under{' '}
               <a href="/find-statistics">Find statistics and data</a>
+              .
             </p>
             <p>
               You'll then be sent an email alert with a link to the latest

--- a/src/explore-education-statistics-frontend/src/pages/help-support.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/help-support.tsx
@@ -70,7 +70,7 @@ function HelpSupportPage() {
             </p>
             <p>
               Once you've created your table, you can download the data it
-              contains for your own offline analysis, or share a permanement
+              contains for your own offline analysis, or share a permanent
               webpage of the created table.
             </p>
             <p>


### PR DESCRIPTION
This change is a review and update of the help and support page. It was last refreshed early in the project so still had references to GOV.UK and us not having all of the publications on the service. I've updated the text for this page.

I've not got npm installed, so haven't run the npm ci commands or edited tests as suggested in the PR template, and it's also worth double checking formatting around the text that's been added.
