### PR TITLE
EES-4345 Increase `maxAllowedContentLength` of public frontend service

### DIFF
--- a/src/explore-education-statistics-frontend/web.config
+++ b/src/explore-education-statistics-frontend/web.config
@@ -77,6 +77,7 @@
           <remove segment="bin"/>
         </hiddenSegments>
       </requestFiltering>
+      <requestLimits maxAllowedContentLength="78643200" />
     </security>
 
     <!-- Make sure error responses are left untouched -->


### PR DESCRIPTION
This PR changes the value of `maxAllowedContentLength` from the default value of `30000000`  to `78643200` bytes for creating permalink snapshots. That's an increase from 28.6mb to 75mb.

See [Request Limits](https://learn.microsoft.com/en-us/iis/configuration/system.webServer/security/requestFiltering/requestLimits/#configuration).

This is being done to allow creating permalink snapshots with a frontend request body content length above the current max limit of 28.6mb.

This follows a change already made by https://github.com/dfe-analytical-services/explore-education-statistics/pull/4086 which has been effective when running locally but not effective in Azure environments where we use iisnode to host the node.js application in IIS.