### PR TITLE
🐛 EES-4345 Fix position of `requestLimits` element.

### DIFF
--- a/src/explore-education-statistics-frontend/web.config
+++ b/src/explore-education-statistics-frontend/web.config
@@ -70,14 +70,14 @@
       </rules>
     </rewrite>
 
-    <!-- 'bin' directory has no special meaning in node.js and apps can be placed in it -->
     <security>
       <requestFiltering removeServerHeader="True">
+        <!-- 'bin' directory has no special meaning in node.js and apps can be placed in it -->
         <hiddenSegments>
           <remove segment="bin"/>
         </hiddenSegments>
+        <requestLimits maxAllowedContentLength="78643200" />
       </requestFiltering>
-      <requestLimits maxAllowedContentLength="78643200" />
     </security>
 
     <!-- Make sure error responses are left untouched -->


### PR DESCRIPTION
This PR fixes the position of the `requestLimits` element following on from https://github.com/dfe-analytical-services/explore-education-statistics/pull/4097.

See [Request Limits](https://learn.microsoft.com/en-us/iis/configuration/system.webServer/security/requestFiltering/requestLimits/#configuration).