### PR TITLE
EES-4273 Remove DataBlock_Highlight* columns from ContentBlock table

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
@@ -289,6 +289,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Name = "Test highlight name 1",
                 Description = "Test highlight description 1",
                 DataBlock = dataBlock1,
+                Release = release,
             };
 
             var dataBlock2 = new DataBlock
@@ -330,6 +331,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Name = "Test highlight name 2",
                 Description = "Test highlight description 2",
                 DataBlock = dataBlock2,
+                Release = release,
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -364,8 +366,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataBlock1.Heading, listResult[0].Heading);
                 Assert.Equal(dataBlock1.Name, listResult[0].Name);
                 Assert.Equal(dataBlock1.Created, listResult[0].Created);
-                Assert.Equal(dataBlock1.HighlightName, listResult[0].HighlightName);
-                Assert.Equal(dataBlock1.HighlightDescription, listResult[0].HighlightDescription);
+                Assert.Equal(featuredTable1.Name, listResult[0].HighlightName);
+                Assert.Equal(featuredTable1.Description, listResult[0].HighlightDescription);
                 Assert.Equal(dataBlock1.Source, listResult[0].Source);
                 Assert.Equal(1, listResult[0].ChartsCount);
                 Assert.True(listResult[0].InContent);
@@ -373,8 +375,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataBlock2.Heading, listResult[1].Heading);
                 Assert.Equal(dataBlock2.Name, listResult[1].Name);
                 Assert.Equal(dataBlock2.Created, listResult[1].Created);
-                Assert.Equal(dataBlock2.HighlightName, listResult[1].HighlightName);
-                Assert.Equal(dataBlock2.HighlightDescription, listResult[1].HighlightDescription);
+                Assert.Equal(featuredTable2.Name, listResult[1].HighlightName);
+                Assert.Equal(featuredTable2.Description, listResult[1].HighlightDescription);
                 Assert.Equal(dataBlock2.Source, listResult[1].Source);
                 Assert.Equal(0, listResult[1].ChartsCount);
                 Assert.False(listResult[1].InContent);
@@ -479,6 +481,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Name = "Test highlight name 1",
                 Description = "Test highlight description 1",
                 DataBlock = dataBlock1,
+                Release = release,
             };
 
             var dataBlock2 = new DataBlock
@@ -516,8 +519,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataBlock1.Heading, viewModel.Heading);
                 Assert.Equal(dataBlock1.Name, viewModel.Name);
                 Assert.Equal(dataBlock1.Created, viewModel.Created);
-                Assert.Equal(dataBlock1.HighlightName, viewModel.HighlightName);
-                Assert.Equal(dataBlock1.HighlightDescription, viewModel.HighlightDescription);
+                Assert.Equal(featuredTable1.Name, viewModel.HighlightName);
+                Assert.Equal(featuredTable1.Description, viewModel.HighlightDescription);
                 Assert.Equal(dataBlock1.Source, viewModel.Source);
                 Assert.Equal(1, viewModel.ChartsCount);
                 Assert.True(viewModel.InContent);
@@ -1125,8 +1128,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Heading = "Old heading",
                 Name = "Old name",
-                HighlightName = "Old highlight name",
-                HighlightDescription = "Old highlight description",
                 Source = "Old source",
                 Order = 5,
                 Query = new ObservationQueryContext

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230616082222_EES4273_RemoveUnusedHighlightColumnsInContentBlocksTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230616082222_EES4273_RemoveUnusedHighlightColumnsInContentBlocksTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230616082222_EES4273_RemoveUnusedHighlightColumnsInContentBlocksTable")]
+    partial class EES4273_RemoveUnusedHighlightColumnsInContentBlocksTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230616082222_EES4273_RemoveUnusedHighlightColumnsInContentBlocksTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230616082222_EES4273_RemoveUnusedHighlightColumnsInContentBlocksTable.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES4273_RemoveUnusedHighlightColumnsInContentBlocksTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataBlock_HighlightDescription",
+                table: "ContentBlock");
+
+            migrationBuilder.DropColumn(
+                name: "DataBlock_HighlightName",
+                table: "ContentBlock");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DataBlock_HighlightDescription",
+                table: "ContentBlock",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DataBlock_HighlightName",
+                table: "ContentBlock",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -120,10 +120,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(CheckIsDataBlock)
                 .OnSuccess(async dataBlock =>
                 {
-                    // Remove as part of EES-4273 - we fetch these from the FeaturedTables table now
-                    dataBlock.HighlightName = null;
-                    dataBlock.HighlightDescription = null;
-
                     var viewModel = _mapper.Map<DataBlockViewModel>(dataBlock);
 
                     var featuredTable = await _context.FeaturedTables.SingleOrDefaultAsync(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
@@ -123,12 +123,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string Name { get; set; }
 
-        // TODO EES-4273 Remove
-        public string? HighlightName { get; set; }
-
-        // TODO EES-4273 Remove
-        public string? HighlightDescription { get; set; }
-
         public string Source { get; set; }
 
         public ObservationQueryContext Query { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -388,16 +388,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .Property(block => block.Heading)
                 .HasColumnName("DataBlock_Heading");
 
-            // TODO EES-4273 Remove
-            modelBuilder.Entity<DataBlock>()
-                .Property(block => block.HighlightName)
-                .HasColumnName("DataBlock_HighlightName");
-
-            // TODO EES-4273 Remove
-            modelBuilder.Entity<DataBlock>()
-                .Property(block => block.HighlightDescription)
-                .HasColumnName("DataBlock_HighlightDescription");
-
             modelBuilder.Entity<DataBlock>()
                 .Property(block => block.Query)
                 .HasColumnName("DataBlock_Query")


### PR DESCRIPTION
This PR removes `DataBlock_HighlightName` and `DataBlock_HighlightDescription` columns from the `ContentBlock` table. These were previously used to store a featured table's name and description. Now featured table information is stored in the `FeaturedTables` table.