### PR TITLE
EES-4090 reorder featured tables

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/FeaturedTableController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/FeaturedTableController.cs
@@ -72,7 +72,7 @@ public class FeaturedTableController : ControllerBase
             .HandleFailuresOrNoContent();
     }
 
-    [HttpPut("releases/{releaesId:guid}/featured-tables/order")]
+    [HttpPut("releases/{releaseId:guid}/featured-tables/order")]
     public async Task<ActionResult<List<FeaturedTableViewModel>>> Reorder(
         Guid releaseId,
         List<Guid> newOrder)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -106,7 +106,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                     Name: "name",
                     Description: "description",
                     SubjectId: Guid.NewGuid(),
-                    DataBlockId: Guid.NewGuid()
+                    DataBlockId: Guid.NewGuid(),
+                    Order: 0
                 ),
             };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
@@ -176,7 +176,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
             return featuredTables
                 .Select(ft => new FeaturedTableViewModel(
-                    ft.Id, ft.Name, ft.Description, ft.DataBlock.Query.SubjectId, ft.DataBlockId))
+                    ft.Id, ft.Name, ft.Description, ft.DataBlock.Query.SubjectId, ft.DataBlockId, ft.Order))
                 .ToList();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/FeaturedTableViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/FeaturedTableViewModel.cs
@@ -8,4 +8,5 @@ public record FeaturedTableViewModel(
     string Name,
     string? Description,
     Guid SubjectId,
-    Guid DataBlockId);
+    Guid DataBlockId,
+    int Order);

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/FeaturedTablesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/FeaturedTablesTable.tsx
@@ -1,0 +1,201 @@
+import Link from '@admin/components/Link';
+import DroppableArea from '@admin/components/DroppableArea';
+import DraggableItem, { DragHandle } from '@admin/components/DraggableItem';
+import { FeaturedTable } from '@admin/services/featuredTableService';
+import { ReleaseDataBlockSummary } from '@admin/services/dataBlockService';
+import {
+  releaseDataBlockEditRoute,
+  ReleaseDataBlockRouteParams,
+} from '@admin/routes/releaseRoutes';
+import Button from '@common/components/Button';
+import ButtonText from '@common/components/ButtonText';
+import FormattedDate from '@common/components/FormattedDate';
+import reorder from '@common/utils/reorder';
+import useToggle from '@common/hooks/useToggle';
+import React, { useEffect, useState } from 'react';
+import { generatePath } from 'react-router';
+import orderBy from 'lodash/orderBy';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+
+interface Props {
+  canUpdateRelease: boolean;
+  dataBlocks: ReleaseDataBlockSummary[];
+  featuredTables: FeaturedTable[];
+  publicationId: string;
+  releaseId: string;
+  onDelete: (dataBlock: ReleaseDataBlockSummary) => void;
+  onSaveOrder: (reorderedTables: FeaturedTable[]) => Promise<void>;
+}
+
+export default function FeaturedTablesTable({
+  canUpdateRelease,
+  dataBlocks,
+  featuredTables,
+  publicationId,
+  releaseId,
+  onDelete,
+  onSaveOrder,
+}: Props) {
+  const [isReordering, toggleIsReordering] = useToggle(false);
+  const [currentFeaturedTables, setCurrentFeaturedTables] = useState(
+    featuredTables,
+  );
+
+  useEffect(() => {
+    setCurrentFeaturedTables(featuredTables);
+  }, [featuredTables]);
+
+  return (
+    <>
+      <div className="dfe-flex dfe-justify-content--space-between">
+        <h3>Featured tables</h3>
+        {canUpdateRelease && currentFeaturedTables.length > 1 && (
+          <Button
+            className="govuk-!-margin-bottom-4"
+            variant="secondary"
+            onClick={async () => {
+              if (isReordering) {
+                await onSaveOrder(currentFeaturedTables);
+              }
+              toggleIsReordering();
+            }}
+          >
+            {isReordering ? 'Save order' : 'Reorder featured tables'}
+          </Button>
+        )}
+      </div>
+
+      <DragDropContext
+        onDragEnd={result => {
+          if (!result.destination) {
+            return;
+          }
+          const reordered = reorder(
+            currentFeaturedTables,
+            result.source.index,
+            result.destination.index,
+          ).map((table, index) => ({
+            ...table,
+            order: index,
+          }));
+          setCurrentFeaturedTables(reordered);
+        }}
+      >
+        <Droppable droppableId="footnotes" isDropDisabled={!isReordering}>
+          {(droppableProvided, droppableSnapshot) => (
+            <table data-testid="featuredTables">
+              <thead>
+                <tr>
+                  <th scope="col" className="govuk-!-width-one-quarter">
+                    Data block name
+                  </th>
+                  <th scope="col">Has chart</th>
+                  <th scope="col">In content</th>
+                  <th scope="col">Featured table name</th>
+                  <th scope="col">Created date</th>
+                  <th scope="col" className="govuk-table__header--actions">
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <DroppableArea
+                droppableProvided={droppableProvided}
+                droppableSnapshot={droppableSnapshot}
+                tag="tbody"
+              >
+                {orderBy(currentFeaturedTables, 'order').map(
+                  (featuredTable, index) => {
+                    const dataBlock = dataBlocks.find(
+                      block => block.id === featuredTable.dataBlockId,
+                    );
+                    return dataBlock ? (
+                      <DraggableItem
+                        hideDragHandle
+                        id={featuredTable.id}
+                        index={index}
+                        isReordering={isReordering}
+                        key={featuredTable.id}
+                        tag="tr"
+                      >
+                        <FeaturedTablesRow
+                          canUpdateRelease={canUpdateRelease}
+                          dataBlock={dataBlock}
+                          featuredTable={featuredTable}
+                          isReordering={isReordering}
+                          link={generatePath<ReleaseDataBlockRouteParams>(
+                            releaseDataBlockEditRoute.path,
+                            {
+                              publicationId,
+                              releaseId,
+                              dataBlockId: featuredTable.dataBlockId,
+                            },
+                          )}
+                          onDelete={onDelete}
+                        />
+                      </DraggableItem>
+                    ) : null;
+                  },
+                )}
+              </DroppableArea>
+            </table>
+          )}
+        </Droppable>
+      </DragDropContext>
+    </>
+  );
+}
+
+interface FeaturedTablesRowProps {
+  canUpdateRelease: boolean;
+  dataBlock: ReleaseDataBlockSummary;
+  featuredTable: FeaturedTable;
+  isReordering: boolean;
+  link: string;
+  onDelete: (dataBlock: ReleaseDataBlockSummary) => void;
+}
+
+function FeaturedTablesRow({
+  canUpdateRelease,
+  dataBlock,
+  featuredTable,
+  isReordering,
+  link,
+  onDelete,
+}: FeaturedTablesRowProps) {
+  return (
+    <>
+      <td>{dataBlock.name}</td>
+      <td>{dataBlock.chartsCount > 0 ? 'Yes' : 'No'}</td>
+      <td>{dataBlock.inContent ? 'Yes' : 'No'}</td>
+      <td>{featuredTable.name}</td>
+      <td>
+        {dataBlock.created ? (
+          <FormattedDate format="d MMMM yyyy HH:mm">
+            {dataBlock.created}
+          </FormattedDate>
+        ) : (
+          'Not available'
+        )}
+      </td>
+      <td className="govuk-table__cell--actions govuk-!-width-one-quarter">
+        {!isReordering ? (
+          <>
+            <Link className="govuk-!-margin-bottom-0" unvisited to={link}>
+              {canUpdateRelease ? 'Edit block' : 'View block'}
+            </Link>
+            {canUpdateRelease && (
+              <ButtonText
+                className="govuk-!-margin-bottom-0"
+                onClick={() => onDelete(dataBlock)}
+              >
+                Delete block
+              </ButtonText>
+            )}
+          </>
+        ) : (
+          <DragHandle className="govuk-!-margin-right-2" />
+        )}
+      </td>
+    </>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -200,6 +200,7 @@ describe('PreReleaseTableToolPage', () => {
       name: 'Test highlight',
       description: 'Test highlight description',
       subjectId: 'subject-1',
+      order: 0,
     },
   ];
   const testSubjects: Subject[] = [

--- a/src/explore-education-statistics-admin/src/queries/dataBlockQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/dataBlockQueries.ts
@@ -1,0 +1,13 @@
+import dataBlockService from '@admin/services/dataBlockService';
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+const dataBlockQueries = createQueryKeys('dataBlocks', {
+  list(releaseId: string) {
+    return {
+      queryKey: [releaseId],
+      queryFn: () => dataBlockService.listDataBlocks(releaseId),
+    };
+  },
+});
+
+export default dataBlockQueries;

--- a/src/explore-education-statistics-admin/src/queries/featuredTableQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/featuredTableQueries.ts
@@ -1,0 +1,13 @@
+import featuredTableService from '@admin/services/featuredTableService';
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+const featuredTableQueries = createQueryKeys('featuredTable', {
+  list(releaseId: string) {
+    return {
+      queryKey: [releaseId],
+      queryFn: () => featuredTableService.listFeaturedTables(releaseId),
+    };
+  },
+});
+
+export default featuredTableQueries;

--- a/src/explore-education-statistics-admin/src/queries/permissionQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/permissionQueries.ts
@@ -1,0 +1,13 @@
+import permissionService from '@admin/services/permissionService';
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+const permissionQueries = createQueryKeys('releaseDataBlocks', {
+  canUpdateRelease(releaseId: string) {
+    return {
+      queryKey: [releaseId],
+      queryFn: () => permissionService.canUpdateRelease(releaseId),
+    };
+  },
+});
+
+export default permissionQueries;

--- a/src/explore-education-statistics-admin/src/services/dataBlockService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataBlockService.ts
@@ -1,10 +1,7 @@
 import client from '@admin/services/utils/service';
 import { DataBlock } from '@common/services/types/blocks';
 import { OmitStrict } from '@common/types';
-import {
-  FeaturedTableBasic,
-  FeaturedTableCreateRequest,
-} from '@admin/services/featuredTableService';
+import { FeaturedTableBasic } from '@admin/services/featuredTableService';
 
 export type ReleaseDataBlock = OmitStrict<DataBlock, 'order' | 'type'>;
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DataSetStep.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DataSetStep.tsx
@@ -13,8 +13,9 @@ import Yup from '@common/validation/yup';
 import Details from '@common/components/Details';
 import DataSetDetailsList from '@common/modules/table-tool/components/DataSetDetailsList';
 import WizardStepFormActions from '@common/modules/table-tool/components/WizardStepFormActions';
-import React, { ReactNode } from 'react';
 import LoadingSpinner from '@common/components/LoadingSpinner';
+import React, { ReactNode } from 'react';
+import orderBy from 'lodash/orderBy';
 
 const formId = 'publicationDataStepForm';
 
@@ -160,7 +161,7 @@ export default function DataSetStep({
                     <div className="govuk-grid-column-two-thirds govuk-grid-column-three-quarters-from-desktop">
                       <DataSetStepContent
                         {...stepProps}
-                        featuredTables={featuredTables}
+                        featuredTables={orderBy(featuredTables, 'order')}
                         isSubmitting={formState.isSubmitting}
                         release={release}
                         renderFeaturedTableLink={renderFeaturedTableLink}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DataSetStep.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DataSetStep.test.tsx
@@ -62,6 +62,7 @@ describe('DataSetStep', () => {
       description: 'Test featured description 1',
       subjectId: 'subject-1',
       dataBlockId: 'dataBlock-1',
+      order: 0,
     },
     {
       id: 'featured-2',
@@ -69,6 +70,7 @@ describe('DataSetStep', () => {
       description: 'Test featured description 2 find me',
       subjectId: 'subject-1',
       dataBlockId: 'dataBlock-2',
+      order: 1,
     },
     {
       id: 'featured-3',
@@ -76,6 +78,7 @@ describe('DataSetStep', () => {
       description: 'Test featured description 3',
       subjectId: 'subject-3',
       dataBlockId: 'dataBlock-3',
+      order: 3,
     },
   ];
 

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -94,6 +94,7 @@ export interface FeaturedTable {
   description?: string;
   subjectId: string;
   dataBlockId: string;
+  order: number;
 }
 
 export interface SubjectMeta {

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -98,7 +98,7 @@ Create table
     [Documentation]    EES-615
     user clicks element    id:filtersForm-submit
     user waits until results table appears    %{WAIT_LONG}
-    user waits until element contains    css:[data-testid="dataTableCaption"]
+    user waits until element contains    testid:dataTableCaption
     ...    Admission Numbers for 'UI test subject' in Barnsley, Birmingham, Camden, Greenwich, Nailsea Youngwood and 1 other location between 2005 and 2018
 
 Validate table rows
@@ -183,14 +183,9 @@ Validate table rows
     user checks table cell in offset row contains    ${row}    4    1    5,669
 
 Save data block
-    user enters text into element    id:dataBlockDetailsForm-name    ${DATABLOCK_NAME}
-    user enters text into element    id:dataBlockDetailsForm-heading    UI test table title
-    user enters text into element    id:dataBlockDetailsForm-source    UI test source
-
-    user clicks checkbox    Set as a featured table for this publication
-    user waits until page contains element    id:dataBlockDetailsForm-highlightName
-    user enters text into element    id:dataBlockDetailsForm-highlightName    UI test featured table name
-    user enters text into element    id:dataBlockDetailsForm-highlightDescription    UI test featured table description
+    user enters text into element    label:Name    ${DATABLOCK_NAME}
+    user enters text into element    label:Table title    UI test table title
+    user enters text into element    label:Source    UI test source
 
     user clicks button    Save data block
     user waits until page contains    Delete this data block
@@ -200,17 +195,81 @@ Validate data block is in list
     user waits until h2 is visible    Data blocks
 
     user waits until table is visible
-    user checks table column heading contains    1    1    Name
-    user checks table column heading contains    1    2    Has chart
-    user checks table column heading contains    1    3    In content
-    user checks table column heading contains    1    4    Featured table name
-    user checks table column heading contains    1    5    Created date
-    user checks table column heading contains    1    6    Actions
+    user checks table column heading contains    1    1    Name    testid:dataBlocks
+    user checks table column heading contains    1    2    Has chart    testid:dataBlocks
+    user checks table column heading contains    1    3    In content    testid:dataBlocks
+    user checks table column heading contains    1    4    Created date    testid:dataBlocks
+    user checks table column heading contains    1    5    Actions    testid:dataBlocks
 
-    user checks table body has x rows    1
-    user checks table cell contains    1    1    ${DATABLOCK_NAME}
-    user checks table cell contains    1    3    No
-    user checks table cell contains    1    4    UI test featured table name
+    user checks table body has x rows    1    testid:dataBlocks
+    user checks table cell contains    1    1    ${DATABLOCK_NAME}    testid:dataBlocks
+    user checks table cell contains    1    3    No    testid:dataBlocks
+
+Start creating a featured table
+    user clicks link    Create data block
+    user waits until table tool wizard step is available    1    Select a data set
+
+Select subject "UI test subject"
+    user waits until page contains    UI test subject    %{WAIT_SMALL}
+    user clicks radio    UI test subject
+    user clicks element    id:publicationDataStepForm-submit
+    user waits until table tool wizard step is available    2    Choose locations    %{WAIT_MEDIUM}
+    user checks previous table tool step contains    1    Data set    UI test subject
+
+Select locations
+    user opens details dropdown    Opportunity area
+    user clicks checkbox    Bolton 001
+
+    user clicks element    id:locationFiltersForm-submit
+    user waits until table tool wizard step is available    3    Choose time period    90
+
+Select time period
+    user waits until page contains element    id:timePeriodForm-start
+    user chooses select option    id:timePeriodForm-start    2009
+    user chooses select option    id:timePeriodForm-end    2017
+    user clicks element    id:timePeriodForm-submit
+    user waits until table tool wizard step is available    4    Choose your filters
+    user checks previous table tool step contains    3    Time period    2009 to 2017    %{WAIT_MEDIUM}
+
+Select indicators
+    user checks indicator checkbox is checked    Admission Numbers
+
+Create table
+    [Documentation]    EES-615
+    user clicks element    id:filtersForm-submit
+    user waits until results table appears    %{WAIT_LONG}
+    user waits until element contains    testid:dataTableCaption
+    ...    Admission Numbers for 'UI test subject' in Bolton 001 between 2009 and 2017
+
+Save data block
+    user enters text into element    label:Name    UI test featured table
+    user enters text into element    label:Table title    UI test featured table title
+    user enters text into element    label:Source    UI test featured table source
+
+    user clicks checkbox    Set as a featured table for this publication
+    user waits until page contains element    label:Featured table name
+    user enters text into element    label:Featured table name    UI test featured table name
+    user enters text into element    label:Featured table description    UI test featured table description
+
+    user clicks button    Save data block
+    user waits until page contains    Delete this data block
+
+Validate data block is in list
+    user clicks link    Back
+    user waits until h2 is visible    Data blocks
+
+    user waits until table is visible
+    user checks table column heading contains    1    1    Data block name    testid:featuredTables
+    user checks table column heading contains    1    2    Has chart    testid:featuredTables
+    user checks table column heading contains    1    3    In content    testid:featuredTables
+    user checks table column heading contains    1    4    Featured table name    testid:featuredTables
+    user checks table column heading contains    1    5    Created date    testid:featuredTables
+    user checks table column heading contains    1    6    Actions    testid:featuredTables
+
+    user checks table body has x rows    1    testid:featuredTables
+    user checks table cell contains    1    1    UI test featured table    testid:featuredTables
+    user checks table cell contains    1    3    No    testid:featuredTables
+    user checks table cell contains    1    4    UI test featured table name    testid:featuredTables
 
 Embed data block into release content
     user clicks link    Content
@@ -351,15 +410,15 @@ Validate marked as 'In content' on data block list
     user waits until h2 is visible    Data blocks
 
     user waits until table is visible
-    user checks table column heading contains    1    1    Name
-    user checks table column heading contains    1    3    In content
+    user checks table column heading contains    1    1    Name    testid:dataBlocks
+    user checks table column heading contains    1    3    In content    testid:dataBlocks
 
     user checks table body has x rows    1
-    user checks table cell contains    1    1    ${DATABLOCK_NAME}
-    user checks table cell contains    1    3    Yes
+    user checks table cell contains    1    1    ${DATABLOCK_NAME}    testid:dataBlocks
+    user checks table cell contains    1    3    Yes    testid:dataBlocks
 
 Navigate to Chart tab
-    user clicks link    Edit block
+    user clicks link    Edit block    testid:dataBlocks
 
     user waits until h2 is visible    Edit data block
     user waits until h2 is visible    ${DATABLOCK_NAME}
@@ -377,10 +436,10 @@ Navigate to Chart tab
 Configure basic line chart
     user clicks button    Line
     user clicks radio    Set an alternative title
-    user enters text into element    id:chartConfigurationForm-title    Test chart title
-    user enters text into element    id:chartConfigurationForm-alt    Test chart alt
-    user enters text into element    id:chartConfigurationForm-height    400
-    user enters text into element    id:chartConfigurationForm-width    900
+    user enters text into element    label:Enter chart title    Test chart title
+    user enters text into element    label:Alt text    Test chart alt
+    user enters text into element    label:Height (pixels)    400
+    user enters text into element    label:Width (pixels)    900
 
 Validate changing data sets
     user clicks link    Data sets
@@ -463,12 +522,12 @@ Save chart and validate marked as 'Has chart' in data blocks list
     user waits until h2 is visible    Data blocks
 
     user waits until table is visible
-    user checks table column heading contains    1    1    Name
-    user checks table column heading contains    1    2    Has chart
+    user checks table column heading contains    1    1    Name    testid:dataBlocks
+    user checks table column heading contains    1    2    Has chart    testid:dataBlocks
 
     user checks table body has x rows    1
-    user checks table cell contains    1    1    ${DATABLOCK_NAME}
-    user checks table cell contains    1    2    Yes
+    user checks table cell contains    1    1    ${DATABLOCK_NAME}    testid:dataBlocks
+    user checks table cell contains    1    2    Yes    testid:dataBlocks
 
 Validate line chart embeds correctly
     user clicks link    Content
@@ -902,9 +961,13 @@ Delete data block
     user clicks button    Delete this data block
     user waits until page does not contain loading spinner
     user clicks button    Confirm
+    user waits until page does not contain button    Confirm
 
-    user waits until h2 is visible    Data blocks
-    user waits until page contains    No data blocks have been created.
+Delete featured table
+    user clicks button    Delete block
+    user waits until page does not contain loading spinner
+    user clicks button    Confirm
+    user waits until page does not contain button    Confirm
 
 
 *** Keywords ***

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -360,17 +360,78 @@ Check created table has footnotes
     user checks list item contains    testid:footnotes    3    ${FOOTNOTE_ALL_FILTER}
 
 Save data block as a featured table
-    user enters text into element    id:dataBlockDetailsForm-name    UI Test data block name
-    user enters text into element    id:dataBlockDetailsForm-heading    UI Test table title
-    user enters text into element    id:dataBlockDetailsForm-source    UI Test source
+    user enters text into element    label:Name    UI Test data block name 1
+    user enters text into element    label:Table title    UI Test table title 1
+    user enters text into element    label:Source    UI Test source 1
 
     user clicks checkbox    Set as a featured table for this publication
-    user waits until page contains element    id:dataBlockDetailsForm-highlightName
-    user enters text into element    id:dataBlockDetailsForm-highlightName    Test highlight name
-    user enters text into element    id:dataBlockDetailsForm-highlightDescription    Test highlight description
+    user waits until page contains element    label:Featured table name
+    user enters text into element    label:Featured table name    Test highlight name 1
+    user enters text into element    label:Featured table description    Test highlight description 1
 
     user clicks button    Save data block
     user waits until page contains    Delete this data block
+
+Create another new data block
+    user clicks link    Create another data block
+    user waits until h2 is visible    Create data block
+    user waits until table tool wizard step is available    1    Select a data set
+
+Select subject "${SUBJECT_2_NAME}"
+    user waits until page contains    ${SUBJECT_2_NAME}
+    user clicks radio    ${SUBJECT_2_NAME}
+    user waits until button is enabled    Next step    %{WAIT_SMALL}
+    user clicks button    Next step
+
+Select locations
+    user waits until table tool wizard step is available    2    Choose locations
+    user opens details dropdown    Opportunity area
+    user clicks checkbox    Bolton 001
+    user waits until button is enabled    Next step    %{WAIT_SMALL}
+    user clicks button    Next step
+
+Select time period
+    user waits until table tool wizard step is available    3    Choose time period
+    user chooses select option    id:timePeriodForm-start    2009
+    user chooses select option    id:timePeriodForm-end    2017
+    user waits until button is enabled    Next step    %{WAIT_SMALL}
+    user clicks button    Next step
+
+Create table
+    user waits until button is enabled    Create table
+    user clicks button    Create table
+
+Save data block as a featured table
+    user enters text into element    label:Name    UI Test data block name 2
+    user enters text into element    label:Table title    UI Test table title 2
+    user enters text into element    label:Source    UI Test source 2
+
+    user clicks checkbox    Set as a featured table for this publication
+    user waits until page contains element    label:Featured table name
+    user enters text into element    label:Featured table name    Test highlight name 2
+    user enters text into element    label:Featured table description    Test highlight description 2
+
+    user clicks button    Save data block
+    user waits until page contains    Delete this data block
+
+Check data blocks are shown in the featured tables table
+    user clicks link    Data blocks
+    user waits until h2 is visible    Data blocks    %{WAIT_MEDIUM}
+
+    user checks table cell contains    1    1    UI Test data block name 1    testid:featuredTables
+    user checks table cell contains    2    1    UI Test data block name 2    testid:featuredTables
+
+Reorder featured tables
+    user clicks button    Reorder featured tables
+    user sets focus to element    css:tbody tr:first-child
+    user presses keys    ${SPACE}
+    user presses keys    ARROW_DOWN
+    user presses keys    ${SPACE}
+    user clicks button    Save order
+
+Check featured tables were reordered
+    user checks table cell contains    1    1    UI Test data block name 2    testid:featuredTables
+    user checks table cell contains    2    1    UI Test data block name 1    testid:featuredTables
 
 Edit footnote
     user clicks link    Footnotes
@@ -532,7 +593,7 @@ Validate table has footnotes
     user checks list has x items    testid:footnotes    3
     user checks list item contains    testid:footnotes    3    ${FOOTNOTE_ALL_FILTER}
 
-Select featured table from subjects step
+Validate featured tables are reordered
     user clicks element    testid:wizardStep-2-goToButton
     user waits until h2 is visible    Go back to previous step
     user clicks button    Confirm
@@ -542,12 +603,18 @@ Select featured table from subjects step
 
     user clicks radio    ${SUBJECT_2_NAME}
 
-    user checks element count is x    css:[data-testid="featuredTables"] li    1
-    user checks element should contain    css:[data-testid="featuredTables"] li:first-child a    Test highlight name
-    user checks element should contain    css:[data-testid="featuredTables"] li:first-child p
-    ...    Test highlight description
+    user checks element count is x    css:[data-testid="featuredTables"] li    2
 
-    user clicks link    Test highlight name
+    user checks element should contain    css:[data-testid="featuredTables"] li:first-child a    Test highlight name 2
+    user checks element should contain    css:[data-testid="featuredTables"] li:first-child p
+    ...    Test highlight description 2
+
+    user checks element should contain    css:[data-testid="featuredTables"] li:nth-child(2) a    Test highlight name 1
+    user checks element should contain    css:[data-testid="featuredTables"] li:nth-child(2) p
+    ...    Test highlight description 1
+
+Select featured table from subjects step
+    user clicks link    Test highlight name 1
     user waits until results table appears    %{WAIT_LONG}
     user waits until page contains element
     ...    xpath://*[@data-testid="dataTableCaption" and text()="Admission Numbers for '${SUBJECT_2_NAME}' for Not specified in Bolton 001, Bolton 004, Nailsea Youngwood and Syon between 2005 and 2017"]

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -293,7 +293,6 @@ Edit data block for amendment
     user checks table cell contains    1    1    ${DATABLOCK_NAME}
     user checks table cell contains    1    2    Yes
     user checks table cell contains    1    3    Yes
-    user checks table cell contains    1    4    None
 
     user clicks link    Edit block    css:tbody > tr:first-child
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -579,7 +579,6 @@ Edit data block for amendment
     user checks table cell contains    1    1    ${DATABLOCK_NAME}
     user checks table cell contains    1    2    Yes
     user checks table cell contains    1    3    Yes
-    user checks table cell contains    1    4    None
 
     user clicks link    Edit block    css:tbody > tr:first-child
 


### PR DESCRIPTION
Adds the ability to reorder featured tables:
- on the data blocks tab featured tables are split out into their own table and can be reordered
- the order is reflected in the data set step of the table tool

Also:
- I made a couple of backend tweaks to fix the endpoint and expose the order to the frontend
- I've replaced `useAsyncHandledRetry` with `react-query` in `ReleaseDataBlocksPage`

**Data blocks tab**
![reorderft1](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/70f32648-a0f2-496b-8dcf-4465a56b1fb3)

**Reordering**
![reorderft2](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/455b71d0-5f40-422e-9a04-88dad58cf898)

