### PR TITLE
EES-4324 preselect and show message when one time period

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -72,14 +72,19 @@ const TimePeriodForm = ({
   const formInitialValues = useMemo(() => {
     const { startYear, startCode, endYear, endCode } = initialValues;
 
-    const start = startYear && startCode ? `${startYear}_${startCode}` : '';
-    const end = endYear && endCode ? `${endYear}_${endCode}` : '';
+    const defaultTimePeriod =
+      options.length === 1 ? `${options[0].year}_${options[0].code}` : '';
+
+    const start =
+      startYear && startCode ? `${startYear}_${startCode}` : defaultTimePeriod;
+    const end =
+      endYear && endCode ? `${endYear}_${endCode}` : defaultTimePeriod;
 
     return {
       start,
       end,
     };
-  }, [initialValues]);
+  }, [initialValues, options]);
 
   const stepHeading = (
     <WizardStepHeading {...stepProps} fieldsetHeading>
@@ -157,7 +162,11 @@ const TimePeriodForm = ({
       {form => {
         return isActive ? (
           <Form id={formId} showSubmitError>
-            <FormFieldset id="timePeriod" legend={stepHeading}>
+            <FormFieldset
+              id="timePeriod"
+              hint={options.length === 1 && 'Only one time period available.'}
+              legend={stepHeading}
+            >
               <FormFieldSelect
                 name="start"
                 label="Start date"

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
@@ -60,9 +60,9 @@ Check glossary info icon appears on release preview
 
 Click glossary info icon and validate glossary entry
     user clicks button    Absence
-    user waits until h2 is visible    Absence
+    ${modal}=    user waits until modal is visible    Absence
     user checks page contains    When a pupil misses (or is absent from) at least 1 possible school session.
-    user clicks button    Close
+    user clicks button    Close    ${modal}
     user waits until page does not contain element    xpath://h2[text()="Absence"]
     user checks page does not contain    When a pupil misses (or is absent from) at least 1 possible school session.
 


### PR DESCRIPTION
When there's only one time period available in the table tool:
- show hint text informing the user
- pre-select the start and end date

Also: an unrelated UI test fix (caused by the new survey banner in the admin).

![timeperiod](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/658d182f-29d1-4a8c-a204-24f6381e1627)
