### PR TITLE
EES-4049 - add data file info to view datablock page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockViewModels.cs
@@ -21,6 +21,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public string Name { get; init; } = string.Empty;
 
+        public string? DataSetName { get; set; }
+        
+        public Guid DataSetId { get; set; }
+
         public string? HighlightName { get; set; }
 
         public string? HighlightDescription { get; set; }

--- a/src/explore-education-statistics-admin/src/components/Page.tsx
+++ b/src/explore-education-statistics-admin/src/components/Page.tsx
@@ -48,7 +48,11 @@ const Page = ({
       <PageHeader wide={wide} />
 
       {showBanner && !isAdminBannerSeen && (
-        <Banner wide={wide} onClose={() => setAdminBannerSeenCookie(true)}>
+        <Banner
+          wide={wide}
+          onClose={() => setAdminBannerSeenCookie(true)}
+          testId="admin-survey-banner"
+        >
           <p className="govuk-!-font-weight-bold">
             Pl-EES-e let us know what you think of EES admin!
           </p>

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testEditableRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testEditableRelease.ts
@@ -120,6 +120,8 @@ export const testEditableRelease: EditableRelease = {
         {
           heading: "'prma' from 'My Pub' in England for 2017/18",
           name: 'DataBlock 1',
+          dataSetId: 'dataSet-1',
+          dataSetName: 'My Pub',
           source: '',
           query: {
             subjectId: '36aa28ce-83ca-49b5-8c27-b34e77b062c9',
@@ -216,6 +218,8 @@ export const testEditableRelease: EditableRelease = {
         charts: [],
         table: emptyTable,
         type: 'DataBlock',
+        dataSetId: 'dataSet-1',
+        dataSetName: 'My Pub',
         id: 'a3197018-66b6-4ce5-97fa-da2355270c40',
         order: 0,
         comments: [],

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
@@ -29,6 +29,8 @@ const emptyTable: Table = {
 
 const basicDataBlock: DataBlock = {
   id: 'datablock-0',
+  dataSetId: 'dataSetId',
+  dataSetName: 'Test data set',
   order: 1,
   type: 'DataBlock',
   name: 'Test data block',
@@ -304,6 +306,8 @@ describe('ReleaseContentContext', () => {
         charts: [],
         table: emptyTable,
         type: 'DataBlock',
+        dataSetId: 'cpih01',
+        dataSetName: 'CPIH01',
         id: '69a9522d-501d-441a-9ee5-260ede5cd85c',
         order: 0,
         comments: [],

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
@@ -142,6 +142,11 @@ const ReleaseDataBlockEditPage = ({
                     url={`${config.PublicAppUrl}/data-tables/fast-track/${dataBlockId}`}
                   />
                 </SummaryListItem>
+                {dataBlock.dataSetName && (
+                  <SummaryListItem term="Data set name">
+                    {dataBlock.dataSetName}
+                  </SummaryListItem>
+                )}
               </SummaryList>
 
               {canUpdateRelease && (

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
@@ -19,6 +19,7 @@ import _tableBuilderService, {
 import { waitFor } from '@testing-library/dom';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import produce from 'immer';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { generatePath, Route } from 'react-router-dom';
@@ -40,6 +41,8 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
 describe('ReleaseDataBlockEditPage', () => {
   const testDataBlock: ReleaseDataBlock = {
     id: 'block-1',
+    dataSetId: 'data-set-1',
+    dataSetName: 'Test data set',
     name: 'Test name 1',
     heading: 'Test title 1',
     highlightName: 'Test highlight name 1',
@@ -225,6 +228,35 @@ describe('ReleaseDataBlockEditPage', () => {
 
     expect(options[0]).toHaveTextContent('Test name 2');
     expect(options[1]).toHaveTextContent('Test name 1');
+  });
+
+  test('renders with correct data block details with data set name', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Select a data block to edit'),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Data set name')).toBeInTheDocument();
+  });
+
+  test('renders with correct data block details without data set name', async () => {
+    dataBlockService.getDataBlock.mockResolvedValue(
+      produce(testDataBlock, draft => {
+        draft.dataSetName = undefined;
+      }),
+    );
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Select a data block to edit'),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Data set name')).not.toBeInTheDocument();
   });
 
   test('clicking `Delete this data block` button shows modal', async () => {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -274,6 +274,8 @@ const DataBlockPageTabs = ({
         ...details,
         query,
         charts,
+        dataSetId: dataBlock?.dataSetId ?? '',
+        dataSetName: dataBlock?.dataSetName ?? '',
         table: {
           tableHeaders: mapUnmappedTableHeaders(tableHeaders),
           indicators: [],

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
@@ -29,6 +29,8 @@ describe('DataBlockPageTabs', () => {
     name: 'Test data block',
     heading: 'Test title',
     id: 'block-1',
+    dataSetId: 'subject-1',
+    dataSetName: 'Test subject',
     source: 'Test source',
     highlightName: '',
     highlightDescription: '',

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -227,6 +227,8 @@ describe('PreReleaseTableToolPage', () => {
 
   const testDataBlock: ReleaseDataBlock = {
     id: 'block-1',
+    dataSetId: 'data-set-1',
+    dataSetName: 'Test data set',
     name: 'Test block',
     highlightName: 'Test highlight name',
     source: '',

--- a/src/explore-education-statistics-admin/src/services/dataBlockService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataBlockService.ts
@@ -1,10 +1,7 @@
 import client from '@admin/services/utils/service';
 import { DataBlock } from '@common/services/types/blocks';
 import { OmitStrict } from '@common/types';
-import {
-  FeaturedTableBasic,
-  FeaturedTableCreateRequest,
-} from '@admin/services/featuredTableService';
+import { FeaturedTableBasic } from '@admin/services/featuredTableService';
 
 export type ReleaseDataBlock = OmitStrict<DataBlock, 'order' | 'type'>;
 

--- a/src/explore-education-statistics-common/src/components/Banner.tsx
+++ b/src/explore-education-statistics-common/src/components/Banner.tsx
@@ -7,11 +7,17 @@ interface Props {
   children: ReactNode;
   wide?: boolean;
   onClose?: () => void;
+  testId?: string;
 }
 
-export default function Banner({ children, wide = false, onClose }: Props) {
+export default function Banner({
+  children,
+  wide = false,
+  onClose,
+  testId,
+}: Props) {
   return (
-    <div className={styles.container}>
+    <div className={styles.container} data-testid={testId}>
       <div
         className={classNames('govuk-width-container', {
           'dfe-width-container--wide': wide,

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/DataBlockTabs.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/DataBlockTabs.test.tsx
@@ -29,6 +29,8 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
 describe('DataBlockTabs', () => {
   const testDataBlock: DataBlock = {
     id: 'block-1',
+    dataSetName: 'Test data set',
+    dataSetId: 'test-data-set',
     type: 'DataBlock',
     heading: '',
     order: 0,
@@ -83,6 +85,8 @@ describe('DataBlockTabs', () => {
 
   const testDataBlockMap: DataBlock = {
     id: 'block-1',
+    dataSetId: 'test-data-set',
+    dataSetName: 'Test data set',
     type: 'DataBlock',
     heading: '',
     order: 0,

--- a/src/explore-education-statistics-common/src/services/types/blocks.ts
+++ b/src/explore-education-statistics-common/src/services/types/blocks.ts
@@ -65,6 +65,8 @@ export type ContentBlock = MarkdownBlock | HtmlBlock;
 export interface DataBlock extends BaseBlock {
   type: 'DataBlock';
   name: string;
+  dataSetName?: string;
+  dataSetId: string;
   highlightName?: string;
   highlightDescription?: string;
   heading: string;

--- a/src/explore-education-statistics-frontend/src/tsconfig.json
+++ b/src/explore-education-statistics-frontend/src/tsconfig.json
@@ -16,7 +16,7 @@
       "@frontend-test/*": [
         "../test/*"
       ]
-    }
+    },
   },
   "exclude": [
     "node_modules"

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
@@ -59,6 +59,8 @@ Check glossary info icon appears on release preview
     user waits until page contains button    Absence
 
 Click glossary info icon and validate glossary entry
+    user closes admin feedback banner if needed
+
     user clicks button    Absence
     user waits until h2 is visible    Absence
     user checks page contains    When a pupil misses (or is absent from) at least 1 possible school session.

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -235,7 +235,7 @@ Confirm data replacement
     user clicks button    Confirm data replacement
     user waits until h2 is visible    Data replacement complete
 
-Edit Ancillary file and replace data
+Edit ancillary file and replace data
     [Documentation]    EES-4315
     user clicks link    Data and files
     user clicks link    Ancillary file uploads
@@ -243,13 +243,16 @@ Edit Ancillary file and replace data
 
     user waits until page contains accordion section    Test ancillary file 1
     user opens accordion section    Test ancillary file 1    id:file-uploads
+
     ${section_1}=    user gets accordion section content element    Test ancillary file 1    id:file-uploads
     user clicks link    Edit file    ${section_1}
     user waits until h2 is visible    Edit ancillary file
     user enters text into element    label:Title    Replacement ancillary file
     user enters text into element    label:Summary    Replacement ancillary file summary updated
+
     user chooses file    label:Upload new file    ${FILES_DIR}test-file-2.txt
     user clicks button    Save file
+
     user waits until page contains accordion section    Replacement ancillary file
     user opens accordion section    Replacement ancillary file    id:file-uploads
 
@@ -299,6 +302,10 @@ Edit data block for amendment
 
     user waits until h2 is visible    ${DATABLOCK_NAME}
     user waits until h2 is visible    Data block details
+
+    user checks page contains element    //*[@data-testid="Data set name-key" and contains(text(), "Data set name")]
+    user checks page contains element
+    ...    //*[@data-testid="Data set name-value" and contains(text(), "Dates test subject")]
 
     user clicks element    testid:wizardStep-4-goToButton
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -200,11 +200,15 @@ User navigates to Data blocks page to edit block
     user waits until h2 is visible    Data blocks    %{WAIT_SMALL}
 
 Edit data block
-    #just updating the table title and source
     user waits until table is visible
+
     user clicks link    Edit block    css:tbody > tr:first-child
     user waits until h2 is visible    ${DATABLOCK_NAME}
     user waits until h2 is visible    Data block details
+
+    user checks page contains element    //*[@data-testid="Data set name-key" and contains(text(), "Data set name")]
+    user checks page contains element
+    ...    //*[@data-testid="Data set name-value" and contains(text(), "Dates test subject")]
 
     user enters text into element    id:dataBlockDetailsForm-name    ${DATABLOCK_NAME}
     user enters text into element    id:dataBlockDetailsForm-heading    Updated dates table title

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -855,3 +855,6 @@ user removes key stat
     [Arguments]    ${tile_num}
     user waits until page contains element    xpath://*[@data-testid="keyStat"][${tile_num}]
     user clicks element    xpath://*[@data-testid="keyStat"][${tile_num}]//button[contains(text(), "Remove")]
+
+user closes admin feedback banner if needed
+    user clicks element if exists    //*[@data-testid="admin-survey-banner"]//button[text()="Close"]


### PR DESCRIPTION
This PR:
* amends the data block page to display the data set name of a given data block. 

Other changes:
* Amended UI tests to check for this new field
* Added a new keyword to close the admin survey banner due to it causing intermittent failures in various suites

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/55030296/789fa1e9-aa63-425a-9812-72a85e1580a7)


![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/55030296/59ab46a4-4757-40f4-aa06-10411d2488f9)
