### PR TITLE
EES-4358 Fix table html for filter name related bugs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,6 +843,9 @@ importers:
       jest-watch-typeahead:
         specifier: ^0.6.1
         version: 0.6.5(jest@26.6.3)
+      open:
+        specifier: ^8.4.1
+        version: 8.4.1
       react-test-renderer:
         specifier: 16.13.1
         version: 16.13.1(react@17.0.2)
@@ -4549,7 +4552,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss@8.4.21)
+      postcss-syntax: 0.36.2(postcss@8.2.15)
     transitivePeerDependencies:
       - supports-color
 
@@ -4561,7 +4564,7 @@ packages:
       postcss-syntax: '>=0.36.2'
     dependencies:
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss@8.4.21)
+      postcss-syntax: 0.36.2(postcss@8.2.15)
       remark: 13.0.0
       unist-util-find-all-after: 3.0.2
     transitivePeerDependencies:
@@ -6395,6 +6398,7 @@ packages:
 
   /bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -9185,6 +9189,7 @@ packages:
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -12031,6 +12036,7 @@ packages:
 
   /nan@2.17.0:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -13135,7 +13141,7 @@ packages:
     dependencies:
       htmlparser2: 3.10.1
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss@8.4.21)
+      postcss-syntax: 0.36.2(postcss@8.2.15)
 
   /postcss-image-set-function@4.0.7(postcss@8.4.21):
     resolution: {integrity: sha512-9T2r9rsvYzm5ndsBE8WgtrMlIT7VbtTfE7b3BQnudUqnBcBo7L758oc+o+pdj/dUV0l5wjwSdjeOH2DZtfv8qw==}
@@ -13896,7 +13902,7 @@ packages:
       svgo: 2.8.0
     dev: false
 
-  /postcss-syntax@0.36.2(postcss@8.4.21):
+  /postcss-syntax@0.36.2(postcss@8.2.15):
     resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==}
     peerDependencies:
       postcss: '>=5.0.0'
@@ -13917,7 +13923,7 @@ packages:
       postcss-scss:
         optional: true
     dependencies:
-      postcss: 8.4.21
+      postcss: 8.2.15
 
   /postcss-unique-selectors@4.0.1:
     resolution: {integrity: sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==}
@@ -16014,7 +16020,7 @@ packages:
       postcss-sass: 0.4.4
       postcss-scss: 2.1.1
       postcss-selector-parser: 6.0.11
-      postcss-syntax: 0.36.2(postcss@8.4.21)
+      postcss-syntax: 0.36.2(postcss@8.2.15)
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
       slash: 3.0.0

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -28,6 +28,7 @@
     "leaflet": "^1.7.1",
     "lodash": "^4.17.21",
     "memoizee": "^0.4.14",
+    "nanoid": "^4.0.0",
     "next": "^11.1.3",
     "qs": "^6.10.1",
     "react": "17.0.2",
@@ -41,7 +42,6 @@
     "react-markdown": "^4.3.1",
     "react-modal": "^3.12.1",
     "recharts": "^2.1.16",
-    "nanoid": "^4.0.0",
     "regenerator-runtime": "0.13.9",
     "sanitize-html": "^2.10.0",
     "use-immer": "^0.6.0",
@@ -87,6 +87,7 @@
     "jest-resolve": "^26.5.2",
     "jest-serializer-html": "^7.0.0",
     "jest-watch-typeahead": "^0.6.1",
+    "open": "^8.4.1",
     "react-test-renderer": "16.13.1",
     "stylelint": "^13.13.1",
     "typescript": "^4.9.5"

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/Header.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/Header.ts
@@ -50,6 +50,16 @@ export default class Header {
     return crossSpan;
   }
 
+  public get maxCrossSpan(): number {
+    let crossSpan = 1;
+    let child = this.getFirstChild();
+    while (child) {
+      crossSpan += 1;
+      child = child.getFirstChild();
+    }
+    return crossSpan;
+  }
+
   public addChild(child: Header): this {
     const lastChild = this.getLastChild();
 
@@ -99,6 +109,10 @@ export default class Header {
 
   public getLastChild(): Header | undefined {
     return last(this.children);
+  }
+
+  public hasSingleMatchingChild(): boolean {
+    return this.children.length === 1 && this.children[0].text === this.text;
   }
 
   public hasSiblings(): boolean {

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableData.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableData.ts
@@ -3,9 +3,9 @@ import {
   Indicator,
   LocationFilter,
   TimePeriodFilter,
-} from '../../types/filters';
-import { FullTable } from '../../types/fullTable';
-import { TableHeadersConfig } from '../../types/tableHeaders';
+} from '@common/modules/table-tool/types/filters';
+import { FullTable } from '@common/modules/table-tool/types/fullTable';
+import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 
 const category1GroupTotalFilter1 = new CategoryFilter({
   value: 'category-1-filter-1',
@@ -23,18 +23,22 @@ const category1Group1Filter2 = new CategoryFilter({
   category: 'Category 1',
 });
 
+export const testInitialTableSubjectMeta: FullTable['subjectMeta'] = {
+  filters: {},
+  footnotes: [],
+  indicators: [],
+  locations: [],
+  boundaryLevels: [],
+  publicationName: 'Publication name',
+  subjectName: 'Subject name',
+  timePeriodRange: [],
+  geoJsonAvailable: true,
+};
+
 const category1Group1Filter3 = new CategoryFilter({
   value: 'category-1-filter-3',
   label: 'Category 1 Filter 3',
   group: 'Group 1',
-  isTotal: false,
-  category: 'Category 1',
-});
-
-const category1Group2Filter4 = new CategoryFilter({
-  value: 'category-1-filter-4',
-  label: 'Category 1 Filter 4',
-  group: 'Group 2',
   isTotal: false,
   category: 'Category 1',
 });
@@ -53,22 +57,6 @@ const category2GroupDefaultFilter2 = new CategoryFilter({
   group: 'Default',
   isTotal: false,
   category: 'Category 2',
-});
-
-const category3Group1Filter1 = new CategoryFilter({
-  value: 'category-3-filter-1',
-  label: 'Category 3 Filter 1',
-  group: 'Group 1',
-  isTotal: false,
-  category: 'Category 3',
-});
-
-const category3Group2Filter2 = new CategoryFilter({
-  value: 'category-3-filter-2',
-  label: 'Category 3 Filter 2',
-  group: 'Group 2',
-  isTotal: false,
-  category: 'Category 3',
 });
 
 const indicator1 = new Indicator({
@@ -127,28 +115,8 @@ const timePeriod2 = new TimePeriodFilter({
   order: 1,
 });
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const timePeriod3 = new TimePeriodFilter({
-  label: '2014/15',
-  year: 2014,
-  code: 'AY',
-  order: 2,
-});
-
-const initialTableSubjectMeta: FullTable['subjectMeta'] = {
-  filters: {},
-  footnotes: [],
-  indicators: [],
-  locations: [],
-  boundaryLevels: [],
-  publicationName: 'Publication name',
-  subjectName: 'Subject name',
-  timePeriodRange: [],
-  geoJsonAvailable: true,
-};
-
 const testSubjectMeta1: FullTable['subjectMeta'] = {
-  ...initialTableSubjectMeta,
+  ...testInitialTableSubjectMeta,
   filters: {
     Category1: {
       name: 'category_1',
@@ -314,7 +282,7 @@ export const testTableWithTwoLevelsOfRowAndColHeadersConfig: TableHeadersConfig 
 
 export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
   subjectMeta: {
-    ...initialTableSubjectMeta,
+    ...testInitialTableSubjectMeta,
     filters: {
       Category1: {
         name: 'category_1',
@@ -663,109 +631,4 @@ export const testTableWithThreeLevelsOfRowAndColHeadersConfig: TableHeadersConfi
   ],
   rows: [indicator1, indicator2],
   rowGroups: [[location1, location2, location3, location4]],
-};
-
-export const testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabels: FullTable = {
-  subjectMeta: {
-    ...initialTableSubjectMeta,
-    filters: {
-      Category1: {
-        name: 'category_1',
-        options: [category1Group1Filter2, category1Group2Filter4],
-        order: 0,
-      },
-      Category3: {
-        name: 'category_3',
-        options: [category3Group1Filter1, category3Group2Filter2],
-        order: 1,
-      },
-    },
-    indicators: [indicator1],
-    locations: [location1],
-    timePeriodRange: [timePeriod1, timePeriod2],
-  },
-  results: [
-    {
-      filters: [category1Group1Filter2.id, category3Group1Filter1.id],
-      geographicLevel: 'localAuthority',
-      locationId: location1.value,
-      measures: {
-        [indicator1.id]: '20',
-      },
-      timePeriod: timePeriod1.id,
-    },
-    {
-      filters: [category1Group1Filter2.id, category3Group1Filter1.id],
-      geographicLevel: 'localAuthority',
-      locationId: location1.value,
-      measures: {
-        [indicator1.id]: '7163',
-      },
-      timePeriod: timePeriod2.id,
-    },
-    {
-      filters: [category1Group1Filter2.id, category3Group2Filter2.id],
-      geographicLevel: 'localAuthority',
-      locationId: location1.value,
-      measures: {
-        [indicator1.id]: '44',
-      },
-      timePeriod: timePeriod1.id,
-    },
-    {
-      filters: [category1Group1Filter2.id, category3Group2Filter2.id],
-      geographicLevel: 'localAuthority',
-      locationId: location1.value,
-      measures: {
-        [indicator1.id]: '32',
-      },
-      timePeriod: timePeriod2.id,
-    },
-    {
-      filters: [category1Group2Filter4.id, category3Group1Filter1.id],
-      geographicLevel: 'localAuthority',
-      locationId: location1.value,
-      measures: {
-        [indicator1.id]: '767',
-      },
-      timePeriod: timePeriod1.id,
-    },
-    {
-      filters: [category1Group2Filter4.id, category3Group1Filter1.id],
-      geographicLevel: 'localAuthority',
-      locationId: location1.value,
-      measures: {
-        [indicator1.id]: '19340',
-      },
-      timePeriod: timePeriod2.id,
-    },
-    {
-      filters: [category1Group2Filter4.id, category3Group2Filter2.id],
-      geographicLevel: 'localAuthority',
-      locationId: location1.value,
-      measures: {
-        [indicator1.id]: '331',
-      },
-      timePeriod: timePeriod1.id,
-    },
-    {
-      filters: [category1Group2Filter4.id, category3Group2Filter2.id],
-      geographicLevel: 'localAuthority',
-      locationId: location1.value,
-      measures: {
-        [indicator1.id]: '2458',
-      },
-      timePeriod: timePeriod2.id,
-    },
-  ],
-};
-
-export const testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabelsConfig: TableHeadersConfig = {
-  columnGroups: [
-    [category3Group1Filter1, category3Group2Filter2],
-    [category1Group1Filter2, category1Group2Filter4],
-  ],
-  columns: [timePeriod1, timePeriod2],
-  rowGroups: [[location1]],
-  rows: [indicator1],
 };

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableDataWithDuplicateLabels.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableDataWithDuplicateLabels.ts
@@ -1,0 +1,291 @@
+import {
+  CategoryFilter,
+  Indicator,
+  LocationFilter,
+  TimePeriodFilter,
+} from '@common/modules/table-tool/types/filters';
+import { FullTable } from '@common/modules/table-tool/types/fullTable';
+import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
+import { testInitialTableSubjectMeta } from '@common/modules/table-tool/utils/__data__/testTableData';
+
+const indicator1 = new Indicator({
+  value: 'indicator-1',
+  label: 'Indicator 1',
+  unit: '',
+  name: 'indicator_1',
+});
+
+const location1 = new LocationFilter({
+  value: 'location-1',
+  label: 'Location 1',
+  level: 'country',
+});
+
+const timePeriod1 = new TimePeriodFilter({
+  label: '2012/13',
+  year: 2012,
+  code: 'AY',
+  order: 0,
+});
+
+const category1Filter1 = new CategoryFilter({
+  value: 'category1_filter1',
+  label: 'Filter 1',
+  group: 'Default',
+  isTotal: false,
+  category: 'Category 1',
+});
+
+const category1Filter2 = new CategoryFilter({
+  value: 'category1_filter2',
+  label: 'Filter 2',
+  group: 'Default',
+  isTotal: false,
+  category: 'Category 1',
+});
+
+// Category 2 filters have the same labels as Category 1
+const category2Filter1 = new CategoryFilter({
+  value: 'category2_filter1',
+  label: 'Filter 1',
+  group: 'Default',
+  isTotal: false,
+  category: 'Category 2',
+});
+
+const category2Filter2 = new CategoryFilter({
+  value: 'category2_filter2',
+  label: 'Filter 2',
+  group: 'Default',
+  isTotal: false,
+  category: 'Category 2',
+});
+
+// Category 3 and 4 both contain the same group labels (Group 1 and Group 2)
+const category3Group1Filter1 = new CategoryFilter({
+  value: 'category3_group1_filter1',
+  label: 'Category 3 Group 1 Filter 1',
+  group: 'Group 1',
+  isTotal: false,
+  category: 'Category 3',
+});
+
+const category3Group2Filter1 = new CategoryFilter({
+  value: 'category3_group2_filter1',
+  label: 'Category 3 Group 2 Filter 1',
+  group: 'Group 2',
+  isTotal: false,
+  category: 'Category 3',
+});
+
+const category4Group1Filter1 = new CategoryFilter({
+  value: 'category4_group1_filter1',
+  label: 'Category 4 Group 1 Filter 1',
+  group: 'Group 1',
+  isTotal: false,
+  category: 'Category 4',
+});
+
+const category4Group2Filter1 = new CategoryFilter({
+  value: 'category4_group2_filter1',
+  label: 'Category 4 Group 2 Filter 1',
+  group: 'Group 2',
+  isTotal: false,
+  category: 'Category 4',
+});
+
+// Filter 1 and 2 in Category 1 have the same labels as Filter 1 and 2 in Category 2
+export const testTableWithDuplicateFilterLabelsInColumnHeadersConfig: TableHeadersConfig = {
+  columns: [category2Filter1, category2Filter2],
+  columnGroups: [[indicator1], [category1Filter1, category1Filter2]],
+  rows: [timePeriod1],
+  rowGroups: [],
+};
+
+export const testTableWithDuplicateFilterLabelsInRowHeadersConfig: TableHeadersConfig = {
+  columns: [timePeriod1],
+  columnGroups: [],
+  rows: [category2Filter1, category2Filter2],
+  rowGroups: [[indicator1], [category1Filter1, category1Filter2]],
+};
+
+export const testTableWithDuplicateFilterLabels: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [category1Filter1, category1Filter2],
+        order: 0,
+      },
+      Category2: {
+        name: 'category_2',
+        options: [category2Filter1, category2Filter2],
+        order: 0,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category1Filter1.id, category2Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '85',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Filter1.id, category2Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '88',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Filter2.id, category2Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '89',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Filter2.id, category2Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '90',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};
+
+// Only Filter 1 in Category 1 and Filter 2 in Category 2 have data. This causes
+// columns / rows to be excluded for Category 1 - Filter 2 and Category 2 Filter 1.
+export const testTableWithDuplicateFilterLabelsAndMissingData: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [category1Filter1, category1Filter2],
+        order: 0,
+      },
+      Category2: {
+        name: 'category_2',
+        options: [category2Filter1, category2Filter2],
+        order: 0,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category1Filter1.id, category2Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '85',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Filter2.id, category2Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '90',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};
+
+export const testTableWithMultipleGroupsWithSameLabelsInColumnHeadersConfig: TableHeadersConfig = {
+  columnGroups: [
+    [category3Group1Filter1, category3Group2Filter1],
+    [category4Group1Filter1, category4Group2Filter1],
+  ],
+  columns: [timePeriod1],
+  rowGroups: [],
+  rows: [indicator1],
+};
+
+export const testTableWithMultipleGroupsWithSameLabelsInRowHeadersConfig: TableHeadersConfig = {
+  columnGroups: [],
+  columns: [indicator1],
+  rowGroups: [
+    [category3Group1Filter1, category3Group2Filter1],
+    [category4Group1Filter1, category4Group2Filter1],
+  ],
+  rows: [timePeriod1],
+};
+
+export const testTableWithMultipleGroupsWithSameLabels: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category3: {
+        name: 'category_3',
+        options: [category3Group1Filter1, category3Group2Filter1],
+        order: 1,
+      },
+      Category4: {
+        name: 'category_4',
+        options: [category4Group1Filter1, category4Group2Filter1],
+        order: 0,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category4Group1Filter1.id, category3Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '20',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category4Group1Filter1.id, category3Group2Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '71',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category4Group2Filter1.id, category3Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '44',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category4Group2Filter1.id, category3Group2Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '32',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableDataWithMergedCells.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableDataWithMergedCells.ts
@@ -1,0 +1,651 @@
+import {
+  CategoryFilter,
+  Indicator,
+  LocationFilter,
+  TimePeriodFilter,
+} from '@common/modules/table-tool/types/filters';
+import { FullTable } from '@common/modules/table-tool/types/fullTable';
+import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
+import { testInitialTableSubjectMeta } from '@common/modules/table-tool/utils/__data__/testTableData';
+
+const indicator1 = new Indicator({
+  value: 'indicator-1',
+  label: 'Indicator 1',
+  unit: '',
+  name: 'indicator_1',
+});
+
+const location1 = new LocationFilter({
+  value: 'location-1',
+  label: 'Location 1',
+  level: 'country',
+});
+
+const timePeriod1 = new TimePeriodFilter({
+  label: '2012/13',
+  year: 2012,
+  code: 'AY',
+  order: 0,
+});
+
+// Label and group are the same
+const category1Group1Filter1 = new CategoryFilter({
+  value: 'category1_group1_filter1',
+  label: 'Category 1 Group 1',
+  group: 'Category 1 Group 1',
+  isTotal: false,
+  category: 'Category 1',
+});
+
+const category1Group2Filter1 = new CategoryFilter({
+  value: 'category1_group2_filter1',
+  label: 'Category 1 Group 2 Filter 1',
+  group: 'Category 1 Group 2',
+  isTotal: false,
+  category: 'Category 1',
+});
+
+// Label and group are the same
+const category1Group2Filter2 = new CategoryFilter({
+  value: 'category1_group2_filter2',
+  label: 'Category 1 Group 2',
+  group: 'Category 1 Group 2',
+  isTotal: false,
+  category: 'Category 1',
+});
+
+const category2Group1Filter1 = new CategoryFilter({
+  value: 'category2_group1_filter1',
+  label: 'Category 2 Group 1 Filter 1',
+  group: 'Group 1',
+  isTotal: false,
+  category: 'Category 2',
+});
+
+const category2Group1Filter2 = new CategoryFilter({
+  value: 'category2_group1_filter2',
+  label: 'Category 2 Group 1 Filter 2',
+  group: 'Group 1',
+  isTotal: false,
+  category: 'Category 2',
+});
+
+export const testTableWithOnlyMergedCellsInColumnHeadersConfig: TableHeadersConfig = {
+  columns: [category1Group1Filter1, category1Group2Filter2],
+  columnGroups: [],
+  rows: [timePeriod1],
+  rowGroups: [[indicator1]],
+};
+
+export const testTableWithOnlyMergedCellsInRowHeadersConfig: TableHeadersConfig = {
+  columns: [timePeriod1],
+  columnGroups: [],
+  rows: [indicator1],
+  rowGroups: [[category1Group1Filter1, category1Group2Filter2]],
+};
+
+export const testTableWithOnlyMergedCellsInHeaders: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [category1Group1Filter1, category1Group2Filter2],
+        order: 0,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category1Group2Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '74',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '85',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};
+
+export const testTableWithMergedAndUnMergedCellsInColumnHeadersConfig: TableHeadersConfig = {
+  columns: [category1Group1Filter1, category1Group2Filter1],
+  columnGroups: [],
+  rows: [timePeriod1],
+  rowGroups: [[indicator1]],
+};
+
+export const testTableWithMergedAndUnmergedCellsInRowHeadersConfig: TableHeadersConfig = {
+  columns: [timePeriod1],
+  columnGroups: [],
+  rows: [indicator1],
+  rowGroups: [[category1Group1Filter1, category1Group2Filter1]],
+};
+
+export const testTableWithMergedAndUnMergedCellsInHeaders: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [category1Group1Filter1, category1Group2Filter1],
+        order: 0,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category1Group2Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '85',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '95',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};
+
+export const testTableWithOnlyMergedCellsInFirstLevelOfColumnHeadersConfig: TableHeadersConfig = {
+  columns: [category2Group1Filter1, category2Group1Filter2],
+  columnGroups: [[category1Group1Filter1, category1Group2Filter2]],
+  rows: [indicator1],
+  rowGroups: [[timePeriod1]],
+};
+
+export const testTableWithOnlyMergedCellsInFirstLevelOfRowHeadersConfig: TableHeadersConfig = {
+  columns: [timePeriod1],
+  columnGroups: [],
+  rows: [indicator1],
+  rowGroups: [
+    [category1Group1Filter1, category1Group2Filter2],
+    [category2Group1Filter1, category2Group1Filter2],
+  ],
+};
+
+export const testTableWithOnlyMergedCellsInFirstLevelOfHeaders: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [category1Group1Filter1, category1Group2Filter2],
+        order: 0,
+      },
+      Category2: {
+        name: 'category_2',
+        options: [category2Group1Filter1, category2Group1Filter2],
+        order: 0,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category1Group1Filter1.id, category2Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '74',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group1Filter1.id, category2Group1Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '85',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter2.id, category2Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '92',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter2.id, category2Group1Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '87',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};
+
+export const testTableWithMergedAndUnmergedCellsInFirstLevelOfColumnHeadersConfig: TableHeadersConfig = {
+  columns: [category2Group1Filter1, category2Group1Filter2],
+  columnGroups: [[category1Group1Filter1, category1Group2Filter1]],
+  rows: [indicator1],
+  rowGroups: [[timePeriod1]],
+};
+
+export const testTableWithMergedAndUnmergedCellsInFirstLevelOfRowHeadersConfig: TableHeadersConfig = {
+  columns: [timePeriod1],
+  columnGroups: [],
+  rows: [indicator1],
+  rowGroups: [
+    [category1Group1Filter1, category1Group2Filter1],
+    [category2Group1Filter1, category2Group1Filter2],
+  ],
+};
+
+export const testTableWithMergedAndUnmergedCellsInFirstLevelOfHeaders: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [category1Group1Filter1, category1Group2Filter1],
+        order: 0,
+      },
+      Category2: {
+        name: 'category_2',
+        options: [category2Group1Filter1, category2Group1Filter2],
+        order: 0,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category1Group1Filter1.id, category2Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '74',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group1Filter1.id, category2Group1Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '85',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter1.id, category2Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '92',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter1.id, category2Group1Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '87',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};
+
+export const testTableWithOnlyMergedCellsInMiddleLevelOfColumnHeadersConfig: TableHeadersConfig = {
+  columns: [category2Group1Filter1, category2Group1Filter2],
+  columnGroups: [
+    [indicator1],
+    [category1Group1Filter1, category1Group2Filter2],
+  ],
+  rows: [timePeriod1],
+  rowGroups: [],
+};
+
+export const testTableWithOnlyMergedCellsInMiddleLevelOfRowsConfig: TableHeadersConfig = {
+  columns: [timePeriod1],
+  columnGroups: [],
+  rows: [category2Group1Filter1, category2Group1Filter2],
+  rowGroups: [[indicator1], [category1Group1Filter1, category1Group2Filter2]],
+};
+
+export const testTableWithOnlyMergedCellsInMiddleLevelOfHeaders: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [category1Group1Filter1, category1Group2Filter2],
+        order: 0,
+      },
+      Category2: {
+        name: 'category_2',
+        options: [category2Group1Filter1, category2Group1Filter2],
+        order: 1,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category1Group2Filter2.id, category2Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '73',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter2.id, category2Group1Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '66',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category2Group1Filter1.id, category1Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '75',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category2Group1Filter2.id, category1Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '70',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};
+
+export const testTableWithMergedAndUnmergedCellsInMiddleLevelOfColumnHeadersConfig: TableHeadersConfig = {
+  columns: [category2Group1Filter1, category2Group1Filter2],
+  columnGroups: [
+    [indicator1],
+    [category1Group1Filter1, category1Group2Filter1, category1Group2Filter2],
+  ],
+  rows: [timePeriod1],
+  rowGroups: [],
+};
+
+export const testTableWithMergedAndUnmergedCellsInMiddleLevelOfRowHeadersConfig: TableHeadersConfig = {
+  columns: [timePeriod1],
+  columnGroups: [],
+  rows: [category2Group1Filter1, category2Group1Filter2],
+  rowGroups: [[indicator1], [category1Group1Filter1, category1Group2Filter1]],
+};
+
+export const testTableWithMergedAndUnmergedCellsInMiddleLevelOfHeaders: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [
+          category1Group1Filter1,
+          category1Group2Filter1,
+          category1Group2Filter2,
+        ],
+        order: 0,
+      },
+      Category2: {
+        name: 'category_2',
+        options: [category2Group1Filter1, category2Group1Filter2],
+        order: 1,
+      },
+    },
+
+    indicators: [indicator1],
+    locations: [location1],
+
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category1Group2Filter2.id, category2Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '79',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter2.id, category2Group1Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '74',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category2Group1Filter1.id, category1Group2Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '87',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category2Group1Filter2.id, category1Group2Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '85',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category2Group1Filter1.id, category1Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '88',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category2Group1Filter2.id, category1Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '85',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};
+
+export const testTableWithOnlyMergedCellsInLastLevelOfColumnHeadersConfig: TableHeadersConfig = {
+  columns: [category1Group1Filter1, category1Group2Filter2],
+  columnGroups: [
+    [indicator1],
+    [category2Group1Filter1, category2Group1Filter2],
+  ],
+  rows: [timePeriod1],
+  rowGroups: [],
+};
+
+export const testTableWithOnlyMergedCellsInLastLevelOfRowHeadersConfig: TableHeadersConfig = {
+  columns: [timePeriod1],
+  columnGroups: [],
+  rows: [category1Group1Filter1, category1Group2Filter2],
+  rowGroups: [[indicator1], [category2Group1Filter1, category2Group1Filter2]],
+};
+
+export const testTableWithOnlyMergedCellsInLastLevelOfHeaders: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [category1Group1Filter1, category1Group2Filter2],
+        order: 0,
+      },
+      Category2: {
+        name: 'category_2',
+        options: [category2Group1Filter1, category2Group1Filter2],
+        order: 0,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category1Group1Filter1.id, category2Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '74',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group1Filter1.id, category2Group1Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '85',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter2.id, category2Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '92',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter2.id, category2Group1Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '87',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};
+
+export const testTableWithMergedAndUnmergedCellsInLastLevelOfColumnHeadersConfig: TableHeadersConfig = {
+  columns: [category1Group1Filter1, category1Group2Filter1],
+  columnGroups: [
+    [indicator1],
+    [category2Group1Filter1, category2Group1Filter2],
+  ],
+  rows: [timePeriod1],
+  rowGroups: [],
+};
+
+export const testTableWithMergedAndUnmergedCellsInLastLevelOfRowHeadersConfig: TableHeadersConfig = {
+  columns: [timePeriod1],
+  columnGroups: [],
+  rows: [category1Group1Filter1, category1Group2Filter1],
+  rowGroups: [[indicator1], [category2Group1Filter1, category2Group1Filter2]],
+};
+
+export const testTableWithMergedAndUnmergedCellsInLastLevelOfHeaders: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [category1Group1Filter1, category1Group2Filter1],
+        order: 0,
+      },
+      Category2: {
+        name: 'category_2',
+        options: [category2Group1Filter1, category2Group1Filter2],
+        order: 0,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category1Group1Filter1.id, category2Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '74',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group1Filter1.id, category2Group1Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '85',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter1.id, category2Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '92',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group2Filter1.id, category2Group1Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '87',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/createExpandedColumnHeaders.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/createExpandedColumnHeaders.test.ts
@@ -1,8 +1,6 @@
 import Header from '@common/modules/table-tool/utils/Header';
 import createExpandedColumnHeaders from '@common/modules/table-tool/utils/createExpandedColumnHeaders';
-import { ExpandedHeader } from '@common/modules/table-tool/utils/mapTableToJson';
-
-// these tests cover the test cases for headers that used to be in MultiHeaderDataTable
+import { TableCellJson } from '@common/modules/table-tool/utils/mapTableToJson';
 
 describe('createExpandedColumnHeaders', () => {
   test('should return a single row of column headers if no groups are provided', () => {
@@ -13,71 +11,55 @@ describe('createExpandedColumnHeaders', () => {
     ];
 
     expect(createExpandedColumnHeaders(columnHeaders)).toEqual<
-      ExpandedHeader[][]
+      TableCellJson[][]
     >([
       [
-        { id: '1', text: '1', span: 1, crossSpan: 1, isGroup: false },
-        { id: '2', text: '2', span: 1, crossSpan: 1, isGroup: false },
-        { id: '3', text: '3', span: 1, crossSpan: 1, isGroup: false },
+        { tag: 'th', text: '1', colSpan: 1, rowSpan: 1, scope: 'col' },
+        { tag: 'th', text: '2', colSpan: 1, rowSpan: 1, scope: 'col' },
+        { tag: 'th', text: '3', colSpan: 1, rowSpan: 1, scope: 'col' },
       ],
     ]);
   });
 
   test('should return multiple rows of column headers if groups are provided', () => {
     const columnHeaders: Header[] = [
-      new Header('1', '1'),
-      new Header('2', '2'),
-      new Header('3', '3').addChild(new Header('2.1', '2.1')),
-      new Header('4', '4').addChild(new Header('3.1', '3.1')),
+      new Header('1', '1').addChild(new Header('1.1', '1.1')),
+      new Header('2', '2').addChild(new Header('2.1', '2.1')),
     ];
 
     expect(createExpandedColumnHeaders(columnHeaders)).toEqual<
-      ExpandedHeader[][]
+      TableCellJson[][]
     >([
       [
         {
-          crossSpan: 1,
-          id: '1',
-          isGroup: false,
-          span: 1,
+          rowSpan: 1,
+          tag: 'th',
+          scope: 'colgroup',
+          colSpan: 1,
           text: '1',
         },
         {
-          crossSpan: 1,
-          id: '2',
-          isGroup: false,
-          span: 1,
+          rowSpan: 1,
+          tag: 'th',
+          scope: 'colgroup',
+          colSpan: 1,
           text: '2',
-        },
-        {
-          crossSpan: 1,
-          id: '3',
-          isGroup: true,
-          span: 1,
-          text: '3',
-        },
-        {
-          crossSpan: 1,
-          id: '4',
-          isGroup: true,
-          span: 1,
-          text: '4',
         },
       ],
       [
         {
-          crossSpan: 1,
-          id: '2.1',
-          isGroup: false,
-          span: 1,
-          text: '2.1',
+          rowSpan: 1,
+          tag: 'th',
+          scope: 'col',
+          colSpan: 1,
+          text: '1.1',
         },
         {
-          crossSpan: 1,
-          id: '3.1',
-          isGroup: false,
-          span: 1,
-          text: '3.1',
+          rowSpan: 1,
+          tag: 'th',
+          scope: 'col',
+          colSpan: 1,
+          text: '2.1',
         },
       ],
     ]);
@@ -92,39 +74,39 @@ describe('createExpandedColumnHeaders', () => {
       ),
     ];
 
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 2,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 2,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -143,67 +125,67 @@ describe('createExpandedColumnHeaders', () => {
         .addChild(new Header('D', 'D').addChild(new Header('F', 'F')))
         .addChild(new Header('E', 'E').addChild(new Header('F', 'F'))),
     ];
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 2,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -226,88 +208,88 @@ describe('createExpandedColumnHeaders', () => {
       ),
     ];
 
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 2,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'G',
+          tag: 'th',
           text: 'G',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -329,67 +311,67 @@ describe('createExpandedColumnHeaders', () => {
         new Header('E', 'E').addChild(new Header('F', 'F')),
       ),
     ];
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: true,
-          crossSpan: 2,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 2,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -411,60 +393,60 @@ describe('createExpandedColumnHeaders', () => {
         new Header('E', 'E').addChild(new Header('F', 'F')),
       ),
     ];
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: true,
-          crossSpan: 3,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 3,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -486,67 +468,67 @@ describe('createExpandedColumnHeaders', () => {
         new Header('E', 'E').addChild(new Header('F', 'F')),
       ),
     ];
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 2,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 2,
         },
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -568,67 +550,67 @@ describe('createExpandedColumnHeaders', () => {
         new Header('G', 'G').addChild(new Header('H', 'H')),
       ),
     ];
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: true,
-          crossSpan: 2,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 2,
         },
         {
-          id: 'G',
+          tag: 'th',
           text: 'G',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -650,67 +632,67 @@ describe('createExpandedColumnHeaders', () => {
         new Header('G', 'G').addChild(new Header('H', 'H')),
       ),
     ];
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 2,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 2,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'G',
+          tag: 'th',
           text: 'G',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -731,46 +713,46 @@ describe('createExpandedColumnHeaders', () => {
           .addChild(new Header('F', 'F')),
       ),
     ];
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 2,
+          colSpan: 2,
+          scope: 'colgroup',
+          rowSpan: 2,
         },
       ],
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 2,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 2,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -793,67 +775,67 @@ describe('createExpandedColumnHeaders', () => {
         )
         .addChild(new Header('D', 'D').addChild(new Header('E', 'E'))),
     ];
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 3,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 3,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 2,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 2,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 2,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -871,39 +853,39 @@ describe('createExpandedColumnHeaders', () => {
           .addChild(new Header('D', 'D')),
       ),
     ];
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 2,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 2,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -923,53 +905,53 @@ describe('createExpandedColumnHeaders', () => {
             .addChild(new Header('F', 'F')),
         ),
     ];
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 3,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 3,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 2,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
       ],
     ];
@@ -990,67 +972,409 @@ describe('createExpandedColumnHeaders', () => {
         )
         .addChild(new Header('D', 'D').addChild(new Header('H', 'H'))),
     ];
-    const expandedColumnHeaders: ExpandedHeader[][] = [
+    const expandedColumnHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 4,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 4,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 2,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'colgroup',
+          rowSpan: 1,
         },
       ],
       [
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'G',
+          tag: 'th',
           text: 'G',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          colSpan: 1,
+          scope: 'col',
+          rowSpan: 1,
+        },
+      ],
+    ];
+
+    expect(createExpandedColumnHeaders(columnHeaders)).toEqual(
+      expandedColumnHeaders,
+    );
+  });
+
+  test('returns correct headers with only headers merged with identical parent in the first row', () => {
+    const colHeaders: Header[] = [
+      new Header('A', 'A').addChild(
+        new Header('A', 'A')
+          .addChild(new Header('C', 'C'))
+          .addChild(new Header('D', 'D')),
+      ),
+      new Header('B', 'B').addChild(
+        new Header('B', 'B')
+          .addChild(new Header('C', 'C'))
+          .addChild(new Header('D', 'D')),
+      ),
+    ];
+
+    const expandedColumnHeaders: TableCellJson[][] = [
+      [
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'A',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'B',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          tag: 'th',
+          text: 'C',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          tag: 'th',
+          text: 'D',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          tag: 'th',
+          text: 'C',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          tag: 'th',
+          text: 'D',
+        },
+      ],
+    ];
+
+    expect(createExpandedColumnHeaders(colHeaders)).toEqual(
+      expandedColumnHeaders,
+    );
+  });
+
+  test('returns correct headers with only headers merged with identical parent in the middle row', () => {
+    const colHeaders: Header[] = [
+      new Header('A', 'A')
+        .addChild(
+          new Header('B', 'B').addChild(
+            new Header('B', 'B')
+              .addChild(new Header('D', 'D'))
+              .addChild(new Header('E', 'E')),
+          ),
+        )
+        .addChild(
+          new Header('C', 'C').addChild(
+            new Header('C', 'C')
+              .addChild(new Header('D', 'D'))
+              .addChild(new Header('E', 'E')),
+          ),
+        ),
+    ];
+
+    const expandedColumnHeaders: TableCellJson[][] = [
+      [
+        {
+          colSpan: 4,
+          rowSpan: 1,
+          scope: 'colgroup',
+          text: 'A',
+          tag: 'th',
+        },
+      ],
+      [
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          text: 'B',
+          tag: 'th',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          text: 'C',
+          tag: 'th',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          text: 'D',
+          tag: 'th',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          text: 'E',
+          tag: 'th',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          text: 'D',
+          tag: 'th',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          text: 'E',
+          tag: 'th',
+        },
+      ],
+    ];
+
+    expect(createExpandedColumnHeaders(colHeaders)).toEqual(
+      expandedColumnHeaders,
+    );
+  });
+
+  test('returns correct headers with only headers merged with identical parent in the last row', () => {
+    const colHeaders: Header[] = [
+      new Header('A', 'A')
+        .addChild(
+          new Header('B', 'B')
+            .addChild(new Header('D', 'D').addChild(new Header('D', 'D')))
+            .addChild(new Header('E', 'E').addChild(new Header('E', 'E'))),
+        )
+        .addChild(
+          new Header('C', 'C')
+            .addChild(new Header('D', 'D').addChild(new Header('D', 'D')))
+            .addChild(new Header('E', 'E').addChild(new Header('E', 'E'))),
+        ),
+    ];
+
+    const expandedColumnHeaders: TableCellJson[][] = [
+      [
+        {
+          colSpan: 4,
+          rowSpan: 1,
+          scope: 'colgroup',
+          text: 'A',
+          tag: 'th',
+        },
+      ],
+      [
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          text: 'B',
+          tag: 'th',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          text: 'C',
+          tag: 'th',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          text: 'D',
+          tag: 'th',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          text: 'E',
+          tag: 'th',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          text: 'D',
+          tag: 'th',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          text: 'E',
+          tag: 'th',
+        },
+      ],
+    ];
+
+    expect(createExpandedColumnHeaders(colHeaders)).toEqual(
+      expandedColumnHeaders,
+    );
+  });
+
+  test('returns correct headers when there are multiple groups with the same labels', () => {
+    const columnHeaders: Header[] = [
+      new Header('A', 'A').addChild(
+        new Header('C', 'C')
+          .addChild(new Header('A', 'A').addChild(new Header('D', 'D')))
+          .addChild(new Header('B', 'B').addChild(new Header('E', 'E'))),
+      ),
+      new Header('B', 'B').addChild(
+        new Header('F', 'F')
+          .addChild(new Header('A', 'A').addChild(new Header('D', 'D')))
+          .addChild(new Header('B', 'B').addChild(new Header('E', 'E'))),
+      ),
+    ];
+
+    const expandedColumnHeaders: TableCellJson[][] = [
+      [
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'A',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'B',
+        },
+      ],
+      [
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'C',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'F',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'A',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'B',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'A',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'B',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          tag: 'th',
+          text: 'D',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          tag: 'th',
+          text: 'E',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          tag: 'th',
+          text: 'D',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          tag: 'th',
+          text: 'E',
         },
       ],
     ];

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/createExpandedColumnHeaders.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/createExpandedColumnHeaders.test.ts
@@ -1042,6 +1042,166 @@ describe('createExpandedColumnHeaders', () => {
     );
   });
 
+  test('returns correct headers with deeply nested rows and multiple identical headers', () => {
+    const columnHeaders: Header[] = [
+      new Header('A', 'A').addChild(
+        new Header('A', 'A').addChild(
+          new Header('A', 'A').addChild(
+            new Header('A', 'A').addChild(new Header('A', 'A')),
+          ),
+        ),
+      ),
+      new Header('B', 'B').addChild(
+        new Header('B', 'B')
+          .addChild(
+            new Header('B', 'B').addChild(
+              new Header('B', 'B').addChild(new Header('B', 'B')),
+            ),
+          )
+          .addChild(
+            new Header('C', 'C').addChild(
+              new Header('D', 'D').addChild(new Header('D1', 'D1')),
+            ),
+          ),
+      ),
+      new Header('E', 'E').addChild(
+        new Header('F', 'F')
+          .addChild(
+            new Header('F', 'F')
+              .addChild(new Header('F', 'F').addChild(new Header('F', 'F')))
+              .addChild(new Header('G', 'G').addChild(new Header('G1', 'G1'))),
+          )
+          .addChild(
+            new Header('H', 'H')
+              .addChild(new Header('I', 'I').addChild(new Header('I', 'I')))
+              .addChild(new Header('J', 'J').addChild(new Header('J', 'J'))),
+          ),
+      ),
+    ];
+
+    const expandedColumnHeaders: TableCellJson[][] = [
+      [
+        {
+          colSpan: 1,
+          rowSpan: 5,
+          scope: 'col',
+          tag: 'th',
+          text: 'A',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 2,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'B',
+        },
+        {
+          colSpan: 4,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'E',
+        },
+      ],
+      [
+        {
+          colSpan: 4,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'F',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 3,
+          scope: 'col',
+          tag: 'th',
+          text: 'B',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'C',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'F',
+        },
+        {
+          colSpan: 2,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'H',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'D',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'col',
+          tag: 'th',
+          text: 'F',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'colgroup',
+          tag: 'th',
+          text: 'G',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'col',
+          tag: 'th',
+          text: 'I',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'col',
+          tag: 'th',
+          text: 'J',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          tag: 'th',
+          text: 'D1',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'col',
+          tag: 'th',
+          text: 'G1',
+        },
+      ],
+    ];
+
+    expect(createExpandedColumnHeaders(columnHeaders)).toEqual(
+      expandedColumnHeaders,
+    );
+  });
+
   test('returns correct headers with only headers merged with identical parent in the first row', () => {
     const colHeaders: Header[] = [
       new Header('A', 'A').addChild(

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/createExpandedRowHeaders.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/createExpandedRowHeaders.test.ts
@@ -1,6 +1,6 @@
 import Header from '../Header';
 import createExpandedRowHeaders from '../createExpandedRowHeaders';
-import { ExpandedHeader } from '../mapTableToJson';
+import { TableCellJson } from '../mapTableToJson';
 
 describe('createExpandedRowHeaders', () => {
   test('should return a single row of row headers if no groups are provided', () => {
@@ -10,31 +10,31 @@ describe('createExpandedRowHeaders', () => {
       new Header('3', '3'),
     ];
 
-    expect(createExpandedRowHeaders(rowHeaders)).toEqual<ExpandedHeader[][]>([
+    expect(createExpandedRowHeaders(rowHeaders)).toEqual<TableCellJson[][]>([
       [
         {
-          crossSpan: 1,
-          id: '1',
-          isGroup: false,
-          span: 1,
+          colSpan: 1,
+          tag: 'th',
+          scope: 'row',
+          rowSpan: 1,
           text: '1',
         },
       ],
       [
         {
-          crossSpan: 1,
-          id: '2',
-          isGroup: false,
-          span: 1,
+          colSpan: 1,
+          tag: 'th',
+          scope: 'row',
+          rowSpan: 1,
           text: '2',
         },
       ],
       [
         {
-          crossSpan: 1,
-          id: '3',
-          isGroup: false,
-          span: 1,
+          colSpan: 1,
+          tag: 'th',
+          scope: 'row',
+          rowSpan: 1,
           text: '3',
         },
       ],
@@ -43,61 +43,41 @@ describe('createExpandedRowHeaders', () => {
 
   test('should return multiple rows of row headers if groups are provided', () => {
     const rowHeaders: Header[] = [
-      new Header('1', '1'),
-      new Header('2', '2'),
-      new Header('3', '3').addChild(new Header('2.1', '2.1')),
-      new Header('4', '4').addChild(new Header('3.1', '3.1')),
+      new Header('1', '1').addChild(new Header('1.1', '1.1')),
+      new Header('2', '2').addChild(new Header('2.1', '2.1')),
     ];
 
-    expect(createExpandedRowHeaders(rowHeaders)).toEqual<ExpandedHeader[][]>([
+    expect(createExpandedRowHeaders(rowHeaders)).toEqual<TableCellJson[][]>([
       [
         {
-          crossSpan: 1,
-          id: '1',
-          isGroup: false,
-          span: 1,
+          colSpan: 1,
+          tag: 'th',
+          scope: 'rowgroup',
+          rowSpan: 1,
           text: '1',
         },
+        {
+          colSpan: 1,
+          tag: 'th',
+          scope: 'row',
+          rowSpan: 1,
+          text: '1.1',
+        },
       ],
       [
         {
-          crossSpan: 1,
-          id: '2',
-          isGroup: false,
-          span: 1,
+          colSpan: 1,
+          tag: 'th',
+          scope: 'rowgroup',
+          rowSpan: 1,
           text: '2',
         },
-      ],
-      [
         {
-          crossSpan: 1,
-          id: '3',
-          isGroup: true,
-          span: 1,
-          text: '3',
-        },
-        {
-          crossSpan: 1,
-          id: '2.1',
-          isGroup: false,
-          span: 1,
+          colSpan: 1,
+          tag: 'th',
+          scope: 'row',
+          rowSpan: 1,
           text: '2.1',
-        },
-      ],
-      [
-        {
-          crossSpan: 1,
-          id: '4',
-          isGroup: true,
-          span: 1,
-          text: '4',
-        },
-        {
-          crossSpan: 1,
-          id: '3.1',
-          isGroup: false,
-          span: 1,
-          text: '3.1',
         },
       ],
     ]);
@@ -112,55 +92,55 @@ describe('createExpandedRowHeaders', () => {
         .addChild(new Header('3', '3'))
         .addChild(new Header('4', '4')),
     ];
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: '1',
+          tag: 'th',
           text: '1',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: '3',
+          tag: 'th',
           text: '3',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: '4',
+          tag: 'th',
           text: '4',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: '2',
+          tag: 'th',
           text: '2',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: '3',
+          tag: 'th',
           text: '3',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: '4',
+          tag: 'th',
           text: '4',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -193,119 +173,119 @@ describe('createExpandedRowHeaders', () => {
             .addChild(new Header('6', '6')),
         ),
     ];
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: '1',
+          tag: 'th',
           text: '1',
-          span: 4,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 4,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: '3',
+          tag: 'th',
           text: '3',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: '5',
+          tag: 'th',
           text: '5',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: '6',
+          tag: 'th',
           text: '6',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: '4',
+          tag: 'th',
           text: '4',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: '5',
+          tag: 'th',
           text: '5',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: '6',
+          tag: 'th',
           text: '6',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: '2',
+          tag: 'th',
           text: '2',
-          span: 4,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 4,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: '3',
+          tag: 'th',
           text: '3',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: '5',
+          tag: 'th',
           text: '5',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: '6',
+          tag: 'th',
           text: '6',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: '4',
+          tag: 'th',
           text: '4',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: '5',
+          tag: 'th',
           text: '5',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: '6',
+          tag: 'th',
           text: '6',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -321,37 +301,37 @@ describe('createExpandedRowHeaders', () => {
           .addChild(new Header('D', 'D')),
       ),
     ];
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -368,67 +348,67 @@ describe('createExpandedRowHeaders', () => {
         .addChild(new Header('D', 'D').addChild(new Header('F', 'F')))
         .addChild(new Header('E', 'E').addChild(new Header('F', 'F'))),
     ];
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -449,90 +429,90 @@ describe('createExpandedRowHeaders', () => {
       ),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'G',
+          tag: 'th',
           text: 'G',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -553,67 +533,67 @@ describe('createExpandedRowHeaders', () => {
       ),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: true,
-          crossSpan: 2,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 2,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -621,7 +601,7 @@ describe('createExpandedRowHeaders', () => {
     expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
   });
 
-  test('returns correct headers with multi-span `rowgroup` merged with its identical groups', () => {
+  test('returns correct headers with multi-rowSpan `rowgroup` merged with its identical groups', () => {
     const rowHeaders: Header[] = [
       new Header('B', 'B').addChild(
         new Header('A', 'A').addChild(new Header('F', 'F')),
@@ -633,44 +613,44 @@ describe('createExpandedRowHeaders', () => {
       ),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 2,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 2,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 2,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -678,7 +658,7 @@ describe('createExpandedRowHeaders', () => {
     expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
   });
 
-  test('returns correct headers with multi-span `rowgroup` header merged with 2 identical groups ', () => {
+  test('returns correct headers with multi-rowSpan `rowgroup` header merged with 2 identical groups ', () => {
     const rowHeaders: Header[] = [
       new Header('A', 'A').addChild(
         new Header('B', 'B').addChild(new Header('C', 'C')),
@@ -693,76 +673,76 @@ describe('createExpandedRowHeaders', () => {
       ),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 2,
-          isGroup: true,
-          crossSpan: 2,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 2,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'G',
+          tag: 'th',
           text: 'G',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -770,7 +750,7 @@ describe('createExpandedRowHeaders', () => {
     expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
   });
 
-  test('does not return `rowgroup` headers with multi-span subgroup with invalid rowspans and colspans', () => {
+  test('does not return `rowgroup` headers with multi-rowSpan subgroup with invalid rowrowSpans and colrowSpans', () => {
     const rowHeaders: Header[] = [
       new Header('B', 'B').addChild(
         new Header('A', 'A').addChild(new Header('E', 'E')),
@@ -784,71 +764,71 @@ describe('createExpandedRowHeaders', () => {
         .addChild(new Header('D', 'D').addChild(new Header('E', 'E'))),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 3,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 3,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 2,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       undefined,
       [
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
-    ] as ExpandedHeader[][];
+    ] as TableCellJson[][];
 
     expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
   });
@@ -862,37 +842,37 @@ describe('createExpandedRowHeaders', () => {
       ),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -911,53 +891,53 @@ describe('createExpandedRowHeaders', () => {
         ),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 3,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 3,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -976,69 +956,69 @@ describe('createExpandedRowHeaders', () => {
         )
         .addChild(new Header('D', 'D').addChild(new Header('H', 'H'))),
     ];
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 4,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 4,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'G',
+          tag: 'th',
           text: 'G',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -1058,67 +1038,67 @@ describe('createExpandedRowHeaders', () => {
       ),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 2,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 2,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'G',
+          tag: 'th',
           text: 'G',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -1138,60 +1118,60 @@ describe('createExpandedRowHeaders', () => {
       ),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: false,
-          crossSpan: 3,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 3,
         },
       ],
       [
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'G',
+          tag: 'th',
           text: 'G',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -1212,67 +1192,67 @@ describe('createExpandedRowHeaders', () => {
       ),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: true,
-          crossSpan: 2,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 2,
         },
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'G',
+          tag: 'th',
           text: 'G',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -1288,53 +1268,53 @@ describe('createExpandedRowHeaders', () => {
         .addChild(new Header('D', 'D').addChild(new Header('F', 'F'))),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 3,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 3,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: false,
-          crossSpan: 2,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 2,
         },
       ],
       [
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -1350,53 +1330,53 @@ describe('createExpandedRowHeaders', () => {
         .addChild(new Header('E', 'E').addChild(new Header('F', 'F'))),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 3,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 3,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: false,
-          crossSpan: 2,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 2,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
     ];
@@ -1408,356 +1388,503 @@ describe('createExpandedRowHeaders', () => {
     const rowHeaders: Header[] = [
       new Header('A', 'A').addChild(
         new Header('A', 'A').addChild(
-          new Header('A', 'A').addChild(new Header('A', 'A')),
+          new Header('A', 'A').addChild(
+            new Header('A', 'A').addChild(new Header('A', 'A')),
+          ),
         ),
       ),
       new Header('B', 'B').addChild(
         new Header('B', 'B')
-          .addChild(new Header('B', 'B').addChild(new Header('B', 'B')))
-          .addChild(new Header('C', 'C').addChild(new Header('D', 'D'))),
+          .addChild(
+            new Header('B', 'B').addChild(
+              new Header('B', 'B').addChild(new Header('B', 'B')),
+            ),
+          )
+          .addChild(
+            new Header('C', 'C').addChild(
+              new Header('D', 'D').addChild(new Header('D1', 'D1')),
+            ),
+          ),
       ),
       new Header('E', 'E').addChild(
         new Header('F', 'F')
           .addChild(
             new Header('F', 'F')
-              .addChild(new Header('F', 'F'))
-              .addChild(new Header('G', 'G')),
+              .addChild(new Header('F', 'F').addChild(new Header('F', 'F')))
+              .addChild(new Header('G', 'G').addChild(new Header('G1', 'G1'))),
           )
           .addChild(
             new Header('H', 'H')
-              .addChild(new Header('I', 'I'))
-              .addChild(new Header('J', 'J')),
+              .addChild(new Header('I', 'I').addChild(new Header('I', 'I')))
+              .addChild(new Header('J', 'J').addChild(new Header('J', 'J'))),
           ),
       ),
     ];
 
-    const expandedRowHeaders: ExpandedHeader[][] = [
+    const expandedRowHeaders: TableCellJson[][] = [
       [
         {
-          id: 'A',
+          tag: 'th',
           text: 'A',
-          span: 1,
-          isGroup: false,
-          crossSpan: 4,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 5,
         },
       ],
       [
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 2,
-          isGroup: true,
-          crossSpan: 2,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 2,
         },
         {
-          id: 'B',
+          tag: 'th',
           text: 'B',
-          span: 1,
-          isGroup: false,
-          crossSpan: 2,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 3,
         },
       ],
       [
         {
-          id: 'C',
+          tag: 'th',
           text: 'C',
-          span: 1,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'D',
+          tag: 'th',
           text: 'D',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
+        },
+        {
+          tag: 'th',
+          text: 'D1',
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'E',
+          tag: 'th',
           text: 'E',
-          span: 4,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 4,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 4,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 4,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'F',
+          tag: 'th',
           text: 'F',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 2,
         },
       ],
       [
         {
-          id: 'G',
+          tag: 'th',
           text: 'G',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          colSpan: 1,
+        },
+        {
+          tag: 'th',
+          text: 'G1',
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 1,
         },
       ],
       [
         {
-          id: 'H',
+          tag: 'th',
           text: 'H',
-          span: 2,
-          isGroup: true,
-          crossSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          colSpan: 1,
         },
         {
-          id: 'I',
+          tag: 'th',
           text: 'I',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 2,
         },
       ],
       [
         {
-          id: 'J',
+          tag: 'th',
           text: 'J',
-          span: 1,
-          isGroup: false,
-          crossSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          colSpan: 2,
         },
       ],
     ];
 
     expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
   });
-  //     new Header('A', 'A')
-  //       .addChild(new Header('B', '').addChild(new Header('C', 'C')))
-  //       .addChild(new Header('D', 'D').addChild(new Header('D', 'D'))),
-  //   ];
 
-  //   const expandedRowHeaders: ExpandedHeader[][] = [
-  //     [
-  //       { id: 'A', text: 'A', span: 2, isGroup: true, crossSpan: 1 },
-  //       { id: 'C', text: 'C', span: 1, isGroup: false, crossSpan: 2 },
-  //     ],
-  //     [{ id: 'D', text: 'D', span: 1, isGroup: false, crossSpan: 2 }],
-  //   ];
-  //   expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
-  // });
+  test('returns correct headers with only headers merged with identical parent in the first row', () => {
+    const rowHeaders: Header[] = [
+      new Header('A', 'A').addChild(
+        new Header('A', 'A')
+          .addChild(new Header('C', 'C'))
+          .addChild(new Header('D', 'D')),
+      ),
+      new Header('B', 'B').addChild(
+        new Header('B', 'B')
+          .addChild(new Header('C', 'C'))
+          .addChild(new Header('D', 'D')),
+      ),
+    ];
 
-  // test.skip('returns correct headers with all colspan = 1 when has empty header cell text', () => {
-  //   const rowHeaders: Header[] = [
-  //     new Header('A', 'A'), // not sure this is valid as would always have child?
-  //     new Header('D', '')
-  //       .addChild(new Header('E', 'E'))
-  //       .addChild(new Header('F', 'F')),
-  //   ];
+    const expandedRowHeaders: TableCellJson[][] = [
+      [
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'A',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'C',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'D',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'B',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'C',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'D',
+        },
+      ],
+    ];
 
-  //   const expandedRowHeaders: ExpandedHeader[][] = [
-  //     [
-  //       {
-  //         crossSpan: 2, // received 1 when shouldnt be
-  //         id: 'A',
-  //         isGroup: false,
-  //         span: 1,
-  //         text: 'A',
-  //       },
-  //     ],
-  //     [
-  //       {
-  //         crossSpan: 2,
-  //         id: 'E',
-  //         isGroup: false,
-  //         span: 1,
-  //         text: 'E',
-  //       },
-  //     ],
-  //     [
-  //       {
-  //         crossSpan: 2,
-  //         id: 'F',
-  //         isGroup: false,
-  //         span: 1,
-  //         text: 'F',
-  //       },
-  //     ],
-  //   ];
+    expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+  });
 
-  //   expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
-  // });
+  test('returns correct headers with only headers merged with identical parent in the middle row', () => {
+    const rowHeaders: Header[] = [
+      new Header('A', 'A')
+        .addChild(
+          new Header('B', 'B').addChild(
+            new Header('B', 'B')
+              .addChild(new Header('D', 'D'))
+              .addChild(new Header('E', 'E')),
+          ),
+        )
+        .addChild(
+          new Header('C', 'C').addChild(
+            new Header('C', 'C')
+              .addChild(new Header('D', 'D'))
+              .addChild(new Header('E', 'E')),
+          ),
+        ),
+    ];
 
-  // test('returns correct column headers for 3 levels with empty header cell text', () => {
-  //   const rowHeaders: Header[] = [
-  //     new Header('A', 'A')
-  //       .addChild(new Header('B', 'B').addChild(new Header('E', 'E')))
-  //       .addChild(new Header('C', 'C').addChild(new Header('F', 'F'))),
+    const expandedRowHeaders: TableCellJson[][] = [
+      [
+        {
+          colSpan: 1,
+          rowSpan: 4,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'A',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'B',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'D',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'E',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'C',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'D',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'E',
+        },
+      ],
+    ];
 
-  //     new Header('G', 'G').addChild(
-  //       new Header('I', '').addChild(new Header('K', 'K')),
-  //     ),
+    expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+  });
 
-  //     new Header('H', 'H').addChild(
-  //       new Header('J', 'J').addChild(new Header('L', 'L')),
-  //     ),
-  //   ];
+  test('returns correct headers with only headers merged with identical parent in the last row', () => {
+    const rowHeaders: Header[] = [
+      new Header('A', 'A')
+        .addChild(
+          new Header('B', 'B')
+            .addChild(new Header('D', 'D').addChild(new Header('D', 'D')))
+            .addChild(new Header('E', 'E').addChild(new Header('E', 'E'))),
+        )
+        .addChild(
+          new Header('C', 'C')
+            .addChild(new Header('D', 'D').addChild(new Header('D', 'D')))
+            .addChild(new Header('E', 'E').addChild(new Header('E', 'E'))),
+        ),
+    ];
 
-  //   const expandedRowHeaders: ExpandedHeader[][] = [
-  //     [
-  //       {
-  //         crossSpan: 1,
-  //         id: 'A',
-  //         isGroup: true,
-  //         span: 2,
-  //         text: 'A',
-  //       },
-  //       {
-  //         crossSpan: 1,
-  //         id: 'B',
-  //         isGroup: true,
-  //         span: 1,
-  //         text: 'B',
-  //       },
-  //       {
-  //         crossSpan: 1,
-  //         id: 'E',
-  //         isGroup: false,
-  //         span: 1,
-  //         text: 'E',
-  //       },
-  //     ],
-  //     [
-  //       {
-  //         crossSpan: 1,
-  //         id: 'C',
-  //         isGroup: true,
-  //         span: 1,
-  //         text: 'C',
-  //       },
-  //       {
-  //         crossSpan: 1,
-  //         id: 'F',
-  //         isGroup: false,
-  //         span: 1,
-  //         text: 'F',
-  //       },
-  //     ],
-  //     [
-  //       {
-  //         crossSpan: 1,
-  //         id: 'G',
-  //         isGroup: true,
-  //         span: 1,
-  //         text: 'G',
-  //       },
+    const expandedRowHeaders: TableCellJson[][] = [
+      [
+        {
+          colSpan: 1,
+          rowSpan: 4,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'A',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'B',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'D',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'E',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'C',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'D',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'E',
+        },
+      ],
+    ];
 
-  //       {
-  //         crossSpan: 2,
-  //         id: 'K',
-  //         isGroup: false,
-  //         span: 1,
-  //         text: 'K',
-  //       },
-  //     ],
-  //     [
-  //       {
-  //         crossSpan: 1,
-  //         id: 'H',
-  //         isGroup: true,
-  //         span: 1,
-  //         text: 'H',
-  //       },
-  //       {
-  //         crossSpan: 1,
-  //         id: 'J',
-  //         isGroup: true,
-  //         span: 1,
-  //         text: 'J',
-  //       },
-  //       {
-  //         crossSpan: 1,
-  //         id: 'L',
-  //         isGroup: false,
-  //         span: 1,
-  //         text: 'L',
-  //       },
-  //     ],
-  //   ];
+    expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+  });
 
-  //   expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
-  // });
+  test('returns the correct headers when there are multiple groups with the same labels', () => {
+    const rowHeaders: Header[] = [
+      new Header('A', 'A').addChild(
+        new Header('C', 'C')
+          .addChild(new Header('A', 'A').addChild(new Header('D', 'D')))
+          .addChild(new Header('B', 'B').addChild(new Header('E', 'E'))),
+      ),
+      new Header('B', 'B').addChild(
+        new Header('F', 'F')
+          .addChild(new Header('A', 'A').addChild(new Header('D', 'D')))
+          .addChild(new Header('B', 'B').addChild(new Header('E', 'E'))),
+      ),
+    ];
 
-  // test('NEW', () => {
-  //   const rowHeaders: Header[] = [
-  //     new Header('A', 'A')
-  //       .addChild(
-  //         new Header('B', 'B').addChild(
-  //           new Header('B', 'B')
-  //             .addChild(
-  //               new Header('C', 'C')
-  //                 .addChild(new Header('E', 'E'))
-  //                 .addChild(new Header('F', 'F')),
-  //             )
-  //             .addChild(
-  //               new Header('D', 'D')
-  //                 .addChild(new Header('E', 'E'))
-  //                 .addChild(new Header('F', 'F')),
-  //             ),
-  //         ),
-  //       )
-  //       .addChild(
-  //         new Header('', '').addChild(
-  //           new Header('G', 'G')
-  //             .addChild(
-  //               new Header('C', 'C')
-  //                 .addChild(new Header('E', 'E'))
-  //                 .addChild(new Header('F', 'F')),
-  //             )
-  //             .addChild(
-  //               new Header('D', 'D')
-  //                 .addChild(new Header('E', 'E'))
-  //                 .addChild(new Header('F', 'F')),
-  //             ),
-  //         ),
-  //       ),
-  //   ];
+    const expandedRowHeaders: TableCellJson[][] = [
+      [
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'A',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'C',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'A',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'D',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'B',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'E',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'B',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 2,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'F',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'A',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'D',
+        },
+      ],
+      [
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'rowgroup',
+          tag: 'th',
+          text: 'B',
+        },
+        {
+          colSpan: 1,
+          rowSpan: 1,
+          scope: 'row',
+          tag: 'th',
+          text: 'E',
+        },
+      ],
+    ];
 
-  //   const expandedRowHeaders: ExpandedHeader[][] = [
-  //     [
-  //       { id: 'A', text: 'A', span: 8, isGroup: true, crossSpan: 1 },
-  //       { id: 'B', text: 'B', span: 4, isGroup: true, crossSpan: 2 },
-  //       { id: 'C', text: 'C', span: 2, isGroup: true, crossSpan: 1 },
-  //       { id: 'E', text: 'E', span: 1, isGroup: false, crossSpan: 1 },
-  //     ],
-  //     [{ id: 'F', text: 'F', span: 1, isGroup: false, crossSpan: 1 }],
-  //     [
-  //       { id: 'D', text: 'D', span: 2, isGroup: true, crossSpan: 1 },
-  //       { id: 'E', text: 'E', span: 1, isGroup: false, crossSpan: 1 },
-  //     ],
-  //     [{ id: 'F', text: 'F', span: 1, isGroup: false, crossSpan: 1 }],
-  //     [
-  //       { id: 'G', text: 'G', span: 4, isGroup: true, crossSpan: 2 },
-  //       { id: 'C', text: 'C', span: 2, isGroup: true, crossSpan: 1 },
-  //       { id: 'E', text: 'E', span: 1, isGroup: false, crossSpan: 1 },
-  //     ],
-  //     [{ id: 'F', text: 'F', span: 1, isGroup: false, crossSpan: 1 }],
-  //     [
-  //       { id: 'D', text: 'D', span: 2, isGroup: true, crossSpan: 1 },
-  //       { id: 'E', text: 'E', span: 1, isGroup: false, crossSpan: 1 },
-  //     ],
-  //     [{ id: 'F', text: 'F', span: 1, isGroup: false, crossSpan: 1 }],
-  //   ];
-
-  //   expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
-  // });
+    expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+  });
 });

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableToJson.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableToJson.test.ts
@@ -8,13 +8,46 @@ import {
   testTableWithTwoLevelsOfRowAndOneLevelOfColHeadersConfig,
   testTableWithOneLevelOfRowsAndTwoLevelsOfColHeadersConfig,
   testTableWithMissingTimePeriod,
-  testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabelsConfig,
-  testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabels,
 } from '@common/modules/table-tool/utils/__data__/testTableData';
+import {
+  testTableWithOnlyMergedCellsInColumnHeadersConfig,
+  testTableWithOnlyMergedCellsInHeaders,
+  testTableWithMergedAndUnMergedCellsInHeaders,
+  testTableWithMergedAndUnMergedCellsInColumnHeadersConfig,
+  testTableWithOnlyMergedCellsInRowHeadersConfig,
+  testTableWithMergedAndUnmergedCellsInRowHeadersConfig,
+  testTableWithOnlyMergedCellsInFirstLevelOfHeaders,
+  testTableWithOnlyMergedCellsInMiddleLevelOfRowsConfig,
+  testTableWithOnlyMergedCellsInFirstLevelOfColumnHeadersConfig,
+  testTableWithMergedAndUnmergedCellsInFirstLevelOfColumnHeadersConfig,
+  testTableWithMergedAndUnmergedCellsInLastLevelOfColumnHeadersConfig,
+  testTableWithOnlyMergedCellsInLastLevelOfColumnHeadersConfig,
+  testTableWithOnlyMergedCellsInFirstLevelOfRowHeadersConfig,
+  testTableWithMergedAndUnmergedCellsInFirstLevelOfHeaders,
+  testTableWithMergedAndUnmergedCellsInFirstLevelOfRowHeadersConfig,
+  testTableWithOnlyMergedCellsInMiddleLevelOfColumnHeadersConfig,
+  testTableWithOnlyMergedCellsInMiddleLevelOfHeaders,
+  testTableWithMergedAndUnmergedCellsInMiddleLevelOfColumnHeadersConfig,
+  testTableWithMergedAndUnmergedCellsInMiddleLevelOfHeaders,
+  testTableWithMergedAndUnmergedCellsInMiddleLevelOfRowHeadersConfig,
+  testTableWithOnlyMergedCellsInLastLevelOfHeaders,
+  testTableWithOnlyMergedCellsInLastLevelOfRowHeadersConfig,
+  testTableWithMergedAndUnmergedCellsInLastLevelOfHeaders,
+  testTableWithMergedAndUnmergedCellsInLastLevelOfRowHeadersConfig,
+} from '@common/modules/table-tool/utils/__data__/testTableDataWithMergedCells';
 import mapTableToJson, {
   TableCellJson,
 } from '@common/modules/table-tool/utils/mapTableToJson';
 import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
+import {
+  testTableWithDuplicateFilterLabelsInColumnHeadersConfig,
+  testTableWithDuplicateFilterLabels,
+  testTableWithDuplicateFilterLabelsAndMissingData,
+  testTableWithDuplicateFilterLabelsInRowHeadersConfig,
+  testTableWithMultipleGroupsWithSameLabelsInColumnHeadersConfig,
+  testTableWithMultipleGroupsWithSameLabels,
+  testTableWithMultipleGroupsWithSameLabelsInRowHeadersConfig,
+} from '@common/modules/table-tool/utils/__data__/testTableDataWithDuplicateLabels';
 
 describe('mapTableToJson', () => {
   test('returns the correct JSON for a table with one level of row and column headers', () => {
@@ -120,7 +153,7 @@ describe('mapTableToJson', () => {
     ]);
   });
 
-  test('returns the correct JSON for  a table with two levels of col headers and one level of row headers', () => {
+  test('returns the correct JSON for a table with two levels of col headers and one level of row headers', () => {
     const result = mapTableToJson({
       tableHeadersConfig: testTableWithOneLevelOfRowsAndTwoLevelsOfColHeadersConfig,
       subjectMeta: testTableWithOneLevelOfRowAndColHeaders.subjectMeta,
@@ -515,134 +548,1845 @@ describe('mapTableToJson', () => {
     ]);
   });
 
-  test('correctly adds groups across three levels of column headers with same labels', () => {
-    const result = mapTableToJson({
-      tableHeadersConfig: testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabelsConfig,
-      subjectMeta:
-        testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabels.subjectMeta,
-      results:
-        testTableWithThreeLevelsOfColHeadersWithMultipleGroupsWithSameLabels.results,
-    }).tableJson;
+  describe('Handles multiple filter groups with the same labels', () => {
+    test('returns the correct JSON when there are multiple groups with the same labels in column headers', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMultipleGroupsWithSameLabelsInColumnHeadersConfig,
+        subjectMeta: testTableWithMultipleGroupsWithSameLabels.subjectMeta,
+        results: testTableWithMultipleGroupsWithSameLabels.results,
+      }).tableJson;
 
-    expect(result.thead).toEqual<TableCellJson[][]>([
-      [
-        { colSpan: 1, rowSpan: 5, tag: 'td' },
-        {
-          colSpan: 4,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Group 1',
-        },
-        {
-          colSpan: 4,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Group 2',
-        },
-      ],
-      [
-        {
-          colSpan: 4,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Category 3 Filter 1',
-        },
-        {
-          colSpan: 4,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Category 3 Filter 2',
-        },
-      ],
-      [
-        {
-          colSpan: 2,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Group 1',
-        },
-        {
-          colSpan: 2,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Group 2',
-        },
-        {
-          colSpan: 2,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Group 1',
-        },
-        {
-          colSpan: 2,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Group 2',
-        },
-      ],
-      [
-        {
-          colSpan: 2,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Category 1 Filter 2',
-        },
-        {
-          colSpan: 2,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Category 1 Filter 4',
-        },
-        {
-          colSpan: 2,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Category 1 Filter 2',
-        },
-        {
-          colSpan: 2,
-          rowSpan: 1,
-          scope: 'colgroup',
-          tag: 'th',
-          text: 'Category 1 Filter 4',
-        },
-      ],
-      [
-        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2012/13' },
-        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2013/14' },
-        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2012/13' },
-        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2013/14' },
-        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2012/13' },
-        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2013/14' },
-        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2012/13' },
-        { colSpan: 1, rowSpan: 1, scope: 'col', tag: 'th', text: '2013/14' },
-      ],
-    ]);
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 4, tag: 'td' },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Group 1',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Group 2',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Category 3 Group 1 Filter 1',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Category 3 Group 2 Filter 1',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Group 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Group 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Group 2',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 4 Group 1 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 4 Group 2 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 4 Group 1 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 4 Group 2 Filter 1',
+          },
+        ],
+      ]);
 
-    expect(result.tbody).toEqual<TableCellJson[][]>([
-      [
-        { colSpan: 1, rowSpan: 1, scope: 'row', tag: 'th', text: 'LA 1' },
-        { tag: 'td', text: '20' },
-        { tag: 'td', text: '7,163' },
-        { tag: 'td', text: '767' },
-        { tag: 'td', text: '19,340' },
-        { tag: 'td', text: '44' },
-        { tag: 'td', text: '32' },
-        { tag: 'td', text: '331' },
-        { tag: 'td', text: '2,458' },
-      ],
-    ]);
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Indicator 1',
+          },
+          { tag: 'td', text: '20' },
+          { tag: 'td', text: '44' },
+          { tag: 'td', text: '71' },
+          { tag: 'td', text: '32' },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when there are multiple groups with the same labels in row headers', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMultipleGroupsWithSameLabelsInRowHeadersConfig,
+        subjectMeta: testTableWithMultipleGroupsWithSameLabels.subjectMeta,
+        results: testTableWithMultipleGroupsWithSameLabels.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 4, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Indicator 1',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Group 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 3 Group 1 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Group 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 4 Group 1 Filter 1',
+          },
+          { tag: 'td', text: '20' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 4 Group 2 Filter 1',
+          },
+          { tag: 'td', text: '44' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 3 Group 2 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Group 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 4 Group 1 Filter 1',
+          },
+          { tag: 'td', text: '71' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 4 Group 2 Filter 1',
+          },
+          { tag: 'td', text: '32' },
+        ],
+      ]);
+    });
+  });
+
+  describe('Handles filters in different groups with the same label', () => {
+    test('returns the correct JSON when column headers contain filters in different groups with the same label', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithDuplicateFilterLabelsInColumnHeadersConfig,
+        subjectMeta: testTableWithDuplicateFilterLabels.subjectMeta,
+        results: testTableWithDuplicateFilterLabels.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 3, tag: 'td' },
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Indicator 1',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Filter 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Filter 2',
+            tag: 'th',
+          },
+        ],
+        [
+          { colSpan: 1, rowSpan: 1, scope: 'col', text: 'Filter 1', tag: 'th' },
+          { colSpan: 1, rowSpan: 1, scope: 'col', text: 'Filter 2', tag: 'th' },
+          { colSpan: 1, rowSpan: 1, scope: 'col', text: 'Filter 1', tag: 'th' },
+          { colSpan: 1, rowSpan: 1, scope: 'col', text: 'Filter 2', tag: 'th' },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: '2012/13',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '85',
+          },
+          {
+            tag: 'td',
+            text: '88',
+          },
+          {
+            tag: 'td',
+            text: '89',
+          },
+          {
+            tag: 'td',
+            text: '90',
+          },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when column headers contain filters in different groups with the same label and have missing data', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithDuplicateFilterLabelsInColumnHeadersConfig,
+        subjectMeta:
+          testTableWithDuplicateFilterLabelsAndMissingData.subjectMeta,
+        results: testTableWithDuplicateFilterLabelsAndMissingData.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 2, tag: 'td' },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Indicator 1',
+            tag: 'th',
+          },
+        ],
+        [
+          { colSpan: 1, rowSpan: 1, scope: 'col', text: 'Filter 1', tag: 'th' },
+          { colSpan: 1, rowSpan: 1, scope: 'col', text: 'Filter 2', tag: 'th' },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: '2012/13',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '85',
+          },
+          {
+            tag: 'td',
+            text: '90',
+          },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when row headers contain filters in different groups with the same label', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithDuplicateFilterLabelsInRowHeadersConfig,
+        subjectMeta: testTableWithDuplicateFilterLabels.subjectMeta,
+        results: testTableWithDuplicateFilterLabels.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 3, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: '2012/13',
+            tag: 'th',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            rowSpan: 4,
+            colSpan: 1,
+            scope: 'rowgroup',
+            text: 'Indicator 1',
+            tag: 'th',
+          },
+          {
+            rowSpan: 2,
+            colSpan: 1,
+            scope: 'rowgroup',
+            text: 'Filter 1',
+            tag: 'th',
+          },
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: 'Filter 1',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '85',
+          },
+        ],
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: 'Filter 2',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '88',
+          },
+        ],
+        [
+          {
+            rowSpan: 2,
+            colSpan: 1,
+            scope: 'rowgroup',
+            text: 'Filter 2',
+            tag: 'th',
+          },
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: 'Filter 1',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '89',
+          },
+        ],
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: 'Filter 2',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '90',
+          },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when row headers contain filters in different groups with the same label and have missing data', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithDuplicateFilterLabelsInRowHeadersConfig,
+        subjectMeta:
+          testTableWithDuplicateFilterLabelsAndMissingData.subjectMeta,
+        results: testTableWithDuplicateFilterLabelsAndMissingData.results,
+      }).tableJson;
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            rowSpan: 2,
+            colSpan: 1,
+            scope: 'rowgroup',
+            text: 'Indicator 1',
+            tag: 'th',
+          },
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: 'Filter 1',
+            tag: 'th',
+          },
+
+          {
+            tag: 'td',
+            text: '85',
+          },
+        ],
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: 'Filter 2',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '90',
+          },
+        ],
+      ]);
+    });
+  });
+
+  describe('Handles merged column headers', () => {
+    test('returns the correct JSON when column headers contain a single row of merged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithOnlyMergedCellsInColumnHeadersConfig,
+        subjectMeta: testTableWithOnlyMergedCellsInHeaders.subjectMeta,
+        results: testTableWithOnlyMergedCellsInHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 1 Group 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 1 Group 2',
+            tag: 'th',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: 'Indicator 1',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '85',
+          },
+          {
+            tag: 'td',
+            text: '74',
+          },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when column headers contain a single row of merged and unmerged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMergedAndUnMergedCellsInColumnHeadersConfig,
+        subjectMeta: testTableWithMergedAndUnMergedCellsInHeaders.subjectMeta,
+        results: testTableWithMergedAndUnMergedCellsInHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 2, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            text: 'Category 1 Group 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 1 Group 2',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 1 Group 2 Filter 1',
+            tag: 'th',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: 'Indicator 1',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '95',
+          },
+          {
+            tag: 'td',
+            text: '85',
+          },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when the first level of column headers contains only merged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithOnlyMergedCellsInFirstLevelOfColumnHeadersConfig,
+        subjectMeta:
+          testTableWithOnlyMergedCellsInFirstLevelOfHeaders.subjectMeta,
+        results: testTableWithOnlyMergedCellsInFirstLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 2, tag: 'td' },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: '2012/13',
+          },
+          { tag: 'td', text: '74' },
+          { tag: 'td', text: '85' },
+          { tag: 'td', text: '92' },
+          { tag: 'td', text: '87' },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when the first level of column headers contains merged and unmerged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMergedAndUnmergedCellsInFirstLevelOfColumnHeadersConfig,
+        subjectMeta:
+          testTableWithMergedAndUnmergedCellsInFirstLevelOfHeaders.subjectMeta,
+        results:
+          testTableWithMergedAndUnmergedCellsInFirstLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 3, tag: 'td' },
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2 Filter 1',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: '2012/13',
+          },
+          { tag: 'td', text: '74' },
+          { tag: 'td', text: '85' },
+          { tag: 'td', text: '92' },
+          { tag: 'td', text: '87' },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when a middle level of column headers contains only merged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithOnlyMergedCellsInMiddleLevelOfColumnHeadersConfig,
+        subjectMeta:
+          testTableWithOnlyMergedCellsInMiddleLevelOfHeaders.subjectMeta,
+        results: testTableWithOnlyMergedCellsInMiddleLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 3, tag: 'td' },
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Indicator 1',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 1 Group 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 1 Group 2',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 2 Group 1 Filter 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 2 Group 1 Filter 2',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 2 Group 1 Filter 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 2 Group 1 Filter 2',
+            tag: 'th',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: '2012/13',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '75',
+          },
+          {
+            tag: 'td',
+            text: '70',
+          },
+          {
+            tag: 'td',
+            text: '73',
+          },
+          {
+            tag: 'td',
+            text: '66',
+          },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when a middle level of column headers contains merged and unmerged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMergedAndUnmergedCellsInMiddleLevelOfColumnHeadersConfig,
+        subjectMeta:
+          testTableWithMergedAndUnmergedCellsInMiddleLevelOfHeaders.subjectMeta,
+        results:
+          testTableWithMergedAndUnmergedCellsInMiddleLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 4, tag: 'td' },
+          {
+            colSpan: 6,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Indicator 1',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'colgroup',
+            text: 'Category 1 Group 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 1 Group 2',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 1 Group 2 Filter 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 1 Group 2',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 2 Group 1 Filter 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 2 Group 1 Filter 2',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 2 Group 1 Filter 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 2 Group 1 Filter 2',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 2 Group 1 Filter 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 2 Group 1 Filter 2',
+            tag: 'th',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: '2012/13',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '88',
+          },
+          {
+            tag: 'td',
+            text: '85',
+          },
+          {
+            tag: 'td',
+            text: '87',
+          },
+          {
+            tag: 'td',
+            text: '85',
+          },
+          {
+            tag: 'td',
+            text: '79',
+          },
+          {
+            tag: 'td',
+            text: '74',
+          },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when the last level of column headers contains only merged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithOnlyMergedCellsInLastLevelOfColumnHeadersConfig,
+        subjectMeta:
+          testTableWithOnlyMergedCellsInLastLevelOfHeaders.subjectMeta,
+        results: testTableWithOnlyMergedCellsInLastLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 3, tag: 'td' },
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Indicator 1',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 2 Group 1 Filter 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 2 Group 1 Filter 2',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 1 Group 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 1 Group 2',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 1 Group 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 1 Group 2',
+            tag: 'th',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: '2012/13',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '74',
+          },
+          {
+            tag: 'td',
+            text: '92',
+          },
+          {
+            tag: 'td',
+            text: '85',
+          },
+          {
+            tag: 'td',
+            text: '87',
+          },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when the last level of column headers contains merged and unmerged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMergedAndUnmergedCellsInLastLevelOfColumnHeadersConfig,
+        subjectMeta:
+          testTableWithMergedAndUnmergedCellsInLastLevelOfHeaders.subjectMeta,
+        results:
+          testTableWithMergedAndUnmergedCellsInLastLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 4, tag: 'td' },
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Indicator 1',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 2 Group 1 Filter 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 2 Group 1 Filter 2',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            text: 'Category 1 Group 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 1 Group 2',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            text: 'Category 1 Group 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            text: 'Category 1 Group 2',
+            tag: 'th',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 1 Group 2 Filter 1',
+            tag: 'th',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            text: 'Category 1 Group 2 Filter 1',
+            tag: 'th',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            rowSpan: 1,
+            colSpan: 1,
+            scope: 'row',
+            text: '2012/13',
+            tag: 'th',
+          },
+          {
+            tag: 'td',
+            text: '74',
+          },
+          {
+            tag: 'td',
+            text: '92',
+          },
+          {
+            tag: 'td',
+            text: '85',
+          },
+          {
+            tag: 'td',
+            text: '87',
+          },
+        ],
+      ]);
+    });
+  });
+
+  describe('Handles merged row headers', () => {
+    test('returns the correct JSON when row headers contain a single row of merged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithOnlyMergedCellsInRowHeadersConfig,
+        subjectMeta: testTableWithOnlyMergedCellsInHeaders.subjectMeta,
+        results: testTableWithOnlyMergedCellsInHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: '2012/13',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          { tag: 'td', text: '85' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          { tag: 'td', text: '74' },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when row headers contain a single row of merged and unmerged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMergedAndUnmergedCellsInRowHeadersConfig,
+        subjectMeta: testTableWithMergedAndUnMergedCellsInHeaders.subjectMeta,
+        results: testTableWithMergedAndUnMergedCellsInHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 2, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: '2012/13',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          { tag: 'td', text: '95' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 2 Filter 1',
+          },
+          { tag: 'td', text: '85' },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when the first level of row headers contains only merged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithOnlyMergedCellsInFirstLevelOfRowHeadersConfig,
+        subjectMeta:
+          testTableWithOnlyMergedCellsInFirstLevelOfHeaders.subjectMeta,
+        results: testTableWithOnlyMergedCellsInFirstLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 2, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: '2012/13',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          { tag: 'td', text: '74' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          { tag: 'td', text: '85' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          { tag: 'td', text: '92' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          { tag: 'td', text: '87' },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when the first level of row headers contains merged and unmerged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMergedAndUnmergedCellsInFirstLevelOfRowHeadersConfig,
+        subjectMeta:
+          testTableWithMergedAndUnmergedCellsInFirstLevelOfHeaders.subjectMeta,
+        results:
+          testTableWithMergedAndUnmergedCellsInFirstLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 3, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: '2012/13',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          { tag: 'td', text: '74' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          { tag: 'td', text: '85' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          { tag: 'td', text: '92' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          { tag: 'td', text: '87' },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when a middle level of row headers contains only merged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithOnlyMergedCellsInMiddleLevelOfRowsConfig,
+        subjectMeta:
+          testTableWithOnlyMergedCellsInMiddleLevelOfHeaders.subjectMeta,
+        results: testTableWithOnlyMergedCellsInMiddleLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 3, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: '2012/13',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Indicator 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          { tag: 'td', text: '75' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          { tag: 'td', text: '70' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          { tag: 'td', text: '73' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          { tag: 'td', text: '66' },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when a middle level of row headers contains merged and unmerged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMergedAndUnmergedCellsInMiddleLevelOfRowHeadersConfig,
+        subjectMeta:
+          testTableWithMergedAndUnmergedCellsInMiddleLevelOfHeaders.subjectMeta,
+        results:
+          testTableWithMergedAndUnmergedCellsInMiddleLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 4, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: '2012/13',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Indicator 1',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          { tag: 'td', text: '88' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          { tag: 'td', text: '85' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          { tag: 'td', text: '87' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          { tag: 'td', text: '85' },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when the last level of row headers contains only merged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithOnlyMergedCellsInLastLevelOfRowHeadersConfig,
+        subjectMeta:
+          testTableWithOnlyMergedCellsInLastLevelOfHeaders.subjectMeta,
+        results: testTableWithOnlyMergedCellsInLastLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 3, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: '2012/13',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Indicator 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          { tag: 'td', text: '74' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          { tag: 'td', text: '92' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          { tag: 'td', text: '85' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          { tag: 'td', text: '87' },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON when the last level of row headers contains merged and unmerged cells', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMergedAndUnmergedCellsInLastLevelOfRowHeadersConfig,
+        subjectMeta:
+          testTableWithMergedAndUnmergedCellsInLastLevelOfHeaders.subjectMeta,
+        results:
+          testTableWithMergedAndUnmergedCellsInLastLevelOfHeaders.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 4, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: '2012/13',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Indicator 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          { tag: 'td', text: '74' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 2 Filter 1',
+          },
+          { tag: 'td', text: '92' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          { tag: 'td', text: '85' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 2 Filter 1',
+          },
+          { tag: 'td', text: '87' },
+        ],
+      ]);
+    });
   });
 
   describe('hasMissingRowsOrColumns', () => {

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/utils/debugTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/utils/debugTable.tsx
@@ -1,0 +1,79 @@
+import openPlaygroundUrl from '@common-test/openPlaygroundUrl';
+import {
+  TableCellJson,
+  TableJson,
+} from '@common/modules/table-tool/utils/mapTableToJson';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+/**
+ * Debug a table by rendering it in the browser.
+ */
+export default async function debugTable({
+  tbody,
+  thead,
+}: Partial<TableJson>): Promise<void> {
+  const renderHeaders = (headers: TableCellJson[][]) =>
+    headers.map((row, rowIndex) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <tr key={rowIndex}>
+        {row.map(({ tag: Tag, text, ...cell }, cellIndex) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Tag {...cell} key={cellIndex}>
+            {text}
+
+            {cell.colSpan !== undefined && (
+              <div className="spanText">{`colSpan: ${cell.colSpan}`}</div>
+            )}
+
+            {cell.rowSpan !== undefined && (
+              <div className="spanText">{`rowSpan: ${cell.rowSpan}`}</div>
+            )}
+          </Tag>
+        ))}
+      </tr>
+    ));
+
+  render(
+    <>
+      <style>
+        {`
+          table {
+            padding: 40px;  
+          }
+          
+          th,
+          td {
+            border: 1px solid #000;
+            padding: 10px;
+            font-family: monospace, sans;
+            font-size: 18px;
+          }
+          
+          [scope="colgroup"],
+          [scope="rowgroup"] {
+            background: #f5f5f5;
+          }
+          
+          [scope="col"],
+          [scope="row"] {
+            background: #dedede;
+          }
+          
+          .spanText {
+            color: #444;
+            font-size: 14px;
+            font-weight: 300;
+          }
+        `}
+      </style>
+
+      <table>
+        {thead && <thead>{renderHeaders(thead)}</thead>}
+        {tbody && <tbody>{renderHeaders(tbody)}</tbody>}
+      </table>
+    </>,
+  );
+
+  await openPlaygroundUrl();
+}

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/mapTableToJson.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/mapTableToJson.ts
@@ -17,14 +17,6 @@ import sumBy from 'lodash/sumBy';
 
 export type Scope = 'colgroup' | 'col' | 'rowgroup' | 'row';
 
-export interface ExpandedHeader {
-  id: string;
-  text: string;
-  span: number;
-  crossSpan: number;
-  isGroup: boolean;
-}
-
 export interface TableCellJson {
   colSpan?: number;
   rowSpan?: number;
@@ -109,18 +101,32 @@ export default function mapTableToJson({
     return addFilters(acc, filters);
   }, []);
 
-  const rows = tableCartesian.map(row => row.map(cell => cell.text));
+  const rows: TableCellJson[][] = tableCartesian.map(row =>
+    row.map(cell => ({ text: cell.text, tag: 'td' })),
+  );
 
   const expandedColumnHeaders = createExpandedColumnHeaders(columnHeaders);
 
   const expandedRowHeaders = createExpandedRowHeaders(rowHeaders);
 
-  const totalColumns = sumBy(expandedRowHeaders[0], header => header.crossSpan);
+  const totalColumns = sumBy(
+    expandedRowHeaders[0],
+    header => header.colSpan ?? 0,
+  );
+
+  // Insert a spacer cell at the start of column headers.
+  const spacerCell: TableCellJson = {
+    colSpan: totalColumns,
+    rowSpan: expandedColumnHeaders.length,
+    tag: 'td',
+  };
+
+  expandedColumnHeaders[0].unshift(spacerCell);
 
   return {
     tableJson: {
-      thead: mapTableHead(expandedColumnHeaders, totalColumns),
-      tbody: mapTableBody(rows, expandedRowHeaders),
+      thead: expandedColumnHeaders,
+      tbody: rows.map((row, index) => [...expandedRowHeaders[index], ...row]),
     },
     hasMissingRowsOrColumns: query
       ? hasMissingRowsOrColumns({
@@ -185,75 +191,4 @@ function addFilters(headers: Header[], filters: Filter[]) {
   });
 
   return headers;
-}
-
-/**
- * Maps the expanded column headers to JSON
- */
-function mapTableHead(
-  expandedColumnHeaders: ExpandedHeader[][],
-  totalColumns: number,
-): TableCellJson[][] {
-  return expandedColumnHeaders.map((columns, rowIndex) => {
-    const row: TableCellJson[] = [];
-    // add a spacer td to the first header row
-    if (rowIndex === 0) {
-      row.push({
-        colSpan: totalColumns,
-        rowSpan: expandedColumnHeaders.length,
-        tag: 'td',
-      });
-    }
-
-    row.push(
-      ...columns.map<TableCellJson>(col => ({
-        colSpan: col.span,
-        rowSpan: col.crossSpan,
-        scope:
-          rowIndex + col.crossSpan !== expandedColumnHeaders.length
-            ? 'colgroup'
-            : 'col',
-        text: col.text,
-        tag: 'th',
-      })),
-    );
-
-    return row;
-  });
-}
-
-/**
- * Maps the table body to JSON
- */
-function mapTableBody(
-  rows: string[][],
-  rowHeaders: ExpandedHeader[][],
-): TableCellJson[][] {
-  return rows.map((row, rowIndex) => {
-    const rowsJson: TableCellJson[] = [];
-
-    // add the row header
-    const rowsHeaderJson: TableCellJson[] = rowHeaders[rowIndex]?.map(
-      header => ({
-        rowSpan: header.span,
-        colSpan: header.crossSpan,
-        scope: header.isGroup ? 'rowgroup' : 'row',
-        text: header.text,
-        tag: 'th',
-      }),
-    );
-
-    rowsJson.push(...rowsHeaderJson);
-
-    rowsJson.push(
-      ...row.map<TableCellJson>(cell => {
-        return {
-          tag: 'td',
-          text: cell,
-        };
-      }),
-    );
-
-    return rowsJson;
-  });
 }

--- a/src/explore-education-statistics-common/test/openPlaygroundUrl.ts
+++ b/src/explore-education-statistics-common/test/openPlaygroundUrl.ts
@@ -1,0 +1,45 @@
+import { screen } from '@testing-library/react';
+import open from 'open';
+
+/**
+ * Render the current DOM and open it in the browser (via Testing Playground).
+ *
+ * @param element Optionally provide a specific element to render.
+ */
+export default async function openPlaygroundUrl(element?: Element) {
+  // Don't try to open in CI if we've left these in by accident
+  if (process.env.CI) {
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  const originalLog = console.log;
+
+  let url = '';
+
+  // eslint-disable-next-line no-console
+  console.log = (message: string, ...args: unknown[]) => {
+    const match = message.match(/https:\/\/testing-playground\.com.+[^\s$]/);
+
+    if (match) {
+      [url] = match;
+    }
+
+    originalLog(message, ...args);
+  };
+
+  await screen.logTestingPlaygroundURL(element);
+
+  // eslint-disable-next-line no-console
+  console.log = originalLog;
+
+  if (!url) {
+    fail(
+      'Could not load playground URL. Check `screen.logTestingPlaygroundURL` still outputs URL in expected format.',
+    );
+
+    return;
+  }
+
+  await open(url);
+}


### PR DESCRIPTION
The permalinks snapshot testing found two discrepancies in the table html which exposed bugs related to having filters and filter groups with the same name.

After this fix goes in there will still be a difference in the table html as the rowspans were wrong in the before version as well.

### 1. The only filters and filter groups in the column headers have the same names
Permalink id: 4a378c3c-6443-4af8-393f-08db371965b6

Here the `All state-funded mainstream institutions` filter is in filter group `All state-funded mainstream institutions` and `All institutions that are not academies` is in the filter group `All institutions that are not academies`, this caused the scope to be incorrectly set to `colgroup` in the after version (using table Json). In both the before and after versions the `rowspan` was incorrectly set to 2. 

Permalink before and after diff:
![snapshotdiff1](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/31724448-3235-4595-9862-a86c117f6481)

With this fix the correct `scope` and `rowspan` is applied:

![fixed1](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/1636941b-19f1-4f2a-94da-cd5ec3d5e5e4)

### 2. Column headers have nested filters in different groups with the same names and some of the columns have no data
Permalink id: 1cca2255-b239-465c-832a-07d17e73606a

Here the Male and Female filters are nested under another group with Male and Female filters, and one of the filters for each has no data so the column is excluded. This also caused the scope to be incorrectly set to `colgroup` in the after version (using tableJson). In both the before and after versions the `rowspan` was incorrectly set to 2. 

Permalink before and after diff:
![snapshotdiff2](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/46d0dae8-9e25-4d64-9183-513c9a98141f)

With this fix the correct `scope` and `rowSpan` is applied:

![fixed2](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/d3ccaa7b-8981-4329-b661-b52688aed607)

### Additional fixes

In the course of this I found that there were multiple issues related to having headers where a whole level of headers contains only merged cells (merged because their parent filter groups have the same label), this results in:
- wrongly setting the scope to colgroup/rowgroup when it's the first or last level of headers
- adding an empty row to column headers when it's a middle level of headers
- having incorrect colspan/rowspan on the merged cells at all levels

I've tried to cover all these cases in unit tests, which has generated a lot of test data. I've split this into 3 files just to make it a bit more manageable.

I've also re-written the existing test for multiple header groups with the same label to tidy up the test data and make it clearer what's being tested. Plus have added a rows version of the test.

