### PR TITLE
EES-4323 Update devopsSPN values to new SPNs' objectIds

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -48,7 +48,10 @@
       "value": 3
     },
     "devopsSPN": {
-      "value": "7c7b8f7c-e1aa-40ff-bc3a-5d4cfa98e49e"
+      "value": "e541f669-7fac-4d33-b480-29b523b9d968",
+      "metadata": {
+         "comments": "ObjectId for s101d-datahub-spn-ees-dfe-gov-uk"
+      }
     },
     "domain": {
       "value": "dev.explore-education-statistics.service.gov.uk"

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -36,7 +36,10 @@
       "value": false
     },
     "devopsSPN": {
-      "value": "702e692e-8bdf-4283-9799-9630cb781e33"
+      "value": "2d5a7bf2-a6b1-4474-b202-ab17dd87c375",
+      "metadata": {
+         "comments": "ObjectId for s101prep-datahub-spn-ees-dfe-gov-uk"
+      }
     },
     "domain": {
       "value": "pre-production.explore-education-statistics.service.gov.uk"

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -39,7 +39,10 @@
       "value": true
     },
     "devopsSPN": {
-      "value": "702e692e-8bdf-4283-9799-9630cb781e33"
+      "value": "911681c3-8cc7-4afc-8355-4cf60359d743",
+      "metadata": {
+         "comments": "ObjectId for s101p-datahub-spn-ees-dfe-gov-uk"
+      }
     },
     "domain": {
       "value": "explore-education-statistics.service.gov.uk"

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -36,7 +36,10 @@
       "value": true
     },
     "devopsSPN": {
-      "value": "10ddc034-bdb0-4655-92ba-4ad6c490d68a"
+      "value": "22888fee-3aa4-411d-8016-bb8a8c3b825a",
+      "metadata": {
+         "comments": "ObjectId for s101t-datahub-spn-ees-dfe-gov-uk"
+      }
     },
     "domain": {
       "value": "test.explore-education-statistics.service.gov.uk"

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -3620,7 +3620,7 @@
             }
           },
           {
-            "tenantId": "9c7d9dd3-840c-4b3f-818e-552865082e16",
+            "tenantId": "[subscription().tenantId]",
             "objectId": "[parameters('devopsSPN')]", // Devops SPN
             "permissions": {
               "keys": [


### PR DESCRIPTION
This PR updates the `devopsSPN` parameter used in the ARM template to the new SPNs' objectIds.

One thing to note is that previously both preprod and prod were using the same SPN. Now they are not.