### PR TITLE
EES-4362 add reference lines between two points

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
@@ -73,6 +73,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
         public AxisReferenceLineStyle? Style;
 
         public int? OtherAxisPosition;
+
+        public string? OtherAxisStart;
+
+        public string? OtherAxisEnd;
     }
 
     [SuppressMessage("ReSharper", "InconsistentNaming")]

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -35,6 +35,7 @@ import { OmitStrict } from '@common/types';
 import parseNumber from '@common/utils/number/parseNumber';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
+import isEqual from 'lodash/isEqual';
 import mapValues from 'lodash/mapValues';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
@@ -545,9 +546,7 @@ const ChartAxisConfiguration = ({
                 form.setFieldValue(
                   'referenceLines',
                   form.values.referenceLines?.filter(
-                    refLine =>
-                      refLine.position !== line.position &&
-                      refLine.label !== line.label,
+                    refLine => !isEqual(refLine, line),
                   ),
                 );
               }}

--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -220,11 +220,14 @@ const HorizontalBarBlock = ({
           {axes.minor.referenceLines?.map(referenceLine =>
             createReferenceLine({
               axis: 'x',
+              axisDomain: minorDomainTicks.domain,
               axisType: 'minor',
               chartData,
               label: referenceLine.label,
               otherAxisDomain: majorDomainTicks.domain,
+              otherAxisEnd: referenceLine.otherAxisEnd,
               otherAxisPosition: referenceLine.otherAxisPosition,
+              otherAxisStart: referenceLine.otherAxisStart,
               position: referenceLine.position,
               style: referenceLine.style,
               x: referenceLine.position,

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -231,11 +231,14 @@ const LineChartBlock = ({
           {axes.minor.referenceLines?.map(referenceLine =>
             createReferenceLine({
               axis: 'y',
+              axisDomain: minorDomainTicks.domain,
               axisType: 'minor',
               chartData,
               label: referenceLine.label,
               otherAxisDomain: majorDomainTicks.domain,
+              otherAxisEnd: referenceLine.otherAxisEnd,
               otherAxisPosition: referenceLine.otherAxisPosition,
+              otherAxisStart: referenceLine.otherAxisStart,
               position: referenceLine.position,
               style: referenceLine.style,
               y: referenceLine.position,

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -212,11 +212,14 @@ const VerticalBarBlock = ({
           {axes.minor.referenceLines?.map(referenceLine =>
             createReferenceLine({
               axis: 'y',
+              axisDomain: minorDomainTicks.domain,
               axisType: 'minor',
               chartData,
               label: referenceLine.label,
               otherAxisDomain: majorDomainTicks.domain,
+              otherAxisEnd: referenceLine.otherAxisEnd,
               otherAxisPosition: referenceLine.otherAxisPosition,
+              otherAxisStart: referenceLine.otherAxisStart,
               position: referenceLine.position,
               style: referenceLine.style,
               y: referenceLine.position,

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/__tests__/getReferenceLineLabelPosition.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/__tests__/getReferenceLineLabelPosition.test.ts
@@ -41,7 +41,7 @@ describe('getReferenceLineLabelPosition', () => {
     });
   });
 
-  test('returns the default position for an X axis line when otherAxisPosition below the minimum', () => {
+  test('returns the default position for an X axis line when otherAxisPosition is below the minimum', () => {
     const result = getReferenceLineLabelPosition({
       axis: 'x',
       axisType: 'minor',
@@ -62,7 +62,7 @@ describe('getReferenceLineLabelPosition', () => {
     });
   });
 
-  test('returns the default position for an X axis line when otherAxisPosition above the maximum', () => {
+  test('returns the default position for an X axis line when otherAxisPosition is above the maximum', () => {
     const result = getReferenceLineLabelPosition({
       axis: 'x',
       axisType: 'minor',
@@ -83,7 +83,7 @@ describe('getReferenceLineLabelPosition', () => {
     });
   });
 
-  test('returns the default position for a Y axis line when otherAxisPosition below the minimum', () => {
+  test('returns the default position for a Y axis line when otherAxisPosition is below the minimum', () => {
     const result = getReferenceLineLabelPosition({
       axis: 'y',
       axisType: 'major',
@@ -104,7 +104,7 @@ describe('getReferenceLineLabelPosition', () => {
     });
   });
 
-  test('returns the default position for a Y axis line when otherAxisPosition above the maximum', () => {
+  test('returns the default position for a Y axis line when otherAxisPosition is above the maximum', () => {
     const result = getReferenceLineLabelPosition({
       axis: 'y',
       axisType: 'major',

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/getReferenceLineLabelPosition.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/getReferenceLineLabelPosition.ts
@@ -22,8 +22,8 @@ export default function getReferenceLineLabelPosition({
   viewBox?: CartesianViewBox;
 }): LabelPosition {
   const { height = 0, width = 0, x = 0, y = 0 } = viewBox ?? {};
-  const defaultXPosition = axis === 'x' ? x : width / 2 + x;
-  const defaultYPosition = axis === 'y' ? y : height / 2 + y;
+  const defaultXPosition = axis === 'y' ? width / 2 + x : x;
+  const defaultYPosition = axis === 'x' ? height / 2 + y : y;
 
   // No custom other axis position or domain so default to middle
   if (
@@ -41,6 +41,7 @@ export default function getReferenceLineLabelPosition({
 
   // Amount to offset from the top on horizontal bar charts so the label is visible when positioned at 100%
   const yOffset = 15;
+
   const yPosition =
     y +
     height * ((otherAxisDomainMax - otherAxisPosition) / otherAxisDomainMax);

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -37,8 +37,11 @@ export type LineChartDataLabelPosition = 'above' | 'below';
 export type BarChartDataLabelPosition = 'inside' | 'outside';
 
 export interface ReferenceLine {
+  endPosition?: string;
   label: string;
+  otherAxisEnd?: string;
   otherAxisPosition?: number;
+  otherAxisStart?: string;
   position: number | string;
   style?: ReferenceLineStyle;
 }


### PR DESCRIPTION
Adds the ability to create a reference line between two data points, for example to explain why there's a gap in the chart:

<img width="743" alt="chart" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/03bde5fa-5bbe-4bd2-8316-e71f14897435">

When adding a reference line on the major axis:
- you can now select 'Between data points' in the Position dropdown
- this reveals dropdowns for start and end points for the line
- you can adjust the other axis position, label and style as normal.

<img width="919" alt="linelabels1" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/4238a708-0308-406b-a49a-0ed4f02bc4a8">
