### PR TITLE
EES-4392 - log info if SlugNotUnique error is thrown

### DIFF
--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -284,7 +284,10 @@ def admin_request(method, endpoint, body=None):
 
         assert response.status_code not in {401, 403}, "Failed to reauthenticate."
 
-    assert response.status_code < 300, f"Admin request responded with {response.status_code} and {response.text}"
+    if response.status_code == 400 and response.text.find("SlugNotUnique") != -1:
+        raise Exception(f"SlugNotUnique for {body}")
+    else:
+        assert response.status_code < 300, f"Admin request responded with {response.status_code} and {response.text}"
     return response
 
 


### PR DESCRIPTION
This PR:

* logs the body to the console if a SlugNotUnique error is encountered