### PR TITLE
EES-4195 Add checklist warning if release has no key stat or headline text block

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
@@ -151,7 +151,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.False(checklist.Valid);
 
-                Assert.Equal(6, checklist.Errors.Count);
+                Assert.Equal(7, checklist.Errors.Count);
 
                 Assert.Equal(DataFileImportsMustBeCompleted, checklist.Errors[0].Code);
                 Assert.Equal(DataFileReplacementsMustBeCompleted, checklist.Errors[1].Code);
@@ -159,6 +159,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(ReleaseNoteRequired, checklist.Errors[3].Code);
                 Assert.Equal(EmptyContentSectionExists, checklist.Errors[4].Code);
                 Assert.Equal(GenericSectionsContainEmptyHtmlBlock, checklist.Errors[5].Code);
+                Assert.Equal(ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock, checklist.Errors[6].Code);
             }
 
             MockUtils.VerifyAllMocks(dataImportService,
@@ -509,7 +510,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         new HtmlBlock
                         {
-                            Body = ""
+                            Body = "Not empty"
                         }
                     }
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -12,6 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         // Content
         EmptyContentSectionExists,
         GenericSectionsContainEmptyHtmlBlock,
+        ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock,
         ContentBlockNotFound,
         IncorrectContentBlockTypeForUpdate,
         ContentBlockAlreadyAttachedToContentSection,

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
@@ -98,6 +98,15 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
               releaseRouteParams,
             ),
           };
+        case 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock':
+          return {
+            message:
+              'Release must contain a key statistic or a non-empty headline text block',
+            link: generatePath<ReleaseRouteParams>(
+              releaseContentRoute.path,
+              releaseRouteParams,
+            ),
+          };
         default:
           // Show error code, even if there is no mapping,
           // as this is better than having invisible errors.

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
@@ -17,6 +17,9 @@ describe('ReleaseStatusChecklist', () => {
               { code: 'DataFileReplacementsMustBeCompleted' },
               { code: 'PublicDataGuidanceRequired' },
               { code: 'ReleaseNoteRequired' },
+              { code: 'EmptyContentSectionExists' },
+              { code: 'GenericSectionsContainEmptyHtmlBlock' },
+              { code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock' },
             ],
           }}
           release={testRelease}
@@ -32,7 +35,7 @@ describe('ReleaseStatusChecklist', () => {
       screen.queryByRole('heading', { name: 'Warnings' }),
     ).not.toBeInTheDocument();
 
-    expect(screen.getByText('4 issues')).toBeInTheDocument();
+    expect(screen.getByText('7 issues')).toBeInTheDocument();
 
     expect(
       screen.getByRole('link', {
@@ -66,6 +69,34 @@ describe('ReleaseStatusChecklist', () => {
       screen.getByRole('link', {
         name:
           'A public release note for this amendment is required, add this near the top of the content page',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/content',
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Release content should not contain any empty sections',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/content',
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Release content should not contain empty text blocks',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/content',
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name:
+          'Release must contain a key statistic or a non-empty headline text block',
       }),
     ).toHaveAttribute(
       'href',

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -139,6 +139,7 @@ export const ReleaseChecklistErrorCode = [
   'ReleaseNoteRequired',
   'EmptyContentSectionExists',
   'GenericSectionsContainEmptyHtmlBlock',
+  'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock',
 ] as const;
 
 export type ReleaseChecklistError = {

--- a/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
@@ -103,6 +103,9 @@ Create some release content
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user waits until page contains button    Add a summary text block    %{WAIT_SMALL}
 
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
+
     user clicks button    Add new section
     user changes accordion section title    1    Dates data block
 

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -2,6 +2,7 @@
 Library             ../../../libs/admin_api.py
 Resource            ../../../libs/admin-common.robot
 Resource            ../../../libs/common.robot
+Resource            ../../../libs/admin/manage-content-common.robot
 Resource            ../../../libs/admin/analyst/role_ui_permissions.robot
 
 Suite Setup         user signs in as bau1
@@ -69,6 +70,11 @@ Check publication owner can add a footnote to ${SUBJECT_NAME}
     user enters text into element    id:footnoteForm-content    test footnote from the publication owner! (analyst)
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes    %{WAIT_SMALL}
+
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
 
 Add public prerelease access list
     user clicks link    Pre-release access

--- a/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
@@ -21,6 +21,13 @@ Create publicly accessible Publication
     user creates test release via api    ${PUBLICATION_ID}    AY    2021
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    Academic year 2021/22
+
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
+
+User approves release
     user approves original release for immediate publication
 
 Create Methodology with some content and images

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -15,8 +15,10 @@ Force Tags          Admin    Local    Dev    AltersData
 *** Variables ***
 ${PUBLICATION_NAME}=                UI tests - prerelease and amend %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=                    Calendar year 2000
-${SCHEDULED_PRERELEASE_WARNING}=    Pre-release users will have access to a preview of the release 24 hours before the scheduled publish date.
-${IMMEDIATE_PRERELEASE_WARNING}=    Pre-release users will not have access to a preview of the release if it is published immediately.
+${SCHEDULED_PRERELEASE_WARNING}=
+...                                 Pre-release users will have access to a preview of the release 24 hours before the scheduled publish date.
+${IMMEDIATE_PRERELEASE_WARNING}=
+...                                 Pre-release users will not have access to a preview of the release if it is published immediately.
 
 
 *** Test Cases ***
@@ -53,6 +55,11 @@ Add metadata guidance
     user enters text into element    id:dataGuidanceForm-subjects-0-content    Test file guidance content
 
     user clicks button    Save guidance
+
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Test headlines summary text for ${PUBLICATION_NAME}
 
 Add public prerelease access list
     user clicks link    Pre-release access
@@ -131,10 +138,10 @@ user creates amendment for release
     user checks page contains tag    Amendment
 
 Add basic release content
-    user clicks link    Content
-    user waits until h1 is visible    ${PUBLICATION_NAME}
-    user waits until h2 is visible    ${PUBLICATION_NAME}
-    user adds basic release content    ${PUBLICATION_NAME}
+    user navigates to content page    ${PUBLICATION_NAME}
+
+    # FALSE to not add headline block, as we needed to add that to publish the original release
+    user adds basic release content    ${PUBLICATION_NAME}    ${FALSE}
 
 Add release note to amendment
     user clicks button    Add note

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Library             ../../libs/admin_api.py
 Resource            ../../libs/admin-common.robot
+Resource            ../../libs/admin/manage-content-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
@@ -23,6 +24,29 @@ Go to release sign off page and verify initial release checklist
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    Financial year 3000-01
 
+Validate checklist errors and warnings
+    user edits release status
+
+    user checks checklist warnings contains
+    ...    4 things you may have forgotten, but do not need to resolve to publish this release.
+    user checks checklist warnings contains link    An in-EES methodology page has not been linked to this publication
+    user checks checklist warnings contains link    No next expected release date has been added
+    user checks checklist warnings contains link    No data files uploaded
+    user checks checklist warnings contains link    A public pre-release access list has not been created
+
+    user checks checklist errors contains
+    ...    1 issue that must be resolved before this release can be published.
+    user checks checklist errors contains link
+    ...    Release must contain a key statistic or a non-empty headline text block
+
+    user checks page does not contain testid    releaseChecklist-success
+
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
+
+Validate checklist errors and warnings after adding headline text block
     user edits release status
 
     user checks checklist warnings contains
@@ -176,3 +200,13 @@ user checks checklist warnings does not contain link
     [Arguments]    ${text}
     user waits until page contains testid    releaseChecklist-warnings
     user waits until parent does not contain element    testid:releaseChecklist-warnings    link:${text}
+
+user checks checklist errors contains
+    [Arguments]    ${text}
+    user waits until page contains testid    releaseChecklist-errors
+    user waits until element contains    testid:releaseChecklist-errors    ${text}
+
+user checks checklist errors contains link
+    [Arguments]    ${text}
+    user waits until page contains testid    releaseChecklist-errors
+    user waits until parent contains element    testid:releaseChecklist-errors    link:${text}

--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -2,6 +2,7 @@
 Library             ../../libs/admin_api.py
 Resource            ../../libs/admin-common.robot
 Resource            ../../libs/public-common.robot
+Resource            ../../libs/admin/manage-content-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
@@ -43,6 +44,11 @@ Add data guidance to archive-publication subject
 
     user clicks button    Save guidance
     user waits until page contains button    Edit guidance
+
+Add headline text block to archive-publication content
+    user navigates to content page    ${PUBLICATION_NAME_ARCHIVE}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
 
 Go to "Sign off" page and approve archive-publication release
     user clicks link    Sign off
@@ -181,6 +187,11 @@ Add data guidance to superseding-publication subject
 
     user clicks button    Save guidance
     user waits until page contains button    Edit guidance
+
+Add headline text block to superseding-publication content
+    user navigates to content page    ${PUBLICATION_NAME_SUPERSEDE}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
 
 Go to "Sign off" page and approve superseding-publication release
     user clicks link    Sign off

--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -52,6 +52,11 @@ Add data guidance to subjects
 Save data guidance
     user clicks button    Save guidance
 
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
+
 Approve first release
     user clicks link    Sign off
     user approves release for immediate publication
@@ -80,6 +85,11 @@ Add data guidance to subjects (second release)
 
 Save data guidance (second release)
     user clicks button    Save guidance
+
+Add headline text block to Content page (second release)
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
 
 Approve release
     user clicks link    Sign off

--- a/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource            ../../libs/admin-common.robot
 Resource            ../../libs/public-common.robot
+Resource            ../../libs/admin/manage-content-common.robot
 Library             ../../libs/admin_api.py
 
 Force Tags          Admin    Local    Dev    AltersData
@@ -349,6 +350,11 @@ Add data guidance to subject
 
 Save data guidance
     user clicks button    Save guidance
+
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
 
 Approve first release
     user clicks link    Sign off

--- a/tests/robot-tests/tests/admin_and_public/bau/legacy_releases.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/legacy_releases.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource            ../../libs/admin-common.robot
+Resource            ../../libs/admin/manage-content-common.robot
 Library             ../../libs/admin_api.py
 
 Force Tags          Admin    Local    Dev    AltersData
@@ -47,6 +48,11 @@ Navigate to admin dashboard to create new release
 Navigate to release in admin
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    Academic year 2020/21
+
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
 
 Approve release
     user clicks link    Sign off

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource            ../../libs/admin-common.robot
+Resource            ../../libs/admin/manage-content-common.robot
 Library             ../../libs/admin_api.py
 
 Force Tags          Admin    Local    Dev    AltersData
@@ -64,6 +65,11 @@ Add data guidance to subject
     user waits until page contains accordion section    UI test subject
     user enters text into data guidance data file content editor    UI test subject    dataguidance content
     user clicks button    Save guidance
+
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
 
 Go to "Sign off" page
     user clicks link    Sign off

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
@@ -27,6 +27,10 @@ Navigate to release content
     user waits until page contains button    Add dashboards section
     user waits until page contains button    Add new section
 
+Add headline text block to release content
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
+
 Add Related dashboards section to release content
     user clicks button    Add dashboards section
     user waits until page contains accordion section    View related dashboard(s)

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -2,6 +2,7 @@
 Library             ../../libs/admin_api.py
 Resource            ../../libs/admin-common.robot
 Resource            ../../libs/public-common.robot
+Resource            ../../libs/admin/manage-content-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
@@ -36,6 +37,11 @@ Create new publication and release via API
 Navigate to release
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    ${RELEASE_1_NAME}
+
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
 
 Add public prerelease access list
     user clicks link    Pre-release access
@@ -423,6 +429,11 @@ Check footnotes were reordered on data block
     user checks list has x items    testid:footnotes    2
     user checks list item contains    testid:footnotes    1    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
     user checks list item contains    testid:footnotes    2    ${FOOTNOTE_ALL}
+
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
 
 Add public prerelease access list for release
     user clicks link    Pre-release access

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -105,9 +105,15 @@ Verify that the methodology is still not publicly accessible by URL without publ
     user navigates to public frontend    ${ACCESSIBLE_METHODOLOGY_URL}
     user waits until page contains    Page not found
 
-Approve the release
+Navigate to release content page and add headline text block
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    ${RELEASE_NAME}
+
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
+
+Approve the release
     user approves original release for immediate publication
 
 Verify that the user cannot edit the status of the methodology

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
@@ -2,6 +2,7 @@
 Library             ../../libs/admin_api.py
 Resource            ../../libs/public-common.robot
 Resource            ../../libs/admin-common.robot
+Resource            ../../libs/admin/manage-content-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
@@ -20,9 +21,15 @@ Create Publication as bau1
     ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
     user creates test release via api    ${PUBLICATION_ID}    AY    2046
 
-Publish release
+Navigate to release and add headline text block
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    Academic year 2046/47
+
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
+
+Publish release
     user approves release for immediate publication
 
 Update publication details

--- a/tests/robot-tests/tests/admin_and_public/bau/subject_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/subject_reordering.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource            ../../libs/admin-common.robot
 Resource            ../../libs/public-common.robot
+Resource            ../../libs/admin/manage-content-common.robot
 Library             ../../libs/admin_api.py
 
 Force Tags          Admin    Local    Dev    AltersData
@@ -178,6 +179,11 @@ Add data guidance for all subjects
     ...    Four guidance content
 
     user clicks button    Save guidance
+
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
 
 Publish release
     user approves original release for immediate publication

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -103,9 +103,14 @@ Navigate to 'Content' page
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user waits until page contains button    Add a summary text block    %{WAIT_SMALL}
 
-Add three accordion sections to release
     user waits for page to finish loading
     user waits until page does not contain loading spinner
+
+Add headline text block
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
+
+Add three accordion sections to release
     user clicks button    Add new section
     user changes accordion section title    1    Dates data block
     user clicks button    Add new section

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
@@ -97,6 +97,11 @@ Add second footnote to subject
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
+Add headline text block to Content page
+    user navigates to content page    ${PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
+
 Add public prerelease access list
     user clicks link    Pre-release access
     user creates public prerelease access list    Test public access list

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -16,13 +16,24 @@ ${METHODOLOGY_ANNEXES_READONLY_ACCORDION}=      id:methodologyAccordion-annexes
 
 
 *** Keywords ***
+user navigates to content page
+    [Arguments]    ${PUBLICATION_NAME}
+    user clicks link    Content
+    user waits until h2 is visible    ${PUBLICATION_NAME}
+    user waits until page contains button    Add a summary text block    %{WAIT_SMALL}
+
+    user waits for page to finish loading
+    user waits until page does not contain loading spinner
+
 user adds basic release content
-    [Arguments]    ${publication}
+    [Arguments]    ${publication}    ${add_headlines_block}=${TRUE}
     user adds summary text block
     user adds content to summary text block    Test summary text for ${publication}
 
-    user adds headlines text block
-    user adds content to headlines text block    Test headlines summary text for ${publication}
+    IF    ${add_headlines_block}
+        user adds headlines text block
+        user adds content to headlines text block    Test headlines summary text for ${publication}
+    END
 
     user waits until button is enabled    Add new section
     user clicks button    Add new section


### PR DESCRIPTION
This PR adds a checklist warning if a release has no key statistic or headline text block, preventing the user from publishing the release. The UI tests have been updated so that they pass given this change.

There is one failing UI test unrelated to this ticket. This will be fixed in EES-4393.