### PR TITLE
EES-4020 - implement automated dependency upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
+  "extends": ["config:base"],
+  "timezone": "Europe/London",
+  "azure-pipelines": {
+    "enabled": true
+  },
+  "vulnerabilityAlerts": {
+    "groupName": "renovate",
+    "dependencyDashboardApproval": false,
+    "minimumReleaseAge": "0d",
+    "rangeStrategy": "update-lockfile",
+    "commitMessageSuffix": "[SECURITY]",
+    "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
+    "prCreation": "immediate"
+  },
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "groupName": "Minor frontend dependencies",
+      "matchUpdateTypes": ["minor", "patch"],
+      "schedule": ["every month"],
+      "enabled": false
+    },
+    {
+      "matchDatasources": ["npm"],
+      "groupName": "Major frontend dependencies",
+      "matchUpdateTypes": ["major"],
+      "schedule": ["every 3 months"],
+      "enabled": false
+    },
+    {
+      "matchDatasources": ["nuget"],
+      "groupName": "Minor backend dependencies",
+      "matchUpdateTypes": ["minor", "patch"],
+      "schedule": ["every month"]
+    },
+    {
+      "matchDatasources": ["nuget"],
+      "groupName": "Major backend dependencies",
+      "matchUpdateTypes": ["major"],
+      "schedule": ["every month"]
+    },
+    {
+      "matchDatasources": ["pypi"],
+      "groupName": "python dependencies"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "groupName": "docker image updates"
+    },
+    {
+      "matchDatasources": ["azure-pipelines-tasks"],
+      "groupName": "azure-pipelines-tasks updates",
+      "extractVersion": "^(?<version>\\d+)"
+    },
+    {
+      "matchPackagePatterns": ["^@ckeditor/", "Mime", "Mime-Detective"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
This PR:
* implements automated dependency upgrade management via [renovate](https://renovatebot.com/). 

For now, we've decided to disable renovate running on the frontend packages until the majority of the frontend dependencies have been upgraded.

At the moment the latest version of `renovate` isn't compatible with the version of node that the project is on so I've decided to not add a pre-commit hook to validate the `renovate.json` file with `renovate-config-validator`. If the config is invalid, an issue will be created via renovate to let us know that something is wrong with the renovate config

⚠️IMPORTANT NOTE⚠️
* It's very important to note that if you push to a given branch that renovate has created, renovate will force push your changes away. This means that if you have to fix up a renovate branch after a dependency has caused breaking changes you will need to first create a branch, point the renovate PR to your desired branch, merge the renovate PR and then start work on your branch (so that renovate doesn't force push your changes away  

Relevant changes:
* Splits PRs dependent on package manager and semver versions of dependencies. Minor and major dependencies will be split up into different PRs to make it easier to manage varying levels of upgrades. 
* Adds a schedule of 1 month for semver minor updates and every 3 months for semver major upgrades (both FE & BE) 