### PR TITLE
EES-4332 - K6 improvements

### DIFF
--- a/tests/performance-tests/README.md
+++ b/tests/performance-tests/README.md
@@ -172,7 +172,7 @@ convention of `big-file1.zip`, `big-file2.zip` etc, and place them in the
 [imports assets folder](src/tests/admin/import/assets). With this naming convention, they will
 be ignored by Git.
 
-### Profiles
+### Common load profiles
 
 Tests which use the [common configuration generators](src/configuration) can have their configuration
 fine-tuned using the following parameters.
@@ -236,6 +236,18 @@ Full sets of options per test are available below as examples:
 `npm run test dist/import.test.js --environment=dev --users=bau1 -- 
 -e PUBLICATION_TITLE="Import publication" -e DATA_FILE="big-file1.zip"`
 
+#### getReleasePage.test.js
+
+##### Profiles
+
+This test supports various different performance testing scenarios.
+
+* PROFILE - supported values are "load", "stress", "spike", "sequential".
+
+Each of these profiles has a default set of configuration out-of-the-box. They can however be
+fine-tuned further using the common override parameters defined in 
+[Common load profiles](#common-load-profiles).
+
 #### publicTableBuilderQuery.test.js
 
 * PUBLICATION_TITLE - default value is "publicTableBuilderQuery.test.ts".
@@ -263,7 +275,8 @@ This test supports various different performance testing scenarios.
 * PROFILE - supported values are "load", "stress", "spike", "sequential".
 
 Each of these profiles has a default set of configuration out-of-the-box. They can however be
-fine-tuned further using the common override parameters defined in .
+fine-tuned further using the common override parameters defined in 
+[Common load profiles](#common-load-profiles).
 
 ##### Query generation
 

--- a/tests/performance-tests/src/configuration/rampingRequestRateProfile.ts
+++ b/tests/performance-tests/src/configuration/rampingRequestRateProfile.ts
@@ -1,6 +1,6 @@
 import { Options } from 'k6/options';
 import merge from 'lodash/merge';
-import { parseIntOptional } from '../utils/utils';
+import { parseFloatOptional, parseIntOptional } from '../utils/utils';
 
 interface Config {
   // Name of the scenario.
@@ -15,10 +15,10 @@ interface Config {
 
 const overrides: Partial<Config> = {
   maxRequestRatePerSecond: parseIntOptional(__ENV.RPS),
-  mainStageDurationMinutes: parseIntOptional(
+  mainStageDurationMinutes: parseFloatOptional(
     __ENV.MAIN_TEST_STAGE_DURATION_MINS,
   ),
-  cooldownStageDurationMinutes: parseIntOptional(
+  cooldownStageDurationMinutes: parseFloatOptional(
     __ENV.MAIN_TEST_STAGE_DURATION_MINS,
   ),
 };

--- a/tests/performance-tests/src/configuration/sequentialRequestsProfile.ts
+++ b/tests/performance-tests/src/configuration/sequentialRequestsProfile.ts
@@ -1,6 +1,6 @@
 import { Options } from 'k6/options';
 import merge from 'lodash/merge';
-import { parseIntOptional } from '../utils/utils';
+import { parseFloatOptional } from '../utils/utils';
 
 interface Config {
   // Total duration of the main stage of the test, providing a steady stream
@@ -9,7 +9,7 @@ interface Config {
 }
 
 const overrides: Partial<Config> = {
-  mainStageDurationMinutes: parseIntOptional(
+  mainStageDurationMinutes: parseFloatOptional(
     __ENV.MAIN_TEST_STAGE_DURATION_MINS,
   ),
 };

--- a/tests/performance-tests/src/configuration/steadyRequestRateProfile.ts
+++ b/tests/performance-tests/src/configuration/steadyRequestRateProfile.ts
@@ -1,6 +1,6 @@
 import { Options } from 'k6/options';
 import merge from 'lodash/merge';
-import { parseIntOptional } from '../utils/utils';
+import { parseFloatOptional, parseIntOptional } from '../utils/utils';
 
 interface Config {
   // Name of the scenario.
@@ -15,10 +15,10 @@ interface Config {
 
 const overrides: Partial<Config> = {
   steadyRequestRatePerSecond: parseIntOptional(__ENV.RPS),
-  mainStageDurationMinutes: parseIntOptional(
+  mainStageDurationMinutes: parseFloatOptional(
     __ENV.MAIN_TEST_STAGE_DURATION_MINS,
   ),
-  cooldownStageDurationMinutes: parseIntOptional(
+  cooldownStageDurationMinutes: parseFloatOptional(
     __ENV.MAIN_TEST_STAGE_DURATION_MINS,
   ),
 };

--- a/tests/performance-tests/src/utils/utils.ts
+++ b/tests/performance-tests/src/utils/utils.ts
@@ -28,3 +28,7 @@ export function stringifyWithoutNulls(obj: object) {
 export function parseIntOptional(int: string) {
   return parseInt(int, 10) || undefined;
 }
+
+export function parseFloatOptional(float: string) {
+  return parseFloat(float) || undefined;
+}


### PR DESCRIPTION
This PR:
- corrects some of the K6 load parameter types to accept floats rather than just ints
- adds support for choosing a "standard" load profile from the `getReleasePage.test.ts`
- updates the README with details around test options