### PR TITLE
EES-4364 - Migrate all existing data sets filters to have group csv column values

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Resources/FilterMigrationFiles/blank-filter-label.meta.csv
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Resources/FilterMigrationFiles/blank-filter-label.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+name_of_filter_0,Filter,,,,,Hint of Filter 0,filter_0_group

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Resources/FilterMigrationFiles/blank-filter-name.meta.csv
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Resources/FilterMigrationFiles/blank-filter-name.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+,Filter,Label of Filter 0,,,,Hint of Filter 0,filter_0_group

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Resources/FilterMigrationFiles/test-data.meta.csv
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Resources/FilterMigrationFiles/test-data.meta.csv
@@ -1,0 +1,4 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+name_of_filter_0,Filter,Label of Filter 0,,,,Hint of Filter 0,filter_0_group
+name_of_filter_1,Filter,Label of Filter 1,,,,Hint of Filter 1,filter_1_group
+name_of_filter_2,Filter,Label of Filter 2,,,,Hint of Filter 2,filter_2_group

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FilterMigrationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FilterMigrationServicePermissionTests.cs
@@ -1,0 +1,50 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+/// <summary>
+/// TODO EES-4372 Remove after the EES-4364 filter migration is complete
+/// </summary>
+public class FilterMigrationServicePermissionTests
+{
+    [Fact]
+    public async Task MigrateGroupCsvColumns()
+    {
+        await PolicyCheckBuilder()
+            .SetupCheck(SecurityPolicies.IsBauUser, false)
+            .AssertForbidden(
+                async userService =>
+                {
+                    var service = SetupService(userService: userService.Object);
+                    return await service.MigrateGroupCsvColumns();
+                }
+            );
+    }
+
+    private static FilterMigrationService SetupService(
+        ContentDbContext? contentDbContext = null,
+        StatisticsDbContext? statisticsDbContext = null,
+        IPrivateBlobStorageService? privateBlobStorageService = null,
+        IUserService? userService = null,
+        ILogger<FilterMigrationService>? logger = null)
+    {
+        return new FilterMigrationService(
+            contentDbContext ?? Mock.Of<ContentDbContext>(),
+            statisticsDbContext ?? Mock.Of<StatisticsDbContext>(),
+            privateBlobStorageService ?? Mock.Of<IPrivateBlobStorageService>(),
+            userService ?? Mock.Of<IUserService>(),
+            logger ?? Mock.Of<ILogger<FilterMigrationService>>()
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FilterMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FilterMigrationServiceTests.cs
@@ -1,0 +1,670 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.StatisticsDbUtils;
+using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+/// <summary>
+/// TODO EES-4372 Remove after the EES-4364 filter migration is complete
+/// </summary>
+public class FilterMigrationServiceTests
+{
+    private readonly DataFixture _fixture = new();
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns()
+    {
+        var subject = _fixture.DefaultSubject()
+            // Filters have non-default filter groups and no group csv column values are set
+            .WithFilters(_fixture.DefaultFilter(filterGroupCount: 2, filterItemCount: 2)
+                .Generate(3))
+            .Generate();
+
+        var file = new File
+        {
+            RootPath = Guid.NewGuid(),
+            SubjectId = subject.Id,
+            Type = FileType.Metadata
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await contentDbContext.Files.AddRangeAsync(file);
+            await contentDbContext.SaveChangesAsync();
+
+            await statisticsDbContext.Subject.AddRangeAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+            "Resources", "FilterMigrationFiles", "test-data.meta.csv");
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupStreamBlob(
+            container: BlobContainers.PrivateReleaseFiles,
+            expectedBlobPath: file.Path(),
+            filePathToStream: metaFilePath);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext,
+                privateBlobStorageService: privateBlobStorageService.Object);
+
+            var result = await service.MigrateGroupCsvColumns(dryRun: false);
+
+            var report = result.AssertRight();
+
+            MockUtils.VerifyAllMocks(privateBlobStorageService);
+
+            var expectedFiltersUpdated = new List<Guid>
+            {
+                subject.Filters[0].Id,
+                subject.Filters[1].Id,
+                subject.Filters[2].Id
+            };
+
+            Assert.Empty(report.Errors);
+            Assert.Empty(report.Information);
+            Assert.Equal(expectedFiltersUpdated, report.FiltersUpdated);
+        }
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            Assert.Equal(3, await statisticsDbContext.Filter.CountAsync());
+
+            var filter0 = await statisticsDbContext.Filter.SingleAsync(f => f.Id == subject.Filters[0].Id);
+            Assert.Equal("filter_0_group", filter0.GroupCsvColumn);
+
+            var filter1 = await statisticsDbContext.Filter.SingleAsync(f => f.Id == subject.Filters[1].Id);
+            Assert.Equal("filter_1_group", filter1.GroupCsvColumn);
+
+            var filter2 = await statisticsDbContext.Filter.SingleAsync(f => f.Id == subject.Filters[2].Id);
+            Assert.Equal("filter_2_group", filter2.GroupCsvColumn);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns_MetaBlobNotFound()
+    {
+        var subject = _fixture.DefaultSubject()
+            .WithFilters(_fixture.DefaultFilter(filterGroupCount: 2, filterItemCount: 2)
+                .Generate(2))
+            .Generate();
+
+        var file = new File
+        {
+            RootPath = Guid.NewGuid(),
+            SubjectId = subject.Id,
+            Type = FileType.Metadata
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await contentDbContext.Files.AddRangeAsync(file);
+            await contentDbContext.SaveChangesAsync();
+
+            await statisticsDbContext.Subject.AddRangeAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupStreamBlobNotFound(
+            container: BlobContainers.PrivateReleaseFiles,
+            expectedBlobPath: file.Path());
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext,
+                privateBlobStorageService: privateBlobStorageService.Object);
+
+            var result = await service.MigrateGroupCsvColumns(dryRun: false);
+
+            MockUtils.VerifyAllMocks(privateBlobStorageService);
+
+            var report = result.AssertRight();
+
+            var expectedErrors = new List<FilterMigrationReportErrorItem>
+            {
+                FilterMigrationReportErrorItem.ExceptionGettingMetaFilters(
+                    subject.Id, file, $"Could not find file at {BlobContainers.PrivateReleaseFiles}/{file.Path()}")
+            };
+
+            Assert.Equal(expectedErrors, report.Errors);
+            Assert.Empty(report.Information);
+            Assert.Empty(report.FiltersUpdated);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns_MetaFilterHasBlankName()
+    {
+        var subject = _fixture.DefaultSubject()
+            .WithFilters(_fixture.DefaultFilter(filterGroupCount: 2, filterItemCount: 2)
+                .Generate(2))
+            .Generate();
+
+        var file = new File
+        {
+            RootPath = Guid.NewGuid(),
+            SubjectId = subject.Id,
+            Type = FileType.Metadata
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await contentDbContext.Files.AddRangeAsync(file);
+            await contentDbContext.SaveChangesAsync();
+
+            await statisticsDbContext.Subject.AddRangeAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+            "Resources", "FilterMigrationFiles", "blank-filter-name.meta.csv");
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupStreamBlob(
+            container: BlobContainers.PrivateReleaseFiles,
+            expectedBlobPath: file.Path(),
+            filePathToStream: metaFilePath);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext,
+                privateBlobStorageService: privateBlobStorageService.Object);
+
+            var result = await service.MigrateGroupCsvColumns(dryRun: false);
+
+            var report = result.AssertRight();
+
+            MockUtils.VerifyAllMocks(privateBlobStorageService);
+
+            var expectedErrors = new List<FilterMigrationReportErrorItem>
+            {
+                FilterMigrationReportErrorItem.ExceptionGettingMetaFilters(
+                    subject.Id, file, $"Csv filter name is null (Parameter 'col_name')")
+            };
+
+            Assert.Equal(expectedErrors, report.Errors);
+            Assert.Empty(report.Information);
+            Assert.Empty(report.FiltersUpdated);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns_MetaFilterHasBlankLabel()
+    {
+        var subject = _fixture.DefaultSubject()
+            .WithFilters(_fixture.DefaultFilter(filterGroupCount: 2, filterItemCount: 2)
+                .Generate(2))
+            .Generate();
+
+        var file = new File
+        {
+            RootPath = Guid.NewGuid(),
+            SubjectId = subject.Id,
+            Type = FileType.Metadata
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await contentDbContext.Files.AddRangeAsync(file);
+            await contentDbContext.SaveChangesAsync();
+
+            await statisticsDbContext.Subject.AddRangeAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+            "Resources", "FilterMigrationFiles", "blank-filter-label.meta.csv");
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupStreamBlob(
+            container: BlobContainers.PrivateReleaseFiles,
+            expectedBlobPath: file.Path(),
+            filePathToStream: metaFilePath);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext,
+                privateBlobStorageService: privateBlobStorageService.Object);
+
+            var result = await service.MigrateGroupCsvColumns(dryRun: false);
+
+            var report = result.AssertRight();
+
+            MockUtils.VerifyAllMocks(privateBlobStorageService);
+
+            var expectedErrors = new List<FilterMigrationReportErrorItem>
+            {
+                FilterMigrationReportErrorItem.ExceptionGettingMetaFilters(
+                    subject.Id, file, $"Csv filter label is null (Parameter 'label')")
+            };
+
+            Assert.Equal(expectedErrors, report.Errors);
+            Assert.Empty(report.Information);
+            Assert.Empty(report.FiltersUpdated);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns_MetaFilterNotFound()
+    {
+        var subject = _fixture.DefaultSubject()
+            // Last filter is not in meta csv file
+            .WithFilters(_fixture.DefaultFilter(filterGroupCount: 2, filterItemCount: 2)
+                .Generate(4))
+            .Generate();
+
+        var file = new File
+        {
+            RootPath = Guid.NewGuid(),
+            SubjectId = subject.Id,
+            Type = FileType.Metadata
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await contentDbContext.Files.AddRangeAsync(file);
+            await contentDbContext.SaveChangesAsync();
+
+            await statisticsDbContext.Subject.AddRangeAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+            "Resources", "FilterMigrationFiles", "test-data.meta.csv");
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupStreamBlob(
+            container: BlobContainers.PrivateReleaseFiles,
+            expectedBlobPath: file.Path(),
+            filePathToStream: metaFilePath);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext,
+                privateBlobStorageService: privateBlobStorageService.Object);
+
+            var result = await service.MigrateGroupCsvColumns(dryRun: false);
+
+            var report = result.AssertRight();
+
+            MockUtils.VerifyAllMocks(privateBlobStorageService);
+
+            var expectedErrors = new List<FilterMigrationReportErrorItem>
+            {
+                FilterMigrationReportErrorItem.MetaFilterNotFound(
+                    subject.Id, file, subject.Filters[3])
+            };
+
+            var expectedFiltersUpdated = new List<Guid>
+            {
+                subject.Filters[0].Id,
+                subject.Filters[1].Id,
+                subject.Filters[2].Id
+            };
+
+            Assert.Equal(expectedErrors, report.Errors);
+            Assert.Empty(report.Information);
+            Assert.Equal(expectedFiltersUpdated, report.FiltersUpdated);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns_FilterLabelMismatch()
+    {
+        var subject = _fixture.DefaultSubject()
+            .WithFilters(_fixture.DefaultFilter(filterGroupCount: 2, filterItemCount: 2)
+                .Generate(3))
+            .Generate();
+
+        // Set the label of one of the filters to be different to the label in the csv
+        // Meta filter name "name_of_filter_1" has label "Label of Filter 1"
+        subject.Filters[1].Label = "Label of Filter 1 modified";
+
+        var file = new File
+        {
+            RootPath = Guid.NewGuid(),
+            SubjectId = subject.Id,
+            Type = FileType.Metadata
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await contentDbContext.Files.AddRangeAsync(file);
+            await contentDbContext.SaveChangesAsync();
+
+            await statisticsDbContext.Subject.AddRangeAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+            "Resources", "FilterMigrationFiles", "test-data.meta.csv");
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupStreamBlob(
+            container: BlobContainers.PrivateReleaseFiles,
+            expectedBlobPath: file.Path(),
+            filePathToStream: metaFilePath);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext,
+                privateBlobStorageService: privateBlobStorageService.Object);
+
+            var result = await service.MigrateGroupCsvColumns(dryRun: false);
+
+            var report = result.AssertRight();
+
+            MockUtils.VerifyAllMocks(privateBlobStorageService);
+
+            var expectedErrors = new List<FilterMigrationReportErrorItem>
+            {
+                FilterMigrationReportErrorItem.FilterLabelMismatch(
+                    subject.Id, file, subject.Filters[1])
+            };
+
+            var expectedFiltersUpdated = new List<Guid>
+            {
+                subject.Filters[0].Id,
+                subject.Filters[2].Id
+            };
+
+            Assert.Equal(expectedErrors, report.Errors);
+            Assert.Empty(report.Information);
+            Assert.Equal(expectedFiltersUpdated, report.FiltersUpdated);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns_MetaFileNotFound()
+    {
+        var subject = _fixture.DefaultSubject()
+            // Filters have non-default filter groups and no group csv column values are set
+            .WithFilters(_fixture.DefaultFilter(filterGroupCount: 2, filterItemCount: 2)
+                .Generate(2))
+            .Generate();
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await statisticsDbContext.Subject.AddRangeAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateGroupCsvColumns(dryRun: false);
+
+            var report = result.AssertRight();
+
+            var expectedErrors = new List<FilterMigrationReportErrorItem>
+            {
+                FilterMigrationReportErrorItem.MetaFileNotFound(subject.Id)
+            };
+
+            Assert.Equal(expectedErrors, report.Errors);
+            Assert.Empty(report.Information);
+            Assert.Empty(report.FiltersUpdated);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns_SomeFiltersHaveGroupCsvColumnValues()
+    {
+        var subject = _fixture.DefaultSubject()
+            // Filters have non-default filter groups but two out of three have group csv column values are already set
+            .WithFilters(_fixture.DefaultFilter()
+                .ForIndex(0, s => s.SetGroupCsvColumn("filter_0_group"))
+                .ForIndex(2, s => s.SetGroupCsvColumn("filter_2_group"))
+                .WithFilterGroups(_ => _fixture.DefaultFilterGroup(filterItemCount: 2)
+                    .Generate(2))
+                .Generate(3))
+            .Generate();
+
+        var file = new File
+        {
+            RootPath = Guid.NewGuid(),
+            SubjectId = subject.Id,
+            Type = FileType.Metadata
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await contentDbContext.Files.AddRangeAsync(file);
+            await contentDbContext.SaveChangesAsync();
+
+            await statisticsDbContext.Subject.AddRangeAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+            "Resources", "FilterMigrationFiles", "test-data.meta.csv");
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupStreamBlob(
+            container: BlobContainers.PrivateReleaseFiles,
+            expectedBlobPath: file.Path(),
+            filePathToStream: metaFilePath);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext,
+                privateBlobStorageService: privateBlobStorageService.Object);
+
+            var result = await service.MigrateGroupCsvColumns(dryRun: false);
+
+            var report = result.AssertRight();
+
+            MockUtils.VerifyAllMocks(privateBlobStorageService);
+
+            var expectedInformation = new List<FilterMigrationReportInfoItem>
+            {
+                FilterMigrationReportInfoItem.FilterAlreadyHasGroupCsvColumnValue(subject.Id, file, subject.Filters[0]),
+                FilterMigrationReportInfoItem.FilterAlreadyHasGroupCsvColumnValue(subject.Id, file, subject.Filters[2])
+            };
+
+            var expectedFiltersUpdated = new List<Guid>
+            {
+                subject.Filters[1].Id
+            };
+
+            Assert.Empty(report.Errors);
+            Assert.Equal(expectedInformation, report.Information);
+            Assert.Equal(expectedFiltersUpdated, report.FiltersUpdated);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns_AllFiltersHaveGroupCsvColumnValues()
+    {
+        var subject = _fixture.DefaultSubject()
+            // Filters have non-default filter groups but all group csv column values are already set
+            .WithFilters(_fixture.DefaultFilter()
+                .ForIndex(0, s => s.SetGroupCsvColumn("filter_0_group"))
+                .ForIndex(1, s => s.SetGroupCsvColumn("filter_1_group"))
+                .WithFilterGroups(_ => _fixture.DefaultFilterGroup(filterItemCount: 2).Generate(2))
+                .Generate(2))
+            .Generate();
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await statisticsDbContext.Subject.AddRangeAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateGroupCsvColumns(dryRun: false);
+
+            var report = result.AssertRight();
+
+            var expectedInformation = new List<FilterMigrationReportInfoItem>
+            {
+                FilterMigrationReportInfoItem.AllFiltersHaveGroupCsvColumnValues(subject.Id)
+            };
+
+            Assert.Empty(report.Errors);
+            Assert.Equal(expectedInformation, report.Information);
+            Assert.Empty(report.FiltersUpdated);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns_FiltersOnlyHaveDefaultFilterGroups()
+    {
+        var subject = _fixture.DefaultSubject()
+            // Filters have only one default filter group each
+            .WithFilters(_fixture.DefaultFilter(filterGroupCount: 1, filterItemCount: 2)
+                .Generate(2))
+            .Generate();
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await statisticsDbContext.Subject.AddRangeAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateGroupCsvColumns(dryRun: false);
+
+            var report = result.AssertRight();
+
+            Assert.Empty(report.Errors);
+            Assert.Empty(report.Information);
+            Assert.Empty(report.FiltersUpdated);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns_EmptyFilters()
+    {
+        var subject = _fixture.DefaultSubject()
+            // Filters have no filter groups
+            .WithFilters(_fixture.DefaultFilter()
+                .Generate(2))
+            .Generate();
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            await statisticsDbContext.Subject.AddRangeAsync(subject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateGroupCsvColumns(dryRun: false);
+
+            var report = result.AssertRight();
+
+            Assert.Empty(report.Errors);
+            Assert.Empty(report.Information);
+            Assert.Empty(report.FiltersUpdated);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateGroupCsvColumns_NoFilters()
+    {
+        await using var contentDbContext = InMemoryContentDbContext();
+        await using var statisticsDbContext = InMemoryStatisticsDbContext();
+
+        var service = SetupService(contentDbContext: contentDbContext,
+            statisticsDbContext: statisticsDbContext);
+
+        var result = await service.MigrateGroupCsvColumns();
+        var report = result.AssertRight();
+
+        Assert.Empty(report.Errors);
+        Assert.Empty(report.Information);
+        Assert.Empty(report.FiltersUpdated);
+    }
+
+    private static FilterMigrationService SetupService(
+        ContentDbContext? contentDbContext = null,
+        StatisticsDbContext? statisticsDbContext = null,
+        IPrivateBlobStorageService? privateBlobStorageService = null,
+        IUserService? userService = null,
+        ILogger<FilterMigrationService>? logger = null)
+    {
+        return new FilterMigrationService(
+            contentDbContext ?? Mock.Of<ContentDbContext>(),
+            statisticsDbContext ?? Mock.Of<StatisticsDbContext>(),
+            privateBlobStorageService ?? Mock.Of<IPrivateBlobStorageService>(MockBehavior.Strict),
+            userService ?? MockUtils.AlwaysTrueUserService().Object,
+            logger ?? Mock.Of<ILogger<FilterMigrationService>>()
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/FilterMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/FilterMigrationController.cs
@@ -1,0 +1,35 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+/// <summary>
+/// TODO EES-4372 Remove after the EES-4364 filter migration is complete
+/// </summary>
+[Route("api")]
+[ApiController]
+[Authorize(Roles = GlobalRoles.RoleNames.BauUser)]
+public class FilterMigrationController : ControllerBase
+{
+    private readonly IFilterMigrationService _filterMigrationService;
+
+    public FilterMigrationController(IFilterMigrationService filterMigrationService)
+    {
+        _filterMigrationService = filterMigrationService;
+    }
+
+    [HttpPatch("bau/migrate-filter-group-csv-columns")]
+    public async Task<ActionResult<FilterMigrationReport>> MigrateGroupCsvColumns(
+        [FromQuery] bool dryRun = true)
+    {
+        return await _filterMigrationService
+            .MigrateGroupCsvColumns(dryRun)
+            .HandleFailuresOrOk();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterMigrationService.cs
@@ -1,0 +1,246 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+/// <summary>
+/// TODO EES-4372 Remove after the EES-4364 filter migration is complete
+/// </summary>
+public class FilterMigrationService : IFilterMigrationService
+{
+    private readonly ContentDbContext _contentDbContext;
+    private readonly StatisticsDbContext _statisticsDbContext;
+    private readonly IPrivateBlobStorageService _privateBlobStorageService;
+    private readonly IUserService _userService;
+    private readonly ILogger<FilterMigrationService> _logger;
+
+    public FilterMigrationService(ContentDbContext contentDbContext,
+        StatisticsDbContext statisticsDbContext,
+        IPrivateBlobStorageService privateBlobStorageService,
+        IUserService userService,
+        ILogger<FilterMigrationService> logger)
+    {
+        _contentDbContext = contentDbContext;
+        _statisticsDbContext = statisticsDbContext;
+        _privateBlobStorageService = privateBlobStorageService;
+        _userService = userService;
+        _logger = logger;
+    }
+
+    public async Task<Either<ActionResult, FilterMigrationReport>> MigrateGroupCsvColumns(
+        bool dryRun = true,
+        CancellationToken cancellationToken = default)
+    {
+        return await _userService.CheckIsBauUser()
+            .OnSuccess(() => DoMigrateGroupCsvColumns(dryRun, cancellationToken));
+    }
+
+    private async Task<Either<ActionResult, FilterMigrationReport>> DoMigrateGroupCsvColumns(
+        bool dryRun = true,
+        CancellationToken cancellationToken = default)
+    {
+        var report = new FilterMigrationReport();
+
+        var filtersWithNonDefaultGroups = await GetFiltersWithNonDefaultGroups(cancellationToken);
+
+        await filtersWithNonDefaultGroups
+            .ToAsyncEnumerable()
+            .ForEachAwaitAsync(async tuple =>
+            {
+                var (subjectId, filters) = tuple;
+
+                // If all filters have a group csv column value already, skip this data set
+                if (filters.All(filter => filter.GroupCsvColumn != null))
+                {
+                    report.AddAllFiltersHaveGroupCsvColumnValues(subjectId);
+                    return;
+                }
+
+                var file = await GetMetaFile(subjectId, cancellationToken);
+                if (file == null)
+                {
+                    report.AddMetaFileNotFound(subjectId);
+                    return;
+                }
+
+                Dictionary<string, FilterRow> metaCsvFilters;
+                try
+                {
+                    var stream = await GetMetaCsvStream(file, cancellationToken);
+                    metaCsvFilters = await GetMetaCsvFilters(stream);
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogError(exception,
+                        "Exception caught getting meta filter rows. (SubjectId={SubjectId}, FileId={FileId}), Path={Path})",
+                        subjectId,
+                        file.Id,
+                        file.Path());
+                    report.AddExceptionGettingMetaFilters(subjectId, file, exception);
+                    return;
+                }
+
+                filters.ForEach(filter =>
+                {
+                    if (!metaCsvFilters.TryGetValue(filter.Name, out var metaCsvFilter))
+                    {
+                        report.AddMetaFilterNotFound(subjectId, file, filter);
+                        return;
+                    }
+
+                    // Sanity check that the filter label matches the label in the metadata file
+                    if (filter.Label != metaCsvFilter.Label)
+                    {
+                        report.AddFilterLabelMismatch(subjectId, file, filter);
+                        return;
+                    }
+
+                    if (!filter.GroupCsvColumn.IsNullOrEmpty())
+                    {
+                        report.AddFilterAlreadyHasGroupCsvColumnValue(subjectId, file, filter);
+                        return;
+                    }
+
+                    _statisticsDbContext.Update(filter);
+                    filter.GroupCsvColumn = metaCsvFilter.GroupCsvColumn;
+                    report.FiltersUpdated.Add(filter.Id);
+                });
+            }, cancellationToken: cancellationToken);
+
+        if (!dryRun && report.FiltersUpdated.Any())
+        {
+            await _statisticsDbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return report;
+    }
+
+    private static async Task<Dictionary<string, FilterRow>> GetMetaCsvFilters(Stream stream)
+    {
+        await using (stream)
+        {
+            Task<Stream> StreamProvider() => Task.FromResult(stream);
+            var metaCsvHeaders = await CsvUtils.GetCsvHeaders(StreamProvider, leaveOpen: true);
+            stream.SeekToBeginning();
+            var metaCsvRows = await CsvUtils.GetCsvRows(StreamProvider);
+
+            return new MetaDataFileReader(metaCsvHeaders)
+                .GetFilterRows(metaCsvRows)
+                .ToDictionary(filterRow => filterRow.Name);
+        }
+    }
+
+    private async Task<Stream> GetMetaCsvStream(
+        File file,
+        CancellationToken cancellationToken = default)
+    {
+        return await _privateBlobStorageService.StreamBlob(
+            containerName: BlobContainers.PrivateReleaseFiles,
+            path: file.Path(),
+            cancellationToken: cancellationToken
+        );
+    }
+
+    private async Task<File?> GetMetaFile(Guid subjectId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _contentDbContext.Files
+            .SingleOrDefaultAsync(file => file.SubjectId == subjectId && file.Type == FileType.Metadata,
+                cancellationToken: cancellationToken);
+    }
+
+    private async Task<Dictionary<Guid, List<Filter>>> GetFiltersWithNonDefaultGroups(
+        CancellationToken cancellationToken = default)
+    {
+        var filtersWithNonDefaultGroups = await _statisticsDbContext.Filter
+            .Where(filter => filter.FilterGroups.Any(filterGroup =>
+                filterGroup.Label != FilterGroup.DefaultFilterGroupLabel))
+            .ToListAsync(cancellationToken: cancellationToken);
+
+        return filtersWithNonDefaultGroups.GroupBy(filter => filter.SubjectId)
+            .ToDictionary(group => group.Key,
+                group => group.ToList());
+    }
+}
+
+internal class MetaDataFileReader
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    private enum MetaColumns
+    {
+        col_name,
+        col_type,
+        label,
+        filter_grouping_column
+    }
+
+    private readonly Dictionary<MetaColumns, int> _metaColumnIndexes;
+
+    public MetaDataFileReader(List<string> metaCsvHeaders)
+    {
+        _metaColumnIndexes = EnumUtil.GetEnumValues<MetaColumns>()
+            .ToDictionary(
+                column => column,
+                column => metaCsvHeaders.FindIndex(h => h.Equals(column.ToString()))
+            );
+    }
+
+    public List<FilterRow> GetFilterRows(IReadOnlyList<IReadOnlyList<string>> metaRowValues)
+    {
+        return metaRowValues
+            .Where(rowValues =>
+            {
+                var columnType = ReadMetaColumnValue(MetaColumns.col_type, rowValues);
+                return "filter".Equals(columnType, StringComparison.OrdinalIgnoreCase);
+            })
+            .Select(GetFilterRow)
+            .ToList();
+    }
+
+    private FilterRow GetFilterRow(IReadOnlyList<string> rowValues)
+    {
+        return new FilterRow(
+            Name: ReadMetaColumnValue(MetaColumns.col_name, rowValues) ??
+                  throw new ArgumentNullException(MetaColumns.col_name.ToString(), "Csv filter name is null"),
+            Label: ReadMetaColumnValue(MetaColumns.label, rowValues)
+                   ?? throw new ArgumentNullException(MetaColumns.label.ToString(), "Csv filter label is null"),
+            GroupCsvColumn: ReadMetaColumnValue(MetaColumns.filter_grouping_column, rowValues));
+    }
+
+    private string? ReadMetaColumnValue(MetaColumns column, IReadOnlyList<string> rowValues)
+    {
+        var columnIndex = _metaColumnIndexes[column];
+        if (columnIndex == -1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(column), $"Meta column: {column} not found in csv headers");
+        }
+
+        return rowValues[columnIndex].Trim().NullIfWhiteSpace();
+    }
+}
+
+internal record FilterRow(string Name, string Label, string? GroupCsvColumn);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFilterMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFilterMigrationService.cs
@@ -1,0 +1,18 @@
+﻿#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+
+/// <summary>
+/// TODO EES-4372 Remove after the EES-4364 filter migration is complete
+/// </summary>
+public interface IFilterMigrationService
+{
+    public Task<Either<ActionResult, FilterMigrationReport>> MigrateGroupCsvColumns(
+        bool dryRun = true,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -5,7 +5,6 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using AutoMapper;
-using Azure.Storage.Blobs;
 using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Pages.Account;
 using GovUk.Education.ExploreEducationStatistics.Admin.Hubs;
@@ -538,6 +537,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IUserReleaseRoleRepository, UserReleaseRoleRepository>();
             services.AddTransient<IUserReleaseInviteRepository, UserReleaseInviteRepository>();
             services.AddTransient<IUserPublicationInviteRepository, UserPublicationInviteRepository>();
+            services.AddTransient<IFilterMigrationService, FilterMigrationService>();
 
             services.AddTransient<INotificationClient>(s =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/FilterMigrationReport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/FilterMigrationReport.cs
@@ -1,0 +1,232 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using static GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.FilterMigrationReportErrorItem;
+using static GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.FilterMigrationReportInfoItem;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+
+public record FilterMigrationReport
+{
+    public List<Guid> FiltersUpdated { get; } = new();
+    public List<FilterMigrationReportInfoItem> Information { get; } = new();
+    public List<FilterMigrationReportErrorItem> Errors { get; } = new();
+
+    public void AddExceptionGettingMetaFilters(Guid subjectId,
+        File file,
+        Exception exception)
+    {
+        Errors.Add(ExceptionGettingMetaFilters(subjectId, file, exception.Message));
+    }
+
+    public void AddAllFiltersHaveGroupCsvColumnValues(Guid subjectId)
+    {
+        Information.Add(AllFiltersHaveGroupCsvColumnValues(subjectId));
+    }
+
+    public void AddFilterAlreadyHasGroupCsvColumnValue(Guid subjectId,
+        File file,
+        Filter filter)
+    {
+        Information.Add(FilterAlreadyHasGroupCsvColumnValue(subjectId, file, filter));
+    }
+
+    public void AddMetaFileNotFound(Guid subjectId)
+    {
+        Errors.Add(MetaFileNotFound(subjectId));
+    }
+
+    public void AddMetaFilterNotFound(Guid subjectId,
+        File file,
+        Filter filter)
+    {
+        Errors.Add(MetaFilterNotFound(subjectId, file, filter));
+    }
+
+    public void AddFilterLabelMismatch(Guid subjectId,
+        File file,
+        Filter filter)
+    {
+        Errors.Add(FilterLabelMismatch(subjectId, file, filter));
+    }
+}
+
+public record FilterMigrationReportInfoItem(FilterMigrationReportInfo Value,
+    Guid SubjectId,
+    Guid? FilterId = null,
+    string? FilterName = null,
+    Guid? FileId = null,
+    string? FilePath = null)
+{
+    private FilterMigrationReportInfoItem(FilterMigrationReportInfo value,
+        Guid subjectId,
+        Filter? filter = null,
+        File? file = null) : this(
+        value,
+        SubjectId: subjectId,
+        FilterId: filter?.Id,
+        FilterName: filter?.Name,
+        FileId: file?.Id,
+        FilePath: file?.Path())
+    {
+    }
+
+    public override string ToString()
+    {
+        var s = $"{Value} ({nameof(SubjectId)}={SubjectId}";
+
+        if (FilterId.HasValue)
+        {
+            s += $", {nameof(FilterId)}={FilterId}";
+        }
+
+        if (FilterName != null)
+        {
+            s += $", {nameof(FilterName)}={FilterName}";
+        }
+
+        if (FileId.HasValue)
+        {
+            s += $", {nameof(FileId)}={FileId}";
+        }
+
+        if (FilePath != null)
+        {
+            s += $", {nameof(FilePath)}={FilePath}";
+        }
+
+        return s + ")";
+    }
+
+    public static FilterMigrationReportInfoItem AllFiltersHaveGroupCsvColumnValues(
+        Guid subjectId)
+    {
+        return new FilterMigrationReportInfoItem(
+            value: FilterMigrationReportInfo.AllFiltersHaveGroupCsvColumnValues,
+            subjectId: subjectId);
+    }
+
+    public static FilterMigrationReportInfoItem FilterAlreadyHasGroupCsvColumnValue(
+        Guid subjectId,
+        File file,
+        Filter filter)
+    {
+        return new FilterMigrationReportInfoItem(
+            value: FilterMigrationReportInfo.FilterAlreadyHasGroupCsvColumnValue,
+            subjectId: subjectId,
+            file: file,
+            filter: filter);
+    }
+}
+
+public record FilterMigrationReportErrorItem(FilterMigrationReportError Value,
+    Guid SubjectId,
+    Guid? FilterId = null,
+    string? FilterName = null,
+    Guid? FileId = null,
+    string? FilePath = null,
+    string? Exception = null)
+{
+    public FilterMigrationReportErrorItem(FilterMigrationReportError value,
+        Guid subjectId,
+        Filter? filter = null,
+        File? file = null,
+        string? exception = null) : this(
+        value,
+        SubjectId: subjectId,
+        FilterId: filter?.Id,
+        FilterName: filter?.Name,
+        FileId: file?.Id,
+        FilePath: file?.Path(),
+        Exception: exception)
+    {
+    }
+
+    public override string ToString()
+    {
+        var s = $"{Value} ({nameof(SubjectId)}={SubjectId}";
+
+        if (FilterId.HasValue)
+        {
+            s += $", {nameof(FilterId)}={FilterId}";
+        }
+
+        if (FilterName != null)
+        {
+            s += $", {nameof(FilterName)}={FilterName}";
+        }
+
+        if (FileId.HasValue)
+        {
+            s += $", {nameof(FileId)}={FileId}";
+        }
+
+        if (FilePath != null)
+        {
+            s += $", {nameof(FilePath)}={FilePath}";
+        }
+
+        if (Exception != null)
+        {
+            s += $", {nameof(Exception)}={Exception}";
+        }
+
+        return s + ")";
+    }
+
+    public static FilterMigrationReportErrorItem MetaFileNotFound(Guid subjectId)
+    {
+        return new FilterMigrationReportErrorItem(
+            value: FilterMigrationReportError.MetaFileNotFound,
+            subjectId: subjectId);
+    }
+
+    public static FilterMigrationReportErrorItem MetaFilterNotFound(Guid subjectId,
+        File file,
+        Filter filter)
+    {
+        return new FilterMigrationReportErrorItem(
+            value: FilterMigrationReportError.MetaFilterNotFound,
+            subjectId: subjectId,
+            file: file,
+            filter: filter);
+    }
+
+    public static FilterMigrationReportErrorItem FilterLabelMismatch(Guid subjectId,
+        File file, Filter filter)
+    {
+        return new FilterMigrationReportErrorItem(
+            value: FilterMigrationReportError.FilterLabelMismatch,
+            subjectId: subjectId,
+            file: file,
+            filter: filter);
+    }
+
+    public static FilterMigrationReportErrorItem ExceptionGettingMetaFilters(Guid subjectId,
+        File file,
+        string exception)
+    {
+        return new FilterMigrationReportErrorItem(
+            value: FilterMigrationReportError.ExceptionGettingMetaFilters,
+            subjectId: subjectId,
+            file: file,
+            exception: exception);
+    }
+}
+
+public enum FilterMigrationReportInfo
+{
+    AllFiltersHaveGroupCsvColumnValues,
+    FilterAlreadyHasGroupCsvColumnValue,
+}
+
+public enum FilterMigrationReportError
+{
+    MetaFileNotFound,
+    ExceptionGettingMetaFilters,
+    MetaFilterNotFound,
+    FilterLabelMismatch,
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/FilterMigrationReport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/FilterMigrationReport.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using static GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.FilterMigrationReportErrorItem;
 using static GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.FilterMigrationReportInfoItem;
 
@@ -54,7 +56,8 @@ public record FilterMigrationReport
     }
 }
 
-public record FilterMigrationReportInfoItem(FilterMigrationReportInfo Value,
+public record FilterMigrationReportInfoItem(
+    [property:JsonConverter(typeof(StringEnumConverter))] FilterMigrationReportInfo Value,
     Guid SubjectId,
     Guid? FilterId = null,
     string? FilterName = null,
@@ -122,7 +125,8 @@ public record FilterMigrationReportInfoItem(FilterMigrationReportInfo Value,
     }
 }
 
-public record FilterMigrationReportErrorItem(FilterMigrationReportError Value,
+public record FilterMigrationReportErrorItem(
+    [property:JsonConverter(typeof(StringEnumConverter))] FilterMigrationReportError Value,
     Guid SubjectId,
     Guid? FilterId = null,
     string? FilterName = null,
@@ -130,7 +134,8 @@ public record FilterMigrationReportErrorItem(FilterMigrationReportError Value,
     string? FilePath = null,
     string? Exception = null)
 {
-    public FilterMigrationReportErrorItem(FilterMigrationReportError value,
+    public FilterMigrationReportErrorItem(
+        FilterMigrationReportError value,
         Guid subjectId,
         Filter? filter = null,
         File? file = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
@@ -35,6 +35,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
                 .ReturnsAsync(() => File.OpenRead(filePathToStream));
         }
 
+        public static IReturnsResult<T> SetupStreamBlobNotFound<T>(
+            this Mock<T> service,
+            IBlobContainer container,
+            string expectedBlobPath) where T : class, IBlobStorageService
+        {
+            return service.Setup(s => s.StreamBlob(container, expectedBlobPath, null, default))
+                .ThrowsAsync(new FileNotFoundException($"Could not find file at {container.Name}/{expectedBlobPath}"));
+        }
+
+        public static IReturnsResult<T> SetupStreamBlobThrows<T>(
+            this Mock<T> service,
+            IBlobContainer container,
+            string expectedBlobPath,
+            Exception exception) where T : class, IBlobStorageService
+        {
+            return service.Setup(s => s.StreamBlob(container, expectedBlobPath, null, default))
+                .ThrowsAsync(exception);
+        }
+
         public static IReturnsResult<T> SetupCheckBlobExists<T>(
             this Mock<T> service,
             IBlobContainer container,
@@ -132,8 +151,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             T2 value,
             JsonSerializerSettings? settings = null,
             CancellationToken cancellationToken = default)
-        where T1 : class, IBlobStorageService
-        where T2 : class
+            where T1 : class, IBlobStorageService
+            where T2 : class
         {
             return service.Setup(s =>
                     s.GetDeserializedJson<T2>(container, path, settings, cancellationToken))
@@ -159,8 +178,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             string path,
             JsonSerializerSettings? settings = null,
             CancellationToken cancellationToken = default)
-        where T1 : class, IBlobStorageService
-        where T2 : class
+            where T1 : class, IBlobStorageService
+            where T2 : class
         {
             return service.Setup(s =>
                     s.GetDeserializedJson<T2>(container, path, settings, cancellationToken))

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/CsvUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/CsvUtils.cs
@@ -24,7 +24,7 @@ public static class CsvUtils
     /// Gets the header values of the first line of the provided CSV.
     /// </summary>
     /// <remarks>
-    /// This method uses and closes the provided Stream.
+    /// This method uses and closes the provided stream, unless leaveOpen is true.
     /// </remarks>
     public static async Task<List<string>> GetCsvHeaders(Func<Task<Stream>> streamProvider,
         bool leaveOpen = false)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/CsvUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/CsvUtils.cs
@@ -7,17 +7,18 @@ using System.Linq;
 using System.Threading.Tasks;
 using CsvHelper;
 using CsvHelper.Configuration;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
 
 public static class CsvUtils
 {
-    public static Task<List<string>> GetCsvHeaders(Stream stream)
-        => GetCsvHeaders(() => Task.FromResult(stream));
+    public static Task<List<string>> GetCsvHeaders(Stream stream,
+        bool leaveOpen = false)
+        => GetCsvHeaders(() => Task.FromResult(stream), leaveOpen);
 
-    public static Task<List<string>> GetCsvHeaders(Task<Stream> stream)
-        => GetCsvHeaders(() => stream);
+    public static Task<List<string>> GetCsvHeaders(Task<Stream> stream,
+        bool leaveOpen = false)
+        => GetCsvHeaders(() => stream, leaveOpen);
 
     /// <summary>
     /// Gets the header values of the first line of the provided CSV.
@@ -25,9 +26,10 @@ public static class CsvUtils
     /// <remarks>
     /// This method uses and closes the provided Stream.
     /// </remarks>
-    public static async Task<List<string>> GetCsvHeaders(Func<Task<Stream>> streamProvider)
+    public static async Task<List<string>> GetCsvHeaders(Func<Task<Stream>> streamProvider,
+        bool leaveOpen = false)
     {
-        using var dataFileReader = new StreamReader(await streamProvider.Invoke());
+        using var dataFileReader = new StreamReader(await streamProvider.Invoke(), leaveOpen: leaveOpen);
         using var csvReader = new CsvReader(dataFileReader, CultureInfo.InvariantCulture);
         await csvReader.ReadAsync();
         csvReader.ReadHeader();
@@ -116,7 +118,7 @@ public static class CsvUtils
                 lastLine = !await csvReader.ReadAsync();
                 continue;
             }
-            
+
             var cellCount = csvDataReader.FieldCount;
 
             var cells = Enumerable
@@ -124,9 +126,9 @@ public static class CsvUtils
                 .Select(csvReader.GetField<string>)
                 .OfType<string>()
                 .ToList();
-            
+
             lastLine = !await csvReader.ReadAsync();
-            
+
             var result = await func.Invoke(cells, currentRowIndex, lastLine);
 
             if (!result)
@@ -135,7 +137,7 @@ public static class CsvUtils
             }
         }
     }
-    
+
     /// <summary>
     /// Execute a given function against batches of rows from the provided CSV. The batch
     /// of rows (a list of lists of cells) and the index of the current batch being processed are
@@ -165,7 +167,7 @@ public static class CsvUtils
         var linesInBatch = new List<List<string>>();
         var batchIndex = 0;
         var rowsProcessed = 0;
-        
+
         await ForEachRow(
             streamProvider,
             async (cells, _, lastLine) =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/FilterGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/FilterGeneratorExtensions.cs
@@ -30,6 +30,9 @@ public static class FilterGeneratorExtensions
     public static Generator<Filter> WithLabel(this Generator<Filter> generator, string label)
         => generator.ForInstance(s => s.SetLabel(label));
 
+    public static Generator<Filter> WithGroupCsvColumn(this Generator<Filter> generator, string groupCsvColumn)
+        => generator.ForInstance(s => s.SetGroupCsvColumn(groupCsvColumn));
+
     public static Generator<Filter> WithFilterGroups(
         this Generator<Filter> generator,
         IEnumerable<FilterGroup> filterGroups)
@@ -59,6 +62,12 @@ public static class FilterGeneratorExtensions
         => setters
             .Set(f => f.Label, label)
             .Set(f => f.Name, label.SnakeCase());
+
+    public static InstanceSetters<Filter> SetGroupCsvColumn(
+        this InstanceSetters<Filter> setters,
+        string groupCsvColumn)
+        => setters
+            .Set(f => f.GroupCsvColumn, groupCsvColumn);
 
     public static InstanceSetters<Filter> SetSubject(
         this InstanceSetters<Filter> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/FilterGroupGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/FilterGroupGeneratorExtensions.cs
@@ -46,7 +46,7 @@ public static class FilterGroupGeneratorExtensions
             .SetDefault(fg => fg.Id)
             .Set(
                 fg => fg.Label, 
-                (_, _, ctx) => ctx.Index == 0 ? "Default" : $"Filter Group {ctx.Index + 2}");
+                (_, _, ctx) => ctx.Index == 0 ? "Default" : $"Filter Group {ctx.Index + 1}");
 
     public static InstanceSetters<FilterGroup> SetLabel(
         this InstanceSetters<FilterGroup> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/IndicatorGroupGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/IndicatorGroupGeneratorExtensions.cs
@@ -34,7 +34,7 @@ public static class IndicatorGroupGeneratorExtensions
             .SetDefault(ig => ig.Id)
             .Set(
                 ig => ig.Label, 
-                (_, _, ctx) => ctx.Index == 0 ? "Default" : $"Indicator Group {ctx.Index + 2}");
+                (_, _, ctx) => ctx.Index == 0 ? "Default" : $"Indicator Group {ctx.Index + 1}");
 
     public static InstanceSetters<IndicatorGroup> SetSubject(
         this InstanceSetters<IndicatorGroup> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/FilterGroup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/FilterGroup.cs
@@ -15,6 +15,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 
         public static IEqualityComparer<FilterGroup> IdComparer { get; } = new IdEqualityComparer();
 
+        public const string DefaultFilterGroupLabel = "Default";
+
         public FilterGroup()
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Models/FilterAndIndicatorValuesReader.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Models/FilterAndIndicatorValuesReader.cs
@@ -18,7 +18,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Models;
 /// </summary>
 public class FilterAndIndicatorValuesReader
 {
-    private const string DefaultFilterGroupLabel = "Default";
     private const string DefaultFilterItemLabel = "Not specified";
 
     private readonly Dictionary<Guid, int> _indicatorColumnIndexes;
@@ -52,7 +51,7 @@ public class FilterAndIndicatorValuesReader
             .SelectMany(f => f.FilterGroups)
             .SelectMany(fg => fg.FilterItems)
             .ToDictionary(
-                fi => $"{fi.FilterGroup.Filter.Label}_{fi.FilterGroup.Label}_{fi.Label}".ToLower(), 
+                fi => $"{fi.FilterGroup.Filter.Label}_{fi.FilterGroup.Label}_{fi.Label}".ToLower(),
                 fi => fi);
     }
 
@@ -69,12 +68,12 @@ public class FilterAndIndicatorValuesReader
         Guid filterId)
     {
         var columnIndex = _filterColumnIndexes[filterId];
-        
+
         if (columnIndex == -1)
         {
             return DefaultFilterItemLabel;
         }
-        
+
         return rowValues[columnIndex].Trim().NullIfWhiteSpace() ?? DefaultFilterItemLabel;
     }
 
@@ -83,22 +82,22 @@ public class FilterAndIndicatorValuesReader
         Guid filterId)
     {
         var columnIndex = _filterGroupColumnIndexes[filterId];
-        
+
         if (columnIndex == -1)
         {
-            return DefaultFilterGroupLabel;
+            return FilterGroup.DefaultFilterGroupLabel;
         }
 
-        return rowValues[columnIndex].Trim().NullIfWhiteSpace() ?? DefaultFilterGroupLabel;
+        return rowValues[columnIndex].Trim().NullIfWhiteSpace() ?? FilterGroup.DefaultFilterGroupLabel;
     }
-    
+
     public FilterItem GetFilterItem(IReadOnlyList<string> rowValues, Filter filter)
     {
         var filterItemLabel = GetFilterItemLabel(rowValues, filter.Id);
         var filterGroupLabel = GetFilterGroupLabel(rowValues, filter.Id);
         return LookupCachedFilterItem(filterItemLabel, filterGroupLabel, filter.Label);
     }
-    
+
     private FilterItem LookupCachedFilterItem(string filterItemLabel, string filterGroupLabel, string filterLabel)
     {
         return _filterItemCache[$"{filterLabel}_{filterGroupLabel}_{filterItemLabel}".ToLower()];


### PR DESCRIPTION
⚠️ This has an associated faffy deploy ticket [EES-4371](https://dfedigital.atlassian.net/browse/EES-4371) ⚠️ 

This PR adds a migration endpoint which copies `filter_grouping_column` from all meta csv files for every filter which has non-default groups.

This follows the change made by #4112 which added a new field `GroupCsvColumn` to `Filter` and began setting the value for every filter with non-default filter groups when importing data. 

### Default filter groups, non-default filter groups and the `filter_grouping_column`
When importing data, filters which are defined in the meta csv file without a value for `filter_grouping_column` will have their filter items added to a single filter group labelled "Default".

The `filter_grouping_column` in the meta csv file allows analysts to define  the name of a column to be found in the data csv file which contains the group for filter items. Where the values for a filter in the data csv file have a corresponding group value they will be added to a group with this label.

### Migration

#### Usage

Make a request to the secured BAU endpoint `PATCH /bau/migrate-filter-group-csv-columns?dryRun={true|false}`.

When option `dryRun=true` no updates are made to the database. The default value is `true`.

#### How it works

The underlying service will query the statistics database for all filters with non-default groups. It will then attempt to query the content database for the meta files corresponding  with the subject id's of all the filters found. For every meta file it will attempt to retrieve the meta csv file from blob storage. For every meta csv file that can be retrieved it will attempt to parse the filter defined by each csv row.

Each filter in the statistics database will be updated, setting `GroupCsvColumn` to the value of `filter_grouping_column` found in the meta file where the filters can be matched. Filters are matched by name and a sanity check is made on their labels.

Any filters where the value is already set i.e. because they have been recently imported after #4112 or added by a previous run of this migration, will be ignored.

#### Report
A report is returned in the response containing arrays of `Information`, `Errors` and `FiltersUpdated`.

Example report:

```
{
  "filtersUpdated": [
    "c797061b-dc43-4a47-b1e5-bc6686b043ea",
    "629d174e-bd2a-4aed-9ed9-697390763f67"
  ],
  "information": [
    {
      "value": "AllFiltersHaveGroupCsvColumnValues",
      "subjectId": "6b67300b-e32a-4abe-e02c-08db7bb31b71"
    }
  ],
  "errors": [
    {
      "value": "MetaFileNotFound",
      "subjectId": "7019e766-b75c-4274-b2ec-0df02d01b2ff"
    },
    {
      "value": "ExceptionGettingMetaFilters",
      "subjectId": "803fbf56-600f-490f-8409-6413a891720d",
      "fileId": "be141b27-0143-41b0-6a88-08d7ec2d8168",
      "filePath": "4fa4fe8e-9a15-46bb-823f-49bf8e0cdec5/data/be141b27-0143-41b0-6a88-08d7ec2d8168",
      "exception": "Could not find file at releases/4fa4fe8e-9a15-46bb-823f-49bf8e0cdec5/data/be141b27-0143-41b0-6a88-08d7ec2d8168"
    },
    {
      "value": "MetaFilterNotFound",
      "subjectId": "6b67300b-e32a-4abe-e02c-08db7bb31b71",
      "filterId": "ace7349c-8fc2-47df-21b4-08db7bb31bb4",
      "filterName": "filter_1",
      "fileId": "9cbfc437-ab47-433d-6016-08db7bb31b7c",
      "filePath": "a7425a4a-3668-4ae2-7fce-08db7bb2e85c/data/9cbfc437-ab47-433d-6016-08db7bb31b7c"
    },
    {
      "value": "FilterLabelMismatch",
      "subjectId": "6b67300b-e32a-4abe-e02c-08db7bb31b71",
      "filterId": "57c58e6f-4b43-457f-21b5-08db7bb31bb4",
      "filterName": "filter_2",
      "fileId": "9cbfc437-ab47-433d-6016-08db7bb31b7c",
      "filePath": "a7425a4a-3668-4ae2-7fce-08db7bb2e85c/data/9cbfc437-ab47-433d-6016-08db7bb31b7c"
    }
  ]
}
```

##### `FiltersUpdated`

Contains the filter id's of all filters which have been updated if `dryRun=false`, or would be updated if `dryRun=true`.

##### Possible `Information` entries

- `AllFiltersHaveGroupCsvColumnValues` - Meta file won't be retrieved because all filters have a `GroupCsvColumn` value.
- `FilterAlreadyHasGroupCsvColumnValue` - Filter is ignored because it has a `GroupCsvColumn` value.

##### Possible `Error` entries

- `MetaFileNotFound` - Occurs when a `File` with type `FileType.Metadata` is not found by subject id in the content database.
- `ExceptionGettingMetaFilters` - Occurs when the meta csv file cannot be retrieved from blob storage or there's some other problem parsing the file such as blank filter names/labels.
- `MetaFilterNotFound` - Occurs when a filter is not found by `col_name` in the meta csv file for the filter name.
- `FilterLabelMismatch` - Occurs when a filter is found in the meta csv file but it doesn't have the expected label.