### PR TITLE
EES-4396 - fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
   "azure-pipelines": {
     "enabled": false
   },
+  "python": {
+    "enabled": false
+  },
   "vulnerabilityAlerts": {
     "groupName": "renovate",
     "dependencyDashboardApproval": false,
@@ -59,10 +62,6 @@
     },
     {
       "matchPackagePatterns": ["^@ckeditor/", "Mime", "Mime-Detective"],
-      "enabled": false
-    },
-    {
-      "fileMatch": ["(^|/)\\.python-version$"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
This PR:
* fixes the renovate config by removing an incompatible rule in the `packageRules` field. To disable python updates, we've instead added an object outside of the `packageRules` field to tell renovate not to attempt to upgrade python dependencies