### PR TITLE
EES-4400 : Accessibility -Alt-text should not be repeated

### DIFF
--- a/src/explore-education-statistics-admin/src/components/PageHeader.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageHeader.tsx
@@ -55,7 +55,7 @@ const PageHeader = ({ wide }: Props) => {
             >
               <span className="govuk-header__logotype">
                 <img
-                  alt="GOV.UK"
+                  alt=""
                   src={logo}
                   className="govuk-header__logotype-crown-fallback-image"
                 />

--- a/src/explore-education-statistics-frontend/src/components/PageHeader.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageHeader.tsx
@@ -17,7 +17,7 @@ const PageHeader = () => (
             >
               <span className="govuk-header__logotype">
                 <img
-                  alt="GOV.UK"
+                  alt=""
                   src={logo.src}
                   className="govuk-header__logotype-crown-fallback-image"
                 />


### PR DESCRIPTION
Alternative text for the <img> element has text that duplicates the existing text.


Element Location:
.govuk-header__logotype-crown-fallback-image
<img alt="GOV.UK" src="/_next/static/image/_/node_modules/govuk-frontend/govuk/assets/images/govuk-logotype-crown.5c77cb65d4bdbe647e3b3ac61362b652.png" class="govuk-header__logotype-crown-fallback-image">
![axe](https://github.com/dfe-analytical-services/explore-education-statistics/assets/93383553/393a7e07-f23b-4809-aad8-bfce1d6fc979)
