### PR TITLE
EES-4398 - fix deployment of public app via docker

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2027,6 +2027,7 @@
         "hostingEnvironment": "",
         "httpsOnly": true,
         "clientAffinityEnabled": false,
+        "reserved": true,
         "siteConfig": {
           "acrUseManagedIdentityCreds": false,
           "http20Enabled": true,
@@ -2103,7 +2104,8 @@
         "name": "[variables('publicPlanName')]",
         "workerSizeId": "0",
         "numberOfWorkers": "1",
-        "hostingEnvironment": ""
+        "hostingEnvironment": "",
+        "reserved": true
       }
     },
     {


### PR DESCRIPTION
This PR: 
* Fixes the recent deployment issues after the switchover to the hybrid container app service plan for the public frontend. This problem stemmed from the fact that we didn't have `reserved` set to true in the public app's service plan and site settings. If you use Linux then `reserved` needs to always be set to true (see https://learn.microsoft.com/en-us/troubleshoot/azure/app-service/faqs-app-service-linux#how-can-i-create-a-linux-app-service-plan-through-an-sdk-or-an-azure-resource-manager-template- and https://github.com/hashicorp/terraform-provider-azurerm/issues/3379 for more details) 