### PR TITLE
EES-4398 - remove linux from app service kind

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2002,7 +2002,7 @@
     {
       "type": "Microsoft.Web/sites",
       "name": "[variables('publicAppName')]",
-      "kind": "app,linux,container",
+      "kind": "app,container",
       "apiVersion": "2021-02-01",
       "location": "[resourceGroup().location]",
       "identity": {
@@ -2084,7 +2084,7 @@
         "Name": "[first(split(parameters('skuPublic'), ' '))]"
       },
       "name": "[variables('publicPlanName')]",
-      "kind": "app,linux,container",
+      "kind": "app,container",
       "apiVersion": "2022-03-01",
       "location": "[resourceGroup().location]",
       "tags": {


### PR DESCRIPTION
This PR : 
* removes `linux` from the kind parameter in order to try to resolve recent issues with public frontend deployments via container app serviice methods