### PR TITLE
EES-4398 - remove prototype PNPM app from cors allow list

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1228,7 +1228,6 @@
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
-              "https://ees-pnpm-linux-container.azurewebsites.net",
               "[concat('https://', variables('publicAppName'), '.azurewebsites.net')]",
               "https://localhost:3000",
               "http://localhost:3000",
@@ -1316,7 +1315,6 @@
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
-              "https://ees-pnpm-linux-container.azurewebsites.net",
               "[concat('https://', variables('publicAppName'), '.azurewebsites.net')]",
               "https://localhost:3000",
               "http://localhost:3000",
@@ -1459,7 +1457,6 @@
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
-              "https://ees-pnpm-linux-container.azurewebsites.net",
               "[concat('https://', variables('publicAppName'), '.azurewebsites.net')]",
               "https://localhost:3000",
               "http://localhost:3000",
@@ -1540,7 +1537,6 @@
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
-              "https://ees-pnpm-linux-container.azurewebsites.net",
               "[concat('https://', variables('publicAppName'), '.azurewebsites.net')]",
               "https://localhost:3000",
               "http://localhost:3000",
@@ -2858,7 +2854,6 @@
           "allowedOrigins": [
             "[concat('https://', parameters('domain'))]",
             "[concat('https://', variables('publicAppName'), '.azurewebsites.net')]",
-            "https://ees-pnpm-linux-container.azurewebsites.net",
             "https://localhost:3000",
             "http://localhost:3000",
             "http://127.0.0.1"


### PR DESCRIPTION
This PR:
* Removes the prototype PNPM app from the allowed cors origins since it is no longer being used