### PR TITLE
EES-4389 - reverting Next.js page caching changes

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -29,7 +29,7 @@ import { logEvent } from '@frontend/services/googleAnalyticsService';
 import glossaryService from '@frontend/services/glossaryService';
 import classNames from 'classnames';
 import orderBy from 'lodash/orderBy';
-import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
+import { GetServerSideProps, NextPage } from 'next';
 import React from 'react';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import ScrollableContainer from '@common/components/ScrollableContainer';
@@ -571,11 +571,13 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
   );
 };
 
-export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
+export const getServerSideProps: GetServerSideProps<Props> = async ({
+  query,
+}) => {
   const {
     publication: publicationSlug,
     release: releaseSlug,
-  } = params as Dictionary<string>;
+  } = query as Dictionary<string>;
 
   const release = await (releaseSlug
     ? publicationService.getPublicationRelease(publicationSlug, releaseSlug)
@@ -585,14 +587,6 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
     props: {
       release,
     },
-    revalidate: process.env.APP_ENV === 'Local' ? 2 : 10,
-  };
-};
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  return {
-    paths: [],
-    fallback: 'blocking',
   };
 };
 

--- a/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication].tsx
@@ -1,5 +1,4 @@
 export {
   default,
-  getStaticProps,
-  getStaticPaths,
+  getServerSideProps,
 } from '@frontend/modules/find-statistics/PublicationReleasePage';

--- a/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication]/[release].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication]/[release].tsx
@@ -1,5 +1,4 @@
 export {
   default,
-  getStaticProps,
-  getStaticPaths,
+  getServerSideProps,
 } from '@frontend/modules/find-statistics/PublicationReleasePage';


### PR DESCRIPTION
This PR:
* removes the Next.js page caching for the public Release pages, in case we need to use it.