### PR TITLE
EES-4398 Change `dependsOn` to reference resource in alternate resource group

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2004,7 +2004,7 @@
       "dependsOn": [
         "[concat('Microsoft.Web/serverfarms/', variables('publicPlanName'))]",
         "[resourceId('microsoft.insights/components/', variables('publicAppInsights'))]",
-        "[resourceId('Microsoft.ContainerRegistry/registries/', parameters('containerRegistryName'))]"
+        "[resourceId(parameters('containerRegistrySubscriptionId'), parameters('containerRegistryResourceGroup'), 'Microsoft.ContainerRegistry/registries', parameters('containerRegistryName'))]"
       ]
     },
     {


### PR DESCRIPTION
This PR follows https://github.com/dfe-analytical-services/explore-education-statistics/pull/4173.

It changes the `dependsOn` to reference the container registry resource which is in a nested deployment template and potentially in an alternate resource group, by providing the subscription id and resource group name.

This attempts to fix the deployment error `Deployment template validation failed: 'The resource 'Microsoft.ContainerRegistry/registries/eesacr' is not defined in the template.`