### PR TITLE
EES-4415 - reintroduce check-node-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   },
   "scripts": {
     "prepare": "husky install",
+    "preinstall": "pnpm check:node",
     "clean": "pnpm -r --parallel exec rm -rf node_modules && rm -rf node_modules",
+    "check:node": "check-node-version --node 16.14.2 --pnpm 8.6.6",
     "fix": "pnpm fix:js && pnpm fix:style",
     "fix:js": "eslint --fix --ext .ts,.tsx,.js,.jsx src tests/performance-tests/src useful-scripts",
     "fix:style": "stylelint --fix src/**/*.{scss,css}",


### PR DESCRIPTION
This PR:
* reintroduces the `check-node-version` responsible for restraining what PNPM + node version everyone is allowed to use on the project. This was previously removed due to the fact that PNPM comes with this functionality out of the box via the `engines` field. It's been discovered that while this is respected and works as expected on Linux + Mac, Windows bypasses this restriction and lets you use whatever Node + PNPM version you want. To prevent this, We've reintroduced `check-node-version` which works cross-platform