### PR TITLE
EES-4398 Change `dependsOn` to reference the container registry nested deployment

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2004,7 +2004,7 @@
       "dependsOn": [
         "[concat('Microsoft.Web/serverfarms/', variables('publicPlanName'))]",
         "[resourceId('microsoft.insights/components/', variables('publicAppInsights'))]",
-        "[resourceId(parameters('containerRegistrySubscriptionId'), parameters('containerRegistryResourceGroup'), 'Microsoft.ContainerRegistry/registries', parameters('containerRegistryName'))]"
+        "[resourceId('Microsoft.Resources/deployments', 'containerRegistryDeployment')]"
       ]
     },
     {


### PR DESCRIPTION
This PR follows https://github.com/dfe-analytical-services/explore-education-statistics/pull/4174.

It changes the `dependsOn` to reference the container registry nested deployment.