### PR TITLE
EES-4398 Remove dependsOn for shared container registry deployment

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2003,8 +2003,7 @@
       },
       "dependsOn": [
         "[concat('Microsoft.Web/serverfarms/', variables('publicPlanName'))]",
-        "[resourceId('microsoft.insights/components/', variables('publicAppInsights'))]",
-        "[resourceId('Microsoft.Resources/deployments', 'containerRegistryDeployment')]"
+        "[resourceId('microsoft.insights/components/', variables('publicAppInsights'))]"
       ]
     },
     {


### PR DESCRIPTION
This PR removes the `dependsOn` which appears to not work when deploying the parent template to a different resource group than the nested template.

Providing this works, we'll have to look at alternative ways of making sure the container registry exists.