### PR TITLE
EES-4385 Add methodology status history

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ApproveSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ApproveSpecificMethodologyAuthorizationHandlerTests.cs
@@ -14,7 +14,7 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Aut
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseRole;
 using static Moq.MockBehavior;
 using IPublicationRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IPublicationRepository;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
@@ -17,7 +17,7 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Uti
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 using static Moq.MockBehavior;
 using IPublicationRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IPublicationRepository;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlerTests.cs
@@ -13,7 +13,7 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Aut
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static Moq.MockBehavior;
 using IPublicationRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IPublicationRepository;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlerTests.cs
@@ -28,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         {
             Id = Guid.NewGuid(),
             MethodologyId = Guid.NewGuid(),
-            Status = MethodologyStatus.Approved,
+            Status = MethodologyApprovalStatus.Approved,
         };
 
         private static readonly Publication OwningPublication = new()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
@@ -80,18 +80,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var methodologyService = new Mock<IMethodologyService>(Strict);
                 var service = BuildService(context, methodologyService: methodologyService.Object);
 
-                var amendmentIdCapture = new List<Guid>();
+                var amendmentCapture = new List<MethodologyVersion>();
                 var viewModel = new MethodologyVersionViewModel();
 
                 methodologyService
-                    .Setup(s => s.GetMethodology(Capture.In(amendmentIdCapture)))
+                    .Setup(s => s.BuildMethodologyVersionViewModel(Capture.In(amendmentCapture)))
                     .ReturnsAsync(viewModel);
 
                 var result = await service.CreateMethodologyAmendment(originalVersion.Id);
                 VerifyAllMocks(methodologyService);
 
                 result.AssertRight(viewModel);
-                amendmentId = Assert.Single(amendmentIdCapture);
+                var amendment = Assert.Single(amendmentCapture);
+                amendmentId = amendment.Id;
             }
 
             // Check that the amendment was successfully saved.  More detailed field-by-field testing is available in
@@ -178,18 +179,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var methodologyService = new Mock<IMethodologyService>(Strict);
                 var service = BuildService(context, methodologyService: methodologyService.Object);
 
-                var amendmentIdCapture = new List<Guid>();
+                var amendmentCapture = new List<MethodologyVersion>();
                 var viewModel = new MethodologyVersionViewModel();
 
                 methodologyService
-                    .Setup(s => s.GetMethodology(Capture.In(amendmentIdCapture)))
+                    .Setup(s => s.BuildMethodologyVersionViewModel(Capture.In(amendmentCapture)))
                     .ReturnsAsync(viewModel);
 
                 var result = await service.CreateMethodologyAmendment(originalVersion.Id);
                 VerifyAllMocks(methodologyService);
 
                 result.AssertRight(viewModel);
-                amendmentId = Assert.Single(amendmentIdCapture);
+                var amendment = Assert.Single(amendmentCapture);
+                amendmentId = amendment.Id;
             }
 
             // Check that the Methodology Files were successfully linked to the Amendment.

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServicePermissionTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
@@ -25,7 +25,7 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentif
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
@@ -311,10 +311,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 VerifyAllMocks(contentService, methodologyVersionRepository);
 
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Id);
-                Assert.Equal("Test approval", updatedMethodologyVersion.InternalReleaseNote);
-                Assert.Null(updatedMethodologyVersion.Published);
-                Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
-                Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
                 Assert.Equal(request.Status, updatedMethodologyVersion.Status);
             }
 
@@ -369,10 +365,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var updatedMethodologyVersion = (await service.UpdateApprovalStatus(methodologyVersion.Id, request)).AssertRight();
 
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Id);
-                Assert.Null(updatedMethodologyVersion.InternalReleaseNote);
-                Assert.Null(updatedMethodologyVersion.Published);
-                Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy); // Immediately is the default
-                Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
                 Assert.Equal(request.Status, updatedMethodologyVersion.Status);
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyContentServiceTests.cs
@@ -18,7 +18,7 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.Validat
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
@@ -18,7 +18,7 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityP
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
@@ -228,6 +228,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 );
         }
 
+        [Fact]
+        public async Task GetMethodologyStatuses()
+        {
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_methodologyVersion, CanViewSpecificMethodology)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = SetupMethodologyService(userService: userService.Object);
+                        return service.GetMethodologyStatuses(_methodologyVersion.Id);
+                    }
+                );
+        }
+
         private MethodologyService SetupMethodologyService(
             ContentDbContext? contentDbContext = null,
             IPersistenceHelper<ContentDbContext>? contentPersistenceHelper = null,
@@ -247,7 +261,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 methodologyImageService ?? Mock.Of<IMethodologyImageService>(),
                 methodologyApprovalService ?? Mock.Of<IMethodologyApprovalService>(Strict),
                 methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
-            userService ?? Mock.Of<IUserService>()
+                userService ?? Mock.Of<IUserService>()
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -2024,6 +2024,201 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             }
         }
 
+        [Fact]
+        public async Task GetMethodologyStatuses()
+        {
+            var methodologyId = Guid.NewGuid();
+            var unrelatedMethodologyId = Guid.NewGuid();
+
+            var methodology = new Methodology
+            {
+                Id = methodologyId,
+                Slug = "pupil-absence-statistics-methodology",
+                OwningPublicationTitle = "Pupil absence statistics: methodology",
+                Versions = ListOf(
+                    new MethodologyVersion
+                    {
+                        PublishingStrategy = Immediately,
+                        Status = Draft,
+                        Version = 0,
+                    },
+                    new MethodologyVersion
+                    {
+                        PublishingStrategy = WithRelease,
+                        Status = Approved,
+                        Version = 1,
+                    }
+                ),
+            };
+
+            var unrelatedMethodology = new Methodology
+            {
+                Id = unrelatedMethodologyId,
+                Slug = "pupil-absence-statistics-methodology",
+                OwningPublicationTitle = "Pupil absence statistics: methodology",
+                Versions = ListOf(new MethodologyVersion
+                {
+                    Id = Guid.NewGuid(),
+                    PublishingStrategy = Immediately,
+                    Status = Draft
+                })
+            };
+
+            var methodologyStatuses = new List<MethodologyStatus>
+            {
+                new()
+                {
+                    MethodologyVersion = methodology.Versions[0],
+                    InternalReleaseNote = "Status 1 note",
+                    ApprovalStatus = Approved,
+                    Created = new DateTime(2000, 1, 1),
+                    CreatedById = UserId,
+                },
+                new()
+                {
+                    MethodologyVersion = methodology.Versions[1],
+                    InternalReleaseNote = "Status 2 note",
+                    ApprovalStatus = Approved,
+                    Created = new DateTime(2001, 1, 1),
+                    CreatedById = UserId,
+                },
+                new()
+                {
+                    MethodologyVersion = unrelatedMethodology.Versions[0],
+                    InternalReleaseNote = "Unrelated note",
+                    ApprovalStatus = Approved,
+                    Created = new DateTime(2002, 1, 1),
+                    CreatedById = Guid.NewGuid(),
+                }
+            };
+
+            var user = new User
+            {
+                Id = UserId,
+                Email = "test@test.com",
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await context.Methodologies.AddRangeAsync(methodology, unrelatedMethodology);
+                await context.MethodologyStatus.AddRangeAsync(methodologyStatuses);
+                await context.Users.AddAsync(user);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyService(context);
+
+                var result = await service.GetMethodologyStatuses(methodology.Versions[0].Id);
+
+                var statuses = result.AssertRight();
+
+                Assert.NotNull(statuses);
+                Assert.Equal(2, statuses.Count);
+
+                Assert.Equal(methodologyStatuses[1].Id, statuses[0].MethodologyStatusId); // because OrderByDesc
+                Assert.Equal(1, statuses[0].MethodologyVersion);
+                Assert.Equal(methodologyStatuses[1].InternalReleaseNote, statuses[0].InternalReleaseNote);
+                Assert.Equal(methodologyStatuses[1].ApprovalStatus, statuses[0].ApprovalStatus);
+                Assert.Equal(methodologyStatuses[1].Created, statuses[0].Created);
+                Assert.Equal("test@test.com", statuses[0].CreatedByEmail);
+
+                Assert.Equal(methodologyStatuses[0].Id, statuses[1].MethodologyStatusId);
+                Assert.Equal(0, statuses[1].MethodologyVersion);
+                Assert.Equal(methodologyStatuses[0].InternalReleaseNote, statuses[1].InternalReleaseNote);
+                Assert.Equal(methodologyStatuses[0].ApprovalStatus, statuses[1].ApprovalStatus);
+                Assert.Equal(methodologyStatuses[0].Created, statuses[1].Created);
+                Assert.Equal("test@test.com", statuses[1].CreatedByEmail);
+            }
+        }
+
+        [Fact]
+        public async Task GetMethodologyStatuses_NoMethodologyVersion()
+        {
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyService(context);
+
+                var result = await service.GetMethodologyStatuses(Guid.NewGuid());
+
+                result.AssertNotFound();
+            }
+        }
+
+        [Fact]
+        public async Task GetMethodologyStatuses_NoStatuses()
+        {
+            var methodologyId = Guid.NewGuid();
+            var unrelatedMethodologyId = Guid.NewGuid();
+
+            var methodology = new Methodology
+            {
+                Id = methodologyId,
+                Slug = "pupil-absence-statistics-methodology",
+                OwningPublicationTitle = "Pupil absence statistics: methodology",
+                Versions = ListOf(
+                    new MethodologyVersion
+                    {
+                        PublishingStrategy = Immediately,
+                        Status = Draft,
+                    },
+                    new MethodologyVersion
+                    {
+                        PublishingStrategy = WithRelease,
+                        Status = Approved,
+                    }
+                ),
+            };
+
+            var unrelatedMethodology = new Methodology
+            {
+                Id = unrelatedMethodologyId,
+                Slug = "pupil-absence-statistics-methodology",
+                OwningPublicationTitle = "Pupil absence statistics: methodology",
+                Versions = ListOf(new MethodologyVersion
+                {
+                    Id = Guid.NewGuid(),
+                    PublishingStrategy = Immediately,
+                    Status = Draft
+                })
+            };
+
+            var methodologyStatuses = new List<MethodologyStatus>
+            {
+                new()
+                {
+                    MethodologyVersion = unrelatedMethodology.Versions[0],
+                    InternalReleaseNote = "Unrelated note",
+                    ApprovalStatus = Approved,
+                    Created = new DateTime(2002, 1, 1),
+                    CreatedById = Guid.NewGuid(),
+                },
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await context.Methodologies.AddRangeAsync(methodology, unrelatedMethodology);
+                await context.MethodologyStatus.AddRangeAsync(methodologyStatuses);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyService(context);
+
+                var result = await service.GetMethodologyStatuses(methodology.Versions[0].Id);
+
+                var statuses = result.AssertRight();
+
+                Assert.NotNull(statuses);
+                Assert.Empty(statuses);
+            }
+        }
+
         private static MethodologyService SetupMethodologyService(
             ContentDbContext contentDbContext,
             IPersistenceHelper<ContentDbContext>? persistenceHelper = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -27,7 +27,7 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentif
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
@@ -19,7 +19,7 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
 using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
 using Unit = GovUk.Education.ExploreEducationStatistics.Common.Model.Unit;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -1328,7 +1328,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(retrievedMethodology.ScheduledForPublishingImmediately);
                 Assert.Null(retrievedMethodology.ScheduledWithReleaseId);
                 Assert.Null(retrievedMethodology.InternalReleaseNote);
-                Assert.Equal(MethodologyStatus.Draft, retrievedMethodology.Status);
+                Assert.Equal(MethodologyApprovalStatus.Draft, retrievedMethodology.Status);
                 Assert.InRange(DateTime.UtcNow
                     .Subtract(retrievedMethodology.Updated!.Value).Milliseconds, 0, 1500);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
@@ -111,5 +111,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
                 .DeleteMethodologyVersion(methodologyVersionId)
                 .HandleFailuresOrNoContent();
         }
+
+        [HttpGet("methodology/{methodologyVersionId:guid}/status")]
+        public Task<ActionResult<List<MethodologyStatusViewModel>>> GetMethodologyStatuses(Guid methodologyVersionId)
+        {
+            return _methodologyService
+                .GetMethodologyStatuses(methodologyVersionId)
+                .HandleFailuresOrOk();
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230706081603_EES4385_CreateMethodologyStatusTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230706081603_EES4385_CreateMethodologyStatusTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230706081603_EES4385_CreateMethodologyStatusTable")]
+    partial class EES4385_CreateMethodologyStatusTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230706081603_EES4385_CreateMethodologyStatusTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230706081603_EES4385_CreateMethodologyStatusTable.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES4385_CreateMethodologyStatusTable : Migration
+    {
+        private const string MigrationId = "20230706081603";
+
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MethodologyStatus",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    MethodologyVersionId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    InternalReleaseNote = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ApprovalStatus = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Created = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CreatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MethodologyStatus", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MethodologyStatus_MethodologyVersions_MethodologyVersionId",
+                        column: x => x.MethodologyVersionId,
+                        principalTable: "MethodologyVersions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_MethodologyStatus_Users_CreatedById",
+                        column: x => x.CreatedById,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MethodologyStatus_CreatedById",
+                table: "MethodologyStatus",
+                column: "CreatedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MethodologyStatus_MethodologyVersionId",
+                table: "MethodologyStatus",
+                column: "MethodologyVersionId");
+
+            migrationBuilder.SqlFromFile(MigrationConstants.ContentMigrationsPath, $"{MigrationId}_MigrateMethodologyInternalReleaseNotes.sql");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MethodologyStatus");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230706081603_MigrateMethodologyInternalReleaseNotes.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230706081603_MigrateMethodologyInternalReleaseNotes.sql
@@ -7,5 +7,6 @@ SELECT NEWID() AS Id,
        MV.Published AS Created,
        NULL AS CreatedById
 FROM [dbo].[MethodologyVersions] MV
-WHERE MV.Published IS NOT NULL;
+WHERE MV.InternalReleaseNote IS NOT NULL
+AND MV.Status = 'Approved';
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230706081603_MigrateMethodologyInternalReleaseNotes.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230706081603_MigrateMethodologyInternalReleaseNotes.sql
@@ -1,0 +1,11 @@
+﻿INSERT INTO [dbo].[MethodologyStatus] (Id, MethodologyVersionId, InternalReleaseNote,
+                                       ApprovalStatus, Created, CreatedById)
+SELECT NEWID() AS Id,
+       MV.Id AS MethodologyVersionId,
+       MV.InternalReleaseNote AS InternalReleaseNote,
+       MV.Status AS ApprovalStatus,
+       MV.Published AS Created,
+       NULL AS CreatedById
+FROM [dbo].[MethodologyVersions] MV
+WHERE MV.Published IS NOT NULL;
+

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlers.cs
@@ -1,13 +1,11 @@
 #nullable enable
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyApprovalService.cs
@@ -1,8 +1,6 @@
 ﻿#nullable enable
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
@@ -34,5 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
         Task<Either<ActionResult, MethodologyVersionViewModel>> UpdateMethodology(
             Guid methodologyVersionId,
             MethodologyUpdateRequest request);
+
+        Task<Either<ActionResult, List<MethodologyStatusViewModel>>> GetMethodologyStatuses(Guid methodologyVersionId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies
@@ -34,6 +35,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
         Task<Either<ActionResult, MethodologyVersionViewModel>> UpdateMethodology(
             Guid methodologyVersionId,
             MethodologyUpdateRequest request);
+
+        Task<MethodologyVersionViewModel> BuildMethodologyVersionViewModel(
+            MethodologyVersion methodologyVersion);
 
         Task<Either<ActionResult, List<MethodologyStatusViewModel>>> GetMethodologyStatuses(Guid methodologyVersionId);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/ManageMethodologyContentViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/ManageMethodologyContentViewModel.cs
@@ -18,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         public string Title { get; set; } = string.Empty;
 
         [JsonConverter(typeof(StringEnumConverter))]
-        public MethodologyStatus Status { get; set; }
+        public MethodologyApprovalStatus Status { get; set; }
 
         public DateTime? Published { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyAmendmentService.cs
@@ -42,7 +42,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 .OnSuccess(HydrateMethodologyVersionForAmendment)
                 .OnSuccess(CreateAndSaveAmendment)
                 .OnSuccessDo(LinkOriginalMethodologyFilesToAmendment)
-                .OnSuccess(amendment => _methodologyService.GetMethodology(amendment.Id));
+                .OnSuccess(amendment =>
+                    _methodologyService.BuildMethodologyVersionViewModel(amendment));
         }
 
         private async Task<Either<ActionResult, MethodologyVersion>> CreateAndSaveAmendment(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
@@ -19,7 +19,7 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.Validat
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies
 {
@@ -165,7 +165,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
         private Task<Either<ActionResult, MethodologyVersion>> CheckCanUpdateStatus(
             MethodologyVersion methodologyVersion,
-            MethodologyStatus requestedStatus)
+            MethodologyApprovalStatus requestedStatus)
         {
             return requestedStatus switch
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
@@ -104,7 +104,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                             await _publishingService.PublishMethodologyFiles(methodologyVersion.Id);
                         }
 
-                        // @MarkFix this gets added even if moving from Draft -> Draft?
                         var methodologyStatus = new MethodologyStatus
                         {
                             MethodologyVersionId = methodologyVersion.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
@@ -71,7 +71,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             MethodologyVersion methodologyVersionToUpdate,
             MethodologyApprovalUpdateRequest request)
         {
-            if (!request.IsStatusUpdateForMethodology(methodologyVersionToUpdate))
+            if (!request.IsStatusUpdateRequired(methodologyVersionToUpdate))
             {
                 // Status unchanged
                 return methodologyVersionToUpdate;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
@@ -15,7 +15,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interf
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Query.Internal;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
@@ -423,7 +423,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         private async Task<Either<ActionResult, MethodologyVersionContent>> CheckCanUpdateMethodologyContent(
             MethodologyVersion methodologyVersion)
         {
-            if (methodologyVersion.Status != MethodologyStatus.Draft)
+            if (methodologyVersion.Status != MethodologyApprovalStatus.Draft)
             {
                 return ValidationActionResult(ValidationErrorMessages.MethodologyMustBeDraft);
             }
@@ -441,7 +441,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         private async Task<Either<ActionResult, Tuple<MethodologyVersionContent, ContentSection>>> CheckCanUpdateMethodologyContent(
             Tuple<MethodologyVersion, ContentSection> tuple)
         {
-            if (tuple.Item1.Status != MethodologyStatus.Draft)
+            if (tuple.Item1.Status != MethodologyApprovalStatus.Draft)
             {
                 return ValidationActionResult(ValidationErrorMessages.MethodologyMustBeDraft);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -266,7 +266,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             MethodologyVersion methodologyVersionToUpdate,
             MethodologyApprovalUpdateRequest request)
         {
-            if (!request.IsStatusUpdateForMethodology(methodologyVersionToUpdate))
+            if (!request.IsStatusUpdateRequired(methodologyVersionToUpdate))
             {
                 return methodologyVersionToUpdate;
             }
@@ -283,7 +283,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             MethodologyVersion methodologyVersionToUpdate,
             MethodologyUpdateRequest request)
         {
-            if (!request.IsDetailUpdateForMethodology(methodologyVersionToUpdate))
+            if (methodologyVersionToUpdate.Title == request.Title)
             {
                 // Details unchanged
                 return methodologyVersionToUpdate;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -211,8 +211,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             return await _persistenceHelper
                 .CheckEntityExists<MethodologyVersion>(id, q =>
                     q.Include(m => m.Methodology))
-                .OnSuccess(methodology => UpdateStatus(methodology, request))
-                .OnSuccess(methodology => UpdateDetails(methodology, request))
+                .OnSuccess(methodologyVersion => UpdateStatus(methodologyVersion, request))
+                .OnSuccess(methodologyVersion => UpdateDetails(methodologyVersion, request))
                 .OnSuccess(BuildMethodologyVersionViewModel);
         }
 
@@ -295,7 +295,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 // this Methodology attempts to set its AlternativeTitle (and Slug) to the same value.  Whilst an
                 // unlikely scenario, it's entirely possible.
                 .OnSuccessDo(methodologyVersion =>
-                    ValidateMethodologySlugUniqueForUpdate(methodologyVersion.Id, request.Slug))
+                    ValidateMethodologySlugUniqueForUpdate(methodologyVersion, request.Slug))
                 .OnSuccess(async methodologyVersion =>
                 {
                     methodologyVersion.Updated = DateTime.UtcNow;
@@ -433,19 +433,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         }
 
         private async Task<Either<ActionResult, Unit>> ValidateMethodologySlugUniqueForUpdate(
-            Guid methodologyVersionId, string slug)
+            MethodologyVersion methodologyVersion, string slug)
         {
-            var methodologyId = await _context
-                .MethodologyVersions
-                .AsQueryable()
-                .Where(m => m.Id == methodologyVersionId)
-                .Select(m => m.MethodologyId)
-                .SingleAsync();
-
             if (await _context
                     .Methodologies
                     .AsQueryable()
-                    .AnyAsync(p => p.Slug == slug && p.Id != methodologyId))
+                    .AnyAsync(p => p.Slug == slug && p.Id != methodologyVersion.MethodologyId))
             {
                 return ValidationActionResult(SlugNotUnique);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -213,10 +213,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                     q.Include(m => m.Methodology))
                 .OnSuccess(methodology => UpdateStatus(methodology, request))
                 .OnSuccess(methodology => UpdateDetails(methodology, request))
-                .OnSuccess(_ => GetMethodology(id));
+                .OnSuccess(BuildMethodologyVersionViewModel);
         }
 
-        private async Task<MethodologyVersionViewModel> BuildMethodologyVersionViewModel(
+        public async Task<MethodologyVersionViewModel> BuildMethodologyVersionViewModel(
             MethodologyVersion methodologyVersion)
         {
             var loadedMethodology = _context.AssertEntityLoaded(methodologyVersion);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
@@ -178,7 +178,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             }
 
             var methodologiesNotApproved = methodologies
-                .Where(m => m.Status != MethodologyStatus.Approved)
+                .Where(m => m.Status != MethodologyApprovalStatus.Approved)
                 .ToList();
 
             if (methodologiesNotApproved.Any())

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -30,7 +30,7 @@ using Newtonsoft.Json;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using IReleaseRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseRepository;
 using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
 using Unit = GovUk.Education.ExploreEducationStatistics.Common.Model.Unit;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyApprovalUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyApprovalUpdateRequest.cs
@@ -23,7 +23,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
             return methodologyVersion.Status != Status
                    || methodologyVersion.PublishingStrategy != PublishingStrategy
                    || methodologyVersion.ScheduledWithReleaseId != WithReleaseId;
-                   //|| methodologyVersion.InternalReleaseNote != LatestInternalReleaseNote; // @MarkFix why internal release note check?
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyApprovalUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyApprovalUpdateRequest.cs
@@ -22,8 +22,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
         {
             return methodologyVersion.Status != Status
                    || methodologyVersion.PublishingStrategy != PublishingStrategy
-                   || methodologyVersion.ScheduledWithReleaseId != WithReleaseId
-                   || methodologyVersion.InternalReleaseNote != LatestInternalReleaseNote;
+                   || methodologyVersion.ScheduledWithReleaseId != WithReleaseId;
+                   //|| methodologyVersion.InternalReleaseNote != LatestInternalReleaseNote; // @MarkFix why internal release note check?
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyApprovalUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyApprovalUpdateRequest.cs
@@ -11,7 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
         public string? LatestInternalReleaseNote { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
-        public MethodologyStatus Status { get; set; }
+        public MethodologyApprovalStatus Status { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public MethodologyPublishingStrategy PublishingStrategy { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyApprovalUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyApprovalUpdateRequest.cs
@@ -18,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
 
         public Guid? WithReleaseId { get; set; }
 
-        public bool IsStatusUpdateForMethodology(MethodologyVersion methodologyVersion)
+        public bool IsStatusUpdateRequired(MethodologyVersion methodologyVersion)
         {
             return methodologyVersion.Status != Status
                    || methodologyVersion.PublishingStrategy != PublishingStrategy

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyUpdateRequest.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System.ComponentModel.DataAnnotations;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.NamingUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology
@@ -11,10 +10,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
         [Required] public string Title { get; set; } = string.Empty;
 
         public string Slug => SlugFromTitle(Title);
-
-        public bool IsDetailUpdateForMethodology(MethodologyVersion methodologyVersion)
-        {
-            return methodologyVersion.Title != Title;
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyVersionViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyVersionViewModel.cs
@@ -29,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
         public string Slug { get; set; } = string.Empty;
 
         [JsonConverter(typeof(StringEnumConverter))]
-        public MethodologyStatus Status { get; set; }
+        public MethodologyApprovalStatus Status { get; set; }
 
         public string Title { get; set; } = string.Empty;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MethodologyStatusViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MethodologyStatusViewModel.cs
@@ -4,21 +4,20 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+
+public record MethodologyStatusViewModel
 {
-    public record MethodologyStatusViewModel
-    {
-        public Guid MethodologyStatusId { get; set; }
+    public Guid MethodologyStatusId { get; set; }
 
-        public string? InternalReleaseNote { get; set; }
+    public string? InternalReleaseNote { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public MethodologyApprovalStatus ApprovalStatus { get; set; }
+    [JsonConverter(typeof(StringEnumConverter))]
+    public MethodologyApprovalStatus ApprovalStatus { get; set; }
 
-        public DateTime? Created { get; set; }
+    public DateTime? Created { get; set; }
 
-        public string? CreatedByEmail { get; set; }
+    public string? CreatedByEmail { get; set; }
 
-        public int MethodologyVersion { get; set; }
-    }
+    public int MethodologyVersion { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MethodologyStatusViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MethodologyStatusViewModel.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
+{
+    public record MethodologyStatusViewModel
+    {
+        public Guid MethodologyStatusId { get; set; }
+
+        public string? InternalReleaseNote { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public MethodologyApprovalStatus ApprovalStatus { get; set; }
+
+        public DateTime? Created { get; set; }
+
+        public string? CreatedByEmail { get; set; }
+
+        public int MethodologyVersion { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MethodologyVersionSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MethodologyVersionSummaryViewModel.cs
@@ -15,7 +15,7 @@ public record MethodologyVersionSummaryViewModel
     public DateTime? Published { get; set; }
 
     [JsonConverter(typeof(StringEnumConverter))]
-    public MethodologyStatus Status { get; set; }
+    public MethodologyApprovalStatus Status { get; set; }
 
     public bool Owned { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyTests.cs
@@ -3,8 +3,8 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
@@ -3,8 +3,8 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
 using static Moq.MockBehavior;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -45,6 +45,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
 
         public virtual DbSet<Methodology> Methodologies { get; set; }
         public virtual DbSet<MethodologyVersion> MethodologyVersions { get; set; }
+        public virtual DbSet<MethodologyStatus> MethodologyStatus { get; set; }
         public virtual DbSet<MethodologyVersionContent> MethodologyContent { get; set; }
         public virtual DbSet<PublicationMethodology> PublicationMethodologies { get; set; }
         public virtual DbSet<MethodologyFile> MethodologyFiles { get; set; }
@@ -172,6 +173,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .HasOne(m => m.CreatedBy)
                 .WithMany()
                 .OnDelete(DeleteBehavior.NoAction);
+
+            modelBuilder.Entity<MethodologyStatus>()
+                .Property(rs => rs.Created)
+                .HasConversion(
+                    v => v,
+                    v => v.HasValue
+                        ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
+                        : null);
+
+            modelBuilder.Entity<MethodologyStatus>()
+                .HasOne(rs => rs.CreatedBy)
+                .WithMany()
+                .OnDelete(DeleteBehavior.NoAction);
+
+            modelBuilder.Entity<MethodologyStatus>()
+                .Property(rs => rs.ApprovalStatus)
+                .HasConversion(new EnumToStringConverter<MethodologyApprovalStatus>());
 
             modelBuilder.Entity<MethodologyFile>()
                 .HasOne(mf => mf.MethodologyVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -156,7 +156,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
 
             modelBuilder.Entity<MethodologyVersion>()
                 .Property(m => m.Status)
-                .HasConversion(new EnumToStringConverter<MethodologyStatus>());
+                .HasConversion(new EnumToStringConverter<MethodologyApprovalStatus>());
 
             modelBuilder.Entity<MethodologyVersion>()
                 .Property(m => m.PublishingStrategy)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyStatus.cs
@@ -3,24 +3,23 @@
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Model
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+public class MethodologyStatus : ICreatedTimestamp<DateTime?>
 {
-    public class MethodologyStatus : ICreatedTimestamp<DateTime?>
-    {
-        public Guid Id { get; set; }
+    public Guid Id { get; set; }
 
-        public Guid MethodologyVersionId { get; set; }
+    public Guid MethodologyVersionId { get; set; }
 
-        public MethodologyVersion MethodologyVersion { get; set; } = null!;
+    public MethodologyVersion MethodologyVersion { get; set; } = null!;
 
-        public string? InternalReleaseNote { get; set; }
+    public string? InternalReleaseNote { get; set; }
 
-        public MethodologyApprovalStatus ApprovalStatus { get; set; }
+    public MethodologyApprovalStatus ApprovalStatus { get; set; }
 
-        public DateTime? Created { get; set; }
+    public DateTime? Created { get; set; }
 
-        public Guid? CreatedById { get; set; }
+    public Guid? CreatedById { get; set; }
 
-        public User? CreatedBy { get; set; }
-    }
+    public User? CreatedBy { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyStatus.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model
+{
+    public class MethodologyStatus : ICreatedTimestamp<DateTime?>
+    {
+        public Guid Id { get; set; }
+
+        public Guid MethodologyVersionId { get; set; }
+
+        public MethodologyVersion MethodologyVersion { get; set; } = null!;
+
+        public string? InternalReleaseNote { get; set; }
+
+        public MethodologyApprovalStatus ApprovalStatus { get; set; }
+
+        public DateTime? Created { get; set; }
+
+        public Guid? CreatedById { get; set; }
+
+        public User? CreatedBy { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyVersion.cs
@@ -3,12 +3,12 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
-    public enum MethodologyStatus
+    public enum MethodologyApprovalStatus
     {
         Draft,
         Approved
@@ -30,7 +30,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string Slug => Methodology.Slug;
 
-        public MethodologyStatus Status { get; set; }
+        public MethodologyApprovalStatus Status { get; set; }
 
         public DateTime? Published { get; set; }
 
@@ -64,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Guid? ScheduledWithReleaseId { get; set; }
 
-        public bool Approved => Status == MethodologyStatus.Approved;
+        public bool Approved => Status == MethodologyApprovalStatus.Approved;
 
         public bool ScheduledForPublishingWithRelease => PublishingStrategy == WithRelease;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
@@ -13,7 +13,7 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
@@ -18,7 +18,7 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 {

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/__tests__/MethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/__tests__/MethodologyPage.test.tsx
@@ -12,11 +12,12 @@ import _methodologyContentService, {
 } from '@admin/services/methodologyContentService';
 import _permissionService from '@admin/services/permissionService';
 import { generatePath, MemoryRouter } from 'react-router';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Route } from 'react-router-dom';
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
+import render from '@common-test/render';
 
 jest.mock('@admin/services/methodologyService');
 jest.mock('@admin/services/methodologyContentService');

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusEditPage.tsx
@@ -1,6 +1,6 @@
 import methodologyService, {
   MethodologyVersion,
-  MethodologyStatus,
+  MethodologyApprovalStatus,
 } from '@admin/services/methodologyService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
@@ -9,7 +9,7 @@ import MethodologyStatusForm from '@admin/pages/methodology/edit-methodology/sta
 import React from 'react';
 
 interface FormValues {
-  status: MethodologyStatus;
+  status: MethodologyApprovalStatus;
   latestInternalReleaseNote: string;
   publishingStrategy?: 'WithRelease' | 'Immediately';
   withReleaseId?: string;

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -1,7 +1,7 @@
 import StatusBlock from '@admin/components/StatusBlock';
 import { useConfig } from '@admin/contexts/ConfigContext';
 import methodologyService, {
-  MethodologyStatus,
+  MethodologyApprovalStatus,
 } from '@admin/services/methodologyService';
 import permissionService from '@admin/services/permissionService';
 import Button from '@common/components/Button';
@@ -18,7 +18,7 @@ import React from 'react';
 import UrlContainer from '@common/components/UrlContainer';
 
 interface FormValues {
-  status: MethodologyStatus;
+  status: MethodologyApprovalStatus;
   latestInternalReleaseNote: string;
   publishingStrategy?: 'WithRelease' | 'Immediately';
   withReleaseId?: string;

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -17,8 +17,9 @@ import SummaryListItem from '@common/components/SummaryListItem';
 import MethodologyStatusEditPage from '@admin/pages/methodology/edit-methodology/status/MethodologyStatusEditPage';
 import React from 'react';
 import UrlContainer from '@common/components/UrlContainer';
-import releaseService, { ReleaseStatus } from '@admin/services/releaseService';
 import FormattedDate from '@common/components/FormattedDate';
+import { useQuery } from '@tanstack/react-query';
+import methodologyQueries from '@admin/queries/methodologyQueries';
 
 interface FormValues {
   status: MethodologyApprovalStatus;
@@ -43,9 +44,8 @@ const MethodologyStatusPage = () => {
 
   const [isEditing, toggleForm] = useToggle(false);
 
-  const { value: methodologyStatuses } = useAsyncRetry<MethodologyStatus[]>(
-    () => methodologyService.getMethodologyStatuses(currentMethodology.id),
-    [currentMethodology],
+  const { data: methodologyStatuses } = useQuery(
+    methodologyQueries.getMethodologyStatuses(currentMethodology.id),
   );
 
   const {
@@ -185,36 +185,34 @@ const MethodologyStatusPage = () => {
                             <th scope="col">By user</th>
                           </tr>
                         </thead>
-                        {methodologyStatuses && (
-                          <tbody>
-                            {methodologyStatuses.map(status => (
-                              <tr key={status.methodologyStatusId}>
-                                <td>
-                                  {status.created ? (
-                                    <FormattedDate format="d MMMM yyyy HH:mm">
-                                      {status.created}
-                                    </FormattedDate>
-                                  ) : (
-                                    'Not available'
-                                  )}
-                                </td>
-                                <td>{status.approvalStatus}</td>
-                                <td>{status.internalReleaseNote}</td>
-                                <td>{`${status.methodologyVersion + 1}`}</td>{' '}
-                                {/* +1 because version starts from 0 in DB */}
-                                <td>
-                                  {status.createdByEmail ? (
-                                    <a href={`mailto:${status.createdByEmail}`}>
-                                      {status.createdByEmail}
-                                    </a>
-                                  ) : (
-                                    'Not available'
-                                  )}
-                                </td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        )}
+                        <tbody>
+                          {methodologyStatuses.map(status => (
+                            <tr key={status.methodologyStatusId}>
+                              <td>
+                                {status.created ? (
+                                  <FormattedDate format="d MMMM yyyy HH:mm">
+                                    {status.created}
+                                  </FormattedDate>
+                                ) : (
+                                  'Not available'
+                                )}
+                              </td>
+                              <td>{status.approvalStatus}</td>
+                              <td>{status.internalReleaseNote}</td>
+                              <td>{`${status.methodologyVersion + 1}`}</td>{' '}
+                              {/* +1 because version starts from 0 in DB */}
+                              <td>
+                                {status.createdByEmail ? (
+                                  <a href={`mailto:${status.createdByEmail}`}>
+                                    {status.createdByEmail}
+                                  </a>
+                                ) : (
+                                  'Not available'
+                                )}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
                       </table>
                     </LoadingSpinner>
                   </>

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/__tests__/MethodologyStatusPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/__tests__/MethodologyStatusPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import _methodologyService, {
   MethodologyVersion,
@@ -14,6 +14,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import { Route } from 'react-router-dom';
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
+import render from '@common-test/render';
 
 jest.mock('@admin/services/methodologyService');
 jest.mock('@admin/services/permissionService');

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodologyStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodologyStatusForm.tsx
@@ -1,7 +1,7 @@
 import {
   MethodologyVersion,
   MethodologyPublishingStrategy,
-  MethodologyStatus,
+  MethodologyApprovalStatus,
 } from '@admin/services/methodologyService';
 import { IdTitlePair } from '@admin/services/types/common';
 import Button from '@common/components/Button';
@@ -17,7 +17,7 @@ import React from 'react';
 import { StringSchema } from 'yup';
 
 export interface FormValues {
-  status: MethodologyStatus;
+  status: MethodologyApprovalStatus;
   latestInternalReleaseNote: string;
   publishingStrategy?: MethodologyPublishingStrategy;
   withReleaseId?: string;
@@ -68,7 +68,7 @@ const MethodologyStatusForm = ({
           <Form id="methodologyStatusForm">
             <h2>Edit methodology status</h2>
 
-            <FormFieldRadioGroup<FormValues, MethodologyStatus>
+            <FormFieldRadioGroup<FormValues, MethodologyApprovalStatus>
               legend="Status"
               hint={
                 isPublished &&

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -158,36 +158,34 @@ const ReleaseStatusPage = () => {
                   <th scope="col">By user</th>
                 </tr>
               </thead>
-              {releaseStatuses && (
-                <tbody>
-                  {releaseStatuses.map(status => (
-                    <tr key={status.releaseStatusId}>
-                      <td>
-                        {status.created ? (
-                          <FormattedDate format="d MMMM yyyy HH:mm">
-                            {status.created}
-                          </FormattedDate>
-                        ) : (
-                          'Not available'
-                        )}
-                      </td>
-                      <td>{status.approvalStatus}</td>
-                      <td>{status.internalReleaseNote}</td>
-                      <td>{`${status.releaseVersion + 1}`}</td>{' '}
-                      {/* +1 because version starts from 0 in DB */}
-                      <td>
-                        {status.createdByEmail ? (
-                          <a href={`mailto:${status.createdByEmail}`}>
-                            {status.createdByEmail}
-                          </a>
-                        ) : (
-                          'Not available'
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              )}
+              <tbody>
+                {releaseStatuses.map(status => (
+                  <tr key={status.releaseStatusId}>
+                    <td>
+                      {status.created ? (
+                        <FormattedDate format="d MMMM yyyy HH:mm">
+                          {status.created}
+                        </FormattedDate>
+                      ) : (
+                        'Not available'
+                      )}
+                    </td>
+                    <td>{status.approvalStatus}</td>
+                    <td>{status.internalReleaseNote}</td>
+                    <td>{`${status.releaseVersion + 1}`}</td>{' '}
+                    {/* +1 because version starts from 0 in DB */}
+                    <td>
+                      {status.createdByEmail ? (
+                        <a href={`mailto:${status.createdByEmail}`}>
+                          {status.createdByEmail}
+                        </a>
+                      ) : (
+                        'Not available'
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
             </table>
           </LoadingSpinner>
         </>

--- a/src/explore-education-statistics-admin/src/queries/methodologyQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/methodologyQueries.ts
@@ -1,0 +1,13 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+import methodologyService from '@admin/services/methodologyService';
+
+const methodologyQueries = createQueryKeys('methodology', {
+  getMethodologyStatuses(methodologyId: string) {
+    return {
+      queryKey: [methodologyId],
+      queryFn: () => methodologyService.getMethodologyStatuses(methodologyId),
+    };
+  },
+});
+
+export default methodologyQueries;

--- a/src/explore-education-statistics-admin/src/queries/releasePermissionQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/releasePermissionQueries.ts
@@ -4,13 +4,13 @@ import releasePermissionService from '@admin/services/releasePermissionService';
 const releasePermissionQueries = createQueryKeys('releasePermission', {
   listRoles(releaseId: string) {
     return {
-      queryKey: ['listReleaseRoles', releaseId],
+      queryKey: [releaseId],
       queryFn: () => releasePermissionService.listRoles(releaseId),
     };
   },
   listInvites(releaseId: string) {
     return {
-      queryKey: ['listReleaseInvites', releaseId],
+      queryKey: [releaseId],
       queryFn: () => releasePermissionService.listInvites(releaseId),
     };
   },

--- a/src/explore-education-statistics-admin/src/services/methodologyContentService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyContentService.ts
@@ -1,5 +1,5 @@
 import { ContentSectionKeys } from '@admin/pages/methodology/edit-methodology/content/context/MethodologyContentContextActionTypes';
-import { MethodologyStatus } from '@admin/services/methodologyService';
+import { MethodologyApprovalStatus } from '@admin/services/methodologyService';
 import { MethodologyNote } from '@admin/services/methodologyNoteService';
 import {
   ContentBlockPostModel,
@@ -16,7 +16,7 @@ export interface MethodologyContent {
   id: string;
   title: string;
   slug: string;
-  status: MethodologyStatus;
+  status: MethodologyApprovalStatus;
   published?: string;
   content: ContentSection<EditableContentBlock>[];
   annexes: ContentSection<EditableContentBlock>[];

--- a/src/explore-education-statistics-admin/src/services/methodologyService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyService.ts
@@ -1,13 +1,13 @@
 import client from '@admin/services/utils/service';
 import { IdTitlePair } from '@admin/services/types/common';
 
-export type MethodologyStatus = 'Draft' | 'Approved';
+export type MethodologyApprovalStatus = 'Draft' | 'Approved';
 export type MethodologyPublishingStrategy = 'WithRelease' | 'Immediately';
 
 export type UpdateMethodology = {
   latestInternalReleaseNote?: string;
   title: string;
-  status: MethodologyStatus;
+  status: MethodologyApprovalStatus;
   publishingStrategy?: MethodologyPublishingStrategy;
   withReleaseId?: string;
 };
@@ -22,7 +22,7 @@ export interface BaseMethodologyVersion {
   amendment: boolean;
   previousVersionId?: string;
   title: string;
-  status: MethodologyStatus;
+  status: MethodologyApprovalStatus;
   published?: string;
   methodologyId: string;
 }

--- a/src/explore-education-statistics-admin/src/services/methodologyService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyService.ts
@@ -48,6 +48,15 @@ export interface MethodologyVersionSummary extends BaseMethodologyVersion {
   };
 }
 
+export interface MethodologyStatus {
+  methodologyStatusId: string;
+  internalReleaseNote: string;
+  approvalStatus: MethodologyApprovalStatus;
+  created: string;
+  createdByEmail?: string;
+  methodologyVersion: number;
+}
+
 const methodologyService = {
   createMethodology(publicationId: string): Promise<MethodologyVersion> {
     return client.post(`/publication/${publicationId}/methodology`);
@@ -84,6 +93,11 @@ const methodologyService = {
 
   deleteMethodology(methodologyId: string): Promise<void> {
     return client.delete(`/methodology/${methodologyId}`);
+  },
+  getMethodologyStatuses(
+    methodologyVersionId: string,
+  ): Promise<MethodologyStatus[]> {
+    return client.get(`/methodology/${methodologyVersionId}/status`);
   },
 };
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -72,8 +72,28 @@ Add annexe content to methodology
     user adds content to accordion section text block    Methodology annexe section 2    1
     ...    Annexe 2    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
 
+Check there is no methodology status history table on Sign off page
+    user clicks link    Sign off
+    user waits until h2 is visible    Sign off
+
+    user checks page does not contain element    testid:methodology-status-history
+
 Approve the methodology for publishing immediately
     user approves methodology for publication    ${PUBLICATION_NAME}
+
+Check methodology status history is correct after approval
+    user waits until h3 is visible    Methodology status history    %{WAIT_SMALL}
+    user checks page contains element    testid:methodology-status-history
+
+    user checks table body has x rows    1    testid:methodology-status-history
+    table cell should contain    testid:methodology-status-history    1    2    Status
+    table cell should contain    testid:methodology-status-history    1    3    Internal note
+    table cell should contain    testid:methodology-status-history    1    4    Methodology version
+    table cell should contain    testid:methodology-status-history    1    5    By user
+    table cell should contain    testid:methodology-status-history    2    2    Approved
+    table cell should contain    testid:methodology-status-history    2    3    Approved by UI tests
+    table cell should contain    testid:methodology-status-history    2    4    1
+    table cell should contain    testid:methodology-status-history    2    5    ees-test.bau1@education.gov.uk
 
 Verify the expected public URL of the methodology on the Sign off tab
     user navigates to methodology    ${PUBLICATION_NAME}    ${PUBLICATION_NAME}
@@ -292,10 +312,36 @@ Add and update another note describing the amendment
     ...    03
     ...    2021
 
+Check methodology status history is correct before approving amendment
+    user clicks link    Sign off
+    user waits until h2 is visible    Sign off
+
+    user waits until h3 is visible    Methodology status history    %{WAIT_SMALL}
+    user checks page contains element    testid:methodology-status-history
+
+    user checks table body has x rows    2    testid:methodology-status-history
+
 Approve the amendment for publishing immediately
     user approves methodology amendment for publication
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME} - Amended methodology
+
+Check methodology status history is correct after approving amendment
+    user waits until h3 is visible    Methodology status history    %{WAIT_SMALL}
+    user checks page contains element    testid:methodology-status-history
+    user checks table body has x rows    3    testid: methodology-status-history
+    table cell should contain    testid:methodology-status-history    2    2    Approved
+    table cell should contain    testid:methodology-status-history    2    3    Approved by UI tests
+    table cell should contain    testid:methodology-status-history    2    4    2
+    table cell should contain    testid:methodology-status-history    2    5    ees-test.bau1@education.gov.uk
+    table cell should contain    testid:methodology-status-history    3    2    Approved
+    table cell should contain    testid:methodology-status-history    3    3    Approved by UI tests
+    table cell should contain    testid:methodology-status-history    3    4    1
+    table cell should contain    testid:methodology-status-history    3    5    ees-test.bau1@education.gov.uk
+    table cell should contain    testid:methodology-status-history    4    2    Approved
+    table cell should contain    testid:methodology-status-history    4    3    Approved by UI tests
+    table cell should contain    testid:methodology-status-history    4    4    1
+    table cell should contain    testid:methodology-status-history    4    5    ees-test.bau1@education.gov.uk
 
 Verify that the user cannot edit the status of the amended methodology
     user clicks link    Sign off
@@ -380,6 +426,17 @@ Schedule a methodology amendment to be published with a release amendment
     ...    methodology_title=${PUBLICATION_NAME} - Amended methodology
     ...    publishing_strategy=WithRelease
     ...    with_release=${PUBLICATION_NAME} - ${RELEASE_NAME}
+
+Check methodology status history table contains new row after approving amendment
+    user checks table body has x rows    4    testid:methodology-status-history
+    table cell should contain    testid:methodology-status-history    2    2    Approved
+    table cell should contain    testid:methodology-status-history    2    3    Approved by UI tests
+    table cell should contain    testid:methodology-status-history    2    4    3
+    table cell should contain    testid:methodology-status-history    2    5    ees-test.bau1@education.gov.uk
+    table cell should contain    testid:methodology-status-history    3    2    Approved
+    table cell should contain    testid:methodology-status-history    3    3    Approved by UI tests
+    table cell should contain    testid:methodology-status-history    3    4    2
+    table cell should contain    testid:methodology-status-history    3    5    ees-test.bau1@education.gov.uk
 
 Cancel the release amendment and validate that the appropriate warning modal is shown
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}


### PR DESCRIPTION
This PR adds a new Methodology status history table to the Methodology sign off page:
![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/44812484/5662f35b-e61f-4c8b-9c89-4d60ef0c07b6)

### Notes
- The existing `MethodologyStatus` has been renamed to `MethodologyApprovalStatus`, matching `ReleaseApprovalStatus`.
- Existing `MethodologyVersion.InternalReleaseNote`s are migrated to `MethodologyStatus.InternalReleaseNote`s.

### Other changes
- Where applicable, we now call `BuildMethodologyVersionViewModel` instead of `GetMethodology` - saving a query and a permission check. Methods that used to call `GetMethodology` already had their own permission checks.
- Renamed some variables from `methodology` to `methodologyVersion` to make the type clearer.
- Removed an unnecessary query in `ValidateMethodologySlugUniqueForUpdate`.
- Remove internal release note comparison check in `IsStatusUpdateRequired`. I don't think we want a methodology status update if just an internal release note changes - I double checked with Laura.

There is further potential cleanup that could be done around the updating of methodologies, but it would take extra time to unpick. The difficulties of making these changes revolves around the unit tests - specifically how they interact with Entity Framework's tracking of entities and the additional mocking that would have to take place.