### PR TITLE
EES-4420 - fix build number environment variable not being set

### DIFF
--- a/azure-pipelines.dfe.yml
+++ b/azure-pipelines.dfe.yml
@@ -275,6 +275,7 @@ jobs:
           Dockerfile: 'docker/Dockerfile.public-frontend'
           buildContext: '$(System.DefaultWorkingDirectory)'
           tags: $(Build.BuildNumber)
+          arguments: '--build-arg BUILD_BUILDNUMBER=$(Build.BuildNumber)'
 
   - job: 'MiscellaneousArtifacts'
     pool:

--- a/docker/Dockerfile.public-frontend
+++ b/docker/Dockerfile.public-frontend
@@ -2,6 +2,9 @@ FROM node:16.14.2-alpine AS builder
 
 WORKDIR /app
 
+ARG BUILD_BUILDNUMBER
+ENV BUILD_BUILDNUMBER=$BUILD_BUILDNUMBER
+
 COPY .npmrc .
 COPY package.json .
 COPY pnpm-lock.yaml .


### PR DESCRIPTION
This PR: 
* fixes the build number not being displayed on the public frontend. This stemmed from it not being explicitly set when the docker image is built