### PR TITLE
EES-4420 - attempt to fix build number environment var not being set

### DIFF
--- a/azure-pipelines.dfe.yml
+++ b/azure-pipelines.dfe.yml
@@ -266,16 +266,27 @@ jobs:
           script: 'pnpm --filter=explore-education-statistics-frontend run build'
 
       - task: Docker@2
-        displayName: 'Build and push public frontend Docker image'
+        displayName: 'Build public frontend Docker image'
         condition: ne(variables['Build.Reason'], 'PullRequest')
         inputs:
           containerRegistry: 's101d-datahub-spn-ees-dfe-gov-uk-docker-managed-service-connection'
           repository: 'ees-public-frontend'
-          command: 'buildAndPush'
+          command: 'build'
           Dockerfile: 'docker/Dockerfile.public-frontend'
           buildContext: '$(System.DefaultWorkingDirectory)'
           tags: $(Build.BuildNumber)
           arguments: '--build-arg BUILD_BUILDNUMBER=$(Build.BuildNumber)'
+
+      - task: Docker@2
+        displayName: 'Push public frontend Docker image'
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+        inputs:
+          containerRegistry: 's101d-datahub-spn-ees-dfe-gov-uk-docker-managed-service-connection'
+          repository: 'ees-public-frontend'
+          command: 'push'
+          Dockerfile: 'docker/Dockerfile.public-frontend'
+          buildContext: '$(System.DefaultWorkingDirectory)'
+          tags: $(Build.BuildNumber)
 
   - job: 'MiscellaneousArtifacts'
     pool:


### PR DESCRIPTION
This PR:
* attempts to fix the `BUILD_BUILDNUMBER` environment variable not being set for the public frontend. based on the comment on https://blog.geralexgr.com/docker/pass-secrets-as-env-variables-on-docker-build-azure-devops, this should fix it