### PR TITLE
EES-3976 - change dev max table cells to 3 million

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -121,6 +121,9 @@
     },
     "immediatePublicationOfScheduledReleasesEnabled": {
       "value": true
+    },
+    "tableBuilderMaxTableCellsAllowed": {
+      "value": 3000000
     }
   }
 }


### PR DESCRIPTION
This PR:
* Temporarily changes the `maxTableCellsAllowed` to 3 million for the development environment. We're temporarily changing this to test how the new hybrid Linux container app service behaves when Next.js is doing heaving lifting when server-side rendering on content-heavy pages such as the table tool page and permalink page