### PR TITLE
EES-4412 - removing broken interpolation in GA event action for All F…

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -442,7 +442,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
               onClick={() => {
                 logEvent({
                   category: 'Downloads',
-                  action: `Release page all files downloads.title}, Release: ${release.title}, File: All files`,
+                  action: `Release page all files, Release: ${release.title}, File: All files`,
                 });
               }}
             >


### PR DESCRIPTION
This PR corrects an incorrect GA event action name for the Download all Files (ZIP) link for Releases.

Previously there was some broken interpolation around `downloads.title}` - but upon looking to fix this, there is no `downloads` variable anyway, so I removed it completely.