### PR TITLE
EES-4422 Copy public prerelease list when creating an amendment

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
@@ -654,10 +654,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var originalFile2 = releaseFiles.First(f =>
                     f.File.Filename == amendmentDataFile2.File.Filename);
                 AssertAmendedReleaseFileCorrect(originalFile2, amendmentDataFile2, amendment);
-                
-                // Assert that the amendment does not have the PreReleaseAccessList copied over from the 
-                // original Release.
-                Assert.Null(amendment.PreReleaseAccessList);
+
+                Assert.Equal(release.PreReleaseAccessList, amendment.PreReleaseAccessList);
 
                 Assert.True(amendment.Amendment);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseAmendmentExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseAmendmentExtensions.cs
@@ -27,7 +27,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
             amendment.CreatedById = createdByUserId;
             amendment.Version = release.Version + 1;
             amendment.PreviousVersionId = release.Id;
-            amendment.PreReleaseAccessList = null;
 
             var context = new Release.CloneContext(amendment);
 

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -209,21 +209,21 @@ Start creating a featured table
     user clicks link    Create data block
     user waits until table tool wizard step is available    1    Select a data set
 
-Select subject "UI test subject"
+Select subject "UI test subject" again
     user waits until page contains    UI test subject    %{WAIT_SMALL}
     user clicks radio    UI test subject
     user clicks element    id:publicationDataStepForm-submit
     user waits until table tool wizard step is available    2    Choose locations    %{WAIT_MEDIUM}
     user checks previous table tool step contains    1    Data set    UI test subject
 
-Select locations
+Select locations again
     user opens details dropdown    Opportunity area
     user clicks checkbox    Bolton 001
 
     user clicks element    id:locationFiltersForm-submit
     user waits until table tool wizard step is available    3    Choose time period    90
 
-Select time period
+Select time period again
     user waits until page contains element    id:timePeriodForm-start
     user chooses select option    id:timePeriodForm-start    2009
     user chooses select option    id:timePeriodForm-end    2017
@@ -231,17 +231,17 @@ Select time period
     user waits until table tool wizard step is available    4    Choose your filters
     user checks previous table tool step contains    3    Time period    2009 to 2017    %{WAIT_MEDIUM}
 
-Select indicators
+Select indicators again
     user checks indicator checkbox is checked    Admission Numbers
 
-Create table
+Create table again
     [Documentation]    EES-615
     user clicks element    id:filtersForm-submit
     user waits until results table appears    %{WAIT_LONG}
     user waits until element contains    testid:dataTableCaption
     ...    Admission Numbers for 'UI test subject' in Bolton 001 between 2009 and 2017
 
-Save data block
+Save data block again
     user enters text into element    label:Name    UI test featured table
     user enters text into element    label:Table title    UI test featured table title
     user enters text into element    label:Source    UI test featured table source
@@ -254,7 +254,7 @@ Save data block
     user clicks button    Save data block
     user waits until page contains    Delete this data block
 
-Validate data block is in list
+Validate data block is in list again
     user clicks link    Back
     user waits until h2 is visible    Data blocks
 

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -151,12 +151,10 @@ Add release note to amendment
     user waits until element contains    css:#releaseNotes li:nth-of-type(1) time    ${date}
     user waits until element contains    css:#releaseNotes li:nth-of-type(1) p    Test release note
 
-Check that Pre-release users and Public access list are empty in new amendment
+Check amendment has no prerelease users
     user clicks link    Pre-release access
     user waits until h2 is visible    Manage pre-release user access
     user checks page contains    No pre-release users have been invited.
-    user clicks link    Public access list
-    user checks page does not contain    Initial test public access list
 
 Check that there is no Pre-release warning text on the sign off page during amendment
     user clicks link    Sign off
@@ -190,10 +188,10 @@ Invite Pre-release users during amendment
     user checks list item contains    testid:invitableList    2    EES-test.ANALYST1@education.gov.uk    ${modal}
     user clicks button    Confirm
 
-Create public prerelease access list for amendment
-    user clicks link    Pre-release access
-    user waits until h2 is visible    Manage pre-release user access
-    user creates public prerelease access list    Amended test public access list
+Check amendment has original release's public access list and then update
+    user clicks link    Public access list
+    user checks page contains    Initial test public access list
+    user updates public prerelease access list    Amended test public access list
 
 Validate prerelease has not started for Analyst user during amendment as it is still in draft
     ${current_url}=    get location

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -704,11 +704,14 @@ Add release note to first amendment
     user waits until element contains    css:#releaseNotes li:nth-of-type(1) time    ${date}
     user waits until element contains    css:#releaseNotes li:nth-of-type(1) p    Test release note one
 
-Create public prerelease access list for amendment
+Check public prerelease access list for amendment is same as original release
     user clicks link    Pre-release access
     user clicks link    Public access list
     user waits until h2 is visible    Public pre-release access list
-    user creates public prerelease access list    Amended public access list
+    user checks page contains    Test public access list
+
+Update public prerelease access list
+    user updates public prerelease access list    Amended public access list
 
 Approve amendment for scheduled release
     ${days_until_release}=    set variable    1

--- a/tests/robot-tests/tests/libs/charts.robot
+++ b/tests/robot-tests/tests/libs/charts.robot
@@ -105,9 +105,9 @@ user checks chart x axis ticks
 user mouses over line chart point
     [Arguments]    ${locator}    ${line}    ${number}
     user waits until parent contains element    ${locator}
-    ...    css:.recharts-line-dots:nth-of-type(${line}) .recharts-symbols:nth-of-type(${number})
+    ...    xpath://*[contains(@class, 'recharts-line-dots')][${line}]/*[contains(@class, 'recharts-symbols')][${number}]
     ${element}=    get child element    ${locator}
-    ...    css:.recharts-line-dots:nth-of-type(${line}) .recharts-symbols:nth-of-type(${number})
+    ...    xpath://*[contains(@class, 'recharts-line-dots')][${line}]/*[contains(@class, 'recharts-symbols')][${number}]
     user waits until element is visible    ${element}
     user mouses over element    ${element}
 


### PR DESCRIPTION
Previously, when amending a release with a public prerelease list, that list would be removed from the amendment, leaving it with no public prerelease list initially.

This PR changes this behaviour so that amendments now have a copy of the previous release's public prerelease list.

### Other changes
I also fixed a UI test unrelated to these changes that were causing a failure in `create_data_block_with_chart.robot` in `Validate basic line chart preview` on the line `user mouses over line chart point    id:chartBuilderPreview    1    1`. I switched to using an xpath selector to avoid `nth-of-type` and how it selects tags not classes.