### PR TITLE
EES-4256 accessible colour for bar chart data labels

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -170,6 +170,11 @@ const ChartConfiguration = ({
             return !(value && legendPosition === 'inline');
           },
         }),
+      });
+    }
+
+    if (definition.type === 'horizontalbar' || definition.type === 'line') {
+      schema = schema.shape({
         dataLabelPosition:
           definition.type === 'line'
             ? Yup.string().oneOf<LineChartDataLabelPosition>(['above', 'below'])
@@ -362,12 +367,14 @@ const ChartConfiguration = ({
                 label="Show data labels"
                 showError={!!form.errors.showDataLabels}
                 conditional={
-                  <FormFieldSelect<FormValues>
-                    label="Data label position"
-                    name="dataLabelPosition"
-                    order={[]}
-                    options={dataLabelPositionOptions}
-                  />
+                  definition.type !== 'verticalbar' && (
+                    <FormFieldSelect<FormValues>
+                      label="Data label position"
+                      name="dataLabelPosition"
+                      order={[]}
+                      options={dataLabelPositionOptions}
+                    />
+                  )
                 }
               />
             )}

--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -23,6 +23,8 @@ import getCategoryLabel from '@common/modules/charts/util/getCategoryLabel';
 import getUnit from '@common/modules/charts/util/getUnit';
 import getMinorAxisDecimalPlaces from '@common/modules/charts/util/getMinorAxisDecimalPlaces';
 import parseNumber from '@common/utils/number/parseNumber';
+import formatPretty from '@common/utils/number/formatPretty';
+import getAccessibleTextColour from '@common/utils/colour/getAccessibleTextColour';
 import React, { memo } from 'react';
 import {
   Bar,
@@ -35,7 +37,8 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import formatPretty from '@common/utils/number/formatPretty';
+
+const defaultLabelTextColour = '#0B0C0C';
 
 export interface HorizontalBarProps extends StackedBarProps {
   legend: LegendConfiguration;
@@ -185,6 +188,13 @@ const HorizontalBarBlock = ({
               label={
                 showDataLabels
                   ? {
+                      fill:
+                        dataLabelPosition === 'outside'
+                          ? defaultLabelTextColour
+                          : getAccessibleTextColour({
+                              backgroundColour: config.colour,
+                              textColour: defaultLabelTextColour,
+                            }),
                       fontSize: 14,
                       position:
                         dataLabelPosition === 'inside'

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -57,7 +57,6 @@ const VerticalBarBlock = ({
   legend,
   includeNonNumericData,
   showDataLabels,
-  dataLabelPosition,
 }: VerticalBarProps) => {
   const [legendProps, renderLegend] = useLegend();
   if (
@@ -179,8 +178,7 @@ const VerticalBarBlock = ({
                   ? {
                       fontSize: 14,
                       offset: 5,
-                      position:
-                        dataLabelPosition === 'inside' ? 'insideTop' : 'top',
+                      position: 'top',
                       formatter: (value: string | number) =>
                         formatPretty(
                           value.toString(),

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/VerticalBarBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/VerticalBarBlock.test.tsx
@@ -23,7 +23,7 @@ describe('VerticalBarBlock', () => {
     legend: testChartConfiguration.legend as LegendConfiguration,
     meta: fullTable.subjectMeta,
     data: fullTable.results,
-    dataLabelPosition: 'inside',
+    dataLabelPosition: 'outside',
   };
 
   const { axes } = props;

--- a/src/explore-education-statistics-common/src/utils/colour/__tests__/getAccessibleTextColour.test.ts
+++ b/src/explore-education-statistics-common/src/utils/colour/__tests__/getAccessibleTextColour.test.ts
@@ -1,0 +1,61 @@
+import getAccessibleTextColour from '@common/utils/colour/getAccessibleTextColour';
+
+describe('getAccessibleTextColour', () => {
+  test('returns the text colour if it has sufficient contrast against the background colour', () => {
+    expect(
+      getAccessibleTextColour({
+        backgroundColour: '#6BACE6',
+        textColour: '#0B0C0C',
+      }),
+    ).toBe('#0B0C0C');
+  });
+
+  test('returns the white if the given text colour does not have sufficient contrast against the background colour and white does', () => {
+    expect(
+      getAccessibleTextColour({
+        backgroundColour: '#801650',
+        textColour: '#0B0C0C',
+      }),
+    ).toBe('#FFFFFF');
+  });
+
+  test('returns the black if the given text colour does not have sufficient contrast against the background colour and white also does not', () => {
+    expect(
+      getAccessibleTextColour({
+        backgroundColour: '#F0F3C4',
+        textColour: '#F8C6B9',
+      }),
+    ).toBe('#000000');
+  });
+
+  test('applies the correct contrast ratio when the WCAG level is AAA', () => {
+    expect(
+      getAccessibleTextColour({
+        backgroundColour: '#6BACE6',
+        textColour: '#262B2B',
+        wcagLevel: 'AAA',
+      }),
+    ).toBe('#FFFFFF');
+  });
+
+  test('applies the correct contrast ratio when the text size is large', () => {
+    expect(
+      getAccessibleTextColour({
+        backgroundColour: '#28A197',
+        textColour: '#FBFDFD',
+        textSize: 'large',
+      }),
+    ).toBe('#FBFDFD');
+  });
+
+  test('applies the correct contrast ratio when the WCAG level is AAA and the text size is large', () => {
+    expect(
+      getAccessibleTextColour({
+        backgroundColour: '#F46A25',
+        textColour: '#0B0C0C',
+        textSize: 'large',
+        wcagLevel: 'AAA',
+      }),
+    ).toBe('#0B0C0C');
+  });
+});

--- a/src/explore-education-statistics-common/src/utils/colour/getAccessibleTextColour.ts
+++ b/src/explore-education-statistics-common/src/utils/colour/getAccessibleTextColour.ts
@@ -1,0 +1,49 @@
+import { hasBadContrast } from 'color2k';
+
+type TextSize = 'normal' | 'large';
+type WcagLevel = 'AA' | 'AAA';
+
+interface Options {
+  backgroundColour: string;
+  textColour: string;
+  textSize?: TextSize;
+  wcagLevel?: WcagLevel;
+}
+
+/**
+ * Checks if the text colour has sufficient contrast against the background colour.
+ * If not, returns white or black.
+ * This isn't infallible, at AAA level especially some background colours will
+ * have contrast problems with white and black text at normal size.
+ */
+export default function getAccessibleTextColour({
+  backgroundColour,
+  textColour,
+  textSize = 'normal',
+  wcagLevel = 'AA',
+}: Options) {
+  const standard = getColor2kStandard(textSize, wcagLevel);
+
+  // The text colour is accessible against the background colour.
+  if (!hasBadContrast(textColour, standard, backgroundColour)) {
+    return textColour;
+  }
+
+  // If white text is accessible return that, otherwise black text.
+  return hasBadContrast(textColour, standard, '#FFFFFF')
+    ? '#000000'
+    : '#FFFFFF';
+}
+
+// Convert to color2k standards
+// https://github.com/ricokahler/color2k/blob/main/src/hasBadContrast.ts
+function getColor2kStandard(textSize: TextSize, wcagLevel: WcagLevel) {
+  switch (wcagLevel) {
+    case 'AA':
+      return textSize === 'normal' ? 'aa' : 'readable';
+    case 'AAA':
+      return textSize === 'normal' ? 'aaa' : 'aa';
+    default:
+      return 'aa';
+  }
+}


### PR DESCRIPTION
Labels placed inside bars in charts can have insufficient colour contrast, to try to prevent this we:
- check the contrast between the text and background colour, if the contrast isn't good enough then change the text colour to white.
- remove the option to place labels inside vertical bars as the text is likely to overflow the bar making it difficult to find a text colour with sufficient contrast for the bar colour and the white background.

![barchart](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/afdaf929-15ff-4189-95d1-397e3cb025d3)
