### PR TITLE
EES-3976 - change max table cell size back to default for dev

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -121,9 +121,6 @@
     },
     "immediatePublicationOfScheduledReleasesEnabled": {
       "value": true
-    },
-    "tableBuilderMaxTableCellsAllowed": {
-      "value": 3000000
     }
   }
 }


### PR DESCRIPTION
This PR: reverts the changes made in https://github.com/dfe-analytical-services/explore-education-statistics/pull/4183 after the testing of EES-3976