### PR TITLE
EES-4425 Prevent duplicate methodologies appearing on public Methodologies page

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/users/components/InviteUserPublicationRoleForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/InviteUserPublicationRoleForm.tsx
@@ -5,7 +5,7 @@ import { Formik } from 'formik';
 import React, { useMemo } from 'react';
 import { InviteUserPublicationRole } from '@admin/pages/users/UserInvitePage';
 import ButtonText from '@common/components/ButtonText';
-import { keyBy } from 'lodash';
+import keyBy from 'lodash/keyBy';
 import orderBy from 'lodash/orderBy';
 import { PublicationSummary } from '@common/services/publicationService';
 

--- a/src/explore-education-statistics-admin/src/pages/users/components/InviteUserReleaseRoleForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/InviteUserReleaseRoleForm.tsx
@@ -6,7 +6,7 @@ import React, { useMemo } from 'react';
 import { IdTitlePair } from '@admin/services/types/common';
 import { InviteUserReleaseRole } from '@admin/pages/users/UserInvitePage';
 import ButtonText from '@common/components/ButtonText';
-import { keyBy } from 'lodash';
+import keyBy from 'lodash/keyBy';
 import orderBy from 'lodash/orderBy';
 
 interface FormValues {

--- a/src/explore-education-statistics-admin/src/prototypes/components/PrototypePublicationForm.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/components/PrototypePublicationForm.tsx
@@ -18,7 +18,7 @@ import WizardStepHeading from '@common/modules/table-tool/components/WizardStepH
 import Button from '@common/components/Button';
 import styles from '@admin/prototypes/components/PrototypePublicationForm.module.scss';
 import PrototypeFormTextSearchInput from '@admin/prototypes/components/PrototypeFormTextSearchInput';
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 import { Formik } from 'formik';
 import React, { useMemo, useState } from 'react';
 

--- a/src/explore-education-statistics-admin/src/services/hubs/utils/retryPolicies.ts
+++ b/src/explore-education-statistics-admin/src/services/hubs/utils/retryPolicies.ts
@@ -4,7 +4,7 @@ import {
   linearBackoffDelay,
 } from '@common/utils/math/retryBackoffDelays';
 import { IRetryPolicy, RetryContext } from '@microsoft/signalr';
-import { clamp } from 'lodash';
+import clamp from 'lodash/clamp';
 
 // Defaults to 10 minutes
 const DEFAULT_MAX_RETRY_TIME = 600000;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -19,7 +19,7 @@ import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizar
 import WizardStepFormActions from '@common/modules/table-tool/components/WizardStepFormActions';
 import WizardStepHeading from '@common/modules/table-tool/components/WizardStepHeading';
 import styles from '@common/modules/table-tool/components/PublicationForm.module.scss';
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 import { Formik } from 'formik';
 import React, { ReactNode, useMemo, useState } from 'react';
 

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyIndexPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyIndexPage.tsx
@@ -13,7 +13,7 @@ import orderBy from 'lodash/orderBy';
 import { GetServerSideProps, NextPage } from 'next';
 import React from 'react';
 import { MethodologySummary } from '@common/services/types/methodology';
-import { uniqWith } from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 
 interface Props {
   themes: MethodologyTheme[];
@@ -116,9 +116,5 @@ function getMethodologiesForTopics(topics: MethodologyTopic[]) {
   const methodologies = topics.flatMap(topic =>
     topic.publications.flatMap(pub => pub.methodologies),
   );
-  return uniqWith(
-    methodologies,
-    (methodology1: MethodologySummary, methodology2: MethodologySummary) =>
-      methodology1.id === methodology2.id,
-  );
+  return uniqBy(methodologies, methodology => methodology.id);
 }

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyIndexPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyIndexPage.tsx
@@ -12,6 +12,8 @@ import PageSearchFormWithAnalytics from '@frontend/components/PageSearchFormWith
 import orderBy from 'lodash/orderBy';
 import { GetServerSideProps, NextPage } from 'next';
 import React from 'react';
+import { MethodologySummary } from '@common/services/types/methodology';
+import { uniqWith } from 'lodash';
 
 interface Props {
   themes: MethodologyTheme[];
@@ -111,7 +113,12 @@ export const getServerSideProps: GetServerSideProps<Props> = async () => {
 export default MethodologyIndexPage;
 
 function getMethodologiesForTopics(topics: MethodologyTopic[]) {
-  return topics.flatMap(topic =>
+  const methodologies = topics.flatMap(topic =>
     topic.publications.flatMap(pub => pub.methodologies),
+  );
+  return uniqWith(
+    methodologies,
+    (methodology1: MethodologySummary, methodology2: MethodologySummary) =>
+      methodology1.id === methodology2.id,
   );
 }

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/__tests__/MethodologyIndexPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/__tests__/MethodologyIndexPage.test.tsx
@@ -101,6 +101,41 @@ const testThemes: MethodologyTheme[] = [
       },
     ],
   },
+  {
+    id: 'theme-3',
+    summary: 'Theme 3 summary',
+    title: 'Theme 3',
+    topics: [
+      {
+        id: 'topic-6',
+        publications: [
+          {
+            id: 'publication-6',
+            methodologies: [
+              {
+                id: 'methodology-6',
+                slug: 'methodology-6-slug',
+                title: 'Methodology 6',
+              },
+            ],
+            title: 'Publication 6',
+          },
+          {
+            id: 'publication-7',
+            methodologies: [
+              {
+                id: 'methodology-6',
+                slug: 'methodology-6-slug',
+                title: 'Methodology 6',
+              },
+            ],
+            title: 'Publication 7',
+          },
+        ],
+        title: 'Topic 6',
+      },
+    ],
+  },
 ];
 
 describe('MethodologyIndexPage', () => {
@@ -116,7 +151,7 @@ describe('MethodologyIndexPage', () => {
     ).toBeInTheDocument();
 
     const themes = screen.getAllByTestId('accordionSection');
-    expect(themes).toHaveLength(2);
+    expect(themes).toHaveLength(3);
 
     const theme1Methodologies = within(themes[0]).getAllByRole('listitem');
 
@@ -149,6 +184,14 @@ describe('MethodologyIndexPage', () => {
         name: 'Methodology 5',
       }),
     ).toHaveAttribute('href', '/methodology/methodology-5-slug');
+
+    const theme3Methodologies = within(themes[2]).getAllByRole('listitem');
+    expect(theme3Methodologies).toHaveLength(1); // Duplicates should be removed
+    expect(
+      within(theme3Methodologies[0]).getByRole('link', {
+        name: 'Methodology 6',
+      }),
+    ).toHaveAttribute('href', '/methodology/methodology-6-slug');
   });
 
   test('renders methodology index page without themes', async () => {


### PR DESCRIPTION
This PR fixes a bug where methodologies could appear multiple times on the public Methodologies page if a single methodology was associated with multiple publications under the same theme.

I went with the simplest fix for this issue. I did consider updating the  `GET /methodology-themes` call in the backend, since I believe we only use this endpoint for the Methodologies page, and since we now only group methodologies by theme, there is no reason for the backend to return methodologies grouped by theme -> topic -> publication.

I discussed this with Dunc. This endpoint will be changed if/when remove topics (as part of EES-4260) so I believe it's ok to leave this for now. If others disagree, I'm happy to discuss / change the approach.

