### PR TITLE
EES-4380 Add more UI tests around methodology prerelease

### DIFF
--- a/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
@@ -13,13 +13,20 @@ Test Setup          fail test fast if required
 *** Variables ***
 ${OWNING_PUBLICATION_NAME}=         UI tests - methodology owning publication %{RUN_IDENTIFIER}
 ${ADOPTING_PUBLICATION_NAME}=       UI tests - adopting methodology publication %{RUN_IDENTIFIER}
+${RELEASE_NAME}=                    Calendar year 2000
 
 
 *** Test Cases ***
-Create Publications and a Methodology to adopt
+Create test data
     user creates test publication via api    ${OWNING_PUBLICATION_NAME}
     user creates methodology for publication    ${OWNING_PUBLICATION_NAME}
-    user creates test publication via api    ${ADOPTING_PUBLICATION_NAME}
+    ${ADOPTING_PUBLICATION_ID}=    user creates test publication via api    ${ADOPTING_PUBLICATION_NAME}
+    user creates test release via api    ${ADOPTING_PUBLICATION_ID}    CY    2000
+
+    user navigates to draft release page from dashboard    ${ADOPTING_PUBLICATION_NAME}    ${RELEASE_NAME}
+    user navigates to content page    ${ADOPTING_PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
 
 Adopt a Methodology
     user navigates to methodologies on publication page    ${ADOPTING_PUBLICATION_NAME}
@@ -40,18 +47,89 @@ Adopt a Methodology
 
 Validate methodology adopted
     ${ROW}=    user gets table row    ${OWNING_PUBLICATION_NAME}    testid:methodologies
-    set suite variable    ${ROW}
     user checks element contains    ${ROW}    Adopted
     user checks element contains    ${ROW}    Draft
     user checks element contains    ${ROW}    Not yet published
     user checks element contains link    ${ROW}    Edit
     user checks element contains button    ${ROW}    Remove
 
+Set methodology to published alongside release
+    user navigates to methodology    ${ADOPTING_PUBLICATION_NAME}    ${OWNING_PUBLICATION_NAME}
+    approve methodology from methodology view    WithRelease    ${ADOPTING_PUBLICATION_NAME} - ${RELEASE_NAME}
+
+Schedule release to be published tomorrow
+    user navigates to draft release page from dashboard    ${ADOPTING_PUBLICATION_NAME}    ${RELEASE_NAME}
+
+    ${day}=    get current datetime    %-d    1
+    ${month}=    get current datetime    %-m    1
+    ${month_word}=    get current datetime    %B    1
+    ${year}=    get current datetime    %Y    1
+
+    user clicks link    Sign off
+    user clicks button    Edit release status
+    user clicks radio    Approved for publication
+    user enters text into element    id:releaseStatusForm-internalReleaseNote    Approved by adopt_methodology tests
+    user waits until page contains element    xpath://label[text()="On a specific date"]/../input
+    user clicks radio    On a specific date
+    user waits until page contains    Publish date
+    user enters text into element    id:releaseStatusForm-publishScheduled-day    ${day}
+    user enters text into element    id:releaseStatusForm-publishScheduled-month    ${month}
+    user enters text into element    id:releaseStatusForm-publishScheduled-year    ${year}
+    user clicks button    Update status
+    user waits until h2 is visible    Confirm publish date
+    user clicks button    Confirm
+
+    user checks summary list contains    Current status    Approved
+    user checks summary list contains    Scheduled release    ${day} ${month_word} ${year}
+    user waits for release process status to be    Scheduled    %{WAIT_MEDIUM}
+
+Invite analyst1 to prerelease
+    user clicks link    Pre-release access
+    user waits until h2 is visible    Manage pre-release user access
+    user enters text into element    css:textarea[name="emails"]    ees-test.analyst1@education.gov.uk
+    user clicks button    Invite new users
+    ${modal}=    user waits until modal is visible    Confirm pre-release invitations
+    user waits until element contains    ${modal}    Email notifications will be sent immediately
+
+    user checks list has x items    testid:invitableList    1    ${modal}
+    user checks list item contains    testid:invitableList    1    ees-test.analyst1@education.gov.uk    ${modal}
+    user clicks button    Confirm
+    user checks table column heading contains    1    1    User email
+    user checks table cell contains    1    1    ees-test.analyst1@education.gov.uk
+
+Get pre-release url
+    ${PRERELEASE_URL}=    Get Value    testid:prerelease-url
+    check that variable is not empty    PRERELEASE_URL    ${PRERELEASE_URL}
+    Set Suite Variable    ${PRERELEASE_URL}
+
+Validate methodology appears in prerelease for analyst1
+    user changes to analyst1
+    user navigates to admin frontend    ${PRERELEASE_URL}
+
+    user clicks link    Methodologies
+    user waits until h1 is visible    Methodologies
+    user waits until page contains    ${OWNING_PUBLICATION_NAME} (Adopted)
+    user clicks link    ${OWNING_PUBLICATION_NAME} (Adopted)
+
+    user waits until page contains title caption    Methodology
+    user waits until h1 is visible    ${OWNING_PUBLICATION_NAME}
+
 Drop adopted Methodology
+    user changes to bau1
+    user navigates to methodologies on publication page    ${ADOPTING_PUBLICATION_NAME}
+
+    ${ROW}=    user gets table row    ${OWNING_PUBLICATION_NAME}    testid:methodologies
     user clicks button    Remove    ${ROW}
     ${modal}=    user waits until modal is visible    Remove methodology
     user clicks button    Confirm    ${modal}
     user waits until modal is not visible    Remove methodology
 
-Validate adopted methodology is dropped
     user waits until page contains    There are no methodologies for this publication yet.
+
+Validate adopted methodology no longer appears in prerelease
+    user changes to analyst1
+    user navigates to admin frontend    ${PRERELEASE_URL}
+
+    user clicks link    Methodologies
+    user waits until h1 is visible    Methodologies
+    user waits until page contains    No methodologies available.

--- a/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
@@ -20,8 +20,8 @@ ${RELEASE_NAME}=                    Calendar year 2000
 Create test data
     user creates test publication via api    ${OWNING_PUBLICATION_NAME}
     user creates methodology for publication    ${OWNING_PUBLICATION_NAME}
-    ${ADOPTING_PUBLICATION_ID}=    user creates test publication via api    ${ADOPTING_PUBLICATION_NAME}
-    user creates test release via api    ${ADOPTING_PUBLICATION_ID}    CY    2000
+    ${adopting_publication_id}=    user creates test publication via api    ${ADOPTING_PUBLICATION_NAME}
+    user creates test release via api    ${adopting_publication_id}    CY    2000
 
     user navigates to draft release page from dashboard    ${ADOPTING_PUBLICATION_NAME}    ${RELEASE_NAME}
     user navigates to content page    ${ADOPTING_PUBLICATION_NAME}
@@ -46,12 +46,12 @@ Adopt a Methodology
     user waits until h2 is visible    Manage methodologies
 
 Validate methodology adopted
-    ${ROW}=    user gets table row    ${OWNING_PUBLICATION_NAME}    testid:methodologies
-    user checks element contains    ${ROW}    Adopted
-    user checks element contains    ${ROW}    Draft
-    user checks element contains    ${ROW}    Not yet published
-    user checks element contains link    ${ROW}    Edit
-    user checks element contains button    ${ROW}    Remove
+    ${row}=    user gets table row    ${OWNING_PUBLICATION_NAME}    testid:methodologies
+    user checks element contains    ${row}    Adopted
+    user checks element contains    ${row}    Draft
+    user checks element contains    ${row}    Not yet published
+    user checks element contains link    ${row}    Edit
+    user checks element contains button    ${row}    Remove
 
 Set methodology to published alongside release
     user navigates to methodology    ${ADOPTING_PUBLICATION_NAME}    ${OWNING_PUBLICATION_NAME}
@@ -118,8 +118,8 @@ Drop adopted Methodology
     user changes to bau1
     user navigates to methodologies on publication page    ${ADOPTING_PUBLICATION_NAME}
 
-    ${ROW}=    user gets table row    ${OWNING_PUBLICATION_NAME}    testid:methodologies
-    user clicks button    Remove    ${ROW}
+    ${row}=    user gets table row    ${OWNING_PUBLICATION_NAME}    testid:methodologies
+    user clicks button    Remove    ${row}
     ${modal}=    user waits until modal is visible    Remove methodology
     user clicks button    Confirm    ${modal}
     user waits until modal is not visible    Remove methodology

--- a/tests/robot-tests/tests/admin/bau/invite_new_users.robot
+++ b/tests/robot-tests/tests/admin/bau/invite_new_users.robot
@@ -20,10 +20,10 @@ ${EMAIL}=               ees-ui-test-%{RUN_IDENTIFIER}@education.gov.uk
 
 *** Test Cases ***
 Create Publication as bau1
-    ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
-    user creates test release via api    ${PUBLICATION_ID}    AY    2000
-    user creates test release via api    ${PUBLICATION_ID}    AY    2001
-    user creates test release via api    ${PUBLICATION_ID}    AY    2002
+    ${publication_id}=    user creates test publication via api    ${PUBLICATION_NAME}
+    user creates test release via api    ${publication_id}    AY    2000
+    user creates test release via api    ${publication_id}    AY    2001
+    user creates test release via api    ${publication_id}    AY    2002
 
 Navigate to Platform administration, Invite new users page
     user clicks link    Platform administration

--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -27,37 +27,37 @@ Navigate to manage users page as bau1
     user checks table column heading contains    1    4    Actions
 
 Check correct test users are present in table
-    ${ROW}=    user gets table row with heading    Analyst1 User1
-    user checks row cell contains text    ${ROW}    1    EES-test.ANALYST1@education.gov.uk
-    user checks row cell contains text    ${ROW}    2    Analyst
-    user checks row cell contains text    ${ROW}    3    Manage
+    ${row}=    user gets table row with heading    Analyst1 User1
+    user checks row cell contains text    ${row}    1    EES-test.ANALYST1@education.gov.uk
+    user checks row cell contains text    ${row}    2    Analyst
+    user checks row cell contains text    ${row}    3    Manage
 
-    ${ROW}=    user gets table row with heading    Analyst2 User2
-    user checks row cell contains text    ${ROW}    1    EES-test.ANALYST2@education.gov.uk
-    user checks row cell contains text    ${ROW}    2    Analyst
-    user checks row cell contains text    ${ROW}    3    Manage
+    ${row}=    user gets table row with heading    Analyst2 User2
+    user checks row cell contains text    ${row}    1    EES-test.ANALYST2@education.gov.uk
+    user checks row cell contains text    ${row}    2    Analyst
+    user checks row cell contains text    ${row}    3    Manage
 
-    ${ROW}=    user gets table row with heading    Bau1 User1
-    user checks row cell contains text    ${ROW}    1    EES-test.BAU1@education.gov.uk
-    user checks row cell contains text    ${ROW}    2    BAU User
-    user checks row cell contains text    ${ROW}    3    Manage
+    ${row}=    user gets table row with heading    Bau1 User1
+    user checks row cell contains text    ${row}    1    EES-test.BAU1@education.gov.uk
+    user checks row cell contains text    ${row}    2    BAU User
+    user checks row cell contains text    ${row}    3    Manage
 
-    ${ROW}=    user gets table row with heading    Bau2 User2
-    user checks row cell contains text    ${ROW}    1    EES-test.BAU2@education.gov.uk
-    user checks row cell contains text    ${ROW}    2    BAU User
-    user checks row cell contains text    ${ROW}    3    Manage
+    ${row}=    user gets table row with heading    Bau2 User2
+    user checks row cell contains text    ${row}    1    EES-test.BAU2@education.gov.uk
+    user checks row cell contains text    ${row}    2    BAU User
+    user checks row cell contains text    ${row}    3    Manage
 
 Assert prerelease users are present in table
     ${list}=    create list    ees-prerelease1@education.gov.uk    ees-prerelease2@education.gov.uk
     user resets user roles via api if required    ${list}
     user reloads page
 
-    ${ROW}=    user gets table row with heading    Prerelease2 User2
+    ${row}=    user gets table row with heading    Prerelease2 User2
 
-    user checks row cell contains text    ${ROW}    1    ees-prerelease2@education.gov.uk
-    user checks row cell contains text    ${ROW}    2    No role
-    user checks row cell contains text    ${ROW}    3    Manage
-    set suite variable    ${PRE_RELEASE_ROW}    ${ROW}
+    user checks row cell contains text    ${row}    1    ees-prerelease2@education.gov.uk
+    user checks row cell contains text    ${row}    2    No role
+    user checks row cell contains text    ${row}    3    Manage
+    set suite variable    ${PRE_RELEASE_ROW}    ${row}
 
 Select a user to manage
     ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -22,8 +22,8 @@ ${DATABLOCK_FEATURED_TABLE_DESCRIPTION}=    UI test featured table description
 
 *** Test Cases ***
 Create test publication and release via API
-    ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
-    user creates test release via api    ${PUBLICATION_ID}    CY    2000
+    ${publication_id}=    user creates test publication via api    ${PUBLICATION_NAME}
+    user creates test release via api    ${publication_id}    CY    2000
 
 Upload subject
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -386,11 +386,22 @@ Validate no methodologies
 
 Create and validate methodology
     user creates methodology for publication    ${PUBLICATION_NAME}
+
+    user clicks link    Manage content
+    user creates new content section    1    Methodology content section 1
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user adds text block to editable accordion section    Methodology content section 1
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user adds content to accordion section text block    Methodology content section 1    1
+    ...    Content 1    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+
     approve methodology from methodology view
+
     user navigates to admin frontend    ${RELEASE_URL}/prerelease/methodologies
     user waits until h1 is visible    Methodologies
     user waits until page contains    ${PUBLICATION_NAME} (Owned)
     user clicks link    ${PUBLICATION_NAME} (Owned)
+
     user waits until h1 is visible    ${PUBLICATION_NAME}
 
 Validate prerelease has started for Analyst user

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -17,8 +17,8 @@ ${PUBLICATION_NAME}=    UI tests - upload files %{RUN_IDENTIFIER}
 
 *** Test Cases ***
 Create test publication and release via api
-    ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
-    user creates test release via api    ${PUBLICATION_ID}    AY    2025
+    ${publication_id}=    user creates test publication via api    ${PUBLICATION_NAME}
+    user creates test release via api    ${publication_id}    AY    2025
 
 Navigate to 'Data and files' page
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -29,20 +29,45 @@ Verify release summary
 Upload subject
     user uploads subject    UI test subject    upload-file-test.csv    upload-file-test.meta.csv
 
-Go to 'Sign Off' page
+Check release isn't publically visible
     user clicks link    Sign off
     user waits for page to finish loading
     user waits until page contains element    testid:public-release-url
-    ${PUBLIC_RELEASE_LINK}=    Get Value    xpath://*[@data-testid="public-release-url"]
+    ${PUBLIC_RELEASE_LINK}=    Get Value    testid:public-release-url
     check that variable is not empty    PUBLIC_RELEASE_LINK    ${PUBLIC_RELEASE_LINK}
     Set Suite Variable    ${PUBLIC_RELEASE_LINK}
 
-Go to Public Release Link
     user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
     user waits until page contains    Page not found
     user checks page does not contain    ${RELEASE_NAME}
 
 Return to admin
+    user navigates to admin dashboard    Bau1
+
+Create methodology for release
+    user creates methodology for publication    ${PUBLICATION_NAME}
+
+    user clicks link    Manage content
+    user creates new content section    1    Methodology content section 1
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user adds text block to editable accordion section    Methodology content section 1
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+    user adds content to accordion section text block    Methodology content section 1    1
+    ...    Content 1    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+
+Set methodology to be published alongside release
+    approve methodology from methodology view    WithRelease    ${PUBLICATION_NAME} - ${RELEASE_NAME}
+
+Check methodology isn't publically visible
+    user waits until page contains element    testid:public-methodology-url
+    ${PUBLIC_METHODOLOGY_LINK}=    Get Value    testid:public-methodology-url
+    check that variable is not empty    PUBLIC_METHODOLOGY_LINK    ${PUBLIC_METHODOLOGY_LINK}
+    Set Suite Variable    ${PUBLIC_METHODOLOGY_LINK}
+
+    user navigates to public frontend    ${PUBLIC_METHODOLOGY_LINK}
+    user waits until page contains    Page not found
+
+Return to admin again
     user navigates to admin dashboard    Bau1
 
 Add public prerelease access list
@@ -98,6 +123,7 @@ Approve release and wait for it to be Scheduled
     user clicks button    Update status
     user waits until h2 is visible    Confirm publish date
     user clicks button    Confirm
+
     # the below fails on dev
     user checks summary list contains    Scheduled release    ${day} ${month_word} ${year}
     user checks summary list contains    Next release expected    January 2001
@@ -111,7 +137,17 @@ Check scheduled release isn't visible on public Table Tool
 
 Go to public release URL and check release isn't visible
     user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
+    user waits until page contains    Page not found
     user waits until page does not contain    ${PUBLICATION_NAME}
+
+Check methodology isn't visible on public Methodologies page
+    user navigates to methodologies page on public frontend
+    user waits until page contains    %{TEST_THEME_NAME}
+    user opens accordion section    %{TEST_THEME_NAME}
+    user checks page does not contain    ${PUBLICATION_NAME}
+
+Check methoodlogy isn't accessible via URL
+    user navigates to public frontend    ${PUBLIC_METHODOLOGY_LINK}
     user waits until page contains    Page not found
 
 Go to admin release summary
@@ -119,19 +155,19 @@ Go to admin release summary
     user navigates to scheduled release page from dashboard    ${PUBLICATION_NAME}
     ...    ${RELEASE_NAME}
 
-Approve release for immediate publication but don't wait to finish
-    user clicks link    Sign off
-    user waits until h2 is visible    Sign off
-    user waits until page contains button    Edit release status
-    user clicks button    Edit release status
-    user waits until h2 is visible    Edit release status
-    user clicks radio    Approved for publication
-    user enters text into element    id:releaseStatusForm-internalReleaseNote    Approved by UI tests
-    user clicks radio    Immediately
-    user clicks button    Update status
-    user waits until h2 is visible    Sign off
-    user checks summary list contains    Current status    Approved
+Approve release for immediate publication
+    user approves original release for immediate publication
 
-Go to public release URL again and check release isn't visible
+Check release has been published
     user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
-    user waits until page contains    Page not found
+    user waits until page contains title caption    Calendar year 2000
+    user waits until h1 is visible    ${PUBLICATION_NAME}
+
+Check methodology has been published
+    user navigates to methodologies page on public frontend
+    user waits until page contains    %{TEST_THEME_NAME}
+    user opens accordion section    %{TEST_THEME_NAME}
+    user clicks link    ${PUBLICATION_NAME}
+
+    user waits until page contains title caption    Methodology
+    user waits until h1 is visible    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource            ../../libs/admin-common.robot
+Resource            ../../libs/public-common.robot
 Resource            ../../libs/admin/manage-content-common.robot
 Library             ../../libs/admin_api.py
 
@@ -63,6 +64,11 @@ Check methodology isn't publically visible
     ${PUBLIC_METHODOLOGY_LINK}=    Get Value    testid:public-methodology-url
     check that variable is not empty    PUBLIC_METHODOLOGY_LINK    ${PUBLIC_METHODOLOGY_LINK}
     Set Suite Variable    ${PUBLIC_METHODOLOGY_LINK}
+
+    user navigates to public methodologies page
+    user waits until page contains    %{TEST_THEME_NAME}
+    user opens accordion section    %{TEST_THEME_NAME}
+    user checks page does not contain    ${PUBLICATION_NAME}
 
     user navigates to public frontend    ${PUBLIC_METHODOLOGY_LINK}
     user waits until page contains    Page not found
@@ -141,12 +147,12 @@ Go to public release URL and check release isn't visible
     user waits until page does not contain    ${PUBLICATION_NAME}
 
 Check methodology isn't visible on public Methodologies page
-    user navigates to methodologies page on public frontend
+    user navigates to public methodologies page
     user waits until page contains    %{TEST_THEME_NAME}
     user opens accordion section    %{TEST_THEME_NAME}
     user checks page does not contain    ${PUBLICATION_NAME}
 
-Check methoodlogy isn't accessible via URL
+Check methodology isn't accessible via URL
     user navigates to public frontend    ${PUBLIC_METHODOLOGY_LINK}
     user waits until page contains    Page not found
 
@@ -163,10 +169,13 @@ Check release has been published
     user waits until page contains title caption    Calendar year 2000
     user waits until h1 is visible    ${PUBLICATION_NAME}
 
-Check methodology has been published
-    user navigates to methodologies page on public frontend
+Check methodology is visible on public Methodologies page
+    user navigates to public methodologies page
     user waits until page contains    %{TEST_THEME_NAME}
     user opens accordion section    %{TEST_THEME_NAME}
+    user waits until page contains    ${PUBLICATION_NAME}
+
+Check methodology has been published
     user clicks link    ${PUBLICATION_NAME}
 
     user waits until page contains title caption    Methodology

--- a/tests/robot-tests/tests/admin_and_public/bau/subject_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/subject_reordering.robot
@@ -235,7 +235,7 @@ Check subject order in data catalogue
     user checks checkbox in position has label    4    Four
 
 Check subject order in data guidance
-    user navigates to find statistics page on public frontend
+    user navigates to public find statistics page
     user clicks link    ${PUBLICATION_NAME}
 
     user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_MEDIUM}

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource            ../../libs/admin-common.robot
+Resource            ../../libs/public-common.robot
 Resource            ../../libs/admin/manage-content-common.robot
 Library             ../../libs/admin_api.py
 

--- a/tests/robot-tests/tests/general_public/statistics_page.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page.robot
@@ -12,7 +12,7 @@ Force Tags          GeneralPublic    Prod
 Navigate to Find Statistics page
     [Tags]    Local    Dev
     environment variable should be set    PUBLIC_URL
-    user navigates to find statistics page on public frontend
+    user navigates to public find statistics page
 
 Validate Related information section and links exist
     ${relatedInformation}=    get webelement    css:[aria-labelledby="related-information"]

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -74,8 +74,8 @@ user selects dashboard theme and topic if possible
     ...    ${theme_name}=%{TEST_THEME_NAME}
     ...    ${topic_name}=%{TEST_TOPIC_NAME}
     user waits until page does not contain loading spinner
-    ${DROPDOWNS_EXIST}=    user checks dashboard theme topic dropdowns exist
-    IF    ${DROPDOWNS_EXIST}
+    ${dropsdowns_exist}=    user checks dashboard theme topic dropdowns exist
+    IF    ${dropsdowns_exist}
         user chooses select option    id:publicationsReleases-themeTopic-themeId    ${theme_name}
         user waits until page contains element    id:publicationsReleases-themeTopic-topicId
         user chooses select option    id:publicationsReleases-themeTopic-topicId    ${topic_name}

--- a/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
+++ b/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
@@ -18,8 +18,8 @@ user goes to methodologies and checks cannot create methodologies for publicatio
 
 user cannot see the create amendment controls for release
     [Arguments]    ${RELEASE_NAME}
-    ${ROW}=    user gets table row    ${RELEASE_NAME}    testid:publication-published-releases
-    user checks element does not contain button    ${ROW}    Amend
+    ${row}=    user gets table row    ${RELEASE_NAME}    testid:publication-published-releases
+    user checks element does not contain button    ${row}    Amend
 
 user cannot see edit controls for release content
     [Arguments]    ${publication}

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -910,6 +910,12 @@ user navigates to data catalogue page on public frontend
     user waits until h1 is visible    Browse our open data
     user waits until page contains    View all of the open data available and choose files to download.
 
+user navigates to methodologies page on public frontend
+    environment variable should be set    PUBLIC_URL
+    user navigates to public frontend    %{PUBLIC_URL}/methodology
+    user waits until h1 is visible    Methodologies
+    user waits until page contains    Browse to find out about the methodology behind specific
+
 check that variable is not empty
     [Arguments]    ${variable_name}    ${variable_value}
     IF    '${variable_value}'=='${EMPTY}'

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -893,29 +893,6 @@ user navigates to public frontend
     enable basic auth headers
     go to    ${URL}
 
-user navigates to find statistics page on public frontend
-    environment variable should be set    PUBLIC_URL
-    user navigates to public frontend    %{PUBLIC_URL}/find-statistics
-    user waits until h1 is visible    Find statistics and data
-
-user navigates to data tables page on public frontend
-    environment variable should be set    PUBLIC_URL
-    user navigates to public frontend    %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible    Create your own tables
-
-user navigates to data catalogue page on public frontend
-    environment variable should be set    PUBLIC_URL
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue
-    user waits until page contains title caption    Data catalogue
-    user waits until h1 is visible    Browse our open data
-    user waits until page contains    View all of the open data available and choose files to download.
-
-user navigates to methodologies page on public frontend
-    environment variable should be set    PUBLIC_URL
-    user navigates to public frontend    %{PUBLIC_URL}/methodology
-    user waits until h1 is visible    Methodologies
-    user waits until page contains    Browse to find out about the methodology behind specific
-
 check that variable is not empty
     [Arguments]    ${variable_name}    ${variable_value}
     IF    '${variable_value}'=='${EMPTY}'

--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -20,7 +20,7 @@ user checks release update
 
 user checks publication is on find statistics page
     [Arguments]    ${publication_name}
-    user navigates to find statistics page on public frontend
+    user navigates to public find statistics page
     user waits until page contains link    ${publication_name}
 
 user waits until details dropdown contains publication
@@ -51,10 +51,28 @@ user goes to release page via breadcrumb
     user waits until h1 is visible    ${publication}
     user waits until page contains title caption    ${release}
 
+user navigates to public find statistics page
+    environment variable should be set    PUBLIC_URL
+    user navigates to public frontend    %{PUBLIC_URL}/find-statistics
+    user waits until h1 is visible    Find statistics and data
+
+user navigates to data tables page on public frontend
+    environment variable should be set    PUBLIC_URL
+    user navigates to public frontend    %{PUBLIC_URL}/data-tables
+    user waits until h1 is visible    Create your own tables
+
+user navigates to data catalogue page on public frontend
+    environment variable should be set    PUBLIC_URL
+    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue
+    user waits until page contains title caption    Data catalogue
+    user waits until h1 is visible    Browse our open data
+    user waits until page contains    View all of the open data available and choose files to download.
+
 user navigates to public methodologies page
     environment variable should be set    PUBLIC_URL
     user navigates to public frontend    %{PUBLIC_URL}/methodology
     user waits until h1 is visible    Methodologies
+    user waits until page contains    Browse to find out about the methodology behind specific
 
 user checks methodology note
     [Arguments]    ${number}    ${displayDate}    ${content}


### PR DESCRIPTION
This PR adds more UI tests around prerelease access for methodologies.

- Add a content section / content block to the prerelease methodology in `prerelease.robot`
- Check an adopted methodology appears correctly in prerelease in `adopt_methodology.robot`
- Check a methodology doesn't appear publically during prerelease in `prerelease_visibility.robot`

Other things are checked during these things, such as that a methodology correctly publishes alongside a specific release if that publishing strategy was chosen for the methodology.

This work was undertaken in response to the bug EES-4379. As a side note, the `Create and validate methodology` test case in `prerelease.robot` previously failed to spot this bug because the created methodology to test prerelease had no content sections/content blocks added, which triggered the issue around `useMethodologyContext`. The bug itself was fixed in this PR: https://github.com/dfe-analytical-services/explore-education-statistics/pull/4114