### PR TITLE
EES-4385 Refetch methodology statuses on MethodologyStatusPage submit

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -44,7 +44,10 @@ const MethodologyStatusPage = () => {
 
   const [isEditing, toggleForm] = useToggle(false);
 
-  const { data: methodologyStatuses } = useQuery(
+  const {
+    data: methodologyStatuses,
+    refetch: refreshMethodologyStatuses,
+  } = useQuery(
     methodologyQueries.getMethodologyStatuses(currentMethodology.id),
   );
 
@@ -89,6 +92,7 @@ const MethodologyStatusPage = () => {
     onMethodologyChange(nextSummary);
 
     refreshPermissions();
+    await refreshMethodologyStatuses();
 
     toggleForm.off();
   };


### PR DESCRIPTION
This fixes an issue where the Methodology status history table wasn't being refreshed after submitting the form on the `MethodologyStatusPage`. Previously, you had to refresh the page for the new status history table entries to appear.