### PR TITLE
Enable productionBrowserSourceMaps for public frontend

### DIFF
--- a/src/explore-education-statistics-frontend/next.config.js
+++ b/src/explore-education-statistics-frontend/next.config.js
@@ -16,6 +16,7 @@ const nextConfig = {
     GA_TRACKING_ID: process.env.GA_TRACKING_ID,
     PUBLIC_URL: process.env.PUBLIC_URL,
   },
+  productionBrowserSourceMaps: true,
   async redirects() {
     return [
       {


### PR DESCRIPTION
We're enabling this to investigate an issue with prerelease_visibility.robot where the `Check methodology has been published` test case is failing. It appears to click the link to the methodology, the link gets highlighted, but the browser doesn't actually go to the page. This seems to only happen inside a webdriver-created window.