### PR TITLE
EES-4352 Switch pipelines to self-hosted runners

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,5 +3,6 @@ build/
 coverage/
 node_modules/
 *.min.js
-
+# Artifacts can leak between jobs on self-hosted runners
+wwwroot/
 src/explore-education-statistics-ckeditor/sample

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,7 @@ coverage/
 node_modules/
 *.min.css
 *.min.js
-
+# Artifacts can leak between jobs on self-hosted runners
+wwwroot/
 # This file is massive and holds the formatter
 src/explore-education-statistics-common/src/modules/charts/files/ukGeoJson.json
-src/explore-education-statistics-frontend/src/html

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -3,5 +3,6 @@ build/
 coverage/
 node_modules/
 *.min.css
-
+# Artifacts can leak between jobs on self-hosted runners
+wwwroot/
 src/explore-education-statistics-ckeditor/sample

--- a/azure-pipelines-ui-tests.dfe.yml
+++ b/azure-pipelines-ui-tests.dfe.yml
@@ -21,8 +21,7 @@ jobs:
   timeoutInMinutes: 160
   cancelTimeoutInMinutes: 10
   condition: succeededOrFailed()
-  pool:
-    vmImage: ubuntu-20.04
+  pool: ees-ubuntu2204-large
   steps:
   - checkout: self
     clean: true
@@ -48,10 +47,10 @@ jobs:
     displayName: Public UI tests
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --env "dev" --file "tests/general_public/" --processes 2
+      arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --env "dev" --file "tests/general_public/" --processes 3
       workingDirectory: tests/robot-tests
     env:
-      SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)  
+      SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
   #- task: PythonScript@0
@@ -59,7 +58,7 @@ jobs:
   #  condition: not(succeeded())
   #  inputs:
   #    scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-  #    arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --env "dev" --file "tests/general_public/" --processes 2 --rerun-failed-suites
+  #    arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --env "dev" --file "tests/general_public/" --processes 3 --rerun-failed-suites
   #    workingDirectory: tests/robot-tests
 
   - task: PublishTestResults@2
@@ -80,8 +79,7 @@ jobs:
   timeoutInMinutes: 160
   cancelTimeoutInMinutes: 10
   condition: succeededOrFailed()
-  pool:
-    vmImage: ubuntu-20.04
+  pool: ees-ubuntu2204-large
   steps:
   - checkout: self
     clean: true
@@ -108,11 +106,11 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public_2" --processes 2
-    #  The magic incantation '"$(variable)"'was added by Mark to resolve an issue with Analyst password that contained apersands.
+      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public_2" --processes 3
+    #  The magic incantation '"$(variable)"'was added by Mark to resolve an issue with Analyst password that contained ampersands.
       workingDirectory: tests/robot-tests
     env:
-      SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)  
+      SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
   #- task: PythonScript@0
@@ -120,7 +118,7 @@ jobs:
   #  condition: not(succeeded())
   #  inputs:
   #    scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-  #    arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public_2" --processes 2 --rerun-failed-suites
+  #    arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public_2" --processes 3 --rerun-failed-suites
   #    workingDirectory: tests/robot-tests
 
   - task: PublishTestResults@2
@@ -140,8 +138,7 @@ jobs:
   timeoutInMinutes: 160
   cancelTimeoutInMinutes: 10
   condition: succeededOrFailed()
-  pool:
-    vmImage: ubuntu-20.04
+  pool: ees-ubuntu2204-large
   steps:
   - checkout: self
     clean: true
@@ -168,10 +165,10 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin" --processes 2
+      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin" --processes 3
       workingDirectory: tests/robot-tests
     env:
-      SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)  
+      SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
   #- task: PythonScript@0
@@ -179,7 +176,7 @@ jobs:
   #  condition: not(succeeded())
   #  inputs:
   #    scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-  #    arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin" --processes 2 --rerun-failed-suites
+  #    arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin" --processes 3 --rerun-failed-suites
   #    workingDirectory: tests/robot-tests
 
   - task: PublishTestResults@2
@@ -195,14 +192,13 @@ jobs:
     inputs:
       path: tests/robot-tests/test-results/
       artifactName: test-results-admin
-      
+
 - job: 'AdminAndPublic'
   displayName: Admin & public suites
   timeoutInMinutes: 160
   cancelTimeoutInMinutes: 10
   condition: succeededOrFailed()
-  pool:
-    vmImage: ubuntu-20.04
+  pool: ees-ubuntu2204-large
   steps:
   - checkout: self
     clean: true
@@ -228,10 +224,10 @@ jobs:
     displayName: Admin public UI tests
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public" --processes 2
+      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public" --processes 3
       workingDirectory: tests/robot-tests
     env:
-      SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)  
+      SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
   #- task: PythonScript@0
@@ -239,7 +235,7 @@ jobs:
   #  condition: not(succeeded())
   #  inputs:
   #    scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-  #    arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public" --processes 2 --rerun-failed-suites
+  #    arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public" --processes 3 --rerun-failed-suites
   #    workingDirectory: tests/robot-tests
 
   - task: PublishTestResults@2

--- a/azure-pipelines.dfe.yml
+++ b/azure-pipelines.dfe.yml
@@ -16,8 +16,7 @@ pr: [ 'master', 'dev' ]
 
 jobs:
   - job: 'Backend'
-    pool:
-      vmImage: 'windows-2022'
+    pool: 'ees-ubuntu2204-large'
     steps:
       - task: UseDotNet@2
         displayName: 'Install .NET Core SDK'
@@ -116,10 +115,7 @@ jobs:
           targetPath: '$(Build.ArtifactStagingDirectory)/processor'
 
   - job: 'Admin'
-    pool:
-      vmImage: 'ubuntu-20.04'
-      demands:
-        - azureps
+    pool: 'ees-ubuntu2204-xlarge'
     steps:
       - task: NodeTool@0
         displayName: 'Install Node.js $(NODE_VERSION)'
@@ -199,9 +195,7 @@ jobs:
           targetPath: '$(Build.ArtifactStagingDirectory)'
 
   - job: 'Frontend'
-    pool:
-      vmImage: 'ubuntu-20.04'
-      demands: azureps
+    pool: 'ees-ubuntu2204-xlarge'
     steps:
       - task: NodeTool@0
         displayName: 'Install Node.js $(NODE_VERSION)'
@@ -290,7 +284,7 @@ jobs:
 
   - job: 'MiscellaneousArtifacts'
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-22.04'
     steps:
       - task: CopyFiles@2
         displayName: 'Copy Pipfiles to tests'


### PR DESCRIPTION
This PR switches the build pipelines to use our self-hosted runner pools:

- `ees-ubuntu2204-large` - 4 vCPUs, 16GB RAM
- `ees-ubuntu2204-xlarge` - 8 vCPUs, 32GB RAM

Note that:
- In some cases, we just use the default Microsoft runners as the tasks aren't very demanding and these runners can spin up really quickly from cold.
- The UI test pipeline has been throttled at 3 processors per test run for now in case it causes more flakiness. We can look into changing this further after some more testing.