### PR TITLE
EES-4441 Add Admin endpoint to get glossary

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/GlossaryServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/GlossaryServiceTests.cs
@@ -19,7 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                await context.AddAsync(
+                await context.GlossaryEntries.AddRangeAsync(
                     new GlossaryEntry
                     {
                         Title = "Exclusion",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/GlossaryServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/GlossaryServiceTests.cs
@@ -1,9 +1,10 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Xunit;
@@ -14,47 +15,113 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
     public class GlossaryServiceTests
     {
         [Fact]
-        public async Task GetGlossaryEntry()
+        public async Task GetGlossary()
         {
+            var entries = new List<GlossaryEntry>
+            {
+                new()
+                {
+                    Title = "Exclusions",
+                    Slug = "exclusions-slug",
+                    Body = "Exclusions body"
+                },
+                new()
+                {
+                    Title = "Absence",
+                    Slug = "absence-slug",
+                    Body = "Absence body"
+                }
+            };
+
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                await context.GlossaryEntries.AddRangeAsync(
-                    new GlossaryEntry
-                    {
-                        Title = "Exclusion",
-                        Slug = "exclusion",
-                        Body = "Exclusion body",
-                    }
-                );
+                await context.GlossaryEntries.AddRangeAsync(entries);
                 await context.SaveChangesAsync();
             }
 
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                var glossaryService = new GlossaryService(
-                    new PersistenceHelper<ContentDbContext>(context));
+                var glossaryService = BuildService(contentDbContext: context);
 
-                var result = await glossaryService.GetGlossaryEntry("exclusion");
+                var result = await glossaryService.GetGlossary();
+
+                Assert.Equal(26, result.Count);
+
+                var categoryA = result[0];
+                Assert.Single(categoryA.Entries);
+
+                AssertGlossaryEntry(entries[1], categoryA.Entries[0]);
+
+                var categoryE = result[4];
+                Assert.Single(categoryE.Entries);
+
+                AssertGlossaryEntry(entries[0], categoryE.Entries[0]);
+            }
+        }
+
+        [Fact]
+        public async Task GetGlossary_NoEntries()
+        {
+            var glossaryService = BuildService();
+
+            var result = await glossaryService.GetGlossary();
+
+            Assert.All(result, category => Assert.Empty(category.Entries));
+        }
+
+        [Fact]
+        public async Task GetGlossaryEntry()
+        {
+            var entry = new GlossaryEntry
+            {
+                Title = "Exclusions",
+                Slug = "exclusions-slug",
+                Body = "Exclusions body"
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                await context.GlossaryEntries.AddRangeAsync(entry);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var glossaryService = BuildService(contentDbContext: context);
+
+                var result = await glossaryService.GetGlossaryEntry("exclusions-slug");
 
                 var viewModel = result.AssertRight();
 
-                Assert.Equal("Exclusion", viewModel.Title);
-                Assert.Equal("exclusion", viewModel.Slug);
-                Assert.Equal("Exclusion body", viewModel.Body);
+                AssertGlossaryEntry(entry, viewModel);
             }
         }
 
         [Fact]
         public async Task GetGlossaryEntry_NotFound()
         {
-            await using var context = InMemoryContentDbContext();
-            var glossaryService = new GlossaryService(
-                new PersistenceHelper<ContentDbContext>(context));
+            var glossaryService = BuildService();
 
-            var result = await glossaryService.GetGlossaryEntry("absence");
+            var result = await glossaryService.GetGlossaryEntry("absence-slug");
 
             result.AssertNotFound();
+        }
+
+        private static void AssertGlossaryEntry(GlossaryEntry glossaryEntry, GlossaryEntryViewModel viewModel)
+        {
+            Assert.Equal(glossaryEntry.Title, viewModel.Title);
+            Assert.Equal(glossaryEntry.Slug, viewModel.Slug);
+            Assert.Equal(glossaryEntry.Body, viewModel.Body);
+        }
+
+        private static GlossaryService BuildService(
+            ContentDbContext? contentDbContext = null)
+        {
+            return new GlossaryService(
+                contentDbContext ?? InMemoryContentDbContext()
+            );
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/GlossaryController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/GlossaryController.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -16,6 +17,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             IGlossaryService glossaryService)
         {
             _glossaryService = glossaryService;
+        }
+
+        [HttpGet("glossary-entries")]
+        public async Task<List<GlossaryCategoryViewModel>> GetGlossary()
+        {
+            return await _glossaryService.GetGlossary();
         }
 
         [HttpGet("glossary-entries/{slug}")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/GlossaryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/GlossaryService.cs
@@ -1,36 +1,41 @@
 #nullable enable
-using System.Linq;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Utils;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 {
     public class GlossaryService : IGlossaryService
     {
-        private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
+        private readonly ContentDbContext _contentDbContext;
 
-        public GlossaryService(IPersistenceHelper<ContentDbContext> persistenceHelper)
+        public GlossaryService(ContentDbContext contentDbContext)
         {
-            _persistenceHelper = persistenceHelper;
+            _contentDbContext = contentDbContext;
+        }
+
+        public async Task<List<GlossaryCategoryViewModel>> GetGlossary()
+        {
+            var glossaryEntries = await _contentDbContext.GlossaryEntries
+                .ToListAsync();
+            return GlossaryUtils.BuildGlossary(glossaryEntries);
         }
 
         public async Task<Either<ActionResult, GlossaryEntryViewModel>> GetGlossaryEntry(string slug)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<GlossaryEntry>(query => query
-                    .Where(e => e.Slug == slug))
-                .OnSuccess(e => new GlossaryEntryViewModel
-                {
-                    Title = e.Title,
-                    Slug = e.Slug,
-                    Body = e.Body,
-                });
+            return await _contentDbContext.GlossaryEntries
+                .SingleOrNotFoundAsync(e => e.Slug == slug)
+                .OnSuccess(e => new GlossaryEntryViewModel(
+                    Title: e.Title,
+                    Slug: e.Slug,
+                    Body: e.Body));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IGlossaryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IGlossaryService.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
@@ -8,6 +9,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IGlossaryService
     {
+        Task<List<GlossaryCategoryViewModel>> GetGlossary();
+
         Task<Either<ActionResult, GlossaryEntryViewModel>> GetGlossaryEntry(string slug);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/GlossaryViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/GlossaryViewModels.cs
@@ -1,21 +1,20 @@
 ﻿#nullable enable
 using System.Collections.Generic;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.ViewModels
+namespace GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+
+public class GlossaryEntryViewModel
 {
-    public class GlossaryEntryViewModel
-    {
-        public string Title { get; set; } = string.Empty;
+    public string Title { get; init; } = string.Empty;
 
-        public string Slug { get; set; } = string.Empty;
+    public string Slug { get; init; } = string.Empty;
 
-        public string Body { get; set; } = string.Empty;
-    }
+    public string Body { get; init; } = string.Empty;
+}
 
-    public class GlossaryCategoryViewModel
-    {
-        public string Heading { get; set; } = string.Empty;
+public class GlossaryCategoryViewModel
+{
+    public string Heading { get; init; } = string.Empty;
 
-        public List<GlossaryEntryViewModel> Entries { get; set; }
-    }
+    public List<GlossaryEntryViewModel> Entries { get; init; } = new();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/GlossaryViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/GlossaryViewModels.cs
@@ -1,20 +1,23 @@
 ﻿#nullable enable
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 
-public class GlossaryEntryViewModel
+public record GlossaryEntryViewModel(string Title, string Slug, string Body);
+
+public record GlossaryCategoryViewModel(char Heading, List<GlossaryEntryViewModel> Entries)
 {
-    public string Title { get; init; } = string.Empty;
+    // ReSharper disable once StringLiteralTypo
+    private static readonly char[] AzCharArray = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".ToCharArray();
 
-    public string Slug { get; init; } = string.Empty;
-
-    public string Body { get; init; } = string.Empty;
-}
-
-public class GlossaryCategoryViewModel
-{
-    public string Heading { get; init; } = string.Empty;
-
-    public List<GlossaryEntryViewModel> Entries { get; init; } = new();
+    public static Dictionary<char, GlossaryCategoryViewModel> BuildGlossaryCategories()
+    {
+        return AzCharArray.ToDictionary(
+            c => c,
+            c => new GlossaryCategoryViewModel(
+                Heading: c,
+                Entries: new List<GlossaryEntryViewModel>()
+            ));
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/GlossaryControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/GlossaryControllerTests.cs
@@ -20,19 +20,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         {
             var glossaryEntries = new List<GlossaryCategoryViewModel>
             {
-                new()
-                {
-                    Heading = "Glossary Category 1",
-                    Entries = new List<GlossaryEntryViewModel>
+                new(
+                    Heading: 'A',
+                    Entries: new List<GlossaryEntryViewModel>
                     {
-                        new()
-                        {
-                            Body = "A body",
-                            Slug = "A slug",
-                            Title = "A title"
-                        }
-                    }
-                }
+                        new(
+                            Body: "A body",
+                            Slug: "A slug",
+                            Title: "A title")
+                    })
             };
 
             var (controller, mocks) = BuildControllerAndDependencies();
@@ -50,12 +46,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         [Fact]
         public async Task GetGlossaryEntry()
         {
-            var glossaryEntry = new GlossaryEntryViewModel
-            {
-                Body = "A body",
-                Slug = "A slug",
-                Title = "A title"
-            };
+            var glossaryEntry = new GlossaryEntryViewModel(
+                Body: "A body",
+                Slug: "A slug",
+                Title: "A title"
+            );
 
             var (controller, mocks) =
                 BuildControllerAndDependencies();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/GlossaryControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/GlossaryControllerTests.cs
@@ -16,7 +16,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
     public class GlossaryControllerTests
     {
         [Fact]
-        public async Task GetAllGlossaryEntries()
+        public async Task GetGlossary()
         {
             var glossaryEntries = new List<GlossaryCategoryViewModel>
             {
@@ -41,7 +41,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
                 .Setup(s => s.GetGlossary())
                 .ReturnsAsync(glossaryEntries);
 
-            var result = await controller.GetAllGlossaryEntries();
+            var result = await controller.GetGlossary();
             VerifyAllMocks(mocks);
 
             Assert.Equal(glossaryEntries, result);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/GlossaryController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/GlossaryController.cs
@@ -23,7 +23,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         }
 
         [HttpGet("glossary-entries")]
-        public async Task<List<GlossaryCategoryViewModel>> GetAllGlossaryEntries()
+        public async Task<List<GlossaryCategoryViewModel>> GetGlossary()
         {
             return await _glossaryCacheService.GetGlossary();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Utils/GlossaryUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Utils/GlossaryUtilsTests.cs
@@ -1,0 +1,89 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Utils;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils;
+
+public class GlossaryUtilsTests
+{
+    // ReSharper disable once StringLiteralTypo
+    private static readonly char[] AzCharArray = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".ToCharArray();
+
+    [Fact]
+    public void BuildGlossary()
+    {
+        var entries = new List<GlossaryEntry>
+        {
+            new()
+            {
+                Title = "Exclusions",
+                Slug = "exclusions-slug",
+                Body = "Exclusions body"
+            },
+            new()
+            {
+                Title = "Absence",
+                Slug = "absence-slug",
+                Body = "Absence body"
+            },
+            new()
+            {
+                Title = "expedient", // lowercase first letter
+                Slug = "expedient-slug",
+                Body = "Expedient body"
+            }
+        };
+
+        var result = GlossaryUtils.BuildGlossary(entries);
+
+        Assert.Equal(26, result.Count);
+
+        var expectedHeadingWithEntries = new[] { 'A', 'E' };
+        Assert.All(result.WithIndex(), tuple =>
+        {
+            var (category, index) = tuple;
+            Assert.Equal(AzCharArray[index], category.Heading);
+            if (!expectedHeadingWithEntries.Contains(category.Heading))
+            {
+                Assert.Empty(category.Entries);
+            }
+        });
+
+        var categoryA = result[0];
+        Assert.Single(categoryA.Entries);
+
+        AssertGlossaryEntry(entries[1], categoryA.Entries[0]);
+
+        var categoryE = result[4];
+        Assert.Equal(2, categoryE.Entries.Count);
+
+        AssertGlossaryEntry(entries[0], categoryE.Entries[0]);
+        AssertGlossaryEntry(entries[2], categoryE.Entries[1]);
+    }
+
+    [Fact]
+    public void ListGlossaryEntries_NoEntries()
+    {
+        var result = GlossaryUtils.BuildGlossary(new List<GlossaryEntry>());
+
+        Assert.Equal(26, result.Count);
+
+        Assert.All(result.WithIndex(), tuple =>
+        {
+            var (category, index) = tuple;
+            Assert.Equal(AzCharArray[index], category.Heading);
+            Assert.Empty(category.Entries);
+        });
+    }
+
+    private static void AssertGlossaryEntry(GlossaryEntry glossaryEntry, GlossaryEntryViewModel viewModel)
+    {
+        Assert.Equal(glossaryEntry.Title, viewModel.Title);
+        Assert.Equal(glossaryEntry.Slug, viewModel.Slug);
+        Assert.Equal(glossaryEntry.Body, viewModel.Body);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Utils/GlossaryUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Utils/GlossaryUtils.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Utils;
+
+public static class GlossaryUtils
+{
+    public static List<GlossaryCategoryViewModel> BuildGlossary(IReadOnlyList<GlossaryEntry> entries)
+    {
+        var categories = GlossaryCategoryViewModel.BuildGlossaryCategories();
+
+        var orderedEntries = entries
+            .OrderBy(e => e.Title)
+            .ToList();
+
+        orderedEntries.ForEach(e =>
+        {
+            categories[char.ToUpper(e.Title[0])]
+                .Entries
+                .Add(new GlossaryEntryViewModel(
+                    Title: e.Title,
+                    Slug: e.Slug,
+                    Body: e.Body
+                ));
+        });
+
+        return categories
+            .Values
+            .OrderBy(c => c.Heading)
+            .ToList();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
@@ -19,7 +19,12 @@ public class GlossaryCacheServiceTests : CacheServiceTestFixture
 {
     private readonly List<GlossaryCategoryViewModel> _glossary = new()
     {
-        new GlossaryCategoryViewModel()
+        new GlossaryCategoryViewModel(
+            Heading: 'A',
+            Entries: new List<GlossaryEntryViewModel>
+            {
+                new(Title: "A title", Slug: "A slug", Body: "A body")
+            })
     };
 
     [Fact]
@@ -93,19 +98,16 @@ public class GlossaryCacheServiceTests : CacheServiceTestFixture
     [Fact]
     public void GlossaryCategoryViewModel_SerializeAndDeserialize()
     {
-        var original = new GlossaryCategoryViewModel
-        {
-            Heading = "Glossary Category 1",
-            Entries = new List<GlossaryEntryViewModel>
+        var original = new GlossaryCategoryViewModel(
+            Heading: 'A',
+            Entries: new List<GlossaryEntryViewModel>
             {
-                new()
-                {
-                    Body = "A body",
-                    Slug = "A slug",
-                    Title = "A title"
-                }
-            }
-        };
+                new(
+                    Body: "A body",
+                    Slug: "A slug",
+                    Title: "A title"
+                )
+            });
 
         var converted = DeserializeObject<GlossaryCategoryViewModel>(SerializeObject(original));
         converted.AssertDeepEqualTo(original);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
@@ -38,7 +38,7 @@ public class GlossaryCacheServiceTests : CacheServiceTestFixture
         var glossaryService = new Mock<IGlossaryService>(Strict);
 
         glossaryService
-            .Setup(s => s.GetAllGlossaryEntries())
+            .Setup(s => s.GetGlossary())
             .ReturnsAsync(_glossary);
 
         var service = BuildService(glossaryService: glossaryService.Object);
@@ -72,7 +72,7 @@ public class GlossaryCacheServiceTests : CacheServiceTestFixture
         var glossaryService = new Mock<IGlossaryService>(Strict);
 
         glossaryService
-            .Setup(s => s.GetAllGlossaryEntries())
+            .Setup(s => s.GetGlossary())
             .ReturnsAsync(_glossary);
 
         PublicBlobCacheService

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/GlossaryServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/GlossaryServiceTests.cs
@@ -11,12 +11,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
     public class GlossaryServiceTests
     {
         [Fact]
-        public async Task GetAllGlossaryEntries()
+        public async Task GetGlossary()
         {
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                await context.AddRangeAsync(
+                await context.GlossaryEntries.AddRangeAsync(
                     new GlossaryEntry
                     {
                         Title = "Exclusion",
@@ -42,7 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             {
                 var glossaryService = new GlossaryService(context);
 
-                var result = await glossaryService.GetAllGlossaryEntries();
+                var result = await glossaryService.GetGlossary();
 
                 Assert.Equal(26, result.Count);
 
@@ -70,16 +70,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetAllGlossaryEntries_NoEntries()
+        public async Task GetGlossary_NoEntries()
         {
             await using var context = InMemoryContentDbContext();
             var glossaryService = new GlossaryService(context);
 
-            var result = await glossaryService.GetAllGlossaryEntries();
+            var result = await glossaryService.GetGlossary();
 
             Assert.Equal(26, result.Count);
 
-            result.ForEach(category => Assert.Empty(category.Entries));
+            Assert.All(result, category => Assert.Empty(category.Entries));
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                await context.AddAsync(
+                await context.GlossaryEntries.AddAsync(
                     new GlossaryEntry
                     {
                         Title = "Exclusion",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/GlossaryServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/GlossaryServiceTests.cs
@@ -1,8 +1,11 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
 
@@ -13,71 +16,55 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task GetGlossary()
         {
+            var entries = new List<GlossaryEntry>
+            {
+                new()
+                {
+                    Title = "Exclusions",
+                    Slug = "exclusions-slug",
+                    Body = "Exclusions body"
+                },
+                new()
+                {
+                    Title = "Absence",
+                    Slug = "absence-slug",
+                    Body = "Absence body"
+                }
+            };
+
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                await context.GlossaryEntries.AddRangeAsync(
-                    new GlossaryEntry
-                    {
-                        Title = "Exclusion",
-                        Slug = "exclusion",
-                        Body = "Exclusion body",
-                    },
-                    new GlossaryEntry
-                    {
-                        Title = "Absence",
-                        Slug = "absence",
-                        Body = "Absence body",
-                    },
-                    new GlossaryEntry
-                    {
-                        Title = "expedient", // lowercase first letter
-                        Slug = "expedient-slug",
-                        Body = "Expedient body"
-                    });
+                await context.GlossaryEntries.AddRangeAsync(entries);
                 await context.SaveChangesAsync();
             }
 
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                var glossaryService = new GlossaryService(context);
+                var glossaryService = BuildService(contentDbContext: context);
 
                 var result = await glossaryService.GetGlossary();
 
                 Assert.Equal(26, result.Count);
 
-                Assert.Equal("A", result[0].Heading);
-                Assert.Single(result[0].Entries);
-                Assert.Equal("Absence", result[0].Entries[0].Title);
-                Assert.Equal("absence", result[0].Entries[0].Slug);
-                Assert.Equal("Absence body", result[0].Entries[0].Body);
+                var categoryA = result[0];
+                Assert.Single(categoryA.Entries);
 
-                Assert.Equal("B", result[1].Heading);
-                Assert.Empty(result[1].Entries);
+                AssertGlossaryEntry(entries[1], categoryA.Entries[0]);
 
-                Assert.Equal("E", result[4].Heading);
-                Assert.Equal(2, result[4].Entries.Count);
-                Assert.Equal("Exclusion", result[4].Entries[0].Title);
-                Assert.Equal("exclusion", result[4].Entries[0].Slug);
-                Assert.Equal("Exclusion body", result[4].Entries[0].Body);
-                Assert.Equal("expedient", result[4].Entries[1].Title);
-                Assert.Equal("expedient-slug", result[4].Entries[1].Slug);
-                Assert.Equal("Expedient body", result[4].Entries[1].Body);
+                var categoryE = result[4];
+                Assert.Single(categoryE.Entries);
 
-                Assert.Equal("Z", result[25].Heading);
-                Assert.Empty(result[25].Entries);
+                AssertGlossaryEntry(entries[0], categoryE.Entries[0]);
             }
         }
 
         [Fact]
         public async Task GetGlossary_NoEntries()
         {
-            await using var context = InMemoryContentDbContext();
-            var glossaryService = new GlossaryService(context);
+            var glossaryService = BuildService();
 
             var result = await glossaryService.GetGlossary();
-
-            Assert.Equal(26, result.Count);
 
             Assert.All(result, category => Assert.Empty(category.Entries));
         }
@@ -85,43 +72,55 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task GetGlossaryEntry()
         {
+            var entry = new GlossaryEntry
+            {
+                Title = "Exclusions",
+                Slug = "exclusions-slug",
+                Body = "Exclusions body"
+            };
+
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                await context.GlossaryEntries.AddAsync(
-                    new GlossaryEntry
-                    {
-                        Title = "Exclusion",
-                        Slug = "exclusion",
-                        Body = "Exclusion body",
-                    }
-                );
+                await context.GlossaryEntries.AddRangeAsync(entry);
                 await context.SaveChangesAsync();
             }
 
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                var glossaryService = new GlossaryService(context);
+                var glossaryService = BuildService(contentDbContext: context);
 
-                var result = await glossaryService.GetGlossaryEntry("exclusion");
+                var result = await glossaryService.GetGlossaryEntry("exclusions-slug");
 
                 var viewModel = result.AssertRight();
 
-                Assert.Equal("Exclusion", viewModel.Title);
-                Assert.Equal("exclusion", viewModel.Slug);
-                Assert.Equal("Exclusion body", viewModel.Body);
+                AssertGlossaryEntry(entry, viewModel);
             }
         }
 
         [Fact]
         public async Task GetGlossaryEntry_NotFound()
         {
-            await using var context = InMemoryContentDbContext();
-            var glossaryService = new GlossaryService(context);
+            var glossaryService = BuildService();
 
-            var result = await glossaryService.GetGlossaryEntry("absence");
+            var result = await glossaryService.GetGlossaryEntry("absence-slug");
 
             result.AssertNotFound();
+        }
+
+        private static void AssertGlossaryEntry(GlossaryEntry glossaryEntry, GlossaryEntryViewModel viewModel)
+        {
+            Assert.Equal(glossaryEntry.Title, viewModel.Title);
+            Assert.Equal(glossaryEntry.Slug, viewModel.Slug);
+            Assert.Equal(glossaryEntry.Body, viewModel.Body);
+        }
+
+        private static GlossaryService BuildService(
+            ContentDbContext? contentDbContext = null)
+        {
+            return new GlossaryService(
+                contentDbContext ?? InMemoryContentDbContext()
+            );
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/GlossaryCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/GlossaryCacheService.cs
@@ -20,12 +20,12 @@ public class GlossaryCacheService : IGlossaryCacheService
     [BlobCache(typeof(GlossaryCacheKey), ServiceName = "public")]
     public Task<List<GlossaryCategoryViewModel>> GetGlossary()
     {
-        return _glossaryService.GetAllGlossaryEntries();
+        return _glossaryService.GetGlossary();
     }
 
     [BlobCache(typeof(GlossaryCacheKey), forceUpdate: true, ServiceName = "public")]
     public Task<List<GlossaryCategoryViewModel>> UpdateGlossary()
     {
-        return _glossaryService.GetAllGlossaryEntries();
+        return _glossaryService.GetGlossary();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GlossaryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GlossaryService.cs
@@ -19,7 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             _contentDbContext = contentDbContext;
         }
 
-        public async Task<List<GlossaryCategoryViewModel>> GetAllGlossaryEntries()
+        public async Task<List<GlossaryCategoryViewModel>> GetGlossary()
         {
             var categories = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".ToCharArray();
             var categoryDictionary = categories.ToDictionary(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GlossaryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GlossaryService.cs
@@ -1,12 +1,14 @@
 #nullable enable
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services
 {
@@ -21,56 +23,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
 
         public async Task<List<GlossaryCategoryViewModel>> GetGlossary()
         {
-            var categories = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".ToCharArray();
-            var categoryDictionary = categories.ToDictionary(
-                c => c.ToString(),
-                c => new GlossaryCategoryViewModel
-                {
-                    Heading = c.ToString(),
-                    Entries = new List<GlossaryEntryViewModel>(),
-                });
-
-            var allGlossaryEntries = await _contentDbContext.GlossaryEntries
-                .ToAsyncEnumerable()
-                .OrderBy(e => e.Title)
+            var glossaryEntries = await _contentDbContext.GlossaryEntries
                 .ToListAsync();
-
-            allGlossaryEntries
-                .ForEach(e =>
-                {
-                    categoryDictionary[e.Title[..1].ToUpper()].Entries
-                        .Add(new GlossaryEntryViewModel
-                    {
-                        Title = e.Title,
-                        Slug = e.Slug,
-                        Body = e.Body,
-                    });
-                });
-
-            return categoryDictionary
-                .Values
-                .OrderBy(c => c.Heading)
-                .ToList();
+            return GlossaryUtils.BuildGlossary(glossaryEntries);
         }
 
         public async Task<Either<ActionResult, GlossaryEntryViewModel>> GetGlossaryEntry(string slug)
         {
-            var glossaryEntry = await _contentDbContext.GlossaryEntries
-                .ToAsyncEnumerable()
-                .Where(e => e.Slug == slug)
-                .SingleOrDefaultAsync();
-
-            if (glossaryEntry == null)
-            {
-                return new NotFoundResult();
-            }
-
-            return new GlossaryEntryViewModel
-            {
-                Title = glossaryEntry!.Title,
-                Slug = glossaryEntry.Slug,
-                Body = glossaryEntry.Body,
-            };
+            return await _contentDbContext.GlossaryEntries
+                .SingleOrNotFoundAsync(e => e.Slug == slug)
+                .OnSuccess(e => new GlossaryEntryViewModel(
+                    Title: e.Title,
+                    Slug: e.Slug,
+                    Body: e.Body
+                ));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IGlossaryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IGlossaryService.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces
 {
     public interface IGlossaryService
     {
-        Task<List<GlossaryCategoryViewModel>> GetAllGlossaryEntries();
+        Task<List<GlossaryCategoryViewModel>> GetGlossary();
 
         Task<Either<ActionResult, GlossaryEntryViewModel>> GetGlossaryEntry(string slug);
     }


### PR DESCRIPTION
This PR adds a new method to the Admin glossary controller to get the glossary.

This is largely a duplicate of the code in the Public glossary controller to get the glossary, with the exception of the code to build the glossary which is made common.

This PR also:

- Renames `GetAllGlossaryEntries` methods to `GetGlossary` since they return a list of categories rather than entries which collectively make up the glossary.
- Changes `GlossaryEntryViewModel` and `GlossaryCategoryViewModel` from `class` to `record` types.
- Changes `GlossaryCategoryViewModel.Heading` from `string` to `char` since we expect this to be a single character in the range A-Z.
- Adds new `GlossaryUtils.BuildGlossary(IReadOnlyList<GlossaryEntry> entries)` to build a glossary for a list of entries which is common to both the Admin and Public services.
- Adds new `GlossaryCategoryViewModel.BuildGlossaryCategories()` to build an empty glossary of categories in the range A-Z.
- Improves the unit tests to assert glossary categories have expected headings and entries for the range A-Z.