### PR TITLE
Disable productionBrowserSourceMaps for public frontend

### DIFF
--- a/src/explore-education-statistics-frontend/next.config.js
+++ b/src/explore-education-statistics-frontend/next.config.js
@@ -16,7 +16,6 @@ const nextConfig = {
     GA_TRACKING_ID: process.env.GA_TRACKING_ID,
     PUBLIC_URL: process.env.PUBLIC_URL,
   },
-  productionBrowserSourceMaps: true,
   async redirects() {
     return [
       {


### PR DESCRIPTION
This undoes the change made in https://github.com/dfe-analytical-services/explore-education-statistics/pull/4205

This should be merged before the next cut to master.