### PR TITLE
EES-4450 fix table rendering when data is missing

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableDataWithMergedCells.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableDataWithMergedCells.ts
@@ -649,3 +649,67 @@ export const testTableWithMergedAndUnmergedCellsInLastLevelOfHeaders: FullTable 
     },
   ],
 };
+
+export const testTableWithMergedCellsAndMissingDataColHeadersConfig: TableHeadersConfig = {
+  columns: [category1Group2Filter1, category1Group1Filter1],
+  columnGroups: [[category2Group1Filter1, category2Group1Filter2]],
+  rows: [timePeriod1],
+  rowGroups: [[indicator1]],
+};
+
+export const testTableWithMergedCellsAndMissingDataRowHeadersConfig: TableHeadersConfig = {
+  columns: [timePeriod1],
+  columnGroups: [[indicator1]],
+  rows: [category1Group2Filter1, category1Group1Filter1],
+  rowGroups: [[category2Group1Filter1, category2Group1Filter2]],
+};
+
+export const testTableWithMergedCellsAndMissingData: FullTable = {
+  subjectMeta: {
+    ...testInitialTableSubjectMeta,
+    filters: {
+      Category1: {
+        name: 'category_1',
+        options: [category1Group1Filter1, category1Group2Filter1],
+        order: 0,
+      },
+      Category2: {
+        name: 'category_2',
+        options: [category2Group1Filter1, category2Group1Filter2],
+        order: 0,
+      },
+    },
+    indicators: [indicator1],
+    locations: [location1],
+    timePeriodRange: [timePeriod1],
+  },
+  results: [
+    {
+      filters: [category1Group2Filter1.id, category2Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '43870',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category2Group1Filter1.id, category1Group1Filter1.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '56840',
+      },
+      timePeriod: timePeriod1.id,
+    },
+    {
+      filters: [category1Group1Filter1.id, category2Group1Filter2.id],
+      geographicLevel: 'country',
+      locationId: location1.value,
+      measures: {
+        [indicator1.id]: '320',
+      },
+      timePeriod: timePeriod1.id,
+    },
+  ],
+};

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/createExpandedColumnHeaders.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/createExpandedColumnHeaders.test.ts
@@ -1543,4 +1543,971 @@ describe('createExpandedColumnHeaders', () => {
       expandedColumnHeaders,
     );
   });
+
+  describe('a mix of rows with merged headers without siblings and merged headers with siblings', () => {
+    test('returns correct headers for scenario 1', () => {
+      const columnHeaders: Header[] = [
+        new Header('A', 'A')
+          .addChild(
+            new Header('C', 'C')
+              .addChild(new Header('D', 'D'))
+              .addChild(new Header('Total', 'Total')),
+          )
+          .addChild(
+            new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+          ),
+        new Header('B', 'B').addChild(
+          new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+        ),
+      ];
+
+      const expandedColumnHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 3,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'B',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'D',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+      ];
+
+      expect(createExpandedColumnHeaders(columnHeaders)).toEqual(
+        expandedColumnHeaders,
+      );
+    });
+
+    test('returns correct headers for scenario 2', () => {
+      const columnHeaders: Header[] = [
+        new Header('A', 'A').addChild(
+          new Header('Total', 'Total').addChild(
+            new Header('Total', 'Total')
+              .addChild(new Header('C', 'C'))
+              .addChild(new Header('D', 'D')),
+          ),
+        ),
+        new Header('B', 'B')
+          .addChild(
+            new Header('Total', 'Total').addChild(
+              new Header('Total', 'Total')
+                .addChild(new Header('C', 'C'))
+                .addChild(new Header('D', 'D')),
+            ),
+          )
+          .addChild(
+            new Header('E', 'E').addChild(
+              new Header('F', 'F')
+                .addChild(new Header('C', 'C'))
+                .addChild(new Header('D', 'D')),
+            ),
+          ),
+      ];
+
+      const expandedColumnHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'B',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'E',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'F',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'D',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'D',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'D',
+          },
+        ],
+      ];
+
+      expect(createExpandedColumnHeaders(columnHeaders)).toEqual(
+        expandedColumnHeaders,
+      );
+    });
+
+    test('returns correct headers for scenario 3', () => {
+      const columnHeaders: Header[] = [
+        new Header('A', 'A').addChild(
+          new Header('Total', 'Total').addChild(
+            new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+          ),
+        ),
+        new Header('B', 'B')
+          .addChild(
+            new Header('Total', 'Total').addChild(
+              new Header('Total', 'Total')
+                .addChild(new Header('Total', 'Total'))
+                .addChild(new Header('D', 'D')),
+            ),
+          )
+          .addChild(
+            new Header('E', 'E').addChild(
+              new Header('F', 'F')
+                .addChild(new Header('Total', 'Total'))
+                .addChild(new Header('D', 'D')),
+            ),
+          ),
+      ];
+
+      const expandedColumnHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'B',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 3,
+            scope: 'col',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'E',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'F',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'D',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'D',
+          },
+        ],
+      ];
+
+      expect(createExpandedColumnHeaders(columnHeaders)).toEqual(
+        expandedColumnHeaders,
+      );
+    });
+
+    test('returns correct headers for scenario 4', () => {
+      const columnHeaders: Header[] = [
+        new Header('E', 'E').addChild(
+          new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+        ),
+        new Header('A', 'A')
+          .addChild(
+            new Header('C', 'C')
+              .addChild(new Header('D', 'D'))
+              .addChild(new Header('Total', 'Total')),
+          )
+          .addChild(
+            new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+          ),
+        new Header('B', 'B').addChild(
+          new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+        ),
+      ];
+
+      const expandedColumnHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'E',
+          },
+          {
+            colSpan: 3,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'B',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'D',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+      ];
+
+      expect(createExpandedColumnHeaders(columnHeaders)).toEqual(
+        expandedColumnHeaders,
+      );
+    });
+
+    test('returns correct headers for scenario 5', () => {
+      const columnHeaders: Header[] = [
+        new Header('A', 'A').addChild(
+          new Header('Total', 'Total').addChild(
+            new Header('Total', 'Total')
+              .addChild(new Header('C', 'C').addChild(new Header('C', 'C')))
+              .addChild(
+                new Header('D', 'D')
+                  .addChild(new Header('G', 'G'))
+                  .addChild(new Header('C', 'C')),
+              ),
+          ),
+        ),
+        new Header('B', 'B')
+          .addChild(
+            new Header('Total', 'Total').addChild(
+              new Header('Total', 'Total')
+                .addChild(
+                  new Header('C', 'C')
+                    .addChild(new Header('G', 'G'))
+                    .addChild(new Header('C', 'C')),
+                )
+                .addChild(
+                  new Header('D', 'D')
+                    .addChild(new Header('G', 'G'))
+                    .addChild(new Header('C', 'C')),
+                ),
+            ),
+          )
+          .addChild(
+            new Header('E', 'E').addChild(
+              new Header('F', 'F').addChild(
+                new Header('C', 'C').addChild(new Header('C', 'C')),
+              ),
+            ),
+          ),
+      ];
+
+      const expandedColumnHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 3,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 5,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'B',
+          },
+        ],
+        [
+          {
+            colSpan: 3,
+            rowSpan: 2,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 4,
+            rowSpan: 2,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'E',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'F',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'D',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'D',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'G',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'G',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'G',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+      ];
+
+      expect(createExpandedColumnHeaders(columnHeaders)).toEqual(
+        expandedColumnHeaders,
+      );
+    });
+
+    test('returns correct headers for scenario 6', () => {
+      const columnHeaders: Header[] = [
+        new Header('A', 'A')
+          .addChild(new Header('C', 'C').addChild(new Header('C', 'C')))
+          .addChild(new Header('D', 'D').addChild(new Header('D', 'D'))),
+        new Header('B', 'B')
+          .addChild(
+            new Header('E', 'E')
+              .addChild(new Header('F', 'F'))
+              .addChild(new Header('G', 'G')),
+          )
+          .addChild(
+            new Header('H', 'H')
+              .addChild(new Header('I', 'I'))
+              .addChild(new Header('J', 'J')),
+          ),
+      ];
+
+      const expandedColumnHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'B',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'D',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'E',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'H',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'F',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'G',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'I',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'J',
+          },
+        ],
+      ];
+
+      expect(createExpandedColumnHeaders(columnHeaders)).toEqual(
+        expandedColumnHeaders,
+      );
+    });
+
+    test('returns correct headers for scenario 7', () => {
+      const columnHeaders: Header[] = [
+        new Header('A', 'A').addChild(
+          new Header('C', 'C')
+            .addChild(new Header('F', 'F').addChild(new Header('G', 'G')))
+            .addChild(new Header('H', 'H').addChild(new Header('H', 'H')))
+            .addChild(new Header('F', 'F').addChild(new Header('F', 'F'))),
+        ),
+
+        new Header('B', 'B').addChild(
+          new Header('E', 'E')
+            .addChild(new Header('H', 'H').addChild(new Header('H', 'H')))
+            .addChild(new Header('F', 'F').addChild(new Header('F', 'F'))),
+        ),
+      ];
+
+      const expandedColumnHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 3,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'B',
+          },
+        ],
+        [
+          {
+            colSpan: 3,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'E',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'F',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'H',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'F',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'H',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'F',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'G',
+          },
+        ],
+      ];
+
+      expect(createExpandedColumnHeaders(columnHeaders)).toEqual(
+        expandedColumnHeaders,
+      );
+    });
+
+    test('returns correct headers for scenario 8', () => {
+      const columnHeaders: Header[] = [
+        new Header('A', 'A').addChild(
+          new Header('C', 'C')
+            .addChild(
+              new Header('F', 'F').addChild(
+                new Header('G', 'G')
+                  .addChild(new Header('X', 'X'))
+                  .addChild(new Header('Y', 'Y')),
+              ),
+            )
+            .addChild(
+              new Header('H', 'H').addChild(
+                new Header('H', 'H')
+                  .addChild(new Header('X', 'X'))
+                  .addChild(new Header('Y', 'Y')),
+              ),
+            ),
+        ),
+        new Header('B', 'B').addChild(
+          new Header('E', 'E')
+            .addChild(
+              new Header('F', 'F').addChild(
+                new Header('F', 'F')
+                  .addChild(new Header('X', 'X'))
+                  .addChild(new Header('Y', 'Y')),
+              ),
+            )
+            .addChild(
+              new Header('H', 'H').addChild(
+                new Header('H', 'H')
+                  .addChild(new Header('X', 'X'))
+                  .addChild(new Header('Y', 'Y')),
+              ),
+            ),
+        ),
+      ];
+
+      const expandedColumnHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'B',
+          },
+        ],
+        [
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 4,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'E',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'F',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'H',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'F',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'H',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'G',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'X',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Y',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'X',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Y',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'X',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Y',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'X',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Y',
+          },
+        ],
+      ];
+
+      expect(createExpandedColumnHeaders(columnHeaders)).toEqual(
+        expandedColumnHeaders,
+      );
+    });
+  });
 });

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/createExpandedRowHeaders.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/createExpandedRowHeaders.test.ts
@@ -1887,4 +1887,1087 @@ describe('createExpandedRowHeaders', () => {
 
     expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
   });
+
+  describe('a mix of rows with merged headers without siblings and merged headers with siblings', () => {
+    test('returns correct headers for scenario 1', () => {
+      const rowHeaders: Header[] = [
+        new Header('A', 'A')
+          .addChild(
+            new Header('C', 'C')
+              .addChild(new Header('D', 'D'))
+              .addChild(new Header('Total', 'Total')),
+          )
+          .addChild(
+            new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+          ),
+        new Header('B', 'B').addChild(
+          new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+        ),
+      ];
+
+      const expandedRowHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 3,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'D',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'B',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+      ];
+
+      expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+    });
+
+    test('returns correct headers for scenario 2', () => {
+      const rowHeaders: Header[] = [
+        new Header('A', 'A').addChild(
+          new Header('Total', 'Total').addChild(
+            new Header('Total', 'Total')
+              .addChild(new Header('C', 'C'))
+              .addChild(new Header('D', 'D')),
+          ),
+        ),
+        new Header('B', 'B')
+          .addChild(
+            new Header('Total', 'Total').addChild(
+              new Header('Total', 'Total')
+                .addChild(new Header('C', 'C'))
+                .addChild(new Header('D', 'D')),
+            ),
+          )
+          .addChild(
+            new Header('E', 'E').addChild(
+              new Header('F', 'F')
+                .addChild(new Header('C', 'C'))
+                .addChild(new Header('D', 'D')),
+            ),
+          ),
+      ];
+
+      const expandedRowHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'D',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'B',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'D',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'E',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'F',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'D',
+          },
+        ],
+      ];
+
+      expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+    });
+
+    test('returns correct headers for scenario 3', () => {
+      const rowHeaders: Header[] = [
+        new Header('A', 'A').addChild(
+          new Header('Total', 'Total').addChild(
+            new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+          ),
+        ),
+        new Header('B', 'B')
+          .addChild(
+            new Header('Total', 'Total').addChild(
+              new Header('Total', 'Total')
+                .addChild(new Header('Total', 'Total'))
+                .addChild(new Header('D', 'D')),
+            ),
+          )
+          .addChild(
+            new Header('E', 'E').addChild(
+              new Header('F', 'F')
+                .addChild(new Header('Total', 'Total'))
+                .addChild(new Header('D', 'D')),
+            ),
+          ),
+      ];
+
+      const expandedRowHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 3,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+
+        [
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'B',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'D',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'E',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'F',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'D',
+          },
+        ],
+      ];
+
+      expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+    });
+
+    test('returns correct headers for scenario 4', () => {
+      const rowHeaders: Header[] = [
+        new Header('E', 'E').addChild(
+          new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+        ),
+        new Header('A', 'A')
+          .addChild(
+            new Header('C', 'C')
+              .addChild(new Header('D', 'D'))
+              .addChild(new Header('Total', 'Total')),
+          )
+          .addChild(
+            new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+          ),
+        new Header('B', 'B').addChild(
+          new Header('Total', 'Total').addChild(new Header('Total', 'Total')),
+        ),
+      ];
+
+      const expandedRowHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'E',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 3,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'D',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'B',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Total',
+          },
+        ],
+      ];
+
+      expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+    });
+
+    test('returns correct headers for scenario 5', () => {
+      const rowHeaders: Header[] = [
+        new Header('A', 'A').addChild(
+          new Header('Total', 'Total').addChild(
+            new Header('Total', 'Total')
+              .addChild(new Header('C', 'C').addChild(new Header('C', 'C')))
+              .addChild(
+                new Header('D', 'D')
+                  .addChild(new Header('G', 'G'))
+                  .addChild(new Header('C', 'C')),
+              ),
+          ),
+        ),
+        new Header('B', 'B')
+          .addChild(
+            new Header('Total', 'Total').addChild(
+              new Header('Total', 'Total')
+                .addChild(
+                  new Header('C', 'C')
+                    .addChild(new Header('G', 'G'))
+                    .addChild(new Header('C', 'C')),
+                )
+                .addChild(
+                  new Header('D', 'D')
+                    .addChild(new Header('G', 'G'))
+                    .addChild(new Header('C', 'C')),
+                ),
+            ),
+          )
+          .addChild(
+            new Header('E', 'E').addChild(
+              new Header('F', 'F').addChild(
+                new Header('C', 'C').addChild(new Header('C', 'C')),
+              ),
+            ),
+          ),
+      ];
+
+      const expandedRowHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 3,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 3,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'D',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'G',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 5,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'B',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Total',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'G',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'D',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'G',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'E',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'F',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+      ];
+
+      expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+    });
+
+    test('returns correct headers for scenario 6', () => {
+      const rowHeaders: Header[] = [
+        new Header('A', 'A')
+          .addChild(new Header('C', 'C').addChild(new Header('C', 'C')))
+          .addChild(new Header('D', 'D').addChild(new Header('D', 'D'))),
+        new Header('B', 'B')
+          .addChild(
+            new Header('E', 'E')
+              .addChild(new Header('F', 'F'))
+              .addChild(new Header('G', 'G')),
+          )
+          .addChild(
+            new Header('H', 'H')
+              .addChild(new Header('I', 'I'))
+              .addChild(new Header('J', 'J')),
+          ),
+      ];
+
+      const expandedRowHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'D',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'B',
+          },
+
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'E',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'F',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'G',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'H',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'I',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'J',
+          },
+        ],
+      ];
+
+      expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+    });
+
+    test('returns correct headers for scenario 7', () => {
+      const rowHeaders: Header[] = [
+        new Header('A', 'A').addChild(
+          new Header('C', 'C')
+            .addChild(new Header('F', 'F').addChild(new Header('G', 'G')))
+            .addChild(new Header('H', 'H').addChild(new Header('H', 'H')))
+            .addChild(new Header('F', 'F').addChild(new Header('F', 'F'))),
+        ),
+
+        new Header('B', 'B').addChild(
+          new Header('E', 'E')
+            .addChild(new Header('H', 'H').addChild(new Header('H', 'H')))
+            .addChild(new Header('F', 'F').addChild(new Header('F', 'F'))),
+        ),
+      ];
+
+      const expandedRowHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 3,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 3,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'F',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'G',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'H',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'F',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'B',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'E',
+          },
+
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'H',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'F',
+          },
+        ],
+      ];
+
+      expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+    });
+
+    test('returns correct headers for scenario 8', () => {
+      const rowHeaders: Header[] = [
+        new Header('A', 'A').addChild(
+          new Header('C', 'C')
+            .addChild(
+              new Header('F', 'F').addChild(
+                new Header('G', 'G')
+                  .addChild(new Header('X', 'X'))
+                  .addChild(new Header('Y', 'Y')),
+              ),
+            )
+            .addChild(
+              new Header('H', 'H').addChild(
+                new Header('H', 'H')
+                  .addChild(new Header('X', 'X'))
+                  .addChild(new Header('Y', 'Y')),
+              ),
+            ),
+        ),
+        new Header('B', 'B').addChild(
+          new Header('E', 'E')
+            .addChild(
+              new Header('F', 'F').addChild(
+                new Header('F', 'F')
+                  .addChild(new Header('X', 'X'))
+                  .addChild(new Header('Y', 'Y')),
+              ),
+            )
+            .addChild(
+              new Header('H', 'H').addChild(
+                new Header('H', 'H')
+                  .addChild(new Header('X', 'X'))
+                  .addChild(new Header('Y', 'Y')),
+              ),
+            ),
+        ),
+      ];
+
+      const expandedRowHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'C',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'F',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'G',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'X',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Y',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'H',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'X',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Y',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'B',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'E',
+          },
+
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'F',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'X',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Y',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'H',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'X',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Y',
+          },
+        ],
+      ];
+
+      expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+    });
+
+    test('returns correct headers for scenario 9', () => {
+      const rowHeaders: Header[] = [
+        new Header('A', 'A')
+          .addChild(new Header('C', 'C').addChild(new Header('C', 'C')))
+          .addChild(new Header('D', 'D').addChild(new Header('D', 'D')))
+          .addChild(
+            new Header('E', 'E')
+              .addChild(new Header('F', 'F'))
+              .addChild(new Header('G', 'G')),
+          ),
+        new Header('B', 'B')
+          .addChild(new Header('C', 'C').addChild(new Header('C', 'C')))
+          .addChild(new Header('E', 'E').addChild(new Header('E', 'E'))),
+      ];
+
+      const expandedRowHeaders: TableCellJson[][] = [
+        [
+          {
+            colSpan: 1,
+            rowSpan: 4,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'A',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'D',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'E',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'F',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'G',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'B',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'C',
+          },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'E',
+          },
+        ],
+      ];
+
+      expect(createExpandedRowHeaders(rowHeaders)).toEqual(expandedRowHeaders);
+    });
+  });
 });

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableToJson.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableToJson.test.ts
@@ -34,6 +34,9 @@ import {
   testTableWithOnlyMergedCellsInLastLevelOfRowHeadersConfig,
   testTableWithMergedAndUnmergedCellsInLastLevelOfHeaders,
   testTableWithMergedAndUnmergedCellsInLastLevelOfRowHeadersConfig,
+  testTableWithMergedCellsAndMissingData,
+  testTableWithMergedCellsAndMissingDataRowHeadersConfig,
+  testTableWithMergedCellsAndMissingDataColHeadersConfig,
 } from '@common/modules/table-tool/utils/__data__/testTableDataWithMergedCells';
 import mapTableToJson, {
   TableCellJson,
@@ -1757,6 +1760,81 @@ describe('mapTableToJson', () => {
         ],
       ]);
     });
+
+    test('returns the correct JSON with merged cells and missing data', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMergedCellsAndMissingDataColHeadersConfig,
+        subjectMeta: testTableWithMergedCellsAndMissingData.subjectMeta,
+        results: testTableWithMergedCellsAndMissingData.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 1, rowSpan: 3, tag: 'td' },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'colgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Category 1 Group 2 Filter 1',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Indicator 1',
+          },
+          { tag: 'td', text: '43,870' },
+          { tag: 'td', text: '56,840' },
+          { tag: 'td', text: '320' },
+        ],
+      ]);
+    });
   });
 
   describe('Handles merged row headers', () => {
@@ -2384,6 +2462,82 @@ describe('mapTableToJson', () => {
             text: 'Category 1 Group 2 Filter 1',
           },
           { tag: 'td', text: '87' },
+        ],
+      ]);
+    });
+
+    test('returns the correct JSON with merged cells and missing data', () => {
+      const result = mapTableToJson({
+        tableHeadersConfig: testTableWithMergedCellsAndMissingDataRowHeadersConfig,
+        subjectMeta: testTableWithMergedCellsAndMissingData.subjectMeta,
+        results: testTableWithMergedCellsAndMissingData.results,
+      }).tableJson;
+
+      expect(result.thead).toEqual<TableCellJson[][]>([
+        [
+          { colSpan: 3, rowSpan: 1, tag: 'td' },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'col',
+            tag: 'th',
+            text: 'Indicator 1',
+          },
+        ],
+      ]);
+
+      expect(result.tbody).toEqual<TableCellJson[][]>([
+        [
+          {
+            colSpan: 1,
+            rowSpan: 2,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 1',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 1 Group 2',
+          },
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 2 Filter 1',
+          },
+          { tag: 'td', text: '43,870' },
+        ],
+        [
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+
+          { tag: 'td', text: '56,840' },
+        ],
+        [
+          {
+            colSpan: 1,
+            rowSpan: 1,
+            scope: 'rowgroup',
+            tag: 'th',
+            text: 'Category 2 Group 1 Filter 2',
+          },
+          {
+            colSpan: 2,
+            rowSpan: 1,
+            scope: 'row',
+            tag: 'th',
+            text: 'Category 1 Group 1',
+          },
+          { tag: 'td', text: '320' },
         ],
       ]);
     });


### PR DESCRIPTION
The permalink migration testing exposed problems caused by our earlier table fixes in https://github.com/dfe-analytical-services/explore-education-statistics/pull/4110

The previous fix corrected row headers when there are collapsed cells (because of duplicate labels), it did this by checking if all the headers at a level were collapsed, so didn't need to span across 2 columns. However it only checked against other headers in the current `rowHeader` (A or B in the below example), it didn't take into account that rows which are excluded because of missing data could mean that all the headers are collapsed at a level in some rowHeaders but not in others. 

Example: there isn't any data for B > E > F/G so those rows have been excluded from the table, meaning that for B all the headers at level 1 are collapsed. There is data for A > E > F/G so those rows are shown.  With the previous fix, C and D in B were given the wrong `colSpan` (1) as all the headers at level 1 under B are collapsed, now it takes into account the headers under A as well and so they are given `colSpan` 2.

![headers-example](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/4680c7d0-5c30-4efb-bf90-44fe8023773e)

