### PR TITLE
Fixing UI test failure in general_public suite

### DIFF
--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -83,7 +83,7 @@ Validate the query could exceed the maximum allowable table size
     user waits until page contains
     ...    Could not create table as the filters chosen may exceed the maximum allowed table size.
     user waits until page contains    Select different filters or download the subject data.
-    user waits until page contains button    Download Exclusions by geographic level (csv, 512 B)    %{WAIT_MEDIUM}
+    user waits until page contains button    Download Exclusions by geographic level (csv, 37 MB)    %{WAIT_MEDIUM}
 
 Go back to Locations step
     user clicks button    Edit locations


### PR DESCRIPTION
Fixing UI tests with the keywords -Validate the query could exceed the maximum allowable table size-
Changed the fie size for the release 'Exclusions by geographic level' to match with that on Dev.