### PR TITLE
EES-4352 Improvements to build pipeline

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,8 @@
 name: CodeQL
 on:
   push:
-    branches: [ dev, master ]
-  pull_request:
-    branches: [ dev ]
-  schedule:
-    - cron: '0 8 * * 1'
+    branches:
+      - dev
 jobs:
   analyze:
     name: Analyze

--- a/azure-pipelines-ui-tests.dfe.yml
+++ b/azure-pipelines-ui-tests.dfe.yml
@@ -22,6 +22,8 @@ jobs:
   cancelTimeoutInMinutes: 10
   condition: succeededOrFailed()
   pool: ees-ubuntu2204-large
+  workspace:
+    clean: all
   steps:
   - checkout: self
     clean: true
@@ -80,6 +82,8 @@ jobs:
   cancelTimeoutInMinutes: 10
   condition: succeededOrFailed()
   pool: ees-ubuntu2204-large
+  workspace:
+    clean: all
   steps:
   - checkout: self
     clean: true
@@ -139,6 +143,8 @@ jobs:
   cancelTimeoutInMinutes: 10
   condition: succeededOrFailed()
   pool: ees-ubuntu2204-large
+  workspace:
+    clean: all
   steps:
   - checkout: self
     clean: true
@@ -199,6 +205,8 @@ jobs:
   cancelTimeoutInMinutes: 10
   condition: succeededOrFailed()
   pool: ees-ubuntu2204-large
+  workspace:
+    clean: all
   steps:
   - checkout: self
     clean: true

--- a/azure-pipelines.dfe.yml
+++ b/azure-pipelines.dfe.yml
@@ -1,5 +1,14 @@
+parameters:
+  - name: DeployBranches
+    displayName: Branches that should be deployed
+    type: object
+    default:
+      - master
+      - dev
+
 variables:
   BuildConfiguration: 'Release'
+  IsBranchDeployable: ${{ containsValue(parameters.DeployBranches, variables['Build.SourceBranchName']) }}
   CI: true
   NODE_VERSION: 16.14.2
   DOTNET_VERSION: 6.0.x
@@ -12,7 +21,9 @@ trigger:
   paths:
     exclude:
     - infrastructure/
-pr: [ 'master', 'dev' ]
+pr:
+  - master
+  - dev
 
 jobs:
   - job: 'Backend'
@@ -261,7 +272,7 @@ jobs:
 
       - task: Docker@2
         displayName: 'Build public frontend Docker image'
-        condition: ne(variables['Build.Reason'], 'PullRequest')
+        condition: eq(variables.IsBranchDeployable, true)
         inputs:
           containerRegistry: 's101d-datahub-spn-ees-dfe-gov-uk-docker-managed-service-connection'
           repository: 'ees-public-frontend'
@@ -273,7 +284,7 @@ jobs:
 
       - task: Docker@2
         displayName: 'Push public frontend Docker image'
-        condition: ne(variables['Build.Reason'], 'PullRequest')
+        condition: eq(variables.IsBranchDeployable, true)
         inputs:
           containerRegistry: 's101d-datahub-spn-ees-dfe-gov-uk-docker-managed-service-connection'
           repository: 'ees-public-frontend'

--- a/azure-pipelines.dfe.yml
+++ b/azure-pipelines.dfe.yml
@@ -167,12 +167,6 @@ jobs:
           script: 'pnpm i'
 
       - task: 'Bash@3'
-        displayName: 'pnpm format'
-        inputs:
-          targetType: 'inline'
-          script: 'pnpm format'
-
-      - task: 'Bash@3'
         displayName: 'pnpm run build'
         inputs:
           targetType: 'inline'

--- a/azure-pipelines.dfe.yml
+++ b/azure-pipelines.dfe.yml
@@ -17,6 +17,8 @@ pr: [ 'master', 'dev' ]
 jobs:
   - job: 'Backend'
     pool: 'ees-ubuntu2204-large'
+    workspace:
+      clean: all
     steps:
       - task: UseDotNet@2
         displayName: 'Install .NET Core SDK'
@@ -116,6 +118,8 @@ jobs:
 
   - job: 'Admin'
     pool: 'ees-ubuntu2204-xlarge'
+    workspace:
+      clean: all
     steps:
       - task: NodeTool@0
         displayName: 'Install Node.js $(NODE_VERSION)'
@@ -196,6 +200,8 @@ jobs:
 
   - job: 'Frontend'
     pool: 'ees-ubuntu2204-xlarge'
+    workspace:
+      clean: all
     steps:
       - task: NodeTool@0
         displayName: 'Install Node.js $(NODE_VERSION)'
@@ -285,6 +291,8 @@ jobs:
   - job: 'MiscellaneousArtifacts'
     pool:
       vmImage: 'ubuntu-22.04'
+    workspace:
+      clean: all
     steps:
       - task: CopyFiles@2
         displayName: 'Copy Pipfiles to tests'


### PR DESCRIPTION
This PR:

- Changes CodeQL to only run on commits to `dev`
- Cleans up the entire workspace before running any jobs to avoid artifacts and state leaking between builds
- Remove an unnecessary format step on the `Admin` job
- Prevents the Docker build tasks from running on manual triggers