### PR TITLE
EES-4463 Fix Notifier subscriptions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.32.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />


### PR DESCRIPTION
This PR fixes an error occurring in the Notifier function project when subscribing to a publication.

The error was occurring in TokenService.GenerateToken:L14:
`var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secretKey));`


Exception:

`Could not load file or assembly 'Microsoft.IdentityModel.Tokens, Version=6.32.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.`

It was caused by the dependency upgrades in #4214, specifically the upgrade to `System.IdentityModel.Tokens.Jwt` from 6.9.0 to 6.32.1.

`System.IdentityModel.Tokens.Jwt` 6.32.1 has a dependency on `Microsoft.IdentityModel.Tokens` (>= 6.32.1). Without explicitly defining this dependency it appears to be picking up an older version 6.8.0 implicitly defined by other dependencies.