### PR TITLE
EES-4463 Preserve function dependencies in build process

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
@@ -15,6 +15,11 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.32.1" />
   </ItemGroup>
   <ItemGroup>
+    <FunctionsPreservedDependencies Include="Microsoft.IdentityModel.Logging.dll" />
+    <FunctionsPreservedDependencies Include="Microsoft.IdentityModel.Tokens.dll" />
+    <FunctionsPreservedDependencies Include="System.IdentityModel.Tokens.Jwt.dll" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Notifier.Model\GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This PR makes a change to the Notifier functions project to include required dependencies which have been filtered out of the build.

The function project build performs a post build clean action which optimises the built output to remove any assemblies that are shared with the function host runtime.

The list of existing dependencies that will be filtered out by the clean includes `Microsoft.IdentityModel.Logging.dll`, `Microsoft.IdentityModel.Tokens.dll` and `System.IdentityModel.Tokens.Jwt.dll`.

This cleaning process works based on matching assemblies by name, not by version. This works and creates a smaller build, but causes a problem if the project depends on newer versions than those provided by the runtime.

It results in runtime exceptions like those we are seeing subscribing to publications:

`System.IdentityModel.Tokens.Jwt`:

```
GovUk.Education.ExploreEducationStatistics.Notifier: Could not load file or assembly 'System.IdentityModel.Tokens.Jwt, Version=6.32.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cann
ot find the file specified.
```

`Microsoft.IdentityModel.Tokens`:

```
GovUk.Education.ExploreEducationStatistics.Notifier: Could not load file or assembly 'Microsoft.IdentityModel.Tokens, Version=6.32.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system canno
t find the file specified.
```

`Microsoft.IdentityModel.Logging`:

```
GovUk.Education.ExploreEducationStatistics.Notifier: Could not load file or assembly 'Microsoft.IdentityModel.Logging, Version=6.32.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cann
ot find the file specified.
```
