### PR TITLE
EES-4447 adjust key stat widths

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatPreview.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatPreview.tsx
@@ -8,7 +8,7 @@ import { OmitStrict } from '@common/types';
 import React from 'react';
 
 export interface EditableKeyStatDisplayProps
-  extends OmitStrict<KeyStatProps, 'children' | 'hasColumn'> {
+  extends OmitStrict<KeyStatProps, 'children' | 'includeWrapper'> {
   isReordering: boolean;
   isEditing: boolean;
   onRemove?: () => void;
@@ -25,7 +25,7 @@ export default function EditableKeyStatPreview({
   const { title } = keyStatProps;
 
   return (
-    <KeyStat {...keyStatProps} hasColumn={false}>
+    <KeyStat {...keyStatProps} includeWrapper={false}>
       {isEditing && !isReordering && (
         <ButtonGroup className="govuk-!-margin-top-2">
           <Button onClick={onEdit}>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
@@ -94,7 +94,7 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
                         ref={draggableProvided.innerRef}
                         className={classNames({
                           [styles.draggable]: isReordering,
-                          [keyStatStyles.column]: !isReordering,
+                          [keyStatStyles.wrapper]: !isReordering,
                           [styles.isDragging]: snapshot.isDragging,
                         })}
                         data-testid="keyStat"

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.module.scss
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.module.scss
@@ -12,6 +12,7 @@
   margin: 0;
   padding: 0.2rem 0 0.2rem 0.5rem;
   position: relative;
+  text-align: left;
   width: 100%;
 
   &[open] {
@@ -51,7 +52,7 @@
   color: govuk-colour('white');
 }
 
-.column {
+.wrapper {
   box-sizing: border-box;
   display: flex;
   flex: 1 0 100%;
@@ -69,11 +70,20 @@
     flex: 1 0 33.33%;
     max-width: 33.33%;
 
-    // If there are four key stat tiles, have two per row
+    // If there are two or four key stat tiles, have two per row
+    &:first-child:nth-last-child(2),
+    &:first-child:nth-last-child(2) ~ &,
     &:first-child:nth-last-child(4),
     &:first-child:nth-last-child(4) ~ & {
       flex: 0 1 50%;
       max-width: 50%;
     }
+  }
+
+  // If there is only one key stat it should be full width
+  &:only-child {
+    flex: 1;
+    max-width: 100%;
+    text-align: center;
   }
 }

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
@@ -12,14 +12,14 @@ export const KeyStatContainer = ({ children }: KeyStatContainerProps) => {
   return <div className={styles.container}>{children}</div>;
 };
 
-interface KeyStatColumnProps {
+interface KeyStatWrapperProps {
   children: ReactNode;
   testId?: string;
 }
 
-export const KeyStatColumn = ({ children, testId }: KeyStatColumnProps) => {
+export const KeyStatWrapper = ({ children, testId }: KeyStatWrapperProps) => {
   return (
-    <div className={styles.column} data-testid={testId}>
+    <div className={styles.wrapper} data-testid={testId}>
       {children}
     </div>
   );
@@ -27,24 +27,24 @@ export const KeyStatColumn = ({ children, testId }: KeyStatColumnProps) => {
 
 export interface KeyStatProps {
   children?: ReactNode;
-  title: string;
-  statistic: string;
-  trend?: string;
   guidanceTitle?: string;
   guidanceText?: string;
-  hasColumn?: boolean;
+  includeWrapper?: boolean;
+  statistic: string;
   testId?: string;
+  title: string;
+  trend?: string;
 }
 
 const KeyStat = ({
   children,
-  title,
-  statistic,
-  trend,
   guidanceTitle = 'Help',
   guidanceText,
-  hasColumn = true,
+  includeWrapper = true,
+  statistic,
   testId = 'keyStat',
+  title,
+  trend,
 }: KeyStatProps) => {
   const body = (
     <>
@@ -72,8 +72,8 @@ const KeyStat = ({
     </>
   );
 
-  return hasColumn ? (
-    <KeyStatColumn testId={testId}>{body}</KeyStatColumn>
+  return includeWrapper ? (
+    <KeyStatWrapper testId={testId}>{body}</KeyStatWrapper>
   ) : (
     body
   );


### PR DESCRIPTION
Changes Key Statistics so the widths are:
- when there's only one Key Stat, it's full width with centred text (I'll check Cam is ok with this before merging)
- when there are two or four Key Stats, they're half width
- any other number of Key Stats, they're one third width

Also, I renamed `column` / `hasColumn` to `wrapper` / `includeWrapper` as it's a wrapper around a single Key Stat rather that around a column of them.

<img width="770" alt="ks1" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/33b28de3-8bd2-4302-be3b-a23808586fd8">

<img width="740" alt="ks2" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/cce96bfa-067f-4e23-a913-f807b9eb65e6">

<img width="739" alt="ks3" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/c3668b00-d3cb-44a8-8b85-6b67dcd73fb8">

<img width="746" alt="ks4" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/100707a5-6b09-45e3-a8eb-e696dd75ac85">



