### PR TITLE
EES-3409 Fix dependency hoisting in frontend Docker build

### DIFF
--- a/docker/Dockerfile.public-frontend
+++ b/docker/Dockerfile.public-frontend
@@ -15,14 +15,14 @@ COPY src/tsconfig.json ./src/tsconfig.json
 
 RUN corepack enable
 
-RUN pnpm i
-RUN pnpm --filter=explore-education-statistics-frontend... install
+RUN pnpm --filter=explore-education-statistics-frontend... --ignore-scripts --frozen-lockfile install
 RUN pnpm --filter=explore-education-statistics-frontend build
 
 FROM node:18.17.0-alpine AS runner
 
 WORKDIR /usr/src/app
 
+COPY --from=builder /app/.npmrc .
 COPY --from=builder /app/package.json .
 COPY --from=builder /app/pnpm-lock.yaml .
 COPY --from=builder /app/pnpm-workspace.yaml .
@@ -31,8 +31,7 @@ COPY --from=builder /app/src/explore-education-statistics-frontend/ ./src/explor
 
 RUN corepack enable
 
-RUN pnpm i
-RUN pnpm --filter=explore-education-statistics-frontend... --prod install --ignore-scripts
+RUN pnpm --filter=explore-education-statistics-frontend... --prod --ignore-scripts --frozen-lockfile install
 
 WORKDIR /usr/src/app/src/explore-education-statistics-frontend
 

--- a/docker/Dockerfile.public-frontend
+++ b/docker/Dockerfile.public-frontend
@@ -1,6 +1,13 @@
-FROM node:18.17.0-alpine AS builder
+FROM node:18.17.0-alpine AS base
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+RUN corepack enable
 
 WORKDIR /app
+
+FROM base AS builder
 
 ARG BUILD_BUILDNUMBER
 ENV BUILD_BUILDNUMBER=$BUILD_BUILDNUMBER
@@ -13,14 +20,12 @@ COPY src/explore-education-statistics-common/ ./src/explore-education-statistics
 COPY src/explore-education-statistics-frontend/ ./src/explore-education-statistics-frontend/
 COPY src/tsconfig.json ./src/tsconfig.json
 
-RUN corepack enable
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm --filter=explore-education-statistics-frontend... --ignore-scripts --frozen-lockfile install
 
-RUN pnpm --filter=explore-education-statistics-frontend... --ignore-scripts --frozen-lockfile install
 RUN pnpm --filter=explore-education-statistics-frontend build
 
-FROM node:18.17.0-alpine AS runner
-
-WORKDIR /usr/src/app
+FROM base AS runner
 
 COPY --from=builder /app/.npmrc .
 COPY --from=builder /app/package.json .
@@ -31,9 +36,10 @@ COPY --from=builder /app/src/explore-education-statistics-frontend/ ./src/explor
 
 RUN corepack enable
 
-RUN pnpm --filter=explore-education-statistics-frontend... --prod --ignore-scripts --frozen-lockfile install
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm --filter=explore-education-statistics-frontend... --prod --ignore-scripts --frozen-lockfile install
 
-WORKDIR /usr/src/app/src/explore-education-statistics-frontend
+WORKDIR /app/src/explore-education-statistics-frontend
 
 ENV NODE_ENV=production
 EXPOSE 3000


### PR DESCRIPTION
This PR primarily fixes dependency hoisting being broken in the frontend Docker build due to not copying the `.npmrc` file.

Other changes:

- Made some performance improvements using cache mounts for the `pnpm install` steps
- Refactored build steps to use a common `base` step
- Removed unnecessary steps that were installing all dependencies

All these changes bring down the current image size down from ~1.2GB to 946MB.