### PR TITLE
EES-3409 - enable buildkit for cache mounts in CI

### DIFF
--- a/azure-pipelines.dfe.yml
+++ b/azure-pipelines.dfe.yml
@@ -281,6 +281,8 @@ jobs:
           buildContext: '$(System.DefaultWorkingDirectory)'
           tags: $(Build.BuildNumber)
           arguments: '--build-arg BUILD_BUILDNUMBER=$(Build.BuildNumber)'
+        env:
+          DOCKER_BUILDKIT: 1
 
       - task: Docker@2
         displayName: 'Push public frontend Docker image'


### PR DESCRIPTION
This PR:
* Enables BuildKit for the docker build task. This is due to the introduction of cache mounts in `Dockerfile.public-frontend`


Full pipeline error: 
```
Step 15/42 : COPY src/tsconfig.json ./src/tsconfig.json
 ---> 6f397caddc58
Step 16/42 : RUN --mount=type=cache,id=pnpm,target=/pnpm/store     pnpm --filter=explore-education-statistics-frontend... --ignore-scripts --frozen-lockfile install
the --mount option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled
##[error]the --mount option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled
##[error]The process '/usr/bin/docker' failed with exit code 1
```