### PR TITLE
EES-4470 - fix typo in public app setting env var

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2070,7 +2070,7 @@
         "GA_TRACKING_ID": "[parameters('publicAppGATrackingId')]",
         "NEXT_CONFIG_MODE": "server",
         "NODE_ENV": "production",
-        "URL": "[concat(variables('publicAppUrl'), '/')]",
+        "PUBLIC_URL": "[concat(variables('publicAppUrl'), '/')]",
         "WEBSITE_NODE_DEFAULT_VERSION": "18.17.0"
       }
     },


### PR DESCRIPTION
This PR:
* Fixes a typo in the public app settings environment variables section. This was due to a bad search and replace when renaming variables