### PR TITLE
EES-4413 alt text validation

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.module.scss
@@ -9,6 +9,13 @@ $locked-border-width: 4px;
   padding: govuk-spacing(2);
   position: relative;
 
+  // stylelint-disable-next-line selector-no-qualifying-type
+  img:not([alt]),
+  img[alt=''] {
+    border: 4px solid $govuk-error-colour;
+    padding: 4px;
+  }
+
   pre {
     white-space: normal;
   }

--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.module.scss
@@ -25,4 +25,11 @@
 .form {
   margin-left: $dfe-comments-width;
   width: 100%;
+
+  // stylelint-disable-next-line selector-no-qualifying-type
+  img:not([alt]),
+  img[alt=''] {
+    border: 4px solid $govuk-error-colour;
+    padding: 4px;
+  }
 }

--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.tsx
@@ -1,7 +1,7 @@
 import { useCommentsContext } from '@admin/contexts/CommentsContext';
 import styles from '@admin/components/editable/EditableContentForm.module.scss';
 import FormFieldEditor from '@admin/components/form/FormFieldEditor';
-import { Element } from '@admin/types/ckeditor';
+import { Element, Node } from '@admin/types/ckeditor';
 import {
   ImageUploadCancelHandler,
   ImageUploadHandler,
@@ -11,6 +11,7 @@ import CommentsList from '@admin/components/comments/CommentsList';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import { Form } from '@common/components/form';
+import WarningMessage from '@common/components/WarningMessage';
 import useAsyncCallback from '@common/hooks/useAsyncCallback';
 import useToggle from '@common/hooks/useToggle';
 import logger from '@common/services/logger';
@@ -64,6 +65,7 @@ const EditableContentForm = ({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [showCommentAddForm, toggleCommentAddForm] = useToggle(false);
+  const [showAltTextMessage, toggleAltTextMessage] = useToggle(false);
 
   useIdleTimer({
     element: containerRef.current ?? document,
@@ -76,20 +78,24 @@ const EditableContentForm = ({
     onIdle,
   });
 
-  const validateElements = useCallback((elements: Element[]) => {
-    let error: string | undefined;
+  const validateElements = useCallback(
+    (elements: Element[]) => {
+      const hasInvalidImage = elements.some(
+        element =>
+          isInvalidImage(element) ||
+          Array.from(element.getChildren()).some(child =>
+            isInvalidImage(child),
+          ),
+      );
 
-    elements.some(element => {
-      if (element.name === 'image' && !element.getAttribute('alt')) {
-        error = 'All images must have alternative (alt) text';
-        return true;
-      }
+      toggleAltTextMessage(hasInvalidImage);
 
-      return false;
-    });
-
-    return error;
-  }, []);
+      return hasInvalidImage
+        ? 'All images must have alternative text'
+        : undefined;
+    },
+    [toggleAltTextMessage],
+  );
 
   const [{ isLoading: isAutoSaving, error: autoSaveError }, handleAutoSave] =
     useAsyncCallback(
@@ -139,7 +145,6 @@ const EditableContentForm = ({
           initialValues={{
             content,
           }}
-          validateOnChange={false}
           validationSchema={Yup.object({
             content: Yup.string().required('Enter content'),
           })}
@@ -149,7 +154,8 @@ const EditableContentForm = ({
             const isSaving = form.isSubmitting || isAutoSaving;
 
             return (
-              <Form id={`${id}-form`}>
+              <Form id={`${id}-form`} visuallyHiddenErrorSummary>
+                {showAltTextMessage && <AltTextWarningMessage />}
                 <FormFieldEditor<FormValues>
                   allowComments={allowComments}
                   error={autoSaveError ? 'Could not save content' : undefined}
@@ -193,3 +199,27 @@ const EditableContentForm = ({
   );
 };
 export default EditableContentForm;
+
+function isInvalidImage(element: Node) {
+  return (
+    (element.name === 'imageBlock' || element.name === 'imageInline') &&
+    !element.getAttribute('alt')
+  );
+}
+
+export function AltTextWarningMessage() {
+  return (
+    <WarningMessage>
+      Alternative text must be added for images, for guidance see{' '}
+      <a
+        href="https://www.w3.org/WAI/tutorials/images/tips/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        W3C tips on writing alternative text
+      </a>
+      . <br />
+      Images without alternative text are outlined in red.
+    </WarningMessage>
+  );
+}

--- a/src/explore-education-statistics-admin/src/types/ckeditor.ts
+++ b/src/explore-education-statistics-admin/src/types/ckeditor.ts
@@ -198,6 +198,7 @@ export interface Node {
   readonly endOffset: number | null;
   readonly index: number | null;
   readonly isEmpty: boolean;
+  readonly name: string;
   readonly nextSibling: Node | null;
   readonly offsetSize: number;
   readonly parent: Element | null;

--- a/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
+++ b/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
@@ -1,3 +1,5 @@
+import ErrorPrefixPageTitle from '@common/components/ErrorPrefixPageTitle';
+import classNames from 'classnames';
 import React, {
   forwardRef,
   MouseEventHandler,
@@ -5,7 +7,6 @@ import React, {
   useEffect,
   useRef,
 } from 'react';
-import ErrorPrefixPageTitle from './ErrorPrefixPageTitle';
 
 export interface ErrorSummaryMessage {
   id: string;
@@ -16,17 +17,20 @@ interface BaseErrorSummaryProps {
   children: ReactNode;
   testId?: string;
   title: string;
+  visuallyHidden?: boolean;
 }
 
 export const BaseErrorSummary = forwardRef<
   HTMLDivElement,
   BaseErrorSummaryProps
 >((props, ref) => {
-  const { children, testId = 'errorSummary', title } = props;
+  const { children, testId = 'errorSummary', title, visuallyHidden } = props;
 
   return (
     <div
-      className="govuk-error-summary"
+      className={classNames('govuk-error-summary', {
+        'govuk-visually-hidden': visuallyHidden,
+      })}
       ref={ref}
       tabIndex={-1}
       data-testid={testId}
@@ -47,6 +51,7 @@ interface ErrorSummaryProps {
   errors: ErrorSummaryMessage[];
   focusOnError?: boolean;
   title?: string;
+  visuallyHidden?: boolean;
   onFocus?: () => void;
   onErrorClick?: MouseEventHandler<HTMLAnchorElement>;
 }
@@ -55,6 +60,7 @@ const ErrorSummary = ({
   errors,
   focusOnError = false,
   title = 'There is a problem',
+  visuallyHidden = false,
   onFocus,
   onErrorClick,
 }: ErrorSummaryProps) => {
@@ -87,13 +93,17 @@ const ErrorSummary = ({
   }, [errors, focusOnError, onFocus]);
 
   return errors.length > 0 ? (
-    <BaseErrorSummary title={title} ref={ref}>
+    <BaseErrorSummary ref={ref} title={title} visuallyHidden={visuallyHidden}>
       <ul className="govuk-list govuk-error-summary__list">
         {errors.map(error => (
           <li key={error.id}>
-            <a href={`#${error.id}`} onClick={onErrorClick}>
-              {error.message}
-            </a>
+            {!visuallyHidden ? (
+              <a href={`#${error.id}`} onClick={onErrorClick}>
+                {error.message}
+              </a>
+            ) : (
+              `${error.message}`
+            )}
           </li>
         ))}
       </ul>

--- a/src/explore-education-statistics-common/src/components/form/Form.tsx
+++ b/src/explore-education-statistics-common/src/components/form/Form.tsx
@@ -26,6 +26,7 @@ interface Props {
   submitId?: string;
   showErrorSummary?: boolean;
   showSubmitError?: boolean;
+  visuallyHiddenErrorSummary?: boolean;
 }
 
 /**
@@ -48,9 +49,10 @@ interface Props {
 const Form = ({
   children,
   id,
-  submitId = `${id}-submit`,
   showErrorSummary = true,
   showSubmitError = false,
+  submitId = `${id}-submit`,
+  visuallyHiddenErrorSummary = false,
 }: Props) => {
   const isMounted = useMountedRef();
 
@@ -127,7 +129,8 @@ const Form = ({
         {showErrorSummary && (
           <ErrorSummary
             errors={allErrors}
-            focusOnError={hasSummaryFocus}
+            focusOnError={hasSummaryFocus && !visuallyHiddenErrorSummary}
+            visuallyHidden={visuallyHiddenErrorSummary}
             onFocus={toggleSummaryFocus.off}
           />
         )}

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFForm.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFForm.tsx
@@ -26,6 +26,7 @@ interface Props<TFormValues extends FieldValues> {
   submitId?: string;
   showErrorSummary?: boolean;
   showSubmitError?: boolean;
+  visuallyHiddenErrorSummary?: boolean;
   onSubmit: (values: TFormValues) => Promise<void>;
 }
 
@@ -52,6 +53,7 @@ export default function RHFForm<TFormValues extends FieldValues>({
   submitId = `${id}-submit`,
   showErrorSummary = true,
   showSubmitError = false,
+  visuallyHiddenErrorSummary = false,
   onSubmit,
 }: Props<TFormValues>) {
   const isMounted = useMountedRef();
@@ -151,7 +153,8 @@ export default function RHFForm<TFormValues extends FieldValues>({
         {showErrorSummary && (
           <ErrorSummary
             errors={allErrors}
-            focusOnError={hasSummaryFocus}
+            focusOnError={hasSummaryFocus && !visuallyHiddenErrorSummary}
+            visuallyHidden={visuallyHiddenErrorSummary}
             onFocus={toggleSummaryFocus.off}
           />
         )}

--- a/src/explore-education-statistics-common/src/styles/_content.scss
+++ b/src/explore-education-statistics-common/src/styles/_content.scss
@@ -7,6 +7,11 @@
     font-size: 1rem;
   }
 
+  img {
+    max-width: 100%;
+    min-width: 50px;
+  }
+
   .image {
     margin: govuk-spacing(6) auto;
     text-align: center;
@@ -15,8 +20,6 @@
   .image img {
     display: block;
     margin: 0 auto govuk-spacing(2);
-    max-width: 100%;
-    min-width: 50px;
   }
 
   .table {

--- a/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
@@ -70,9 +70,29 @@ Update the Methodology Content
     ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
     user adds content to accordion section text block    Methodology content section 1    1
     ...    Adding Methodology content    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
-    user adds image to accordion section text block    Methodology content section 1    1    test-infographic.png
+
+    user checks accordion section contains x blocks    Methodology content section 1    1
+    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+
+Verify that validation prevents adding an image without alt text
+    user adds image without alt text to accordion section text block    Methodology content section 1    1
+    ...    test-infographic.png    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
+
+    user checks page contains    All images must have alternative text
+
+    user clicks element    xpath://img
+    user clicks element    xpath://button[span[.="Change image text alternative"]]
+    user enters text into element    label:Text alternative    Alt text for the uploaded content image
+    user clicks element    css:button.ck-button-save
+
+    user checks accordion section text block contains image with alt text    Methodology content section 1    1
     ...    Alt text for the uploaded content image    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
 
+    user clicks button    Save
+
+    user checks page does not contain    All images must have alternative text
+
+Add Methodology Annexes
     user creates new content section    1    Methodology annex section 1    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
     user adds text block to editable accordion section    Methodology annex section 1
     ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
@@ -81,10 +101,6 @@ Update the Methodology Content
     user adds image to accordion section text block    Methodology annex section 1    1    dfe-logo.jpg
     ...    Alt text for the uploaded annex image    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
 
-    user checks accordion section contains x blocks    Methodology content section 1    1
-    ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
-    user checks accordion section text block contains image with alt text    Methodology content section 1    1
-    ...    Alt text for the uploaded content image    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
     user checks accordion section contains x blocks    Methodology annex section 1    1
     ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
     user checks accordion section text block contains image with alt text    Methodology annex section 1    1

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -364,10 +364,34 @@ user adds image to accordion section text block
     user waits until parent contains element    ${block}
     ...    xpath://img[starts-with(@src, "/api/") and @alt="${alt_text}"]
 
-    # Workaround to remove the eager "All images must have alternative (alt) text" validation error that persists
+    # Workaround to remove the eager "All images must have alternative text" validation error that persists
     # even after setting the alt text
     user presses keys    TAB
     user presses keys    SHIFT+TAB
+
+    user clicks button    Save    ${block}
+
+user adds image without alt text to accordion section text block
+    [Arguments]
+    ...    ${section_name}
+    ...    ${block_num}
+    ...    ${filename}=test-infographic.png
+    ...    ${parent}=[data-testid="accordion"]
+
+    ${block}=    user starts editing accordion section text block    ${section_name}    ${block_num}    ${parent}
+
+    # If we don't do this, `Insert paragraph after block` circle button on image doesn't appear
+    user presses keys    ${\n}
+    user presses keys    ARROW_UP
+
+    choose file
+    ...    xpath://button[span[.="Insert image"]]/following-sibling::input[@type="file"]
+    ...    ${FILES_DIR}${filename}
+    user clicks element    xpath://div[@title="Insert paragraph after block"]
+
+    # wait for the API to save the image and for the src attribute to be updated before continuing
+    user waits until parent contains element    ${block}
+    ...    xpath://img[starts-with(@src, "/api/")]
 
     user clicks button    Save    ${block}
 


### PR DESCRIPTION
- Fixes the validation for images without alt text
- In addition to the standard error, it shows a warning message with a link to more info about writing alt text
- When editing a block, images without alt text are outline in red
- Adds a UI test to check the validation works

Also, fixes the bug where large images can overflow content blocks.

![alttext](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/df665176-2452-46ce-845c-6c12c971e6a9)
