### PR TITLE
EES-4481 Improved EF query efficiency getting comments.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/CommentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/CommentServiceTests.cs
@@ -10,11 +10,9 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using Microsoft.AspNetCore.Mvc;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
@@ -37,7 +35,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                                 new HtmlBlock
                                 {
                                     Created = new DateTime(2001, 1, 1),
-                                    Comments = AsList(new Comment {Content = "Existing comment"})
+                                    Comments = AsList(new Comment
+                                    {
+                                        Content = "Existing comment"
+                                    })
                                 }
                             )
                         }
@@ -60,7 +61,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     release.Id,
                     release.Content[0].ContentSection.Id,
                     release.Content[0].ContentSection.Content[0].Id,
-                    new CommentSaveRequest {Content = "New comment"});
+                    new CommentSaveRequest
+                    {
+                        Content = "New comment"
+                    });
 
                 var viewModel = result.AssertRight();
                 Assert.Equal("New comment", viewModel.Content);
@@ -87,10 +91,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseId: Guid.NewGuid(),
                     contentSectionId: Guid.NewGuid(),
                     contentBlockId: Guid.NewGuid(),
-                    new CommentSaveRequest {Content = "New comment"});
+                    new CommentSaveRequest
+                    {
+                        Content = "New comment"
+                    });
 
-                var actionResult = result.AssertLeft();
-                Assert.IsType<NotFoundResult>(actionResult);
+                result.AssertNotFound();
             }
         }
 
@@ -106,7 +112,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await contentDbContext.SaveChangesAsync();
             }
 
-            await using (var contentDbContext = InMemoryApplicationDbContext())
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var service = SetupCommentService(contentDbContext: contentDbContext);
 
@@ -114,10 +120,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseId: release.Id,
                     contentSectionId: Guid.NewGuid(),
                     contentBlockId: Guid.NewGuid(),
-                    new CommentSaveRequest {Content = "New comment"});
+                    new CommentSaveRequest
+                    {
+                        Content = "New comment"
+                    });
 
-                var actionResult = result.AssertLeft();
-                Assert.IsType<NotFoundResult>(actionResult);
+                result.AssertNotFound();
             }
         }
 
@@ -154,9 +162,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseId: release.Id,
                     contentSectionId: release.Content[0].ContentSection.Id,
                     contentBlockId: Guid.NewGuid(),
-                    new CommentSaveRequest {Content = "New comment"});
+                    new CommentSaveRequest
+                    {
+                        Content = "New comment"
+                    });
 
-                result.AssertBadRequest(ContentBlockNotFound);
+                result.AssertNotFound();
             }
         }
 
@@ -281,15 +292,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task SetResolved_NoComment()
         {
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryApplicationDbContext())
             {
                 var service = SetupCommentService(contentDbContext: contentDbContext);
                 var result = await service.SetResolved(Guid.NewGuid(), resolve: true);
-                var actionResult = result.AssertLeft();
-                Assert.IsType<NotFoundResult>(actionResult);
+                result.AssertNotFound();
             }
-
         }
 
         [Fact]
@@ -332,7 +340,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     contentDbContext: contentDbContext,
                     userId: userId);
                 var result = await service.UpdateComment(comment.Id,
-                    new CommentSaveRequest {Content = "Existing comment updated"});
+                    new CommentSaveRequest
+                    {
+                        Content = "Existing comment updated"
+                    });
 
                 var viewModel = result.AssertRight();
                 Assert.Equal("Existing comment updated", viewModel.Content);
@@ -357,15 +368,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task UpdateComment_NoComment()
         {
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryApplicationDbContext())
             {
                 var service = SetupCommentService(contentDbContext: contentDbContext);
                 var result = await service.UpdateComment(Guid.NewGuid(),
-                    new CommentSaveRequest {Content = "Existing comment updated"});
+                    new CommentSaveRequest
+                    {
+                        Content = "Existing comment updated"
+                    });
 
-                var actionResult = result.AssertLeft();
-                Assert.IsType<NotFoundResult>(actionResult);
+                result.AssertNotFound();
             }
         }
 
@@ -435,14 +447,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task DeleteComment_NoComment()
         {
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryApplicationDbContext())
             {
                 var service = SetupCommentService(contentDbContext);
                 var result = await service.DeleteComment(Guid.NewGuid());
 
-                var actionResult = result.AssertLeft();
-                Assert.IsType<NotFoundResult>(actionResult);
+                result.AssertNotFound();
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -188,7 +188,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                             ? new User
                             {
 #pragma warning disable 612
-                                FirstName = comment.LegacyCreatedBy,
+                                FirstName = comment.LegacyCreatedBy ?? "",
 #pragma warning restore 612
                                 LastName = ""
                             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230817144249_EES4481_AlterCommentContentNotNull.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230817144249_EES4481_AlterCommentContentNotNull.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230817144249_EES4481_AlterCommentContentNotNull")]
+    partial class EES4481_AlterCommentContentNotNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230817144249_EES4481_AlterCommentContentNotNull.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230817144249_EES4481_AlterCommentContentNotNull.cs
@@ -1,0 +1,34 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations;
+
+[ExcludeFromCodeCoverage]
+public partial class EES4481_AlterCommentContentNotNull : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "Content",
+            table: "Comment",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "Content",
+            table: "Comment",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -10,7 +10,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         PartialDateNotValid,
 
         // Content
-        ContentBlockNotFound,
         IncorrectContentBlockTypeForUpdate,
         ContentBlockAlreadyAttachedToContentSection,
         IncorrectContentBlockTypeForAttach,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/CommentViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/CommentViewModel.cs
@@ -1,16 +1,17 @@
+#nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
-    public class CommentViewModel
+    public record CommentViewModel
     {
-        public Guid Id { get; set; }
-        public string Content { get; set; }
-        public DateTime Created { get; set; }
-        public User CreatedBy { get; set; }
-        public DateTime? Updated { get; set; }
-        public DateTime? Resolved { get; set; }
-        public User ResolvedBy { get; set; }
+        public Guid Id { get; init; }
+        public string Content { get; init; } = string.Empty;
+        public DateTime Created { get; init; }
+        public User CreatedBy { get; init; } = null!;
+        public DateTime? Updated { get; init; }
+        public DateTime? Resolved { get; init; }
+        public User ResolvedBy { get; init; } = null!;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/CommentSaveRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/CommentSaveRequest.cs
@@ -1,8 +1,12 @@
+#nullable enable
+
+using System.ComponentModel.DataAnnotations;
+
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent
 {
     public class CommentSaveRequest
     {
-        public string Content { get; set; }
+        [Required] public string Content { get; set; } = string.Empty;
         public bool? SetResolved { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Comment.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Comment.cs
@@ -1,20 +1,22 @@
-﻿using System;
+﻿#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
-    public class Comment
+    public class Comment : ICreatedUpdatedTimestamps<DateTime, DateTime?>
     {
         public Guid Id { get; set; }
-        public ContentBlock ContentBlock { get; set; }
+        public ContentBlock ContentBlock { get; set; } = null!;
         public Guid ContentBlockId { get; set; }
-        public string Content { get; set; }
+        public string? Content { get; set; }
         public DateTime Created { get; set; }
-        public User CreatedBy { get; set; }
+        public User CreatedBy { get; set; } = null!;
         public Guid? CreatedById { get; set; }
-        [Obsolete] public string LegacyCreatedBy { get; set; }
+        [Obsolete] public string? LegacyCreatedBy { get; set; }
         public DateTime? Updated { get; set; }
         public DateTime? Resolved { get; set; }
-        public User ResolvedBy { get; set; }
+        public User ResolvedBy { get; set; } = null!;
         public Guid? ResolvedById { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Comment.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Comment.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public Guid Id { get; set; }
         public ContentBlock ContentBlock { get; set; } = null!;
         public Guid ContentBlockId { get; set; }
-        public string? Content { get; set; }
+        public string Content { get; set; } = string.Empty;
         public DateTime Created { get; set; }
         public User CreatedBy { get; set; } = null!;
         public Guid? CreatedById { get; set; }


### PR DESCRIPTION
This PR improves the EF query efficiency getting comments and adding a new comment in the Admin `CommentService`.

It removes result set duplication by refactoring includes, splitting queries, and avoids returning content sections and blocks just check that a content block exists.

Previously, methods `GetComments` and `AddComment` both executed `CheckContentSectionExists` which in turn used method `HydrateContentSectionsAndBlocks`:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/4147126/5e1312b7-eff7-4c05-b0f1-19e9a88542cf)

This method had a few different purposes:

- To allow checking a content block exists when navigated via the content sections and content blocks collections of the release.
- To include the comments of every content block. Only relevant to `GetComments`.
- To include the "created by" and "resolved by" users of each comment for populating the view model. Only relevant to `GetComments`.

Unfortunately this produced a horrendous set of joins in the translated SQL query.
It was also not limited by the content section and content block of the request, so it fetched all comments, content blocks and content sections of the release.

The generated SQL resultset included columns for every field of `Release`, `ReleaseContentSection`, `ContentBlock`, and `Comment` which are all related collections, and two sets of `User` columns which are reference properties. Redundant information for all of these entities would be duplicated across rows for every comment in every content block in every section.

This is now all removed in favour of one query to make sure the content block exists, and then a separate query to get the comment(s).

### Other changes

- Add the `ICreatedUpdatedTimestamps` to `Comment` to avoid needing to manually set `Created` and `Updated` values.
- Refactor `CommentViewModel` to be of record type.
- Add database migration to make `Comment.Content` not-null (seen as a result of enabling the nullable context for `Comment`).