### PR TITLE
EES-4483 Alter type columns from nvarchar(max) to nvarchar(25) and add indexes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230818085314_EES4483_AddMissingIndexes.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230818085314_EES4483_AddMissingIndexes.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230818085314_EES4483_AddMissingIndexes")]
+    partial class EES4483_AddMissingIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230818085314_EES4483_AddMissingIndexes.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230818085314_EES4483_AddMissingIndexes.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations;
+
+public partial class EES4483_AddMissingIndexes : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "Type",
+            table: "Files",
+            type: "nvarchar(25)",
+            maxLength: 25,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "Type",
+            table: "ContentSections",
+            type: "nvarchar(25)",
+            maxLength: 25,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "Type",
+            table: "ContentBlock",
+            type: "nvarchar(25)",
+            maxLength: 25,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Files_Type",
+            table: "Files",
+            column: "Type");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ContentSections_Type",
+            table: "ContentSections",
+            column: "Type");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ContentBlock_Type",
+            table: "ContentBlock",
+            column: "Type");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_Files_Type",
+            table: "Files");
+
+        migrationBuilder.DropIndex(
+            name: "IX_ContentSections_Type",
+            table: "ContentSections");
+
+        migrationBuilder.DropIndex(
+            name: "IX_ContentBlock_Type",
+            table: "ContentBlock");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "Type",
+            table: "Files",
+            type: "nvarchar(max)",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(25)",
+            oldMaxLength: 25);
+
+        migrationBuilder.AlterColumn<string>(
+            name: "Type",
+            table: "ContentSections",
+            type: "nvarchar(max)",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(25)",
+            oldMaxLength: 25);
+
+        migrationBuilder.AlterColumn<string>(
+            name: "Type",
+            table: "ContentBlock",
+            type: "nvarchar(max)",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(25)",
+            oldMaxLength: 25);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -335,56 +335,57 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .WithMany()
                 .OnDelete(DeleteBehavior.NoAction);
 
-            modelBuilder.Entity<File>()
-                .Property(f => f.ContentType)
-                .HasMaxLength(255);
-
-            modelBuilder.Entity<File>()
-                .Property(b => b.Type)
-                .HasConversion(new EnumToStringConverter<FileType>());
-
-            modelBuilder.Entity<File>()
-                .HasOne(b => b.Replacing)
-                .WithOne()
-                .HasForeignKey<File>(b => b.ReplacingId)
-                .IsRequired(false);
-
-            modelBuilder.Entity<File>()
-                .HasOne(b => b.ReplacedBy)
-                .WithOne()
-                .HasForeignKey<File>(b => b.ReplacedById)
-                .IsRequired(false);
-
-            modelBuilder.Entity<File>()
-                .Property(comment => comment.Created)
-                .HasConversion(
-                    v => v,
-                    v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
+            modelBuilder.Entity<File>(entity =>
+            {
+                entity.Property(e => e.ContentType)
+                    .HasMaxLength(255);
+                entity.Property(e => e.Type)
+                    .HasConversion(new EnumToStringConverter<FileType>())
+                    .HasMaxLength(25);
+                entity.HasIndex(e => e.Type);
+                entity.HasOne(b => b.Replacing)
+                    .WithOne()
+                    .HasForeignKey<File>(b => b.ReplacingId)
+                    .IsRequired(false);
+                entity.HasOne(b => b.ReplacedBy)
+                    .WithOne()
+                    .HasForeignKey<File>(b => b.ReplacedById)
+                    .IsRequired(false);
+                entity.Property(e => e.Created)
+                    .HasConversion(
+                        v => v,
+                        v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
+            });
 
             modelBuilder.Entity<Release>()
                 .HasOne(r => r.PreviousVersion)
                 .WithMany()
                 .OnDelete(DeleteBehavior.NoAction);
 
-            modelBuilder.Entity<ContentBlock>()
-                .ToTable("ContentBlock")
-                .HasDiscriminator<string>("Type");
+            modelBuilder.Entity<ContentBlock>(entity =>
+            {
+                entity.ToTable("ContentBlock")
+                    .HasDiscriminator<string>("Type");
+                entity.Property("Type")
+                    .HasMaxLength(25);
+                entity.HasIndex("Type");
+                entity.Property(e => e.Created)
+                    .HasConversion(
+                        v => v,
+                        v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
+                entity.Property(e => e.Locked)
+                    .HasConversion(
+                        v => v,
+                        v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
+            });
 
-            modelBuilder.Entity<ContentBlock>()
-                .Property(block => block.Created)
-                .HasConversion(
-                    v => v,
-                    v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
-
-            modelBuilder.Entity<ContentBlock>()
-                .Property(comment => comment.Locked)
-                .HasConversion(
-                    v => v,
-                    v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
-
-            modelBuilder.Entity<ContentSection>()
-                .Property(b => b.Type)
-                .HasConversion(new EnumToStringConverter<ContentSectionType>());
+            modelBuilder.Entity<ContentSection>(entity =>
+            {
+                entity.Property(e => e.Type)
+                    .HasConversion(new EnumToStringConverter<ContentSectionType>())
+                    .HasMaxLength(25);
+                entity.HasIndex(e => e.Type);
+            });
 
             modelBuilder.Entity<Release>()
                 .Property(release => release.NextReleaseDate)


### PR DESCRIPTION
This PR alters the columns of the following properties from type `nvarchar(max)` to `nvarchar(25)`and adds indexes to those fields to benefit database queries filtering on type.

- `File.Type`
- `ContentBlock.Type`
- `ContentSection.Type`

Columns with data type `nvarchar(max)` cannot be indexed.