### PR TITLE
EES-4355 use filter groups in stacked bar charts

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
@@ -18,6 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
         public AxisGroupBy? GroupBy;
 
         public string? GroupByFilter;
+        public bool GroupByFilterGroups;
 
         public string SortBy = null!;
         public bool SortAsc = true;

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
@@ -463,6 +463,7 @@ const ChartBuilder = ({
                         definition={definition}
                         data={data}
                         meta={meta}
+                        stacked={options?.stacked}
                         includeNonNumericData={options?.includeNonNumericData}
                         onChange={handleAxisConfigurationChange}
                         onSubmit={actions.updateChartAxis}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
@@ -123,6 +123,7 @@ const ChartLegendConfiguration = ({
 
     const dataSetCategoryConfigs = getDataSetCategoryConfigs({
       dataSetCategories,
+      groupByFilterGroups: axisMajor.groupByFilterGroups,
       legendItems: legendItems.current,
       meta,
     });

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
@@ -89,8 +89,12 @@ describe('ChartAxisConfiguration', () => {
   };
   const testMinorAxisConfiguration: AxisConfiguration = {
     dataSets: [],
-    type: 'minor',
+    max: undefined,
+    min: undefined,
     referenceLines: [],
+    size: 50,
+    tickSpacing: 1,
+    type: 'minor',
     visible: true,
   };
 
@@ -504,6 +508,147 @@ describe('ChartAxisConfiguration', () => {
           },
         };
         expect(handleSubmit).toHaveBeenCalledWith(formValues);
+      });
+    });
+
+    test('does not show the `Group by filter groups` option when data is not grouped by a filter with filter groups and bars are not stacked', async () => {
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-major"
+            type="major"
+            axesConfiguration={{
+              ...testAxesConfiguration,
+              major: {
+                ...testMajorAxisConfiguration,
+                groupBy: 'filters',
+                groupByFilter: 'school_type',
+              },
+            }}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            onChange={noop}
+            onSubmit={noop}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      expect(
+        screen.queryByLabelText('Group by filter groups'),
+      ).not.toBeInTheDocument();
+    });
+
+    test('does not show the `Group by filter groups` option when data is grouped by a filter with filter groups but bars are not stacked', () => {
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-major"
+            type="major"
+            axesConfiguration={{
+              ...testAxesConfiguration,
+              major: {
+                ...testMajorAxisConfiguration,
+                groupBy: 'filters',
+                groupByFilter: 'characteristic',
+              },
+            }}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            onChange={noop}
+            onSubmit={noop}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      expect(
+        screen.queryByLabelText('Group by filter groups'),
+      ).not.toBeInTheDocument();
+    });
+
+    test('shows the `Group by filter groups` option when data is grouped by a filter with filter groups and bars are stacked', async () => {
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-major"
+            type="major"
+            axesConfiguration={{
+              ...testAxesConfiguration,
+              major: {
+                ...testMajorAxisConfiguration,
+                groupBy: 'filters',
+                groupByFilter: 'characteristic',
+              },
+            }}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            stacked
+            onChange={noop}
+            onSubmit={noop}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      expect(
+        screen.getByLabelText('Group by filter groups'),
+      ).toBeInTheDocument();
+    });
+
+    test('setting `Group by filter groups`', async () => {
+      const handleSubmit = jest.fn();
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-major"
+            type="major"
+            axesConfiguration={{
+              ...testAxesConfiguration,
+              major: {
+                ...testMajorAxisConfiguration,
+                groupBy: 'filters',
+                groupByFilter: 'characteristic',
+              },
+            }}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            stacked
+            onChange={noop}
+            onSubmit={handleSubmit}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      userEvent.click(screen.getByLabelText('Group by filter groups'));
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Save chart options' }),
+      );
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith({
+          dataSets: testMajorAxisConfiguration.dataSets,
+          groupBy: 'filters',
+          groupByFilter: 'characteristic',
+          groupByFilterGroups: true,
+          min: 0,
+          max: undefined,
+          referenceLines: [],
+          showGrid: true,
+          size: 50,
+          sortAsc: true,
+          sortBy: 'name',
+          tickConfig: 'default',
+          tickSpacing: 1,
+          type: 'major',
+          visible: true,
+          unit: '',
+          label: {
+            text: '',
+          },
+        });
       });
     });
   });

--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -37,6 +37,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import groupBy from 'lodash/groupBy';
 
 const defaultLabelTextColour = '#0B0C0C';
 
@@ -56,6 +57,7 @@ const HorizontalBarBlock = ({
   barThickness,
   width,
   stacked = false,
+
   axes,
   legend,
   includeNonNumericData,
@@ -82,7 +84,16 @@ const HorizontalBarBlock = ({
     includeNonNumericData,
   });
 
-  const chartData = dataSetCategories.map(toChartData);
+  const groupedDataSetCategories = groupBy(
+    dataSetCategories,
+    dataSetCategory => dataSetCategory.filter.group,
+  );
+
+  const chartData = axes.major.groupByFilterGroups
+    ? Object.entries(groupedDataSetCategories).map(([groupKey, group]) =>
+        Object.assign({}, ...group.map(toChartData), { name: groupKey }),
+      )
+    : dataSetCategories.map(toChartData);
 
   const minorDomainTicks = getMinorAxisDomainTicks(chartData, axes.minor);
   const majorDomainTicks = getMajorAxisDomainTicks(chartData, axes.major);

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -58,6 +58,7 @@ export interface AxisConfiguration {
   type: AxisType;
   groupBy?: AxisGroupBy;
   groupByFilter?: string;
+  groupByFilterGroups?: boolean;
   sortBy?: string;
   sortAsc?: boolean;
   dataSets: DataSet[];

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/getDataSetCategoryConfigs.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/getDataSetCategoryConfigs.test.ts
@@ -1,0 +1,1159 @@
+import {
+  DataGroupingConfig,
+  MapDataSetConfig,
+} from '@common/modules/charts/types/chart';
+import { DataSet, DataSetCategory } from '@common/modules/charts/types/dataSet';
+import getDataSetCategoryConfigs, {
+  DataSetCategoryConfig,
+} from '@common/modules/charts/util/getDataSetCategoryConfigs';
+import {
+  CategoryFilter,
+  Indicator,
+  LocationFilter,
+  TimePeriodFilter,
+} from '@common/modules/table-tool/types/filters';
+import { LegendItem } from '@common/modules/charts/types/legend';
+import generateDataSetKey from '@common/modules/charts/util/generateDataSetKey';
+import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
+import expandDataSet from '@common/modules/charts/util/expandDataSet';
+import omit from 'lodash/omit';
+
+describe('getDataSetCategoryConfigs', () => {
+  const testFilterGroup1Item1 = new CategoryFilter({
+    category: 'Filter1',
+    group: 'Filter group 1',
+    label: 'Filter group 1 item 1',
+    value: 'filter-group-1-item-1',
+  });
+  const testFilterGroup1Item2 = new CategoryFilter({
+    category: 'Filter1',
+    group: 'Filter group 1',
+    label: 'Filter group 1 item 2',
+    value: 'filter-group-1-item-2',
+  });
+  const testFilterGroup2Item1 = new CategoryFilter({
+    category: 'Filter1',
+    group: 'Filter group 2',
+    label: 'Filter group 2 item 1',
+    value: 'filter-group-2-item-1',
+  });
+  const testFilterGroup2Item2 = new CategoryFilter({
+    category: 'Filter1',
+    group: 'Filter group 2',
+    label: 'Filter group 2 item 2',
+    value: 'filter-group-2-item-2',
+  });
+  const testIndicator1 = new Indicator({
+    label: 'Indicator 1',
+    name: 'indicator-1-name',
+    unit: '',
+    value: 'indicator-1',
+  });
+  const testLocation1 = new LocationFilter({
+    id: 'location-1-id',
+    label: 'Location 1',
+    level: 'country',
+    value: 'location-1',
+  });
+  const testTimePeriod1 = new TimePeriodFilter({
+    year: 2020,
+    code: 'AY',
+    label: '2020/21',
+    order: 0,
+  });
+
+  const testSubjectMeta: FullTableMeta = {
+    boundaryLevels: [],
+    filters: {
+      Filter1: {
+        name: 'filter-1',
+        options: [
+          testFilterGroup1Item1,
+          testFilterGroup1Item2,
+          testFilterGroup2Item1,
+          testFilterGroup2Item2,
+        ],
+        order: 0,
+      },
+    },
+    footnotes: [],
+    geoJsonAvailable: false,
+    indicators: [testIndicator1],
+    locations: [testLocation1],
+    publicationName: 'Publication 1',
+    subjectName: 'Subject 1',
+    timePeriodRange: [testTimePeriod1],
+  };
+
+  const testDataSet1: DataSet = {
+    filters: [testFilterGroup1Item1.id],
+    indicator: testIndicator1.id,
+    timePeriod: testTimePeriod1.id,
+    location: {
+      level: testLocation1.level,
+      value: testLocation1.value,
+    },
+  };
+
+  const testDataSet2: DataSet = {
+    filters: [testFilterGroup1Item2.id],
+    indicator: testIndicator1.id,
+    timePeriod: testTimePeriod1.id,
+    location: {
+      level: testLocation1.level,
+      value: testLocation1.value,
+    },
+  };
+
+  const testDataSet3: DataSet = {
+    filters: [testFilterGroup2Item1.id],
+    indicator: testIndicator1.id,
+    timePeriod: testTimePeriod1.id,
+    location: {
+      level: testLocation1.level,
+      value: testLocation1.value,
+    },
+  };
+
+  const testDataSet4: DataSet = {
+    filters: [testFilterGroup2Item2.id],
+    indicator: testIndicator1.id,
+    timePeriod: testTimePeriod1.id,
+    location: {
+      level: testLocation1.level,
+      value: testLocation1.value,
+    },
+  };
+
+  const testDataGrouping: DataGroupingConfig = {
+    customGroups: [],
+    numberOfGroups: 5,
+    type: 'EqualIntervals',
+  };
+
+  test('returns configs correctly when grouped by time period', () => {
+    const testDataSetCategories: DataSetCategory[] = [
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet1, testTimePeriod1)]: {
+            dataSet: testDataSet1,
+            value: 30,
+          },
+          [generateDataSetKey(testDataSet2, testTimePeriod1)]: {
+            dataSet: testDataSet2,
+            value: 70,
+          },
+          [generateDataSetKey(testDataSet3, testTimePeriod1)]: {
+            dataSet: testDataSet3,
+            value: 60,
+          },
+          [generateDataSetKey(testDataSet4, testTimePeriod1)]: {
+            dataSet: testDataSet4,
+            value: 40,
+          },
+        },
+        filter: testTimePeriod1,
+      },
+    ];
+
+    const result = getDataSetCategoryConfigs({
+      dataSetCategories: testDataSetCategories,
+      legendItems: [],
+      meta: testSubjectMeta,
+    });
+
+    const expected: DataSetCategoryConfig[] = [
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 1, Location 1)',
+          colour: '#12436D',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet1, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet1, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet1, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 2, Location 1)',
+          colour: '#F46A25',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet2, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet2, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet2, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 1, Location 1)',
+          colour: '#801650',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet3, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet3, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet3, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 2, Location 1)',
+          colour: '#28A197',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet4, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet4, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet4, testTimePeriod1),
+        ),
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('returns configs correctly when grouped by location', () => {
+    const testDataSetCategories: DataSetCategory[] = [
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet1, testLocation1)]: {
+            dataSet: testDataSet1,
+            value: 30,
+          },
+          [generateDataSetKey(testDataSet2, testLocation1)]: {
+            dataSet: testDataSet2,
+            value: 70,
+          },
+          [generateDataSetKey(testDataSet3, testLocation1)]: {
+            dataSet: testDataSet3,
+            value: 60,
+          },
+          [generateDataSetKey(testDataSet4, testLocation1)]: {
+            dataSet: testDataSet4,
+            value: 40,
+          },
+        },
+        filter: testLocation1,
+      },
+    ];
+
+    const result = getDataSetCategoryConfigs({
+      dataSetCategories: testDataSetCategories,
+      legendItems: [],
+      meta: testSubjectMeta,
+    });
+
+    const expected: DataSetCategoryConfig[] = [
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 1, 2020/21)',
+          colour: '#12436D',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet1, testLocation1),
+        dataSet: expandDataSet(testDataSet1, testSubjectMeta),
+        rawDataSet: JSON.parse(generateDataSetKey(testDataSet1, testLocation1)),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 2, 2020/21)',
+          colour: '#F46A25',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet2, testLocation1),
+        dataSet: expandDataSet(testDataSet2, testSubjectMeta),
+        rawDataSet: JSON.parse(generateDataSetKey(testDataSet2, testLocation1)),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 1, 2020/21)',
+          colour: '#801650',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet3, testLocation1),
+        dataSet: expandDataSet(testDataSet3, testSubjectMeta),
+        rawDataSet: JSON.parse(generateDataSetKey(testDataSet3, testLocation1)),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 2, 2020/21)',
+          colour: '#28A197',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet4, testLocation1),
+        dataSet: expandDataSet(testDataSet4, testSubjectMeta),
+        rawDataSet: JSON.parse(generateDataSetKey(testDataSet4, testLocation1)),
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('returns configs correctly when grouped by indicator', () => {
+    const testDataSetCategories: DataSetCategory[] = [
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet1, testIndicator1)]: {
+            dataSet: testDataSet1,
+            value: 30,
+          },
+          [generateDataSetKey(testDataSet2, testIndicator1)]: {
+            dataSet: testDataSet2,
+            value: 70,
+          },
+          [generateDataSetKey(testDataSet3, testIndicator1)]: {
+            dataSet: testDataSet3,
+            value: 60,
+          },
+          [generateDataSetKey(testDataSet4, testIndicator1)]: {
+            dataSet: testDataSet4,
+            value: 40,
+          },
+        },
+        filter: testIndicator1,
+      },
+    ];
+
+    const result = getDataSetCategoryConfigs({
+      dataSetCategories: testDataSetCategories,
+      legendItems: [],
+      meta: testSubjectMeta,
+    });
+
+    const expected: DataSetCategoryConfig[] = [
+      {
+        config: {
+          label: 'Filter group 1 item 1, Location 1, 2020/21',
+          colour: '#12436D',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet1, testIndicator1),
+        dataSet: expandDataSet(testDataSet1, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet1, testIndicator1),
+        ),
+      },
+      {
+        config: {
+          label: 'Filter group 1 item 2, Location 1, 2020/21',
+          colour: '#F46A25',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet2, testIndicator1),
+        dataSet: expandDataSet(testDataSet2, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet2, testIndicator1),
+        ),
+      },
+      {
+        config: {
+          label: 'Filter group 2 item 1, Location 1, 2020/21',
+          colour: '#801650',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet3, testIndicator1),
+        dataSet: expandDataSet(testDataSet3, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet3, testIndicator1),
+        ),
+      },
+      {
+        config: {
+          label: 'Filter group 2 item 2, Location 1, 2020/21',
+          colour: '#28A197',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet4, testIndicator1),
+        dataSet: expandDataSet(testDataSet4, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet4, testIndicator1),
+        ),
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('returns configs correctly when grouped by filters without filter groups', () => {
+    const testDataSetCategories: DataSetCategory[] = [
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet1, testFilterGroup1Item1)]: {
+            dataSet: testDataSet1,
+            value: 30,
+          },
+        },
+        filter: testFilterGroup1Item1,
+      },
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet2, testFilterGroup1Item2)]: {
+            dataSet: testDataSet2,
+            value: 70,
+          },
+        },
+        filter: testFilterGroup1Item2,
+      },
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet3, testFilterGroup2Item1)]: {
+            dataSet: testDataSet3,
+            value: 60,
+          },
+        },
+        filter: testFilterGroup2Item1,
+      },
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet4, testFilterGroup2Item2)]: {
+            dataSet: testDataSet4,
+            value: 40,
+          },
+        },
+        filter: testFilterGroup2Item2,
+      },
+    ];
+    const result = getDataSetCategoryConfigs({
+      dataSetCategories: testDataSetCategories,
+      legendItems: [],
+      meta: testSubjectMeta,
+    });
+
+    const expected: DataSetCategoryConfig[] = [
+      {
+        config: {
+          label: 'Indicator 1 (Location 1, 2020/21)',
+          colour: '#12436D',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet1, testFilterGroup1Item1),
+        dataSet: expandDataSet(testDataSet1, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet1, testFilterGroup1Item1),
+        ),
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('returns configs correctly when grouped by filters and filter groups', () => {
+    const testDataSetCategories: DataSetCategory[] = [
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet1)]: {
+            dataSet: testDataSet1,
+            value: 30,
+          },
+        },
+        filter: testFilterGroup1Item1,
+      },
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet2)]: {
+            dataSet: testDataSet2,
+            value: 70,
+          },
+        },
+        filter: testFilterGroup1Item2,
+      },
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet3)]: {
+            dataSet: testDataSet3,
+            value: 60,
+          },
+        },
+        filter: testFilterGroup2Item1,
+      },
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet4)]: {
+            dataSet: testDataSet4,
+            value: 40,
+          },
+        },
+        filter: testFilterGroup2Item2,
+      },
+    ];
+
+    const result = getDataSetCategoryConfigs({
+      dataSetCategories: testDataSetCategories,
+      groupByFilterGroups: true,
+      legendItems: [],
+      meta: testSubjectMeta,
+    });
+
+    const expected: DataSetCategoryConfig[] = [
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 1, Location 1, 2020/21)',
+          colour: '#12436D',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet1),
+        dataSet: expandDataSet(testDataSet1, testSubjectMeta),
+        rawDataSet: testDataSet1,
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 2, Location 1, 2020/21)',
+          colour: '#F46A25',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet2),
+        dataSet: expandDataSet(testDataSet2, testSubjectMeta),
+        rawDataSet: testDataSet2,
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 1, Location 1, 2020/21)',
+          colour: '#801650',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet3),
+        dataSet: expandDataSet(testDataSet3, testSubjectMeta),
+        rawDataSet: testDataSet3,
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 2, Location 1, 2020/21)',
+          colour: '#28A197',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet4),
+        dataSet: expandDataSet(testDataSet4, testSubjectMeta),
+        rawDataSet: testDataSet4,
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('returns config from existing legend items if present', () => {
+    const testDataSetCategories: DataSetCategory[] = [
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet1, testTimePeriod1)]: {
+            dataSet: testDataSet1,
+            value: 30,
+          },
+          [generateDataSetKey(testDataSet2, testTimePeriod1)]: {
+            dataSet: testDataSet2,
+            value: 70,
+          },
+          [generateDataSetKey(testDataSet3, testTimePeriod1)]: {
+            dataSet: testDataSet3,
+            value: 60,
+          },
+          [generateDataSetKey(testDataSet4, testTimePeriod1)]: {
+            dataSet: testDataSet4,
+            value: 40,
+          },
+        },
+        filter: testTimePeriod1,
+      },
+    ];
+
+    const testLegendItems: LegendItem[] = [
+      {
+        colour: '#28A197',
+        dataSet: omit(testDataSet1, 'timePeriod'),
+        label: 'Label 1',
+      },
+      {
+        colour: '#6BACE6',
+        dataSet: omit(testDataSet2, 'timePeriod'),
+        label: 'Label 2',
+      },
+      {
+        colour: '#28A197',
+        dataSet: omit(testDataSet3, 'timePeriod'),
+        label: 'Label 3',
+      },
+      {
+        colour: '#6BACE6',
+        dataSet: omit(testDataSet4, 'timePeriod'),
+        label: 'Label 4',
+      },
+    ];
+
+    const result = getDataSetCategoryConfigs({
+      dataSetCategories: testDataSetCategories,
+      legendItems: testLegendItems,
+      meta: testSubjectMeta,
+    });
+
+    const expected: DataSetCategoryConfig[] = [
+      {
+        config: {
+          label: 'Label 1',
+          colour: '#28A197',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet1, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet1, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet1, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Label 2',
+          colour: '#6BACE6',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet2, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet2, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet2, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Label 3',
+          colour: '#28A197',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet3, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet3, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet3, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Label 4',
+          colour: '#6BACE6',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet4, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet4, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet4, testTimePeriod1),
+        ),
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('returns config from data sets if present and there is no legend config', () => {
+    const testDataSetCategories: DataSetCategory[] = [
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet1, testTimePeriod1)]: {
+            dataSet: {
+              ...testDataSet1,
+              config: {
+                colour: '#28A197',
+                label: 'Label 1',
+              },
+            },
+            value: 30,
+          },
+          [generateDataSetKey(testDataSet2, testTimePeriod1)]: {
+            dataSet: {
+              ...testDataSet2,
+              config: {
+                colour: '#6BACE6',
+                label: 'Label 2',
+              },
+            },
+            value: 70,
+          },
+          [generateDataSetKey(testDataSet3, testTimePeriod1)]: {
+            dataSet: {
+              ...testDataSet3,
+              config: {
+                colour: '#28A197',
+                label: 'Label 3',
+              },
+            },
+            value: 60,
+          },
+          [generateDataSetKey(testDataSet4, testTimePeriod1)]: {
+            dataSet: {
+              ...testDataSet4,
+              config: {
+                colour: '#6BACE6',
+                label: 'Label 4',
+              },
+            },
+            value: 40,
+          },
+        },
+        filter: testTimePeriod1,
+      },
+    ];
+
+    const result = getDataSetCategoryConfigs({
+      dataSetCategories: testDataSetCategories,
+      legendItems: [],
+      meta: testSubjectMeta,
+    });
+
+    const expected: DataSetCategoryConfig[] = [
+      {
+        config: {
+          label: 'Label 1',
+          colour: '#28A197',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet1, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet1, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet1, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Label 2',
+          colour: '#6BACE6',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet2, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet2, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet2, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Label 3',
+          colour: '#28A197',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet3, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet3, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet3, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Label 4',
+          colour: '#6BACE6',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet4, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet4, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet4, testTimePeriod1),
+        ),
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('returns the default config is there is no legend or data set config', () => {
+    const testDataSetCategories: DataSetCategory[] = [
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet1, testTimePeriod1)]: {
+            dataSet: testDataSet1,
+            value: 30,
+          },
+          [generateDataSetKey(testDataSet2, testTimePeriod1)]: {
+            dataSet: testDataSet2,
+            value: 70,
+          },
+          [generateDataSetKey(testDataSet3, testTimePeriod1)]: {
+            dataSet: testDataSet3,
+            value: 60,
+          },
+          [generateDataSetKey(testDataSet4, testTimePeriod1)]: {
+            dataSet: testDataSet4,
+            value: 40,
+          },
+        },
+        filter: testTimePeriod1,
+      },
+    ];
+
+    const result = getDataSetCategoryConfigs({
+      dataSetCategories: testDataSetCategories,
+      legendItems: [],
+      meta: testSubjectMeta,
+    });
+
+    const expected: DataSetCategoryConfig[] = [
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 1, Location 1)',
+          colour: '#12436D',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet1, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet1, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet1, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 2, Location 1)',
+          colour: '#F46A25',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet2, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet2, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet2, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 1, Location 1)',
+          colour: '#801650',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet3, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet3, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet3, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 2, Location 1)',
+          colour: '#28A197',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet4, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet4, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet4, testTimePeriod1),
+        ),
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('returns the deprecated data grouping if present', () => {
+    const testDataSetCategories: DataSetCategory[] = [
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet1, testTimePeriod1)]: {
+            dataSet: testDataSet1,
+            value: 30,
+          },
+          [generateDataSetKey(testDataSet2, testTimePeriod1)]: {
+            dataSet: testDataSet2,
+            value: 70,
+          },
+          [generateDataSetKey(testDataSet3, testTimePeriod1)]: {
+            dataSet: testDataSet3,
+            value: 60,
+          },
+          [generateDataSetKey(testDataSet4, testTimePeriod1)]: {
+            dataSet: testDataSet4,
+            value: 40,
+          },
+        },
+        filter: testTimePeriod1,
+      },
+    ];
+
+    const testDeprecatedDataGrouping: DataGroupingConfig = {
+      customGroups: [],
+      numberOfGroups: 7,
+      type: 'Quantiles',
+    };
+
+    const result = getDataSetCategoryConfigs({
+      dataSetCategories: testDataSetCategories,
+      deprecatedDataClassification: 'Quantiles',
+      deprecatedDataGroups: 7,
+      legendItems: [],
+      meta: testSubjectMeta,
+    });
+
+    const expected: DataSetCategoryConfig[] = [
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 1, Location 1)',
+          colour: '#12436D',
+        },
+        dataGrouping: testDeprecatedDataGrouping,
+        dataKey: generateDataSetKey(testDataSet1, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet1, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet1, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 2, Location 1)',
+          colour: '#F46A25',
+        },
+        dataGrouping: testDeprecatedDataGrouping,
+        dataKey: generateDataSetKey(testDataSet2, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet2, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet2, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 1, Location 1)',
+          colour: '#801650',
+        },
+        dataGrouping: testDeprecatedDataGrouping,
+        dataKey: generateDataSetKey(testDataSet3, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet3, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet3, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 2, Location 1)',
+          colour: '#28A197',
+        },
+        dataGrouping: testDeprecatedDataGrouping,
+        dataKey: generateDataSetKey(testDataSet4, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet4, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet4, testTimePeriod1),
+        ),
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('returns the data set data grouping if present', () => {
+    const testDataSetCategories: DataSetCategory[] = [
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet1, testTimePeriod1)]: {
+            dataSet: testDataSet1,
+            value: 30,
+          },
+          [generateDataSetKey(testDataSet2, testTimePeriod1)]: {
+            dataSet: testDataSet2,
+            value: 70,
+          },
+          [generateDataSetKey(testDataSet3, testTimePeriod1)]: {
+            dataSet: testDataSet3,
+            value: 60,
+          },
+          [generateDataSetKey(testDataSet4, testTimePeriod1)]: {
+            dataSet: testDataSet4,
+            value: 40,
+          },
+        },
+        filter: testTimePeriod1,
+      },
+    ];
+
+    const testDataSetConfigs: MapDataSetConfig[] = [
+      {
+        dataSet: omit(testDataSet1, 'timePeriod'),
+        dataGrouping: {
+          customGroups: [],
+          numberOfGroups: 2,
+          type: 'EqualIntervals',
+        },
+      },
+      {
+        dataSet: omit(testDataSet2, 'timePeriod'),
+        dataGrouping: {
+          customGroups: [],
+          numberOfGroups: 9,
+          type: 'Quantiles',
+        },
+      },
+      {
+        dataSet: omit(testDataSet3, 'timePeriod'),
+        dataGrouping: {
+          customGroups: [{ min: 0, max: 10 }],
+          numberOfGroups: 9,
+          type: 'Custom',
+        },
+      },
+      {
+        dataSet: omit(testDataSet4, 'timePeriod'),
+        dataGrouping: {
+          customGroups: [
+            { min: 0, max: 10 },
+            { min: 11, max: 20 },
+          ],
+          numberOfGroups: 9,
+          type: 'Custom',
+        },
+      },
+    ];
+
+    const result = getDataSetCategoryConfigs({
+      dataSetCategories: testDataSetCategories,
+      dataSetConfigs: testDataSetConfigs,
+      legendItems: [],
+      meta: testSubjectMeta,
+    });
+
+    const expected: DataSetCategoryConfig[] = [
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 1, Location 1)',
+          colour: '#12436D',
+        },
+        dataGrouping: {
+          customGroups: [],
+          numberOfGroups: 2,
+          type: 'EqualIntervals',
+        },
+        dataKey: generateDataSetKey(testDataSet1, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet1, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet1, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 2, Location 1)',
+          colour: '#F46A25',
+        },
+        dataGrouping: {
+          customGroups: [],
+          numberOfGroups: 9,
+          type: 'Quantiles',
+        },
+        dataKey: generateDataSetKey(testDataSet2, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet2, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet2, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 1, Location 1)',
+          colour: '#801650',
+        },
+        dataGrouping: {
+          customGroups: [{ min: 0, max: 10 }],
+          numberOfGroups: 9,
+          type: 'Custom',
+        },
+        dataKey: generateDataSetKey(testDataSet3, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet3, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet3, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 2, Location 1)',
+          colour: '#28A197',
+        },
+        dataGrouping: {
+          customGroups: [
+            { min: 0, max: 10 },
+            { min: 11, max: 20 },
+          ],
+          numberOfGroups: 9,
+          type: 'Custom',
+        },
+        dataKey: generateDataSetKey(testDataSet4, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet4, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet4, testTimePeriod1),
+        ),
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('returns the default data grouping if no deprecated or data set data grouping present', () => {
+    const testDataSetCategories: DataSetCategory[] = [
+      {
+        dataSets: {
+          [generateDataSetKey(testDataSet1, testTimePeriod1)]: {
+            dataSet: testDataSet1,
+            value: 30,
+          },
+          [generateDataSetKey(testDataSet2, testTimePeriod1)]: {
+            dataSet: testDataSet2,
+            value: 70,
+          },
+          [generateDataSetKey(testDataSet3, testTimePeriod1)]: {
+            dataSet: testDataSet3,
+            value: 60,
+          },
+          [generateDataSetKey(testDataSet4, testTimePeriod1)]: {
+            dataSet: testDataSet4,
+            value: 40,
+          },
+        },
+        filter: testTimePeriod1,
+      },
+    ];
+
+    const result = getDataSetCategoryConfigs({
+      dataSetCategories: testDataSetCategories,
+      legendItems: [],
+      meta: testSubjectMeta,
+    });
+
+    const expected: DataSetCategoryConfig[] = [
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 1, Location 1)',
+          colour: '#12436D',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet1, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet1, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet1, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 1 item 2, Location 1)',
+          colour: '#F46A25',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet2, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet2, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet2, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 1, Location 1)',
+          colour: '#801650',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet3, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet3, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet3, testTimePeriod1),
+        ),
+      },
+      {
+        config: {
+          label: 'Indicator 1 (Filter group 2 item 2, Location 1)',
+          colour: '#28A197',
+        },
+        dataGrouping: testDataGrouping,
+        dataKey: generateDataSetKey(testDataSet4, testTimePeriod1),
+        dataSet: expandDataSet(testDataSet4, testSubjectMeta),
+        rawDataSet: JSON.parse(
+          generateDataSetKey(testDataSet4, testTimePeriod1),
+        ),
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
@@ -199,10 +199,13 @@ function getCategoryFilters(
  * Create a map of data sets to their respective key
  * so they can be used in the chart data.
  */
-function createKeyedDataSets(
-  dataSets: Pair<ChildDataSet, number>[],
-  filter: Filter,
-): DataSetCategory['dataSets'] {
+function createKeyedDataSets({
+  dataSets,
+  filter,
+}: {
+  dataSets: Pair<ChildDataSet, number>[];
+  filter?: Filter;
+}): DataSetCategory['dataSets'] {
   return dataSets.reduce<DataSetCategory['dataSets']>(
     (acc, [childDataSet, value]) => {
       const { dataSet } = childDataSet;
@@ -278,8 +281,8 @@ function getSortedDataSetCategoryRange(
 interface Options {
   axisConfiguration: AxisConfiguration;
   data: TableDataResult[];
-  meta: FullTableMeta;
   includeNonNumericData?: boolean;
+  meta: FullTableMeta;
 }
 
 /**
@@ -318,8 +321,8 @@ interface Options {
 export default function createDataSetCategories({
   axisConfiguration,
   data,
-  meta,
   includeNonNumericData = false,
+  meta,
 }: Options): DataSetCategory[] {
   const categoryFilters = getCategoryFilters(axisConfiguration, meta);
   const childDataSets = getChildDataSets(axisConfiguration, meta);
@@ -373,7 +376,10 @@ export default function createDataSetCategories({
 
       return {
         filter,
-        dataSets: createKeyedDataSets(matchingDataSets, filter),
+        dataSets: createKeyedDataSets({
+          dataSets: matchingDataSets,
+          filter: !axisConfiguration.groupByFilterGroups ? filter : undefined,
+        }),
       };
     })
     .filter(category => Object.values(category.dataSets).length > 0);


### PR DESCRIPTION
Currently using stacked bar charts when the chart is grouped by filters with filter groups doesn't work, you just get inidividual bars:

<img width="742" alt="before" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/f47e7678-40d5-4ee0-8bec-886779161db9">

This PR adds an option to use filter groups in stacked bar charts. The option is added to the chart configuration tab and will only appear when you select 'Stacked bars' and the chart if grouped by a filter with filter groups.

When the option is selected the charts will now stack correctly.

<img width="752" alt="stacked" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/48d8a708-78f4-4d7d-bd4b-98ea3f1c7f7e">
