### PR TITLE
EES-4376 Allow uses to edit methodologies in higher review if they ha…

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/MethodologyContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/MethodologyContentPage.tsx
@@ -27,8 +27,7 @@ export const MethodologyContentPageInternal = () => {
   const { methodology, canUpdateMethodology, isPreRelease } =
     useMethodologyContentState();
 
-  const canUpdateContent =
-    !isPreRelease && canUpdateMethodology && methodology.status === 'Draft';
+  const canUpdateContent = !isPreRelease && canUpdateMethodology;
 
   return (
     <EditingContextProvider editingMode={canUpdateContent ? 'edit' : 'preview'}>


### PR DESCRIPTION
…ve permission

This PR fixes a defect found in testing that an approver couldn't edit a methodology that was in higher review. This was not aligned with the permissions approvers have on releases.

The backend methodology update permissions endpoint already returns false if a methodology is approved, so there is no reason to check the status at all in the frontend when determining whether the methodology content can be edited.

NOTE: There is a difference in behaviour between the UpdateSpecificMethodology auth handler and UpdateSpecificRelease auth handler. This will be addressed in EES-2908.