### PR TITLE
EES-4479 fix set page view panel icon

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.module.scss
@@ -26,10 +26,13 @@
 }
 
 .button {
+  align-items: center;
   background: $govuk-brand-colour;
   border: 4px solid transparent;
   color: govuk-colour('white');
   cursor: pointer;
+  display: flex;
+  justify-content: space-between;
   font-size: 1.5rem;
   font-weight: 700;
   line-height: 1.25;
@@ -43,19 +46,6 @@
   &:focus-visible {
     border-color: govuk-colour('yellow');
     outline: none;
-  }
-}
-
-.button :global(.govuk-accordion__icon) {
-  &::before,
-  &::after {
-    background-color: govuk-colour('white');
-  }
-}
-
-.open :global(.govuk-accordion__icon) {
-  &::after {
-    content: none;
   }
 }
 

--- a/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.tsx
@@ -47,7 +47,12 @@ const EditablePageModeToggle = ({
         aria-expanded={isOpen}
       >
         Set page view
-        <span className="govuk-accordion__icon" aria-hidden />
+        <span
+          className={classNames('govuk-accordion-nav__chevron', {
+            'govuk-accordion-nav__chevron--down': isOpen,
+          })}
+          aria-hidden
+        />
       </button>
       <div aria-labelledby="pageViewToggleButton" className={styles.content}>
         <FormRadioGroup


### PR DESCRIPTION
The ‘Set page view’ panel on release content in the admin used to have a plus / minus icon on the top right, it’s disappeared as a result of the govuk-frontend update as the icon used, `govuk-accordion__icon`, no longer exists. This replaces it with the chevron icon used in the new accordions.

![panel](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/2af32c13-03f6-4536-bc48-79d62238482d)
