### PR TITLE
EES-4021 Allow custom magic.mgc file paths to be configured via local appsettings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ remote-profile
 
 .DS_Store
 
+src/GovUk.Education.ExploreEducationStatistics.*/appsettings.Local.json
 src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Idp.json
 
 ## IdentityServer Developer Signing key

--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ The project is primarily composed of two areas:
 
 ### Public frontend (for general public users)
 
-- **UI**
+- **UI** - `src/explore-education-statistics-frontend`
   - NextJS React app
   - Depends on:
     - Content API
     - Data API
     - Notifier
 
-- **Content API**
+- **Content API** - `src/GovUk.Education.ExploreEducationStatistics.Content.Api`
   - Depends on:
     - Publisher - to generate its cache
 
-- **Data API**
+- **Data API** - `src/GovUk.Education.ExploreEducationStatistics.Data.Api`
   - Depends on:
     - SQLServer `statistics` database (known as `public-statistics` in non-local environments)
 
@@ -28,12 +28,12 @@ The project is primarily composed of two areas:
 
 ### Admin (for admins and analysts)
 
-- **UI**
+- **UI** - `src/explore-education-statistics-admin`
   - CRA React app
   - Depends on:
     - Admin API
 
-- **Admin API**
+- **Admin API** - `src/GovUk.Education.ExploreEducationStatistics.Admin`
   - Depends on:
     - SQLServer `content` database
     - SQLServer `statistics` database
@@ -41,14 +41,14 @@ The project is primarily composed of two areas:
     - Notifier
     - Data Processor
 
-- **Publisher**
+- **Publisher** - `src/GovUk.Education.ExploreEducationStatistics.Publisher`
   - Azure function for publishing admin content to the public frontend
 
-- **Notifier**
+- **Notifier** - `src/GovUk.Education.ExploreEducationStatistics.Notifier`
   - Azure function for sending notifications
 
-- **Data Processor**
-  - Azure function for handling dataset imports into the admin. Also referred to as the "importer".
+- **Data Processor** - `src/GovUk.Education.ExploreEducationStatistics.Data.Processor`
+  - Azure function for handling dataset imports into the admin. Also referred to as the 'importer' or just 'processor'.
 
 ## Getting started
 
@@ -119,7 +119,7 @@ potentially happen on Mac (but this needs to be confirmed).
 This could result in the following projects failing to work correctly:
 
 - Admin (unlikely to have an issue, but still mentioned in case)
-- Processor (will error during file validation)
+- Data Processor (will error during file validation)
 
 To fix this, you need to create an `appsettings.Local.json` file in the relevant project e.g.
 

--- a/README.md
+++ b/README.md
@@ -54,76 +54,87 @@ The project is primarily composed of two areas:
 
 ### Requirements
 
-You will need the following groups of dependencies to run the project successfully:
+You will need the following groups of dependencies to run the project successfully.
 
-1. To run applications in this service you will require the following:
+To run applications in this service you will require the following:
 
    - [NodeJS v18+](https://nodejs.org/)
    - [.NET Core v6.0](https://dotnet.microsoft.com/download/dotnet-core/6.0)
    - [Azure Functions Core Tools v4+](https://github.com/Azure/azure-functions-core-tools)
    
-2. To run the databases:
+To run the databases:
    - [Docker and Docker Compose](https://docs.docker.com/) - see [Setting up the database](#setting-up-the-database-and-storage-emulator)
 
-3. To emulate Azure storage services (blobs, tables and queues) you will require one of the following 
-   options.
-   - [Azurite for Docker and Docker Compose](https://docs.docker.com/) - recommended approach. See [Setting up the storage emulator](#setting-up-the-database-and-storage-emulator)
+To emulate Azure storage services (blobs, tables and queues) you will require one of the following options.
+   - [Azurite for Docker and Docker Compose](https://docs.docker.com/) - recommended, see [Setting up the storage emulator](#setting-up-the-database-and-storage-emulator)
+   - Alternatively, if opting to not use Storage Explorer at all, you could create your own Storage
+     Account on Azure and amend your storage connection strings to point to this.
+     - [Azure Storage Account](https://azure.microsoft.com/en-gb/services/storage/)
+     - [Running against other databases](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator#start-and-initialize-the-storage-emulator)
 
-     - Alternatively, if opting to not use Storage Explorer at all, you could create your own Storage
-       Account on Azure and amend your storage connection strings to point to this.
-       - [Azure Storage Account](https://azure.microsoft.com/en-gb/services/storage/)
-       - [Running against other databases](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator#start-and-initialize-the-storage-emulator)
+### Setup libmagic (Linux and Mac only)
 
+#### Linux only 
 
-4. Setup libmagic (Linux and Mac only)
+Add symlinks to `libmagic-1`:
 
-**Linux only** 
+```sh
+cd /usr/lib/x86_64-linux-gnu/
+sudo ln -s libmagic.so.1.0.0 libmagic-1.so
+sudo ln -s libmagic.so.1.0.0 libmagic-1.so.1
+```
 
-  Add symlinks to libmagic-1:
+See [bug raised with the library](https://github.com/hey-red/Mime/issues/36) for more info.
 
-   ```sh
-   cd /usr/lib/x86_64-linux-gnu/
-   sudo ln -s libmagic.so.1.0.0 libmagic-1.so
-   sudo ln -s libmagic.so.1.0.0 libmagic-1.so.1
-   ```
+#### Mac only
 
-   See [bug raised with the library](https://github.com/hey-red/Mime/issues/36) for more info.
-   
-   Use correct version of `magic.mgc` file (Ubuntu 22.04 or later only):
+Install and link `libmagic`:
 
-   If you're using Ubuntu 22.04 or later you'll need to place an updated [magic.mgc](https://github.com/hey-red/Mime/blob/master/src/Mime/content/magic.mgc) file in `src/GovUk.Education.ExploreEducationStatistics.Common/libs` due to an issue with mismatched versions of `libmagic` and `magic.mgc`. You will then need to rebuild the project to ensure the new file is copied to the output directory.
+```sh
+brew install libmagic
+brew link libmagic
+env ARCHFLAGS="-arch x86_64" sudo gem install ruby-filemagic -- --with-magic-include=/usr/local/include --with-magic-lib=/usr/local/lib/
+```
 
-**Mac only**
+Download and link the `dylib` magic file.
 
-   Install and link libmagic:
+Depending on the arch of your machine, you will need to download a different dylib file dependent 
+on the architecture of your machine. You can find the correct file [in the runtimes section](https://github.com/hey-red/Mime/tree/master/src/Mime/runtimes) 
+of the library.
 
-    ```sh
-    brew install libmagic
-    brew link libmagic
-    env ARCHFLAGS="-arch x86_64" sudo gem install ruby-filemagic -- --with-magic-include=/usr/local/include --with-magic-lib=/usr/local/lib/
-    ```
+Download this file and place it somewhere where you won't accidentally delete it. Then link it to 
+the correct location:
 
+```sh
+sudo ln -s /Users/${whoami}/path/to/folder/libmagic-1.dylib /usr/local/liblibmagic-1
+sudo ln -s /Users/${whoami}/path/to/folder/libmagic-1.dylib /usr/local/lib/liblibmagic-1
+```
 
-  Download and link the `dylib` magic file.
+### Fix `magic.mgc` file version mismatches (Linux and maybe Mac only)
 
-    Depending on the arch of your machine, you will need to download a different dylib file dependent on the arch of your machine. You can find the correct file [in the runtimes section](https://github.com/hey-red/Mime/tree/master/src/Mime/runtimes) of the library
+If you're using Ubuntu 22.04, or later you'll most likely be using a `libmagic-1` binary that isn't
+synchronized correctly with the `magic.mgc` file distributed with the builds. A similar thing may 
+potentially happen on Mac (but this needs to be confirmed).
 
-    Download this file and place it somewhere where you won't accidentally delete it. Then link it to the correct location:
+This could result in the following projects failing to work correctly:
 
-    ```sh
-    sudo ln -s /Users/${whoami}/path/to/folder/libmagic-1.dylib /usr/local/liblibmagic-1
-    sudo ln -s /Users/${whoami}/path/to/folder/libmagic-1.dylib /usr/local/lib/liblibmagic-1
-    ```
+- Admin (unlikely to have an issue, but still mentioned in case)
+- Processor (will error during file validation)
 
-  Upgrade version of `Mime` in `src/GovUk.Education.ExploreEducationStatistics.Common`
+To fix this, you need to create an `appsettings.Local.json` file in the relevant project e.g.
 
-  You'll need to upgrade the version of Mime to `3.4.0` in order for it to work with the new version of `libmagic`. You can do this by editing the `Mime` dependency in the `src/GovUk.Education.ExploreEducationStatistics.Common/` cs proj file:
+```
+touch src/GovUk.Education.ExploreEducationStatistics.Data.Processor/appsettings.Local.json
+```
 
-  ```sh
-    <PackageReference Include="Mime" Version="3.4.0" />
-  ```
+Then ensure it has the following:
 
-  you'll then need to rebuild the project to ensure changes take effect.
+```json
+{
+  "MagicFilePath": "/usr/lib/file/magic.mgc"
+}
+```
+The above should work for Ubuntu, but you can change this path to whatever you want on your filesystem.
 
 ### Install PNPM via corepack
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Program.cs
@@ -32,6 +32,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                         $"appsettings.{Environment.GetEnvironmentVariable("BootstrapUsersConfiguration")}.json", 
                         optional: true, 
                         reloadOnChange: true);
+
+                    builder.AddJsonFile(
+                        "appsettings.Local.json",
+                        optional: true,
+                        reloadOnChange: true);
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Resources/test-no-xml.svg
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Resources/test-no-xml.svg
@@ -1,0 +1,86 @@
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='288.00pt' height='288.00pt' viewBox='0 0 288.00 288.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHwyODguMDB8MC4wMHwyODguMDA='>
+    <rect x='0.00' y='0.00' width='288.00' height='288.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHwyODguMDB8MC4wMHwyODguMDA=)'>
+<rect x='0.00' y='0.00' width='288.00' height='288.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDIuOTN8MjAxLjYzfDUuNDh8MjU2LjUw'>
+    <rect x='42.93' y='5.48' width='158.70' height='251.02' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuOTN8MjAxLjYzfDUuNDh8MjU2LjUw)'>
+<rect x='42.93' y='5.48' width='158.70' height='251.02' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='42.93,219.69 201.63,219.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,173.03 201.63,173.03 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,126.38 201.63,126.38 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,79.73 201.63,79.73 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,33.08 201.63,33.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='61.53,256.50 61.53,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='99.50,256.50 99.50,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='137.47,256.50 137.47,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='175.44,256.50 175.44,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,243.01 201.63,243.01 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,196.36 201.63,196.36 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,149.71 201.63,149.71 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,103.06 201.63,103.06 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,56.41 201.63,56.41 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,9.75 201.63,9.75 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='80.52,256.50 80.52,5.48 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='118.49,256.50 118.49,5.48 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='156.45,256.50 156.45,5.48 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='194.42,256.50 194.42,5.48 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='50.14,171.53 57.74,156.67 65.33,145.73 72.92,138.15 80.52,133.37 88.11,130.83 95.70,129.97 103.30,130.23 110.89,131.05 118.49,131.87 126.08,132.12 133.67,131.26 141.27,128.72 148.86,123.94 156.45,116.36 164.05,105.43 171.64,90.57 179.23,71.23 186.83,46.86 194.42,16.89 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='50.14,245.09 57.74,215.13 65.33,190.77 72.92,171.44 80.52,156.60 88.11,145.67 95.70,138.10 103.30,133.33 110.89,130.80 118.49,129.95 126.08,130.22 133.67,131.05 141.27,131.88 148.86,132.15 156.45,131.29 164.05,128.76 171.64,123.99 179.23,116.43 186.83,105.50 194.42,90.65 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHwyODguMDB8MC4wMHwyODguMDA=)'>
+<text x='38.00' y='246.16' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='38.00' y='199.51' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>500</text>
+<text x='38.00' y='152.86' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='38.00' y='106.21' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1500</text>
+<text x='38.00' y='59.56' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2000</text>
+<text x='38.00' y='12.90' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2500</text>
+<polyline points='40.19,243.01 42.93,243.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.19,196.36 42.93,196.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.19,149.71 42.93,149.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.19,103.06 42.93,103.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.19,56.41 42.93,56.41 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.19,9.75 42.93,9.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='80.52,259.24 80.52,256.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='118.49,259.24 118.49,256.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='156.45,259.24 156.45,256.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='194.42,259.24 194.42,256.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='80.52' y='267.74' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='118.49' y='267.74' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='156.45' y='267.74' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='194.42' y='267.74' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='122.28' y='280.20' text-anchor='middle' style='font-size: 11.00px; font-family: "Arial";' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.36,130.99) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Arial";' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<rect x='212.59' y='100.39' width='69.93' height='61.19' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='218.07' y='114.91' style='font-size: 11.00px; font-family: "Arial";' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text>
+<rect x='218.07' y='121.55' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<line x1='219.80' y1='130.19' x2='233.62' y2='130.19' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<rect x='218.07' y='138.83' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<line x1='219.80' y1='147.47' x2='233.62' y2='147.47' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<text x='240.83' y='133.34' style='font-size: 8.80px; font-family: "Arial";' textLength='36.21px' lengthAdjust='spacingAndGlyphs'>relation 1</text>
+<text x='240.83' y='150.62' style='font-size: 8.80px; font-family: "Arial";' textLength='36.21px' lengthAdjust='spacingAndGlyphs'>relation 2</text>
+</g>
+</svg>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Resources/test.svg
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Resources/test.svg
@@ -1,0 +1,87 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='288.00pt' height='288.00pt' viewBox='0 0 288.00 288.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHwyODguMDB8MC4wMHwyODguMDA='>
+    <rect x='0.00' y='0.00' width='288.00' height='288.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHwyODguMDB8MC4wMHwyODguMDA=)'>
+<rect x='0.00' y='0.00' width='288.00' height='288.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDIuOTN8MjAxLjYzfDUuNDh8MjU2LjUw'>
+    <rect x='42.93' y='5.48' width='158.70' height='251.02' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuOTN8MjAxLjYzfDUuNDh8MjU2LjUw)'>
+<rect x='42.93' y='5.48' width='158.70' height='251.02' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='42.93,219.69 201.63,219.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,173.03 201.63,173.03 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,126.38 201.63,126.38 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,79.73 201.63,79.73 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,33.08 201.63,33.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='61.53,256.50 61.53,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='99.50,256.50 99.50,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='137.47,256.50 137.47,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='175.44,256.50 175.44,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,243.01 201.63,243.01 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,196.36 201.63,196.36 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,149.71 201.63,149.71 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,103.06 201.63,103.06 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,56.41 201.63,56.41 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.93,9.75 201.63,9.75 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='80.52,256.50 80.52,5.48 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='118.49,256.50 118.49,5.48 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='156.45,256.50 156.45,5.48 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='194.42,256.50 194.42,5.48 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='50.14,171.53 57.74,156.67 65.33,145.73 72.92,138.15 80.52,133.37 88.11,130.83 95.70,129.97 103.30,130.23 110.89,131.05 118.49,131.87 126.08,132.12 133.67,131.26 141.27,128.72 148.86,123.94 156.45,116.36 164.05,105.43 171.64,90.57 179.23,71.23 186.83,46.86 194.42,16.89 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='50.14,245.09 57.74,215.13 65.33,190.77 72.92,171.44 80.52,156.60 88.11,145.67 95.70,138.10 103.30,133.33 110.89,130.80 118.49,129.95 126.08,130.22 133.67,131.05 141.27,131.88 148.86,132.15 156.45,131.29 164.05,128.76 171.64,123.99 179.23,116.43 186.83,105.50 194.42,90.65 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHwyODguMDB8MC4wMHwyODguMDA=)'>
+<text x='38.00' y='246.16' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='38.00' y='199.51' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>500</text>
+<text x='38.00' y='152.86' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='38.00' y='106.21' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1500</text>
+<text x='38.00' y='59.56' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2000</text>
+<text x='38.00' y='12.90' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2500</text>
+<polyline points='40.19,243.01 42.93,243.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.19,196.36 42.93,196.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.19,149.71 42.93,149.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.19,103.06 42.93,103.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.19,56.41 42.93,56.41 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.19,9.75 42.93,9.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='80.52,259.24 80.52,256.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='118.49,259.24 118.49,256.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='156.45,259.24 156.45,256.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='194.42,259.24 194.42,256.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='80.52' y='267.74' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='118.49' y='267.74' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='156.45' y='267.74' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='194.42' y='267.74' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='122.28' y='280.20' text-anchor='middle' style='font-size: 11.00px; font-family: "Arial";' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.36,130.99) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Arial";' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<rect x='212.59' y='100.39' width='69.93' height='61.19' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='218.07' y='114.91' style='font-size: 11.00px; font-family: "Arial";' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text>
+<rect x='218.07' y='121.55' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<line x1='219.80' y1='130.19' x2='233.62' y2='130.19' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<rect x='218.07' y='138.83' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<line x1='219.80' y1='147.47' x2='233.62' y2='147.47' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<text x='240.83' y='133.34' style='font-size: 8.80px; font-family: "Arial";' textLength='36.21px' lengthAdjust='spacingAndGlyphs'>relation 1</text>
+<text x='240.83' y='150.62' style='font-size: 8.80px; font-family: "Arial";' textLength='36.21px' lengthAdjust='spacingAndGlyphs'>relation 2</text>
+</g>
+</svg>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/FileTypeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/FileTypeServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,6 +7,7 @@ using System.Text.RegularExpressions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -31,32 +33,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
     
     public class FileTypeServiceTests
     {
-        // ideally this would be detected as application/msword, but this is close enough
-        private static readonly FileInfo Doc = new FileInfo("test.doc", "application/CDFV2");
+        private static readonly FileInfo Doc = new("test.doc", "application/msword");
         
-        private static readonly FileInfo Docx = new FileInfo("test.docx", 
+        private static readonly FileInfo Docx = new("test.docx",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
         
-        private static readonly FileInfo Ods = new FileInfo("test.ods", 
+        private static readonly FileInfo Ods = new("test.ods",
             "application/vnd.oasis.opendocument.spreadsheet");
         
-        private static readonly FileInfo Odt = new FileInfo("test.odt", 
+        private static readonly FileInfo Odt = new("test.odt",
             "application/vnd.oasis.opendocument.text");
         
-        // ideally this would be detected as application/msexcel or application/vnd.ms-excel, but this is close enough
-        private static readonly FileInfo Xls = new FileInfo("test.xls", "application/CDFV2");
-        private static readonly FileInfo Xlsx = new FileInfo("test.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        private static readonly FileInfo Xlsx2 = new FileInfo("test2.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        private static readonly FileInfo Csv = new FileInfo("test.csv", "application/csv");
-        private static readonly FileInfo Txt = new FileInfo("test.txt", "text/plain");
-        private static readonly FileInfo Pdf = new FileInfo("test.pdf", "application/pdf");
-        private static readonly FileInfo Bmp = new FileInfo("test.bmp", "image/bmp");
-        private static readonly FileInfo Gif = new FileInfo("test.gif", "image/gif");
-        private static readonly FileInfo Jpg = new FileInfo("test.jpg", "image/jpeg");
-        private static readonly FileInfo Png = new FileInfo("test.png", "image/png");
-        private static readonly FileInfo Zip = new FileInfo("test.zip", "application/x-compressed");
+        private static readonly FileInfo Xls = new("test.xls", "application/vnd.ms-excel");
+        private static readonly FileInfo Xlsx = new("test.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        private static readonly FileInfo Xlsx2 = new("test2.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        private static readonly FileInfo Csv = new("test.csv", "text/csv");
+        private static readonly FileInfo Txt = new("test.txt", "text/plain");
+        private static readonly FileInfo Pdf = new("test.pdf", "application/pdf");
+        private static readonly FileInfo Bmp = new("test.bmp", "image/bmp");
+        private static readonly FileInfo Gif = new("test.gif", "image/gif");
+        private static readonly FileInfo Jpg = new("test.jpg", "image/jpeg");
+        private static readonly FileInfo Png = new("test.png", "image/png");
+        private static readonly FileInfo Zip = new("test.zip", "application/x-compressed");
         
-        private static readonly List<FileInfo> ImageTypes = new List<FileInfo>
+        private static readonly List<FileInfo> ImageTypes = new()
         {
             Bmp,
             Gif,
@@ -64,18 +64,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             Png
         };
         
-        private static readonly List<FileInfo> CsvTypes = new List<FileInfo>
+        private static readonly List<FileInfo> CsvTypes = new()
         {
             Csv,
             Txt,
         };
         
-        private static readonly List<FileInfo> ArchiveTypes = new List<FileInfo>
+        private static readonly List<FileInfo> ArchiveTypes = new()
         {
             Zip,
         };
         
-        private static readonly List<FileInfo> AllTypes = new List<FileInfo>
+        private static readonly List<FileInfo> AllTypes = new()
         {
             Doc,
             Docx,
@@ -223,9 +223,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         
         private static void AssertMimeTypeCorrect(FileInfo fileInfo)
         {
-            var service = new FileTypeService(Mock.Of<ILogger<FileTypeService>>());
+            var service = BuildService();
 
-            var filePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+            var filePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
                 "Resources" + Path.DirectorySeparatorChar + fileInfo.Filename);
             
             var formFile = new Mock<IFormFile>();
@@ -242,9 +242,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         private static void AssertHasMatchingMimeType(FileInfo fileInfo, List<Regex> availableMimeTypes, 
             bool expectedToSucceed)
         {
-            var service = new FileTypeService(Mock.Of<ILogger<FileTypeService>>());
+            var service = BuildService();
 
-            var filePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+            var filePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
                 "Resources" + Path.DirectorySeparatorChar + fileInfo.Filename);
             
             var formFile = new Mock<IFormFile>();
@@ -255,6 +255,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             var result = service.HasMatchingMimeType(formFile.Object, availableMimeTypes).Result;
             
             Assert.Equal(expectedToSucceed, result);
+        }
+
+        private static IConfiguration DefaultConfiguration()
+        {
+            return new ConfigurationBuilder().Build();
+        }
+
+        private static FileTypeService BuildService(IConfiguration? configuration = null)
+        {
+            return new FileTypeService(
+                Mock.Of<ILogger<FileTypeService>>(),
+                configuration ?? DefaultConfiguration()
+            );
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/FileTypeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/FileTypeServiceTests.cs
@@ -54,6 +54,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         private static readonly FileInfo Gif = new("test.gif", "image/gif");
         private static readonly FileInfo Jpg = new("test.jpg", "image/jpeg");
         private static readonly FileInfo Png = new("test.png", "image/png");
+        private static readonly FileInfo Svg = new("test.svg", "image/svg+xml");
+        private static readonly FileInfo SvgNoXml = new("test-no-xml.svg", "image/svg+xml");
         private static readonly FileInfo Zip = new("test.zip", "application/x-compressed");
         
         private static readonly List<FileInfo> ImageTypes = new()
@@ -171,7 +173,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         {
             AssertMimeTypeCorrect(Png);
         }
-        
+
+        [Fact]
+        public void GetMimeType_Svg()
+        {
+            AssertMimeTypeCorrect(Svg);
+        }
+
+        [Fact]
+        public void GetMimeType_Svg_NoXml()
+        {
+            AssertMimeTypeCorrect(SvgNoXml);
+        }
+
         [Fact]
         public void GetMimeType_Txt()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -30,7 +30,7 @@
         <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />
         <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-        <PackageReference Include="Mime" Version="3.1.0" />
+        <PackageReference Include="Mime" Version="3.5.1" />
         <PackageReference Include="Mime-Detective" Version="0.0.6-beta5" />
         <PackageReference Include="Thinktecture.EntityFrameworkCore.BulkOperations" Version="4.5.1" />
         <PackageReference Include="ZstdSharp.Port" Version="0.7.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileTypeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileTypeService.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using HeyRed.Mime;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using MimeDetective.Extensions;
 using FileType = MimeDetective.FileType;
@@ -37,10 +38,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         };
 
         private readonly ILogger<FileTypeService> _logger;
+        private readonly IConfiguration _configuration;
 
-        public FileTypeService(ILogger<FileTypeService> logger)
+        public FileTypeService(ILogger<FileTypeService> logger, IConfiguration configuration)
         {
             _logger = logger;
+            _configuration = configuration;
         }
 
         public async Task<string> GetMimeType(IFormFile file)
@@ -199,7 +202,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         private string GuessMagicInfo(Stream fileStream, MagicOpenFlags flag)
         {
             using var reader = new StreamReader(fileStream);
-            var magic = new Magic(flag);
+
+            var dbPath = _configuration.GetValue<string>("MagicFilePath");
+            var magic = new Magic(flag, dbPath);
+
             var bufferSize = reader.BaseStream.Length >= 1024 ? 1024 : (int) reader.BaseStream.Length;
             return magic.Read(reader.BaseStream, bufferSize);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.ApplicationInsights;
@@ -21,10 +22,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
                     webBuilder.UseStartup<Startup>();
                     webBuilder.ConfigureKestrel(serverOptions => { serverOptions.AddServerHeader = false; });
                 })
+                .ConfigureAppConfiguration((_, builder) =>
+                {
+                    builder.AddJsonFile(
+                        "appsettings.Local.json",
+                        optional: true,
+                        reloadOnChange: true);
+                })
                 .ConfigureLogging(
                     builder =>
                     {
-                        // Capture logs from early in the application startup 
+                        // Capture logs from early in the application startup
                         // pipeline from Startup.cs or Program.cs itself.
                         builder.AddApplicationInsights();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.ApplicationInsights;
@@ -20,6 +21,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
                 {
                     webBuilder.UseStartup<Startup>();
                     webBuilder.ConfigureKestrel(serverOptions => { serverOptions.AddServerHeader = false; });
+                })
+                .ConfigureAppConfiguration((_, builder) =>
+                {
+                    builder.AddJsonFile(
+                        "appsettings.Local.json",
+                        optional: true,
+                        reloadOnChange: true);
                 })
                 .ConfigureLogging(builder =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage1Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage1Tests.cs
@@ -16,6 +16,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfa
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Services;
 using Microsoft.Azure.WebJobs;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -133,7 +134,7 @@ public class ProcessorStage1Tests
         var validatorService = new ValidatorService(
             Mock.Of<ILogger<ValidatorService>>(),
             privateBlobStorageService.Object,
-            new FileTypeService(Mock.Of<ILogger<FileTypeService>>()),
+            new FileTypeService(Mock.Of<ILogger<FileTypeService>>(), new ConfigurationBuilder().Build()),
             dataImportService);
 
         var processorService = BuildProcessorService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/GovUk.Education.ExploreEducationStatistics.Data.Processor.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/GovUk.Education.ExploreEducationStatistics.Data.Processor.csproj
@@ -27,5 +27,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
+    <None Update="appsettings.Local.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Startup.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Reflection;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Functions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
@@ -47,6 +49,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
                 .AddSingleton<IDbContextSupplier, DbContextSupplier>()
                 .BuildServiceProvider();
             HandleRestart(serviceProvider);
+        }
+
+        public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder builder)
+        {
+            var binDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var rootDir = Path.GetFullPath(Path.Combine(binDir!, ".."));
+
+            builder.ConfigurationBuilder
+                .AddJsonFile($"{rootDir}/appsettings.Local.json", optional: true, reloadOnChange: true);
         }
 
         private static void HandleRestart(IServiceProvider serviceProvider)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
@@ -26,5 +26,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
+    <None Update="appsettings.Local.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -1,7 +1,8 @@
 ﻿#nullable enable
 using System;
+using System.IO;
+using System.Reflection;
 using AutoMapper;
-using Azure.Storage.Blobs;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Functions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
@@ -114,6 +115,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
 
             AddPersistenceHelper<ContentDbContext>(builder.Services);
             AddPersistenceHelper<StatisticsDbContext>(builder.Services);
+        }
+
+        public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder builder)
+        {
+            var binDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var rootDir = Path.GetFullPath(Path.Combine(binDir!, ".."));
+
+            builder.ConfigurationBuilder
+                .AddJsonFile($"{rootDir}/appsettings.Local.json", optional: true, reloadOnChange: true);
         }
 
         private static string GetConfigurationValue(IServiceProvider provider, string key)


### PR DESCRIPTION
This PR fixes longstanding version mismatches between `libmagic` and the `magic.mgc` file distributed in the builds by allowing a custom `magic.mgc` file path to be configured.

This can be achieved simply by adding an `appsettings.Local.json` in a project which uses file validation (i.e. `Data.Processor` or `Admin`):

```json
{
  "MagicFilePath": "/usr/lib/file/magic.mgc"
}
```

The above should work for Ubuntu, but you can change this to whatever path you want on your filesystem, as long as it's a working `magic.mgc` file.

## Related changes

- Upgraded Mime library and updated file type tests now that various file detections work correctly
- Added tests for SVG files now that they are correctly detected by upgrading Mime library. This also resolves [EES-4399](https://dfedigital.atlassian.net/browse/EES-4399).