### PR TITLE
EES-4376 Defer to `CheckCanUpdateMethodologyVersion` to check permission updating methodology content

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
-using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -423,9 +422,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         private async Task<Either<ActionResult, MethodologyVersionContent>> CheckCanUpdateMethodologyContent(
             MethodologyVersion methodologyVersion)
         {
-            if (methodologyVersion.Status != MethodologyApprovalStatus.Draft)
+            if (methodologyVersion.Status == MethodologyApprovalStatus.Approved)
             {
-                return ValidationActionResult(ValidationErrorMessages.MethodologyMustBeDraft);
+                return new ForbidResult();
             }
 
             if (methodologyVersion.MethodologyContent == null)
@@ -441,9 +440,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         private async Task<Either<ActionResult, Tuple<MethodologyVersionContent, ContentSection>>> CheckCanUpdateMethodologyContent(
             Tuple<MethodologyVersion, ContentSection> tuple)
         {
-            if (tuple.Item1.Status != MethodologyApprovalStatus.Draft)
+            if (tuple.Item1.Status == MethodologyApprovalStatus.Approved)
             {
-                return ValidationActionResult(ValidationErrorMessages.MethodologyMustBeDraft);
+                return new ForbidResult();
             }
 
             return await _userService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -32,7 +32,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         UserAlreadyHasReleaseRoles,
 
         // Methodology
-        MethodologyMustBeDraft,
         MethodologyCannotDependOnPublishedRelease,
         MethodologyCannotDependOnRelease,
         CannotAdoptMethodologyAlreadyLinkedToPublication,


### PR DESCRIPTION
This PR changes the `MethodologyContentService` to always use `UserServiceExtensions.CheckCanUpdateMethodologyVersion` (which in turn uses `UpdateSpecificMethodologyAuthorizationHandler`) for checking permission to update methodology content unless the status  is `Approved` in which case a forbidden response is returned early.

Previously we returned a validation error early `MethodologyMustBeDraft` if the status was not `Draft`.

This resulted in a bug when the status was in `HigherLevelReview` where in certain circumstances already evaluated by the auth handler, users should still be able to update methodology content.

