### PR TITLE
EES-4495 Tidy ReleaseSubjectRepository, changing methods to soft delete orphaned subjects by default

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -319,7 +319,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             releaseDataFileService.Setup(service => service.Delete(release.Id, file.Id, false))
                 .ReturnsAsync(Unit.Instance);
 
-            releaseSubjectRepository.Setup(service => service.SoftDeleteReleaseSubject(release.Id, subject.Id))
+            releaseSubjectRepository.Setup(service => service.DeleteReleaseSubject(release.Id, subject.Id, true))
                 .Returns(Task.CompletedTask);
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -481,7 +481,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(Unit.Instance);
 
             releaseSubjectRepository.Setup(service =>
-                    service.SoftDeleteReleaseSubject(release.Id, It.IsIn(subject.Id, replacementSubject.Id)))
+                    service.DeleteReleaseSubject(release.Id, It.IsIn(subject.Id, replacementSubject.Id), true))
                 .Returns(Task.CompletedTask);
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -519,8 +519,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
 
                 releaseSubjectRepository.Verify(
-                    mock => mock.SoftDeleteReleaseSubject(release.Id,
-                        It.IsIn(subject.Id, replacementSubject.Id)), Times.Exactly(2));
+                    mock => mock.DeleteReleaseSubject(release.Id,
+                        It.IsIn(subject.Id, replacementSubject.Id), true),
+                    Times.Exactly(2));
 
                 result.AssertRight();
             }
@@ -1017,7 +1018,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var latestIdTitleViewModel = result.AssertRight();
 
                 Assert.NotNull(latestIdTitleViewModel);
-                Assert.Equal(publication.LatestPublishedReleaseId, latestIdTitleViewModel!.Id);
+                Assert.Equal(publication.LatestPublishedReleaseId, latestIdTitleViewModel.Id);
                 Assert.Equal("Calendar year 2022", latestIdTitleViewModel.Title);
             }
         }
@@ -1214,7 +1215,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 mock.DeleteAll(release.Id, false)).ReturnsAsync(Unit.Instance);
 
             releaseSubjectRepository.Setup(mock =>
-                mock.SoftDeleteAllReleaseSubjects(release.Id)).Returns(Task.CompletedTask);
+                mock.DeleteAllReleaseSubjects(release.Id, true)).Returns(Task.CompletedTask);
 
             cacheService
                 .Setup(mock => mock.DeleteCacheFolderAsync(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -240,7 +240,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     await _context.SaveChangesAsync();
 
-                    await _releaseSubjectRepository.SoftDeleteAllReleaseSubjects(releaseId);
+                    await _releaseSubjectRepository.DeleteAllReleaseSubjects(releaseId: releaseId);
                 });
         }
 
@@ -559,8 +559,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccessDo(deletePlan => _dataBlockService.DeleteDataBlocks(deletePlan.DeleteDataBlockPlan))
                 .OnSuccessVoid(async deletePlan =>
                 {
-                    await _releaseSubjectRepository.SoftDeleteReleaseSubject(releaseId, deletePlan.SubjectId);
-                    await _cacheService.DeleteItemAsync(new PrivateSubjectMetaCacheKey(releaseId, deletePlan.SubjectId));
+                    await _releaseSubjectRepository.DeleteReleaseSubject(releaseId: releaseId,
+                        subjectId: deletePlan.SubjectId);
+                    await _cacheService.DeleteItemAsync(new PrivateSubjectMetaCacheKey(releaseId: releaseId,
+                        subjectId: deletePlan.SubjectId));
                 })
                 .OnSuccess(() => _releaseDataFileService.Delete(releaseId, fileId));
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
@@ -282,7 +282,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             if (statsRelease != null)
             {
-                await _releaseSubjectRepository.DeleteAllReleaseSubjects(statsRelease.Id);
+                await _releaseSubjectRepository.DeleteAllReleaseSubjects(releaseId: statsRelease.Id,
+                    softDeleteOrphanedSubjects: false);
                 _statisticsContext.Release.Remove(statsRelease);
                 await _statisticsContext.SaveChangesAsync();
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Repository/ReleaseSubjectRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Repository/ReleaseSubjectRepositoryTests.cs
@@ -2,10 +2,12 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Fixtures;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
@@ -15,20 +17,129 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
 {
     public class ReleaseSubjectRepositoryTests
     {
+        private readonly DataFixture _fixture = new();
+
         [Fact]
         public async Task DeleteReleaseSubject()
         {
+            var subject = _fixture.DefaultSubject().Generate();
+
             var releaseSubject = new ReleaseSubject
             {
-                Release = new Release(),
-                Subject = new Subject(),
+                Release = _fixture.DefaultStatsRelease(),
+                Subject = subject
             };
 
             var contextId = Guid.NewGuid().ToString();
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
             {
-                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.Subject.AddRangeAsync(subject);
+                await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
+
+            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(
+                    releaseSubject.ReleaseId, releaseSubject.SubjectId))
+                .Returns(Task.CompletedTask);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildReleaseSubjectRepository(statisticsDbContext,
+                    footnoteRepository: footnoteRepository.Object);
+
+                await service.DeleteReleaseSubject(releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId);
+
+                MockUtils.VerifyAllMocks(footnoteRepository);
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+            {
+                Assert.Empty(statisticsDbContext.ReleaseSubject.ToList());
+
+                var subjects = statisticsDbContext.Subject.IgnoreQueryFilters().ToList();
+                Assert.Single(subjects);
+                Assert.Equal(subject.Id, subjects[0].Id);
+                Assert.True(subjects[0].SoftDeleted);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteReleaseSubject_NonOrphanedSubject()
+        {
+            var subject = _fixture.DefaultSubject().Generate();
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = _fixture.DefaultStatsRelease(),
+                Subject = subject
+            };
+
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = _fixture.DefaultStatsRelease(),
+                Subject = subject
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.Subject.AddRangeAsync(subject);
+                await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
+
+            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(
+                    releaseSubject2.ReleaseId, releaseSubject2.SubjectId))
+                .Returns(Task.CompletedTask);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildReleaseSubjectRepository(statisticsDbContext,
+                    footnoteRepository: footnoteRepository.Object);
+
+                await service.DeleteReleaseSubject(releaseId: releaseSubject2.ReleaseId,
+                    subjectId: releaseSubject2.SubjectId);
+
+                MockUtils.VerifyAllMocks(footnoteRepository);
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+            {
+                var releaseSubjects = statisticsDbContext.ReleaseSubject.ToList();
+                Assert.Single(releaseSubjects);
+                Assert.Equal(releaseSubject1.ReleaseId, releaseSubjects[0].ReleaseId);
+                Assert.Equal(subject.Id, releaseSubjects[0].SubjectId);
+
+                var subjects = statisticsDbContext.Subject.ToList();
+                Assert.Single(subjects);
+                Assert.Equal(subject.Id, subjects[0].Id);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteReleaseSubject_SoftDeleteFalse()
+        {
+            var subject = _fixture.DefaultSubject();
+
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = _fixture.DefaultStatsRelease(),
+                Subject = subject
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.Subject.AddRangeAsync(subject);
+                await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
             }
 
@@ -47,7 +158,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
                     .Setup(
                         s =>
                             s.Delete(
-                                It.Is<Subject>(subject => subject.Id == releaseSubject.SubjectId),
+                                releaseSubject.SubjectId,
                                 It.IsAny<StatisticsDbContext>()
                             )
                     );
@@ -55,7 +166,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
                 var service = BuildReleaseSubjectRepository(statisticsDbContext,
                     footnoteRepository: footnoteRepository.Object,
                     subjectDeleter: subjectDeleter.Object);
-                await service.DeleteReleaseSubject(releaseSubject.ReleaseId, releaseSubject.SubjectId);
+
+                await service.DeleteReleaseSubject(
+                    releaseId: releaseSubject.ReleaseId,
+                    subjectId: releaseSubject.SubjectId,
+                    softDeleteOrphanedSubject: false);
 
                 MockUtils.VerifyAllMocks(footnoteRepository, subjectDeleter);
             }
@@ -67,62 +182,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
         }
 
         [Fact]
-        public async Task DeleteReleaseSubject_SoftDeleteOrphanedSubject()
+        public async Task DeleteReleaseSubject_NotFound()
         {
+            var subject = _fixture.DefaultSubject().Generate();
+
             var releaseSubject = new ReleaseSubject
             {
-                Release = new Release(),
-                Subject = new Subject(),
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
-            {
-                await statisticsDbContext.AddAsync(releaseSubject);
-                await statisticsDbContext.SaveChangesAsync();
-            }
-
-            var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
-
-            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(
-                    releaseSubject.ReleaseId, releaseSubject.SubjectId))
-                .Returns(Task.CompletedTask);
-
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
-            {
-                var service = BuildReleaseSubjectRepository(statisticsDbContext,
-                    footnoteRepository: footnoteRepository.Object);
-
-                await service.DeleteReleaseSubject(releaseSubject.ReleaseId, releaseSubject.SubjectId, true);
-
-                MockUtils.VerifyAllMocks(footnoteRepository);
-            }
-
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
-            {
-                Assert.Empty(statisticsDbContext.ReleaseSubject.ToList());
-
-                var subjects = statisticsDbContext.Subject.IgnoreQueryFilters().ToList();
-                Assert.Single(subjects);
-                Assert.Equal(releaseSubject.Subject.Id, subjects[0].Id);
-                Assert.True(subjects[0].SoftDeleted);
-            }
-        }
-
-        [Fact]
-        public async Task DeleteReleaseSubject_NonOrphanedSubject()
-        {
-            var subject = new Subject();
-
-            var releaseSubject1 = new ReleaseSubject
-            {
-                Release = new Release(),
-                Subject = subject,
-            };
-            var releaseSubject2 = new ReleaseSubject
-            {
-                Release = new Release(),
+                Release = _fixture.DefaultStatsRelease(),
                 Subject = subject
             };
 
@@ -130,51 +196,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
             {
-                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
-                await statisticsDbContext.SaveChangesAsync();
-            }
-
-            var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
-
-            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(
-                    releaseSubject2.ReleaseId, releaseSubject2.SubjectId))
-                .Returns(Task.CompletedTask);
-
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
-            {
-                var service = BuildReleaseSubjectRepository(statisticsDbContext,
-                    footnoteRepository: footnoteRepository.Object);
-                await service.DeleteReleaseSubject(releaseSubject2.ReleaseId, releaseSubject2.SubjectId);
-
-                MockUtils.VerifyAllMocks(footnoteRepository);
-            }
-
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
-            {
-                var releaseSubjects = statisticsDbContext.ReleaseSubject.ToList();
-                Assert.Single(releaseSubjects);
-                Assert.Equal(subject.Id, releaseSubjects[0].SubjectId);
-
-                var subjects = statisticsDbContext.Subject.ToList();
-                Assert.Single(subjects);
-                Assert.Equal(subject.Id, subjects[0].Id);
-            }
-        }
-
-        [Fact]
-        public async Task DeleteReleaseSubject_NotFound()
-        {
-            var releaseSubject = new ReleaseSubject
-            {
-                Release = new Release(),
-                Subject = new Subject(),
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
-            {
-                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.Subject.AddRangeAsync(subject);
+                await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
             }
 
@@ -190,7 +213,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
                     footnoteRepository: footnoteRepository.Object);
 
                 // Try to delete non-existing ReleaseSubject
-                await service.DeleteReleaseSubject(Guid.NewGuid(), Guid.NewGuid());
+                await service.DeleteReleaseSubject(releaseId: Guid.NewGuid(),
+                    subjectId: Guid.NewGuid());
 
                 MockUtils.VerifyAllMocks(footnoteRepository);
             }
@@ -200,36 +224,93 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
                 // Check that other ReleaseSubject has not been deleted
                 var releaseSubjects = statisticsDbContext.ReleaseSubject.ToList();
                 Assert.Single(releaseSubjects);
-                Assert.Equal(releaseSubject.SubjectId, releaseSubjects[0].SubjectId);
+                Assert.Equal(subject.Id, releaseSubjects[0].SubjectId);
 
                 var subjects = statisticsDbContext.Subject.ToList();
                 Assert.Single(subjects);
-                Assert.Equal(releaseSubject.SubjectId, subjects[0].Id);
+                Assert.Equal(subject.Id, subjects[0].Id);
             }
         }
 
         [Fact]
         public async Task DeleteAllReleaseSubjects()
         {
-            var release = new Release();
+            var release = _fixture.DefaultStatsRelease().Generate();
 
             var releaseSubject1 = new ReleaseSubject
             {
                 Release = release,
-                Subject = new Subject(),
+                Subject = _fixture.DefaultSubject()
             };
 
             var releaseSubject2 = new ReleaseSubject
             {
                 Release = release,
-                Subject = new Subject(),
+                Subject = _fixture.DefaultSubject()
             };
 
             var contextId = Guid.NewGuid().ToString();
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
             {
-                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await statisticsDbContext.Release.AddRangeAsync(release);
+                await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
+
+            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(release.Id,
+                    It.IsIn(releaseSubject1.SubjectId, releaseSubject2.SubjectId)))
+                .Returns(Task.CompletedTask);
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildReleaseSubjectRepository(statisticsDbContext,
+                    footnoteRepository: footnoteRepository.Object);
+
+                await service.DeleteAllReleaseSubjects(releaseId: release.Id);
+
+                MockUtils.VerifyAllMocks(footnoteRepository);
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+            {
+                Assert.Empty(statisticsDbContext.ReleaseSubject.ToList());
+
+                var subjects = statisticsDbContext.Subject.IgnoreQueryFilters().ToList();
+                Assert.Equal(2, subjects.Count);
+                Assert.Equal(releaseSubject1.SubjectId, subjects[0].Id);
+                Assert.True(subjects[0].SoftDeleted);
+
+                Assert.Equal(releaseSubject2.SubjectId, subjects[1].Id);
+                Assert.True(subjects[1].SoftDeleted);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteAllReleaseSubjects_SoftDeleteFalse()
+        {
+            var release = _fixture.DefaultStatsRelease().Generate();
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = _fixture.DefaultSubject()
+            };
+
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = _fixture.DefaultSubject()
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.Release.AddRangeAsync(release);
+                await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject1, releaseSubject2);
                 await statisticsDbContext.SaveChangesAsync();
             }
 
@@ -247,14 +328,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
                     .Setup(
                         s =>
                             s.Delete(
-                                It.Is<Subject>(subject => subject.Id == releaseSubject1.SubjectId),
+                                releaseSubject1.SubjectId,
                                 It.IsAny<StatisticsDbContext>()
                             )
                     );
                 subjectDeleter
                     .Setup(
                         s => s.Delete(
-                            It.Is<Subject>(subject => subject.Id == releaseSubject2.SubjectId),
+                            releaseSubject2.SubjectId,
                             It.IsAny<StatisticsDbContext>()
                         )
                     );
@@ -262,7 +343,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
                 var service = BuildReleaseSubjectRepository(statisticsDbContext,
                     footnoteRepository: footnoteRepository.Object,
                     subjectDeleter: subjectDeleter.Object);
-                await service.DeleteAllReleaseSubjects(release.Id);
+
+                await service.DeleteAllReleaseSubjects(releaseId: release.Id,
+                    softDeleteOrphanedSubjects: false);
 
                 MockUtils.VerifyAllMocks(footnoteRepository, subjectDeleter);
             }
@@ -270,59 +353,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Repository
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
             {
                 Assert.Empty(statisticsDbContext.ReleaseSubject.ToList());
-            }
-        }
-
-        [Fact]
-        public async Task DeleteAllReleaseSubjects_SoftDeleteOrphanedSubjects()
-        {
-            var release = new Release();
-
-            var releaseSubject1 = new ReleaseSubject
-            {
-                Release = release,
-                Subject = new Subject(),
-            };
-            var releaseSubject2 = new ReleaseSubject
-            {
-                Release = release,
-                Subject = new Subject(),
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
-            {
-                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
-                await statisticsDbContext.SaveChangesAsync();
-            }
-
-            var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
-
-            footnoteRepository.Setup(mock => mock.DeleteFootnotesBySubject(release.Id,
-                    It.IsIn(releaseSubject1.SubjectId, releaseSubject2.SubjectId)))
-                .Returns(Task.CompletedTask);
-
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
-            {
-                var service = BuildReleaseSubjectRepository(statisticsDbContext,
-                    footnoteRepository: footnoteRepository.Object);
-                await service.DeleteAllReleaseSubjects(release.Id, true);
-
-                MockUtils.VerifyAllMocks(footnoteRepository);
-            }
-
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(contextId))
-            {
-                Assert.Empty(statisticsDbContext.ReleaseSubject.ToList());
-
-                var subjects = statisticsDbContext.Subject.IgnoreQueryFilters().ToList();
-                Assert.Equal(2, subjects.Count);
-                Assert.Equal(releaseSubject1.SubjectId, subjects[0].Id);
-                Assert.True(subjects[0].SoftDeleted);
-
-                Assert.Equal(releaseSubject2.SubjectId, subjects[1].Id);
-                Assert.True(subjects[1].SoftDeleted);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IReleaseSubjectRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IReleaseSubjectRepository.cs
@@ -6,9 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Inter
 
 public interface IReleaseSubjectRepository
 {
-    Task SoftDeleteAllReleaseSubjects(Guid releaseId);
+    Task DeleteReleaseSubject(Guid releaseId, Guid subjectId, bool softDeleteOrphanedSubject = true);
 
-    Task SoftDeleteReleaseSubject(Guid releaseId, Guid subjectId);
-
-    Task DeleteAllReleaseSubjects(Guid releaseId, bool softDeleteOrphanedSubjects = false);
+    Task DeleteAllReleaseSubjects(Guid releaseId, bool softDeleteOrphanedSubjects = true);
 }


### PR DESCRIPTION
This PR tidies up the methods of `ReleaseSubjectRepository` following an investigation into how a data set appears to have been imported successfully and then deleted except for leaving a `ReleaseSubject` and `Subject` remaining.

In that particular case the subject was not marked as soft deleted. After reviewing the code I was unable to spot how that could arise, since subjects are only not marked as soft deleted when bulk deleting a UI test topic which wouldn't occur in Production.

However as part of the review I've made the following changes to tidy up `ReleaseSubjectRepository`:

- Change methods to have the options `softDeleteOrphanedSubject` default `true` since this is the case everywhere except when bulk deleting a UI test topic. This simplifies `IReleaseSubjectRepository` to have only two methods, and fixes a problem where one of the public methods of `ReleaseSubjectRepository` was missing from the interface.
- Use `Any` instead of `Count` to determine if a subject is orphaned in method `DeleteSubjectIfOrphaned` since it's more efficient.
- Remove unnecessary `Include` for the subject in method `DeleteAllReleaseSubjects` which isn't required to query subject id's.
- Within `DeleteReleaseSubject` prefer looking up the subject where required rather than passing `releaseSubject.Subject` to another method after `releaseSubject` has already been deleted.
- Use named parameters for `releaseId` and `subjectId` to avoid confusion where they both exist in method calls.
- Tidy up `ReleaseSubjectRepositoryTests` and change to use test data generators.