### PR TITLE
EES-4506 fix release contact us link

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/ContactUsSection.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/ContactUsSection.tsx
@@ -10,7 +10,7 @@ const ContactUsSection = ({
 }) => {
   return (
     <>
-      <h3>Contact us</h3>
+      <h3 id="contact-us">Contact us</h3>
       <p>
         If you have a specific enquiry about {publicationTitle} statistics and
         data:


### PR DESCRIPTION
Restores the anchor for the release page contact us link that was accidentally removed as part of https://github.com/dfe-analytical-services/explore-education-statistics/pull/4209