### PR TITLE
EES-4462 fix missing table header border style

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.module.scss
@@ -47,34 +47,39 @@ $border-width: 1px;
 
 .tableHead {
   td {
-    background: #fff;
+    background: govuk-colour('white');
     position: relative;
     z-index: 3;
   }
 
-  .emptyColumnHeaderCell {
-    background: govuk-colour('light-grey');
-    height: 46px;
-    z-index: 1;
+  // Uses the spacer cell to cover the left border
+  // of header cells. We can't just remove the
+  // left border on the first cell in header rows
+  // because this causes inconsistent styling when there
+  // are merged cells which span down through rows.
+  td::after {
+    background: govuk-colour('white');
+    bottom: 0;
+    content: '';
+    position: absolute;
+    right: -1px;
+    top: 0;
+    width: 1px;
   }
 
   th {
     background: govuk-colour('light-grey');
     border-bottom: 1px solid $govuk-border-colour;
-    border-right: 1px solid $govuk-border-colour;
+    border-left: 1px solid $govuk-border-colour;
     padding: govuk-spacing(2);
     position: relative;
     text-align: center;
     z-index: 2;
   }
 
-  tr:first-child:last-child th {
+  tr:only-child th {
     background: govuk-colour('white');
-    border-right: 0;
+    border-left: 0;
     text-align: right;
-  }
-
-  th:last-child {
-    border-right: 0;
   }
 }


### PR DESCRIPTION
Fixes a styling issue where the right border is missing on table header cells when a row above has a merged cell at the end.

I've gone for a slightly hacky CSS fix as it seemed the simplest way. It is possible using JS but would involve checking previous rows for merged cells at the end and adding a class to the affected cell to show the border, which seemed less efficient. Happy to discuss though.

**Before**
![missingborder](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/9cd33c24-8dfa-42e4-b4fa-fe13dae632b1)

**After**
![fixed](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/cb81abff-a2f9-48b9-afe2-cbff855efa64)
