### PR TITLE
EES-4507 fix data block save bug

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -377,7 +377,6 @@ const DataBlockPageTabs = ({
           <TabsSection title="Data source" id="dataBlockTabs-dataSource">
             {!isLoading && tableState && (
               <DataBlockSourceWizard
-                key={saveNumber}
                 dataBlock={dataBlock}
                 tableToolState={tableState}
                 onSave={handleDataBlockSourceSave}


### PR DESCRIPTION
Fixes a bug where when you edit an existing data block and save it the table and lists of selected filters etc revert to how they were before your changes. If you refreshed the changes had actually been saved.