### PR TITLE
EES-4504 Add Methodology.LatestPublishedVersionId column

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
@@ -78,13 +78,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     var (
                         handler,
                         methodologyRepository,
-                        methodologyVersionRepository,
                         userPublicationRoleRepository
                         ) = CreateHandlerAndDependencies();
-
-                    methodologyVersionRepository
-                        .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
-                        .ReturnsAsync(false);
 
                     // If the Claim given to the handler isn't enough to make the handler succeed, it'll go on to check
                     // the user's Publication Roles.  
@@ -103,39 +98,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     var authContext = CreateAuthContext(user, DraftFirstVersion);
 
                     await handler.HandleAsync(authContext);
-                    VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
-                        userPublicationRoleRepository);
+                    VerifyAllMocks(methodologyRepository, userPublicationRoleRepository);
 
                     // Verify that the presence of the "DeleteAllMethodologies" Claim and no other will pass the handler test
                     Assert.Equal(expectClaimToSucceed, authContext.HasSucceeded);
-                });
-            }
-
-            [Fact]
-            public async Task UserWithCorrectClaimCannotDeletePubliclyAccessibleMethodology()
-            {
-                await ForEachSecurityClaimAsync(async claim =>
-                {
-                    var (
-                        handler,
-                        _,
-                        methodologyVersionRepository,
-                        userPublicationRoleRepository
-                        ) = CreateHandlerAndDependencies();
-
-                    methodologyVersionRepository
-                        .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
-                        .ReturnsAsync(true);
-
-                    var user = CreateClaimsPrincipal(UserId, claim);
-                    var authContext = CreateAuthContext(user, DraftFirstVersion);
-
-                    await handler.HandleAsync(authContext);
-                    VerifyAllMocks(methodologyVersionRepository, userPublicationRoleRepository);
-
-                    // Verify that the presence of the "DeleteAllMethodologies" Claim still doesn't allow the user to
-                    // do this with a publicly accessible version.
-                    Assert.False(authContext.HasSucceeded);
                 });
             }
 
@@ -147,19 +113,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     var (
                         handler,
                         _,
-                        methodologyVersionRepository,
                         userPublicationRoleRepository
                         ) = CreateHandlerAndDependencies();
-
-                    methodologyVersionRepository
-                        .Setup(s => s.IsPubliclyAccessible(ApprovedFirstVersion.Id))
-                        .ReturnsAsync(false);
 
                     var user = CreateClaimsPrincipal(UserId, claim);
                     var authContext = CreateAuthContext(user, ApprovedFirstVersion);
 
                     await handler.HandleAsync(authContext);
-                    VerifyAllMocks(methodologyVersionRepository, userPublicationRoleRepository);
+                    VerifyAllMocks(userPublicationRoleRepository);
 
                     // Verify that the presence of the "DeleteAllMethodologies" Claim still doesn't allow the user to
                     // do this with an approved version.
@@ -177,13 +138,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     var (
                         handler,
                         methodologyRepository,
-                        methodologyVersionRepository,
                         userPublicationRoleRepository
                         ) = CreateHandlerAndDependencies();
-
-                    methodologyVersionRepository
-                        .Setup(s => s.IsPubliclyAccessible(DraftAmendmentVersion.Id))
-                        .ReturnsAsync(false);
 
                     // If the Claim given to the handler isn't enough to make the handler succeed, it'll go on to check
                     // the user's Publication Roles.  
@@ -202,8 +158,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     var authContext = CreateAuthContext(user, DraftAmendmentVersion);
 
                     await handler.HandleAsync(authContext);
-                    VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
-                        userPublicationRoleRepository);
+                    VerifyAllMocks(methodologyRepository, userPublicationRoleRepository);
 
                     // Verify that the presence of the "DeleteAllMethodologies" Claim and no other will pass the handler test
                     Assert.Equal(expectClaimToSucceed, authContext.HasSucceeded);
@@ -218,19 +173,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     var (
                         handler,
                         _,
-                        methodologyVersionRepository,
                         userPublicationRoleRepository
                         ) = CreateHandlerAndDependencies();
-
-                    methodologyVersionRepository
-                        .Setup(s => s.IsPubliclyAccessible(ApprovedAmendmentVersion.Id))
-                        .ReturnsAsync(false);
 
                     var user = CreateClaimsPrincipal(UserId, claim);
                     var authContext = CreateAuthContext(user, ApprovedAmendmentVersion);
 
                     await handler.HandleAsync(authContext);
-                    VerifyAllMocks(methodologyVersionRepository, userPublicationRoleRepository);
+                    VerifyAllMocks(userPublicationRoleRepository);
 
                     // Verify that the presence of the "DeleteAllMethodologies" Claim still doesn't allow the user to
                     // do this with an approved version.
@@ -251,13 +201,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         var (
                             handler,
                             methodologyRepository,
-                            methodologyVersionRepository,
                             userPublicationRoleRepository
                             ) = CreateHandlerAndDependencies();
-
-                        methodologyVersionRepository
-                            .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
-                            .ReturnsAsync(false);
 
                         methodologyRepository.Setup(s =>
                                 s.GetOwningPublication(DraftFirstVersion.MethodologyId))
@@ -271,8 +216,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         var authContext = CreateAuthContext(user, DraftFirstVersion);
 
                         await handler.HandleAsync(authContext);
-                        VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
-                            userPublicationRoleRepository);
+                        VerifyAllMocks(methodologyRepository, userPublicationRoleRepository);
 
                         // Verify that the presence of a Publication Owner role for this user that is related to a
                         // Publication that uses this Methodology will pass the handler test
@@ -286,13 +230,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 var (
                     handler,
                     methodologyRepository,
-                    methodologyVersionRepository,
                     userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
-
-                methodologyVersionRepository
-                    .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
-                    .ReturnsAsync(false);
 
                 methodologyRepository.Setup(s =>
                         s.GetOwningPublication(DraftFirstVersion.MethodologyId))
@@ -306,34 +245,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 var authContext = CreateAuthContext(user, DraftFirstVersion);
 
                 await handler.HandleAsync(authContext);
-                VerifyAllMocks(methodologyRepository, methodologyVersionRepository, userPublicationRoleRepository);
+                VerifyAllMocks(methodologyRepository, userPublicationRoleRepository);
 
                 // Verify that the user cannot perform this action if they have no Publication Roles.
-                Assert.False(authContext.HasSucceeded);
-            }
-
-            [Fact]
-            public async Task UserWithPublicationOwnerRoleCannotDeletePubliclyAccessibleMethodology()
-            {
-                var (
-                    handler,
-                    _,
-                    methodologyVersionRepository,
-                    userPublicationRoleRepository
-                    ) = CreateHandlerAndDependencies();
-
-                methodologyVersionRepository
-                    .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
-                    .ReturnsAsync(true);
-
-                var user = CreateClaimsPrincipal(UserId);
-                var authContext = CreateAuthContext(user, DraftFirstVersion);
-
-                await handler.HandleAsync(authContext);
-
-                // Verify that the fact that the version is publicly accessible doesn't even need to check the
-                // users' Publication Roles to determine whether or not they can do this.
-                VerifyAllMocks(methodologyVersionRepository, userPublicationRoleRepository);
                 Assert.False(authContext.HasSucceeded);
             }
 
@@ -343,13 +257,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 var (
                     handler,
                     _,
-                    methodologyVersionRepository,
                     userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
-
-                methodologyVersionRepository
-                    .Setup(s => s.IsPubliclyAccessible(ApprovedFirstVersion.Id))
-                    .ReturnsAsync(false);
 
                 var user = CreateClaimsPrincipal(UserId);
                 var authContext = CreateAuthContext(user, ApprovedFirstVersion);
@@ -358,7 +267,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
                 // Verify that the fact that the version is approved doesn't even need to check the
                 // users' Publication Roles to determine whether or not they can do this.
-                VerifyAllMocks(methodologyVersionRepository, userPublicationRoleRepository);
+                VerifyAllMocks(userPublicationRoleRepository);
                 Assert.False(authContext.HasSucceeded);
             }
 
@@ -372,13 +281,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         var (
                             handler,
                             methodologyRepository,
-                            methodologyVersionRepository,
                             userPublicationRoleRepository
                             ) = CreateHandlerAndDependencies();
-
-                        methodologyVersionRepository
-                            .Setup(s => s.IsPubliclyAccessible(DraftAmendmentVersion.Id))
-                            .ReturnsAsync(false);
 
                         methodologyRepository.Setup(s =>
                                 s.GetOwningPublication(DraftAmendmentVersion.MethodologyId))
@@ -392,8 +296,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         var authContext = CreateAuthContext(user, DraftAmendmentVersion);
 
                         await handler.HandleAsync(authContext);
-                        VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
-                            userPublicationRoleRepository);
+                        VerifyAllMocks(methodologyRepository, userPublicationRoleRepository);
 
                         // Verify that the presence of a Publication Owner role for this user that is related to a
                         // Publication that uses this Methodology will pass the handler test
@@ -407,13 +310,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 var (
                     handler,
                     _,
-                    methodologyVersionRepository,
                     userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
-
-                methodologyVersionRepository
-                    .Setup(s => s.IsPubliclyAccessible(ApprovedAmendmentVersion.Id))
-                    .ReturnsAsync(false);
 
                 var user = CreateClaimsPrincipal(UserId);
                 var authContext = CreateAuthContext(user, ApprovedAmendmentVersion);
@@ -422,7 +320,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
                 // Verify that the fact that the version is approved doesn't even need to check the
                 // users' Publication Roles to determine whether or not they can do this.
-                VerifyAllMocks(methodologyVersionRepository, userPublicationRoleRepository);
+                VerifyAllMocks(userPublicationRoleRepository);
                 Assert.False(authContext.HasSucceeded);
             }
         }
@@ -437,23 +335,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         private static (
             DeleteSpecificMethodologyAuthorizationHandler,
             Mock<IMethodologyRepository>,
-            Mock<IMethodologyVersionRepository>,
             Mock<IUserPublicationRoleRepository>)
             CreateHandlerAndDependencies()
         {
             var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
-            var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(Strict);
 
             var handler = new DeleteSpecificMethodologyAuthorizationHandler(
-                methodologyVersionRepository.Object,
                 methodologyRepository.Object,
                 new AuthorizationHandlerResourceRoleService(
                     Mock.Of<IUserReleaseRoleRepository>(Strict),
                     userPublicationRoleRepository.Object,
                     Mock.Of<IPublicationRepository>(Strict)));
 
-            return (handler, methodologyRepository, methodologyVersionRepository, userPublicationRoleRepository);
+            return (handler, methodologyRepository, userPublicationRoleRepository);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
@@ -55,7 +55,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         userPublicationRoleRepository
                         ) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
+                    methodologyVersionRepository.Setup(mock =>
+                            mock.IsPubliclyAccessible(MethodologyVersion))
                         .ReturnsAsync(true);
 
                     // Only the MakeAmendmentsOfAllMethodologies claim alongside the publicly-accessible Methodology
@@ -96,7 +97,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         userPublicationRoleRepository
                         ) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
+                    methodologyVersionRepository.Setup(mock =>
+                            mock.IsPubliclyAccessible(MethodologyVersion))
                         .ReturnsAsync(false);
 
                     var user = CreateClaimsPrincipal(UserId, claim);
@@ -129,7 +131,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             userPublicationRoleRepository
                             ) = CreateHandlerAndDependencies();
 
-                        methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
+                        methodologyVersionRepository.Setup(mock =>
+                                mock.IsPubliclyAccessible(MethodologyVersion))
                             .ReturnsAsync(true);
 
                         methodologyRepository.Setup(s =>
@@ -164,7 +167,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
 
-                methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
+                methodologyVersionRepository.Setup(mock =>
+                        mock.IsPubliclyAccessible(MethodologyVersion))
                     .ReturnsAsync(true);
 
                 methodologyRepository.Setup(s =>
@@ -195,7 +199,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     methodologyVersionRepository,
                     userPublicationRoleRepository) = CreateHandlerAndDependencies();
 
-                methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
+                methodologyVersionRepository.Setup(mock =>
+                        mock.IsPubliclyAccessible(MethodologyVersion))
                     .ReturnsAsync(false);
 
                 var user = CreateClaimsPrincipal(UserId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
@@ -44,7 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         public class ClaimTests
         {
             [Fact]
-            public async Task UserWithCorrectClaimCanCreateAmendmentOfPubliclyAccessibleMethodology()
+            public async Task UserWithCorrectClaimCanCreateAmendmentOfLatestPublishedMethodologyVersion()
             {
                 await ForEachSecurityClaimAsync(async claim =>
                 {
@@ -56,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(MethodologyVersion))
+                            mock.IsLatestPublishedVersion(MethodologyVersion))
                         .ReturnsAsync(true);
 
                     // Only the MakeAmendmentsOfAllMethodologies claim alongside the publicly-accessible Methodology
@@ -86,7 +86,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
 
             [Fact]
-            public async Task UserWithCorrectClaimCannotCreateAmendmentOfPrivateMethodology()
+            public async Task UserWithCorrectClaimCannotCreateAmendmentIfNotLatestPublishedMethodologyVersion()
             {
                 await ForEachSecurityClaimAsync(async claim =>
                 {
@@ -98,7 +98,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(MethodologyVersion))
+                            mock.IsLatestPublishedVersion(MethodologyVersion))
                         .ReturnsAsync(false);
 
                     var user = CreateClaimsPrincipal(UserId, claim);
@@ -118,7 +118,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         {
             [Fact]
             public async Task
-                UserWithLinkedPublicationOwnerRoleCanCreateAmendmentOfPubliclyAccessibleMethodologyOwnedByPublication()
+                UserWithLinkedPublicationOwnerRoleCanCreateAmendmentOfLatestPublishedMethodologyVersionOwnedByPublication()
             {
                 await GetEnumValues<PublicationRole>()
                     .ToAsyncEnumerable()
@@ -132,7 +132,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             ) = CreateHandlerAndDependencies();
 
                         methodologyVersionRepository.Setup(mock =>
-                                mock.IsPubliclyAccessible(MethodologyVersion))
+                                mock.IsLatestPublishedVersion(MethodologyVersion))
                             .ReturnsAsync(true);
 
                         methodologyRepository.Setup(s =>
@@ -158,7 +158,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
             [Fact]
             public async Task
-                UserWithoutLinkedPublicationOwnerRoleCannotCreateAmendmentOfPubliclyAccessibleMethodology()
+                UserWithoutLinkedPublicationOwnerRoleCannotCreateAmendmentOfLatestPublishedMethodologyVersion()
             {
                 var (
                     handler,
@@ -168,7 +168,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
-                        mock.IsPubliclyAccessible(MethodologyVersion))
+                        mock.IsLatestPublishedVersion(MethodologyVersion))
                     .ReturnsAsync(true);
 
                 methodologyRepository.Setup(s =>
@@ -191,7 +191,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
 
             [Fact]
-            public async Task UserWithLinkedPublicationOwnerRoleCannotCreateAmendmentOfPrivateMethodology()
+            public async Task UserWithLinkedPublicationOwnerRoleCannotCreateAmendmentIfNotLatestPublishedMethodologyVersion()
             {
                 var (
                     handler,
@@ -200,7 +200,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     userPublicationRoleRepository) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
-                        mock.IsPubliclyAccessible(MethodologyVersion))
+                        mock.IsLatestPublishedVersion(MethodologyVersion))
                     .ReturnsAsync(false);
 
                 var user = CreateClaimsPrincipal(UserId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandlerTests.cs
@@ -51,7 +51,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         _,
                         _) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
+                    methodologyVersionRepository.Setup(mock =>
+                            mock.IsPubliclyAccessible(MethodologyVersion))
                         .ReturnsAsync(true);
 
                     var user = CreateClaimsPrincipal(UserId, claim);
@@ -88,7 +89,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         publicationRepository
                         ) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    methodologyVersionRepository.Setup(mock =>
+                            mock.IsPubliclyAccessible(methodologyVersion))
                         .ReturnsAsync(false);
 
                     // Only the ApproveAllMethodologies claim should allow approving a Methodology
@@ -147,7 +149,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         publicationRepository
                         ) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    methodologyVersionRepository.Setup(mock =>
+                            mock.IsPubliclyAccessible(methodologyVersion))
                         .ReturnsAsync(false);
 
                     // Only the ApproveAllMethodologies claim should allow approving a Methodology
@@ -205,7 +208,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         publicationRepository
                         ) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
+                    methodologyVersionRepository.Setup(mock =>
+                            mock.IsPubliclyAccessible(MethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository
@@ -268,7 +272,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         publicationRepository
                         ) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
+                    methodologyVersionRepository.Setup(mock =>
+                            mock.IsPubliclyAccessible(MethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository
@@ -323,7 +328,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     publicationRepository
                     ) = CreateHandlerAndDependencies();
 
-                methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
+                methodologyVersionRepository.Setup(mock =>
+                        mock.IsPubliclyAccessible(MethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository
@@ -372,7 +378,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     publicationRepository
                     ) = CreateHandlerAndDependencies();
 
-                methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
+                methodologyVersionRepository.Setup(mock =>
+                        mock.IsPubliclyAccessible(MethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandlerTests.cs
@@ -39,7 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         public class ClaimsTests
         {
             [Fact]
-            public async Task NoClaimsAllowApprovingPubliclyAccessibleMethodology()
+            public async Task NoClaimsAllowApprovingLatestPublishedMethodologyVersion()
             {
                 await ForEachSecurityClaimAsync(async claim =>
                 {
@@ -52,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         _) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(MethodologyVersion))
+                            mock.IsLatestPublishedVersion(MethodologyVersion))
                         .ReturnsAsync(true);
 
                     var user = CreateClaimsPrincipal(UserId, claim);
@@ -69,7 +69,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
 
             [Fact]
-            public async Task UserWithCorrectClaimCanApproveNonPubliclyAccessibleDraftMethodology()
+            public async Task UserWithCorrectClaimCanApproveNonLatestPublishedDraftMethodologyVersion()
             {
                 var methodologyVersion = new MethodologyVersion
                 {
@@ -90,7 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(methodologyVersion))
+                            mock.IsLatestPublishedVersion(methodologyVersion))
                         .ReturnsAsync(false);
 
                     // Only the ApproveAllMethodologies claim should allow approving a Methodology
@@ -129,7 +129,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
 
             [Fact]
-            public async Task UserWithCorrectClaimCanApproveNonPubliclyAccessibleApprovedMethodology()
+            public async Task UserWithCorrectClaimCanApproveNonLatestPublishedApprovedMethodologyVersion()
             {
                 var methodologyVersion = new MethodologyVersion
                 {
@@ -150,7 +150,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(methodologyVersion))
+                            mock.IsLatestPublishedVersion(methodologyVersion))
                         .ReturnsAsync(false);
 
                     // Only the ApproveAllMethodologies claim should allow approving a Methodology
@@ -209,7 +209,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(MethodologyVersion))
+                            mock.IsLatestPublishedVersion(MethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository
@@ -273,7 +273,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(MethodologyVersion))
+                            mock.IsLatestPublishedVersion(MethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository
@@ -329,7 +329,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
-                        mock.IsPubliclyAccessible(MethodologyVersion))
+                        mock.IsLatestPublishedVersion(MethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository
@@ -379,7 +379,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
-                        mock.IsPubliclyAccessible(MethodologyVersion))
+                        mock.IsLatestPublishedVersion(MethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandlerTests.cs
@@ -47,7 +47,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         public class ClaimsTests
         {
             [Fact]
-            public async Task NoClaimsAllowMarkingPubliclyAccessibleMethodologyAsDraft()
+            public async Task NoClaimsAllowMarkingLatestPublishedMethodologyVersionAsDraft()
             {
                 await ForEachSecurityClaimAsync(async claim =>
                 {
@@ -60,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         _) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
+                            mock.IsLatestPublishedVersion(HigherReviewMethodologyVersion))
                         .ReturnsAsync(true);
 
                     var user = CreateClaimsPrincipal(UserId, claim);
@@ -77,7 +77,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
 
             [Fact]
-            public async Task UserWithCorrectClaimCanMarkNonPubliclyAccessibleMethodologyAsDraft()
+            public async Task UserWithCorrectClaimCanMarkNonLatestPublishedMethodologyVersionAsDraft()
             {
                 await ForEachSecurityClaimAsync(async claim =>
                 {
@@ -91,7 +91,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
+                            mock.IsLatestPublishedVersion(HigherReviewMethodologyVersion))
                         .ReturnsAsync(false);
 
                     // Only the MarkAllMethodologiesDraft claim should allow a non publicly accessible Methodology to
@@ -147,7 +147,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
+                            mock.IsLatestPublishedVersion(HigherReviewMethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository.Setup(mock =>
@@ -204,7 +204,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(ApprovedMethodologyVersion))
+                            mock.IsLatestPublishedVersion(ApprovedMethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository.Setup(mock =>
@@ -268,7 +268,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
+                            mock.IsLatestPublishedVersion(HigherReviewMethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository.Setup(s =>
@@ -329,7 +329,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(ApprovedMethodologyVersion))
+                            mock.IsLatestPublishedVersion(ApprovedMethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository.Setup(mock =>
@@ -384,7 +384,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
-                        mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
+                        mock.IsLatestPublishedVersion(HigherReviewMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(s =>
@@ -425,7 +425,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
-                        mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
+                        mock.IsLatestPublishedVersion(HigherReviewMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(s =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandlerTests.cs
@@ -59,7 +59,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         _,
                         _) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(HigherReviewMethodologyVersion.Id))
+                    methodologyVersionRepository.Setup(mock =>
+                            mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
                         .ReturnsAsync(true);
 
                     var user = CreateClaimsPrincipal(UserId, claim);
@@ -89,7 +90,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         publicationRepository
                         ) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(HigherReviewMethodologyVersion.Id))
+                    methodologyVersionRepository.Setup(mock =>
+                            mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
                         .ReturnsAsync(false);
 
                     // Only the MarkAllMethodologiesDraft claim should allow a non publicly accessible Methodology to
@@ -145,7 +147,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(HigherReviewMethodologyVersion.Id))
+                            mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository.Setup(mock =>
@@ -202,7 +204,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(ApprovedMethodologyVersion.Id))
+                            mock.IsPubliclyAccessible(ApprovedMethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository.Setup(mock =>
@@ -265,7 +267,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         publicationRepository
                         ) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(HigherReviewMethodologyVersion.Id))
+                    methodologyVersionRepository.Setup(mock =>
+                            mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository.Setup(s =>
@@ -326,7 +329,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
-                            mock.IsPubliclyAccessible(ApprovedMethodologyVersion.Id))
+                            mock.IsPubliclyAccessible(ApprovedMethodologyVersion))
                         .ReturnsAsync(false);
 
                     methodologyRepository.Setup(mock =>
@@ -380,7 +383,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     publicationRepository
                     ) = CreateHandlerAndDependencies();
 
-                methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(HigherReviewMethodologyVersion.Id))
+                methodologyVersionRepository.Setup(mock =>
+                        mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(s =>
@@ -420,7 +424,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     publicationRepository
                     ) = CreateHandlerAndDependencies();
 
-                methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(HigherReviewMethodologyVersion.Id))
+                methodologyVersionRepository.Setup(mock =>
+                        mock.IsPubliclyAccessible(HigherReviewMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(s =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsHigherReviewAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsHigherReviewAuthorizationHandlerTests.cs
@@ -72,7 +72,6 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 await handler.HandleAsync(authContext);
                 VerifyAllMocks(methodologyVersionRepository);
 
-                // No claims should allow a publicly accessible Methodology to be marked as draft
                 Assert.False(authContext.HasSucceeded);
             });
         }
@@ -95,8 +94,6 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                         mock.IsPubliclyAccessible(DraftMethodologyVersion))
                     .ReturnsAsync(false);
 
-                // Only the SubmitAllMethodologiesToHigherReview claim should allow a non publicly accessible
-                // Methodology to be marked as draft
                 var expectedToPassByClaimAlone = claim == SubmitAllMethodologiesToHigherReview;
 
                 if (!expectedToPassByClaimAlone)
@@ -409,7 +406,6 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
             await handler.HandleAsync(authContext);
             VerifyAllMocks(methodologyRepository, methodologyVersionRepository, userReleaseRoleRepository);
 
-            // A user with no role on the owning Publication of this Methodology is not allowed to mark it as draft
             Assert.False(authContext.HasSucceeded);
         }
 
@@ -453,7 +449,6 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 userPublicationRoleRepository,
                 publicationRepository);
 
-            // A user with no role on the owning Publication of this Methodology is not allowed to mark it as draft
             Assert.False(authContext.HasSucceeded);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsHigherReviewAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsHigherReviewAuthorizationHandlerTests.cs
@@ -60,7 +60,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     _) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock => 
-                        mock.IsPubliclyAccessible(DraftMethodologyVersion.Id))
+                        mock.IsPubliclyAccessible(DraftMethodologyVersion))
                     .ReturnsAsync(true);
 
                 var user = CreateClaimsPrincipal(UserId, claim);
@@ -92,7 +92,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock => 
-                        mock.IsPubliclyAccessible(DraftMethodologyVersion.Id))
+                        mock.IsPubliclyAccessible(DraftMethodologyVersion))
                     .ReturnsAsync(false);
 
                 // Only the SubmitAllMethodologiesToHigherReview claim should allow a non publicly accessible
@@ -149,7 +149,8 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     publicationRepository
                     ) = CreateHandlerAndDependencies();
 
-                methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(DraftMethodologyVersion.Id))
+                methodologyVersionRepository.Setup(mock =>
+                        mock.IsPubliclyAccessible(DraftMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(mock =>
@@ -206,7 +207,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
-                        mock.IsPubliclyAccessible(ApprovedMethodologyVersion.Id))
+                        mock.IsPubliclyAccessible(ApprovedMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(mock =>
@@ -269,7 +270,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     publicationRepository
                     ) = CreateHandlerAndDependencies();
 
-                methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(DraftMethodologyVersion.Id))
+                methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(DraftMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(s =>
@@ -330,7 +331,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
-                        mock.IsPubliclyAccessible(ApprovedMethodologyVersion.Id))
+                        mock.IsPubliclyAccessible(ApprovedMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(mock =>
@@ -384,7 +385,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 publicationRepository
                 ) = CreateHandlerAndDependencies();
 
-            methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(DraftMethodologyVersion.Id))
+            methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(DraftMethodologyVersion))
                 .ReturnsAsync(false);
 
             methodologyRepository.Setup(s =>
@@ -424,7 +425,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 publicationRepository
                 ) = CreateHandlerAndDependencies();
 
-            methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(DraftMethodologyVersion.Id))
+            methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(DraftMethodologyVersion))
                 .ReturnsAsync(false);
 
             methodologyRepository.Setup(s =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsHigherReviewAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsHigherReviewAuthorizationHandlerTests.cs
@@ -47,7 +47,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
     public class ClaimsTests
     {
         [Fact]
-        public async Task NoClaimsAllowMarkingPubliclyAccessibleMethodologyHigherReview()
+        public async Task NoClaimsAllowMarkingLatestPublishedMethodologyVersionHigherReview()
         {
             await ForEachSecurityClaimAsync(async claim =>
             {
@@ -60,7 +60,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     _) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock => 
-                        mock.IsPubliclyAccessible(DraftMethodologyVersion))
+                        mock.IsLatestPublishedVersion(DraftMethodologyVersion))
                     .ReturnsAsync(true);
 
                 var user = CreateClaimsPrincipal(UserId, claim);
@@ -77,7 +77,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
         }
 
         [Fact]
-        public async Task UserWithCorrectClaimCanMarkNonPubliclyAccessibleMethodologyHigherReview()
+        public async Task UserWithCorrectClaimCanMarkNonLatestPublishedMethodologyVersionHigherReview()
         {
             await ForEachSecurityClaimAsync(async claim =>
             {
@@ -91,7 +91,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock => 
-                        mock.IsPubliclyAccessible(DraftMethodologyVersion))
+                        mock.IsLatestPublishedVersion(DraftMethodologyVersion))
                     .ReturnsAsync(false);
 
                 var expectedToPassByClaimAlone = claim == SubmitAllMethodologiesToHigherReview;
@@ -147,7 +147,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
-                        mock.IsPubliclyAccessible(DraftMethodologyVersion))
+                        mock.IsLatestPublishedVersion(DraftMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(mock =>
@@ -204,7 +204,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
-                        mock.IsPubliclyAccessible(ApprovedMethodologyVersion))
+                        mock.IsLatestPublishedVersion(ApprovedMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(mock =>
@@ -267,7 +267,8 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     publicationRepository
                     ) = CreateHandlerAndDependencies();
 
-                methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(DraftMethodologyVersion))
+                methodologyVersionRepository.Setup(mock =>
+                        mock.IsLatestPublishedVersion(DraftMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(s =>
@@ -328,7 +329,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
-                        mock.IsPubliclyAccessible(ApprovedMethodologyVersion))
+                        mock.IsLatestPublishedVersion(ApprovedMethodologyVersion))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(mock =>
@@ -382,7 +383,8 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 publicationRepository
                 ) = CreateHandlerAndDependencies();
 
-            methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(DraftMethodologyVersion))
+            methodologyVersionRepository.Setup(mock =>
+                    mock.IsLatestPublishedVersion(DraftMethodologyVersion))
                 .ReturnsAsync(false);
 
             methodologyRepository.Setup(s =>
@@ -421,7 +423,8 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 publicationRepository
                 ) = CreateHandlerAndDependencies();
 
-            methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(DraftMethodologyVersion))
+            methodologyVersionRepository.Setup(mock =>
+                    mock.IsLatestPublishedVersion(DraftMethodologyVersion))
                 .ReturnsAsync(false);
 
             methodologyRepository.Setup(s =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
@@ -105,7 +105,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 });
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                        mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -213,7 +214,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(Unit.Instance);
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                        mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -297,7 +299,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                        mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -372,7 +375,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                        mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
             userReleaseRoleService.Setup(mock =>
@@ -453,7 +457,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                        mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
             userReleaseRoleService.Setup(mock =>
@@ -583,7 +588,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                        mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -665,7 +671,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                        mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(true);
 
             publishingService.Setup(mock => mock.PublishMethodologyFiles(methodologyVersion.Id))
@@ -769,7 +776,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                        mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -857,7 +865,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                        mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -883,17 +892,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var updatedMethodology = await context
+                var updatedMethodologyVersion = await context
                     .MethodologyVersions
                     .Include(m => m.Methodology)
                     .SingleAsync(m => m.Id == methodologyVersion.Id);
 
-                Assert.Null(updatedMethodology.Published);
-                Assert.Equal(Approved, updatedMethodology.Status);
-                Assert.Equal(WithRelease, updatedMethodology.PublishingStrategy);
-                Assert.Equal(scheduledWithRelease.Id, updatedMethodology.ScheduledWithReleaseId);
-                Assert.True(updatedMethodology.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
+                Assert.Null(updatedMethodologyVersion.Published);
+                Assert.Equal(Approved, updatedMethodologyVersion.Status);
+                Assert.Equal(WithRelease, updatedMethodologyVersion.PublishingStrategy);
+                Assert.Equal(scheduledWithRelease.Id, updatedMethodologyVersion.ScheduledWithReleaseId);
+                Assert.True(updatedMethodologyVersion.Updated.HasValue);
+                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
             }
         }
 
@@ -1154,7 +1163,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                        mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -1252,7 +1262,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(methodologyVersion.Id))
+                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                        mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
             userReleaseRoleService.Setup(mock =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
@@ -610,21 +610,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
                 Assert.Equal(request.Status, updatedMethodologyVersion.Status);
                 Assert.Equal(request.LatestInternalReleaseNote, updatedMethodologyVersion.InternalReleaseNote);
+                Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
             }
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var updatedMethodology = await context
+                var updatedMethodologyVersion = await context
                     .MethodologyVersions
                     .Include(m => m.Methodology)
                     .SingleAsync(m => m.Id == methodologyVersion.Id);
 
-                Assert.False(updatedMethodology.Published.HasValue);
-                Assert.Equal(Approved, updatedMethodology.Status);
-                Assert.Equal(Immediately, updatedMethodology.PublishingStrategy);
-                Assert.Equal(request.LatestInternalReleaseNote, updatedMethodology.InternalReleaseNote);
-                Assert.True(updatedMethodology.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
+                Assert.False(updatedMethodologyVersion.Published.HasValue);
+                Assert.Equal(Approved, updatedMethodologyVersion.Status);
+                Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
+                Assert.Equal(request.LatestInternalReleaseNote, updatedMethodologyVersion.InternalReleaseNote);
+                Assert.True(updatedMethodologyVersion.Updated.HasValue);
+                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
+                Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
             }
         }
 
@@ -707,22 +709,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
                 Assert.Equal(request.Status, updatedMethodologyVersion.Status);
                 Assert.Equal(request.LatestInternalReleaseNote, updatedMethodologyVersion.InternalReleaseNote);
+                Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
             }
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var updatedMethodology = await context
+                var updatedMethodologyVersion = await context
                     .MethodologyVersions
                     .Include(m => m.Methodology)
                     .SingleAsync(m => m.Id == methodologyVersion.Id);
 
-                Assert.True(updatedMethodology.Published.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Published!.Value).Milliseconds, 0, 1500);
-                Assert.Equal(Approved, updatedMethodology.Status);
-                Assert.Equal(Immediately, updatedMethodology.PublishingStrategy);
-                Assert.Equal(request.LatestInternalReleaseNote, updatedMethodology.InternalReleaseNote);
-                Assert.True(updatedMethodology.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
+                Assert.True(updatedMethodologyVersion.Published.HasValue);
+                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Published!.Value).Milliseconds, 0, 1500);
+                Assert.Equal(Approved, updatedMethodologyVersion.Status);
+                Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
+                Assert.Equal(request.LatestInternalReleaseNote, updatedMethodologyVersion.InternalReleaseNote);
+                Assert.True(updatedMethodologyVersion.Updated.HasValue);
+                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
+                Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
             }
         }
 
@@ -792,19 +796,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Id);
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
+                Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
                 Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
             }
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var updatedMethodology = await context
+                var updatedMethodologyVersion = await context
                     .MethodologyVersions
+                    .Include(mv => mv.Methodology)
                     .SingleAsync(m => m.Id == methodologyVersion.Id);
 
-                Assert.Equal(Approved, updatedMethodology.Status);
-                Assert.Equal(Immediately, updatedMethodology.PublishingStrategy);
-                // Existing ScheduledWithReleaseId is cleared as requested publishing strategy is not WithRelease
-                Assert.Null(updatedMethodology.ScheduledWithReleaseId);
+                Assert.Equal(Approved, updatedMethodologyVersion.Status);
+                Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
+                Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
+                Assert.Null(updatedMethodologyVersion.ScheduledWithReleaseId);
             }
         }
 
@@ -884,6 +890,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Null(updatedMethodologyVersion.Published);
                 Assert.Equal(WithRelease, updatedMethodologyVersion.PublishingStrategy);
                 Assert.Equal(request.Status, updatedMethodologyVersion.Status);
+                Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
 
                 Assert.NotNull(updatedMethodologyVersion.ScheduledWithRelease);
                 Assert.Equal(scheduledWithRelease.Id, updatedMethodologyVersion.ScheduledWithRelease!.Id);
@@ -903,6 +910,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(scheduledWithRelease.Id, updatedMethodologyVersion.ScheduledWithReleaseId);
                 Assert.True(updatedMethodologyVersion.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
+                Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
             }
         }
 
@@ -1186,21 +1194,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
                 Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
                 Assert.Equal(request.Status, updatedMethodologyVersion.Status);
+                Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
             }
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var updatedMethodology = await context
+                var updatedMethodologyVersion = await context
                     .MethodologyVersions
                     .Include(m => m.Methodology)
                     .SingleAsync(m => m.Id == methodologyVersion.Id);
 
-                Assert.Null(updatedMethodology.Published);
-                Assert.Equal(Draft, updatedMethodology.Status);
-                Assert.Equal(Immediately, updatedMethodology.PublishingStrategy);
-                Assert.Equal("A release note", updatedMethodology.InternalReleaseNote);
-                Assert.True(updatedMethodology.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
+                Assert.Null(updatedMethodologyVersion.Published);
+                Assert.Equal(Draft, updatedMethodologyVersion.Status);
+                Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
+                Assert.Equal("A release note", updatedMethodologyVersion.InternalReleaseNote);
+                Assert.True(updatedMethodologyVersion.Updated.HasValue);
+                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
+                Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
             }
         }
 
@@ -1309,20 +1319,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
                 Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
                 Assert.Equal(request.Status, updatedMethodologyVersion.Status);
+                Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
             }
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var updatedMethodology = await context
+                var updatedMethodologyVersion = await context
                     .MethodologyVersions
                     .Include(m => m.Methodology)
                     .SingleAsync(m => m.Id == methodologyVersion.Id);
 
-                Assert.Null(updatedMethodology.Published);
-                Assert.Equal(HigherLevelReview, updatedMethodology.Status);
-                Assert.Equal("A release note", updatedMethodology.InternalReleaseNote);
-                Assert.True(updatedMethodology.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
+                Assert.Null(updatedMethodologyVersion.Published);
+                Assert.Equal(HigherLevelReview, updatedMethodologyVersion.Status);
+                Assert.Equal("A release note", updatedMethodologyVersion.InternalReleaseNote);
+                Assert.True(updatedMethodologyVersion.Updated.HasValue);
+                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
+                Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
@@ -105,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 });
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                    mock.IsToBePublished(It.Is<MethodologyVersion>(mv =>
                         mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
@@ -214,7 +214,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(Unit.Instance);
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                    mock.IsToBePublished(It.Is<MethodologyVersion>(mv =>
                         mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
@@ -299,7 +299,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                    mock.IsToBePublished(It.Is<MethodologyVersion>(mv =>
                         mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
@@ -375,7 +375,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                    mock.IsToBePublished(It.Is<MethodologyVersion>(mv =>
                         mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
@@ -457,7 +457,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                    mock.IsToBePublished(It.Is<MethodologyVersion>(mv =>
                         mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
@@ -588,7 +588,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                    mock.IsToBePublished(It.Is<MethodologyVersion>(mv =>
                         mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
@@ -673,7 +673,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                    mock.IsToBePublished(It.Is<MethodologyVersion>(mv =>
                         mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(true);
 
@@ -780,7 +780,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                    mock.IsToBePublished(It.Is<MethodologyVersion>(mv =>
                         mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
@@ -871,7 +871,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                    mock.IsToBePublished(It.Is<MethodologyVersion>(mv =>
                         mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
@@ -1171,7 +1171,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                    mock.IsToBePublished(It.Is<MethodologyVersion>(mv =>
                         mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 
@@ -1272,7 +1272,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             methodologyVersionRepository.Setup(mock =>
-                    mock.IsPubliclyAccessible(It.Is<MethodologyVersion>(mv =>
+                    mock.IsToBePublished(It.Is<MethodologyVersion>(mv =>
                         mv.Id == methodologyVersion.Id)))
                 .ReturnsAsync(false);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataBlockMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataBlockMigrationController.cs
@@ -1,15 +1,12 @@
 ﻿#nullable enable
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Services.DataBlockMigrationService;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Services.DataBlockMigrationService.DataBlockMapMigrationPlan;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/MethodologyMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/MethodologyMigrationController.cs
@@ -1,0 +1,72 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
+{
+    [Route("api")]
+    [ApiController]
+    [Authorize(Roles = RoleNames.BauUser)]
+    public class MethodologyMigrationController : ControllerBase
+    {
+        private readonly ContentDbContext _context;
+        private readonly IMethodologyVersionRepository _methodologyVersionRepository;
+
+        public MethodologyMigrationController(
+            ContentDbContext context,
+            IMethodologyVersionRepository methodologyVersionRepository)
+        {
+            _context = context;
+            _methodologyVersionRepository = methodologyVersionRepository;
+        }
+
+        public class MethodologyMigrationResult
+        {
+            public Guid MethodologyId { get; set; }
+            public Guid? LatestMethodologyVersionId { get; set; }
+        }
+
+        [HttpPatch("migration/set-methodology-latest-published-version-ids")]
+        public async Task<ActionResult<List<MethodologyMigrationResult>>> MigrateMethodologyLatestPublishedVersionIds(
+            [FromQuery] bool dryRun = true)
+        {
+            var allMethodologies = await _context.Methodologies
+                .Include(m => m.Versions)
+                .ToListAsync();
+
+            var results = new List<MethodologyMigrationResult>();
+
+            foreach (var methodology in allMethodologies)
+            {
+                var latestPublishedMethodologyVersion = await methodology.Versions
+                    .ToAsyncEnumerable()
+                    .WhereAwait(async mv => await _methodologyVersionRepository.IsPubliclyAccessible(mv))
+                    .SingleOrDefaultAsync();
+
+                methodology.LatestPublishedVersionId = latestPublishedMethodologyVersion?.Id;
+
+                var migrationResult = new MethodologyMigrationResult
+                {
+                    MethodologyId = methodology.Id,
+                    LatestMethodologyVersionId = latestPublishedMethodologyVersion?.Id,
+                };
+                results.Add(migrationResult);
+            }
+
+            if (!dryRun)
+            {
+                await _context.SaveChangesAsync();
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/MethodologyMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/MethodologyMigrationController.cs
@@ -10,6 +10,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
 
+// !!!!!
+// TODO: Move `MethodologyVersionRepository#IsToBePublished` `MethodologyApprovalService` and change to be private after removing this controller
+// !!!!!
+
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
 {
     [Route("api")]
@@ -48,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
             {
                 var latestPublishedMethodologyVersion = await methodology.Versions
                     .ToAsyncEnumerable()
-                    .WhereAwait(async mv => await _methodologyVersionRepository.IsPubliclyAccessible(mv))
+                    .WhereAwait(async mv => await _methodologyVersionRepository.IsToBePublished(mv))
                     .SingleOrDefaultAsync();
 
                 methodology.LatestPublishedVersionId = latestPublishedMethodologyVersion?.Id;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230905080337_EES4504_AddLatestPublishedVersionIdToMethodologiesTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230905080337_EES4504_AddLatestPublishedVersionIdToMethodologiesTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230905080337_EES4504_AddLatestPublishedVersionIdToMethodologiesTable")]
+    partial class EES4504_AddLatestPublishedVersionIdToMethodologiesTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230905080337_EES4504_AddLatestPublishedVersionIdToMethodologiesTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230905080337_EES4504_AddLatestPublishedVersionIdToMethodologiesTable.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES4504_AddLatestPublishedVersionIdToMethodologiesTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "LatestPublishedVersionId",
+                table: "Methodologies",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Methodologies_LatestPublishedVersionId",
+                table: "Methodologies",
+                column: "LatestPublishedVersionId",
+                unique: true,
+                filter: "[LatestPublishedVersionId] IS NOT NULL");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Methodologies_MethodologyVersions_LatestPublishedVersionId",
+                table: "Methodologies",
+                column: "LatestPublishedVersionId",
+                principalTable: "MethodologyVersions",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Methodologies_MethodologyVersions_LatestPublishedVersionId",
+                table: "Methodologies");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Methodologies_LatestPublishedVersionId",
+                table: "Methodologies");
+
+            migrationBuilder.DropColumn(
+                name: "LatestPublishedVersionId",
+                table: "Methodologies");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlers.cs
@@ -17,16 +17,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
     public class DeleteSpecificMethodologyAuthorizationHandler
         : AuthorizationHandler<DeleteSpecificMethodologyRequirement, MethodologyVersion>
     {
-        private readonly IMethodologyVersionRepository _methodologyVersionRepository;
         private readonly IMethodologyRepository _methodologyRepository;
         private readonly AuthorizationHandlerResourceRoleService _authorizationHandlerResourceRoleService;
 
         public DeleteSpecificMethodologyAuthorizationHandler(
-            IMethodologyVersionRepository methodologyVersionRepository,
             IMethodologyRepository methodologyRepository,
             AuthorizationHandlerResourceRoleService authorizationHandlerResourceRoleService)
         {
-            _methodologyVersionRepository = methodologyVersionRepository;
             _methodologyRepository = methodologyRepository;
             _authorizationHandlerResourceRoleService = authorizationHandlerResourceRoleService;
         }
@@ -36,12 +33,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             DeleteSpecificMethodologyRequirement requirement,
             MethodologyVersion methodologyVersion)
         {
-            // If the Methodology is already public, it cannot be deleted.
-            if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion.Id))
-            {
-                return;
-            }
-
             if (methodologyVersion.Status == Approved)
             {
                 return;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlers.cs
@@ -36,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             MethodologyVersion methodologyVersion)
         {
             // Amendments can only be created from Methodologies that are already publicly-accessible.
-            if (!await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion.Id))
+            if (!await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion))
             {
                 return;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlers.cs
@@ -36,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             MethodologyVersion methodologyVersion)
         {
             // Amendments can only be created from Methodologies that are already publicly-accessible.
-            if (!await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion))
+            if (!await _methodologyVersionRepository.IsLatestPublishedVersion(methodologyVersion))
             {
                 return;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandler.cs
@@ -38,7 +38,7 @@ public class MarkMethodologyAsApprovedAuthorizationHandler :
     {
         // If the Methodology is already public, it cannot be approved
         // An approved Methodology that isn't public can be approved to change attributes associated with approval
-        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion))
+        if (await _methodologyVersionRepository.IsLatestPublishedVersion(methodologyVersion))
         {
             return;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandler.cs
@@ -38,7 +38,7 @@ public class MarkMethodologyAsApprovedAuthorizationHandler :
     {
         // If the Methodology is already public, it cannot be approved
         // An approved Methodology that isn't public can be approved to change attributes associated with approval
-        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion.Id))
+        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion))
         {
             return;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandler.cs
@@ -39,7 +39,7 @@ public class MarkMethodologyAsDraftAuthorizationHandler : AuthorizationHandler<
         MethodologyVersion methodologyVersion)
     {
         // If the Methodology is already public, it cannot be marked as draft
-        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion.Id))
+        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion))
         {
             return;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandler.cs
@@ -39,7 +39,7 @@ public class MarkMethodologyAsDraftAuthorizationHandler : AuthorizationHandler<
         MethodologyVersion methodologyVersion)
     {
         // If the Methodology is already public, it cannot be marked as draft
-        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion))
+        if (await _methodologyVersionRepository.IsLatestPublishedVersion(methodologyVersion))
         {
             return;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsHigherLevelReviewAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsHigherLevelReviewAuthorizationHandler.cs
@@ -38,8 +38,7 @@ public class MarkMethodologyAsHigherLevelReviewAuthorizationHandler : Authorizat
         MarkMethodologyAsHigherLevelReviewRequirement requirement,
         MethodologyVersion methodologyVersion)
     {
-        // If the Methodology is already public, it cannot be marked for higher level review
-        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion.Id))
+        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion))
         {
             return;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsHigherLevelReviewAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsHigherLevelReviewAuthorizationHandler.cs
@@ -38,7 +38,7 @@ public class MarkMethodologyAsHigherLevelReviewAuthorizationHandler : Authorizat
         MarkMethodologyAsHigherLevelReviewRequirement requirement,
         MethodologyVersion methodologyVersion)
     {
-        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion))
+        if (await _methodologyVersionRepository.IsLatestPublishedVersion(methodologyVersion))
         {
             return;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
@@ -101,7 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
                         // We cannot rely on Methodology.LatestPublishedVersionId, as it may now be incorrect,
                         // if we are approving and publishing this methodology version.
-                        var isToBePublished = await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion);
+                        var isToBePublished = await _methodologyVersionRepository.IsToBePublished(methodologyVersion);
 
                         if (isToBePublished)
                         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
@@ -99,7 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
                         methodologyVersion.Updated = DateTime.UtcNow;
 
-                        var isPubliclyAccessible = await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion.Id);
+                        var isPubliclyAccessible = await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion);
 
                         if (isPubliclyAccessible)
                         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
@@ -99,11 +99,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
                         methodologyVersion.Updated = DateTime.UtcNow;
 
-                        var isPubliclyAccessible = await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion);
+                        // We cannot rely on Methodology.LatestPublishedVersionId, as it may now be incorrect,
+                        // if we are approving and publishing this methodology version.
+                        var isToBePublished = await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion);
 
-                        if (isPubliclyAccessible)
+                        if (isToBePublished)
                         {
                             methodologyVersion.Published = DateTime.UtcNow;
+                            methodologyVersion.Methodology.LatestPublishedVersionId = methodologyVersion.Id;
 
                             await _publishingService.PublishMethodologyFiles(methodologyVersion.Id);
                         }
@@ -119,7 +122,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
                         await _context.SaveChangesAsync();
 
-                        if (isPubliclyAccessible)
+                        if (isToBePublished)
                         {
                             // Update the 'All Methodologies' cache item
                             await _methodologyCacheService.UpdateSummariesTree();
@@ -138,7 +141,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         {
             var owningPublicationId = await _context.PublicationMethodologies
                 .Where(pm => pm.MethodologyId == methodologyVersion.MethodologyId
-                && pm.Owner)
+                             && pm.Owner)
                 .Select(pm => pm.PublicationId)
                 .SingleAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
@@ -38,36 +38,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 await contentDbContext.SaveChangesAsync();
             }
 
-            Guid methodologyId;
+            Guid methodologyVersionId;
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
-                var methodology = await service.CreateMethodologyForPublication(publication.Id, userId);
+                var methodologyVersion = await service.CreateMethodologyForPublication(publication.Id, userId);
                 await contentDbContext.SaveChangesAsync();
-                methodologyId = methodology.Id;
+                methodologyVersionId = methodologyVersion.Id;
             }
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var methodology = await contentDbContext
+                var methodologyVersion = await contentDbContext
                     .MethodologyVersions
                     .Include(m => m.Methodology)
                     .ThenInclude(p => p.Publications)
                     .ThenInclude(p => p.Publication)
-                    .SingleAsync(m => m.Id == methodologyId);
+                    .SingleAsync(m => m.Id == methodologyVersionId);
 
                 var savedPublication = await contentDbContext.Publications.SingleAsync(p => p.Id == publication.Id);
 
-                Assert.Equal(Immediately, methodology.PublishingStrategy);
-                Assert.NotNull(methodology.Methodology);
-                Assert.Single(methodology.Methodology.Publications);
-                Assert.Equal(savedPublication, methodology.Methodology.Publications[0].Publication);
-                Assert.Equal(savedPublication.Title, methodology.Title);
-                Assert.Equal(savedPublication.Slug, methodology.Slug);
-                Assert.NotNull(methodology.Created);
-                Assert.InRange(DateTime.UtcNow.Subtract(methodology.Created!.Value).Milliseconds, 0, 1500);
-                Assert.Equal(userId, methodology.CreatedById);
+                Assert.Equal(Immediately, methodologyVersion.PublishingStrategy);
+                Assert.NotNull(methodologyVersion.Methodology);
+                Assert.Single(methodologyVersion.Methodology.Publications);
+                Assert.Equal(savedPublication, methodologyVersion.Methodology.Publications[0].Publication);
+                Assert.Equal(savedPublication.Title, methodologyVersion.Title);
+                Assert.Equal(savedPublication.Slug, methodologyVersion.Slug);
+                Assert.NotNull(methodologyVersion.Created);
+                Assert.InRange(DateTime.UtcNow.Subtract(methodologyVersion.Created!.Value).Milliseconds, 0, 1500);
+                Assert.Equal(userId, methodologyVersion.CreatedById);
             }
         }
 
@@ -905,7 +905,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.True(await service.IsPubliclyAccessible(methodologyVersion.Id));
+                await contentDbContext.Entry(methodologyVersion)
+                    .ReloadAsync();
+
+                Assert.True(await service.IsPubliclyAccessible(methodologyVersion));
             }
         }
 
@@ -950,7 +953,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.True(await service.IsPubliclyAccessible(methodologyVersion.Id));
+                await contentDbContext.Entry(methodologyVersion)
+                    .ReloadAsync();
+
+                Assert.True(await service.IsPubliclyAccessible(methodologyVersion));
             }
         }
 
@@ -987,7 +993,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.False(await service.IsPubliclyAccessible(methodologyVersion.Id));
+                Assert.False(await service.IsPubliclyAccessible(methodologyVersion));
             }
         }
 
@@ -1032,7 +1038,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.False(await service.IsPubliclyAccessible(methodologyVersion.Id));
+                Assert.False(await service.IsPubliclyAccessible(methodologyVersion));
             }
         }
 
@@ -1076,7 +1082,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.False(await service.IsPubliclyAccessible(methodologyVersion.Id));
+                await contentDbContext.Entry(methodologyVersion)
+                    .ReloadAsync();
+
+                Assert.False(await service.IsPubliclyAccessible(methodologyVersion));
             }
         }
 
@@ -1134,9 +1143,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.False(await service.IsPubliclyAccessible(previousVersion.Id));
-                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion.Id));
-                Assert.False(await service.IsPubliclyAccessible(latestDraftVersion.Id));
+                await contentDbContext.Entry(previousVersion)
+                    .ReloadAsync();
+                await contentDbContext.Entry(latestPublishedVersion)
+                    .ReloadAsync();
+                await contentDbContext.Entry(latestDraftVersion)
+                    .ReloadAsync();
+
+                Assert.False(await service.IsPubliclyAccessible(previousVersion));
+                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion));
+                Assert.False(await service.IsPubliclyAccessible(latestDraftVersion));
             }
         }
 
@@ -1202,9 +1218,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.False(await service.IsPubliclyAccessible(previousVersion.Id));
-                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion.Id));
-                Assert.False(await service.IsPubliclyAccessible(latestApprovedVersion.Id));
+                await contentDbContext.Entry(previousVersion)
+                    .ReloadAsync();
+                await contentDbContext.Entry(latestPublishedVersion)
+                    .ReloadAsync();
+                await contentDbContext.Entry(latestApprovedVersion)
+                    .ReloadAsync();
+
+                Assert.False(await service.IsPubliclyAccessible(previousVersion));
+                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion));
+                Assert.False(await service.IsPubliclyAccessible(latestApprovedVersion));
             }
         }
 
@@ -1272,9 +1295,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.False(await service.IsPubliclyAccessible(previousVersion.Id));
-                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion.Id));
-                Assert.False(await service.IsPubliclyAccessible(latestDraftVersion.Id));
+                await contentDbContext.Entry(previousVersion)
+                    .ReloadAsync();
+                await contentDbContext.Entry(latestPublishedVersion)
+                    .ReloadAsync();
+                await contentDbContext.Entry(latestDraftVersion)
+                    .ReloadAsync();
+
+                Assert.False(await service.IsPubliclyAccessible(previousVersion));
+                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion));
+                Assert.False(await service.IsPubliclyAccessible(latestDraftVersion));
             }
         }
 
@@ -1347,9 +1377,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.False(await service.IsPubliclyAccessible(previousVersion.Id));
-                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion.Id));
-                Assert.False(await service.IsPubliclyAccessible(latestApprovedVersion.Id));
+                await contentDbContext.Entry(previousVersion)
+                    .ReloadAsync();
+                await contentDbContext.Entry(latestPublishedVersion)
+                    .ReloadAsync();
+                await contentDbContext.Entry(latestApprovedVersion)
+                    .ReloadAsync();
+
+                Assert.False(await service.IsPubliclyAccessible(previousVersion));
+                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion));
+                Assert.False(await service.IsPubliclyAccessible(latestApprovedVersion));
             }
         }
 
@@ -1387,7 +1424,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.False(await service.IsPubliclyAccessible(methodologyVersion.Id));
+                await contentDbContext.Entry(methodologyVersion)
+                    .ReloadAsync();
+
+                Assert.False(await service.IsPubliclyAccessible(methodologyVersion));
             }
         }
 
@@ -1426,7 +1466,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
                 await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                    service.IsPubliclyAccessible(methodologyVersion.Id));
+                    service.IsPubliclyAccessible(methodologyVersion));
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
@@ -343,6 +343,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
 
             var methodology = new Methodology
             {
+                LatestPublishedVersion = latestPublishedVersion,
                 Versions = ListOf(previousVersion, latestPublishedVersion, latestDraftVersion)
             };
 
@@ -542,6 +543,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
 
             var methodology1 = new Methodology
             {
+                LatestPublishedVersionId = Guid.Parse("926750dc-b079-4acb-a6a2-71b550920e81"),
                 Versions = ListOf(
                     new MethodologyVersion
                     {
@@ -572,6 +574,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
 
             var methodology2 = new Methodology
             {
+                LatestPublishedVersionId = Guid.Parse("2d6632b9-2480-4c34-b298-123064b6f04e"),
                 Versions = ListOf(
                     new MethodologyVersion
                     {
@@ -1689,6 +1692,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
+                var methodologyVersionId = Guid.NewGuid();
                 var publicationMethodology = new PublicationMethodology
                 {
                     Publication = new Publication
@@ -1699,8 +1703,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                     Owner = true,
                     Methodology = new Methodology
                     {
+                        LatestPublishedVersionId = Guid.NewGuid(),
                         Versions = ListOf(new MethodologyVersion
                         {
+                            Id = methodologyVersionId,
                             Status = Approved,
                             PublishingStrategy = Immediately,
                         }),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
@@ -822,7 +822,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         }
 
         [Fact]
-        public async Task IsPubliclyAccessible_ApprovedAndPublishedImmediately()
+        public async Task IsToBePublished_ApprovedAndPublishedImmediately()
         {
             var methodologyVersion = new MethodologyVersion
             {
@@ -857,12 +857,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 await contentDbContext.Entry(methodologyVersion)
                     .ReloadAsync();
 
-                Assert.True(await service.IsPubliclyAccessible(methodologyVersion));
+                Assert.True(await service.IsToBePublished(methodologyVersion));
             }
         }
 
         [Fact]
-        public async Task IsPubliclyAccessible_ApprovedAndScheduledWithLiveRelease()
+        public async Task IsToBePublished_ApprovedAndScheduledWithLiveRelease()
         {
             var liveRelease = new Release
             {
@@ -905,12 +905,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 await contentDbContext.Entry(methodologyVersion)
                     .ReloadAsync();
 
-                Assert.True(await service.IsPubliclyAccessible(methodologyVersion));
+                Assert.True(await service.IsToBePublished(methodologyVersion));
             }
         }
 
         [Fact]
-        public async Task IsPubliclyAccessible_PublishedImmediatelyButNotApprovedIsNotAccessible()
+        public async Task IsToBePublished_PublishedImmediatelyButNotApprovedIsNotAccessible()
         {
             var methodologyVersion = new MethodologyVersion
             {
@@ -942,12 +942,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.False(await service.IsPubliclyAccessible(methodologyVersion));
+                Assert.False(await service.IsToBePublished(methodologyVersion));
             }
         }
 
         [Fact]
-        public async Task IsPubliclyAccessible_ScheduledWithLiveReleaseButNotApprovedIsNotAccessible()
+        public async Task IsToBePublished_ScheduledWithLiveReleaseButNotApprovedIsNotAccessible()
         {
             var liveRelease = new Release
             {
@@ -987,12 +987,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
-                Assert.False(await service.IsPubliclyAccessible(methodologyVersion));
+                Assert.False(await service.IsToBePublished(methodologyVersion));
             }
         }
 
         [Fact]
-        public async Task IsPubliclyAccessible_ApprovedButScheduledWithNonLiveReleaseIsNotAccessible()
+        public async Task IsToBePublished_ApprovedButScheduledWithNonLiveReleaseIsNotAccessible()
         {
             var nonLiveRelease = new Release
             {
@@ -1034,12 +1034,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 await contentDbContext.Entry(methodologyVersion)
                     .ReloadAsync();
 
-                Assert.False(await service.IsPubliclyAccessible(methodologyVersion));
+                Assert.False(await service.IsToBePublished(methodologyVersion));
             }
         }
 
         [Fact]
-        public async Task IsPubliclyAccessible_ApprovedAndPublishedImmediatelyIsAccessibleIfNextVersionIsDraft()
+        public async Task IsToBePublished_ApprovedAndPublishedImmediatelyIsAccessibleIfNextVersionIsDraft()
         {
             var previousVersion = new MethodologyVersion
             {
@@ -1099,15 +1099,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 await contentDbContext.Entry(latestDraftVersion)
                     .ReloadAsync();
 
-                Assert.False(await service.IsPubliclyAccessible(previousVersion));
-                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion));
-                Assert.False(await service.IsPubliclyAccessible(latestDraftVersion));
+                Assert.False(await service.IsToBePublished(previousVersion));
+                Assert.True(await service.IsToBePublished(latestPublishedVersion));
+                Assert.False(await service.IsToBePublished(latestDraftVersion));
             }
         }
 
         [Fact]
         public async Task
-            IsPubliclyAccessible_ApprovedAndPublishedImmediatelyIsAccessibleIfNextVersionIsScheduledWithNonLiveRelease()
+            IsToBePublished_ApprovedAndPublishedImmediatelyIsAccessibleIfNextVersionIsScheduledWithNonLiveRelease()
         {
             var nonLiveRelease = new Release
             {
@@ -1174,14 +1174,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 await contentDbContext.Entry(latestApprovedVersion)
                     .ReloadAsync();
 
-                Assert.False(await service.IsPubliclyAccessible(previousVersion));
-                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion));
-                Assert.False(await service.IsPubliclyAccessible(latestApprovedVersion));
+                Assert.False(await service.IsToBePublished(previousVersion));
+                Assert.True(await service.IsToBePublished(latestPublishedVersion));
+                Assert.False(await service.IsToBePublished(latestApprovedVersion));
             }
         }
 
         [Fact]
-        public async Task IsPubliclyAccessible_ApprovedAndScheduledWithLiveReleaseIsAccessibleIfNextVersionIsDraft()
+        public async Task IsToBePublished_ApprovedAndScheduledWithLiveReleaseIsAccessibleIfNextVersionIsDraft()
         {
             var liveRelease = new Release
             {
@@ -1251,15 +1251,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 await contentDbContext.Entry(latestDraftVersion)
                     .ReloadAsync();
 
-                Assert.False(await service.IsPubliclyAccessible(previousVersion));
-                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion));
-                Assert.False(await service.IsPubliclyAccessible(latestDraftVersion));
+                Assert.False(await service.IsToBePublished(previousVersion));
+                Assert.True(await service.IsToBePublished(latestPublishedVersion));
+                Assert.False(await service.IsToBePublished(latestDraftVersion));
             }
         }
 
         [Fact]
         public async Task
-            IsPubliclyAccessible_ApprovedAndScheduledWithLiveReleaseIsAccessibleIfNextVersionIsScheduledWithNonLiveRelease()
+            IsToBePublished_ApprovedAndScheduledWithLiveReleaseIsAccessibleIfNextVersionIsScheduledWithNonLiveRelease()
         {
             var liveRelease = new Release
             {
@@ -1333,15 +1333,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 await contentDbContext.Entry(latestApprovedVersion)
                     .ReloadAsync();
 
-                Assert.False(await service.IsPubliclyAccessible(previousVersion));
-                Assert.True(await service.IsPubliclyAccessible(latestPublishedVersion));
-                Assert.False(await service.IsPubliclyAccessible(latestApprovedVersion));
+                Assert.False(await service.IsToBePublished(previousVersion));
+                Assert.True(await service.IsToBePublished(latestPublishedVersion));
+                Assert.False(await service.IsToBePublished(latestApprovedVersion));
             }
         }
 
         [Fact]
         public async Task
-            IsPubliclyAccessible_ApprovedAndPublishedImmediatelyButPublicationNotPublishedIsNotAccessible()
+            IsToBePublished_ApprovedAndPublishedImmediatelyButPublicationNotPublishedIsNotAccessible()
         {
             var methodologyVersion = new MethodologyVersion
             {
@@ -1376,12 +1376,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 await contentDbContext.Entry(methodologyVersion)
                     .ReloadAsync();
 
-                Assert.False(await service.IsPubliclyAccessible(methodologyVersion));
+                Assert.False(await service.IsToBePublished(methodologyVersion));
             }
         }
 
         [Fact]
-        public async Task IsPubliclyAccessible_ScheduledWithReleaseNotFoundIsNotAccessible()
+        public async Task IsToBePublished_ScheduledWithReleaseNotFoundIsNotAccessible()
         {
             var methodologyVersion = new MethodologyVersion
             {
@@ -1415,7 +1415,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 var service = BuildMethodologyVersionRepository(contentDbContext);
 
                 await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                    service.IsPubliclyAccessible(methodologyVersion));
+                    service.IsToBePublished(methodologyVersion));
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -134,6 +134,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     v => v,
                     v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
 
+            modelBuilder.Entity<Methodology>()
+                .HasOne(m => m.LatestPublishedVersion)
+                .WithOne()
+                .HasForeignKey<Methodology>(m => m.LatestPublishedVersionId)
+                .IsRequired(false);
+
             modelBuilder.Entity<MethodologyVersionContent>().ToTable("MethodologyVersions");
             modelBuilder.Entity<MethodologyVersionContent>().Property<Guid>("MethodologyVersionId");
             modelBuilder.Entity<MethodologyVersionContent>().HasKey("MethodologyVersionId");

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
@@ -21,6 +21,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<MethodologyVersion> Versions { get; set; } = new();
 
+        public Guid? LatestPublishedVersionId { get; set; }
+
+        public MethodologyVersion? LatestPublishedVersion { get; set; }
+
         public PublicationMethodology OwningPublication()
         {
             if (Publications.IsNullOrEmpty())

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
@@ -17,7 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 
         Task<List<MethodologyVersion>> GetLatestPublishedVersionByPublication(Guid publicationId);
 
-        Task<bool> IsPubliclyAccessible(Guid methodologyVersionId);
+        Task<bool> IsPubliclyAccessible(MethodologyVersion methodologyVersion);
 
         Task PublicationTitleChanged(Guid publicationId, string originalSlug, string updatedTitle, string updatedSlug);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
@@ -17,6 +17,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 
         Task<List<MethodologyVersion>> GetLatestPublishedVersionByPublication(Guid publicationId);
 
+        Task<bool> IsLatestPublishedVersion(MethodologyVersion methodologyVersion);
+
         Task<bool> IsPubliclyAccessible(MethodologyVersion methodologyVersion);
 
         Task PublicationTitleChanged(Guid publicationId, string originalSlug, string updatedTitle, string updatedSlug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
@@ -19,7 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 
         Task<bool> IsLatestPublishedVersion(MethodologyVersion methodologyVersion);
 
-        Task<bool> IsPubliclyAccessible(MethodologyVersion methodologyVersion);
+        Task<bool> IsToBePublished(MethodologyVersion methodologyVersion);
 
         Task PublicationTitleChanged(Guid publicationId, string originalSlug, string updatedTitle, string updatedSlug);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
@@ -157,7 +157,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
             return methodologyVersion.Id == methodologyVersion.Methodology.LatestPublishedVersionId;
         }
 
-        public async Task<bool> IsPubliclyAccessible(MethodologyVersion methodologyVersion)
+        // TODO: Move IsToBePublished to MethodologyApprovalService and change to private after MethodologyMigrationController has been removed
+        public async Task<bool> IsToBePublished(MethodologyVersion methodologyVersion)
         {
             // A version that's not approved can't be publicly accessible
             if (!methodologyVersion.Approved)
@@ -165,7 +166,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                 return false;
             }
 
-            // A methodology with a newer published version cannot be live
+            // A methodology version with a newer published version cannot be live
             var nextVersion = await GetNextVersion(methodologyVersion);
             if (nextVersion?.Approved == true)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
@@ -111,14 +111,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
             return await methodology.Versions.FirstOrDefaultAsync(IsPubliclyAccessible);
         }
 
-        public async Task<bool> IsPubliclyAccessible(Guid methodologyVersionId)
-        {
-            var methodologyVersion = await _contentDbContext.MethodologyVersions
-                .FindAsync(methodologyVersionId);
-
-            return await IsPubliclyAccessible(methodologyVersion);
-        }
-
         // This method is responsible for keeping Methodology Titles and Slugs in sync with their owning Publications
         // where appropriate.  Methodologies always keep track of their owning Publication's title for
         // optimisation purposes, but Methodology.Slug is used for the actual Slug for all of its Methodology
@@ -173,7 +165,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
             return false;
         }
 
-        private async Task<bool> IsPubliclyAccessible(MethodologyVersion methodologyVersion)
+        public async Task<bool> IsPubliclyAccessible(MethodologyVersion methodologyVersion)
         {
             // A version that's not approved can't be publicly accessible
             if (!methodologyVersion.Approved)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandlerTests.cs
@@ -20,14 +20,14 @@ public class ViewMethodologyVersionAuthorizationHandlerTests
     };
 
     [Fact]
-    public async Task MethodologyVersionIsPubliclyAccessible()
+    public async Task MethodologyVersionIsLatestPublishedVersion()
     {
         var (
             handler,
             methodologyVersionRepository
             ) = CreateHandlerAndDependencies();
 
-        methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(_methodologyVersion))
+        methodologyVersionRepository.Setup(mock => mock.IsLatestPublishedVersion(_methodologyVersion))
             .ReturnsAsync(true);
 
         var authContext =
@@ -41,14 +41,14 @@ public class ViewMethodologyVersionAuthorizationHandlerTests
     }
 
     [Fact]
-    public async Task MethodologyVersionIsNotPubliclyAccessible()
+    public async Task MethodologyVersionIsNotLatestPublishedVersion()
     {
         var (
             handler,
             methodologyVersionRepository
             ) = CreateHandlerAndDependencies();
 
-        methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(_methodologyVersion))
+        methodologyVersionRepository.Setup(mock => mock.IsLatestPublishedVersion(_methodologyVersion))
             .ReturnsAsync(false);
 
         var authContext =

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandlerTests.cs
@@ -27,7 +27,7 @@ public class ViewMethodologyVersionAuthorizationHandlerTests
             methodologyVersionRepository
             ) = CreateHandlerAndDependencies();
 
-        methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(_methodologyVersion.Id))
+        methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(_methodologyVersion))
             .ReturnsAsync(true);
 
         var authContext =
@@ -48,7 +48,7 @@ public class ViewMethodologyVersionAuthorizationHandlerTests
             methodologyVersionRepository
             ) = CreateHandlerAndDependencies();
 
-        methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(_methodologyVersion.Id))
+        methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(_methodologyVersion))
             .ReturnsAsync(false);
 
         var authContext =

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandler.cs
@@ -24,7 +24,7 @@ public class ViewMethodologyVersionAuthorizationHandler :
         ViewMethodologyVersionRequirement requirement,
         MethodologyVersion methodologyVersion)
     {
-        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion))
+        if (await _methodologyVersionRepository.IsLatestPublishedVersion(methodologyVersion))
         {
             context.Succeed(requirement);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/AuthorizationHandlers/ViewMethodologyVersionAuthorizationHandler.cs
@@ -24,7 +24,7 @@ public class ViewMethodologyVersionAuthorizationHandler :
         ViewMethodologyVersionRequirement requirement,
         MethodologyVersion methodologyVersion)
     {
-        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion.Id))
+        if (await _methodologyVersionRepository.IsPubliclyAccessible(methodologyVersion))
         {
             context.Succeed(requirement);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
@@ -6,7 +6,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
-using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
@@ -125,7 +125,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 var service = SetupMethodologyService(contentDbContext,
                     methodologyVersionRepository.Object);
 
-                var result = await service.GetLatestByRelease(release.Id);
+                var result = await service.GetLatestVersionByRelease(release);
 
                 Assert.Equal(methodologies, result);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
@@ -6,7 +6,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Extensions.Configuration;
@@ -74,29 +73,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         [Fact]
         public async Task PublishMethodologyFilesIfApplicableForRelease_ReleaseHasNoRelatedMethodologies()
         {
-            var releaseId = Guid.NewGuid();
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+            };
 
             var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
-            var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
-            var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
             var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
 
-            methodologyService.Setup(mock => mock.GetLatestByRelease(releaseId))
+            methodologyService.Setup(mock => mock.GetLatestVersionByRelease(release))
                 .ReturnsAsync(new List<MethodologyVersion>());
+
+            releaseService.Setup(mock => mock.Get(release.Id))
+                .ReturnsAsync(release);
 
             // No other invocations on the services expected because the release has no related methodologies
 
             var service = BuildPublishingService(methodologyService: methodologyService.Object,
-                publicBlobStorageService: publicBlobStorageService.Object,
-                privateBlobStorageService: privateBlobStorageService.Object,
                 releaseService: releaseService.Object);
 
-            await service.PublishMethodologyFilesIfApplicableForRelease(releaseId);
+            await service.PublishMethodologyFilesIfApplicableForRelease(release.Id);
 
-            MockUtils.VerifyAllMocks(methodologyService,
-                publicBlobStorageService,
-                privateBlobStorageService,
-                releaseService);
+            MockUtils.VerifyAllMocks(methodologyService, releaseService);
         }
 
         [Fact]
@@ -123,7 +121,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             methodologyService.Setup(mock => mock.IsBeingPublishedAlongsideRelease(methodologyVersion, release))
                 .ReturnsAsync(false);
 
-            methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
+            methodologyService.Setup(mock => mock.GetLatestVersionByRelease(release))
                 .ReturnsAsync(ListOf(methodologyVersion));
 
             releaseService.Setup(mock => mock.Get(release.Id))
@@ -169,7 +167,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             methodologyService.Setup(mock => mock.IsBeingPublishedAlongsideRelease(methodologyVersion, release))
                 .ReturnsAsync(true);
 
-            methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
+            methodologyService.Setup(mock => mock.GetLatestVersionByRelease(release))
                 .ReturnsAsync(AsList(methodologyVersion));
 
             methodologyService.Setup(mock => mock.GetFiles(methodologyVersion.Id, Image))
@@ -234,7 +232,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             methodologyService.Setup(mock => mock.IsBeingPublishedAlongsideRelease(methodologyVersion, release))
                 .ReturnsAsync(false);
 
-            methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
+            methodologyService.Setup(mock => mock.GetLatestVersionByRelease(release))
                 .ReturnsAsync(ListOf(methodologyVersion));
 
             releaseService.Setup(mock => mock.Get(release.Id))
@@ -280,7 +278,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             methodologyService.Setup(mock => mock.IsBeingPublishedAlongsideRelease(methodologyVersion, release))
                 .ReturnsAsync(true);
 
-            methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
+            methodologyService.Setup(mock => mock.GetLatestVersionByRelease(release))
                 .ReturnsAsync(ListOf(methodologyVersion));
 
             methodologyService.Setup(mock => mock.GetFiles(methodologyVersion.Id, Image))
@@ -346,7 +344,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             methodologyService.Setup(mock => mock.IsBeingPublishedAlongsideRelease(methodologyVersion, release))
                 .ReturnsAsync(false);
 
-            methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
+            methodologyService.Setup(mock => mock.GetLatestVersionByRelease(release))
                 .ReturnsAsync(ListOf(methodologyVersion));
 
             releaseService.Setup(mock => mock.Get(release.Id))

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
@@ -79,7 +79,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
             var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
             var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
-            var publicationRepository = new Mock<IPublicationRepository>(MockBehavior.Strict);
             var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
 
             methodologyService.Setup(mock => mock.GetLatestByRelease(releaseId))
@@ -90,7 +89,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var service = BuildPublishingService(methodologyService: methodologyService.Object,
                 publicBlobStorageService: publicBlobStorageService.Object,
                 privateBlobStorageService: privateBlobStorageService.Object,
-                publicationRepository: publicationRepository.Object,
                 releaseService: releaseService.Object);
 
             await service.PublishMethodologyFilesIfApplicableForRelease(releaseId);
@@ -98,7 +96,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             MockUtils.VerifyAllMocks(methodologyService,
                 publicBlobStorageService,
                 privateBlobStorageService,
-                publicationRepository,
                 releaseService);
         }
 
@@ -121,14 +118,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
             var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
             var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
-            var publicationRepository = new Mock<IPublicationRepository>(MockBehavior.Strict);
             var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.IsBeingPublishedAlongsideRelease(methodologyVersion, release))
+                .ReturnsAsync(false);
 
             methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
                 .ReturnsAsync(ListOf(methodologyVersion));
-
-            publicationRepository.Setup(mock => mock.IsPublished(release.PublicationId))
-                .ReturnsAsync(true);
 
             releaseService.Setup(mock => mock.Get(release.Id))
                 .ReturnsAsync(release);
@@ -138,7 +134,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var service = BuildPublishingService(methodologyService: methodologyService.Object,
                 publicBlobStorageService: publicBlobStorageService.Object,
                 privateBlobStorageService: privateBlobStorageService.Object,
-                publicationRepository: publicationRepository.Object,
                 releaseService: releaseService.Object);
 
             await service.PublishMethodologyFilesIfApplicableForRelease(release.Id);
@@ -146,7 +141,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             MockUtils.VerifyAllMocks(methodologyService,
                 publicBlobStorageService,
                 privateBlobStorageService,
-                publicationRepository,
                 releaseService);
         }
 
@@ -170,17 +164,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
             var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
             var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
-            var publicationRepository = new Mock<IPublicationRepository>(MockBehavior.Strict);
             var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.IsBeingPublishedAlongsideRelease(methodologyVersion, release))
+                .ReturnsAsync(true);
 
             methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
                 .ReturnsAsync(AsList(methodologyVersion));
 
             methodologyService.Setup(mock => mock.GetFiles(methodologyVersion.Id, Image))
                 .ReturnsAsync(new List<File>());
-
-            publicationRepository.Setup(mock => mock.IsPublished(release.PublicationId))
-                .ReturnsAsync(true);
 
             // Invocations on the storage services expected because the methodology is scheduled with this release
 
@@ -206,7 +199,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 methodologyService: methodologyService.Object,
                 publicBlobStorageService: publicBlobStorageService.Object,
                 privateBlobStorageService: privateBlobStorageService.Object,
-                publicationRepository: publicationRepository.Object,
                 releaseService: releaseService.Object);
 
             await service.PublishMethodologyFilesIfApplicableForRelease(release.Id);
@@ -214,7 +206,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             MockUtils.VerifyAllMocks(methodologyService,
                 publicBlobStorageService,
                 privateBlobStorageService,
-                publicationRepository,
                 releaseService);
         }
 
@@ -238,14 +229,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
             var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
             var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
-            var publicationRepository = new Mock<IPublicationRepository>(MockBehavior.Strict);
             var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.IsBeingPublishedAlongsideRelease(methodologyVersion, release))
+                .ReturnsAsync(false);
 
             methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
                 .ReturnsAsync(ListOf(methodologyVersion));
-
-            publicationRepository.Setup(mock => mock.IsPublished(release.PublicationId))
-                .ReturnsAsync(true);
 
             releaseService.Setup(mock => mock.Get(release.Id))
                 .ReturnsAsync(release);
@@ -255,7 +245,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var service = BuildPublishingService(methodologyService: methodologyService.Object,
                 publicBlobStorageService: publicBlobStorageService.Object,
                 privateBlobStorageService: privateBlobStorageService.Object,
-                publicationRepository: publicationRepository.Object,
                 releaseService: releaseService.Object);
 
             await service.PublishMethodologyFilesIfApplicableForRelease(release.Id);
@@ -263,7 +252,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             MockUtils.VerifyAllMocks(methodologyService,
                 publicBlobStorageService,
                 privateBlobStorageService,
-                publicationRepository,
                 releaseService);
         }
 
@@ -287,17 +275,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
             var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
             var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
-            var publicationRepository = new Mock<IPublicationRepository>(MockBehavior.Strict);
             var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.IsBeingPublishedAlongsideRelease(methodologyVersion, release))
+                .ReturnsAsync(true);
 
             methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
                 .ReturnsAsync(ListOf(methodologyVersion));
 
             methodologyService.Setup(mock => mock.GetFiles(methodologyVersion.Id, Image))
                 .ReturnsAsync(new List<File>());
-
-            publicationRepository.Setup(mock => mock.IsPublished(release.PublicationId))
-                .ReturnsAsync(false);
 
             // Invocations on the storage services expected because this will be the first published release.
             // The methodology and its files will be published for the first time with this release
@@ -324,7 +311,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 methodologyService: methodologyService.Object,
                 publicBlobStorageService: publicBlobStorageService.Object,
                 privateBlobStorageService: privateBlobStorageService.Object,
-                publicationRepository: publicationRepository.Object,
                 releaseService: releaseService.Object);
 
             await service.PublishMethodologyFilesIfApplicableForRelease(release.Id);
@@ -332,7 +318,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             MockUtils.VerifyAllMocks(methodologyService,
                 publicBlobStorageService,
                 privateBlobStorageService,
-                publicationRepository,
                 releaseService);
         }
 
@@ -356,14 +341,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
             var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
             var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
-            var publicationRepository = new Mock<IPublicationRepository>(MockBehavior.Strict);
             var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.IsBeingPublishedAlongsideRelease(methodologyVersion, release))
+                .ReturnsAsync(false);
 
             methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
                 .ReturnsAsync(ListOf(methodologyVersion));
-
-            publicationRepository.Setup(mock => mock.IsPublished(release.PublicationId))
-                .ReturnsAsync(true);
 
             releaseService.Setup(mock => mock.Get(release.Id))
                 .ReturnsAsync(release);
@@ -375,7 +359,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 methodologyService: methodologyService.Object,
                 publicBlobStorageService: publicBlobStorageService.Object,
                 privateBlobStorageService: privateBlobStorageService.Object,
-                publicationRepository: publicationRepository.Object,
                 releaseService: releaseService.Object);
 
             await service.PublishMethodologyFilesIfApplicableForRelease(release.Id);
@@ -383,7 +366,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             MockUtils.VerifyAllMocks(methodologyService,
                 publicBlobStorageService,
                 privateBlobStorageService,
-                publicationRepository,
                 releaseService);
         }
 
@@ -411,7 +393,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             IPrivateBlobStorageService? privateBlobStorageService = null,
             IPublicBlobStorageService? publicBlobStorageService = null,
             IMethodologyService? methodologyService = null,
-            IPublicationRepository? publicationRepository = null,
             IReleaseService? releaseService = null,
             ILogger<PublishingService>? logger = null,
             IConfiguration? configuration = null)
@@ -420,7 +401,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 privateBlobStorageService ?? Mock.Of<IPrivateBlobStorageService>(MockBehavior.Strict),
                 publicBlobStorageService ?? Mock.Of<IPublicBlobStorageService>(MockBehavior.Strict),
                 methodologyService ?? Mock.Of<IMethodologyService>(MockBehavior.Strict),
-                publicationRepository ?? Mock.Of<IPublicationRepository>(MockBehavior.Strict),
                 releaseService ?? Mock.Of<IReleaseService>(MockBehavior.Strict),
                 logger ?? Mock.Of<ILogger<PublishingService>>(),
                 configuration ?? DefaultConfigurationMock().Object

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
@@ -11,7 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
     {
         Task<MethodologyVersion> Get(Guid methodologyVersionId);
 
-        Task<List<MethodologyVersion>> GetLatestByRelease(Guid releaseId);
+        Task<List<MethodologyVersion>> GetLatestVersionByRelease(Release release);
 
         Task<List<File>> GetFiles(Guid methodologyVersionId, params FileType[] types);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
@@ -15,9 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task<List<File>> GetFiles(Guid methodologyVersionId, params FileType[] types);
 
-        Task SetPublishedDatesIfApplicable(Guid publicationId);
-
-        Task SetAsLatestPublishedVersion(MethodologyVersion methodologyVersion);
+        Task Publish(MethodologyVersion methodologyVersion);
 
         Task<bool> IsBeingPublishedAlongsideRelease(MethodologyVersion methodologyVersion, Release release);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
@@ -16,5 +16,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         Task<List<File>> GetFiles(Guid methodologyVersionId, params FileType[] types);
 
         Task SetPublishedDatesIfApplicable(Guid publicationId);
+
+        Task SetAsLatestPublishedVersion(MethodologyVersion methodologyVersion);
+
+        Task<bool> IsBeingPublishedAlongsideRelease(MethodologyVersion methodologyVersion, Release release);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
@@ -33,9 +33,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             return await _context.MethodologyVersions.FindAsync(methodologyVersionId);
         }
 
-        public async Task<List<MethodologyVersion>> GetLatestByRelease(Guid releaseId) // @MarkFix could accept a Release here
+        public async Task<List<MethodologyVersion>> GetLatestVersionByRelease(Release release)
         {
-            var release = await _context.Releases.FindAsync(releaseId);
             return await _methodologyVersionRepository.GetLatestVersionByPublication(release.PublicationId);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
@@ -33,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             return await _context.MethodologyVersions.FindAsync(methodologyVersionId);
         }
 
-        public async Task<List<MethodologyVersion>> GetLatestByRelease(Guid releaseId)
+        public async Task<List<MethodologyVersion>> GetLatestByRelease(Guid releaseId) // @MarkFix could accept a Release here
         {
             var release = await _context.Releases.FindAsync(releaseId);
             return await _methodologyVersionRepository.GetLatestVersionByPublication(release.PublicationId);
@@ -62,13 +62,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             await _context.SaveChangesAsync();
         }
 
-        public async Task SetAsLatestPublishedVersion(MethodologyVersion methodologyVersion)
+        public async Task Publish(MethodologyVersion methodologyVersion)
         {
+            // NOTE: Methodology files are published separately
+
             await _context.Entry(methodologyVersion)
                 .Reference(mv => mv.Methodology)
                 .LoadAsync();
 
             methodologyVersion.Methodology.LatestPublishedVersionId = methodologyVersion.Id;
+            methodologyVersion.Published = DateTime.UtcNow;
+
             await _context.SaveChangesAsync();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -112,19 +112,10 @@ public class PublishingCompletionService : IPublishingCompletionService
                 {
                     if (await _methodologyService.IsBeingPublishedAlongsideRelease(methodologyVersion, release))
                     {
-                        await _methodologyService.SetAsLatestPublishedVersion(methodologyVersion);
-                        // @MarkFix can also update published date here?
+                        await _methodologyService.Publish(methodologyVersion);
                     }
                 }
-
             });
-
-        // Set the published date on any methodologies used by these publications that are now publicly accessible
-        // as a result of releases being published
-        await directlyRelatedPublicationIds
-            .ToAsyncEnumerable()
-            .ForEachAwaitAsync(publicationId =>
-                _methodologyService.SetPublishedDatesIfApplicable(publicationId));
 
         // Update the cached publication and any cached superseded publications.
         // If this is the first live release of the publication, the superseding is now enforced

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -100,14 +100,15 @@ public class PublishingCompletionService : IPublishingCompletionService
             .ToAsyncEnumerable()
             .ForEachAwaitAsync(async releaseId =>
             {
-                var methodologyVersions = await _methodologyService.GetLatestByRelease(releaseId);
+                var release = await _releaseService.Get(releaseId);
+                var methodologyVersions =
+                    await _methodologyService.GetLatestVersionByRelease(release);
 
                 if (!methodologyVersions.Any())
                 {
                     return;
                 }
 
-                var release = await _releaseService.Get(releaseId);
                 foreach (var methodologyVersion in methodologyVersions)
                 {
                     if (await _methodologyService.IsBeingPublishedAlongsideRelease(methodologyVersion, release))

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -60,14 +59,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task PublishMethodologyFilesIfApplicableForRelease(Guid releaseId)
         {
-            var methodologyVersions = await _methodologyService.GetLatestByRelease(releaseId);
+            var release = await _releaseService.Get(releaseId);
+            var methodologyVersions = await _methodologyService.GetLatestVersionByRelease(release);
 
             if (!methodologyVersions.Any())
             {
                 return;
             }
 
-            var release = await _releaseService.Get(releaseId);
             foreach (var methodologyVersion in methodologyVersions)
             {
                 if (await _methodologyService.IsBeingPublishedAlongsideRelease(methodologyVersion, release))

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -63,34 +63,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task PublishMethodologyFilesIfApplicableForRelease(Guid releaseId)
         {
-            var methodologies = await _methodologyService.GetLatestByRelease(releaseId);
+            var methodologyVersions = await _methodologyService.GetLatestByRelease(releaseId);
 
-            if (methodologies.Any())
+            if (methodologyVersions.Any())
             {
                 // Publish the files of the latest methodologies of this release that
                 // aren't already accessible but depended on this release being published,
                 // since those methodologies will be published for the first time with this release
                 var release = await _releaseService.Get(releaseId);
                 var firstRelease = !await _publicationRepository.IsPublished(release.PublicationId);
-                foreach (var methodology in methodologies)
+                foreach (var methodologyVersion in methodologyVersions)
                 {
-                    if (methodology.Approved)
+                    if (methodologyVersion.Approved)
                     {
                         // Include methodologies scheduled immediately that will now be accessible
                         // because this Publication's first release is being published
                         var firstReleaseAndMethodologyScheduledImmediately =
                             firstRelease &&
-                            methodology.ScheduledForPublishingImmediately;
+                            methodologyVersion.ScheduledForPublishingImmediately;
 
                         // Include methodologies scheduled to be published with this release
                         var methodologyScheduledWithThisRelease =
-                            methodology.ScheduledForPublishingWithRelease
-                            && methodology.ScheduledWithReleaseId == releaseId;
+                            methodologyVersion.ScheduledForPublishingWithRelease
+                            && methodologyVersion.ScheduledWithReleaseId == releaseId;
 
                         if (firstReleaseAndMethodologyScheduledImmediately ||
                             methodologyScheduledWithThisRelease)
                         {
-                            await PublishMethodologyFiles(methodology);
+                            await PublishMethodologyFiles(methodologyVersion);
                         }
                     }
                 }


### PR DESCRIPTION
This PR adds a new column to the `Methodologies` table: `LatestPublishedVersionId`. This keeps track of the latest published methodology version for that specific methodology, which allows us to avoid calling `MethodologyVersionRepository#IsPubliclyAccessible` in most cases.

This work was undertaken as the first step towards introducing redirects for previous, replaced slugs - specifically for redirects for previous methodology slugs. EES-4504 is a subtask of this work.

:rotating_light:  A BAU migration endpoint (`PATCH migration/set-methodology-latest-published-version-ids`) will need to be hit when these changes are deployed, to set `LatestPublishedVersionId` for existing methodologies. :rotating_light:

There is also new local data due to these changes: `ees-mssql-data-62.zip`.

We still need to call `IsPubliclyAccessible` when a methodology's latest published version changes, but in all other cases we now rely on the new `LatestPublishedVersionId` column to determine whether a particular methodology version is publicly accessible.

A methodology's `LatestPublishedVersionId` can be set in two cases:
- When a methodologyVersion is approved and will be published immediately - in Admin's `MethodologyApprovalService#UpdateStatus`
- When a methodologyVersion is published in tandem with a release being published - in Publisher's `PublishingCompletionService#CompletePublishingIfAllPriorStagesComplete`

### Other notable changes
- Both `UpdateSpecificMethodologyAuthorizationHandler` and `DeleteSpecificMethodologyAuthorizationHandler` made redundant calls to `IsPubliclyAccessible`, since publicly accessible methodology versions are a subset of approved methodology versions, which both auth handlers were already checking. So I've removed those `IsPubliclyAccessible` calls.
- I've updated `IsPubliclyAccessible` to take a `MethodologyVersion` as an argument instead of a `Guid`. This prevents us from having to make another call to fetch a methodology version that we already had.
- I've changed when a MethodologyVersion's published field is set - when a methodology is published alongside a release, LatestPublishedVersionId and Published are set at the same time.
- I've changed `Methodology` to `MethodologyVersion` in various cases to remove any ambiguity as to which object you're dealing with.