### PR TITLE
EES-4376 Don't show unapproved methodologies in prerelease and admin

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
@@ -110,7 +110,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
                 Type = ReleaseType.OfficialStatistics,
             };
 
-            var unattachedDataBlocks = new List<Admin.ViewModels.DataBlockViewModel>
+            var unattachedDataBlocks = new List<DataBlockViewModel>
             {
                 new()
             };
@@ -141,12 +141,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
                 new MethodologyVersion
                 {
                     Id = Guid.NewGuid(),
-                    AlternativeTitle = "Methodology 1 title"
+                    AlternativeTitle = "Methodology 1 title",
+                    Status = MethodologyApprovalStatus.Approved,
                 },
                 new MethodologyVersion
                 {
                     Id = Guid.NewGuid(),
-                    AlternativeTitle = "Methodology 2 title"
+                    AlternativeTitle = "Methodology 2 title",
+                    Status = MethodologyApprovalStatus.Approved,
+                },
+                new MethodologyVersion
+                {
+                    Id = Guid.NewGuid(),
+                    AlternativeTitle = "Methodology should not appear 1",
+                    Status = MethodologyApprovalStatus.Draft,
+                },
+                new MethodologyVersion
+                {
+                    Id = Guid.NewGuid(),
+                    AlternativeTitle = "Methodology should not appear 2",
+                    Status = MethodologyApprovalStatus.HigherLevelReview,
                 }
             );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
@@ -62,12 +62,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                 {
                     var (release, unattachedDataBlocks, files) = releaseBlocksAndFiles;
 
-                    var methodologies = await _methodologyVersionRepository.GetLatestVersionByPublication(release.PublicationId);
+                    var methodologyVersions = await _methodologyVersionRepository.GetLatestVersionByPublication(release.PublicationId);
+
+                    var approvedMethodologyVersions = await methodologyVersions
+                        .ToAsyncEnumerable()
+                        .Where(mv => mv.Approved)
+                        .ToListAsync();
 
                     var releaseViewModel = _mapper.Map<ManageContentPageViewModel.ReleaseViewModel>(release);
                     releaseViewModel.DownloadFiles = files.ToList();
                     releaseViewModel.Publication.Methodologies =
-                        _mapper.Map<List<IdTitleViewModel>>(methodologies);
+                        _mapper.Map<List<IdTitleViewModel>>(approvedMethodologyVersions);
 
                     // TODO EES-3319 - remove backwards-compatibility for Map Configuration without its
                     // own Boundary Level selection


### PR DESCRIPTION
This PR fixes a bug where unapproved methodologies would appear in release content under Quick links in admin and prerelease . Now only approved methodologies appear here.

NOTE: Filtering out methodologies that are approved isn't perfect, as it's still possible for a methodology to appear on prerelease, but for the methodology to not be live when the release is published, if the methodology is scheduled to be published with a different release - but this is such an edge cause I hesitated to even write this paragraph.