### PR TITLE
EES-4278 Use `releaseId` in call to create permalink if available and improve error handling

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Net.Http;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Xunit;
@@ -31,6 +32,13 @@ public static class HttpResponseMessageTestExtensions
     public static T AssertOk<T>(this HttpResponseMessage message, T expectedBody)
     {
         Assert.Equal(OK, message.StatusCode);
+        return message.AssertBodyEqualTo(expectedBody);
+    }
+
+    public static T AssertCreated<T>(this HttpResponseMessage message, T expectedBody, string expectedLocation)
+    {
+        Assert.Equal(Created, message.StatusCode);
+        Assert.Equal(new Uri(expectedLocation), message.Headers.Location);
         return message.AssertBodyEqualTo(expectedBody);
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PermalinkControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PermalinkControllerTests.cs
@@ -8,6 +8,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
@@ -18,8 +19,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
-using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers;
 
@@ -36,9 +35,12 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
     public async Task CreatePermalink()
     {
         var createRequest = new PermalinkCreateRequest();
-        var expectedResult = new PermalinkViewModel();
+        var expectedResult = new PermalinkViewModel
+        {
+            Id = Guid.NewGuid()
+        };
 
-        var permalinkService = new Mock<IPermalinkService>(Strict);
+        var permalinkService = new Mock<IPermalinkService>(MockBehavior.Strict);
 
         permalinkService
             .Setup(s => s.CreatePermalink(It.Is<PermalinkCreateRequest>(r => r.IsDeepEqualTo(createRequest)),
@@ -52,9 +54,9 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
             requestUri: "/api/permalink-snapshot",
             content: new JsonNetContent(createRequest));
 
-        VerifyAllMocks(permalinkService);
+        MockUtils.VerifyAllMocks(permalinkService);
 
-        response.AssertOk(expectedResult);
+        response.AssertCreated(expectedResult, $"http://localhost/api/permalink-snapshot/{expectedResult.Id}");
     }
 
     [Fact]
@@ -62,9 +64,12 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
     {
         var releaseId = Guid.NewGuid();
         var createRequest = new PermalinkCreateRequest();
-        var expectedResult = new PermalinkViewModel();
+        var expectedResult = new PermalinkViewModel
+        {
+            Id = Guid.NewGuid()
+        };
 
-        var permalinkService = new Mock<IPermalinkService>(Strict);
+        var permalinkService = new Mock<IPermalinkService>(MockBehavior.Strict);
 
         permalinkService
             .Setup(s => s.CreatePermalink(releaseId, It.Is<PermalinkCreateRequest>(r => r.IsDeepEqualTo(createRequest)),
@@ -78,9 +83,9 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
             requestUri: $"/api/permalink-snapshot/release/{releaseId}",
             content: new JsonNetContent(createRequest));
 
-        VerifyAllMocks(permalinkService);
+        MockUtils.VerifyAllMocks(permalinkService);
 
-        response.AssertOk(expectedResult);
+        response.AssertCreated(expectedResult, $"http://localhost/api/permalink-snapshot/{expectedResult.Id}");
     }
 
     [Fact]
@@ -92,7 +97,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
             Id = permalinkId
         };
 
-        var permalinkService = new Mock<IPermalinkService>(Strict);
+        var permalinkService = new Mock<IPermalinkService>(MockBehavior.Strict);
 
         permalinkService
             .Setup(s => s.GetPermalink(permalinkId, It.IsAny<CancellationToken>()))
@@ -109,7 +114,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
             }
         );
 
-        VerifyAllMocks(permalinkService);
+        MockUtils.VerifyAllMocks(permalinkService);
 
         response.AssertOk(permalink);
     }
@@ -119,7 +124,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
     {
         var permalinkId = Guid.NewGuid();
 
-        var permalinkService = new Mock<IPermalinkService>(Strict);
+        var permalinkService = new Mock<IPermalinkService>(MockBehavior.Strict);
 
         permalinkService
             .Setup(s => s.GetPermalink(permalinkId, It.IsAny<CancellationToken>()))
@@ -136,7 +141,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
             }
         );
 
-        VerifyAllMocks(permalinkService);
+        MockUtils.VerifyAllMocks(permalinkService);
 
         response.AssertNotFound();
     }
@@ -145,7 +150,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
     public async Task GetPermalink_Csv()
     {
         var permalinkId = Guid.NewGuid();
-        var permalinkService = new Mock<IPermalinkService>(Strict);
+        var permalinkService = new Mock<IPermalinkService>(MockBehavior.Strict);
 
         permalinkService
             .Setup(s => s
@@ -166,7 +171,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
             }
         );
 
-        VerifyAllMocks(permalinkService);
+        MockUtils.VerifyAllMocks(permalinkService);
 
         response.AssertOk("Test csv");
     }
@@ -176,7 +181,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
     {
         var permalinkId = Guid.NewGuid();
 
-        var permalinkService = new Mock<IPermalinkService>(Strict);
+        var permalinkService = new Mock<IPermalinkService>(MockBehavior.Strict);
 
         permalinkService
             .Setup(s => s
@@ -194,7 +199,7 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
             }
         );
 
-        VerifyAllMocks(permalinkService);
+        MockUtils.VerifyAllMocks(permalinkService);
 
         response.AssertNotFound();
     }
@@ -212,7 +217,10 @@ public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<Tes
     private WebApplicationFactory<TestStartup> SetupApp(IPermalinkService? permalinkService = null)
     {
         return _testApp.ConfigureServices(
-            services => { services.AddTransient(_ => permalinkService ?? Mock.Of<IPermalinkService>(Strict)); }
+            services =>
+            {
+                services.AddTransient(_ => permalinkService ?? Mock.Of<IPermalinkService>(MockBehavior.Strict));
+            }
         );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PermalinkController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PermalinkController.cs
@@ -59,18 +59,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
         }
 
         [HttpPost("permalink-snapshot")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<PermalinkViewModel>> CreatePermalink(
             [FromBody] PermalinkCreateRequest request,
             CancellationToken cancellationToken = default)
         {
             return await _permalinkService
                 .CreatePermalink(request, cancellationToken)
-                .HandleFailuresOrOk();
+                .HandleFailuresOr(permalink => CreatedAtAction(nameof(GetPermalink), new
+                {
+                    permalinkId = permalink.Id
+                }, permalink));
         }
 
         [HttpPost("permalink-snapshot/release/{releaseId:guid}")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<PermalinkViewModel>> CreatePermalink(
             Guid releaseId,
             [FromBody] PermalinkCreateRequest request,
@@ -78,7 +83,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
         {
             return await _permalinkService
                 .CreatePermalink(releaseId, request, cancellationToken)
-                .HandleFailuresOrOk();
+                .HandleFailuresOr(permalink => CreatedAtAction(nameof(GetPermalink), new
+                {
+                    permalinkId = permalink.Id
+                }, permalink));
         }
     }
 }

--- a/src/explore-education-statistics-common/src/services/permalinkSnapshotService.ts
+++ b/src/explore-education-statistics-common/src/services/permalinkSnapshotService.ts
@@ -1,6 +1,6 @@
 import { TableJson } from '@common/modules/table-tool/utils/mapTableToJson';
 import { dataApi } from '@common/services/api';
-import { TableDataQuery } from '@common/services/tableBuilderService';
+import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
 import { Footnote } from '@common/services/types/footnotes';
 
 export type TableHeader =
@@ -40,15 +40,25 @@ export interface PermalinkSnapshot {
 }
 
 interface CreatePermalink {
-  query: TableDataQuery;
+  query: ReleaseTableDataQuery;
   configuration: {
     tableHeaders: UnmappedTableHeadersConfig;
   };
 }
 
 const permalinkSnapshotService = {
-  createPermalink(query: CreatePermalink): Promise<PermalinkSnapshot> {
-    return dataApi.post(`/permalink-snapshot`, query);
+  createPermalink(permalink: CreatePermalink): Promise<PermalinkSnapshot> {
+    const {
+      query: { releaseId, ...query },
+      configuration,
+    } = permalink;
+    const data = {
+      query,
+      configuration,
+    };
+    return releaseId
+      ? dataApi.post(`/permalink-snapshot/release/${releaseId}`, data)
+      : dataApi.post(`/permalink-snapshot`, data);
   },
   async getPermalink(id: string): Promise<PermalinkSnapshot> {
     return dataApi.get(`/permalink-snapshot/${id}`, {

--- a/src/explore-education-statistics-common/src/services/permalinkSnapshotService.ts
+++ b/src/explore-education-statistics-common/src/services/permalinkSnapshotService.ts
@@ -48,17 +48,10 @@ interface CreatePermalink {
 
 const permalinkSnapshotService = {
   createPermalink(permalink: CreatePermalink): Promise<PermalinkSnapshot> {
-    const {
-      query: { releaseId, ...query },
-      configuration,
-    } = permalink;
-    const data = {
-      query,
-      configuration,
-    };
+    const { releaseId } = permalink.query;
     return releaseId
-      ? dataApi.post(`/permalink-snapshot/release/${releaseId}`, data)
-      : dataApi.post(`/permalink-snapshot`, data);
+      ? dataApi.post(`/permalink-snapshot/release/${releaseId}`, permalink)
+      : dataApi.post(`/permalink-snapshot`, permalink);
   },
   async getPermalink(id: string): Promise<PermalinkSnapshot> {
     return dataApi.get(`/permalink-snapshot/${id}`, {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
@@ -12,13 +12,13 @@ import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeader
 import publicationService from '@common/services/publicationService';
 import Link from '@frontend/components/Link';
 import tableBuilderService, {
-  TableDataQuery,
+  ReleaseTableDataQuery,
 } from '@common/services/tableBuilderService';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
 import React, { memo, ReactNode, useRef } from 'react';
 
 interface TableToolFinalStepProps {
-  query: TableDataQuery;
+  query: ReleaseTableDataQuery;
   table: FullTable;
   tableHeaders: TableHeadersConfig;
   selectedPublication: SelectedPublication;

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
@@ -7,7 +7,7 @@ import UrlContainer from '@common/components/UrlContainer';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
 import permalinkSnapshotService from '@common/services/permalinkSnapshotService';
-import { TableDataQuery } from '@common/services/tableBuilderService';
+import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
 import ButtonLink from '@frontend/components/ButtonLink';
 import React, { useEffect, useState } from 'react';
 
@@ -16,7 +16,7 @@ const linkInstructions =
 
 interface Props {
   tableHeaders?: TableHeadersConfig;
-  query: TableDataQuery;
+  query: ReleaseTableDataQuery;
 }
 
 const TableToolShare = ({ tableHeaders, query }: Props) => {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
@@ -4,8 +4,11 @@ import ButtonGroup from '@common/components/ButtonGroup';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import ScreenReaderMessage from '@common/components/ScreenReaderMessage';
 import UrlContainer from '@common/components/UrlContainer';
+import useToggle from '@common/hooks/useToggle';
+import ErrorMessage from '@common/components/ErrorMessage';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
+import logger from '@common/services/logger';
 import permalinkSnapshotService from '@common/services/permalinkSnapshotService';
 import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
 import ButtonLink from '@frontend/components/ButtonLink';
@@ -23,6 +26,7 @@ const TableToolShare = ({ tableHeaders, query }: Props) => {
   const [permalinkUrl, setPermalinkUrl] = useState('');
   const [permalinkLoading, setPermalinkLoading] = useState<boolean>(false);
   const [screenReaderMessage, setScreenReaderMessage] = useState('');
+  const [permalinkError, togglePermalinkError] = useToggle(false);
 
   useEffect(() => {
     setPermalinkUrl('');
@@ -34,17 +38,26 @@ const TableToolShare = ({ tableHeaders, query }: Props) => {
     }
     setPermalinkLoading(true);
 
-    const { id } = await permalinkSnapshotService.createPermalink({
-      query,
-      configuration: {
-        tableHeaders: mapUnmappedTableHeaders(tableHeaders),
-      },
-    });
+    try {
+      const { id } = await permalinkSnapshotService.createPermalink({
+        query,
+        configuration: {
+          tableHeaders: mapUnmappedTableHeaders(tableHeaders),
+        },
+      });
 
-    setPermalinkUrl(`${process.env.PUBLIC_URL}data-tables/permalink/${id}`);
-    setPermalinkLoading(false);
+      setPermalinkUrl(`${process.env.PUBLIC_URL}data-tables/permalink/${id}`);
+      setPermalinkLoading(false);
 
-    setScreenReaderMessage(`Shareable link generated. ${linkInstructions}`);
+      setScreenReaderMessage(`Shareable link generated. ${linkInstructions}`);
+    } catch (err) {
+      logger.error(err);
+      togglePermalinkError();
+      setScreenReaderMessage(
+        `Error: There was a problem generating the share link.`,
+      );
+      setPermalinkLoading(false);
+    }
   };
 
   const handleCopyClick = () => {
@@ -64,9 +77,15 @@ const TableToolShare = ({ tableHeaders, query }: Props) => {
             size="sm"
             text="Generating shareable link"
           >
-            <ButtonText onClick={handlePermalinkClick}>
-              Generate shareable link
-            </ButtonText>
+            {permalinkError ? (
+              <ErrorMessage>
+                There was a problem generating the share link.
+              </ErrorMessage>
+            ) : (
+              <ButtonText onClick={handlePermalinkClick}>
+                Generate shareable link
+              </ButtonText>
+            )}
           </LoadingSpinner>
         </>
       ) : (

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
@@ -1,4 +1,5 @@
 import TableToolShare from '@frontend/modules/table-tool/components/TableToolShare';
+import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
 import {
   testTableHeaders,
   testQuery,
@@ -9,6 +10,7 @@ import _permalinkSnapshotService, {
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
 
 jest.mock('@common/services/permalinkSnapshotService');
 
@@ -16,10 +18,15 @@ const permalinkSnapshotService = _permalinkSnapshotService as jest.Mocked<
   typeof _permalinkSnapshotService
 >;
 
+const tableQuery: ReleaseTableDataQuery = {
+  releaseId: 'release-1',
+  ...testQuery,
+};
+
 describe('TableToolShare', () => {
   test('renders the generate button', () => {
     render(
-      <TableToolShare query={testQuery} tableHeaders={testTableHeaders} />,
+      <TableToolShare query={tableQuery} tableHeaders={testTableHeaders} />,
     );
 
     expect(screen.getByText('Save table')).toBeInTheDocument();
@@ -33,7 +40,7 @@ describe('TableToolShare', () => {
       id: 'permalink-id',
     } as PermalinkSnapshot);
     render(
-      <TableToolShare query={testQuery} tableHeaders={testTableHeaders} />,
+      <TableToolShare query={tableQuery} tableHeaders={testTableHeaders} />,
     );
 
     userEvent.click(
@@ -41,6 +48,17 @@ describe('TableToolShare', () => {
         name: 'Generate shareable link',
       }),
     );
+
+    await waitFor(() => {
+      expect(permalinkSnapshotService.createPermalink).toHaveBeenCalledWith<
+        Parameters<typeof permalinkSnapshotService.createPermalink>
+      >({
+        query: tableQuery,
+        configuration: {
+          tableHeaders: mapUnmappedTableHeaders(testTableHeaders),
+        },
+      });
+    });
 
     await waitFor(() => {
       expect(screen.getByText('Generated share link')).toBeInTheDocument();
@@ -77,7 +95,7 @@ describe('TableToolShare', () => {
     } as PermalinkSnapshot);
 
     render(
-      <TableToolShare query={testQuery} tableHeaders={testTableHeaders} />,
+      <TableToolShare query={tableQuery} tableHeaders={testTableHeaders} />,
     );
 
     userEvent.click(


### PR DESCRIPTION
This PR makes a frontend change to use releaseId in call to create permalink if it's available which will be the case if navigating to the table tool from a release page.

This fixes a bug where a user can be viewing a table for a data set which is not part of the latest published release (in the time series) and without including the release id, no `ReleaseSubject` is found for the subject id of the query and the latest published release.

It also makes an improvement to the error handling so that the user is aware if an error has occurred when clicking 'Generate shareable link'.

### Other changes

- Change the backend to return 201 Created responses instead of 200 OK using `CreatedAtAction`.