### PR TITLE
EES-4512 allow links in footnotes

### DIFF
--- a/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
@@ -7,6 +7,8 @@ import {
   Editor as EditorType,
   Element,
   GlossaryPlugin,
+  PluginName,
+  ToolbarOption,
 } from '@admin/types/ckeditor';
 import { defaultAllowedHeadings } from '@admin/config/ckEditorConfig';
 import useCKEditorConfig from '@admin/hooks/useCKEditorConfig';
@@ -43,9 +45,10 @@ export interface FormEditorProps {
   hideLabel?: boolean;
   hint?: string;
   id: string;
+  includePlugins?: ReadonlySet<PluginName> | Set<PluginName>;
   label: string;
   testId?: string;
-  toolbarConfig?: string[];
+  toolbarConfig?: ReadonlyArray<ToolbarOption> | Array<ToolbarOption>;
   value: string;
   onAutoSave?: (values: string) => void;
   onBlur?: () => void;
@@ -66,6 +69,7 @@ const FormEditor = ({
   hideLabel,
   hint,
   id,
+  includePlugins,
   label,
   testId,
   toolbarConfig,
@@ -91,6 +95,7 @@ const FormEditor = ({
     allowComments,
     allowedHeadings,
     editorInstance,
+    includePlugins,
     toolbarConfig,
     onAutoSave,
     onCancelComment,
@@ -208,8 +213,14 @@ const FormEditor = ({
       );
 
       editorInstance.current = editor;
-      commentsPlugin.current = editor.plugins.get<CommentsPlugin>('Comments');
-      glossaryPlugin.current = editor.plugins.get<GlossaryPlugin>('Glossary');
+
+      if (editor.plugins.has<CommentsPlugin>('Comments')) {
+        commentsPlugin.current = editor.plugins.get<CommentsPlugin>('Comments');
+      }
+
+      if (editor.plugins.has<GlossaryPlugin>('Glossary')) {
+        glossaryPlugin.current = editor.plugins.get<GlossaryPlugin>('Glossary');
+      }
 
       setMarkersOrder(getMarkersOrder([...editor.model.markers]));
     },

--- a/src/explore-education-statistics-admin/src/config/ckEditorConfig.ts
+++ b/src/explore-education-statistics-admin/src/config/ckEditorConfig.ts
@@ -1,45 +1,57 @@
 import {
   AlignmentConfig,
   HeadingOption,
+  PluginName,
   ResizeOption,
+  ToolbarOption,
 } from '@admin/types/ckeditor';
-import { Dictionary } from '@admin/types';
 
-export const toolbarConfigs: Dictionary<string[]> = {
-  full: [
-    'heading',
-    '|',
-    'bold',
-    'italic',
-    'link',
-    '|',
-    'bulletedList',
-    'numberedList',
-    '|',
-    'blockQuote',
-    'insertTable',
-    'toggleTableCaption',
-    'imageUpload',
-    'alignment',
-    '|',
-    'redo',
-    'undo',
-    '|',
-    'comment',
-    'glossary',
-  ],
-  simple: [
-    'bold',
-    'italic',
-    'link',
-    '|',
-    'bulletedList',
-    'numberedList',
-    '|',
-    'redo',
-    'undo',
-  ],
-};
+export const toolbarConfigFull: ReadonlyArray<ToolbarOption> = [
+  'heading',
+  '|',
+  'bold',
+  'italic',
+  'link',
+  '|',
+  'bulletedList',
+  'numberedList',
+  '|',
+  'blockQuote',
+  'insertTable',
+  'toggleTableCaption',
+  'imageUpload',
+  'alignment',
+  '|',
+  'redo',
+  'undo',
+  '|',
+  'comment',
+  'glossary',
+];
+export const toolbarConfigSimple: ReadonlyArray<ToolbarOption> = [
+  'bold',
+  'italic',
+  'link',
+  '|',
+  'bulletedList',
+  'numberedList',
+  '|',
+  'redo',
+  'undo',
+];
+export const toolbarConfigLinkOnly: ReadonlyArray<ToolbarOption> = ['link'];
+
+export const corePlugins: ReadonlySet<PluginName> = new Set<PluginName>([
+  'Essentials',
+  'Paragraph',
+]);
+
+export const pluginsConfigLinksOnly: ReadonlySet<PluginName> =
+  new Set<PluginName>(['Link']);
+
+export const pluginsConfigSimple: ReadonlySet<PluginName> = new Set<PluginName>(
+  ['Bold', 'Italic', 'Link', 'List'],
+);
 
 export const defaultAllowedHeadings: string[] = ['h3', 'h4', 'h5'];
 

--- a/src/explore-education-statistics-admin/src/hooks/useCKEditorConfig.ts
+++ b/src/explore-education-statistics-admin/src/hooks/useCKEditorConfig.ts
@@ -1,12 +1,19 @@
 import {
   alignmentOptions,
+  corePlugins,
   headingOptions,
   imageToolbar,
   resizeOptions,
   tableContentToolbar,
-  toolbarConfigs,
+  toolbarConfigFull,
 } from '@admin/config/ckEditorConfig';
-import { Editor, EditorConfig } from '@admin/types/ckeditor';
+import {
+  Editor as EditorType,
+  EditorConfig,
+  PluginName,
+  ToolbarOption,
+} from '@admin/types/ckeditor';
+import Editor from 'explore-education-statistics-ckeditor';
 import { useCommentsContext } from '@admin/contexts/CommentsContext';
 import {
   ImageUploadCancelHandler,
@@ -19,7 +26,8 @@ const useCKEditorConfig = ({
   allowComments,
   allowedHeadings,
   editorInstance,
-  toolbarConfig = toolbarConfigs.full,
+  includePlugins,
+  toolbarConfig = toolbarConfigFull,
   onAutoSave,
   onCancelComment,
   onClickAddComment,
@@ -29,13 +37,14 @@ const useCKEditorConfig = ({
 }: {
   allowComments?: boolean;
   allowedHeadings?: string[];
-  editorInstance?: MutableRefObject<Editor | undefined>;
+  editorInstance?: MutableRefObject<EditorType | undefined>;
   glossaryItems?: {
     title: string;
     slug: string;
     body: string;
   }[];
-  toolbarConfig?: string[];
+  includePlugins?: ReadonlySet<PluginName> | Set<PluginName>;
+  toolbarConfig?: ReadonlyArray<ToolbarOption> | Array<ToolbarOption>;
   onAutoSave?: (content: string) => void;
   onCancelComment?: () => void;
   onClickAddComment?: () => void;
@@ -93,6 +102,13 @@ const useCKEditorConfig = ({
               types: ['jpeg', 'png', 'gif', 'bmp', 'tiff', 'svg+xml'],
             },
           }
+        : undefined,
+      removePlugins: includePlugins
+        ? Editor.builtinPlugins?.filter(
+            plugin =>
+              !corePlugins.has(plugin.pluginName) &&
+              !includePlugins.has(plugin.pluginName),
+          )
         : undefined,
       table: {
         contentToolbar: tableContentToolbar,
@@ -196,6 +212,7 @@ const useCKEditorConfig = ({
     allowedHeadings,
     editorInstance,
     hasImageUpload,
+    includePlugins,
     onAutoSave,
     onCancelComment,
     onClickAddComment,

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
@@ -1,5 +1,5 @@
 import FormFieldEditor from '@admin/components/form/FormFieldEditor';
-import { toolbarConfigs } from '@admin/config/ckEditorConfig';
+import { toolbarConfigSimple } from '@admin/config/ckEditorConfig';
 import toHtml from '@admin/utils/markdown/toHtml';
 import toMarkdown from '@admin/utils/markdown/toMarkdown';
 import Button from '@common/components/Button';
@@ -85,7 +85,7 @@ const EditableKeyStatDataBlockForm = ({
 
           <FormFieldEditor<KeyStatDataBlockFormValues>
             name="guidanceText"
-            toolbarConfig={toolbarConfigs.simple}
+            toolbarConfig={toolbarConfigSimple}
             label="Guidance text"
           />
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
@@ -1,5 +1,8 @@
 import FormFieldEditor from '@admin/components/form/FormFieldEditor';
-import { toolbarConfigs } from '@admin/config/ckEditorConfig';
+import {
+  pluginsConfigSimple,
+  toolbarConfigSimple,
+} from '@admin/config/ckEditorConfig';
 import toHtml from '@admin/utils/markdown/toHtml';
 import toMarkdown from '@admin/utils/markdown/toMarkdown';
 import Button from '@common/components/Button';
@@ -108,7 +111,8 @@ export default function EditableKeyStatTextForm({
 
             <FormFieldEditor<KeyStatTextFormValues>
               name="guidanceText"
-              toolbarConfig={toolbarConfigs.simple}
+              includePlugins={pluginsConfigSimple}
+              toolbarConfig={toolbarConfigSimple}
               label="Guidance text"
             />
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacementCompletePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacementCompletePage.tsx
@@ -11,6 +11,7 @@ import dataReplacementService from '@admin/services/dataReplacementService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import sanitizeHtml from '@common/utils/sanitizeHtml';
 import React from 'react';
 import { generatePath, RouteComponentProps } from 'react-router';
 
@@ -102,7 +103,7 @@ const ReleaseDataFileReplacementCompletePage = ({
                           },
                         )}
                       >
-                        {footnote.content}
+                        {sanitizeHtml(footnote.content, { allowedTags: [] })}
                       </Link>
                     </li>
                   ))}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
@@ -29,6 +29,7 @@ import useToggle from '@common/hooks/useToggle';
 import useMountedRef from '@common/hooks/useMountedRef';
 import React, { useMemo, useState } from 'react';
 import { generatePath } from 'react-router';
+import sanitizeHtml from '@common/utils/sanitizeHtml';
 
 interface Props {
   publicationId: string;
@@ -280,7 +281,7 @@ const DataFileReplacementPlan = ({
             return (
               <Details
                 key={footnote.id}
-                summary={footnote.content}
+                summary={sanitizeHtml(footnote.content, { allowedTags: [] })}
                 summaryAfter={
                   <Tag
                     className="govuk-!-margin-left-2"

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
@@ -1,4 +1,7 @@
-import { toolbarConfigs } from '@admin/config/ckEditorConfig';
+import {
+  pluginsConfigSimple,
+  toolbarConfigSimple,
+} from '@admin/config/ckEditorConfig';
 import FormFieldEditor from '@admin/components/form/FormFieldEditor';
 import releaseDataGuidanceService from '@admin/services/releaseDataGuidanceService';
 import Accordion from '@common/components/Accordion';
@@ -182,7 +185,8 @@ const ReleaseDataGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
                                   renderContent={() =>
                                     isEditing ? (
                                       <FormFieldEditor<DataGuidanceFormValues>
-                                        toolbarConfig={toolbarConfigs.simple}
+                                        includePlugins={pluginsConfigSimple}
+                                        toolbarConfig={toolbarConfigSimple}
                                         name={`subjects[${index}].content`}
                                         label="File guidance content"
                                         testId="fileGuidanceContent"

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnoteForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnoteForm.tsx
@@ -7,10 +7,15 @@ import {
   SubjectSelectionType,
 } from '@admin/services/footnoteService';
 import footnoteToFlatFootnote from '@admin/services/utils/footnote/footnoteToFlatFootnote';
+import {
+  pluginsConfigLinksOnly,
+  toolbarConfigLinkOnly,
+} from '@admin/config/ckEditorConfig';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import { Form, FormFieldRadioGroup } from '@common/components/form';
-import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
+import sanitizeHtml from '@common/utils/sanitizeHtml';
+import FormFieldEditor from '@admin/components/form/FormFieldEditor';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
 import deepmerge from 'deepmerge';
@@ -106,8 +111,12 @@ const FootnoteForm = ({
             'At least one Subject, Indicator or Filter must be selected',
           );
         }
+        const sanitizedValues = {
+          ...values,
+          content: sanitizeHtml(values.content, { allowedTags: ['a'] }),
+        };
 
-        await onSubmit(values);
+        await onSubmit(sanitizedValues);
       }}
     >
       {form => (
@@ -124,7 +133,12 @@ const FootnoteForm = ({
             to.
           </p>
 
-          <FormFieldTextArea<BaseFootnote> name="content" label="Footnote" />
+          <FormFieldEditor<BaseFootnote>
+            name="content"
+            label="Footnote"
+            includePlugins={pluginsConfigLinksOnly}
+            toolbarConfig={toolbarConfigLinkOnly}
+          />
 
           {orderBy(
             Object.values(footnoteMeta.subjects),

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnotesList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnotesList.tsx
@@ -19,6 +19,7 @@ import classNames from 'classnames';
 import React, { useMemo, useState } from 'react';
 import { generatePath } from 'react-router';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+import ContentHtml from '@common/components/ContentHtml';
 
 interface Props {
   publicationId: string;
@@ -87,7 +88,10 @@ const FootnotesList = ({
                     testId={`Footnote - ${content}`}
                   >
                     <div className={styles.row}>
-                      <div className={styles.rowContent}>{content}</div>
+                      <ContentHtml
+                        className={styles.rowContent}
+                        html={content}
+                      />
 
                       {!isReordering && canUpdateRelease && (
                         <ButtonGroup className={styles.rowActions}>

--- a/src/explore-education-statistics-admin/src/types/ckeditor-ambient.d.ts
+++ b/src/explore-education-statistics-admin/src/types/ckeditor-ambient.d.ts
@@ -7,10 +7,15 @@
 // we can actually import) should go here.
 
 declare module 'explore-education-statistics-ckeditor' {
-  import { EditorClass, EditorConfig } from '@admin/types/ckeditor';
+  import {
+    EditorClass,
+    EditorConfig,
+    PluginClass,
+  } from '@admin/types/ckeditor';
 
   // https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-classic_classiceditor-ClassicEditor.html
   interface CustomEditor extends EditorClass {
+    builtinPlugins?: PluginClass[];
     new (
       element: string | HTMLElement,
       config: EditorConfig,

--- a/src/explore-education-statistics-admin/src/types/ckeditor.ts
+++ b/src/explore-education-statistics-admin/src/types/ckeditor.ts
@@ -76,6 +76,11 @@ export interface EditorConfig {
 
 export interface PluginCollection {
   get<T extends Plugin>(key: string): T;
+  has<T extends Plugin>(key: string): T;
+}
+
+export interface PluginClass {
+  get pluginName(): PluginName;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -224,3 +229,50 @@ export interface RootElement extends Element {
   getChild(index: number): Element;
   getChildren(): Iterable<Element>;
 }
+
+export type PluginName =
+  | 'Alignment'
+  | 'Autoformat'
+  | 'Autosave'
+  | 'BlockQuote'
+  | 'Bold'
+  | 'Comments'
+  | 'CustomUploadAdapter'
+  | 'Essentials'
+  | 'Glossary'
+  | 'Heading'
+  | 'Image'
+  | 'ImageCaption'
+  | 'ImageResize'
+  | 'ImageStyle'
+  | 'ImageToolbar'
+  | 'ImageUpload'
+  | 'Indent'
+  | 'Italic'
+  | 'Link'
+  | 'List'
+  | 'MediaEmbed'
+  | 'Paragraph'
+  | 'PasteFromOffice'
+  | 'Table'
+  | 'TableToolbar'
+  | 'TableCaption'
+  | 'TextTransformation';
+
+export type ToolbarOption =
+  | '|'
+  | 'alignment'
+  | 'blockQuote'
+  | 'bold'
+  | 'bulletedList'
+  | 'comment'
+  | 'glossary'
+  | 'heading'
+  | 'imageUpload'
+  | 'insertTable'
+  | 'italic'
+  | 'link'
+  | 'numberedList'
+  | 'redo'
+  | 'toggleTableCaption'
+  | 'undo';

--- a/src/explore-education-statistics-admin/src/utils/ckeditor/customUploadAdapterPlugin.ts
+++ b/src/explore-education-statistics-admin/src/utils/ckeditor/customUploadAdapterPlugin.ts
@@ -1,4 +1,4 @@
-import { Editor } from '@admin/types/ckeditor';
+import { Editor, PluginName, PluginClass } from '@admin/types/ckeditor';
 import CustomUploadAdapter, {
   ImageUploadCancelHandler,
   ImageUploadHandler,
@@ -9,7 +9,11 @@ export default function customUploadAdapterPlugin(
   onUpload: ImageUploadHandler,
   onCancel?: ImageUploadCancelHandler,
 ) {
-  return class CustomUploadAdapterPlugin {
+  return class CustomUploadAdapterPlugin implements PluginClass {
+    get pluginName(): PluginName {
+      return 'CustomUploadAdapter';
+    }
+
     constructor(editor: Editor) {
       const fileRepository =
         editor.plugins.get<FileRepository>('FileRepository');

--- a/src/explore-education-statistics-common/src/components/FigureFootnotes.tsx
+++ b/src/explore-education-statistics-common/src/components/FigureFootnotes.tsx
@@ -1,7 +1,8 @@
 import CollapsibleList from '@common/components/CollapsibleList';
+import ContentHtml from '@common/components/ContentHtml';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 import { Footnote } from '@common/services/types/footnotes';
 import React from 'react';
-import VisuallyHidden from './VisuallyHidden';
 
 interface Props {
   footnotes: Footnote[];
@@ -27,7 +28,9 @@ const FigureFootnotes = ({ footnotes, headingHiddenText, id }: Props) => {
         testId="footnotes"
       >
         {footnotes.map(footnote => (
-          <li key={footnote.id}>{footnote.label}</li>
+          <li key={footnote.id}>
+            <ContentHtml html={footnote.label} />
+          </li>
         ))}
       </CollapsibleList>
     </>

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataGuidanceDataFile.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataGuidanceDataFile.tsx
@@ -97,7 +97,9 @@ const ReleaseDataGuidanceDataFile = ({ subject, renderContent }: Props) => {
         <Details summary="Footnotes">
           <ol data-testid="Footnotes">
             {footnotes.map(footnote => (
-              <li key={footnote.id}>{footnote.label}</li>
+              <li key={footnote.id}>
+                <ContentHtml html={footnote.label} />
+              </li>
             ))}
           </ol>
         </Details>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/downloadTableOdsFile.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/downloadTableOdsFile.test.ts
@@ -133,5 +133,28 @@ describe('downloadTableOdsFile', () => {
         v: '(3) Test footnote 3',
       });
     });
+
+    test('formats footnote with link', () => {
+      const sheet = utils.aoa_to_sheet([
+        ['test', 'test', 'test'],
+        ['test', 'test', 'test'],
+        ['test', 'test', 'test'],
+      ]);
+
+      expect(sheet['!ref']).toBe('A1:C3');
+
+      appendFootnotes(sheet, [
+        {
+          id: '1',
+          label: 'Test footnote 1. <a href="http://gov.uk">Test link</a>',
+        },
+      ]);
+
+      expect(sheet['!ref']).toBe('A1:C5');
+      expect(sheet.A5).toEqual({
+        t: 's',
+        v: '(1) Test footnote 1. Test link (http://gov.uk)',
+      });
+    });
   });
 });

--- a/src/explore-education-statistics-common/src/utils/sanitizeHtml.ts
+++ b/src/explore-education-statistics-common/src/utils/sanitizeHtml.ts
@@ -12,8 +12,9 @@ export type SanitizeHtmlOptions = {
   allowedSchemesByTag?: Dictionary<string[]>;
   allowedStyles?: Dictionary<Dictionary<RegExp[]>>;
   filterTags?: Dictionary<TagFilter>;
-  transformTags?: Dictionary<string | sanitize.Transformer>;
   parseStyleAttributes?: boolean;
+  transformTags?: Dictionary<string | sanitize.Transformer>;
+  textFilter?: (text: string, tagName: string) => string;
 };
 
 export const defaultSanitizeOptions: SanitizeHtmlOptions = {

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -297,7 +297,7 @@ Update footnote
     user waits until h2 is visible    Footnotes
     user clicks link    Edit footnote    testid:Footnote - ${FOOTNOTE_1}
     user waits until h2 is visible    Edit footnote
-    user enters text into element    label:Footnote    ${FOOTNOTE_UPDATED}
+    user enters text into element    id:footnoteForm-content    ${FOOTNOTE_UPDATED}
     user clicks button    Save footnote
     user waits until page contains    ${FOOTNOTE_UPDATED}
     user checks page does not contain    ${FOOTNOTE_1}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -86,7 +86,7 @@ Create footnote for both subjects
 
     user clicks footnote subject radio    ${SUBJECT_1_NAME}    Applies to all data
     user clicks footnote subject radio    ${SUBJECT_2_NAME}    Applies to all data
-    user enters text into element    label:Footnote    ${FOOTNOTE_ALL}
+    user enters text into element    id:footnoteForm-content    ${FOOTNOTE_ALL}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -103,7 +103,7 @@ Create footnote for both subject indicators
     user opens footnote subject dropdown    ${SUBJECT_2_NAME}    Indicators
     user clicks footnote subject checkbox    ${SUBJECT_2_NAME}    Indicators    Admission Numbers
 
-    user enters text into element    label:Footnote    ${FOOTNOTE_ALL_INDICATOR}
+    user enters text into element    id:footnoteForm-content    ${FOOTNOTE_ALL_INDICATOR}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -119,7 +119,7 @@ Create footnote for both subject filters
     user opens footnote subject dropdown    ${SUBJECT_2_NAME}    Random Filter
     user clicks footnote subject checkbox    ${SUBJECT_2_NAME}    Random Filter    Select all
 
-    user enters text into element    label:Footnote    ${FOOTNOTE_ALL_FILTER}
+    user enters text into element    id:footnoteForm-content    ${FOOTNOTE_ALL_FILTER}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -129,7 +129,7 @@ Create footnote for subject 1
 
     user clicks footnote subject radio    ${SUBJECT_1_NAME}    Applies to all data
 
-    user enters text into element    label:Footnote    ${FOOTNOTE_SUBJECT_1}
+    user enters text into element    id:footnoteForm-content    ${FOOTNOTE_SUBJECT_1}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -142,7 +142,7 @@ Create footnote for subject 1 indicators
     user clicks footnote subject checkbox    ${SUBJECT_1_NAME}    Indicators    Authorised absence rate
     user clicks footnote subject checkbox    ${SUBJECT_1_NAME}    Indicators    Number of persistent absentees
 
-    user enters text into element    label:Footnote    ${FOOTNOTE_SUBJECT_1_INDICATOR}
+    user enters text into element    id:footnoteForm-content    ${FOOTNOTE_SUBJECT_1_INDICATOR}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -158,7 +158,7 @@ Create footnote for subject 1 filters
     user opens footnote subject dropdown    ${SUBJECT_1_NAME}    Colour
     user clicks footnote subject checkbox    ${SUBJECT_1_NAME}    Colour    Select all
 
-    user enters text into element    label:Footnote    ${FOOTNOTE_SUBJECT_1_FILTER}
+    user enters text into element    id:footnoteForm-content    ${FOOTNOTE_SUBJECT_1_FILTER}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -172,7 +172,7 @@ Create footnote for subject 1 filter groups
     user clicks footnote subject checkbox    ${SUBJECT_1_NAME}    School type    Combined
     user clicks footnote subject checkbox    ${SUBJECT_1_NAME}    School type    Individual
 
-    user enters text into element    label:Footnote    ${FOOTNOTE_SUBJECT_1_FILTER_GROUP}
+    user enters text into element    id:footnoteForm-content    ${FOOTNOTE_SUBJECT_1_FILTER_GROUP}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -191,7 +191,7 @@ Create footnote for subject 1 filter items
     user clicks footnote subject checkbox    ${SUBJECT_1_NAME}    Colour    Blue
     user clicks footnote subject checkbox    ${SUBJECT_1_NAME}    Colour    Orange
 
-    user enters text into element    label:Footnote    ${FOOTNOTE_SUBJECT_1_FILTER_ITEM}
+    user enters text into element    id:footnoteForm-content    ${FOOTNOTE_SUBJECT_1_FILTER_ITEM}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -215,7 +215,7 @@ Create footnote for subject 1 with mixture of indicators and filters
     user clicks footnote subject checkbox    ${SUBJECT_1_NAME}    Colour    Blue
     user clicks footnote subject checkbox    ${SUBJECT_1_NAME}    Colour    Orange
 
-    user enters text into element    label:Footnote    ${FOOTNOTE_SUBJECT_1_MIXTURE}
+    user enters text into element    id:footnoteForm-content    ${FOOTNOTE_SUBJECT_1_MIXTURE}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -445,7 +445,7 @@ Edit footnote
     user clicks link    Edit footnote    testid:Footnote - ${FOOTNOTE_ALL_INDICATOR}
 
     user waits until h2 is visible    Edit footnote
-    user enters text into element    label:Footnote    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
+    user enters text into element    id:footnoteForm-content    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
     user clicks button    Save footnote
     user waits until page contains    ${FOOTNOTE_ALL_INDICATOR_UPDATED}
     user checks page does not contain    ${FOOTNOTE_ALL_INDICATOR}

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
@@ -62,7 +62,7 @@ Add footnote to second Subject
     user clicks link    Create footnote
     user waits until h2 is visible    Create footnote
     user clicks footnote subject radio    ${SECOND_SUBJECT}    Applies to all data
-    user enters text into element    label:Footnote    Footnote 1 ${SECOND_SUBJECT}
+    user enters text into element    id:footnoteForm-content    Footnote 1 ${SECOND_SUBJECT}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -73,7 +73,7 @@ Add second footnote to second Subject
     user clicks footnote subject radio    ${SECOND_SUBJECT}    Applies to specific data
     user opens footnote subject dropdown    ${SECOND_SUBJECT}    Indicators
     user clicks footnote subject checkbox    ${SECOND_SUBJECT}    Indicators    Admission Numbers
-    user enters text into element    label:Footnote    Footnote 2 ${SECOND_SUBJECT}
+    user enters text into element    id:footnoteForm-content    Footnote 2 ${SECOND_SUBJECT}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -82,7 +82,7 @@ Add footnote to subject
     user clicks link    Create footnote
     user waits until h2 is visible    Create footnote
     user clicks footnote subject radio    ${SUBJECT_NAME}    Applies to all data
-    user enters text into element    label:Footnote    Footnote 1 ${SUBJECT_NAME}
+    user enters text into element    id:footnoteForm-content    Footnote 1 ${SUBJECT_NAME}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -94,7 +94,7 @@ Add second footnote to subject
     user opens footnote subject dropdown    ${SUBJECT_NAME}    Cheese
     user clicks footnote subject checkbox    ${SUBJECT_NAME}    Cheese    Stilton
     user clicks footnote subject checkbox    ${SUBJECT_NAME}    Cheese    Feta
-    user enters text into element    label:Footnote    Footnote 2 ${SUBJECT_NAME}
+    user enters text into element    id:footnoteForm-content    Footnote 2 ${SUBJECT_NAME}
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes
 
@@ -410,16 +410,16 @@ Add footnote to "upload file test filter" subject file
     user clicks link    Create footnote
     user waits until h2 is visible    Create footnote
     user clicks footnote subject radio    ${THIRD_SUBJECT}    Applies to all data
-    user clicks element    label:Footnote
-    user enters text into element    label:Footnote    upload file test filter footnote
+    user clicks element    id:footnoteForm-content
+    user enters text into element    id:footnoteForm-content    upload file test filter footnote
     user clicks button    Save footnote
     user waits until page contains element    testid:Footnote - upload file test filter footnote
     user waits until h2 is visible    Footnotes
 
 Update Seven filters footnote
     user clicks link    Edit footnote    testid:Footnote - Footnote 1 ${SUBJECT_NAME}
-    user clicks element    label:Footnote
-    user enters text into element    label:Footnote    Updating ${SUBJECT_NAME} footnote
+    user clicks element    id:footnoteForm-content
+    user enters text into element    id:footnoteForm-content    Updating ${SUBJECT_NAME} footnote
     user clicks button    Save footnote
     user waits until page contains element    testid:Footnote - Updating ${SUBJECT_NAME} footnote
 


### PR DESCRIPTION
Adds the ability to put links in footnotes by changing it to use a very cut down CKEditor and making sure that any other attributes are stripped out.

![footnoteform](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/5cf2605a-4e27-4a22-ba95-34c58ef4b3d3)
