### PR TITLE
chore: Remove ignored Mime dependency from Renovate and tidy up config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "python": {
     "enabled": false
   },
+  "ignoreDeps": ["Mime-Detective"],
   "vulnerabilityAlerts": {
     "groupName": "renovate",
     "dependencyDashboardApproval": false,
@@ -59,14 +60,6 @@
     {
       "matchDatasources": ["dotnet-version"],
       "groupName": ".NET version",
-      "enabled": false
-    },
-    {
-      "packageNames": ["node"],
-      "enabled": false
-    },
-    {
-      "matchPackagePatterns": ["^@ckeditor/", "Mime", "Mime-Detective"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
This PR makes changes to the Renovate configuration.

- ~~It adds `ignoreDeps` configuration to ignore Moq.~~ We decided as a team to continue to receive Moq version updates.
- It removes the ignore on the Mime dependency which is not required after #4283.
- It switches ignored Mime-Detective to use `ignoreDeps` as a shorter way of ignoring dependencies than using `matchPackagePatterns` combined with `enabled`.
- It removes the ignore on ckeditor because all frontend dependencies are ignored.
- It removes the following config because that doesn't appear to be supported in the docs:

```
    {
      "packageNames": ["node"],
      "enabled": false
    },
```