### PR TITLE
EES-4530 Change Renovate config to ignore upgrading Automapper

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,18 @@
       ],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Restrict AutoMapper due to incompatibility with IdentityServer4.EntityFramework.Storage",
+      "matchDatasources": ["nuget"],
+      "matchPackageNames": ["AutoMapper"],
+      "allowedVersions": "<=9.0.0"
+    },
+    {
+      "description": "Restrict AutoMapper.Extensions.Microsoft.DependencyInjection to correspond with AutoMapper version",
+      "matchDatasources": ["nuget"],
+      "matchPackageNames": ["AutoMapper.Extensions.Microsoft.DependencyInjection"],
+      "allowedVersions": "<=7.0.0"
     }
   ]
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -40,7 +40,7 @@
   <ItemGroup>
     <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.21" PrivateAssets="all" />
-    <PackageReference Include="AutoMapper" Version="9.0.0" />
+    <!-- TODO remove AutoMapper.Extensions.Microsoft.DependencyInjection with AutoMapper v13 -->
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="GovukNotify" Version="6.1.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.52" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
@@ -9,8 +9,6 @@
 
     <ItemGroup>
         <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
-        <PackageReference Include="AutoMapper" Version="9.0.0" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
         <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
@@ -5,7 +5,6 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Runtime.Serialization;
-using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
@@ -109,7 +108,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Guid EmbedBlockId { get; set; }
 
-        [JsonIgnore, IgnoreMap]
+        [JsonIgnore]
         public EmbedBlock EmbedBlock { get; set; }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GovUk.Education.ExploreEducationStatistics.Content.Services.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GovUk.Education.ExploreEducationStatistics.Content.Services.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
-        <PackageReference Include="AutoMapper" Version="9.0.0" />
+        <!-- TODO remove AutoMapper.Extensions.Microsoft.DependencyInjection with AutoMapper v13 -->
         <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
     <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.21" PrivateAssets="all" />
-    <PackageReference Include="AutoMapper" Version="9.0.0" />
+    <!-- TODO remove AutoMapper.Extensions.Microsoft.DependencyInjection with AutoMapper v13 -->
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.21" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
@@ -6,7 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="9.0.0" />
         <PackageReference Include="CsvHelper" Version="30.0.1" />
         <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
This PR changes the Renovate config to restrict the versions of `Automapper` and `AutoMapper.Extensions.Microsoft.DependencyInjection` due to the versions of `Microsoft.AspNetCore.ApiAuthorization.IdentityServer:3.1.32`  -> `IdentityServer4.EntityFramework.Storage:3.0.0` -> that we use  in Admin depending on `AutoMapper` 9.0.0.

It's possible that if we did some additional work to upgrade `IdentityServer`, `IdentityServer4.EntityFramework` and `IdentityServer4.EntityFramework.Storage` to 3.1.4 then we might be able to use more recent versions (but still old) i.e. `AutoMapper` 10.1.1 and `AutoMapper.Extensions.Microsoft.DependencyInjection` 8.1.1.

However when I attempted this update I consistently got the following error:

```
IdentityServer4.Hosting.IdentityServerMiddleware[0]
      Unhandled exception: Method not found: '!!0 AutoMapper.IMapper.Map(System.Object)'.
      System.MissingMethodException: Method not found: '!!0 AutoMapper.IMapper.Map(System.Object)'.
         at IdentityServer4.EntityFramework.Mappers.PersistedGrantMappers.ToEntity(PersistedGrant model)
```

Using an outdated version of IdentityServer is the problem here and it's going to cause us a major problem if we want to update to .NET 7 or the upcoming LTS release, .NET 8.

We can't update to the latest version of IdentityServer without a licence and IdentityServer4 already reached end-of-support on 13/12/22. IdentityServer4 won't be receiving any updates like we'd need to upgrade to future versions of .NET or to fix this issue with AutoMapper.

### Other changes
- Remove `IgnoreMap` from `EmbedBlockLink`. It shouldn't be needed because `EmbedBlock` is not a field of the target type `EmbedBlockLinkViewModel`. `IgnoreMap` is removed by AutoMapper v11.
- Declare `AutoMapper.Extensions.Microsoft.DependencyInjection` as a dependency only in projects where it's required.
- Add a TODO to remind us that `AutoMapper.Extensions.Microsoft.DependencyInjection` is being removed with `AutoMapper` 13 (it's getting merged into `AutoMapper`).