### PR TITLE
EES-4435 replace Formik with RHF in front end

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
@@ -9,6 +9,7 @@ import React, {
   memo,
   MouseEventHandler,
   ReactNode,
+  Ref,
 } from 'react';
 
 export interface FormBaseInputProps extends FormLabelProps {
@@ -20,6 +21,7 @@ export interface FormBaseInputProps extends FormLabelProps {
   hint?: string;
   id: string;
   inputMode?: HTMLAttributes<HTMLInputElement>['inputMode'];
+  inputRef?: Ref<HTMLInputElement>;
   list?: string;
   name: string;
   width?: 20 | 10 | 5 | 4 | 3 | 2;
@@ -44,6 +46,7 @@ const FormBaseInput = ({
   hideLabel,
   id,
   inputMode,
+  inputRef,
   label,
   labelSize,
   width,
@@ -66,6 +69,7 @@ const FormBaseInput = ({
       })}
       id={id}
       inputMode={inputMode}
+      ref={inputRef}
       type={type}
     />
   );

--- a/src/explore-education-statistics-common/src/components/form/FormSelect.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormSelect.tsx
@@ -7,6 +7,7 @@ import React, {
   CSSProperties,
   FocusEventHandler,
   ReactNode,
+  Ref,
 } from 'react';
 import ErrorMessage from '../ErrorMessage';
 
@@ -25,6 +26,7 @@ export interface FormSelectProps extends FormLabelProps {
   error?: string;
   id: string;
   inline?: boolean;
+  inputRef?: Ref<HTMLSelectElement>;
   hint?: string;
   name: string;
   onBlur?: FocusEventHandler;
@@ -45,6 +47,7 @@ const FormSelect = ({
   error,
   id,
   inline = false,
+  inputRef,
   hint,
   hideLabel,
   label,
@@ -93,6 +96,7 @@ const FormSelect = ({
           id={id}
           name={name}
           disabled={disabled}
+          ref={inputRef}
           onBlur={onBlur}
           onChange={onChange}
           value={value}

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormField.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormField.tsx
@@ -1,0 +1,139 @@
+import useRegister from '@common/components/form/rhf/hooks/useRegister';
+import getErrorMessage from '@common/components/form/rhf/util/getErrorMessage';
+import { useFormIdContext } from '@common/components/form/contexts/FormIdContext';
+import FormGroup from '@common/components/form/FormGroup';
+import React, {
+  ChangeEvent,
+  ChangeEventHandler,
+  ComponentType,
+  ReactNode,
+  useMemo,
+} from 'react';
+import {
+  FieldValues,
+  FieldElement,
+  Path,
+  useFormContext,
+  ChangeHandler,
+} from 'react-hook-form';
+
+export type RHFFormFieldComponentProps<Props, TFormValues> =
+  FormFieldProps<TFormValues> &
+    Omit<Props, 'name' | 'id' | 'value' | 'error'> & {
+      id?: string;
+      name: Path<TFormValues>;
+    };
+
+export interface FormFieldProps<TFormValues> {
+  id?: string;
+  formGroup?: boolean;
+  formGroupClass?: string;
+  name: Path<TFormValues>;
+  showError?: boolean;
+}
+
+interface FormFieldInputProps {
+  error?: ReactNode | string;
+  id: string;
+}
+
+type InternalFormFieldProps<P> = Omit<P, 'id' | 'value' | 'error'> & {
+  as?: ComponentType<FormFieldInputProps & P>;
+  children?:
+    | ((props: {
+        id: string;
+        field: FieldElement & { error?: string };
+      }) => ReactNode)
+    | ReactNode;
+  id?: string;
+  type?: 'checkbox' | 'radio' | 'text' | 'number';
+};
+
+export default function RHFFormField<
+  Value extends FieldValues,
+  Props = Record<string, unknown>,
+>({
+  as,
+  children,
+  formGroup = true,
+  formGroupClass,
+  id: customId,
+  name,
+  showError = true,
+  ...props
+}: FormFieldProps<Value> & InternalFormFieldProps<Props>) {
+  const {
+    formState: { errors },
+    register,
+  } = useFormContext<Value>();
+
+  const { ref: inputRef, ...field } = useRegister(name, register);
+  const { fieldId } = useFormIdContext();
+  const id = fieldId(name, customId);
+
+  const error = getErrorMessage(errors, name, showError);
+
+  const component = useMemo(() => {
+    const typedProps = props as {
+      onBlur?: ChangeHandler;
+      onChange?: ChangeEventHandler;
+    };
+    const Component = as as ComponentType<FormFieldInputProps>;
+
+    if (Component) {
+      return (
+        <Component
+          {...props}
+          {...field}
+          id={fieldId(name, customId)}
+          name={name}
+          error={error}
+          inputRef={inputRef}
+          onChange={(event: ChangeEvent) => {
+            if (typedProps.onChange) {
+              typedProps.onChange(event);
+            }
+
+            if (!event.isDefaultPrevented()) {
+              field.onChange(event);
+            }
+          }}
+          onBlur={(event: FocusEvent) => {
+            if (typedProps.onBlur) {
+              typedProps.onBlur(event);
+            }
+            if (!event.defaultPrevented) {
+              field.onBlur(event);
+            }
+          }}
+        />
+      );
+    }
+
+    return typeof children === 'function'
+      ? children({
+          id,
+          field: { ...field, error },
+        })
+      : children;
+  }, [
+    as,
+    children,
+    customId,
+    error,
+    field,
+    fieldId,
+    id,
+    inputRef,
+    name,
+    props,
+  ]);
+
+  return formGroup ? (
+    <FormGroup hasError={!!error} className={formGroupClass}>
+      {component}
+    </FormGroup>
+  ) : (
+    component
+  );
+}

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxGroup.tsx
@@ -1,0 +1,79 @@
+import FormCheckboxGroup, {
+  CheckboxOption,
+  FormCheckboxGroupProps,
+} from '@common/components/form/FormCheckboxGroup';
+import { useFormIdContext } from '@common/components/form/contexts/FormIdContext';
+import useRegister from '@common/components/form/rhf/hooks/useRegister';
+import handleAllRHFCheckboxChange from '@common/components/form/rhf/util/handleAllRHFCheckboxChange';
+import getErrorMessage from '@common/components/form/rhf/util/getErrorMessage';
+import React from 'react';
+import { FieldValues, Path, useFormContext, useWatch } from 'react-hook-form';
+
+export interface Props<TFormValues extends FieldValues>
+  extends Omit<FormCheckboxGroupProps, 'name' | 'value' | 'id'> {
+  name: Path<TFormValues>;
+  id?: string;
+  options: CheckboxOption[];
+  showError?: boolean;
+}
+
+export default function RHFFormFieldCheckboxGroup<
+  TFormValues extends FieldValues,
+>({
+  name,
+  id: customId,
+  options,
+  showError = true,
+  ...props
+}: Props<TFormValues>) {
+  const {
+    formState: { errors, submitCount },
+    register,
+    setValue,
+    trigger,
+  } = useFormContext<TFormValues>();
+
+  const { ref: inputRef, ...field } = useRegister(name, register);
+  const { fieldId } = useFormIdContext();
+  const id = fieldId(name, customId);
+  const selectedValues = useWatch({ name }) || [];
+  const { onAllChange, onChange } = props;
+
+  return (
+    <FormCheckboxGroup
+      {...props}
+      {...field}
+      error={getErrorMessage(errors, name, showError)}
+      id={id}
+      inputRef={inputRef}
+      options={options}
+      value={selectedValues}
+      onAllChange={(event, checked) => {
+        onAllChange?.(event, checked, options);
+
+        if (event.isDefaultPrevented()) {
+          return;
+        }
+
+        handleAllRHFCheckboxChange({
+          checked,
+          name,
+          options,
+          selectedValues,
+          setValue,
+          submitCount,
+          trigger,
+        });
+      }}
+      onChange={(event, option) => {
+        onChange?.(event, option);
+
+        if (event.isDefaultPrevented()) {
+          return;
+        }
+
+        field.onChange(event);
+      }}
+    />
+  );
+}

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxMenu.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxMenu.tsx
@@ -1,0 +1,52 @@
+import DetailsMenu from '@common/components/DetailsMenu';
+import { FormFieldCheckboxSearchGroupProps } from '@common/components/form/FormFieldCheckboxSearchGroup';
+import RHFFormCheckboxSelectedCount from '@common/components/form/rhf/RHFFormCheckboxSelectedCount';
+import RHFFormFieldCheckboxSearchGroup from '@common/components/form/rhf/RHFFormFieldCheckboxSearchGroup';
+import RHFFormFieldCheckboxGroup from '@common/components/form/rhf/RHFFormFieldCheckboxGroup';
+import get from 'lodash/get';
+import React, { useEffect, useState } from 'react';
+import { FieldValues, useFormContext } from 'react-hook-form';
+
+interface Props<TFormValues extends FieldValues>
+  extends FormFieldCheckboxSearchGroupProps<TFormValues> {
+  legend: string;
+  open?: boolean;
+}
+
+export default function RHFFormFieldCheckboxMenu<
+  TFormValues extends FieldValues,
+>(props: Props<TFormValues>) {
+  const { name, open: defaultOpen = false, options, legend } = props;
+  const [open, setOpen] = useState(defaultOpen);
+
+  const {
+    formState: { errors },
+  } = useFormContext();
+
+  useEffect(() => {
+    if (!open && get(errors, name)) {
+      setOpen(true);
+    }
+  }, [errors, name, open, setOpen]);
+
+  return (
+    <DetailsMenu
+      open={open}
+      jsRequired
+      summary={legend}
+      summaryAfter={<RHFFormCheckboxSelectedCount name={name} />}
+    >
+      {options.length > 1 ? (
+        <RHFFormFieldCheckboxSearchGroup
+          selectAll
+          legendHidden
+          {...props}
+          name={name}
+          options={options}
+        />
+      ) : (
+        <RHFFormFieldCheckboxGroup {...props} name={name} options={options} />
+      )}
+    </DetailsMenu>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxSearchGroup.tsx
@@ -1,0 +1,76 @@
+import FormCheckboxSearchGroup, {
+  FormCheckboxSearchGroupProps,
+} from '@common/components/form/FormCheckboxSearchGroup';
+import { useFormIdContext } from '@common/components/form/contexts/FormIdContext';
+import useRegister from '@common/components/form/rhf/hooks/useRegister';
+import handleAllRHFCheckboxChange from '@common/components/form/rhf/util/handleAllRHFCheckboxChange';
+import getErrorMessage from '@common/components/form/rhf/util/getErrorMessage';
+import React from 'react';
+import { FieldValues, Path, useFormContext, useWatch } from 'react-hook-form';
+
+export interface RHFFormFieldCheckboxSearchGroupProps<
+  TFormValues extends FieldValues,
+> extends Omit<FormCheckboxSearchGroupProps, 'name' | 'value' | 'id'> {
+  name: Path<TFormValues>;
+  id?: string;
+  showError?: boolean;
+}
+
+export default function RHFFormFieldCheckboxSearchGroup<
+  TFormValues extends FieldValues,
+>({
+  name,
+  id: customId,
+  showError = true,
+  ...props
+}: RHFFormFieldCheckboxSearchGroupProps<TFormValues>) {
+  const {
+    formState: { errors, submitCount },
+    register,
+    setValue,
+    trigger,
+  } = useFormContext<TFormValues>();
+
+  const { ref: inputRef, ...field } = useRegister(name, register);
+  const { fieldId } = useFormIdContext();
+  const id = fieldId(name, customId);
+  const selectedValues = useWatch({ name }) || [];
+  const { onAllChange, onChange } = props;
+
+  return (
+    <FormCheckboxSearchGroup
+      {...props}
+      {...field}
+      error={getErrorMessage(errors, name, showError)}
+      id={id}
+      inputRef={inputRef}
+      value={selectedValues}
+      onAllChange={(event, checked, options) => {
+        onAllChange?.(event, checked, options);
+
+        if (event.isDefaultPrevented()) {
+          return;
+        }
+
+        handleAllRHFCheckboxChange({
+          checked,
+          name,
+          options,
+          selectedValues,
+          setValue,
+          submitCount,
+          trigger,
+        });
+      }}
+      onChange={(event, option) => {
+        onChange?.(event, option);
+
+        if (event.isDefaultPrevented()) {
+          return;
+        }
+
+        field.onChange(event);
+      }}
+    />
+  );
+}

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldRadioGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldRadioGroup.tsx
@@ -4,7 +4,7 @@ import FormRadioGroup, {
 import useRegister from '@common/components/form/rhf/hooks/useRegister';
 import { useFormIdContext } from '@common/components/form/contexts/FormIdContext';
 import { RadioChangeEventHandler } from '@common/components/form/FormRadio';
-import get from 'lodash/get';
+import getErrorMessage from '@common/components/form/rhf/util/getErrorMessage';
 import React, { memo, useCallback } from 'react';
 import { FieldValues, Path, useFormContext, useWatch } from 'react-hook-form';
 
@@ -56,7 +56,7 @@ function RHFFormFieldRadioGroup<TFormValues extends FieldValues>({
     <FormRadioGroup
       {...props}
       {...field}
-      error={showError ? (get(errors, name)?.message as string) : ''}
+      error={getErrorMessage(errors, name, showError)}
       id={id}
       inputRef={inputRef}
       value={selectedValue}
@@ -65,4 +65,4 @@ function RHFFormFieldRadioGroup<TFormValues extends FieldValues>({
   );
 }
 
-export default memo(RHFFormFieldRadioGroup);
+export default memo(RHFFormFieldRadioGroup) as typeof RHFFormFieldRadioGroup;

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldSelect.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldSelect.tsx
@@ -1,0 +1,22 @@
+import RHFFormField, {
+  RHFFormFieldComponentProps,
+} from '@common/components/form/rhf/RHFFormField';
+import FormSelect, {
+  FormSelectProps,
+} from '@common/components/form/FormSelect';
+import React from 'react';
+import { FieldValues } from 'react-hook-form';
+
+type Props<TFormValues extends FieldValues> = RHFFormFieldComponentProps<
+  FormSelectProps,
+  TFormValues
+>;
+
+export default function RHFFormFieldSelect<TFormValues extends FieldValues>({
+  name,
+  ...props
+}: Props<TFormValues>) {
+  return <RHFFormField {...props} name={name} as={FormSelect} />;
+}
+
+RHFFormFieldSelect.unordered = [] as [];

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldTextInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldTextInput.tsx
@@ -1,0 +1,20 @@
+import RHFFormField, {
+  RHFFormFieldComponentProps,
+} from '@common/components/form/rhf/RHFFormField';
+import FormTextInput, {
+  FormTextInputProps,
+} from '@common/components/form/FormTextInput';
+import React from 'react';
+import { FieldValues } from 'react-hook-form';
+
+type Props<TFormValues extends FieldValues> = RHFFormFieldComponentProps<
+  FormTextInputProps,
+  TFormValues
+>;
+
+export default function RHFFormFieldTextInput<TFormValues extends FieldValues>({
+  name,
+  ...props
+}: Props<TFormValues>) {
+  return <RHFFormField {...props} name={name} as={FormTextInput} />;
+}

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFForm.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFForm.test.tsx
@@ -139,7 +139,7 @@ describe('Form', () => {
   });
 
   test('calls `onSubmit` handler when form is submitted successfully', async () => {
-    const handleSubmitForm = jest.fn();
+    const handleSubmit = jest.fn();
 
     render(
       <FormProvider
@@ -150,7 +150,7 @@ describe('Form', () => {
           firstName: Yup.string().defined(),
         })}
       >
-        <RHFForm id="test-form" onSubmit={handleSubmitForm}>
+        <RHFForm id="test-form" onSubmit={handleSubmit}>
           The form
           <button type="submit">Submit</button>
         </RHFForm>
@@ -160,7 +160,7 @@ describe('Form', () => {
     userEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
-      expect(handleSubmitForm).toHaveBeenCalledTimes(1);
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldCheckboxGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldCheckboxGroup.test.tsx
@@ -1,0 +1,569 @@
+import Yup from '@common/validation/yup';
+import RHFFormFieldCheckboxGroup from '@common/components/form/rhf/RHFFormFieldCheckboxGroup';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+describe('RHFFormFieldCheckboxGroup', () => {
+  test('renders with correct default ids without form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFFormFieldCheckboxGroup
+          name="test"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { label: 'Checkbox 1', value: '1' },
+            { label: 'Checkbox 2', value: '2' },
+            { label: 'Checkbox 3', value: '3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'test');
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute('id', 'test-1');
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute('id', 'test-2');
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute('id', 'test-3');
+  });
+
+  test('renders with correct default ids with form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldCheckboxGroup
+            name="test"
+            legend="Test checkboxes"
+            selectAll
+            options={[
+              { label: 'Checkbox 1', value: '1' },
+              { label: 'Checkbox 2', value: '2' },
+              { label: 'Checkbox 3', value: '3' },
+            ]}
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'testForm-test');
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'testForm-test-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'testForm-test-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'testForm-test-3',
+    );
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldCheckboxGroup
+            id="customId"
+            name="test"
+            legend="Test checkboxes"
+            selectAll
+            options={[
+              { label: 'Checkbox 1', value: '1' },
+              { label: 'Checkbox 2', value: '2' },
+              { id: 'customOption', label: 'Checkbox 3', value: '3' },
+            ]}
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute(
+      'id',
+      'testForm-customId',
+    );
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'testForm-customId-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'testForm-customId-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'testForm-customId-customOption',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFFormFieldCheckboxGroup
+          id="customId"
+          name="test"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { label: 'Checkbox 1', value: '1' },
+            { label: 'Checkbox 2', value: '2' },
+            { id: 'customOption', label: 'Checkbox 3', value: '3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'customId');
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'customId-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'customId-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'customId-customOption',
+    );
+  });
+
+  test('checking option checks it', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFFormFieldCheckboxGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const checkbox = screen.getByLabelText('Checkbox 1');
+
+    expect(checkbox).not.toBeChecked();
+
+    userEvent.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+  });
+
+  test('un-checking option un-checks it', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: ['1'],
+        }}
+      >
+        <RHFFormFieldCheckboxGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const checkbox = screen.getByLabelText('Checkbox 1');
+
+    expect(checkbox).toBeChecked();
+
+    userEvent.click(checkbox);
+
+    expect(checkbox).not.toBeChecked();
+  });
+
+  test('clicking `Select all 3 options` button checks all values', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFFormFieldCheckboxGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const checkbox1 = screen.getByLabelText('Checkbox 1');
+    const checkbox2 = screen.getByLabelText('Checkbox 2');
+    const checkbox3 = screen.getByLabelText('Checkbox 3');
+
+    expect(checkbox1).not.toBeChecked();
+    expect(checkbox2).not.toBeChecked();
+    expect(checkbox3).not.toBeChecked();
+
+    userEvent.click(screen.getByText('Select all 3 options'));
+
+    expect(checkbox1).toBeChecked();
+    expect(checkbox2).toBeChecked();
+    expect(checkbox3).toBeChecked();
+  });
+
+  test('clicking `Unselect all 3 options` button un-checks all values', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: ['1', '2', '3'],
+        }}
+      >
+        <RHFFormFieldCheckboxGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const checkbox1 = screen.getByLabelText('Checkbox 1');
+    const checkbox2 = screen.getByLabelText('Checkbox 2');
+    const checkbox3 = screen.getByLabelText('Checkbox 3');
+
+    expect(checkbox1).toBeChecked();
+    expect(checkbox2).toBeChecked();
+    expect(checkbox3).toBeChecked();
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Unselect all 3 options' }),
+    );
+
+    expect(checkbox1).not.toBeChecked();
+    expect(checkbox2).not.toBeChecked();
+    expect(checkbox3).not.toBeChecked();
+  });
+
+  test('checking all options renders the `Unselect all 3 options` button', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFFormFieldCheckboxGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const checkbox1 = screen.getByLabelText('Checkbox 1');
+    const checkbox2 = screen.getByLabelText('Checkbox 2');
+    const checkbox3 = screen.getByLabelText('Checkbox 3');
+
+    expect(checkbox1).not.toBeChecked();
+    expect(
+      screen.getByRole('button', { name: 'Select all 3 options' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Unselect all 3 options' }),
+    ).not.toBeInTheDocument();
+
+    userEvent.click(checkbox1);
+    userEvent.click(checkbox2);
+    userEvent.click(checkbox3);
+
+    expect(checkbox1).toBeChecked();
+    expect(checkbox2).toBeChecked();
+    expect(checkbox3).toBeChecked();
+    expect(
+      screen.queryByRole('button', { name: 'Select all 3 options' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Unselect all 3 options' }),
+    ).toBeInTheDocument();
+  });
+
+  test('un-checking any options renders the `Select all 3 options` button', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: ['1', '2', '3'],
+        }}
+      >
+        <RHFFormFieldCheckboxGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const checkbox = screen.getByLabelText('Checkbox 1');
+
+    expect(checkbox).toBeChecked();
+    expect(
+      screen.queryByRole('button', { name: 'Select all 3 options' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Unselect all 3 options' }),
+    ).toBeInTheDocument();
+
+    userEvent.click(checkbox);
+
+    expect(checkbox).not.toBeChecked();
+    expect(
+      screen.getByRole('button', { name: 'Select all 3 options' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Unselect all 3 options' }),
+    ).not.toBeInTheDocument();
+  });
+
+  describe('error messages', () => {
+    test('does not display validation message when checkboxes are untouched', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: [],
+          }}
+          validationSchema={Yup.object({
+            test: Yup.array().min(1, 'Select at least one option'),
+          })}
+        >
+          <RHFFormFieldCheckboxGroup
+            name="test"
+            id="checkboxes"
+            legend="Test checkboxes"
+            selectAll
+            options={[
+              { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+              { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+              { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
+    });
+
+    test('displays validation message when form is submitted', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: [],
+          }}
+          validationSchema={Yup.object({
+            test: Yup.array().min(1, 'Select at least one option'),
+          })}
+        >
+          <RHFForm
+            id="testId"
+            showErrorSummary={false}
+            onSubmit={Promise.resolve}
+          >
+            <RHFFormFieldCheckboxGroup
+              name="test"
+              id="checkboxes"
+              legend="Test checkboxes"
+              selectAll
+              options={[
+                { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+                { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+                { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+              ]}
+            />
+            <button type="submit">Submit</button>
+          </RHFForm>
+        </FormProvider>,
+      );
+
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Select at least one option'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('displays validation message when checkboxes have been touched', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: [],
+          }}
+          validationSchema={Yup.object({
+            test: Yup.array().min(1, 'Select at least one option'),
+          })}
+        >
+          <RHFFormFieldCheckboxGroup
+            name="test"
+            id="checkboxes"
+            legend="Test checkboxes"
+            options={[
+              { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+              { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+              { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      userEvent.tab();
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Select at least one option'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('displays validation message when no checkboxes are checked', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: ['1'],
+          }}
+          validationSchema={Yup.object({
+            test: Yup.array().min(1, 'Select at least one option'),
+          })}
+        >
+          <RHFFormFieldCheckboxGroup
+            name="test"
+            id="checkboxes"
+            legend="Test checkboxes"
+            selectAll
+            options={[
+              { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+              { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+              { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      const checkbox = screen.getByLabelText('Checkbox 1');
+
+      expect(checkbox).toBeChecked();
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
+
+      userEvent.click(checkbox);
+
+      expect(checkbox).not.toBeChecked();
+
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Select at least one option'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message when `showError` is false', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: ['1'],
+          }}
+          validationSchema={Yup.object({
+            test: Yup.array().min(1, 'Select at least one option'),
+          })}
+        >
+          <RHFFormFieldCheckboxGroup
+            name="test"
+            id="checkboxes"
+            legend="Test checkboxes"
+            selectAll
+            showError={false}
+            options={[
+              { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+              { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+              { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      const checkbox = screen.getByLabelText('Checkbox 1');
+
+      expect(checkbox).toBeChecked();
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
+
+      userEvent.click(checkbox);
+
+      expect(checkbox).not.toBeChecked();
+
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Select at least one option'),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldCheckboxSearchGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldCheckboxSearchGroup.test.tsx
@@ -1,0 +1,543 @@
+import RHFFormFieldCheckboxSearchGroup from '@common/components/form/rhf/RHFFormFieldCheckboxSearchGroup';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import Yup from '@common/validation/yup';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+jest.mock('lodash/debounce');
+
+describe('RHFFormFieldCheckboxSearchGroup', () => {
+  test('renders with correct default ids without form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFFormFieldCheckboxSearchGroup
+          name="test"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { label: 'Checkbox 1', value: '1' },
+            { label: 'Checkbox 2', value: '2' },
+            { label: 'Checkbox 3', value: '3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'test');
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('id', 'test-search');
+
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'test-options-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'test-options-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'test-options-3',
+    );
+  });
+
+  test('renders with correct default ids with form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldCheckboxSearchGroup
+            name="test"
+            legend="Test checkboxes"
+            selectAll
+            options={[
+              { label: 'Checkbox 1', value: '1' },
+              { label: 'Checkbox 2', value: '2' },
+              { label: 'Checkbox 3', value: '3' },
+            ]}
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'testForm-test');
+
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'id',
+      'testForm-test-search',
+    );
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'testForm-test-options-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'testForm-test-options-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'testForm-test-options-3',
+    );
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldCheckboxSearchGroup
+            id="customId"
+            name="test"
+            legend="Test checkboxes"
+            selectAll
+            options={[
+              { label: 'Checkbox 1', value: '1' },
+              { label: 'Checkbox 2', value: '2' },
+              { id: 'customOption', label: 'Checkbox 3', value: '3' },
+            ]}
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute(
+      'id',
+      'testForm-customId',
+    );
+
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'id',
+      'testForm-customId-search',
+    );
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'testForm-customId-options-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'testForm-customId-options-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'testForm-customId-options-customOption',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFFormFieldCheckboxSearchGroup
+          id="customId"
+          name="test"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { label: 'Checkbox 1', value: '1' },
+            { label: 'Checkbox 2', value: '2' },
+            { id: 'customOption', label: 'Checkbox 3', value: '3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'customId');
+
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'id',
+      'customId-search',
+    );
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'customId-options-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'customId-options-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'customId-options-customOption',
+    );
+  });
+
+  test('checking option checks it', async () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFFormFieldCheckboxSearchGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const checkbox = screen.getByLabelText('Checkbox 1');
+
+    expect(checkbox).not.toBeChecked();
+
+    userEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  test('un-checking option un-checks it', async () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: ['1'],
+        }}
+      >
+        <RHFFormFieldCheckboxSearchGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const checkbox = screen.getByLabelText('Checkbox 1');
+
+    expect(checkbox).toBeChecked();
+
+    userEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+    });
+  });
+
+  test('clicking `Select all 3 options` button checks all values', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFFormFieldCheckboxSearchGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+          selectAll
+        />
+      </FormProvider>,
+    );
+
+    userEvent.click(screen.getByText('Select all 3 options'));
+
+    expect(screen.getByLabelText('Checkbox 1')).toBeChecked();
+    expect(screen.getByLabelText('Checkbox 2')).toBeChecked();
+    expect(screen.getByLabelText('Checkbox 3')).toBeChecked();
+  });
+
+  test('clicking `Unselect all 3 options` button un-checks all values', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: ['1', '2', '3'],
+        }}
+      >
+        <RHFFormFieldCheckboxSearchGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+          selectAll
+        />
+      </FormProvider>,
+    );
+
+    const checkbox1 = screen.getByLabelText('Checkbox 1');
+    const checkbox2 = screen.getByLabelText('Checkbox 2');
+    const checkbox3 = screen.getByLabelText('Checkbox 3');
+
+    expect(checkbox1).toBeChecked();
+    expect(checkbox2).toBeChecked();
+    expect(checkbox3).toBeChecked();
+
+    userEvent.click(screen.getByText('Unselect all 3 options'));
+
+    expect(checkbox1).not.toBeChecked();
+    expect(checkbox2).not.toBeChecked();
+    expect(checkbox3).not.toBeChecked();
+  });
+
+  test('checking all options renders the `Unselect all 3 options` button', async () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: [],
+        }}
+      >
+        <RHFFormFieldCheckboxSearchGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+          selectAll
+        />
+      </FormProvider>,
+    );
+
+    const checkbox1 = screen.getByLabelText('Checkbox 1');
+    const checkbox2 = screen.getByLabelText('Checkbox 2');
+    const checkbox3 = screen.getByLabelText('Checkbox 3');
+
+    expect(checkbox1).not.toBeChecked();
+    expect(screen.queryByText('Select all 3 options')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Unselect all 3 options'),
+    ).not.toBeInTheDocument();
+
+    userEvent.click(checkbox1);
+    userEvent.click(checkbox2);
+    userEvent.click(checkbox3);
+
+    await waitFor(() => {
+      expect(checkbox1).toBeChecked();
+      expect(checkbox2).toBeChecked();
+      expect(checkbox3).toBeChecked();
+
+      expect(
+        screen.queryByText('Select all 3 options'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Unselect all 3 options')).toBeInTheDocument();
+    });
+  });
+
+  test('un-checking any options renders the `Select all 3 options` button ', async () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: ['1', '2', '3'],
+        }}
+      >
+        <RHFFormFieldCheckboxSearchGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+          selectAll
+        />
+      </FormProvider>,
+    );
+
+    const checkbox = screen.getByLabelText('Checkbox 1');
+
+    expect(checkbox).toBeChecked();
+    expect(screen.queryByText('Unselect all 3 options')).toBeInTheDocument();
+    expect(screen.queryByText('Select all 3 options')).not.toBeInTheDocument();
+
+    userEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+      expect(
+        screen.queryByText('Unselect all 3 options'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Select all 3 options')).toBeInTheDocument();
+    });
+  });
+
+  describe('error messages', () => {
+    test('does not display validation message when checkboxes are untouched', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: [],
+          }}
+          validationSchema={Yup.object({
+            test: Yup.array().required('Select at least one option'),
+          })}
+        >
+          <RHFFormFieldCheckboxSearchGroup
+            name="test"
+            id="checkboxes"
+            legend="Test checkboxes"
+            options={[
+              { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+              { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+              { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
+    });
+
+    test('displays validation message when no checkboxes are checked', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: ['1'],
+          }}
+          validationSchema={Yup.object({
+            test: Yup.array()
+              .min(1, 'Select at least one option')
+              .required('Select at least one option'),
+          })}
+        >
+          <RHFFormFieldCheckboxSearchGroup
+            name="test"
+            id="checkboxes"
+            legend="Test checkboxes"
+            options={[
+              { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+              { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+              { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      const checkbox = screen.getByLabelText('Checkbox 1');
+
+      expect(checkbox).toBeChecked();
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
+
+      userEvent.click(checkbox);
+
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(checkbox).not.toBeChecked();
+        expect(
+          screen.queryByText('Select at least one option'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message when `showError` is false', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: ['1'],
+          }}
+          validationSchema={Yup.object({
+            test: Yup.array()
+              .min(1, 'Select at least one option')
+              .required('Select at least one option'),
+          })}
+        >
+          <RHFFormFieldCheckboxSearchGroup
+            name="test"
+            id="checkboxes"
+            legend="Test checkboxes"
+            showError={false}
+            options={[
+              { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+              { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+              { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      const checkbox = screen.getByLabelText('Checkbox 1');
+
+      expect(checkbox).toBeChecked();
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
+
+      userEvent.click(checkbox);
+
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(checkbox).not.toBeChecked();
+        expect(
+          screen.queryByText('Select at least one option'),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  test('providing a search term does not remove checkboxes that have already been checked', async () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: ['1'],
+        }}
+      >
+        <RHFFormFieldCheckboxSearchGroup
+          name="test"
+          id="checkboxes"
+          legend="Test checkboxes"
+          searchLabel="Search options"
+          options={[
+            { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+            { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+            { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const searchInput = screen.getByLabelText('Search options');
+
+    expect(screen.getByLabelText('Checkbox 1')).toBeChecked();
+
+    userEvent.type(searchInput, '2');
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Checkbox/)).toHaveLength(2);
+    });
+    expect(screen.getByLabelText('Checkbox 1')).toBeChecked();
+    expect(screen.getByLabelText('Checkbox 2')).not.toBeChecked();
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldSelect.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldSelect.test.tsx
@@ -1,0 +1,355 @@
+import RHFFormFieldSelect from '@common/components/form/rhf/RHFFormFieldSelect';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import Yup from '@common/validation/yup';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+describe('RHFFormFieldSelect', () => {
+  test('renders with correct defaults ids with form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: '',
+        }}
+      >
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldSelect
+            name="test"
+            label="Test values"
+            hint="Test hint"
+            options={[
+              { value: '', label: '' },
+              { value: '1', label: 'Option 1' },
+              { value: '2', label: 'Option 2' },
+              { value: '3', label: 'Option 3' },
+            ]}
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-test-hint',
+    );
+    expect(screen.getByLabelText('Test values')).toHaveAttribute(
+      'id',
+      'testForm-test',
+    );
+  });
+
+  test('renders with correct defaults ids without form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: '',
+        }}
+      >
+        <RHFFormFieldSelect
+          name="test"
+          label="Test values"
+          hint="Test hint"
+          options={[
+            { value: '', label: '' },
+            { value: '1', label: 'Option 1' },
+            { value: '2', label: 'Option 2' },
+            { value: '3', label: 'Option 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute('id', 'test-hint');
+    expect(screen.getByLabelText('Test values')).toHaveAttribute('id', 'test');
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: '',
+        }}
+      >
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldSelect
+            name="test"
+            id="customId"
+            label="Test values"
+            hint="Test hint"
+            options={[
+              { value: '', label: '' },
+              { value: '1', label: 'Option 1' },
+              { value: '2', label: 'Option 2' },
+              { value: '3', label: 'Option 3' },
+            ]}
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-customId-hint',
+    );
+    expect(screen.getByLabelText('Test values')).toHaveAttribute(
+      'id',
+      'testForm-customId',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: '',
+        }}
+      >
+        <RHFFormFieldSelect
+          name="test"
+          id="customId"
+          label="Test values"
+          hint="Test hint"
+          options={[
+            { value: '', label: '' },
+            { value: '1', label: 'Option 1' },
+            { value: '2', label: 'Option 2' },
+            { value: '3', label: 'Option 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'customId-hint',
+    );
+    expect(screen.getByLabelText('Test values')).toHaveAttribute(
+      'id',
+      'customId',
+    );
+  });
+
+  test('changing options changes the select value', async () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: '',
+        }}
+      >
+        <RHFFormFieldSelect
+          name="test"
+          id="select"
+          label="Test values"
+          options={[
+            { value: '', label: '' },
+            { value: '1', label: 'Option 1' },
+            { value: '2', label: 'Option 2' },
+            { value: '3', label: 'Option 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const select = screen.getByLabelText('Test values') as HTMLInputElement;
+
+    expect(select.value).toBe('');
+
+    userEvent.selectOptions(select, '1');
+
+    await waitFor(() => {
+      expect(select.value).toBe('1');
+    });
+  });
+
+  describe('error messages', () => {
+    test('does not display validation message when select is untouched', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: '',
+          }}
+          validationSchema={Yup.object({
+            test: Yup.string().required('Select an option'),
+          })}
+        >
+          <RHFFormFieldSelect
+            name="test"
+            id="select"
+            label="Test values"
+            options={[
+              { value: '', label: '' },
+              { value: '1', label: 'Option 1' },
+              { value: '2', label: 'Option 2' },
+              { value: '3', label: 'Option 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
+    });
+
+    test('displays validation message when an invalid option is selected', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: '1',
+          }}
+          validationSchema={Yup.object({
+            test: Yup.string().required('Select an option'),
+          })}
+        >
+          <RHFFormFieldSelect
+            name="test"
+            id="select"
+            label="Test values"
+            options={[
+              { value: '', label: '' },
+              { value: '1', label: 'Option 1' },
+              { value: '2', label: 'Option 2' },
+              { value: '3', label: 'Option 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      const select = screen.getByLabelText('Test values') as HTMLInputElement;
+
+      expect(select.value).toBe('1');
+      expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
+
+      userEvent.selectOptions(select, '');
+
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(select.value).toBe('');
+        expect(screen.queryByText('Select an option')).toBeInTheDocument();
+      });
+    });
+
+    test('displays validation message when form is submitted', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: '',
+          }}
+          validationSchema={Yup.object({
+            test: Yup.string().required('Select an option'),
+          })}
+        >
+          <RHFForm
+            id="testForm"
+            showErrorSummary={false}
+            onSubmit={Promise.resolve}
+          >
+            <RHFFormFieldSelect
+              name="test"
+              id="customId"
+              label="Test values"
+              hint="Test hint"
+              options={[
+                { value: '', label: '' },
+                { value: '1', label: 'Option 1' },
+                { value: '2', label: 'Option 2' },
+                { value: '3', label: 'Option 3' },
+              ]}
+            />
+            <button type="submit">Submit</button>
+          </RHFForm>
+        </FormProvider>,
+      );
+
+      expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Select an option')).toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message when `showError` is false and invalid option is selected', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: '1',
+          }}
+          validationSchema={Yup.object({
+            test: Yup.string().required('Select an option'),
+          })}
+        >
+          <RHFFormFieldSelect
+            name="test"
+            id="select"
+            label="Test values"
+            showError={false}
+            options={[
+              { value: '', label: '' },
+              { value: '1', label: 'Option 1' },
+              { value: '2', label: 'Option 2' },
+              { value: '3', label: 'Option 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      const select = screen.getByLabelText('Test values') as HTMLInputElement;
+
+      expect(select.value).toBe('1');
+      expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
+
+      userEvent.selectOptions(select, '');
+
+      await waitFor(() => {
+        expect(select.value).toBe('');
+        expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message when `showError` is false and form is submitted', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: '',
+          }}
+          validationSchema={Yup.object({
+            test: Yup.string().required('Select an option'),
+          })}
+        >
+          <RHFForm id="testForm" onSubmit={Promise.resolve}>
+            <RHFFormFieldSelect
+              name="test"
+              id="customId"
+              label="Test values"
+              hint="Test hint"
+              showError={false}
+              options={[
+                { value: '', label: '' },
+                { value: '1', label: 'Option 1' },
+                { value: '2', label: 'Option 2' },
+                { value: '3', label: 'Option 3' },
+              ]}
+            />
+            <button type="submit">Submit</button>
+          </RHFForm>
+        </FormProvider>,
+      );
+
+      const select = screen.getByLabelText('Test values') as HTMLInputElement;
+
+      expect(select.value).toBe('');
+      expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByText('Submit'));
+
+      await waitFor(() => {
+        expect(select.value).toBe('');
+        expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/rhf/util/getErrorMessage.ts
+++ b/src/explore-education-statistics-common/src/components/form/rhf/util/getErrorMessage.ts
@@ -1,0 +1,10 @@
+import { get } from 'lodash';
+import { FieldValues, FieldErrors, Path } from 'react-hook-form';
+
+export default function getErrorMessage<TValues extends FieldValues>(
+  errors: FieldErrors<TValues>,
+  name: Path<TValues>,
+  showError = true,
+): string {
+  return showError ? (get(errors, name)?.message as string) ?? '' : '';
+}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DataSetStep.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DataSetStep.tsx
@@ -17,8 +17,6 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import React, { ReactNode } from 'react';
 import orderBy from 'lodash/orderBy';
 
-const formId = 'publicationDataStepForm';
-
 export type DataSetFormSubmitHandler = (values: { subjectId: string }) => void;
 
 export interface DataSetFormValues {
@@ -108,7 +106,7 @@ export default function DataSetStep({
         {({ formState }) => {
           return (
             <RHFForm
-              id={formId}
+              id="publicationDataStepForm"
               onSubmit={async ({ subjectId: id }) => {
                 await goToNextStep(async () => {
                   await onSubmit({ subjectId: id });
@@ -126,7 +124,7 @@ export default function DataSetStep({
                         : 'govuk-grid-column-one-third govuk-grid-column-one-quarter-from-desktop'
                     }
                   >
-                    <RHFFormFieldRadioGroup
+                    <RHFFormFieldRadioGroup<DataSetFormValues>
                       className="govuk-!-margin-bottom-2"
                       disabled={formState.isSubmitting}
                       legend={renderLegend()}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -38,8 +38,6 @@ export interface FormValues {
 
 export type FilterFormSubmitHandler = (values: FormValues) => void;
 
-const formId = 'filtersForm';
-
 const TableQueryErrorCodes = [
   'QueryExceedsMaxAllowableTableSize',
   'RequestCancelled',
@@ -119,7 +117,7 @@ const FiltersForm = ({
     <WizardStepHeading {...stepProps}>Choose your filters</WizardStepHeading>
   );
 
-  const handleSubmitForm = async (values: FormValues) => {
+  const handleSubmit = async (values: FormValues) => {
     setPreviousValues({ ...values });
 
     try {
@@ -203,7 +201,7 @@ const FiltersForm = ({
         });
         if (isActive) {
           return (
-            <RHFForm id={formId} showSubmitError onSubmit={handleSubmitForm}>
+            <RHFForm id="filtersForm" showSubmitError onSubmit={handleSubmit}>
               {tableQueryError && formState.submitCount > 0 && (
                 <TableQueryError
                   errorCode={tableQueryError}
@@ -288,7 +286,6 @@ const FiltersForm = ({
                               disabled={formState.isSubmitting}
                               groupLabel={filterGroup.legend}
                               hint={filterGroup.hint}
-                              id={`${formId}-${filterName}`}
                               key={filterKey}
                               legend={filterGroup.legend}
                               name={filterName}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -1,8 +1,11 @@
 import CollapsibleList from '@common/components/CollapsibleList';
-import { Form, FormFieldset } from '@common/components/form';
+import { FormFieldset } from '@common/components/form';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import RHFFormFieldCheckboxGroupsMenu from '@common/components/form/rhf/RHFFormFieldCheckboxGroupsMenu';
+import RHFFormFieldCheckboxMenu from '@common/components/form/rhf/RHFFormFieldCheckboxMenu';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
-import FormFieldCheckboxGroupsMenu from '@common/modules/table-tool/components/FormFieldCheckboxGroupsMenu';
 import ResetFormOnPreviousStep from '@common/modules/table-tool/components/ResetFormOnPreviousStep';
 import WizardStepSummary from '@common/modules/table-tool/components/WizardStepSummary';
 import {
@@ -13,24 +16,21 @@ import {
 import locationLevelsMap from '@common/utils/locationLevelsMap';
 import { Dictionary } from '@common/types/util';
 import Yup from '@common/validation/yup';
-import { Formik } from 'formik';
 import mapValues from 'lodash/mapValues';
 import sortBy from 'lodash/sortBy';
 import React, { useMemo } from 'react';
-import FormFieldCheckboxMenu from './FormFieldCheckboxMenu';
+import { ObjectSchema } from 'yup';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
 
-export interface LocationFormValues {
+interface FormValues {
   locations: Dictionary<string[]>;
 }
 
 export type LocationFiltersFormSubmitHandler = (values: {
   locationIds: string[];
 }) => void;
-
-const formId = 'locationFiltersForm';
 
 interface Props extends InjectedWizardProps {
   options: SubjectMeta['locations'];
@@ -129,42 +129,49 @@ const LocationFiltersForm = ({
     };
   }, [initialValues, hasSingleOption, keyedOptions, options]);
 
+  const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
+    return Yup.object({
+      locations: Yup.object().test(
+        'required',
+        'Select at least one location',
+        (value: Dictionary<string[]>) =>
+          Object.values(value).some(groupOptions => groupOptions.length > 0),
+      ),
+    });
+  }, []);
+
+  const handleSubmit = async (values: FormValues) => {
+    const locationIds = Object.values(values.locations).flat();
+    await goToNextStep(async () => {
+      await onSubmit({ locationIds });
+    });
+  };
+
   return (
-    <Formik<LocationFormValues>
+    <FormProvider
       enableReinitialize
       initialValues={initialFormValues}
-      validateOnBlur={false}
-      validationSchema={Yup.object<LocationFormValues>({
-        locations: Yup.object().test(
-          'required',
-          'Select at least one location',
-          (value: Dictionary<string[]>) => {
-            return Object.values(value).some(
-              groupOptions => groupOptions.length > 0,
-            );
-          },
-        ),
-      })}
-      onSubmit={async values => {
-        const locationIds = Object.values(values.locations).flat();
-        await goToNextStep(async () => {
-          await onSubmit({ locationIds });
-        });
-      }}
+      validationSchema={validationSchema}
     >
-      {form => {
+      {({ formState, getValues, reset }) => {
+        const showError =
+          !formState.isValid &&
+          (Object.keys(formState.touchedFields).length ||
+            formState.isSubmitted);
+
         if (isActive) {
           return (
-            <Form {...form} id={formId} showSubmitError>
+            <RHFForm
+              id="locationFiltersForm"
+              showSubmitError
+              showErrorSummary={!!showError}
+              onSubmit={handleSubmit}
+            >
               <FormFieldset
                 id="levels"
                 legend={stepHeading}
                 hint="Select at least one"
-                error={
-                  typeof form.errors.locations === 'string'
-                    ? form.errors.locations
-                    : ''
-                }
+                error={showError ? 'Select at least one location' : ''}
               >
                 <div className="govuk-grid-row">
                   <div className="govuk-grid-column-one-half-from-desktop">
@@ -175,13 +182,12 @@ const LocationFiltersForm = ({
                       const searchOnly = levelKey === 'school';
 
                       return hasSubGroups && !searchOnly ? (
-                        <FormFieldCheckboxGroupsMenu
+                        <RHFFormFieldCheckboxGroupsMenu
                           key={levelKey}
                           name={`locations.${levelKey}`}
-                          disabled={form.isSubmitting}
+                          disabled={formState.isSubmitting}
                           groupLabel={level.legend}
                           legend={level.legend}
-                          legendHidden
                           open={hasSingleOption}
                           order={[]}
                           options={level.options.map(group => ({
@@ -194,10 +200,10 @@ const LocationFiltersForm = ({
                           }))}
                         />
                       ) : (
-                        <FormFieldCheckboxMenu
+                        <RHFFormFieldCheckboxMenu
                           key={levelKey}
                           name={`locations.${levelKey}`}
-                          disabled={form.isSubmitting}
+                          disabled={formState.isSubmitting}
                           groupLabel={level.legend}
                           legend={level.legend}
                           legendHidden
@@ -229,14 +235,16 @@ const LocationFiltersForm = ({
 
               <WizardStepFormActions
                 {...stepProps}
-                isSubmitting={form.isSubmitting}
+                isSubmitting={formState.isSubmitting}
               />
-            </Form>
+            </RHFForm>
           );
         }
 
+        const values = getValues();
+
         const locationLevels: Dictionary<FilterOption[]> = mapValues(
-          form.values.locations,
+          values.locations,
           (locations, level) =>
             locations.reduce<FilterOption[]>((acc, value) => {
               const levelOptions = keyedOptions[level];
@@ -276,11 +284,11 @@ const LocationFiltersForm = ({
                 ))}
             </SummaryList>
 
-            <ResetFormOnPreviousStep {...stepProps} onReset={form.resetForm} />
+            <ResetFormOnPreviousStep {...stepProps} onReset={reset} />
           </WizardStepSummary>
         );
       }}
-    </Formik>
+    </FormProvider>
   );
 };
 

--- a/src/explore-education-statistics-frontend/src/modules/cookies/CookiesPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/cookies/CookiesPage.tsx
@@ -1,17 +1,18 @@
 import Button from '@common/components/Button';
 import ButtonText from '@common/components/ButtonText';
-import { Form, FormFieldRadioGroup, FormGroup } from '@common/components/form';
+import RHFFormFieldRadioGroup from '@common/components/form/rhf/RHFFormFieldRadioGroup';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
 import useMounted from '@common/hooks/useMounted';
 import { Dictionary } from '@common/types';
 import Yup from '@common/validation/yup';
 import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
 import { useCookies } from '@frontend/hooks/useCookies';
-import { Formik } from 'formik';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import { parseCookies } from 'nookies';
-import React, { useState } from 'react';
+import React from 'react';
 import { StringSchema } from 'yup';
 import styles from './CookiesPage.module.scss';
 
@@ -24,7 +25,6 @@ interface Props {
 }
 
 function CookiesPage({ cookies }: Props) {
-  const [submitted, setSubmitted] = useState(false);
   const { back } = useRouter();
 
   const { getCookie, setBannerSeenCookie, setGADisabledCookie } =
@@ -40,44 +40,11 @@ function CookiesPage({ cookies }: Props) {
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          {submitted && (
-            <div
-              id="submit-notification"
-              className={styles.submitNotification}
-              role="alert"
-            >
-              <h2>Your cookie settings were saved</h2>
-              <p>We have stored your cookie settings.</p>
-              <p>
-                <ButtonText onClick={() => back()}>
-                  Go back to the page you were looking at
-                </ButtonText>
-              </p>
-            </div>
-          )}
-
-          <p>
-            Cookies are files saved on your phone, tablet or computer when you
-            visit a website.
-          </p>
-          <p>
-            We use cookies to store information about how you use the GOV.UK
-            website, such as the pages you visit.
-          </p>
-
           {isMounted ? (
-            <Formik<FormValues>
-              enableReinitialize
+            <FormProvider
               initialValues={{
                 googleAnalytics:
                   getCookie('disableGA') === 'true' ? 'off' : 'on',
-              }}
-              onSubmit={values => {
-                setSubmitted(true);
-                window.scrollTo(0, 0);
-
-                setBannerSeenCookie(true);
-                setGADisabledCookie(values.googleAnalytics !== 'on');
               }}
               validationSchema={Yup.object<FormValues>({
                 googleAnalytics: Yup.string()
@@ -85,86 +52,108 @@ function CookiesPage({ cookies }: Props) {
                   .oneOf(['on', 'off']) as StringSchema<'on' | 'off'>,
               })}
             >
-              {() => {
+              {({ formState }) => {
                 return (
-                  <Form id="cookieSettingsForm">
-                    <h2 className="govuk-!-margin-top-6">Cookie settings</h2>
-
+                  <>
+                    {formState.isSubmitted && (
+                      <div
+                        id="submit-notification"
+                        className={styles.submitNotification}
+                        role="alert"
+                      >
+                        <h2>Your cookie settings were saved</h2>
+                        <p>We have stored your cookie settings.</p>
+                        <p>
+                          <ButtonText onClick={() => back()}>
+                            Go back to the page you were looking at
+                          </ButtonText>
+                        </p>
+                      </div>
+                    )}
                     <p>
-                      We use 2 types of cookie. You can choose which cookies
-                      you're happy for us to use.
+                      Cookies are files saved on your phone, tablet or computer
+                      when you visit a website.
                     </p>
+                    <p>
+                      We use cookies to store information about how you use the
+                      GOV.UK website, such as the pages you visit.
+                    </p>
+                    <RHFForm
+                      id="cookieSettingsForm"
+                      onSubmit={async values => {
+                        window.scrollTo(0, 0);
+                        setBannerSeenCookie(true);
+                        setGADisabledCookie(values.googleAnalytics !== 'on');
+                      }}
+                    >
+                      <h2 className="govuk-!-margin-top-6">Cookie settings</h2>
 
-                    <section className="govuk-!-margin-bottom-6">
-                      <h3>Cookies that measure website use</h3>
                       <p>
-                        We use Google Analytics to measure how you use the
-                        website so we can improve it based on user needs. Google
-                        Analytics sets cookies that store anonymised information
-                        about:
-                      </p>
-                      <ul>
-                        <li>how you got to the site</li>
-                        <li>
-                          the pages you visit on GOV.UK and how long you spend
-                          on each page
-                        </li>
-                        <li>
-                          what you click on while you're visiting the site
-                        </li>
-                      </ul>
-                      <p>
-                        We do not allow Google to use or share the data about
-                        how you use this site.
+                        We use 2 types of cookie. You can choose which cookies
+                        you're happy for us to use.
                       </p>
 
-                      <FormGroup>
-                        <FormFieldRadioGroup<FormValues>
+                      <section className="govuk-!-margin-bottom-6">
+                        <h3>Cookies that measure website use</h3>
+                        <p>
+                          We use Google Analytics to measure how you use the
+                          website so we can improve it based on user needs.
+                          Google Analytics sets cookies that store anonymised
+                          information about:
+                        </p>
+                        <ul>
+                          <li>how you got to the site</li>
+                          <li>
+                            the pages you visit on GOV.UK and how long you spend
+                            on each page
+                          </li>
+                          <li>
+                            what you click on while you're visiting the site
+                          </li>
+                        </ul>
+                        <p>
+                          We do not allow Google to use or share the data about
+                          how you use this site.
+                        </p>
+                        <RHFFormFieldRadioGroup<FormValues>
+                          name="googleAnalytics"
                           legend="Allow Google Analytics cookies"
                           legendHidden
                           inline
-                          orderDirection={['desc']}
-                          showError={false}
-                          name="googleAnalytics"
-                          id="googleAnalytics"
                           options={[
-                            {
-                              label: 'On',
-                              value: 'on',
-                            },
-                            {
-                              label: 'Off',
-                              value: 'off',
-                            },
+                            { value: 'on', label: 'On' },
+                            { value: 'off', label: 'Off' },
                           ]}
+                          order={[]}
+                          showError={false}
                         />
-                      </FormGroup>
-                    </section>
-                    <section className="govuk-!-margin-bottom-6">
-                      <h3>Strictly necessary cookies</h3>
-                      <p>These essential cookies do things like:</p>
-                      <ul>
-                        <li>
-                          remember the notifications you've seen so we do not
-                          show them to you again
-                        </li>
-                        <li>remember your cookie settings</li>
-                      </ul>
-                      <p>They always need to be on.</p>
-                    </section>
+                      </section>
+                      <section className="govuk-!-margin-bottom-6">
+                        <h3>Strictly necessary cookies</h3>
+                        <p>These essential cookies do things like:</p>
+                        <ul>
+                          <li>
+                            remember the notifications you've seen so we do not
+                            show them to you again
+                          </li>
+                          <li>remember your cookie settings</li>
+                        </ul>
+                        <p>They always need to be on.</p>
+                      </section>
 
-                    <p>
-                      <Link to="/cookies/details">
-                        Find out more about cookies on Explore education
-                        statistics
-                      </Link>
-                    </p>
+                      <p>
+                        <Link to="/cookies/details">
+                          Find out more about cookies on Explore education
+                          statistics
+                        </Link>
+                      </p>
 
-                    <Button type="submit">Save changes</Button>
-                  </Form>
+                      <Button type="submit">Save changes</Button>
+                    </RHFForm>
+                  </>
                 );
               }}
-            </Formik>
+            </FormProvider>
           ) : (
             <p>
               <Link to="/cookies/details">

--- a/src/explore-education-statistics-frontend/src/modules/subscriptions/SubscriptionPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/subscriptions/SubscriptionPage.tsx
@@ -1,5 +1,7 @@
 import Button from '@common/components/Button';
-import { FormFieldTextInput, Form } from '@common/components/form';
+import RHFFormFieldTextInput from '@common/components/form/rhf/RHFFormFieldTextInput';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
 import useMounted from '@common/hooks/useMounted';
 import publicationService, {
   PublicationTitle,
@@ -10,7 +12,6 @@ import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
 import notificationService from '@frontend/services/notificationService';
 import classNames from 'classnames';
-import { Formik } from 'formik';
 import { GetServerSideProps, NextPage } from 'next';
 import React, { useState } from 'react';
 import withAxiosHandler from '@frontend/middleware/ssr/withAxiosHandler';
@@ -19,8 +20,6 @@ import styles from './SubscriptionPage.module.scss';
 interface FormValues {
   email: string;
 }
-
-const formId = 'subscriptionForm';
 
 interface Props {
   slug: string;
@@ -101,7 +100,8 @@ const SubscriptionPage: NextPage<Props> = ({
           </ul>
 
           {isMounted && (
-            <Formik<FormValues>
+            <FormProvider
+              enableReinitialize
               initialValues={{
                 email: '',
               }}
@@ -110,25 +110,30 @@ const SubscriptionPage: NextPage<Props> = ({
                   .required('Email is required')
                   .email('Enter a valid email'),
               })}
-              onSubmit={handleFormSubmit}
             >
-              {form => (
-                <Form id={formId} showSubmitError>
-                  <FormFieldTextInput<FormValues>
-                    label="Enter your email address"
-                    hint="This will only be used to subscribe you to updates. You can unsubscribe at any time"
-                    name="email"
-                    width={20}
-                  />
+              {({ formState }) => {
+                return (
+                  <RHFForm
+                    id="subscriptionForm"
+                    showSubmitError
+                    onSubmit={handleFormSubmit}
+                  >
+                    <RHFFormFieldTextInput<FormValues>
+                      label="Enter your email address"
+                      hint="This will only be used to subscribe you to updates. You can unsubscribe at any time"
+                      name="email"
+                      width={20}
+                    />
 
-                  <Button type="submit" disabled={form.isSubmitting}>
-                    {form.isSubmitting && form.isValid
-                      ? 'Submitting'
-                      : 'Subscribe'}
-                  </Button>
-                </Form>
-              )}
-            </Formik>
+                    <Button type="submit" disabled={formState.isSubmitting}>
+                      {formState.isSubmitting && formState.isValid
+                        ? 'Submitting'
+                        : 'Subscribe'}
+                    </Button>
+                  </RHFForm>
+                );
+              }}
+            </FormProvider>
           )}
         </>
       )}

--- a/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
@@ -82,7 +82,7 @@ Unselect England as a location
 
     # Workaround to avoid error summary stealing focus when closing dropdown
     user sets focus to element    id:locationFiltersForm-submit
-    user waits until h2 is visible    There is a problem
+    user waits until page contains    Select at least one location
 
     user closes details dropdown    National
 


### PR DESCRIPTION
Replaces uses of Formik with React Hook Form in the front end code base:
- table tool publication, location and time period steps
- cookies page
- subscription page

I haven't replaced Formik on the data catalogue page as this page will be changing fairly soon so it didn't seem worthwhile.