### PR TITLE
EES-4511 update ancillary file tab and text

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
@@ -43,7 +43,7 @@ const ReleaseDataPage = () => {
         </TabsSection>
         <TabsSection
           id={releaseDataPageTabIds.fileUploads}
-          title="Ancillary file uploads"
+          title="Supporting file uploads"
         >
           <ReleaseFileUploadsSection
             publicationId={release.publicationId}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -73,9 +73,37 @@ export default function ReleaseFileUploadsSection({
       <InsetText>
         <h3>Before you start</h3>
         <p>
-          Ancillary files are additional files attached to the release for users
-          to download. They will appear in the associated files list on the
-          release page and the download files page.
+          Supporting files are additional files attached to the release page for
+          users to download. These should be used sparingly and only when there
+          is no alternative. Please contact{' '}
+          <a href="mailto:explore.statistics@education.gov.uk">
+            explore.statistics@education.gov.uk
+          </a>{' '}
+          for advice if you are unsure.
+        </p>
+        <p>
+          As the publisher you are responsible for the accessibility of any
+          supporting files and ensuring that they are in line with the{' '}
+          <a
+            href="https://www.legislation.gov.uk/uksi/2018/852/contents/made"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Public Sector Bodies accessibility regulations 2018
+          </a>
+          .
+        </p>
+        <p>
+          If you are attaching a spreadsheet not in CSV format, then you must
+          review it against the{' '}
+          <a
+            href="https://analysisfunction.civilservice.gov.uk/policy-store/making-spreadsheets-accessible-a-brief-checklist-of-the-basics/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Analytical Function checklist for accessible spreadsheets
+          </a>
+          .
         </p>
       </InsetText>
 

--- a/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
@@ -72,7 +72,7 @@ Add data guidance
     user clicks button    Save guidance
 
 Add ancillary file
-    user clicks link    Ancillary file uploads
+    user clicks link    Supporting file uploads
     user waits until h2 is visible    Add file to release
     user enters text into element    label:Title    Test ancillary file 1
     user enters text into element    label:Summary    Test ancillary file 1 summary

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -81,10 +81,10 @@ Check subject appears in 'Data blocks' page
 
     user waits until page contains    Updated Absence in PRUs
 
-Navigate to 'Data and files' page - 'Ancillary file uploads' tab
+Navigate to 'Data and files' page - 'Supporting file uploads' tab
     user clicks link    Data and files
     user waits until h2 is visible    Add data file to release
-    user clicks link    Ancillary file uploads
+    user clicks link    Supporting file uploads
     user waits until h2 is visible    Add file to release
     user waits until page contains    No files have been uploaded
 
@@ -148,11 +148,11 @@ Validate 'Explore data and files' section
     user checks element contains button    ${other_files}    Test 1 (txt, 12 B)
     user checks element should contain    ${other_files}    Test 1 summary
 
-Navigate back to 'Ancillary file uploads' tab
+Navigate back to 'Supporting file uploads' tab
     user clicks link    Data and files
     user waits until h2 is visible    Add data file to release
 
-    user clicks link    Ancillary file uploads
+    user clicks link    Supporting file uploads
     user waits until h2 is visible    Add file to release
 
 Change ancillary file

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -44,7 +44,7 @@ Add data guidance
     user clicks button    Save guidance
 
 Add ancillary file
-    user clicks link    Ancillary file uploads
+    user clicks link    Supporting file uploads
     user waits until h2 is visible    Add file to release
 
     user enters text into element    label:Title    Test ancillary file 1
@@ -243,7 +243,7 @@ Confirm data replacement
 Edit ancillary file and replace data
     [Documentation]    EES-4315
     user clicks link    Data and files
-    user clicks link    Ancillary file uploads
+    user clicks link    Supporting file uploads
     user waits until h2 is visible    Uploaded files
 
     user waits until page contains accordion section    Test ancillary file 1
@@ -412,7 +412,7 @@ Verify that the Data and Files are unchanged
 
 Verify that the ancillary file is unchanged
     user clicks link    Data and files
-    user clicks link    Ancillary file uploads
+    user clicks link    Supporting file uploads
     user waits until h2 is visible    Uploaded files
     user waits until page contains accordion section    Test ancillary file 1
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -54,7 +54,7 @@ Add data guidance
     user clicks button    Save guidance
 
 Add ancillary file
-    user clicks link    Ancillary file uploads
+    user clicks link    Supporting file uploads
     user waits until h2 is visible    Add file to release
 
     user enters text into element    label:Title    Test ancillary file 1
@@ -554,7 +554,7 @@ Confirm amendment has footnotes
 
 Add ancillary file to amendment
     user clicks link    Data and files
-    user clicks link    Ancillary file uploads
+    user clicks link    Supporting file uploads
     user waits until h2 is visible    Add file to release
 
     user enters text into element    label:Title    Test ancillary file 2


### PR DESCRIPTION
Changes the 'Ancillary file uploads' tab to ‘Supporting file uploads’ and updates the 'before you start' text.

![supporting-files](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/963557fb-2261-4801-84f7-b0a4848ddd58)
