### PR TITLE
EES-4530: Change Renovate config to allow major updates to EF CLI tools version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,12 +71,10 @@
       "description": "Packages which need major versions to be in sync with the EF Core version or the .NET version",
       "matchDatasources": ["nuget"],
       "matchPackagePrefixes": [
-        "dotnet-ef",
         "Microsoft.AspNetCore",
         "Microsoft.EntityFrameworkCore",
         "Microsoft.Extensions",
         "Thinktecture.EntityFrameworkCore",
-        "Microsoft.VisualStudio.Web.CodeGeneration.Design",
         "MockQueryable.Moq"
       ],
       "matchUpdateTypes": ["major"],

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -59,7 +59,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.21" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.21" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="6.0.21" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.16" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />


### PR DESCRIPTION
This PR makes a small change to the Renovate config to allow major version updates to the [.NET Core CLI](https://learn.microsoft.com/en-us/ef/core/cli/dotnet).

The tools are backwards compatible with EF 6. I tested creating a database migration using the latest tools and @markhiveit helped me check there is no dependency on having .NET 7 SDK installed.

After merging this Renovate should detect a change, updating .NET Command-line Tools 6.0.21 to .NET Command-line Tools 7.0.10.

### Other changes
- Remove Admin dependency on `Microsoft.VisualStudio.Web.CodeGeneration.Design` which is related to the .[NET Core scaffolding engine](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/tools/dotnet-aspnet-codegenerator?view=aspnetcore-7.0). It provides the command line tool `dotnet aspnet-codegenerator` to be able to scaffold controllers, views, pages etc. I believe we don't use this.
