### PR TITLE
EES-4349 fix broken visually hidden footnotes heading text

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -140,6 +140,7 @@ const DataBlockTabs = ({
                   key={dataBlock.id}
                   captionTitle={dataBlock?.heading}
                   dataBlockId={dataBlock.id}
+                  footnotesHeadingHiddenText={`for ${dataBlock?.heading}`}
                   fullTable={fullTable}
                   source={dataBlock?.source}
                   tableHeadersConfig={

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -13,6 +13,7 @@ interface Props {
   captionTitle?: string;
   dataBlockId?: string;
   footnotesClassName?: string;
+  footnotesHeadingHiddenText?: string;
   fullTable: FullTable;
   query?: ReleaseTableDataQuery;
   source?: string;
@@ -26,6 +27,7 @@ const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
       captionTitle,
       dataBlockId,
       footnotesClassName,
+      footnotesHeadingHiddenText,
       fullTable,
       query,
       source,
@@ -81,10 +83,10 @@ const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
                 ? `dataTableFootnotes-${dataBlockId}`
                 : 'dataTableFootnotes'
             }
+            footnotesHeadingHiddenText={footnotesHeadingHiddenText}
             ref={dataTableRef}
             footnotes={subjectMeta.footnotes}
             source={source}
-            footnotesHeadingHiddenText={`for ${captionTitle}`}
           />
         </>
       );


### PR DESCRIPTION
On the table tool the Footnotes heading had visually hidden text for screen reader users of “for undefined”. This removes the hidden text, it's only needed on the footnotes heading on data blocks as there can be multiple data blocks on a release page.