### PR TITLE
EES-4531 Fix unpublished adopted methodology bug

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlerTests.cs
@@ -8,7 +8,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using Moq;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
@@ -250,6 +251,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             IMethodologyImageService? methodologyImageService = null,
             IMethodologyApprovalService? methodologyApprovalService = null,
             IMethodologyCacheService? methodologyCacheService = null,
+            IPublishingService? publishingService = null,
             IUserService? userService = null)
         {
             return new(
@@ -261,6 +263,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 methodologyImageService ?? Mock.Of<IMethodologyImageService>(),
                 methodologyApprovalService ?? Mock.Of<IMethodologyApprovalService>(Strict),
                 methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
+                publishingService ?? Mock.Of<IPublishingService>(Strict),
                 userService ?? Mock.Of<IUserService>()
             );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -71,7 +71,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         new List<AllMethodologiesThemeViewModel>()));
 
             var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(Strict);
-            methodologyVersionRepository.Setup(mock => mock.IsToBePublished(
+            methodologyVersionRepository.Setup(mock => mock.GetMethodologyVersionToBePublished(
                     It.Is<Methodology>(m => m.Id == methodology.Id)))
                 .ReturnsAsync((Guid?)null);
 
@@ -151,7 +151,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         new List<AllMethodologiesThemeViewModel>()));
 
             var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(Strict);
-            methodologyVersionRepository.Setup(mock => mock.IsToBePublished(
+            methodologyVersionRepository.Setup(mock => mock.GetMethodologyVersionToBePublished(
                     It.Is<Methodology>(m => m.Id == methodology.Id)))
                 .ReturnsAsync(methodology.Versions[0].Id);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -87,7 +87,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
                     // If the adopted methodology is unpublished, it may require publishing,
                     // if the adopting publication is live
-                    var versionToBePublishedId = await _methodologyVersionRepository.IsToBePublished(methodology);
+                    var versionToBePublishedId = await _methodologyVersionRepository
+                        .GetMethodologyVersionToBePublished(methodology);
                     if (versionToBePublishedId != null)
                     {
                         var versionToBePublished = _context.MethodologyVersions

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
@@ -21,6 +21,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 
         Task<bool> IsToBePublished(MethodologyVersion methodologyVersion);
 
+        Task<Guid?> IsToBePublished(Methodology methodology);
+
         Task PublicationTitleChanged(Guid publicationId, string originalSlug, string updatedTitle, string updatedSlug);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 
         Task<bool> IsToBePublished(MethodologyVersion methodologyVersion);
 
-        Task<Guid?> IsToBePublished(Methodology methodology);
+        Task<Guid?> GetMethodologyVersionToBePublished(Methodology methodology);
 
         Task PublicationTitleChanged(Guid publicationId, string originalSlug, string updatedTitle, string updatedSlug);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
@@ -189,7 +189,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
             return await IsVersionScheduledForPublishingWithPublishedRelease(methodologyVersion);
         }
 
-        public async Task<Guid?> IsToBePublished(Methodology methodology)
+        public async Task<Guid?> GetMethodologyVersionToBePublished(Methodology methodology)
         {
             await _contentDbContext.Entry(methodology)
                 .Collection(m => m.Versions)


### PR DESCRIPTION
This fixes an issue that arose of the work to introduce the `Methodology.LatestPublishedVersionId` column in EES-4504.

We missed the scenario where a unpublished methodology could be published if it is adopted by a publication that is already live.

Before EES-4504, this would have meant that the methodology version's files wouldn't have been published and it's published date wouldn't have been set, but as whether it was public was determined by IsPubiclyAccessible (now IsToBePublished), they would appear on the public page. After the ticket, the methodology version won't appear to be published at all, since now the service mostly checks the Methodology.LatestPublishedVersionId column to determine if something is live.

