### PR TITLE
EES-4547 Fix snapshot generation for methodologies page

### DIFF
--- a/src/explore-education-statistics-common/src/components/AccordionSection.tsx
+++ b/src/explore-education-statistics-common/src/components/AccordionSection.tsx
@@ -160,7 +160,10 @@ function HeadingContent({
   return (
     <>
       <span className={classes.sectionHeadingText}>
-        <span className="govuk-accordion__section-heading-text-focus">
+        <span
+          id="theme-heading"
+          className={classNames('govuk-accordion__section-heading-text-focus')}
+        >
           {heading}
         </span>
       </span>

--- a/src/explore-education-statistics-common/src/components/AccordionSection.tsx
+++ b/src/explore-education-statistics-common/src/components/AccordionSection.tsx
@@ -161,8 +161,8 @@ function HeadingContent({
     <>
       <span className={classes.sectionHeadingText}>
         <span
-          id="theme-heading"
-          className={classNames('govuk-accordion__section-heading-text-focus')}
+          data-testid="accordionSection-heading"
+          className="govuk-accordion__section-heading-text-focus"
         >
           {heading}
         </span>

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
@@ -16,7 +16,9 @@ exports[`AccordionSection renders correctly with required props 1`] = `
               type="button"
       >
         <span class="govuk-accordion__section-heading-text">
-          <span class="govuk-accordion__section-heading-text-focus">
+          <span id="theme-heading"
+                class="govuk-accordion__section-heading-text-focus"
+          >
             Test heading
           </span>
         </span>
@@ -66,7 +68,9 @@ exports[`AccordionSection renders with caption 1`] = `
               type="button"
       >
         <span class="govuk-accordion__section-heading-text">
-          <span class="govuk-accordion__section-heading-text-focus">
+          <span id="theme-heading"
+                class="govuk-accordion__section-heading-text-focus"
+          >
             Test heading
           </span>
         </span>
@@ -121,7 +125,9 @@ exports[`AccordionSection renders with different heading size 1`] = `
               type="button"
       >
         <span class="govuk-accordion__section-heading-text">
-          <span class="govuk-accordion__section-heading-text-focus">
+          <span id="theme-heading"
+                class="govuk-accordion__section-heading-text-focus"
+          >
             Test heading
           </span>
         </span>

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`AccordionSection renders correctly with required props 1`] = `
               type="button"
       >
         <span class="govuk-accordion__section-heading-text">
-          <span id="theme-heading"
+          <span data-testid="accordionSection-heading"
                 class="govuk-accordion__section-heading-text-focus"
           >
             Test heading
@@ -68,7 +68,7 @@ exports[`AccordionSection renders with caption 1`] = `
               type="button"
       >
         <span class="govuk-accordion__section-heading-text">
-          <span id="theme-heading"
+          <span data-testid="accordionSection-heading"
                 class="govuk-accordion__section-heading-text-focus"
           >
             Test heading
@@ -125,7 +125,7 @@ exports[`AccordionSection renders with different heading size 1`] = `
               type="button"
       >
         <span class="govuk-accordion__section-heading-text">
-          <span id="theme-heading"
+          <span data-testid="accordionSection-heading"
                 class="govuk-accordion__section-heading-text-focus"
           >
             Test heading

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyIndexPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyIndexPage.tsx
@@ -80,7 +80,7 @@ const MethodologyIndexPage: NextPage<Props> = ({ themes = [] }) => {
                 <ul className="govuk-!-margin-top-0">
                   {orderBy(getMethodologiesForTopics(topics), 'title').map(
                     methodology => (
-                      <li key={methodology.id}>
+                      <li key={methodology.id} id="methodology-heading">
                         <Link to={`/methodology/${methodology.slug}`}>
                           {methodology.title}
                         </Link>

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyIndexPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyIndexPage.tsx
@@ -80,7 +80,7 @@ const MethodologyIndexPage: NextPage<Props> = ({ themes = [] }) => {
                 <ul className="govuk-!-margin-top-0">
                   {orderBy(getMethodologiesForTopics(topics), 'title').map(
                     methodology => (
-                      <li key={methodology.id} id="methodology-heading">
+                      <li key={methodology.id}>
                         <Link to={`/methodology/${methodology.slug}`}>
                           {methodology.title}
                         </Link>

--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -209,19 +209,12 @@ class SnapshotService:
         themes = []
 
         for theme_index, theme_html in enumerate(theme_sections):
-            theme = {"theme_heading": theme_html.select_one(f"#themes-{theme_index + 1}-heading").string, "topics": []}
+            theme = {"theme_heading": theme_html.select_one(f"#theme-heading").string, "methodologies": []}
 
-            topics = theme_html.select('[id^="topic-details-"]') or []
+            methodologies = theme_html.select(f"#methodology-heading") or []
 
-            for topic_html in topics:
-                topic = {"topic_heading": topic_html.select_one('[id^="topic-heading-"]').string, "methodologies": []}
-
-                methodologies = topic_html.select('[id^="methodology-heading-"]') or []
-
-                for methodology_heading in methodologies:
-                    topic["methodologies"].append(methodology_heading.string)
-
-                theme["topics"].append(topic)
+            for methodology_heading in methodologies:
+                theme["methodologies"].append(methodology_heading.string)
 
             themes.append(theme)
         return json.dumps(themes, sort_keys=True, indent=2)

--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -209,9 +209,12 @@ class SnapshotService:
         themes = []
 
         for theme_index, theme_html in enumerate(theme_sections):
-            theme = {"theme_heading": theme_html.select_one(f"#theme-heading").string, "methodologies": []}
+            theme = {
+                "theme_heading": theme_html.select_one(f"[data-testid='accordionSection-heading']").string,
+                "methodologies": [],
+            }
 
-            methodologies = theme_html.select(f"#methodology-heading") or []
+            methodologies = theme_html.select(f"li") or []
 
             for methodology_heading in methodologies:
                 theme["methodologies"].append(methodology_heading.string)


### PR DESCRIPTION
This fixes an issue caused when the methodologies page was reworked to remove topics and update to use the new GOV.UK accordions.

As we've added new id tags to elements to generate the methodologies' page snapshot, the snapshots for production can be updated once this has been deployed to production.