### PR TITLE
EES-4531 Only allow published methodologies to be adopted

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -44,6 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             // Setup methodology owned by a different publication
             var methodology = new Methodology
             {
+                LatestPublishedVersionId = Guid.NewGuid(),
                 Publications = new List<PublicationMethodology>
                 {
                     new()
@@ -51,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         Publication = new Publication(),
                         Owner = true
                     }
-                }
+                },
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -101,6 +102,45 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         }
 
         [Fact]
+        public async Task AdoptMethodology_CannotAdoptUnpublishedMethodology()
+        {
+            var publication = new Publication();
+
+            // Setup methodology owned by a different publication
+            var methodology = new Methodology
+            {
+                LatestPublishedVersionId = null, // methodology is unpublished
+                Publications = new List<PublicationMethodology>
+                {
+                    new()
+                    {
+                        Publication = new Publication(),
+                        Owner = true
+                    }
+                },
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await context.Publications.AddAsync(publication);
+                await context.Methodologies.AddAsync(methodology);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyService(
+                    contentDbContext: context);
+
+                var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+                    service.AdoptMethodology(publication.Id, methodology.Id));
+                Assert.Equal("Cannot adopt an unpublished methodology", exception.Message);
+            }
+        }
+
+        [Fact]
         public async Task AdoptMethodology_AlreadyAdoptedByPublicationFails()
         {
             var publication = new Publication();
@@ -108,6 +148,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             // Setup methodology adopted by this publication
             var methodology = new Methodology
             {
+                LatestPublishedVersionId = Guid.NewGuid(),
                 Publications = new List<PublicationMethodology>
                 {
                     new()
@@ -167,6 +208,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             // Setup methodology owned by this publication
             var methodology = new Methodology
             {
+                LatestPublishedVersionId = Guid.NewGuid(),
                 Publications = new List<PublicationMethodology>
                 {
                     new()
@@ -174,7 +216,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         Publication = publication,
                         Owner = true
                     }
-                }
+                },
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -527,7 +569,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var methodology = new Methodology
             {
-                Slug = "test-publication"
+                LatestPublishedVersionId = Guid.NewGuid(),
+                Slug = "test-publication",
             };
 
             var publication = new Publication
@@ -603,6 +646,68 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(publication.Id, viewModel.OwningPublication.Id);
                 Assert.Equal("Owning publication", viewModel.OwningPublication.Title);
                 Assert.Empty(viewModel.OtherPublications);
+            }
+        }
+
+        [Fact]
+        public async Task GetAdoptableMethodologies_NoUnpublishedMethodologies()
+        {
+            var methodology = new Methodology
+            {
+                LatestPublishedVersionId = null, // methodology is unpublished
+                Slug = "test-publication",
+            };
+
+            var publication = new Publication
+            {
+                Title = "Owning publication",
+                Methodologies = new List<PublicationMethodology>
+                {
+                    new()
+                    {
+                        Methodology = methodology,
+                        Owner = true
+                    }
+                }
+            };
+
+            var methodologyVersion = new MethodologyVersion
+            {
+                Methodology = methodology,
+                InternalReleaseNote = "Test approval",
+                Published = null,
+                PublishingStrategy = Immediately,
+                Status = Draft,
+                AlternativeTitle = "Alternative title"
+            };
+
+            var adoptingPublication = new Publication();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await context.Publications.AddRangeAsync(publication, adoptingPublication);
+                await context.Methodologies.AddAsync(methodology);
+                await context.MethodologyVersions.AddAsync(methodologyVersion);
+                await context.SaveChangesAsync();
+            }
+
+            var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
+            methodologyRepository.Setup(mock =>
+                    mock.GetUnrelatedToPublication(adoptingPublication.Id))
+                .ReturnsAsync(ListOf(methodology));
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyService(
+                    contentDbContext: context,
+                    methodologyRepository: methodologyRepository.Object);
+
+                var result = await service.GetAdoptableMethodologies(adoptingPublication.Id);
+                var adoptableMethodologyList = result.AssertRight();
+
+                Assert.Empty(adoptableMethodologyList);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/MethodologyMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/MethodologyMigrationController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -23,13 +24,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
     {
         private readonly ContentDbContext _context;
         private readonly IMethodologyVersionRepository _methodologyVersionRepository;
+        private readonly IMethodologyCacheService _methodologyCacheService;
 
         public MethodologyMigrationController(
             ContentDbContext context,
-            IMethodologyVersionRepository methodologyVersionRepository)
+            IMethodologyVersionRepository methodologyVersionRepository,
+            IMethodologyCacheService methodologyCacheService)
         {
             _context = context;
             _methodologyVersionRepository = methodologyVersionRepository;
+            _methodologyCacheService = methodologyCacheService;
         }
 
         public class MethodologyMigrationResult
@@ -68,6 +72,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
             if (!dryRun)
             {
                 await _context.SaveChangesAsync();
+                await _methodologyCacheService.UpdateSummariesTree();
             }
 
             return results;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -65,9 +65,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 .CheckEntityExists<Publication>(publicationId, q =>
                     q.Include(p => p.Methodologies))
                 .OnSuccess(_userService.CheckCanAdoptMethodologyForPublication)
-                .OnSuccessDo(_ => _persistenceHelper.CheckEntityExists<Methodology>(methodologyId))
-                .OnSuccess<ActionResult, Publication, Unit>(async publication =>
+                .OnSuccessCombineWith(_ => _persistenceHelper.CheckEntityExists<Methodology>(methodologyId))
+                .OnSuccess<ActionResult, Tuple<Publication,Methodology>, Unit>(async tuple =>
                 {
+                    var (publication, methodology) = tuple;
+
+                    if (methodology.LatestPublishedVersionId == null)
+                    {
+                        throw new ArgumentException("Cannot adopt an unpublished methodology");
+                    }
+
                     if (publication.Methodologies.Any(pm => pm.MethodologyId == methodologyId))
                     {
                         return ValidationActionResult(CannotAdoptMethodologyAlreadyLinkedToPublication);
@@ -123,10 +130,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 .OnSuccess(_userService.CheckCanAdoptMethodologyForPublication)
                 .OnSuccess(async publication =>
                 {
-                    var methodologies = await _methodologyRepository.GetUnrelatedToPublication(publication.Id);
-                    var latestVersions = await methodologies.SelectAsync(methodology =>
-                        _methodologyVersionRepository.GetLatestVersion(methodology.Id));
-                    return (await latestVersions.SelectAsync(BuildMethodologyVersionViewModel)).ToList();
+                    var publishedMethodologies = (await _methodologyRepository
+                        .GetUnrelatedToPublication(publication.Id))
+                        .Where(m => m.LatestPublishedVersionId != null);
+                    var latestVersions = await publishedMethodologies
+                        .SelectAsync(methodology => _methodologyVersionRepository.GetLatestVersion(methodology.Id));
+                    return (await latestVersions
+                        .SelectAsync(BuildMethodologyVersionViewModel)).ToList();
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -219,6 +219,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return source.Where(item => item is not null)!;
         }
 
+        public static IAsyncEnumerable<T> WhereNotNull<T>(this IAsyncEnumerable<T?> source)
+            where T: class
+        {
+            return source.Where(item => item is not null)!;
+        }
+
         public static IEnumerable<(T item, int index)> WithIndex<T>(this IEnumerable<T> self) =>
             self.Select((item, index) => (item, index));
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
@@ -170,12 +170,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         }
 
         [Fact]
-        public async Task GetUnrelatedToPublication()
+        public async Task GetPublishedMethodologiesUnrelatedToPublication()
         {
             var publication = new Publication();
 
             var methodologyOwnedByThisPublication = new Methodology
             {
+                LatestPublishedVersionId = Guid.NewGuid(),
                 Publications = new List<PublicationMethodology>
                 {
                     new()
@@ -193,6 +194,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
 
             var methodologyAdoptedByThisPublication = new Methodology
             {
+                LatestPublishedVersionId = Guid.NewGuid(),
                 Publications = new List<PublicationMethodology>
                 {
                     new()
@@ -208,8 +210,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 }
             };
 
+            var unpublishedMethodologyUnrelatedToThisPublication = new Methodology
+            {
+                LatestPublishedVersionId = null,
+                Publications = new List<PublicationMethodology>
+                {
+                    new()
+                    {
+                        Publication = new Publication(),
+                        Owner = true
+                    },
+                    new()
+                    {
+                        Publication = new Publication(),
+                        Owner = false
+                    }
+                }
+            };
+
             var methodologyUnrelatedToThisPublication = new Methodology
             {
+                LatestPublishedVersionId = Guid.NewGuid(),
                 Publications = new List<PublicationMethodology>
                 {
                     new()
@@ -233,6 +254,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 await contentDbContext.Methodologies.AddRangeAsync(
                     methodologyOwnedByThisPublication,
                     methodologyAdoptedByThisPublication,
+                    unpublishedMethodologyUnrelatedToThisPublication,
                     methodologyUnrelatedToThisPublication
                 );
 
@@ -243,7 +265,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyRepository(contentDbContext);
 
-                var result = await service.GetUnrelatedToPublication(publication.Id);
+                var result = await service.GetPublishedMethodologiesUnrelatedToPublication(publication.Id);
 
                 Assert.Single(result);
                 Assert.Equal(methodologyUnrelatedToThisPublication.Id, result[0].Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyRepository.cs
@@ -13,6 +13,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 
         Task<List<Guid>> GetAllPublicationIds(Guid methodologyId);
 
-        Task<List<Methodology>> GetUnrelatedToPublication(Guid publicationId);
+        Task<List<Methodology>> GetPublishedMethodologiesUnrelatedToPublication(Guid publicationId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
@@ -49,11 +49,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                 .ToListAsync();
         }
 
-        public async Task<List<Methodology>> GetUnrelatedToPublication(Guid publicationId)
+        public async Task<List<Methodology>> GetPublishedMethodologiesUnrelatedToPublication(Guid publicationId)
         {
             return await _contentDbContext.Methodologies
                 .Include(m => m.Publications)
-                .Where(m => m.Publications.All(pm => pm.PublicationId != publicationId))
+                .Where(m =>
+                    m.Publications.All(pm => pm.PublicationId != publicationId)
+                    && m.LatestPublishedVersionId != null)
                 .ToListAsync();
         }
     }

--- a/src/explore-education-statistics-admin/src/pages/methodology/adopt-methodology/components/AdoptMethodologyForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/adopt-methodology/components/AdoptMethodologyForm.tsx
@@ -83,16 +83,18 @@ const AdoptMethodologyForm = ({ methodologies, onCancel, onSubmit }: Props) => {
       initialValues={{ methodologyId: '' }}
       onSubmit={handleSubmit}
       validationSchema={Yup.object<FormValues>({
-        methodologyId: Yup.string().required('Select a methodology to adopt'),
+        methodologyId: Yup.string().required(
+          'Select a published methodology to adopt',
+        ),
       })}
     >
       <Form id="adoptMethodologyForm">
         <FormFieldRadioSearchGroup
           id="selectMethodology"
-          legend="Select a methodology"
+          legend="Select a published methodology"
           name="methodologyId"
           options={radioOptions}
-          searchLabel="Search for a methodology"
+          searchLabel="Search for a published methodology"
         />
         <ButtonGroup>
           <Button type="submit">Save</Button>

--- a/src/explore-education-statistics-admin/src/pages/methodology/adopt-methodology/components/__tests__/AdoptMethodologyForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/adopt-methodology/components/__tests__/AdoptMethodologyForm.test.tsx
@@ -59,10 +59,12 @@ describe('AdoptMethodologyForm', () => {
       />,
     );
 
-    expect(screen.getByText('Select a methodology')).toBeInTheDocument();
+    expect(
+      screen.getByText('Select a published methodology'),
+    ).toBeInTheDocument();
 
     expect(
-      screen.getByLabelText('Search for a methodology'),
+      screen.getByLabelText('Search for a published methodology'),
     ).toBeInTheDocument();
 
     const radios = screen.getAllByRole('radio');
@@ -141,7 +143,9 @@ describe('AdoptMethodologyForm', () => {
     });
 
     expect(
-      screen.getByRole('link', { name: 'Select a methodology to adopt' }),
+      screen.getByRole('link', {
+        name: 'Select a published methodology to adopt',
+      }),
     ).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
   });

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationAdoptMethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationAdoptMethodologyPage.test.tsx
@@ -77,11 +77,13 @@ describe('PublicationAdoptMethodologyPage', () => {
     expect(screen.getByText('Adopt a methodology')).toBeInTheDocument();
 
     await waitFor(() =>
-      expect(screen.getByText('Select a methodology')).toBeInTheDocument(),
+      expect(
+        screen.getByText('Select a published methodology'),
+      ).toBeInTheDocument(),
     );
 
     expect(
-      screen.getByLabelText('Search for a methodology'),
+      screen.getByLabelText('Search for a published methodology'),
     ).toBeInTheDocument();
 
     const radios = screen.getAllByRole('radio');
@@ -113,10 +115,12 @@ describe('PublicationAdoptMethodologyPage', () => {
       ).toBeInTheDocument(),
     );
 
-    expect(screen.queryByText('Select a methodology')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Select a published methodology'),
+    ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByLabelText('Search for a methodology'),
+      screen.queryByLabelText('Search for a published methodology'),
     ).not.toBeInTheDocument();
 
     expect(screen.queryByRole('radio')).not.toBeInTheDocument();
@@ -147,7 +151,9 @@ describe('PublicationAdoptMethodologyPage', () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByText('Select a methodology')).toBeInTheDocument(),
+      expect(
+        screen.getByText('Select a published methodology'),
+      ).toBeInTheDocument(),
     );
 
     userEvent.click(screen.getByLabelText('Methodology 2'));
@@ -184,7 +190,9 @@ describe('PublicationAdoptMethodologyPage', () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByText('Select a methodology')).toBeInTheDocument(),
+      expect(
+        screen.getByText('Select a published methodology'),
+      ).toBeInTheDocument(),
     );
 
     userEvent.click(screen.getByRole('button', { name: 'Cancel' }));

--- a/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
@@ -17,9 +17,21 @@ ${RELEASE_NAME}=                    Calendar year 2000
 
 
 *** Test Cases ***
-Create test data
-    user creates test publication via api    ${OWNING_PUBLICATION_NAME}
+Create owning publication release and publish
+    ${owning_publication_id}=    user creates test publication via api    ${OWNING_PUBLICATION_NAME}
+    user creates test release via api    ${owning_publication_id}    CY    2001
+    user navigates to draft release page from dashboard    ${OWNING_PUBLICATION_NAME}    Calendar year 2001
+    user navigates to content page    ${OWNING_PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
+    user approves release for immediate publication
+
+Create owning publication methodology and publish
     user creates methodology for publication    ${OWNING_PUBLICATION_NAME}
+    user approves methodology for publication    ${OWNING_PUBLICATION_NAME}    ${OWNING_PUBLICATION_NAME}
+    user creates methodology amendment for publication    ${OWNING_PUBLICATION_NAME}    ${OWNING_PUBLICATION_NAME}
+
+Create adopting publication
     ${adopting_publication_id}=    user creates test publication via api    ${ADOPTING_PUBLICATION_NAME}
     user creates test release via api    ${adopting_publication_id}    CY    2000
 

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -218,12 +218,22 @@ Approve the owned methodology and verify the warning disappears
     ...    1 thing you may have forgotten, but do not need to resolve to publish this release.
     user checks checklist warnings does not contain link    A methodology for this publication is not yet approved
 
-Adopt a Draft methodology
-    user creates test publication via api    ${ADOPTED_PUBLICATION_NAME}
+Create published methodology for adopted publication
+    ${adopted_publication_id}    user creates test publication via api    ${ADOPTED_PUBLICATION_NAME}
+    user creates test release via api    ${adopted_publication_id}    CY    2001
+    user navigates to draft release page from dashboard    ${ADOPTED_PUBLICATION_NAME}    Calendar year 2001
+    user navigates to content page    ${ADOPTED_PUBLICATION_NAME}
+    user adds headlines text block
+    user adds content to headlines text block    Headline text block text
+    user approves release for immediate publication
+
     user creates methodology for publication    ${ADOPTED_PUBLICATION_NAME}
+    user approves methodology for publication    ${ADOPTED_PUBLICATION_NAME}    ${ADOPTED_PUBLICATION_NAME}
 
-    user waits until page contains link    ${ADOPTED_PUBLICATION_NAME}
+Create new draft amendment for methodology
+    user creates methodology amendment for publication    ${ADOPTED_PUBLICATION_NAME}    ${ADOPTED_PUBLICATION_NAME}
 
+Adopt a methodology with a draft amendment
     user navigates to methodologies on publication page    ${PUBLICATION_NAME}
 
     user clicks link    Adopt an existing methodology
@@ -231,7 +241,7 @@ Adopt a Draft methodology
     user clicks radio    ${ADOPTED_PUBLICATION_NAME}
     user clicks button    Save
 
-Check that having a Draft methodology adopted by this Release's Publication will show a checklist warning
+Check that having a draft methodology amendment adopted by this Release's Publication will show a checklist warning
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    Financial year 3000-01
     user edits release status
@@ -239,7 +249,7 @@ Check that having a Draft methodology adopted by this Release's Publication will
     ...    2 things you may have forgotten, but do not need to resolve to publish this release.
     user checks checklist warnings contains link    A methodology for this publication is not yet approved
 
-Approve the adopted methodology and verify the warning disappears
+Approve the adopted methodology amendment and verify the warning disappears
     user approves methodology for publication    ${ADOPTED_PUBLICATION_NAME}
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    Financial year 3000-01


### PR DESCRIPTION
In testing for EES-4504, we noticed that we weren't covering this scenario:
- A unpublished publication creates a new methodology. That methodology remains unpublished.
- A live publication adopts that unpublished methodology.

In this instance, we might expect the methodology to be published as soon as it is adopted. And so we would need to set `LatestPublishedVersionId` alongside the methodology verison's published date, and publish related files.

This PR fixes this issue by only allowing published methodologies to be adopted. This means we don't have to cover the above scenario of potentially needing to publish a methodology at the moment it is adopted. 

This is more intuitive for users - someone adopting a methodology may not realise they're publishing it - and also simplifies the logic - e.g. if someone adopts a methodology and thereby publishes it, what happens if they unadopt it?

### Other changes

- Added a call to update cached methodology summaries as part of the MethodologyMigrationController endpoint.