### PR TITLE
EES-4426 Remove MethodologyVersion.InternalReleaseNote

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
@@ -120,7 +120,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 VerifyAllMocks(contentService, methodologyVersionRepository);
 
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Id);
-                Assert.Equal("Test approval", updatedMethodologyVersion.InternalReleaseNote);
                 Assert.Null(updatedMethodologyVersion.Published);
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
                 Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
@@ -139,6 +138,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(Immediately, updatedMethodology.PublishingStrategy);
                 Assert.True(updatedMethodology.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
+
+                var statusList = await context
+                    .MethodologyStatus
+                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
+                    .ToListAsync();
+                var status = Assert.Single(statusList);
+                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
+                Assert.Equal("Test approval", status.InternalReleaseNote);
+                Assert.Equal(Approved, status.ApprovalStatus);
+                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
+                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -237,7 +247,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 VerifyAllMocks(contentService, imageService, methodologyVersionRepository);
 
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Id);
-                Assert.Equal("Test approval", updatedMethodologyVersion.InternalReleaseNote);
                 Assert.Null(updatedMethodologyVersion.Published);
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
                 Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
@@ -256,6 +265,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(Immediately, updatedMethodology.PublishingStrategy);
                 Assert.True(updatedMethodology.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
+
+                var statusList = await context
+                    .MethodologyStatus
+                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
+                    .ToListAsync();
+                var status = Assert.Single(statusList);
+                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
+                Assert.Equal("Test approval", status.InternalReleaseNote);
+                Assert.Equal(Approved, status.ApprovalStatus);
+                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
+                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -604,12 +624,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 VerifyAllMocks(contentService, methodologyVersionRepository);
 
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Id);
-                Assert.Equal("Test approval", updatedMethodologyVersion.InternalReleaseNote);
                 Assert.False(updatedMethodologyVersion.Published.HasValue);
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
                 Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
                 Assert.Equal(request.Status, updatedMethodologyVersion.Status);
-                Assert.Equal(request.LatestInternalReleaseNote, updatedMethodologyVersion.InternalReleaseNote);
                 Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
             }
 
@@ -623,10 +641,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.False(updatedMethodologyVersion.Published.HasValue);
                 Assert.Equal(Approved, updatedMethodologyVersion.Status);
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
-                Assert.Equal(request.LatestInternalReleaseNote, updatedMethodologyVersion.InternalReleaseNote);
                 Assert.True(updatedMethodologyVersion.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
                 Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
+
+                var statusList = await context
+                    .MethodologyStatus
+                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
+                    .ToListAsync();
+                var status = Assert.Single(statusList);
+                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
+                Assert.Equal("Test approval", status.InternalReleaseNote);
+                Assert.Equal(Approved, status.ApprovalStatus);
+                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
+                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -702,13 +730,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     methodologyCacheService);
 
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Id);
-                Assert.Equal("Test approval", updatedMethodologyVersion.InternalReleaseNote);
                 Assert.True(updatedMethodologyVersion.Published.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Published!.Value).Milliseconds, 0, 1500);
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
                 Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
                 Assert.Equal(request.Status, updatedMethodologyVersion.Status);
-                Assert.Equal(request.LatestInternalReleaseNote, updatedMethodologyVersion.InternalReleaseNote);
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
             }
 
@@ -723,10 +749,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Published!.Value).Milliseconds, 0, 1500);
                 Assert.Equal(Approved, updatedMethodologyVersion.Status);
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
-                Assert.Equal(request.LatestInternalReleaseNote, updatedMethodologyVersion.InternalReleaseNote);
                 Assert.True(updatedMethodologyVersion.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
+
+                var statusList = await context
+                    .MethodologyStatus
+                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
+                    .ToListAsync();
+                var status = Assert.Single(statusList);
+                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
+                Assert.Equal("Test approval", status.InternalReleaseNote);
+                Assert.Equal(Approved, status.ApprovalStatus);
+                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
+                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -886,7 +922,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 VerifyAllMocks(contentService, methodologyVersionRepository);
 
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Id);
-                Assert.Equal("Test approval", updatedMethodologyVersion.InternalReleaseNote);
                 Assert.Null(updatedMethodologyVersion.Published);
                 Assert.Equal(WithRelease, updatedMethodologyVersion.PublishingStrategy);
                 Assert.Equal(request.Status, updatedMethodologyVersion.Status);
@@ -911,6 +946,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.True(updatedMethodologyVersion.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
                 Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
+
+                var statusList = await context
+                    .MethodologyStatus
+                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
+                    .ToListAsync();
+                var status = Assert.Single(statusList);
+                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
+                Assert.Equal("Test approval", status.InternalReleaseNote);
+                Assert.Equal(Approved, status.ApprovalStatus);
+                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
+                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -1133,7 +1179,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var methodologyVersion = new MethodologyVersion
             {
-                InternalReleaseNote = "Test approval",
                 Published = null,
                 PublishingStrategy = Immediately,
                 Status = Approved,
@@ -1189,7 +1234,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Id);
 
-                Assert.Equal("A release note", updatedMethodologyVersion.InternalReleaseNote);
                 Assert.Null(updatedMethodologyVersion.Published);
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
                 Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
@@ -1207,10 +1251,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Null(updatedMethodologyVersion.Published);
                 Assert.Equal(Draft, updatedMethodologyVersion.Status);
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
-                Assert.Equal("A release note", updatedMethodologyVersion.InternalReleaseNote);
                 Assert.True(updatedMethodologyVersion.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
                 Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
+
+                var statusList = await context
+                    .MethodologyStatus
+                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
+                    .ToListAsync();
+                var status = Assert.Single(statusList);
+                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
+                Assert.Equal("A release note", status.InternalReleaseNote);
+                Assert.Equal(Draft, status.ApprovalStatus);
+                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
+                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -1220,7 +1274,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             var owningPublicationId = Guid.NewGuid();
             var methodologyVersion = new MethodologyVersion
             {
-                InternalReleaseNote = "Test approval",
                 Published = null,
                 Status = Draft,
                 Methodology = new Methodology
@@ -1314,7 +1367,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Id);
 
-                Assert.Equal("A release note", updatedMethodologyVersion.InternalReleaseNote);
                 Assert.Null(updatedMethodologyVersion.Published);
                 Assert.Equal(Immediately, updatedMethodologyVersion.PublishingStrategy);
                 Assert.Null(updatedMethodologyVersion.ScheduledWithRelease);
@@ -1331,10 +1383,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 Assert.Null(updatedMethodologyVersion.Published);
                 Assert.Equal(HigherLevelReview, updatedMethodologyVersion.Status);
-                Assert.Equal("A release note", updatedMethodologyVersion.InternalReleaseNote);
                 Assert.True(updatedMethodologyVersion.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
                 Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
+
+                var statusList = await context
+                    .MethodologyStatus
+                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
+                    .ToListAsync();
+                var status = Assert.Single(statusList);
+                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
+                Assert.Equal("A release note", status.InternalReleaseNote);
+                Assert.Equal(HigherLevelReview, status.ApprovalStatus);
+                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
+                Assert.Equal(UserId, status.CreatedById);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
@@ -138,17 +138,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(Immediately, updatedMethodology.PublishingStrategy);
                 Assert.True(updatedMethodology.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
-
-                var statusList = await context
-                    .MethodologyStatus
-                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
-                    .ToListAsync();
-                var status = Assert.Single(statusList);
-                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
-                Assert.Equal("Test approval", status.InternalReleaseNote);
-                Assert.Equal(Approved, status.ApprovalStatus);
-                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
-                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -265,17 +254,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(Immediately, updatedMethodology.PublishingStrategy);
                 Assert.True(updatedMethodology.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
-
-                var statusList = await context
-                    .MethodologyStatus
-                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
-                    .ToListAsync();
-                var status = Assert.Single(statusList);
-                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
-                Assert.Equal("Test approval", status.InternalReleaseNote);
-                Assert.Equal(Approved, status.ApprovalStatus);
-                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
-                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -644,17 +622,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.True(updatedMethodologyVersion.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
                 Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
-
-                var statusList = await context
-                    .MethodologyStatus
-                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
-                    .ToListAsync();
-                var status = Assert.Single(statusList);
-                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
-                Assert.Equal("Test approval", status.InternalReleaseNote);
-                Assert.Equal(Approved, status.ApprovalStatus);
-                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
-                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -752,17 +719,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.True(updatedMethodologyVersion.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
                 Assert.Equal(methodologyVersion.Id, updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
-
-                var statusList = await context
-                    .MethodologyStatus
-                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
-                    .ToListAsync();
-                var status = Assert.Single(statusList);
-                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
-                Assert.Equal("Test approval", status.InternalReleaseNote);
-                Assert.Equal(Approved, status.ApprovalStatus);
-                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
-                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -946,17 +902,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.True(updatedMethodologyVersion.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
                 Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
-
-                var statusList = await context
-                    .MethodologyStatus
-                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
-                    .ToListAsync();
-                var status = Assert.Single(statusList);
-                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
-                Assert.Equal("Test approval", status.InternalReleaseNote);
-                Assert.Equal(Approved, status.ApprovalStatus);
-                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
-                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -1175,7 +1120,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         }
 
         [Fact]
-        public async Task UpdateApprovalStatus_UnapprovingMethodology()
+        public async Task UpdateApprovalStatus_MovingApprovedMethodologyToDraft()
         {
             var methodologyVersion = new MethodologyVersion
             {
@@ -1254,17 +1199,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.True(updatedMethodologyVersion.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
                 Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
-
-                var statusList = await context
-                    .MethodologyStatus
-                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
-                    .ToListAsync();
-                var status = Assert.Single(statusList);
-                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
-                Assert.Equal("A release note", status.InternalReleaseNote);
-                Assert.Equal(Draft, status.ApprovalStatus);
-                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
-                Assert.Equal(UserId, status.CreatedById);
             }
         }
 
@@ -1386,17 +1320,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.True(updatedMethodologyVersion.Updated.HasValue);
                 Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
                 Assert.Null(updatedMethodologyVersion.Methodology.LatestPublishedVersionId);
-
-                var statusList = await context
-                    .MethodologyStatus
-                    .Where(ms => ms.MethodologyVersionId == methodologyVersion.Id)
-                    .ToListAsync();
-                var status = Assert.Single(statusList);
-                Assert.Equal(methodologyVersion.Id, status.MethodologyVersionId);
-                Assert.Equal("A release note", status.InternalReleaseNote);
-                Assert.Equal(HigherLevelReview, status.ApprovalStatus);
-                Assert.InRange(DateTime.UtcNow.Subtract(status.Created!.Value).Milliseconds, 0, 1500);
-                Assert.Equal(UserId, status.CreatedById);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -589,11 +589,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             var methodologyVersion = new MethodologyVersion
             {
                 Methodology = methodology,
-                InternalReleaseNote = "Test approval",
                 Published = null,
                 PublishingStrategy = Immediately,
                 Status = Draft,
                 AlternativeTitle = "Alternative title"
+            };
+
+            var methodologyStatus = new MethodologyStatus
+            {
+                MethodologyVersion = methodologyVersion,
+                InternalReleaseNote = "Test approval",
+                ApprovalStatus = Approved,
             };
 
             var adoptingPublication = new Publication();
@@ -605,6 +611,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await context.Publications.AddRangeAsync(publication, adoptingPublication);
                 await context.Methodologies.AddAsync(methodology);
                 await context.MethodologyVersions.AddAsync(methodologyVersion);
+                await context.MethodologyStatus.AddAsync(methodologyStatus);
                 await context.SaveChangesAsync();
             }
 
@@ -660,7 +667,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 {
                     new()
                     {
-                        InternalReleaseNote = "Test approval",
                         Published = null,
                         PublishingStrategy = Immediately,
                         Status = Draft,
@@ -794,7 +800,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             var methodologyVersion = new MethodologyVersion
             {
                 Methodology = methodology,
-                InternalReleaseNote = "Test approval",
                 Published = new DateTime(2020, 5, 25),
                 PublishingStrategy = WithRelease,
                 ScheduledWithRelease = new Release
@@ -807,6 +812,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 AlternativeTitle = "Alternative title"
             };
 
+            var methodologyStatus = new MethodologyStatus
+            {
+                MethodologyVersion = methodologyVersion,
+                InternalReleaseNote = "Test approval",
+            };
+
             var contentDbContextId = Guid.NewGuid().ToString();
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -814,6 +825,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await context.Methodologies.AddAsync(methodology);
                 await context.Publications.AddRangeAsync(owningPublication, adoptingPublication1, adoptingPublication2);
                 await context.MethodologyVersions.AddAsync(methodologyVersion);
+                await context.MethodologyStatus.AddAsync(methodologyStatus);
                 await context.SaveChangesAsync();
             }
 
@@ -1127,7 +1139,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         Id = Guid.NewGuid(),
                         Version = 0,
                         AlternativeTitle = "Methodology 1 Version 1",
-                        InternalReleaseNote = "Methodology 1 Version 1 release note",
                         Published = new DateTime(2021, 1, 1),
                         Status = Approved
                     }
@@ -1143,7 +1154,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         Id = Guid.NewGuid(),
                         Version = 0,
                         AlternativeTitle = "Methodology 2 Version 1",
-                        InternalReleaseNote = "Methodology 2 Version 1 release note",
                         Published = new DateTime(2021, 1, 1),
                         Status = Approved
                     },
@@ -1167,7 +1177,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         Id = Guid.NewGuid(),
                         Version = 0,
                         AlternativeTitle = "Methodology 3 Version 1",
-                        InternalReleaseNote = "Methodology 3 Version 1 release note",
                         Published = new DateTime(2021, 1, 1),
                         Status = Approved
                     },
@@ -1176,7 +1185,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         Id = Guid.NewGuid(),
                         Version = 1,
                         AlternativeTitle = "Methodology 3 Version 2",
-                        InternalReleaseNote = "Methodology 3 Version 2 release note",
                         Published = new DateTime(2022, 1, 1),
                         Status = Approved
                     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -816,6 +816,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 MethodologyVersion = methodologyVersion,
                 InternalReleaseNote = "Test approval",
+                ApprovalStatus = Approved,
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -1135,7 +1135,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     OwningPublicationTitle = "Methodology scheduled with this Release"
                 },
-                InternalReleaseNote = "A note"
             };
 
             // This Methodology has nothing to do with the Release being deleted.
@@ -1146,8 +1145,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 ScheduledWithReleaseId = Guid.NewGuid(),
                 Methodology = new Methodology
                 {
-                    OwningPublicationTitle = "Methodology scheduled with another Release"
-                }
+                    OwningPublicationTitle = "Methodology scheduled with another Release",
+                },
             };
 
             var userReleaseRole = new UserReleaseRole
@@ -1313,13 +1312,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 // Assert that Methodologies that were scheduled to go out with this Release are no longer scheduled
                 // to do so
-                var retrievedMethodology = context.MethodologyVersions.Single(m => m.Id == methodologyScheduledWithRelease.Id);
-                Assert.True(retrievedMethodology.ScheduledForPublishingImmediately);
-                Assert.Null(retrievedMethodology.ScheduledWithReleaseId);
-                Assert.Null(retrievedMethodology.InternalReleaseNote);
-                Assert.Equal(MethodologyApprovalStatus.Draft, retrievedMethodology.Status);
+                var retrievedMethodologyVersion = context.MethodologyVersions.Single(m => m.Id == methodologyScheduledWithRelease.Id);
+                Assert.True(retrievedMethodologyVersion.ScheduledForPublishingImmediately);
+                Assert.Null(retrievedMethodologyVersion.ScheduledWithReleaseId);
+                Assert.Equal(MethodologyApprovalStatus.Draft, retrievedMethodologyVersion.Status);
                 Assert.InRange(DateTime.UtcNow
-                    .Subtract(retrievedMethodology.Updated!.Value).Milliseconds, 0, 1500);
+                    .Subtract(retrievedMethodologyVersion.Updated!.Value).Milliseconds, 0, 1500);
 
                 // Assert that Methodologies that were scheduled to go out with other Releases remain unaffected
                 var unrelatedMethodology = context.MethodologyVersions.Single(m => m.Id == methodologyScheduledWithAnotherRelease.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230915150510_EES4426_RemoveInternalReleaseNoteFromMethodologyVersionTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230915150510_EES4426_RemoveInternalReleaseNoteFromMethodologyVersionTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230915150510_EES4426_RemoveInternalReleaseNoteFromMethodologyVersionTable")]
+    partial class EES4426_RemoveInternalReleaseNoteFromMethodologyVersionTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230915150510_EES4426_RemoveInternalReleaseNoteFromMethodologyVersionTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230915150510_EES4426_RemoveInternalReleaseNoteFromMethodologyVersionTable.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES4426_RemoveInternalReleaseNoteFromMethodologyVersionTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InternalReleaseNote",
+                table: "MethodologyVersions");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "InternalReleaseNote",
+                table: "MethodologyVersions",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyApprovalService.cs
@@ -95,7 +95,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                         methodologyVersion.ScheduledWithReleaseId = WithRelease == request.PublishingStrategy
                             ? request.WithReleaseId
                             : null;
-                        methodologyVersion.InternalReleaseNote = request.LatestInternalReleaseNote;
 
                         methodologyVersion.Updated = DateTime.UtcNow;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -249,7 +249,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
             var viewModel = _mapper.Map<MethodologyVersionViewModel>(loadedMethodologyVersion);
 
-            viewModel.InternalReleaseNote = await GetLatestInternalNote(loadedMethodologyVersion);
+            viewModel.InternalReleaseNote = await GetLatestInternalReleaseNote(loadedMethodologyVersion.Id);
 
             viewModel.OwningPublication = owningPublication;
             viewModel.OtherPublications = otherPublications;
@@ -427,11 +427,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 });
         }
 
-        private async Task<string?> GetLatestInternalNote(MethodologyVersion methodologyVersion)
+        private async Task<string?> GetLatestInternalReleaseNote(Guid methodologyVersionId)
         {
             // NOTE: Gets latest internal note for this version, not for the entire methodology
             return await _context.MethodologyStatus
-                .Where(ms => methodologyVersion.Id == ms.MethodologyVersionId)
+                .Where(ms => methodologyVersionId == ms.MethodologyVersionId)
                 .OrderByDescending(ms => ms.Created)
                 .Select(ms => ms.InternalReleaseNote)
                 .FirstOrDefaultAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -232,7 +232,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         m.Status = Draft;
                         m.ScheduledWithRelease = null;
                         m.ScheduledWithReleaseId = null;
-                        m.InternalReleaseNote = null;
                         m.Updated = DateTime.UtcNow;
                     });
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
@@ -181,7 +181,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 // general fields
                 Id = Guid.NewGuid(),
                 AlternativeTitle = "Alternative Title",
-                InternalReleaseNote = "Internal Release Note",
 
                 // creation and update fields
                 Created = DateTime.Today.AddDays(-2),
@@ -218,7 +217,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
             Assert.NotEqual(Guid.Empty, amendment.Id);
             Assert.NotEqual(originalVersion.Id, amendment.Id);
             Assert.Equal(originalVersion.AlternativeTitle, amendment.AlternativeTitle);
-            Assert.Null(amendment.InternalReleaseNote);
 
             // Check creation and update fields.
             Assert.Equal(creationTime, amendment.Created);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyVersion.cs
@@ -41,8 +41,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<MethodologyNote> Notes { get; set; } = new();
 
-        public string? InternalReleaseNote { get; set; }
-
         public Methodology Methodology { get; set; } = null!;
 
         public Guid MethodologyId { get; set; }
@@ -109,7 +107,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             copy.ScheduledWithRelease = null;
             copy.ScheduledWithReleaseId = null;
             copy.Methodology = null!;
-            copy.InternalReleaseNote = null;
 
             copy.MethodologyContent = MethodologyContent.Clone(createdDate);
 


### PR DESCRIPTION
This PR removes the InternalReleaseNote column from the MethodologyVersion table. This work was opened up by the creation of the MethodologyStatus table in EES-4385. Now that internal notes are stored in methodology statuses, there was no reason to also store them on methodology versions.

The only change to note is adding the `GetLatestMethodologyStatus` method which is called in `BuildMethodologyVersionViewModel`. `GetLatestMethodologyStatus` gets the latest `MethodologyStatus` for the specific version passed to it, rather than getting the latest status for the entire methodology. I reviewed the surrounding code and think this is the correct choice - although I suspect if we did pass the latest status for the entire methodology we would probably get the same result regardless.
