### PR TITLE
EES-4444 Fix UI test failures and assert page loading state using network requests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,6 +874,9 @@ importers:
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
+      xhr-mock:
+        specifier: ^2.5.1
+        version: 2.5.1
 
   src/explore-education-statistics-frontend:
     dependencies:
@@ -1944,8 +1947,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.8
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.22.8)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.8)
     transitivePeerDependencies:
@@ -1959,8 +1962,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.9.0)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.9.0)
     transitivePeerDependencies:
@@ -3068,13 +3071,13 @@ packages:
     dependencies:
       '@babel/core': 7.22.8
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.22.6(@babel/core@7.22.8)
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.22.8)
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-split-export-declaration': 7.18.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3088,13 +3091,13 @@ packages:
     dependencies:
       '@babel/core': 7.9.0
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.22.6(@babel/core@7.9.0)
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.9.0)
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-split-export-declaration': 7.18.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -9802,6 +9805,10 @@ packages:
       domhandler: 5.0.3
       entities: 4.4.0
 
+  /dom-walk@0.1.2:
+    resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
+    dev: true
+
   /domelementtype@1.3.1:
     resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
     dev: true
@@ -11320,6 +11327,13 @@ packages:
       ini: 1.3.8
       kind-of: 6.0.3
       which: 1.3.1
+
+  /global@4.4.0:
+    resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
+    dependencies:
+      min-document: 2.19.0
+      process: 0.11.10
+    dev: true
 
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -13583,6 +13597,12 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /min-document@2.19.0:
+    resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
+    dependencies:
+      dom-walk: 0.1.2
+    dev: true
+
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -15623,7 +15643,6 @@ packages:
   /process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
-    dev: false
 
   /promise-inflight@1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
@@ -15674,7 +15693,6 @@ packages:
 
   /punycode@1.3.2:
     resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
-    dev: false
 
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
@@ -15706,7 +15724,6 @@ packages:
     resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
     engines: {node: '>=0.4.x'}
     deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
-    dev: false
 
   /querystring@0.2.1:
     resolution: {integrity: sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==}
@@ -18318,7 +18335,6 @@ packages:
     dependencies:
       punycode: 1.3.2
       querystring: 0.2.0
-    dev: false
 
   /use-immer@0.9.0(immer@10.0.2)(react@17.0.2):
     resolution: {integrity: sha512-/L+enLi0nvuZ6j4WlyK0US9/ECUtV5v9RUbtxnn5+WbtaXYUaOBoKHDNL9I5AETdurQ4rIFIj/s+Z5X80ATyKw==}
@@ -19166,6 +19182,13 @@ packages:
   /x-is-string@0.1.0:
     resolution: {integrity: sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w==}
     dev: false
+
+  /xhr-mock@2.5.1:
+    resolution: {integrity: sha512-UKOjItqjFgPUwQGPmRAzNBn8eTfIhcGjBVGvKYAWxUQPQsXNGD6KEckGTiHwyaAUp9C9igQlnN1Mp79KWCg7CQ==}
+    dependencies:
+      global: 4.4.0
+      url: 0.11.0
+    dev: true
 
   /xlsx@0.17.5:
     resolution: {integrity: sha512-lXNU0TuYsvElzvtI6O7WIVb9Zar1XYw7Xb3VAx2wn8N/n0whBYrCnHMxtFyIiUU1Wjf09WzmLALDfBO5PqTb1g==}

--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -12,6 +12,7 @@ import {
   ApplicationInsightsContextProvider,
   useApplicationInsights,
 } from '@common/contexts/ApplicationInsightsContext';
+import { NetworkActivityContextProvider } from '@common/contexts/NetworkActivityContext';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React, { lazy, Suspense, useEffect } from 'react';
@@ -75,39 +76,41 @@ function App() {
         >
           <BrowserRouter>
             <ApplicationInsightsTracking />
-            <QueryClientProvider client={queryClient}>
-              <AuthContextProvider>
-                <LastLocationContextProvider>
-                  <PageErrorBoundary>
-                    <Switch>
-                      {Object.entries(apiAuthorizationRouteList).map(
-                        ([key, authRoute]) => (
-                          <Route exact key={key} {...authRoute} />
-                        ),
-                      )}
+            <NetworkActivityContextProvider>
+              <QueryClientProvider client={queryClient}>
+                <AuthContextProvider>
+                  <LastLocationContextProvider>
+                    <PageErrorBoundary>
+                      <Switch>
+                        {Object.entries(apiAuthorizationRouteList).map(
+                          ([key, authRoute]) => (
+                            <Route exact key={key} {...authRoute} />
+                          ),
+                        )}
 
-                      {Object.entries(routes).map(([key, route]) => (
-                        <ProtectedRoute key={key} {...route} />
-                      ))}
+                        {Object.entries(routes).map(([key, route]) => (
+                          <ProtectedRoute key={key} {...route} />
+                        ))}
 
-                      {/* Prototype pages are protected by default. To open them up change the ProtectedRoute to: */}
-                      {/* <Route path="/prototypes" component={PrototypesEntry} /> */}
-                      <ProtectedRoute
-                        path="/prototypes"
-                        protectionAction={user => user.permissions.isBauUser}
-                        component={PrototypesEntry}
-                      />
+                        {/* Prototype pages are protected by default. To open them up change the ProtectedRoute to: */}
+                        {/* <Route path="/prototypes" component={PrototypesEntry} /> */}
+                        <ProtectedRoute
+                          path="/prototypes"
+                          protectionAction={user => user.permissions.isBauUser}
+                          component={PrototypesEntry}
+                        />
 
-                      <ProtectedRoute
-                        path="*"
-                        allowAnonymousUsers
-                        component={PageNotFoundPage}
-                      />
-                    </Switch>
-                  </PageErrorBoundary>
-                </LastLocationContextProvider>
-              </AuthContextProvider>
-            </QueryClientProvider>
+                        <ProtectedRoute
+                          path="*"
+                          allowAnonymousUsers
+                          component={PageNotFoundPage}
+                        />
+                      </Switch>
+                    </PageErrorBoundary>
+                  </LastLocationContextProvider>
+                </AuthContextProvider>
+              </QueryClientProvider>
+            </NetworkActivityContextProvider>
           </BrowserRouter>
         </ApplicationInsightsContextProvider>
       )}

--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -5,17 +5,24 @@ import apiAuthorizationRouteList from '@admin/components/api-authorization/ApiAu
 import PageErrorBoundary from '@admin/components/PageErrorBoundary';
 import ProtectedRoute from '@admin/components/ProtectedRoute';
 import { AuthContextProvider } from '@admin/contexts/AuthContext';
-import { ConfigContextProvider } from '@admin/contexts/ConfigContext';
+import {
+  ConfigContextProvider,
+  useConfig,
+} from '@admin/contexts/ConfigContext';
 import ServiceProblemsPage from '@admin/pages/errors/ServiceProblemsPage';
 import routes from '@admin/routes/routes';
 import {
-  ApplicationInsightsContextProvider,
+  ApplicationInsightsContextProvider as BaseApplicationInsightsContextProvider,
   useApplicationInsights,
 } from '@common/contexts/ApplicationInsightsContext';
 import { NetworkActivityContextProvider } from '@common/contexts/NetworkActivityContext';
+import composeProviders from '@common/hocs/composeProviders';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import React, { lazy, Suspense, useEffect } from 'react';
+import {
+  QueryClient,
+  QueryClientProvider as BaseQueryClientProvider,
+} from '@tanstack/react-query';
+import React, { lazy, ReactNode, Suspense, useEffect } from 'react';
 import { Route, Switch, useHistory } from 'react-router';
 import { BrowserRouter } from 'react-router-dom';
 import PageNotFoundPage from './pages/errors/PageNotFoundPage';
@@ -67,55 +74,70 @@ function PrototypesEntry() {
   );
 }
 
-function App() {
+export default function App() {
   return (
-    <ConfigContextProvider>
-      {config => (
-        <ApplicationInsightsContextProvider
-          instrumentationKey={config.AppInsightsKey}
-        >
-          <BrowserRouter>
-            <ApplicationInsightsTracking />
-            <NetworkActivityContextProvider>
-              <QueryClientProvider client={queryClient}>
-                <AuthContextProvider>
-                  <LastLocationContextProvider>
-                    <PageErrorBoundary>
-                      <Switch>
-                        {Object.entries(apiAuthorizationRouteList).map(
-                          ([key, authRoute]) => (
-                            <Route exact key={key} {...authRoute} />
-                          ),
-                        )}
+    <Providers>
+      <PageErrorBoundary>
+        <ApplicationInsightsTracking />
 
-                        {Object.entries(routes).map(([key, route]) => (
-                          <ProtectedRoute key={key} {...route} />
-                        ))}
+        <Switch>
+          {Object.entries(apiAuthorizationRouteList).map(([key, authRoute]) => (
+            <Route exact key={key} {...authRoute} />
+          ))}
 
-                        {/* Prototype pages are protected by default. To open them up change the ProtectedRoute to: */}
-                        {/* <Route path="/prototypes" component={PrototypesEntry} /> */}
-                        <ProtectedRoute
-                          path="/prototypes"
-                          protectionAction={user => user.permissions.isBauUser}
-                          component={PrototypesEntry}
-                        />
+          {Object.entries(routes).map(([key, route]) => (
+            <ProtectedRoute key={key} {...route} />
+          ))}
 
-                        <ProtectedRoute
-                          path="*"
-                          allowAnonymousUsers
-                          component={PageNotFoundPage}
-                        />
-                      </Switch>
-                    </PageErrorBoundary>
-                  </LastLocationContextProvider>
-                </AuthContextProvider>
-              </QueryClientProvider>
-            </NetworkActivityContextProvider>
-          </BrowserRouter>
-        </ApplicationInsightsContextProvider>
-      )}
-    </ConfigContextProvider>
+          {/* Prototype pages are protected by default. To open them up change the ProtectedRoute to: */}
+          {/* <Route path="/prototypes" component={PrototypesEntry} /> */}
+          <ProtectedRoute
+            path="/prototypes"
+            protectionAction={user => user.permissions.isBauUser}
+            component={PrototypesEntry}
+          />
+
+          <ProtectedRoute
+            path="*"
+            allowAnonymousUsers
+            component={PageNotFoundPage}
+          />
+        </Switch>
+      </PageErrorBoundary>
+    </Providers>
   );
 }
 
-export default App;
+const Providers = composeProviders(
+  ConfigContextProvider,
+  ApplicationInsightsContextProvider,
+  BrowserRouter,
+  NetworkActivityContextProvider,
+  QueryClientProvider,
+  AuthContextProvider,
+  LastLocationContextProvider,
+);
+
+function ApplicationInsightsContextProvider({
+  children,
+}: {
+  children?: ReactNode;
+}) {
+  const config = useConfig();
+
+  return (
+    <BaseApplicationInsightsContextProvider
+      instrumentationKey={config.AppInsightsKey}
+    >
+      {children}
+    </BaseApplicationInsightsContextProvider>
+  );
+}
+
+function QueryClientProvider({ children }: { children?: ReactNode }) {
+  return (
+    <BaseQueryClientProvider client={queryClient}>
+      {children}
+    </BaseQueryClientProvider>
+  );
+}

--- a/src/explore-education-statistics-admin/src/contexts/AuthContext.tsx
+++ b/src/explore-education-statistics-admin/src/contexts/AuthContext.tsx
@@ -39,7 +39,7 @@ export const AuthContext = createContext<AuthContextState | undefined>(
 );
 
 interface Props {
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 interface State {

--- a/src/explore-education-statistics-admin/src/contexts/ConfigContext.tsx
+++ b/src/explore-education-statistics-admin/src/contexts/ConfigContext.tsx
@@ -5,7 +5,7 @@ import React, { createContext, ReactNode, useContext } from 'react';
 export const ConfigContext = createContext<Config | undefined>(undefined);
 
 interface ConfigContextProviderProps {
-  children: (config: Config) => ReactNode;
+  children?: ReactNode;
 }
 
 export const ConfigContextProvider = ({
@@ -15,7 +15,7 @@ export const ConfigContextProvider = ({
 
   return (
     <ConfigContext.Provider value={value}>
-      {!isLoading && value ? children(value) : null}
+      {!isLoading && value ? children : null}
     </ConfigContext.Provider>
   );
 };

--- a/src/explore-education-statistics-admin/src/contexts/LastLocationContext.tsx
+++ b/src/explore-education-statistics-admin/src/contexts/LastLocationContext.tsx
@@ -6,7 +6,7 @@ import { useLocation } from 'react-router';
 const LastLocationContext = createContext<Location | undefined>(undefined);
 
 interface LastLocationContextProviderProps {
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 export const LastLocationContextProvider = ({

--- a/src/explore-education-statistics-admin/src/services/methodologyImageService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyImageService.ts
@@ -1,21 +1,24 @@
 import client from '@admin/services/utils/service';
 import { ImageUploadResult } from '@admin/types/ckeditor';
 import { ImageProgressHandler } from '@admin/utils/ckeditor/CustomUploadAdapter';
-import { CancellablePromise } from '@common/types/promise';
 import { AxiosProgressEvent } from 'axios';
 
 const methodologyImageService = {
   upload(
     methodologyId: string,
     file: File,
-    onProgress?: ImageProgressHandler,
-  ): CancellablePromise<ImageUploadResult> {
+    options: {
+      signal?: AbortSignal;
+      onProgress?: ImageProgressHandler;
+    } = {},
+  ): Promise<ImageUploadResult> {
     const data = new FormData();
     data.append('file', file);
 
     return client.post(`/methodologies/${methodologyId}/images`, data, {
+      signal: options.signal,
       onUploadProgress(event: AxiosProgressEvent) {
-        onProgress?.(event.loaded, event.total ?? 0);
+        options.onProgress?.(event.loaded, event.total ?? 0);
       },
     });
   },

--- a/src/explore-education-statistics-admin/src/services/releaseFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseFileService.ts
@@ -4,9 +4,10 @@ import parseContentDisposition from '@common/utils/http/parseContentDisposition'
 
 const releaseFileService = {
   downloadAllFilesZip(releaseId: string): Promise<void> {
-    return client.axios
+    return client
       .get<Blob>(`/release/${releaseId}/files`, {
         responseType: 'blob',
+        rawResponse: true,
       })
       .then(({ data, headers }) => {
         const disposition = parseContentDisposition(

--- a/src/explore-education-statistics-admin/src/services/releaseImageService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseImageService.ts
@@ -1,21 +1,24 @@
 import client from '@admin/services/utils/service';
 import { ImageUploadResult } from '@admin/types/ckeditor';
 import { ImageProgressHandler } from '@admin/utils/ckeditor/CustomUploadAdapter';
-import { CancellablePromise } from '@common/types/promise';
 import { AxiosProgressEvent } from 'axios';
 
 const releaseImageService = {
   upload(
     releaseId: string,
     file: File,
-    onProgress?: ImageProgressHandler,
-  ): CancellablePromise<ImageUploadResult> {
+    options: {
+      signal?: AbortSignal;
+      onProgress?: ImageProgressHandler;
+    } = {},
+  ): Promise<ImageUploadResult> {
     const data = new FormData();
     data.append('file', file);
 
     return client.post(`/releases/${releaseId}/images`, data, {
+      signal: options.signal,
       onUploadProgress(event: AxiosProgressEvent) {
-        onProgress?.(event.loaded, event.total ?? 0);
+        options.onProgress?.(event.loaded, event.total ?? 0);
       },
     });
   },

--- a/src/explore-education-statistics-admin/src/services/utils/configureAxios.ts
+++ b/src/explore-education-statistics-admin/src/services/utils/configureAxios.ts
@@ -3,29 +3,21 @@ import adminApi from '@admin/services/utils/service';
 import { dataApi } from '@common/services/api';
 
 const configureAxios = () => {
-  dataApi.axios.defaults.baseURL = '/api/data';
+  dataApi.baseURL = '/api/data';
 
   const clients = [dataApi, adminApi];
 
   clients.forEach(client => {
-    client.axios.interceptors.request.use(
-      async config => {
-        const token = await authService.getAccessToken();
+    client.addRequestInterceptor(async config => {
+      const token = await authService.getAccessToken();
 
-        if (token) {
-          // eslint-disable-next-line no-param-reassign
-          config.headers.Authorization = `Bearer ${token}`;
-        }
+      if (token) {
+        // eslint-disable-next-line no-param-reassign
+        config.headers.Authorization = `Bearer ${token}`;
+      }
 
-        return config;
-      },
-      error => Promise.reject(error),
-    );
-
-    client.axios.interceptors.response.use(
-      response => response,
-      error => Promise.reject(error),
-    );
+      return config;
+    });
   });
 };
 

--- a/src/explore-education-statistics-admin/src/services/utils/configureAxios.ts
+++ b/src/explore-education-statistics-admin/src/services/utils/configureAxios.ts
@@ -2,23 +2,23 @@ import authService from '@admin/components/api-authorization/AuthorizeService';
 import adminApi from '@admin/services/utils/service';
 import { dataApi } from '@common/services/api';
 
-const configureAxios = () => {
+export default function configureAxios() {
   dataApi.baseURL = '/api/data';
 
   const clients = [dataApi, adminApi];
 
   clients.forEach(client => {
-    client.addRequestInterceptor(async config => {
-      const token = await authService.getAccessToken();
+    client.addRequestInterceptor({
+      onRequest: async config => {
+        const token = await authService.getAccessToken();
 
-      if (token) {
-        // eslint-disable-next-line no-param-reassign
-        config.headers.Authorization = `Bearer ${token}`;
-      }
+        if (token) {
+          // eslint-disable-next-line no-param-reassign
+          config.headers.Authorization = `Bearer ${token}`;
+        }
 
-      return config;
+        return config;
+      },
     });
   });
-};
-
-export default configureAxios;
+}

--- a/src/explore-education-statistics-admin/src/services/utils/service.ts
+++ b/src/explore-education-statistics-admin/src/services/utils/service.ts
@@ -1,14 +1,7 @@
 import Client from '@common/services/api/Client';
-import axios from 'axios';
-import qs from 'qs';
 
-export const baseURL = '/api/';
-
-const axiosInstance = axios.create({
-  baseURL,
-  paramsSerializer: params => qs.stringify(params, { arrayFormat: 'comma' }),
+const client = new Client({
+  baseURL: '/api/',
 });
-
-const client = new Client(axiosInstance);
 
 export default client;

--- a/src/explore-education-statistics-admin/src/services/utils/service.ts
+++ b/src/explore-education-statistics-admin/src/services/utils/service.ts
@@ -1,7 +1,13 @@
+import {
+  networkActivityRequestInterceptor,
+  networkActivityResponseInterceptor,
+} from '@common/contexts/NetworkActivityContext';
 import Client from '@common/services/api/Client';
 
 const client = new Client({
   baseURL: '/api/',
+  requestInterceptors: [networkActivityRequestInterceptor],
+  responseInterceptors: [networkActivityResponseInterceptor],
 });
 
 export default client;

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -28,6 +28,7 @@
     "leaflet": "^1.7.1",
     "lodash": "^4.17.21",
     "memoizee": "^0.4.14",
+    "nanoid": "^4.0.0",
     "next": "^12.3.4",
     "qs": "^6.11.2",
     "react": "17.0.2",
@@ -41,7 +42,6 @@
     "react-markdown": "^4.3.1",
     "react-modal": "^3.16.1",
     "recharts": "^2.7.2",
-    "nanoid": "^4.0.0",
     "regenerator-runtime": "0.13.9",
     "sanitize-html": "^2.11.0",
     "use-immer": "^0.9.0",
@@ -89,7 +89,8 @@
     "open": "^8.4.1",
     "react-test-renderer": "17.0.2",
     "stylelint": "^15.7.0",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "xhr-mock": "^2.5.1"
   },
   "scripts": {
     "lint": "pnpm lint:js && pnpm lint:style",

--- a/src/explore-education-statistics-common/src/contexts/NetworkActivityContext.tsx
+++ b/src/explore-education-statistics-common/src/contexts/NetworkActivityContext.tsx
@@ -1,0 +1,189 @@
+import useMountedRef from '@common/hooks/useMountedRef';
+import {
+  RequestInterceptor,
+  ResponseInterceptor,
+} from '@common/services/api/Client';
+import React, {
+  createContext,
+  ReactNode,
+  SetStateAction,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+const EVENT_NETWORK_REQUEST = 'ees:network_request';
+const EVENT_NETWORK_REQUEST_ERROR = 'ees:network_request_error';
+const EVENT_NETWORK_RESPONSE = 'ees:network_response';
+const EVENT_NETWORK_RESPONSE_ERROR = 'ees:network_response_error';
+
+const dataAttribute = 'data-network-activity';
+
+export type NetworkActivityStatus = 'active' | 'idle';
+
+export interface NetworkActivityState {
+  status: NetworkActivityStatus;
+  requestCount: number;
+}
+
+const NetworkActivityContext = createContext<NetworkActivityState | undefined>(
+  undefined,
+);
+
+export interface NetworkActivityContextProviderProps {
+  children?: ReactNode;
+  idleTimeout?: number;
+}
+
+/**
+ * Provider that listens for network activity events.
+ *
+ * Upon receiving these events, the provider will update the `data-network-activity`
+ * attribute on the document body to notify other listeners (outside of React) on
+ * the current state.
+ *
+ * This is primarily used by Robot Framework tests to identify when the network is
+ * idle and the page can be considered to be 'loaded' before proceeding with assertions.
+ *
+ * This provider works by using client interceptors to hook into the request/response
+ * lifecycle. These dispatch custom DOM events that we can listen for in the provider.
+ */
+export function NetworkActivityContextProvider({
+  children,
+  idleTimeout = 500,
+}: NetworkActivityContextProviderProps) {
+  const requestCount = useRef<number>(0);
+
+  const isMountedRef = useMountedRef();
+  const [state, _setState] = useState<NetworkActivityState>({
+    status: 'idle',
+    requestCount: 0,
+  });
+
+  const setState = useCallback(
+    (setter: SetStateAction<NetworkActivityState>) => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      _setState(prevState => {
+        const nextState =
+          typeof setter === 'function' ? setter(prevState) : setter;
+
+        document.body.setAttribute(dataAttribute, nextState.status);
+
+        return nextState;
+      });
+    },
+    [isMountedRef],
+  );
+
+  useEffect(() => {
+    if (document.body.hasAttribute(dataAttribute)) {
+      throw new Error(
+        `Cannot have more than once instance of ${NetworkActivityContextProvider.name}`,
+      );
+    }
+
+    document.body.setAttribute(dataAttribute, 'idle');
+
+    return () => {
+      document.body.removeAttribute(dataAttribute);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleRequest = () => {
+      requestCount.current += 1;
+
+      setState({
+        status: 'active',
+        requestCount: requestCount.current,
+      });
+    };
+
+    const handleResponse = () => {
+      requestCount.current -= 1;
+
+      setState(prevState => ({
+        ...prevState,
+        requestCount: requestCount.current,
+      }));
+
+      setTimeout(() => {
+        if (requestCount.current < 1) {
+          setState({
+            status: 'idle',
+            requestCount: requestCount.current,
+          });
+        }
+      }, idleTimeout);
+    };
+
+    window.addEventListener(EVENT_NETWORK_REQUEST, handleRequest);
+    window.addEventListener(EVENT_NETWORK_REQUEST_ERROR, handleResponse);
+    window.addEventListener(EVENT_NETWORK_RESPONSE, handleResponse);
+    window.addEventListener(EVENT_NETWORK_RESPONSE_ERROR, handleResponse);
+
+    return () => {
+      window.removeEventListener(EVENT_NETWORK_REQUEST, handleRequest);
+      window.removeEventListener(EVENT_NETWORK_REQUEST_ERROR, handleResponse);
+      window.removeEventListener(EVENT_NETWORK_RESPONSE, handleResponse);
+      window.removeEventListener(EVENT_NETWORK_RESPONSE_ERROR, handleResponse);
+    };
+  }, [idleTimeout, setState]);
+
+  return (
+    <NetworkActivityContext.Provider value={state}>
+      {children}
+    </NetworkActivityContext.Provider>
+  );
+}
+
+export function useNetworkActivityContext(): NetworkActivityState {
+  const context = useContext(NetworkActivityContext);
+
+  if (!context) {
+    throw new Error(
+      `Must be used within a ${NetworkActivityContextProvider.name}`,
+    );
+  }
+
+  return context;
+}
+
+export const networkActivityRequestInterceptor: RequestInterceptor = {
+  onRequest: config => {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(EVENT_NETWORK_REQUEST));
+    }
+
+    return config;
+  },
+  onError: error => {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(EVENT_NETWORK_REQUEST_ERROR));
+    }
+
+    return Promise.reject(error);
+  },
+};
+
+export const networkActivityResponseInterceptor: ResponseInterceptor = {
+  onResponse: response => {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(EVENT_NETWORK_RESPONSE));
+    }
+
+    return response;
+  },
+  onError: error => {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(EVENT_NETWORK_RESPONSE_ERROR));
+    }
+
+    return Promise.reject(error);
+  },
+};

--- a/src/explore-education-statistics-common/src/contexts/__tests__/NetworkActivityContext.test.tsx
+++ b/src/explore-education-statistics-common/src/contexts/__tests__/NetworkActivityContext.test.tsx
@@ -1,0 +1,183 @@
+import {
+  NetworkActivityContextProvider,
+  networkActivityRequestInterceptor,
+  networkActivityResponseInterceptor,
+  NetworkActivityState,
+  useNetworkActivityContext,
+} from '@common/contexts/NetworkActivityContext';
+import Client from '@common/services/api/Client';
+import { renderHook } from '@testing-library/react-hooks';
+import { AxiosError } from 'axios';
+import React, { FC } from 'react';
+import xhrMock from 'xhr-mock';
+
+describe('useNetworkActivityContext', () => {
+  const wrapper: FC = ({ children }) => (
+    <NetworkActivityContextProvider>{children}</NetworkActivityContextProvider>
+  );
+
+  beforeEach(() => {
+    xhrMock.setup();
+    xhrMock.get('/test', (_, res) => {
+      return res.status(200);
+    });
+  });
+
+  afterEach(() => {
+    xhrMock.teardown();
+  });
+
+  test('toggles status to `active` when request starts', async () => {
+    const client = createTestClient();
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useNetworkActivityContext(),
+      { wrapper },
+    );
+
+    expect(result.current).toEqual<NetworkActivityState>({
+      status: 'idle',
+      requestCount: 0,
+    });
+    expect(document.body).toHaveAttribute('data-network-activity', 'idle');
+
+    const request = client.get('/test');
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual<NetworkActivityState>({
+      status: 'active',
+      requestCount: 1,
+    });
+    expect(document.body).toHaveAttribute('data-network-activity', 'active');
+
+    await request;
+  });
+
+  test('toggles status back to `idle` when no more requests within the idle timeout', async () => {
+    const client = createTestClient();
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useNetworkActivityContext(),
+      { wrapper },
+    );
+
+    expect(result.current).toEqual<NetworkActivityState>({
+      status: 'idle',
+      requestCount: 0,
+    });
+    expect(document.body).toHaveAttribute('data-network-activity', 'idle');
+
+    await client.get('/test');
+
+    // Request has completed, but status does not switch to `idle` until timeout expires
+    expect(result.current).toEqual<NetworkActivityState>({
+      status: 'active',
+      requestCount: 0,
+    });
+    expect(document.body).toHaveAttribute('data-network-activity', 'active');
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual<NetworkActivityState>({
+      status: 'idle',
+      requestCount: 0,
+    });
+    expect(document.body).toHaveAttribute('data-network-activity', 'idle');
+  });
+
+  test('updates `requestCount` correctly when multiple concurrent requests', async () => {
+    const client = createTestClient();
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useNetworkActivityContext(),
+      { wrapper },
+    );
+
+    expect(result.current).toEqual<NetworkActivityState>({
+      status: 'idle',
+      requestCount: 0,
+    });
+    expect(document.body).toHaveAttribute('data-network-activity', 'idle');
+
+    const request = Promise.all([
+      client.get('/test'),
+      client.get('/test'),
+      client.get('/test'),
+    ]);
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual<NetworkActivityState>({
+      status: 'active',
+      requestCount: 3,
+    });
+    expect(document.body).toHaveAttribute('data-network-activity', 'active');
+
+    await request;
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual<NetworkActivityState>({
+      status: 'idle',
+      requestCount: 0,
+    });
+    expect(document.body).toHaveAttribute('data-network-activity', 'idle');
+  });
+
+  test('updates `requestCount` correctly when error response', async () => {
+    const client = createTestClient();
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useNetworkActivityContext(),
+      { wrapper },
+    );
+
+    xhrMock.get('/test-error', (req, res) => {
+      return res.status(500).body({
+        message: 'Something went wrong',
+      });
+    });
+
+    expect(result.current).toEqual<NetworkActivityState>({
+      status: 'idle',
+      requestCount: 0,
+    });
+    expect(document.body).toHaveAttribute('data-network-activity', 'idle');
+
+    const request = client.get('/test-error');
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual<NetworkActivityState>({
+      status: 'active',
+      requestCount: 1,
+    });
+    expect(document.body).toHaveAttribute('data-network-activity', 'active');
+
+    try {
+      await request;
+    } catch (err) {
+      const error = err as AxiosError;
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.response?.status).toBe(500);
+      expect(error.response?.data).toEqual({
+        message: 'Something went wrong',
+      });
+    }
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual<NetworkActivityState>({
+      status: 'idle',
+      requestCount: 0,
+    });
+    expect(document.body).toHaveAttribute('data-network-activity', 'idle');
+  });
+});
+
+function createTestClient(): Client {
+  return new Client({
+    requestInterceptors: [networkActivityRequestInterceptor],
+    responseInterceptors: [networkActivityResponseInterceptor],
+  });
+}

--- a/src/explore-education-statistics-common/src/hocs/composeProviders.tsx
+++ b/src/explore-education-statistics-common/src/hocs/composeProviders.tsx
@@ -1,0 +1,22 @@
+import React, { ComponentType, ReactNode } from 'react';
+
+interface ProviderProps {
+  children?: ReactNode;
+}
+
+export default function composeProviders(
+  ...providers: ComponentType<ProviderProps>[]
+): ComponentType<ProviderProps> {
+  return function Providers({ children }: ProviderProps) {
+    return (
+      <>
+        {providers.reduceRight(
+          (acc, Provider) => (
+            <Provider>{acc}</Provider>
+          ),
+          children,
+        )}
+      </>
+    );
+  };
+}

--- a/src/explore-education-statistics-common/src/services/api/Client.ts
+++ b/src/explore-education-statistics-common/src/services/api/Client.ts
@@ -1,4 +1,3 @@
-import { CancellablePromise } from '@common/types/promise';
 import Axios, {
   AxiosInstance,
   AxiosPromise,
@@ -31,7 +30,7 @@ export default class Client {
   public get<T = unknown>(
     url: string,
     config?: AxiosRequestConfig,
-  ): CancellablePromise<T> {
+  ): Promise<T> {
     return this.handlePromise(this.axios.get(url, config));
   }
 
@@ -39,7 +38,7 @@ export default class Client {
     url: string,
     data?: unknown,
     config?: AxiosRequestConfig,
-  ): CancellablePromise<T> {
+  ): Promise<T> {
     return this.handlePromise(this.axios.post(url, data, config));
   }
 
@@ -47,7 +46,7 @@ export default class Client {
     url: string,
     data?: unknown,
     config?: AxiosRequestConfig,
-  ): CancellablePromise<T> {
+  ): Promise<T> {
     return this.handlePromise(this.axios.put(url, data, config));
   }
 
@@ -55,26 +54,20 @@ export default class Client {
     url: string,
     data?: unknown,
     config?: AxiosRequestConfig,
-  ): CancellablePromise<T> {
+  ): Promise<T> {
     return this.handlePromise(this.axios.patch(url, data, config));
   }
 
   public delete<T = unknown>(
     url: string,
     config?: AxiosRequestConfig,
-  ): CancellablePromise<T> {
+  ): Promise<T> {
     return this.handlePromise(this.axios.delete(url, config));
   }
 
-  private handlePromise<T>(promise: AxiosPromise<T>): CancellablePromise<T> {
-    const cancelToken = Axios.CancelToken.source();
+  private async handlePromise<T>(promise: AxiosPromise<T>): Promise<T> {
+    const { data } = await promise;
 
-    const cancellablePromise = promise.then(
-      ({ data }) => data,
-    ) as CancellablePromise<T>;
-
-    cancellablePromise.cancel = cancelToken.cancel;
-
-    return cancellablePromise;
+    return data;
   }
 }

--- a/src/explore-education-statistics-common/src/services/api/__mocks__/Client.ts
+++ b/src/explore-education-statistics-common/src/services/api/__mocks__/Client.ts
@@ -1,9 +1,0 @@
-import mockObject from '@common-test/mockObject';
-
-const actual = jest.requireActual('../Client');
-
-const service = actual.default;
-
-const mock = mockObject(service);
-
-export default mock;

--- a/src/explore-education-statistics-common/src/services/api/index.ts
+++ b/src/explore-education-statistics-common/src/services/api/index.ts
@@ -1,9 +1,17 @@
+import {
+  networkActivityRequestInterceptor,
+  networkActivityResponseInterceptor,
+} from '@common/contexts/NetworkActivityContext';
 import Client from './Client';
 
 export const contentApi = new Client({
   baseURL: process.env.CONTENT_API_BASE_URL,
+  requestInterceptors: [networkActivityRequestInterceptor],
+  responseInterceptors: [networkActivityResponseInterceptor],
 });
 
 export const dataApi = new Client({
   baseURL: process.env.DATA_API_BASE_URL,
+  requestInterceptors: [networkActivityRequestInterceptor],
+  responseInterceptors: [networkActivityResponseInterceptor],
 });

--- a/src/explore-education-statistics-common/src/services/api/index.ts
+++ b/src/explore-education-statistics-common/src/services/api/index.ts
@@ -1,17 +1,9 @@
-import axios from 'axios';
-import qs from 'qs';
 import Client from './Client';
 
-export const contentApi = new Client(
-  axios.create({
-    baseURL: process.env.CONTENT_API_BASE_URL,
-    paramsSerializer: params => qs.stringify(params, { arrayFormat: 'comma' }),
-  }),
-);
+export const contentApi = new Client({
+  baseURL: process.env.CONTENT_API_BASE_URL,
+});
 
-export const dataApi = new Client(
-  axios.create({
-    baseURL: process.env.DATA_API_BASE_URL,
-    paramsSerializer: params => qs.stringify(params, { arrayFormat: 'comma' }),
-  }),
-);
+export const dataApi = new Client({
+  baseURL: process.env.DATA_API_BASE_URL,
+});

--- a/src/explore-education-statistics-common/src/services/downloadService.ts
+++ b/src/explore-education-statistics-common/src/services/downloadService.ts
@@ -11,9 +11,7 @@ const downloadService = {
   async downloadFiles(releaseId: string, fileIds: string[]): Promise<void> {
     const query = qs.stringify({ fileIds }, { arrayFormat: 'comma' });
 
-    downloadFile(
-      `${contentApi.axios.defaults.baseURL}/releases/${releaseId}/files?${query}`,
-    );
+    downloadFile(`${contentApi.baseURL}/releases/${releaseId}/files?${query}`);
   },
 };
 

--- a/src/explore-education-statistics-common/src/types/dom.d.ts
+++ b/src/explore-education-statistics-common/src/types/dom.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Define custom events here.
+ */
+interface GlobalEventHandlersEventMap {
+  'ees:network_request': CustomEvent;
+  'ees:network_request_error': CustomEvent;
+  'ees:network_response': CustomEvent;
+  'ees:network_response_error': CustomEvent;
+}

--- a/src/explore-education-statistics-common/src/types/promise.ts
+++ b/src/explore-education-statistics-common/src/types/promise.ts
@@ -1,3 +1,0 @@
-export class CancellablePromise<T> extends Promise<T> {
-  cancel(): void {}
-}

--- a/src/explore-education-statistics-common/src/types/promise.ts
+++ b/src/explore-education-statistics-common/src/types/promise.ts
@@ -1,3 +1,3 @@
-export interface CancellablePromise<T> extends Promise<T> {
-  cancel(): void;
+export class CancellablePromise<T> extends Promise<T> {
+  cancel(): void {}
 }

--- a/src/explore-education-statistics-frontend/src/loadEnv.ts
+++ b/src/explore-education-statistics-frontend/src/loadEnv.ts
@@ -1,9 +1,7 @@
 import getConfig from 'next/config';
 
-export default function loadEnv() {
-  const { publicRuntimeConfig } = getConfig();
+const { publicRuntimeConfig } = getConfig();
 
-  Object.assign(process.env, publicRuntimeConfig, {
-    APP_ROOT_ID: '__next',
-  });
-}
+Object.assign(process.env, publicRuntimeConfig, {
+  APP_ROOT_ID: '__next',
+});

--- a/src/explore-education-statistics-frontend/src/pages/_app.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/_app.tsx
@@ -1,15 +1,14 @@
 // Import order is important - these should be at the top
 import '@frontend/polyfill';
+import '@frontend/loadEnv';
 import '../styles/_all.scss';
 import {
   ApplicationInsightsContextProvider,
   useApplicationInsights,
 } from '@common/contexts/ApplicationInsightsContext';
 import useMounted from '@common/hooks/useMounted';
-import { contentApi, dataApi } from '@common/services/api';
 import { Dictionary } from '@common/types';
 import { useCookies } from '@frontend/hooks/useCookies';
-import notificationApi from '@frontend/services/clients/notificationApi';
 import NextApp, { AppContext, AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -19,10 +18,7 @@ import {
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query';
-import loadEnv from '@frontend/loadEnv';
 import { parseCookies } from 'nookies';
-
-loadEnv();
 
 const ApplicationInsightsTracking = () => {
   const appInsights = useApplicationInsights();
@@ -53,13 +49,6 @@ const App = ({ Component, pageProps, cookies }: Props) => {
   const router = useRouter();
   const { getCookie } = useCookies(cookies);
   const [queryClient] = useState(() => new QueryClient());
-
-  loadEnv();
-
-  contentApi.axios.defaults.baseURL = process.env.CONTENT_API_BASE_URL;
-  dataApi.axios.defaults.baseURL = process.env.DATA_API_BASE_URL;
-  notificationApi.axios.defaults.baseURL =
-    process.env.NOTIFICATION_API_BASE_URL;
 
   useMounted(() => {
     if (process.env.GA_TRACKING_ID && getCookie('disableGA') !== 'true') {
@@ -100,8 +89,6 @@ export default App;
 
 App.getInitialProps = async (appContext: AppContext) => {
   const appProps = await NextApp.getInitialProps(appContext);
-
-  loadEnv();
 
   return {
     ...appProps,

--- a/src/explore-education-statistics-frontend/src/pages/_app.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import {
   ApplicationInsightsContextProvider,
   useApplicationInsights,
 } from '@common/contexts/ApplicationInsightsContext';
+import { NetworkActivityContextProvider } from '@common/contexts/NetworkActivityContext';
 import useMounted from '@common/hooks/useMounted';
 import { Dictionary } from '@common/types';
 import { useCookies } from '@frontend/hooks/useCookies';
@@ -76,11 +77,13 @@ const App = ({ Component, pageProps, cookies }: Props) => {
 
       <ApplicationInsightsTracking />
 
-      <QueryClientProvider client={queryClient}>
-        <Hydrate state={pageProps.dehydratedState}>
-          <Component {...pageProps} />
-        </Hydrate>
-      </QueryClientProvider>
+      <NetworkActivityContextProvider>
+        <QueryClientProvider client={queryClient}>
+          <Hydrate state={pageProps.dehydratedState}>
+            <Component {...pageProps} />
+          </Hydrate>
+        </QueryClientProvider>
+      </NetworkActivityContextProvider>
     </ApplicationInsightsContextProvider>
   );
 };

--- a/src/explore-education-statistics-frontend/src/services/clients/notificationApi.ts
+++ b/src/explore-education-statistics-frontend/src/services/clients/notificationApi.ts
@@ -1,7 +1,13 @@
+import {
+  networkActivityRequestInterceptor,
+  networkActivityResponseInterceptor,
+} from '@common/contexts/NetworkActivityContext';
 import Client from '@common/services/api/Client';
 
 const notificationApi = new Client({
   baseURL: process.env.NOTIFICATION_API_BASE_URL,
+  requestInterceptors: [networkActivityRequestInterceptor],
+  responseInterceptors: [networkActivityResponseInterceptor],
 });
 
 export default notificationApi;

--- a/src/explore-education-statistics-frontend/src/services/clients/notificationApi.ts
+++ b/src/explore-education-statistics-frontend/src/services/clients/notificationApi.ts
@@ -1,12 +1,7 @@
 import Client from '@common/services/api/Client';
-import axios from 'axios';
-import qs from 'qs';
 
-const notificationApi = new Client(
-  axios.create({
-    baseURL: process.env.NOTIFICATION_API_BASE_URL,
-    paramsSerializer: params => qs.stringify(params, { arrayFormat: 'comma' }),
-  }),
-);
+const notificationApi = new Client({
+  baseURL: process.env.NOTIFICATION_API_BASE_URL,
+});
 
 export default notificationApi;

--- a/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
@@ -91,7 +91,7 @@ Validate Analyst1 cannot create a release for Pupil absence publication
 
 Navigate to Absence release
     ${ROW}=    user gets table row    Academic year 2016/17    testid:publication-published-releases
-    user clicks element    xpath://*[text()="View"]    ${ROW}
+    user clicks link containing text    View    ${ROW}
 
     user waits until h1 is visible    Pupil absence in schools in England
     user waits until h2 is visible    Release summary
@@ -102,12 +102,12 @@ Validate Analyst1 can see Absence release summary
 
 Validate Analyst1 can see 'Content' page
     user clicks link    Content
-    user waits for page to finish loading
+    user waits until page finishes loading
     user waits until h2 is visible    Pupil absence in schools in England    %{WAIT_SMALL}
 
 Validate Analyst1 can see 'Content' page key stats
     user waits until page contains element    id:releaseHeadlines    %{WAIT_LONG}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user scrolls to element    id:releaseHeadlines
     user checks key stat contents    1    Overall absence rate    4.7%    Up from 4.6% in 2015/16    90
     user checks key stat guidance    1    What is overall absence?

--- a/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
@@ -84,7 +84,7 @@ Create data block table
 
 Create chart for data block
     user waits until page contains link    Chart
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks link    Chart
 
     user clicks button    Choose an infographic as alternative

--- a/tests/robot-tests/tests/admin/analyst/invite_contributor_as_publication_owner.robot
+++ b/tests/robot-tests/tests/admin/analyst/invite_contributor_as_publication_owner.robot
@@ -184,5 +184,4 @@ Cancel contributor invite
 user clicks remove user button for row
     [Arguments]    ${text}
     ${row}=    get webelement    xpath://tbody/tr/td[.="${text}"]/..
-    ${remove_user_button}=    get child element    ${row}    xpath://button[text()="Remove"]
-    user clicks element    ${remove_user_button}
+    user clicks button    Remove    ${row}

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -41,7 +41,7 @@ Check publication owner can update methodology summary
 
 Check publication owner cannot approve methodology for publication
     user clicks link    Sign off
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks button    Edit status
 
     user waits until h2 is visible    Edit methodology status
@@ -64,14 +64,14 @@ Check publication owner can add data guidance to ${SUBJECT_NAME}
     user clicks button    Save guidance
 
 Navigate to 'Footnotes' page
-    user waits for page to finish loading
+    user waits until page finishes loading
     user clicks link    Footnotes
     user waits until h2 is visible    Footnotes
 
 Check publication owner can add a footnote to ${SUBJECT_NAME}
     user waits until page contains link    Create footnote
     user clicks link    Create footnote
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks footnote subject radio    ${SUBJECT_NAME}    Applies to all data
     user clicks element    id:footnoteForm-content
     user enters text into element    id:footnoteForm-content    test footnote from the publication owner! (analyst)
@@ -85,12 +85,12 @@ Add headline text block to Content page
 
 Add public prerelease access list
     user clicks link    Pre-release access
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user creates public prerelease access list    Test public access list
 
 Go to "Sign off" page
     user clicks link    Sign off
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks button    Edit release status
 
 Check publication owner can edit release status to "Ready for higher review"
@@ -162,7 +162,7 @@ Check release approver can approve methodology for publication
     user navigates to methodology    ${PUBLICATION_NAME}    ${PUBLICATION_NAME} - Updated methodology
 
     user clicks link    Sign off
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks button    Edit status
 
     user waits until h2 is visible    Edit methodology status

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_approver_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_approver_ui_permissions.robot
@@ -48,7 +48,7 @@ Check cannot create an amendment of a published release
 Check cannot see the readonly or editable version of the "Release access" section of the "Team access" page
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
     user clicks link    Team access
-    user waits for page to finish loading
+    user waits until page finishes loading
     user waits until h3 is not visible    Update release access
     user waits until h3 is not visible    Release access
     user waits until page does not contain link    Manage release contributors

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_contributor_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_contributor_ui_permissions.robot
@@ -53,7 +53,7 @@ Check cannot approve a draft release
 Check cannot see the readonly or editable version of the "Release access" section of the "Team access" page
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
     user clicks link    Team access
-    user waits for page to finish loading
+    user waits until page finishes loading
     user waits until h3 is not visible    Update release access
     user waits until h3 is not visible    Release access
     user waits until page does not contain link    Manage release contributors

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_viewer_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_viewer_ui_permissions.robot
@@ -53,7 +53,7 @@ Check cannot edit the release status of a Draft Release
 Check cannot see the readonly or editable version of the "Release access" section of the "Team access" page
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
     user clicks link    Team access
-    user waits for page to finish loading
+    user waits until page finishes loading
     user waits until h3 is not visible    Update release access
     user waits until h3 is not visible    Release access
     user waits until page does not contain link    Manage release contributors

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -980,7 +980,7 @@ Delete chart from data block
     user clicks link    Chart
     user clicks button    Delete chart
     user clicks button    Confirm
-    user waits until element does not contain infographic chart    id:chartBuilderPreview
+    user waits until page does not contain element    id:chartBuilderPreview
 
 Delete data block
     user clicks button    Delete this data block

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -32,20 +32,21 @@ Upload subject
     user uploads subject    UI test subject    upload-file-test.csv    upload-file-test.meta.csv
 
 Navigate to 'Footnotes' page
-    user waits for page to finish loading
+    user waits until page finishes loading
     user clicks link    Footnotes
     user waits until h2 is visible    Footnotes
 
 Create footnote
     user waits until page contains link    Create footnote
     user clicks link    Create footnote
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks footnote subject radio    UI test subject    Applies to all data
     user clicks element    id:footnoteForm-content
     user enters text into element    id:footnoteForm-content    ${FOOTNOTE_1}
     user clicks radio    Applies to all data
     user clicks button    Save footnote
     user waits until h2 is visible    Footnotes    %{WAIT_SMALL}
+    user waits until page finishes loading
 
 Start creating a data block
     user clicks link    Data blocks
@@ -301,12 +302,13 @@ Update footnote
     user clicks button    Save footnote
     user waits until page contains    ${FOOTNOTE_UPDATED}
     user checks page does not contain    ${FOOTNOTE_1}
+    user waits until page finishes loading
 
-Navigate to content tab
+Navigate to release content page
     user clicks link    Content
-    user waits until element is visible    //*[@class="dfe-page-editing"]//h2[text()="${PUBLICATION_NAME}"]
+    user waits until h2 is visible    ${PUBLICATION_NAME}
 
-Check updated footnote is displayed in content Tab
+Check updated footnote is displayed in release content page
     [Documentation]    EES-3136
     user clicks button    Test data block section
     ${section}=    user gets accordion section content element    Test data block section
@@ -423,7 +425,7 @@ Navigate to Chart tab
     user waits until h2 is visible    Edit data block
     user waits until h2 is visible    ${DATABLOCK_NAME}
 
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
     # Set url in suite variable so that we
     # can get back to this page quickly
@@ -595,7 +597,7 @@ Configure basic vertical bar chart
     user navigates to admin frontend    ${DATABLOCK_URL}
 
     user waits until h2 is visible    ${DATABLOCK_NAME}    %{WAIT_MEDIUM}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
     user clicks link    Chart
     user configures basic chart    Vertical bar    500    800
@@ -693,7 +695,7 @@ Save and validate vertical bar chart embeds correctly
 Configure basic horizontal bar chart
     user navigates to admin frontend    ${DATABLOCK_URL}
     user waits until h2 is visible    ${DATABLOCK_NAME}    %{WAIT_SMALL}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
     user clicks link    Chart
     user configures basic chart    Horizontal bar    600    700
@@ -734,6 +736,7 @@ Save and validate horizontal bar chart embeds correctly
     user clicks link    Chart configuration
     user clicks button    Save chart options
     user waits until button is enabled    Save chart options
+    user waits until page finishes loading
 
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
@@ -778,7 +781,7 @@ Save and validate horizontal bar chart embeds correctly
 Configure basic geographic chart
     user navigates to admin frontend    ${DATABLOCK_URL}
     user waits until h2 is visible    ${DATABLOCK_NAME}    %{WAIT_SMALL}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
     user clicks link    Chart
     user configures basic chart    Geographic    700    600
@@ -815,7 +818,7 @@ Change geographic chart legend
     user enters text into element    id:chartLegendConfigurationForm-items-3-label    Admissions in 2017
     user enters text into element    id:chartLegendConfigurationForm-items-4-label    Admissions in 2018
 
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
 Validate basic geographic chart preview
     user waits until element does not contain bar chart    id:chartBuilderPreview
@@ -907,13 +910,13 @@ Validate basic geographic chart preview updates correctly
 
 Save and validate geographic chart embeds correctly
     user scrolls to the bottom of the page
-    user clicks element    //*[@id="chartDataGroupingsConfigurationForm-submit"]
-    user waits until page does not contain loading spinner
+    user clicks element    id:chartDataGroupingsConfigurationForm-submit
+    user waits until page finishes loading
 
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user opens accordion section    ${CONTENT_SECTION_NAME}    id:releaseMainContent
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
     ${datablock}=    set variable    testid:Data block - ${DATABLOCK_NAME}
     user waits until page contains element    ${datablock}
@@ -937,7 +940,7 @@ Configure basic infographic chart
     user navigates to admin frontend    ${DATABLOCK_URL}
 
     user waits until h2 is visible    ${DATABLOCK_NAME}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
     user clicks link    Chart
     user waits until h3 is visible    Choose chart type
@@ -952,6 +955,7 @@ Validate basic infographic chart preview
 Save and validate infographic chart embeds correctly
     user clicks button    Save chart options
     user waits until button is enabled    Save chart options
+    user waits until page finishes loading
 
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
@@ -972,7 +976,7 @@ Delete embedded data block
 Delete chart from data block
     user navigates to admin frontend    ${DATABLOCK_URL}
     user waits until h2 is visible    ${DATABLOCK_NAME}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks link    Chart
     user clicks button    Delete chart
     user clicks button    Confirm
@@ -980,13 +984,13 @@ Delete chart from data block
 
 Delete data block
     user clicks button    Delete this data block
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks button    Confirm
     user waits until page does not contain button    Confirm
 
 Delete featured table
     user clicks button    Delete block
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks button    Confirm
     user waits until page does not contain button    Confirm
 

--- a/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
@@ -81,7 +81,7 @@ Verify that validation prevents adding an image without alt text
     user checks page contains    All images must have alternative text
 
     user clicks element    xpath://img
-    user clicks element    xpath://button[span[.="Change image text alternative"]]
+    user clicks button    Change image text alternative
     user enters text into element    label:Text alternative    Alt text for the uploaded content image
     user clicks element    css:button.ck-button-save
 

--- a/tests/robot-tests/tests/admin/bau/delete_subject.robot
+++ b/tests/robot-tests/tests/admin/bau/delete_subject.robot
@@ -137,7 +137,7 @@ Create table
 
 Navigate to Create chart tab
     user waits until page contains link    Chart
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks link    Chart
     user clicks button    Choose an infographic as alternative
     choose file    id:chartConfigurationForm-file    ${FILES_DIR}dfe-logo.jpg

--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -68,7 +68,7 @@ Select a user to manage
 
     user clicks link    Manage    ${PRE_RELEASE_ROW}
     user waits until page contains title    Manage user
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user waits until h1 is visible    Prerelease2 User2    10
 
 Check the initial manage user page
@@ -167,7 +167,7 @@ Give the user owner access to some publications
 Give the user the BAU User role
     user chooses select option    //*[@name="selectedRoleId"]    BAU User
     user clicks button    Update role
-    user waits for page to finish loading
+    user waits until page finishes loading
     user checks selected option label    //*[@name="selectedRoleId"]    BAU User
 
 Remove publication owner access for one of the publications from user while they are BAU
@@ -212,7 +212,7 @@ Give the user approver access to a release while they are BAU and manually set t
 
     user chooses select option    //*[@name="selectedRoleId"]    Analyst
     user clicks button    Update role
-    user waits for page to finish loading
+    user waits until page finishes loading
     user checks selected option label    //*[@name="selectedRoleId"]    Analyst
 
 Remove approver access for release from user after they have manually been set to Analyst

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -73,7 +73,7 @@ Add Useful information related page link to release
     user clicks button    Add related page link
     user enters text into element    id:relatedPageForm-description    Test link one
     user enters text into element    id:relatedPageForm-url    http://test1.example.com/test1
-    user clicks element    //button[text()="Create link"]    //*[@id="relatedPageForm"]
+    user clicks button    Create link    id:relatedPageForm
     user checks page does not contain element    id:${SECONDARY_STATS_TABLE_TAB_ID}
 
 Add secondary statistics
@@ -236,4 +236,4 @@ user clicks the nth key stats tile button
     [Arguments]
     ...    ${tile_number}
     ...    ${button_text}
-    user clicks element    //*[@data-testid="keyStat"][${tile_number}]//button[contains(., "${button_text}")]
+    user clicks button containing text    ${button_text}    xpath://*[@data-testid="keyStat"][${tile_number}]

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -105,7 +105,7 @@ Change secondary statistics
     user checks select contains option    name:selectedDataBlock    Key Stats Data Block 1
     user checks select contains option    name:selectedDataBlock    Key Stats Data Block 2
     user chooses and embeds data block    Data Block 2
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user waits until element is visible    //*[@id="${SECONDARY_STATS_TABLE_TAB_ID}"]    %{WAIT_MEDIUM}
     user checks page contains    Data Block 2 title
     user checks page contains button    Change secondary stats

--- a/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
@@ -10,7 +10,7 @@ Test Setup          fail test fast if required
 
 *** Variables ***
 ${RELEASE_NAME}=        Academic year Q1 2020/21
-${PUBLICATION_NAME}=    UI tests - comments %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    UI tests - release content authoring %{RUN_IDENTIFIER}
 ${SECTION_1_TITLE}=     First content section
 ${BLOCK_1_CONTENT}=     Block 1 content
 ${BLOCK_2_CONTENT}=     Block 2 content

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -240,6 +240,7 @@ Adopt a methodology with a draft amendment
     user waits until h2 is visible    Adopt a methodology
     user clicks radio    ${ADOPTED_PUBLICATION_NAME}
     user clicks button    Save
+    user waits until page finishes loading
 
 Check that having a draft methodology amendment adopted by this Release's Publication will show a checklist warning
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -270,7 +270,7 @@ Check data catalogue page contains archive and superseding publication subjects
     user checks page contains    This is not the latest data
 
     user clicks button    Change publication
-    user waits for page to finish loading
+    user waits until page finishes loading
     user waits until page contains    Choose a publication
 
     user clicks radio    %{TEST_THEME_NAME}
@@ -299,7 +299,7 @@ Check data catalogue page contains superseded warning for archived publication (
 
     user clicks radio    ${PUBLICATION_NAME_ARCHIVE}
     user clicks button    Next step
-    user waits for page to finish loading
+    user waits until page finishes loading
 
     user checks summary list contains    Publication    ${PUBLICATION_NAME_ARCHIVE}
 
@@ -466,7 +466,7 @@ Check data catalogue page is correct after archive-publication has been unarchiv
     user checks page does not contain    This is not the latest data
 
     user clicks button    Change publication
-    user waits for page to finish loading
+    user waits until page finishes loading
     user waits until page contains    Choose a publication
 
     user clicks radio    %{TEST_THEME_NAME}

--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -112,7 +112,7 @@ Choose publication
     user clicks button    Next step
 
 Check page displays correct data
-    user waits for page to finish loading
+    user waits until page finishes loading
     user waits until h1 is visible    Browse our open data
     user checks page contains    Choose a release
     user clicks radio    ${RELEASE_NAME} 2021/22

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -32,7 +32,7 @@ Upload subject
 
 Check release isn't publically visible
     user clicks link    Sign off
-    user waits for page to finish loading
+    user waits until page finishes loading
     user waits until page contains element    testid:public-release-url
     ${PUBLIC_RELEASE_LINK}=    Get Value    testid:public-release-url
     check that variable is not empty    PUBLIC_RELEASE_LINK    ${PUBLIC_RELEASE_LINK}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
@@ -39,6 +39,7 @@ Add Related dashboards section to release content
     user starts editing text block    id:related-dashboards-content
     user presses keys    Related dashboards test text
     user clicks button    Save & close
+    user waits until page finishes loading
     user waits until element contains    id:related-dashboards-content    Edit block
 
 Add an accordion section to release content
@@ -58,7 +59,9 @@ Add text block with link to absence glossary entry to accordion section
     user clicks button    Insert
     user waits until modal is not visible    Insert glossary link
     user clicks button    Save & close
-    user waits until element contains    ${block}    Absence
+    user waits until page finishes loading
+    user waits until parent contains button    ${block}    Edit block
+    user waits until parent contains button    ${block}    Absence
 
 Check glossary info icon appears on release preview
     user clicks radio    Preview release page

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -452,7 +452,7 @@ Edit footnote
 Check footnote was updated on data block
     # set focus to 'data blocks' link to ensure the click doesn't set focus to the data blocks link
     # This results in a failure whereby the tests stay on the footnote page
-    user sets focus to element    //a[text()="Data blocks"]    //*[@aria-label="Release"]
+    user sets focus to element    link:Data blocks   xpath://*[@aria-label="Release"]
     user clicks link    Data blocks
 
     user waits until h2 is visible    Data blocks    %{WAIT_SMALL}
@@ -479,7 +479,7 @@ Reorder footnotes
     user clicks button    Save order
 
 Check footnotes were reordered on data block
-    user sets focus to element    //a[text()="Data blocks"]    //*[@aria-label="Release"]
+    user sets focus to element    link:Data blocks    xpath://*[@aria-label="Release"]
     user clicks link    Data blocks
 
     user waits until h2 is visible    Data blocks    %{WAIT_SMALL}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -178,7 +178,7 @@ Verify that methodology hash links open accoridon sections correctly
     user checks page contains    Content 3
 
     user navigates to public frontend    ${METHODOLOGY_URL}#content-section-4-test-title-4
-    user waits for page to finish loading
+    user waits until page finishes loading
 
     user checks page contains    4.-test-.title 4
     user checks page contains    Content 4

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -85,7 +85,7 @@ Create data block table
 
 Create chart for data block
     user waits until page contains link    Chart
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks link    Chart
 
     user clicks button    Choose an infographic as alternative
@@ -103,8 +103,8 @@ Navigate to 'Content' page
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user waits until page contains button    Add a summary text block    %{WAIT_SMALL}
 
-    user waits for page to finish loading
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
+    user waits until page finishes loading
 
 Add headline text block
     user adds headlines text block
@@ -198,7 +198,7 @@ Return to Admin and create amendment
 Change the Release type
     user waits until page contains link    Edit release summary
     user clicks link    Edit release summary
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user waits until h2 is visible    Edit release summary
     user checks page contains radio    Experimental statistics
     user clicks radio    Experimental statistics
@@ -430,8 +430,8 @@ Verify that the footnotes are unchanged
 Verify that release content is unchanged
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
-    user waits for page to finish loading
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
+    user waits until page finishes loading
 
     user checks there are x accordion sections    3    id:releaseMainContent
     user checks accordion is in position    Dates data block    1    id:releaseMainContent

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -105,7 +105,7 @@ Create data block table
 
 Create chart for data block
     user waits until page contains link    Chart
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks link    Chart
 
     user clicks button    Choose an infographic as alternative
@@ -131,8 +131,8 @@ Add free text key stat
     user checks key stat guidance    1    Guidance title    Guidance text
 
 Add three accordion sections to release
-    user waits for page to finish loading
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
+    user waits until page finishes loading
     user clicks button    Add new section
     user changes accordion section title    1    Dates data block
     user clicks button    Add new section
@@ -215,6 +215,7 @@ Edit data block
 
     user clicks button    Save data block
     user waits until page contains button    Delete this data block
+    user waits until page finishes loading
 
 Navigate to the 'Content' page
     user clicks link    Content
@@ -447,7 +448,7 @@ Return to Admin and create first amendment
 Change the Release type
     user waits until page contains link    Edit release summary
     user clicks link    Edit release summary
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user waits until h2 is visible    Edit release summary
     user checks page contains radio    Experimental statistics
     user clicks radio    Experimental statistics
@@ -611,7 +612,7 @@ Save data block for amendment
 
 Update data block chart for amendment
     user waits until page contains link    Chart    %{WAIT_SMALL}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks link    Chart
 
     user waits until page contains element    id:chartConfigurationForm-title    %{WAIT_SMALL}
@@ -624,7 +625,7 @@ Update data block chart for amendment
     user checks textarea contains    id:chartConfigurationForm-alt    Amended sample alt text
 
     user clicks button    Save chart options
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user waits until page contains element    id:chartBuilderPreview
     user checks infographic chart contains alt    id:chartBuilderPreview    Amended sample alt text
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
@@ -114,9 +114,8 @@ Approve release
 Go to public Table Tool page
     user navigates to data tables page on public frontend
 
-Select "Test Topic" publication
+Select "Test theme" publication
     environment variable should be set    TEST_THEME_NAME
-    environment variable should be set    TEST_TOPIC_NAME
     user clicks radio    %{TEST_THEME_NAME}
     user clicks radio    ${PUBLICATION_NAME}
     user clicks element    id:publicationForm-submit

--- a/tests/robot-tests/tests/general_public/miscellaneous.robot
+++ b/tests/robot-tests/tests/general_public/miscellaneous.robot
@@ -19,7 +19,7 @@ Verify can accept cookie banner
     cookie should not exist    ees_banner_seen
     cookie should not exist    ees_disable_google_analytics
 
-    user clicks element    xpath://button[text()="Accept analytics cookies"]
+    user clicks button    Accept analytics cookies
 
     cookie should have value    ees_banner_seen    true
     cookie should have value    ees_disable_google_analytics    false
@@ -64,7 +64,7 @@ Validate Cookies page
 
 Disable google analytics
     user clicks element    id:cookieSettingsForm-googleAnalytics-off
-    user clicks element    xpath://button[text()="Save changes"]
+    user clicks button    Save changes
     user waits until page contains    Your cookie settings were saved
 
     cookie should have value    ees_banner_seen    true
@@ -77,7 +77,7 @@ Enable google analytics
 
     sleep    1    # NOTE(mark): Without the wait, the click doesn't select the radio despite the DOM being loaded
     user clicks element    id:cookieSettingsForm-googleAnalytics-on
-    user clicks element    xpath://button[text()="Save changes"]
+    user clicks button    Save changes
     user waits until page contains    Your cookie settings were saved
     cookie should have value    ees_banner_seen    true
     cookie should have value    ees_disable_google_analytics    false

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -304,7 +304,7 @@ Check Regional and local authority (LA) breakdown table has footnotes
     [Tags]    Failing
     ${accordion}=    user opens accordion section    Regional and local authority (LA) breakdown    id:content
     user scrolls down    500
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     ${data_block_table}=    user gets data block table from parent    LAD map    ${accordion}
     user checks list has x items    testid:footnotes    2    ${data_block_table}
     user checks list item contains    testid:footnotes    1
@@ -386,7 +386,7 @@ Clicking "Create tables" takes user to Table Tool page with absence publication 
     [Tags]    Failing
     user clicks link    View or create your own tables
     user waits until h1 is visible    Create your own tables    %{WAIT_MEDIUM}
-    user waits for page to finish loading
+    user waits until page finishes loading
 
     user waits until table tool wizard step is available    2    Select a data set
     user checks previous table tool step contains    1    Publication    Pupil absence in schools in England

--- a/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
@@ -70,7 +70,7 @@ Validate Number of schools row results
     user checks table cell contains    1    4    349
 
 Go back to Locations step
-    user clicks element    xpath://button[contains(text(), "Edit locations")]
+    user clicks button    Edit locations
     user waits until table tool wizard step is available    3    Choose locations
 
 Unselect England as a location

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -73,9 +73,9 @@ user selects dashboard theme and topic if possible
     [Arguments]
     ...    ${theme_name}=%{TEST_THEME_NAME}
     ...    ${topic_name}=%{TEST_TOPIC_NAME}
-    user waits until page does not contain loading spinner
-    ${dropsdowns_exist}=    user checks dashboard theme topic dropdowns exist
-    IF    ${dropsdowns_exist}
+    user waits until page finishes loading
+    ${dropdowns_exist}=    user checks dashboard theme topic dropdowns exist
+    IF    ${dropdowns_exist}
         user chooses select option    id:publicationsReleases-themeTopic-themeId    ${theme_name}
         user waits until page contains element    id:publicationsReleases-themeTopic-topicId
         user chooses select option    id:publicationsReleases-themeTopic-topicId    ${topic_name}
@@ -96,7 +96,7 @@ user navigates to release page from dashboard
     ...    ${THEME_NAME}
     ...    ${TOPIC_NAME}
 
-    user waits for page to finish loading
+    user waits until page finishes loading
     ${ROW}=    user gets table row    ${RELEASE_NAME}    testid:${RELEASE_TABLE_TESTID}
     user scrolls to element    ${ROW}
 
@@ -191,7 +191,7 @@ user navigates to publication page from dashboard
     user clicks link    ${publication}
     user waits until h1 is visible    ${publication}
     user waits until h2 is visible    Manage releases
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
 user creates methodology for publication
     [Arguments]
@@ -500,7 +500,7 @@ user approves amended release for immediate publication
 user approves release for immediate publication
     [Arguments]    ${release_type}=original    ${NEXT_RELEASE_MONTH}=01    ${NEXT_RELEASE_YEAR}=2200
     user clicks link    Sign off
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user waits until h2 is visible    Sign off
     user waits until page contains button    Edit release status
     user clicks button    Edit release status
@@ -571,7 +571,7 @@ user puts release into draft
 
 user puts release into higher level review
     user clicks link    Sign off
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user waits until h2 is visible    Sign off    %{WAIT_SMALL}
     user clicks button    Edit release status
     user waits until h2 is visible    Edit release status    %{WAIT_SMALL}
@@ -589,7 +589,7 @@ user approves release for scheduled publication
     ...    ${next_release_year}=2200
     ...    ${update_amendment_published_date}=${False}
     user clicks link    Sign off
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user waits until h2 is visible    Sign off    %{WAIT_SMALL}
     user waits until page contains button    Edit release status    %{WAIT_SMALL}
 
@@ -721,7 +721,7 @@ user removes publication access from analyst
     ${row}=    get child element    ${table}
     ...    xpath://tbody/tr[td[//th[text()="Publication"] and text()="${PUBLICATION_NAME}"] and td[//th[text()="Role"] and text()="${ROLE}"]]
     user clicks button    Remove    ${row}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
 user gives release access to analyst
     [Arguments]
@@ -749,7 +749,7 @@ user removes release access from analyst
     ${row}=    get child element    ${table}
     ...    xpath://tbody/tr[td[//th[text()="Publication"] and text()="${PUBLICATION_NAME}"] and td[//th[text()="Release"] and text()="${RELEASE_NAME}"] and td[//th[text()="Role"] and text()="${ROLE}"]]
     user clicks button    Remove    ${row}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
 user goes to manage user
     [Arguments]    ${EMAIL_ADDRESS}

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -100,7 +100,7 @@ user navigates to release page from dashboard
     ${ROW}=    user gets table row    ${RELEASE_NAME}    testid:${RELEASE_TABLE_TESTID}
     user scrolls to element    ${ROW}
 
-    user clicks element    xpath://a[text()="${LINK_TEXT}"]    ${ROW}    # "user clicks link" doesn't work
+    user clicks link by visible text    ${LINK_TEXT}    ${ROW}
     user waits until h2 is visible    Release summary    %{WAIT_SMALL}
 
 user navigates to draft release page from dashboard
@@ -823,6 +823,13 @@ get release id from url
     ${release_id}=    Get From List    ${release_id_match}    0
     [Return]    ${release_id}
 
+user clicks the nth key stats tile button
+    [Arguments]
+    ...    ${tile_num}
+    ...    ${button_text}
+    user waits until page contains element    xpath://*[@data-testid="keyStat"][${tile_num}]
+    user clicks button containing text    ${button_text}    xpath://*[@data-testid="keyStat"][${tile_num}]
+
 user adds free text key stat
     [Arguments]    ${title}    ${statistic}    ${trend}    ${guidance_title}    ${guidance_text}
     user clicks button    Add free text key statistic
@@ -841,10 +848,7 @@ user adds free text key stat
 
 user updates free text key stat
     [Arguments]    ${tile_num}    ${title}    ${statistic}    ${trend}    ${guidance_title}    ${guidance_text}
-    user waits until page contains element    xpath://*[@data-testid="keyStat"][${tile_num}]
-
-    user clicks element    xpath://*[@data-testid="keyStat"][${tile_num}]//button[contains(text(), "Edit")]
-
+    user clicks the nth key stats tile button    ${tile_num}    Edit
     user waits until page contains button    Save
 
     user enters text into element    xpath://*[@data-testid="keyStat"][${tile_num}]//input[@name="title"]    ${title}
@@ -862,8 +866,7 @@ user updates free text key stat
 
 user removes key stat
     [Arguments]    ${tile_num}
-    user waits until page contains element    xpath://*[@data-testid="keyStat"][${tile_num}]
-    user clicks element    xpath://*[@data-testid="keyStat"][${tile_num}]//button[contains(text(), "Remove")]
+    user clicks the nth key stats tile button    ${tile_num}    Remove
 
 user closes admin feedback banner if needed
     user clicks element if exists    //*[@data-testid="admin-survey-banner"]//button[text()="Close"]

--- a/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
+++ b/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
@@ -36,7 +36,7 @@ user cannot see edit controls for release content
 
 user cannot see the edit release status controls for release
     user clicks link    Sign off
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user checks page does not contain    Edit release status
 
 user cannot see the enabled approve release controls for release
@@ -54,7 +54,7 @@ user can see the create amendment controls for release
 
 user cannot see the edit status controls for methodology
     user clicks link    Sign off
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user checks page does not contain    Edit status
 
 user cannot see the remove controls for methodology

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -49,7 +49,7 @@ user creates new content section
     ...    ${content_section_name}
     ...    ${parent}=css:body
 
-    user clicks element    xpath://button[.="Add new section"]    ${parent}
+    user clicks button    Add new section    ${parent}
     user changes accordion section title    ${section_number}    ${content_section_name}    ${parent}
 
 user creates data block for dates csv
@@ -355,7 +355,7 @@ user adds image to accordion section text block
     choose file
     ...    xpath://button[span[.="Insert image"]]/following-sibling::input[@type="file"]
     ...    ${FILES_DIR}${filename}
-    user clicks element    xpath://button[span[.="Change image text alternative"]]
+    user clicks button    Change image text alternative
     user enters text into element    label:Text alternative    ${alt_text}
     user clicks element    css:button.ck-button-save
     user clicks element    xpath://div[@title="Insert paragraph after block"]

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -22,8 +22,8 @@ user navigates to content page
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user waits until page contains button    Add note    %{WAIT_SMALL}
 
-    user waits for page to finish loading
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
+    user waits until page finishes loading
 
 user adds basic release content
     [Arguments]    ${publication}    ${add_headlines_block}=${TRUE}
@@ -166,7 +166,7 @@ user chooses and embeds data block
     user waits until button is enabled    Embed    %{WAIT_SMALL}
     user clicks button    Embed
     user waits until page does not contain button    Embed    %{WAIT_MEDIUM}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
 user opens nth editable accordion section
     [Arguments]
@@ -235,7 +235,7 @@ user adds data block to editable accordion section
     ...    ${parent}=css:[data-testid="accordion"]
 
     ${section}=    user gets accordion section content element    ${section_name}    ${parent}
-    user waits for page to finish loading
+    user waits until page finishes loading
     user clicks button    Add data block    ${section}
     ${block_list}=    get child element    ${section}    css:select[name="selectedDataBlock"]
     user chooses select option    ${block_list}    Dates data block name
@@ -370,6 +370,7 @@ user adds image to accordion section text block
     user presses keys    SHIFT+TAB
 
     user clicks button    Save    ${block}
+    user waits until page finishes loading
 
 user adds image without alt text to accordion section text block
     [Arguments]
@@ -394,6 +395,7 @@ user adds image without alt text to accordion section text block
     ...    xpath://img[starts-with(@src, "/api/")]
 
     user clicks button    Save    ${block}
+    user waits until page finishes loading
 
 user removes image from accordion section text block
     [Arguments]
@@ -416,6 +418,7 @@ user removes image from accordion section text block
     # Delete the empty line left by the deleted image.
     user presses keys    DELETE
     user clicks button    ${save_button}    ${block}
+    user waits until page finishes loading
 
 user saves autosaving text block
     [Arguments]    ${parent}
@@ -427,6 +430,7 @@ user saves autosaving text block
     sleep    0.2
 
     user clicks button    Save & close    ${parent}
+    user waits until page finishes loading
     user waits until parent does not contain button    ${parent}    Save & close    %{WAIT_SMALL}
 
 user checks accordion section text block contains
@@ -468,9 +472,8 @@ user deletes editable accordion section content block
     ${block}=    get accordion section block    ${section_name}    ${block_num}    ${parent}
     user clicks button    Remove block    ${block}
     user clicks button    Confirm
-    # avoid blocks being lazy loaded
-    user waits until page does not contain loading spinner
-    Sleep    0.75
+    user waits until page finishes loading
+    sleep    0.75
     user scrolls down    1
 
 user deletes editable accordion section

--- a/tests/robot-tests/tests/libs/bootstrap_data/bootstrap_common.robot
+++ b/tests/robot-tests/tests/libs/bootstrap_data/bootstrap_common.robot
@@ -94,7 +94,7 @@ user creates a fully populated draft release
 
     # add data guidance
     user clicks link    Data guidance
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user enters text into element    id:dataGuidanceForm-content    Test data guidance content
     user waits until page contains accordion section    ${SUBJECT_NAME}
     user enters text into data guidance data file content editor    ${SUBJECT_NAME}
@@ -102,12 +102,12 @@ user creates a fully populated draft release
     user clicks button    Save guidance
 
     # add footnote
-    user waits for page to finish loading
+    user waits until page finishes loading
     user clicks link    Footnotes
     user waits until h2 is visible    Footnotes
     user waits until page contains link    Create footnote
     user clicks link    Create footnote
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user clicks footnote subject radio    ${SUBJECT_NAME}    Applies to all data
     user clicks element    id:footnoteForm-content
     user enters text into element    id:footnoteForm-content    test footnote
@@ -116,5 +116,5 @@ user creates a fully populated draft release
 
     # add public prerelease access list
     user clicks link    Pre-release access
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user creates public prerelease access list    Test public access list

--- a/tests/robot-tests/tests/libs/charts.robot
+++ b/tests/robot-tests/tests/libs/charts.robot
@@ -178,14 +178,14 @@ user checks infographic chart contains alt
 
 user configures basic chart
     [Arguments]    ${CHART_TYPE}    ${CHART_HEIGHT}    ${CHART_WIDTH}
-    user waits for page to finish loading
+    user waits until page finishes loading
     ${CHART_TYPE_LIST}=    create list    Line    Horizontal bar    Vertical bar    Geographic
     should contain    ${CHART_TYPE_LIST}    ${CHART_TYPE}
 
     user waits until h3 is visible    Choose chart type    %{WAIT_SMALL}
     user clicks button    ${CHART_TYPE}
 
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
     user enters text into element    id:chartConfigurationForm-height    ${CHART_HEIGHT}
     user enters text into element    id:chartConfigurationForm-width    ${CHART_WIDTH}
 

--- a/tests/robot-tests/tests/libs/charts.robot
+++ b/tests/robot-tests/tests/libs/charts.robot
@@ -33,7 +33,7 @@ user waits until element contains infographic chart
 
 user waits until element does not contain infographic chart
     [Arguments]    ${locator}
-    user waits until parent contains element    ${locator}    css:img
+    user waits until parent does not contain element    ${locator}    css:img
 
 user waits until element contains chart tooltip
     [Arguments]    ${locator}

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -181,21 +181,15 @@ user checks css property value
     ${actual_value}=    user gets css property value    ${locator}    ${property}
     should be equal    ${value}    ${actual_value}
 
-user waits for page to finish loading
-    # This is required because despite the DOM being loaded, and even a button being enabled, React/NextJS
-    # hasn't finished processing the page, and so click are intermittently ignored. I'm wrapping
-    # this sleep in a keyword such that if we find a way to check whether the JS processing has finished in the
-    # future, we can change it here.
-    sleep    1
-
-user waits until page does not contain loading spinner
-    # NOTE: The wait below is to prevent a transient error in CI ('Element 'css:[class^="LoadingSpinner"]' did not
-    # disappear in 30 seconds.')
-
-    # Also, we're only interested in loading spinners that aren't lazy loaders that are waiting for user interaction
-    # prior to loading their content.
+user waits until page finishes loading
+    [Arguments]    ${spinner_timeout}=%{WAIT_MEDIUM}    ${network_timeout}=%{WAIT_MEDIUM}
+    # We're only interested in loading spinners that aren't lazy loaders that are
+    # waiting for user interaction prior to loading their content.
     user waits until page does not contain element    //*[@class!="lazyload-wrapper"]/*[@data-testid="loadingSpinner"]
-    ...    %{WAIT_MEDIUM}
+    ...    ${spinner_timeout}
+    # Wait to ensure network activity attribute is updated in DOM
+    sleep    0.5
+    user waits until page does not contain element    css:body[data-network-activity="active"]    ${network_timeout}
 
 user sets focus to element
     [Arguments]    ${selector}    ${parent}=css:body
@@ -513,6 +507,10 @@ user clicks link
 user clicks link by visible text
     [Arguments]    ${text}    ${parent}=css:body
     user clicks element    xpath:.//a[text()="${text}"]    ${parent}
+
+user clicks link containing text
+    [Arguments]    ${text}    ${parent}=css:body
+    user clicks element    xpath:.//a[contains(text(), ${text})]    ${parent}
 
 user clicks button
     [Arguments]    ${text}    ${parent}=css:body
@@ -912,7 +910,7 @@ user waits until table tool wizard step is available
     # this visible check passes when it should fail?!
     user waits until element is visible    xpath://h2|h3//*[contains(text(),"${table_tool_step_title}")]
     ...    %{WAIT_SMALL}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
 user gets data block from parent
     [Arguments]    ${data_block_name}    ${parent}

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -510,7 +510,7 @@ user clicks link by visible text
 
 user clicks link containing text
     [Arguments]    ${text}    ${parent}=css:body
-    user clicks element    xpath:.//a[contains(text(), ${text})]    ${parent}
+    user clicks element    xpath:.//a[contains(text(), "${text}")]    ${parent}
 
 user clicks button
     [Arguments]    ${text}    ${parent}=css:body
@@ -519,7 +519,7 @@ user clicks button
 
 user clicks button containing text
     [Arguments]    ${text}    ${parent}=css:body
-    user clicks element    xpath://button[contains(text(),${text})]    ${parent}
+    user clicks element    xpath://button[contains(text(), "${text}")]    ${parent}
 
 user waits until page contains button
     [Arguments]    ${text}    ${wait}=${timeout}

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -523,32 +523,38 @@ user clicks button containing text
 
 user waits until page contains button
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until page contains element    xpath://button[text()="${text}"]    ${wait}
+    user waits until page contains element    xpath://button[text()="${text}" or .//*[text()="${text}"]]    ${wait}
 
 user checks page contains button
     [Arguments]    ${text}
-    user checks page contains element    xpath://button[text()="${text}"]
+    user checks page contains element    xpath://button[text()="${text}" or .//*[text()="${text}"]]
 
 user checks page does not contain button
     [Arguments]    ${text}
-    user checks page does not contain element    xpath://button[text()="${text}"]
+    user checks page does not contain element    xpath://button[text()="${text}" or .//*[text()="${text}"]]
 
 user waits until page does not contain button
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until page does not contain element    xpath://button[text()="${text}"]    ${wait}
+    user waits until page does not contain element    xpath://button[text()="${text}" or .//*[text()="${text}"]]
+    ...    ${wait}
 
 user waits until button is enabled
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is enabled    xpath://button[text()="${text}"]    ${wait}
+    user waits until element is enabled    xpath://button[text()="${text}" or .//*[text()="${text}"]]    ${wait}
+
+user waits until parent contains button
+    [Arguments]    ${parent}    ${text}    ${wait}=${timeout}
+    user waits until parent contains element    ${parent}
+    ...    xpath:.//button[text()="${text}" or .//*[text()="${text}"]]    ${wait}
 
 user waits until parent does not contain button
     [Arguments]    ${parent}    ${text}    ${wait}=${timeout}
-    user waits until parent does not contain element    ${parent}    xpath://button[text()="${text}"]    ${wait}
+    user waits until parent does not contain element    ${parent}
+    ...    xpath:.//button[text()="${text}" or .//*[text()="${text}"]]    ${wait}
 
 user gets button element
     [Arguments]    ${text}    ${parent}=css:body
-    user waits until parent contains element    ${parent}
-    ...    xpath:.//button[text()="${text}" or .//*[text()="${text}"]]
+    user waits until parent contains button    ${parent}    ${text}
     ${button}=    get child element    ${parent}    xpath:.//button[text()="${text}" or .//*[text()="${text}"]]
     [Return]    ${button}
 

--- a/tests/robot-tests/tests/libs/table_tool.robot
+++ b/tests/robot-tests/tests/libs/table_tool.robot
@@ -66,11 +66,11 @@ user checks category checkbox is checked
 
 user clicks select all for category
     [Arguments]    ${category_label}
-    user clicks element    xpath://legend[text()="${category_label}"]/..//button[contains(text(), "Select")]
+    user clicks button containing text    Select all    xpath://legend[text()="${category_label}"]/..
 
 user clicks unselect all for category
     [Arguments]    ${category_label}
-    user clicks element    xpath://legend[text()="${category_label}"]/..//button[contains(text(), "Unselect")]
+    user clicks button containing text    Unselect all    xpath://legend[text()="${category_label}"]/..
 
 user checks location checkbox is checked
     [Arguments]    ${location_label}

--- a/tests/robot-tests/tests/libs/table_tool.robot
+++ b/tests/robot-tests/tests/libs/table_tool.robot
@@ -6,7 +6,7 @@ Resource    ./common.robot
 user waits until results table appears
     [Arguments]    ${wait_time}
     user waits until page contains element    css:table thead th    ${wait_time}
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading
 
 user clicks indicator checkbox
     [Arguments]    ${indicator_label}

--- a/tests/robot-tests/tests/libs/tables-common.robot
+++ b/tests/robot-tests/tests/libs/tables-common.robot
@@ -73,18 +73,12 @@ user checks headed table body row cell contains
 
 user clicks link in table cell
     [Arguments]    ${row}    ${column}    ${link_text}    ${parent}=css:table
-    user waits until parent contains element    ${parent}
-    ...    xpath:.//tbody/tr[${row}]/td[${column}]/a[contains(., "${link_text}")]
-    ${link}=    get child element
-    ...    ${parent}
-    ...    xpath:.//tbody/tr[${row}]/td[${column}]/a[contains(., "${link_text}")]
-    user clicks element    ${link}
+    user waits until parent contains element    ${parent}    xpath:.//tbody/tr[${row}]/td[${column}]
+    ${cell}=    get child element    ${parent}    xpath:.//tbody/tr[${row}]/td[${column}]
+    user clicks link containing text    ${link_text}    ${cell}
 
 user clicks button in table cell
     [Arguments]    ${row}    ${column}    ${button_text}    ${parent}=css:table
-    user waits until parent contains element    ${parent}
-    ...    xpath:.//tbody/tr[${row}]/td[${column}]/button[contains(., "${button_text}")]
-    ${button}=    get child element
-    ...    ${parent}
-    ...    xpath:.//tbody/tr[${row}]/td[${column}]/button[contains(., "${button_text}")]
-    user clicks element    ${button}
+    user waits until parent contains element    ${parent}    xpath:.//tbody/tr[${row}]/td[${column}]
+    ${cell}=    get child element    ${parent}    xpath:.//tbody/tr[${row}]/td[${column}]
+    user clicks button containing text    ${button_text}    ${cell}

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -195,14 +195,6 @@ def get_child_elements(parent_locator: object, child_locator: str):
         raise_assertion_error(err)
 
 
-def user_waits_for_page_to_finish_loading():
-    # This is required because despite the DOM being loaded, and even a button being enabled,
-    # React/NextJS hasn't finished processing the page, and so click are intermittently ignored.
-    # I'm wrapping this sleep in a keyword such that if we find a way to check whether the JS
-    # processing has finished in the future, we can change it here.
-    time.sleep(0.2)
-
-
 def user_sets_focus_to_element(selector):
     sl.wait_until_page_contains_element(selector)
     sl.set_focus_to_element(selector)

--- a/tests/robot-tests/tests/visual_testing/tables_and_charts.robot
+++ b/tests/robot-tests/tests/visual_testing/tables_and_charts.robot
@@ -169,4 +169,4 @@ user waits for chart to appear
     ELSE
         Fail    Unhandled chart type ${chart_type}
     END
-    user waits until page does not contain loading spinner
+    user waits until page finishes loading


### PR DESCRIPTION
This PR deals primarily deals with UI test failures revolving around pages not being ready and network requests not having completed.

## Page loading

In some cases, we're not waiting sufficiently long enough for the page to complete loading. This is leading to the DOM not being ready to actually receive things like click events. This can lead to the intermittent failures where a link was clicked, but no navigation occurred.

Unfortunately, there isn't really any good way to figure out when React has fully prepared the DOM and we just have to rely on a combination of implicit and explicit waits.

## Network requests

In a number of cases, network requests will be initiated by an action (e.g. clicking some button), but the tests won't wait for these to finish before moving on to validate that the action has completed.

We have tried to rectify this by implementing additional hooks on `Client` so that we now monitor network activity:

- When there are any network requests in progress, we add a `data-network-activity="active"` state to the `body`
- When the network goes idle, we toggle this state to `data-network-activity="idle"`

We can then watch for this using Robot Framework to wait for inflight requests to complete.

**Note** - This only hooks into requests we make using `Client` and not raw XHR, fetch or any other type of HTTP client.

## Changes to loading keywords

- Renamed `user waits for page to finish loading` to the more consistent `user waits until page finishes loading`. This now handles waiting for the network to become idle.
- Removed the `user waits for page to not contain loading spinner` in favour of `user waits until page finishes loading`. The loading spinner keyword is redundant as we're only ever really interested in the loading state of the entire page (not just a spinner).

## Other changes

- Added `composeProviders` HOC that allows us to flatten down the 'provider tree of doom' in our application entrypoints.
- Cleaned up various UI tests to use `user clicks button/link` keywords
- Updated `user clicks button` keywords to search for text in nested elements