### PR TITLE
EES-4557 Show all methodologies associated with release on Admin Cont…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
@@ -177,7 +177,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var methodologyService = new Mock<IMethodologyService>(Strict);
 
             methodologyService
-                .Setup(s => s.ListLatestMethodologyVersions(_id))
+                .Setup(s => s.ListLatestMethodologyVersions(_id, false))
                 .ReturnsAsync(ListOf(new MethodologyVersionSummaryViewModel()));
 
             var controller = SetupMethodologyController(methodologyService.Object);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ManageContentPageController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ManageContentPageController.cs
@@ -21,10 +21,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Manag
         }
 
         [HttpGet("release/{releaseId:guid}/content")]
-        public async Task<ActionResult<ManageContentPageViewModel>> GetManageContentPageData(Guid releaseId)
+        public async Task<ActionResult<ManageContentPageViewModel>> GetManageContentPageData(Guid releaseId,
+            [FromQuery] bool isPrerelease = false)
         {
             return await _manageContentPageService
-                .GetManageContentPageViewModel(releaseId)
+                .GetManageContentPageViewModel(releaseId, isPrerelease)
                 .HandleFailuresOrOk();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
@@ -78,10 +78,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
         }
 
         [HttpGet("publication/{publicationId:guid}/methodologies")]
-        public async Task<ActionResult<List<MethodologyVersionSummaryViewModel>>> ListLatestMethodologyVersions(Guid publicationId)
+        public async Task<ActionResult<List<MethodologyVersionSummaryViewModel>>> ListLatestMethodologyVersions(
+            Guid publicationId,
+            [FromQuery] bool isPrerelease = false)
         {
             return await _methodologyService
-                .ListLatestMethodologyVersions(publicationId)
+                .ListLatestMethodologyVersions(publicationId, isPrerelease)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IManageContentPageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IManageContentPageService.cs
@@ -8,6 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 {
     public interface IManageContentPageService
     {
-        Task<Either<ActionResult, ManageContentPageViewModel>> GetManageContentPageViewModel(Guid releaseId);
+        Task<Either<ActionResult, ManageContentPageViewModel>> GetManageContentPageViewModel(
+            Guid releaseId, bool isPrerelease = false);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
@@ -27,7 +27,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 
         Task<Either<ActionResult, MethodologyVersionViewModel>> GetMethodology(Guid methodologyVersionId);
 
-        Task<Either<ActionResult, List<MethodologyVersionSummaryViewModel>>> ListLatestMethodologyVersions(Guid publicationId);
+        Task<Either<ActionResult, List<MethodologyVersionSummaryViewModel>>> ListLatestMethodologyVersions(
+            Guid publicationId,
+            bool isPrerelease = false);
 
         Task<Either<ActionResult, List<IdTitleViewModel>>> GetUnpublishedReleasesUsingMethodology(
             Guid methodologyVersionId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Manag
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -24,6 +25,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
 {
     public class ManageContentPageService : IManageContentPageService
     {
+        private readonly ContentDbContext _contentDbContext;
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
         private readonly IMapper _mapper;
         private readonly IDataBlockService _dataBlockService;
@@ -32,6 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
         private readonly IUserService _userService;
 
         public ManageContentPageService(
+            ContentDbContext contentDbContext,
             IPersistenceHelper<ContentDbContext> persistenceHelper,
             IMapper mapper,
             IDataBlockService dataBlockService,
@@ -39,6 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
             IReleaseFileService releaseFileService,
             IUserService userService)
         {
+            _contentDbContext = contentDbContext;
             _persistenceHelper = persistenceHelper;
             _mapper = mapper;
             _dataBlockService = dataBlockService;
@@ -62,16 +66,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                 {
                     var (release, unattachedDataBlocks, files) = releaseBlocksAndFiles;
 
-                    List<MethodologyVersion> methodologyVersions;
+                    var methodologyVersions =
+                        await _methodologyVersionRepository.GetLatestVersionByPublication(release.PublicationId);
+
                     if (isPrerelease)
                     {
-                        methodologyVersions = await _methodologyVersionRepository
-                            .GetLatestPublishedVersionByPublication(release.PublicationId);
-                    }
-                    else
-                    {
-                        methodologyVersions = await _methodologyVersionRepository
-                            .GetLatestVersionByPublication(release.PublicationId);
+                        // Get latest approved version
+                        methodologyVersions = await methodologyVersions
+                            .ToAsyncEnumerable()
+                            .SelectAwait(async version =>
+                            {
+                                if (version.Status == MethodologyApprovalStatus.Approved)
+                                {
+                                    return version;
+                                }
+
+                                if (version.PreviousVersionId == null)
+                                {
+                                    return null;
+                                }
+
+                                // If there is a previous version, it must be approved, because cannot
+                                // create an amendment for an unpublished version
+                                return await _contentDbContext.MethodologyVersions
+                                    .FirstAsync(mv => mv.Id == version.PreviousVersionId);
+                            })
+                            .WhereNotNull()
+                            .ToListAsync();
                     }
 
                     var releaseViewModel = _mapper.Map<ManageContentPageViewModel.ReleaseViewModel>(release);

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseContentPage.tsx
@@ -14,7 +14,7 @@ const PreReleaseContentPage = ({
   const { releaseId } = match.params;
 
   const { value: content, isLoading } = useAsyncHandledRetry(
-    () => releaseContentService.getContent(releaseId),
+    () => releaseContentService.getContent(releaseId, true),
     [releaseId],
   );
 

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
@@ -32,7 +32,7 @@ const PreReleaseMethodologiesPage = ({
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [externalMethodology, latestMethodologyVersions] = await Promise.all([
       publicationService.getExternalMethodology(publicationId),
-      methodologyService.listLatestMethodologyVersions(publicationId),
+      methodologyService.listLatestMethodologyVersions(publicationId, true),
     ]);
 
     return {

--- a/src/explore-education-statistics-admin/src/services/methodologyService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyService.ts
@@ -85,8 +85,11 @@ const methodologyService = {
 
   listLatestMethodologyVersions(
     publicationId: string,
+    isPrerelease = false,
   ): Promise<MethodologyVersionSummary[]> {
-    return client.get(`/publication/${publicationId}/methodologies`);
+    return client.get(`/publication/${publicationId}/methodologies`, {
+      params: { isPrerelease },
+    });
   },
 
   listMethodologiesForApproval(): Promise<MethodologyVersion[]> {

--- a/src/explore-education-statistics-admin/src/services/releaseContentService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseContentService.ts
@@ -37,8 +37,10 @@ export interface ContentBlockAttachRequest {
 }
 
 const releaseContentService = {
-  getContent(releaseId: string): Promise<ReleaseContent> {
-    return client.get<ReleaseContent>(`/release/${releaseId}/content`);
+  getContent(releaseId: string, isPrerelease = false): Promise<ReleaseContent> {
+    return client.get<ReleaseContent>(`/release/${releaseId}/content`, {
+      params: { isPrerelease },
+    });
   },
   addContentSection(
     releaseId: string,

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -180,6 +180,8 @@ Publish the scheduled release
     set suite variable    ${EXPECTED_PUBLISHED_DATE}
     ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}
 
+    user waits for caches to expire
+
 Verify newly published release is on Find Statistics page
     user checks publication is on find statistics page    ${PUBLICATION_NAME}
 


### PR DESCRIPTION
This PR ensures that the correct methodologies are displayed on Admin prerelease pages and on Admin release content pages.

This fixes the bug introduced by EES-4376.

The rules for displaying methodologies are now:
- On prerelease pages, only methodologies with a latest published version be displayed.
- On admin content pages, a methodology with any version will be displayed.

Other problems surrounding this will be dealt with in EES-4565 and EES-4566. For example, this now allows prerelease users to potentially see draft methodologies by utilising the `GetManageContentPageData` endpoint. They were seeing unpublished methodologies up until recently anyway, and this is next in lined to be fixed.