### PR TITLE
EES-4448 - updating Draft Releases, Scheduled Releases and Your Appro…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -338,7 +338,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         [Fact]
         public async Task ListReleasesForApproval()
         {
-            var releases = ListOf(new ReleaseViewModel
+            var releases = ListOf(new ReleaseSummaryViewModel
             {
                 Id = Guid.NewGuid()
             });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -1708,11 +1708,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     var viewModel = Assert.Single(viewModels);
                     Assert.Equal(higherReviewReleaseWithApproverRoleForUser.Id, viewModel.Id);
                     
-                    // Assert that we have a fully populated ReleaseViewModel, including details from the owning
+                    // Assert that we have a fully populated ReleaseSummaryViewModel, including details from the owning
                     // Publication.
                     Assert.Equal(
                         higherReviewReleaseWithApproverRoleForUser.Publication.Title, 
-                        viewModel.PublicationTitle);
+                        viewModel.Publication!.Title);
                 }
             }
             

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -199,7 +199,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpGet("releases/draft")]
-        public async Task<ActionResult<List<ReleaseViewModel>>> ListDraftReleases()
+        public async Task<ActionResult<List<ReleaseSummaryViewModel>>> ListDraftReleases()
         {
             return await _releaseService
                 .ListReleasesWithStatuses(ReleaseApprovalStatus.Draft, ReleaseApprovalStatus.HigherLevelReview)
@@ -207,7 +207,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpGet("releases/approvals")]
-        public async Task<ActionResult<List<ReleaseViewModel>>> ListUsersReleasesForApproval()
+        public async Task<ActionResult<List<ReleaseSummaryViewModel>>> ListUsersReleasesForApproval()
         {
             return await _releaseService
                 .ListUsersReleasesForApproval()
@@ -215,7 +215,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpGet("releases/scheduled")]
-        public async Task<ActionResult<List<ReleaseViewModel>>> ListScheduledReleases()
+        public async Task<ActionResult<List<ReleaseSummaryViewModel>>> ListScheduledReleases()
         {
             return await _releaseService
                 .ListScheduledReleases()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -73,6 +73,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 
             CreateMap<Theme, IdTitleViewModel>();
             CreateMap<Topic, IdTitleViewModel>();
+            CreateMap<Publication, PublicationSummaryViewModel>();
             CreateMap<Publication, PublicationViewModel>()
                 .ForMember(
                     dest => dest.Theme,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -31,12 +31,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, IdTitleViewModel>> GetLatestPublishedRelease(Guid publicationId);
 
-        Task<Either<ActionResult, List<ReleaseViewModel>>> ListReleasesWithStatuses(
+        Task<Either<ActionResult, List<ReleaseSummaryViewModel>>> ListReleasesWithStatuses(
             params ReleaseApprovalStatus[] releaseApprovalStatues);
 
-        Task<Either<ActionResult, List<ReleaseViewModel>>> ListUsersReleasesForApproval();
+        Task<Either<ActionResult, List<ReleaseSummaryViewModel>>> ListUsersReleasesForApproval();
 
-        Task<Either<ActionResult, List<ReleaseViewModel>>> ListScheduledReleases();
+        Task<Either<ActionResult, List<ReleaseSummaryViewModel>>> ListScheduledReleases();
 
         Task<Either<ActionResult, DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId, Guid fileId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -263,7 +263,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 if (loadedMethodologyVersion.ScheduledWithRelease != null)
                 {
                     await _context.Entry(loadedMethodologyVersion.ScheduledWithRelease)
-                        .Reference(r => r!.Publication)
+                        .Reference(r => r.Publication)
                         .LoadAsync();
 
                     var title =

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseRepository.cs
@@ -55,12 +55,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .Where(r => r.UserId == userId)
                 .Select(r => r.PublicationId)
                 .ToListAsync();
+            
             var userPublicationRoleReleaseIds = await _contentDbContext
                 .Releases
                 .AsQueryable()
                 .Where(r => userPublicationIds.Contains(r.PublicationId))
                 .Select(r => r.Id)
                 .ToListAsync();
+            
             userReleaseIds.AddRange(userPublicationRoleReleaseIds);
             userReleaseIds = userReleaseIds.Distinct().ToList();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -415,7 +415,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
-        public async Task<Either<ActionResult, List<ReleaseViewModel>>> ListReleasesWithStatuses(
+        public async Task<Either<ActionResult, List<ReleaseSummaryViewModel>>> ListReleasesWithStatuses(
             params ReleaseApprovalStatus[] releaseApprovalStatuses)
         {
             return await _userService
@@ -435,7 +435,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .ToAsyncEnumerable()
                         .SelectAwait(async release =>
                         {
-                            var releaseViewModel = _mapper.Map<ReleaseViewModel>(release);
+                            var releaseViewModel = _mapper.Map<ReleaseSummaryViewModel>(release);
                             releaseViewModel.Permissions =
                                 await PermissionsUtils.GetReleasePermissions(_userService, release);
                             return releaseViewModel;
@@ -443,7 +443,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
-        public async Task<Either<ActionResult, List<ReleaseViewModel>>> ListUsersReleasesForApproval()
+        public async Task<Either<ActionResult, List<ReleaseSummaryViewModel>>> ListUsersReleasesForApproval()
         {
             var userId = _userService.GetUserId();
 
@@ -471,10 +471,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     && releaseIdsForApproval.Contains(release.Id))
                 .ToListAsync();
 
-            return _mapper.Map<List<ReleaseViewModel>>(releasesForApproval);
+            return _mapper.Map<List<ReleaseSummaryViewModel>>(releasesForApproval);
         }
 
-        public async Task<Either<ActionResult, List<ReleaseViewModel>>> ListScheduledReleases()
+        public async Task<Either<ActionResult, List<ReleaseSummaryViewModel>>> ListScheduledReleases()
         {
             return await _userService
                 .CheckCanAccessSystem()
@@ -493,7 +493,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .ToAsyncEnumerable()
                         .SelectAwait(async release =>
                         {
-                            var releaseViewModel = _mapper.Map<ReleaseViewModel>(release);
+                            var releaseViewModel = _mapper.Map<ReleaseSummaryViewModel>(release);
                             releaseViewModel.Permissions =
                                 await PermissionsUtils.GetReleasePermissions(_userService, release);
                             return releaseViewModel;
@@ -643,7 +643,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             // Require publication / release graph to be able to work out:
             // If the release is the latest
-            return values.Include(r => r.Publication)
+            return values
+                .Include(r => r.Publication)
                 .Include(r => r.ReleaseStatuses);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -117,7 +117,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public int Year { get; init; }
     }
 
-    public class ReleaseSummaryViewModel
+    public record ReleaseSummaryViewModel
     {
         public Guid Id { get; init; }
 
@@ -149,8 +149,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public bool Amendment { get; init; }
 
+        public bool LatestRelease { get; init; }
+
         public Guid? PreviousVersionId { get; init; }
 
         public ReleasePermissions? Permissions { get; set; }
+
+        public PublicationSummaryViewModel? Publication { get; set; }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ApprovalsTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ApprovalsTab.tsx
@@ -1,5 +1,5 @@
 import ApprovalsTable from '@admin/pages/admin-dashboard/components/ApprovalsTable';
-import { Release } from '@admin/services/releaseService';
+import { DashboardReleaseSummary } from '@admin/services/releaseService';
 import { MethodologyVersion } from '@admin/services/methodologyService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import React from 'react';
@@ -7,7 +7,7 @@ import React from 'react';
 interface Props {
   isLoading: boolean;
   methodologyApprovals: MethodologyVersion[];
-  releaseApprovals: Release[];
+  releaseApprovals: DashboardReleaseSummary[];
 }
 
 export default function ApprovalsTab({

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ApprovalsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ApprovalsTable.tsx
@@ -1,6 +1,6 @@
 import Link from '@admin/components/Link';
 import { MethodologyVersion } from '@admin/services/methodologyService';
-import { Release } from '@admin/services/releaseService';
+import { DashboardReleaseSummary } from '@admin/services/releaseService';
 import {
   MethodologyRouteParams,
   methodologyContentRoute,
@@ -18,7 +18,7 @@ import merge from 'lodash/merge';
 
 interface Props {
   methodologyApprovals: MethodologyVersion[];
-  releaseApprovals: Release[];
+  releaseApprovals: DashboardReleaseSummary[];
 }
 
 export default function ApprovalsTable({
@@ -26,25 +26,25 @@ export default function ApprovalsTable({
   releaseApprovals,
 }: Props) {
   const releasesByPublication: Dictionary<{
-    releases?: Release[];
+    releases: DashboardReleaseSummary[];
   }> = useMemo(() => {
-    return releaseApprovals.reduce<Dictionary<{ releases: Release[] }>>(
-      (acc, release) => {
-        if (acc[release.publicationTitle]) {
-          acc[release.publicationTitle].releases.push(release);
-        } else {
-          acc[release.publicationTitle] = {
-            releases: [release],
-          };
-        }
-        return acc;
-      },
-      {},
-    );
+    return releaseApprovals.reduce<
+      Dictionary<{ releases: DashboardReleaseSummary[] }>
+    >((acc, release) => {
+      if (acc[release.publication.title]) {
+        acc[release.publication.title].releases.push(release);
+      } else {
+        acc[release.publication.title] = {
+          ...acc[release.publication.title],
+          releases: [release],
+        };
+      }
+      return acc;
+    }, {});
   }, [releaseApprovals]);
 
   const methodologiesByPublication: Dictionary<{
-    methodologies?: MethodologyVersion[];
+    methodologies: MethodologyVersion[];
   }> = useMemo(() => {
     return methodologyApprovals.reduce<
       Dictionary<{ methodologies: MethodologyVersion[] }>
@@ -103,8 +103,8 @@ export default function ApprovalsTable({
 
 interface PublicationRowProps {
   publication: string;
-  methodologies?: MethodologyVersion[];
-  releases?: Release[];
+  methodologies: MethodologyVersion[];
+  releases: DashboardReleaseSummary[];
 }
 
 function PublicationRow({
@@ -129,7 +129,7 @@ function PublicationRow({
           <td>
             <Link
               to={generatePath<ReleaseRouteParams>(releaseContentRoute.path, {
-                publicationId: release.publicationId,
+                publicationId: release.publication.id,
                 releaseId: release.id,
               })}
             >

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
@@ -1,7 +1,10 @@
 import Link from '@admin/components/Link';
 import DraftReleaseRowIssues from '@admin/pages/admin-dashboard/components/DraftReleaseRowIssues';
 import { getReleaseApprovalStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
-import { Release } from '@admin/services/releaseService';
+import {
+  ReleaseSummaryWithPermissions,
+  DashboardReleaseSummary,
+} from '@admin/services/releaseService';
 import {
   ReleaseRouteParams,
   releaseSummaryRoute,
@@ -14,7 +17,7 @@ import { generatePath } from 'react-router';
 
 interface Props {
   isBauUser: boolean;
-  release: Release;
+  release: DashboardReleaseSummary & ReleaseSummaryWithPermissions;
   onDelete: () => void;
 }
 
@@ -34,7 +37,7 @@ const DraftReleaseRow = ({ isBauUser, release, onDelete }: Props) => {
         <Link
           className="govuk-!-margin-right-4 govuk-!-display-inline-block"
           to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
-            publicationId: release.publicationId,
+            publicationId: release.publication.id,
             releaseId: release.id,
           })}
         >
@@ -42,11 +45,11 @@ const DraftReleaseRow = ({ isBauUser, release, onDelete }: Props) => {
           <VisuallyHidden> {release.title}</VisuallyHidden>
         </Link>
 
-        {release.amendment && release.previousVersionId && (
+        {release.previousVersionId && (
           <Link
             className="govuk-!-margin-right-4 govuk-!-display-inline-block"
             to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
-              publicationId: release.publicationId,
+              publicationId: release.publication.id,
               releaseId: release.previousVersionId,
             })}
           >

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
@@ -1,12 +1,12 @@
 import DraftReleasesTable from '@admin/pages/admin-dashboard/components/DraftReleasesTable';
-import { Release } from '@admin/services/releaseService';
+import { DashboardReleaseSummary } from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import React from 'react';
 
 interface Props {
   isBauUser: boolean;
   isLoading: boolean;
-  releases: Release[];
+  releases: DashboardReleaseSummary[];
   onChangeRelease: () => void;
 }
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTable.tsx
@@ -7,7 +7,7 @@ import {
 } from '@admin/pages/publication/components/PublicationGuidance';
 import releaseService, {
   DeleteReleasePlan,
-  Release,
+  DashboardReleaseSummary,
 } from '@admin/services/releaseService';
 import ButtonText from '@common/components/ButtonText';
 import InfoIcon from '@common/components/InfoIcon';
@@ -19,7 +19,7 @@ import React, { useMemo, useState } from 'react';
 interface PublicationRowProps {
   isBauUser: boolean;
   publication: string;
-  releases: Release[];
+  releases: DashboardReleaseSummary[];
   onDelete: (releaseId: string) => void;
 }
 const PublicationRow = ({
@@ -49,7 +49,7 @@ const PublicationRow = ({
 
 interface DraftReleasesTableProps {
   isBauUser: boolean;
-  releases: Release[];
+  releases: DashboardReleaseSummary[];
   onChangeRelease: () => void;
 }
 
@@ -67,17 +67,21 @@ const DraftReleasesTable = ({
   const [showDraftStatusGuidance, toggleDraftStatusGuidance] = useToggle(false);
   const [showIssuesGuidance, toggleIssuesGuidance] = useToggle(false);
 
-  const releasesByPublication: Dictionary<Release[]> = useMemo(() => {
-    return releases.reduce<Dictionary<Release[]>>((acc, release) => {
-      if (acc[release.publicationTitle]) {
-        acc[release.publicationTitle].push(release);
-      } else {
-        acc[release.publicationTitle] = [release];
-      }
+  const releasesByPublication: Dictionary<DashboardReleaseSummary[]> =
+    useMemo(() => {
+      return releases.reduce<Dictionary<DashboardReleaseSummary[]>>(
+        (acc, release) => {
+          if (acc[release.publication.title]) {
+            acc[release.publication.title].push(release);
+          } else {
+            acc[release.publication.title] = [release];
+          }
 
-      return acc;
-    }, {});
-  }, [releases]);
+          return acc;
+        },
+        {},
+      );
+    }, [releases]);
 
   return (
     <>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTab.tsx
@@ -1,11 +1,11 @@
 import ScheduledReleasesTable from '@admin/pages/admin-dashboard/components/ScheduledReleasesTable';
-import { Release } from '@admin/services/releaseService';
+import { DashboardReleaseSummary } from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import React from 'react';
 
 interface Props {
   isLoading: boolean;
-  releases: Release[];
+  releases: DashboardReleaseSummary[];
 }
 
 const ScheduledReleasesTab = ({ isLoading, releases }: Props) => {

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
@@ -3,7 +3,7 @@ import {
   ScheduledStagesGuidanceModal,
   ScheduledStatusGuidanceModal,
 } from '@admin/pages/publication/components/PublicationGuidance';
-import { Release } from '@admin/services/releaseService';
+import { DashboardReleaseSummary } from '@admin/services/releaseService';
 import ButtonText from '@common/components/ButtonText';
 import InfoIcon from '@common/components/InfoIcon';
 import useToggle from '@common/hooks/useToggle';
@@ -13,7 +13,7 @@ import React, { useMemo } from 'react';
 
 interface PublicationRowProps {
   publication: string;
-  releases: Release[];
+  releases: DashboardReleaseSummary[];
 }
 
 const PublicationRow = ({ publication, releases }: PublicationRowProps) => {
@@ -27,7 +27,7 @@ const PublicationRow = ({ publication, releases }: PublicationRowProps) => {
       {releases.map(release => (
         <ScheduledReleaseRow
           key={release.id}
-          publicationId={release.publicationId}
+          publicationId={release.publication.id}
           release={release}
         />
       ))}
@@ -36,7 +36,7 @@ const PublicationRow = ({ publication, releases }: PublicationRowProps) => {
 };
 
 interface ScheduledReleasesTableProps {
-  releases: Release[];
+  releases: DashboardReleaseSummary[];
 }
 
 const ScheduledReleasesTable = ({ releases }: ScheduledReleasesTableProps) => {
@@ -45,17 +45,21 @@ const ScheduledReleasesTable = ({ releases }: ScheduledReleasesTableProps) => {
   const [showScheduledStagesGuidance, toggleScheduledStagesGuidance] =
     useToggle(false);
 
-  const releasesByPublication: Dictionary<Release[]> = useMemo(() => {
-    return releases.reduce<Dictionary<Release[]>>((acc, release) => {
-      if (acc[release.publicationTitle]) {
-        acc[release.publicationTitle].push(release);
-      } else {
-        acc[release.publicationTitle] = [release];
-      }
+  const releasesByPublication: Dictionary<DashboardReleaseSummary[]> =
+    useMemo(() => {
+      return releases.reduce<Dictionary<DashboardReleaseSummary[]>>(
+        (acc, release) => {
+          if (acc[release.publication.title]) {
+            acc[release.publication.title].push(release);
+          } else {
+            acc[release.publication.title] = [release];
+          }
 
-      return acc;
-    }, {});
-  }, [releases]);
+          return acc;
+        },
+        {},
+      );
+    }, [releases]);
   return (
     <>
       {releases.length === 0 ? (

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ApprovalsTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ApprovalsTable.test.tsx
@@ -1,6 +1,6 @@
 import ApprovalsTable from '@admin/pages/admin-dashboard/components/ApprovalsTable';
 import { MethodologyVersion } from '@admin/services/methodologyService';
-import { Release } from '@admin/services/releaseService';
+import { DashboardReleaseSummary } from '@admin/services/releaseService';
 import { waitFor, within } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
@@ -9,30 +9,32 @@ import { MemoryRouter } from 'react-router';
 describe('ApprovalsTable', () => {
   const testMethodologies: MethodologyVersion[] = [
     {
-      id: 'c8c911e3-39c1-452b-801f-25bb79d1deb7',
-      methodologyId: 'b8bd000c-f9d8-4319-a2b3-6bc18675e5ac',
+      id: 'methodology-version-1',
+      methodologyId: 'methodology-1',
       owningPublication: {
-        id: 'bf2b4284-6b84-46b0-aaaa-a2e0a23be2a9',
-        title: 'Permanent and fixed-period exclusions in England',
+        id: 'publication-1',
+        title: 'Publication 1 title',
       },
       otherPublications: [],
       published: '2018-08-25T00:00:00',
       publishingStrategy: 'Immediately',
-      slug: 'permanent-and-fixed-period-exclusions-in-england',
+      slug: 'methodology-1-slug',
       status: 'Approved',
-      title: 'Pupil exclusion statistics: methodology',
+      title: 'Methodology 1',
       amendment: false,
     },
   ];
 
-  const testReleases: Release[] = [
+  const testReleases: DashboardReleaseSummary[] = [
     {
       id: 'test-id',
       title: 'Academic year 2016/17',
       slug: '2024-25',
-      publicationId: 'bf2b4284-6b84-46b0-aaaa-a2e0a23be2a9',
-      publicationTitle: 'Permanent and fixed-period exclusions in England',
-      publicationSlug: 'pub-slug',
+      publication: {
+        id: 'publication-1',
+        title: 'Publication 1 title',
+        slug: 'publication-1-slug',
+      },
       year: 2024,
       yearTitle: '2024/25',
       nextReleaseDate: {
@@ -41,16 +43,13 @@ describe('ApprovalsTable', () => {
         day: '',
       },
       live: false,
+      latestRelease: false,
       timePeriodCoverage: {
         value: 'AY',
         label: 'Academic year',
       },
-      preReleaseAccessList: '<p>Test public access list</p>',
-      preReleaseUsersOrInvitesAdded: false,
-      latestRelease: false,
       type: 'NationalStatistics',
       approvalStatus: 'Approved',
-      notifySubscribers: false,
       amendment: false,
       permissions: {
         canAddPrereleaseUsers: true,
@@ -59,17 +58,16 @@ describe('ApprovalsTable', () => {
         canDeleteRelease: false,
         canMakeAmendmentOfRelease: false,
       },
-      updatePublishedDate: false,
     },
     {
       id: '86d868cf-ff4b-4325-ef26-08d93c9b5089',
       title: 'Academic year 2024/25',
       slug: '2024-25',
-      publicationId: '959bd40c-4685-46ff-396d-08d93c9b5159',
-      publicationTitle:
-        'UI tests - Publication and Release UI Permissions Publication Owner',
-      publicationSlug:
-        'ui-tests-publication-and-release-ui-permissions-publication-owner',
+      publication: {
+        id: 'publication-2',
+        title: 'Publication 2 title',
+        slug: 'publication-2-slug',
+      },
       year: 2024,
       yearTitle: '2024/25',
       nextReleaseDate: {
@@ -79,16 +77,14 @@ describe('ApprovalsTable', () => {
       },
       publishScheduled: '2048-11-16',
       live: false,
+      latestRelease: false,
       timePeriodCoverage: {
         value: 'AY',
         label: 'Academic year',
       },
-      preReleaseAccessList: '<p>Test public access list</p>',
-      preReleaseUsersOrInvitesAdded: false,
-      latestRelease: false,
       type: 'NationalStatistics',
       approvalStatus: 'Approved',
-      notifySubscribers: false,
+      previousVersionId: 'old-release-2-id',
       amendment: false,
       permissions: {
         canAddPrereleaseUsers: true,
@@ -97,7 +93,6 @@ describe('ApprovalsTable', () => {
         canDeleteRelease: false,
         canMakeAmendmentOfRelease: false,
       },
-      updatePublishedDate: false,
     },
   ];
 
@@ -119,7 +114,7 @@ describe('ApprovalsTable', () => {
     expect(rows).toHaveLength(6);
 
     expect(within(rows[1]).getByRole('columnheader')).toHaveTextContent(
-      'Permanent and fixed-period exclusions in England',
+      'Publication 1 title',
     );
 
     const row3cells = within(rows[2]).getAllByRole('cell');
@@ -130,16 +125,14 @@ describe('ApprovalsTable', () => {
     ).toBeInTheDocument();
 
     const row4cells = within(rows[3]).getAllByRole('cell');
-    expect(row4cells[0]).toHaveTextContent(
-      'Pupil exclusion statistics: methodology',
-    );
+    expect(row4cells[0]).toHaveTextContent('Methodology 1');
     expect(row4cells[1]).toHaveTextContent('Methodology');
     expect(
       within(row4cells[2]).getByRole('link', { name: /Review this page/ }),
     ).toBeInTheDocument();
 
     expect(within(rows[4]).getByRole('columnheader')).toHaveTextContent(
-      'UI tests - Publication and Release UI Permissions Publication Owner',
+      'Publication 2 title',
     );
 
     const row6cells = within(rows[5]).getAllByRole('cell');

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/DraftReleasesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/DraftReleasesTable.test.tsx
@@ -1,6 +1,6 @@
 import DraftReleasesTable from '@admin/pages/admin-dashboard/components/DraftReleasesTable';
 import _releaseService, {
-  ReleaseWithPermissions,
+  DashboardReleaseSummary,
 } from '@admin/services/releaseService';
 import { waitFor, within } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
@@ -13,71 +13,136 @@ jest.mock('@admin/services/releaseService');
 const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 
 describe('DraftReleasesTable', () => {
-  const testReleases: ReleaseWithPermissions[] = [
+  const testReleases: DashboardReleaseSummary[] = [
     {
       id: 'release-1',
       latestRelease: true,
       slug: 'release-1-slug',
       title: 'Release 1',
-      publicationId: 'publication-1',
-      publicationTitle: 'Publication 1',
+      year: 2020,
+      yearTitle: '2020/21',
+      publication: {
+        id: 'publication-1',
+        title: 'Publication 1',
+        slug: 'publication-1-slug',
+      },
+      nextReleaseDate: {
+        year: '2200',
+        month: '1',
+        day: '',
+      },
+      live: false,
+      timePeriodCoverage: {
+        value: 'AY',
+        label: 'Academic year',
+      },
+      type: 'NationalStatistics',
+      approvalStatus: 'Draft',
+      amendment: false,
       permissions: {
+        canViewRelease: true,
         canUpdateRelease: true,
         canDeleteRelease: false,
         canMakeAmendmentOfRelease: false,
         canAddPrereleaseUsers: false,
       },
-      approvalStatus: 'Draft',
-    } as ReleaseWithPermissions,
+    },
     {
       id: 'release-2',
       latestRelease: true,
       slug: 'release-2-slug',
       title: 'Release 2',
-      publicationId: 'publication-2',
-      publicationTitle: 'Publication 2',
+      year: 2021,
+      yearTitle: '2021/22',
+      publication: {
+        id: 'publication-2',
+        title: 'Publication 2',
+        slug: 'publication-2-slug',
+      },
+      nextReleaseDate: {
+        year: '2200',
+        month: '1',
+        day: '',
+      },
+      live: false,
+      timePeriodCoverage: {
+        value: 'AY',
+        label: 'Academic year',
+      },
+      type: 'NationalStatistics',
+      approvalStatus: 'Draft',
+      amendment: true,
+      previousVersionId: 'previous-version-id',
       permissions: {
+        canViewRelease: true,
         canDeleteRelease: true,
         canUpdateRelease: true,
         canMakeAmendmentOfRelease: false,
         canAddPrereleaseUsers: false,
       },
-      approvalStatus: 'Draft',
-      amendment: true,
-      previousVersionId: 'previous-version-id',
-    } as ReleaseWithPermissions,
+    },
     {
       id: 'release-3',
       latestRelease: false,
       slug: 'release-3-slug',
       title: 'Release 3',
-      publicationId: 'publication-1',
-      publicationTitle: 'Publication 1',
+      year: 2022,
+      yearTitle: '2022/23',
+      publication: {
+        id: 'publication-1',
+        title: 'Publication 1',
+        slug: 'publication-1-slug',
+      },
+      nextReleaseDate: {
+        year: '2200',
+        month: '1',
+        day: '',
+      },
+      live: false,
+      timePeriodCoverage: {
+        value: 'AY',
+        label: 'Academic year',
+      },
+      type: 'NationalStatistics',
+      approvalStatus: 'HigherLevelReview',
+      amendment: false,
       permissions: {
+        canViewRelease: true,
         canUpdateRelease: true,
         canDeleteRelease: true,
         canMakeAmendmentOfRelease: false,
         canAddPrereleaseUsers: false,
       },
-      approvalStatus: 'HigherLevelReview',
-    } as ReleaseWithPermissions,
+    },
     {
       id: 'release-4',
       latestRelease: true,
       slug: 'release-4-slug',
       title: 'Release 4',
-      publicationId: 'publication-3',
-      publicationTitle: 'Publication 3',
+      year: 2023,
+      yearTitle: '2023/24',
+      publication: {
+        id: 'publication-3',
+        title: 'Publication 3',
+        slug: 'publication-3-slug',
+      },
+      live: false,
+      timePeriodCoverage: {
+        value: 'AY',
+        label: 'Academic year',
+      },
+      type: 'NationalStatistics',
+      approvalStatus: 'HigherLevelReview',
+      amendment: true,
+      previousVersionId: 'previous-version-id',
       permissions: {
+        canViewRelease: true,
         canDeleteRelease: true,
         canUpdateRelease: true,
         canMakeAmendmentOfRelease: false,
         canAddPrereleaseUsers: false,
       },
-      approvalStatus: 'HigherLevelReview',
-      amendment: true,
-      previousVersionId: 'previous-version-id',
-    } as ReleaseWithPermissions,
+    },
   ];
 
   beforeEach(() => {

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ScheduledReleasesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ScheduledReleasesTable.test.tsx
@@ -1,6 +1,6 @@
 import ScheduledReleasesTable from '@admin/pages/admin-dashboard/components/ScheduledReleasesTable';
 import _releaseService, {
-  ReleaseWithPermissions,
+  DashboardReleaseSummary,
 } from '@admin/services/releaseService';
 import { waitFor, within } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
@@ -11,71 +11,123 @@ jest.mock('@admin/services/releaseService');
 const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 
 describe('ScheduledReleasesTable', () => {
-  const testReleases: ReleaseWithPermissions[] = [
+  const testReleases: DashboardReleaseSummary[] = [
     {
       id: 'release-1',
       latestRelease: true,
       publishScheduled: '2021-06-30T00:00:00',
       slug: 'release-1-slug',
       title: 'Release 1',
-      publicationId: 'publication-1',
-      publicationTitle: 'Publication 1',
+      amendment: false,
+      live: false,
+      year: 2021,
+      yearTitle: '2021',
+      timePeriodCoverage: {
+        value: 'AY',
+        label: 'Academic year',
+      },
+      type: 'NationalStatistics',
+      publication: {
+        id: 'publication-1',
+        slug: 'publication-1-slug',
+        title: 'Publication 1',
+      },
       permissions: {
+        canViewRelease: true,
         canUpdateRelease: true,
         canAddPrereleaseUsers: false,
         canDeleteRelease: false,
         canMakeAmendmentOfRelease: false,
       },
       approvalStatus: 'Approved',
-    } as ReleaseWithPermissions,
+    },
     {
       id: 'release-2',
       latestRelease: true,
       publishScheduled: '2021-05-30T00:00:00',
       slug: 'release-2-slug',
       title: 'Release 2',
-      publicationId: 'publication-2',
-      publicationTitle: 'Publication 2',
+      amendment: false,
+      live: false,
+      year: 2021,
+      yearTitle: '2021',
+      timePeriodCoverage: {
+        value: 'AY',
+        label: 'Academic year',
+      },
+      type: 'NationalStatistics',
+      publication: {
+        id: 'publication-2',
+        slug: 'publication-2-slug',
+        title: 'Publication 2',
+      },
       permissions: {
+        canViewRelease: true,
         canUpdateRelease: true,
         canAddPrereleaseUsers: false,
         canDeleteRelease: false,
         canMakeAmendmentOfRelease: false,
       },
       approvalStatus: 'Approved',
-    } as ReleaseWithPermissions,
+    },
     {
       id: 'release-3',
       latestRelease: false,
       publishScheduled: '2021-01-01T00:00:00',
       slug: 'release-3-slug',
       title: 'Release 3',
-      publicationId: 'publication-1',
-      publicationTitle: 'Publication 1',
+      amendment: false,
+      live: false,
+      year: 2021,
+      yearTitle: '2021',
+      timePeriodCoverage: {
+        value: 'AY',
+        label: 'Academic year',
+      },
+      type: 'NationalStatistics',
+      publication: {
+        id: 'publication-1',
+        slug: 'publication-1-slug',
+        title: 'Publication 1',
+      },
       permissions: {
+        canViewRelease: true,
         canUpdateRelease: true,
         canDeleteRelease: true,
         canAddPrereleaseUsers: false,
         canMakeAmendmentOfRelease: false,
       },
       approvalStatus: 'Approved',
-    } as ReleaseWithPermissions,
+    },
     {
       id: 'release-4',
       latestRelease: true,
       publishScheduled: '2021-05-30T00:00:00',
       slug: 'release-4-slug',
       title: 'Release 4',
-      publicationId: 'publication-3',
-      publicationTitle: 'Publication 3',
+      amendment: false,
+      live: false,
+      year: 2021,
+      yearTitle: '2021',
+      timePeriodCoverage: {
+        value: 'AY',
+        label: 'Academic year',
+      },
+      type: 'NationalStatistics',
+      publication: {
+        id: 'publication-3',
+        slug: 'publication-3-slug',
+        title: 'Publication 3',
+      },
       permissions: {
+        canViewRelease: true,
         canUpdateRelease: true,
         canAddPrereleaseUsers: false,
         canDeleteRelease: false,
         canMakeAmendmentOfRelease: false,
       },
       approvalStatus: 'Approved',
-    } as ReleaseWithPermissions,
+    },
   ];
 
   beforeEach(() => {

--- a/src/explore-education-statistics-admin/src/pages/publication/__data__/testReleases.ts
+++ b/src/explore-education-statistics-admin/src/pages/publication/__data__/testReleases.ts
@@ -17,6 +17,7 @@ export const testReleaseSummaries: ReleaseSummary[] = [
     yearTitle: '2023/24',
     live: false,
     amendment: false,
+    latestRelease: false,
   },
   {
     id: 'release-2',
@@ -32,6 +33,7 @@ export const testReleaseSummaries: ReleaseSummary[] = [
     yearTitle: '2022/23',
     live: false,
     amendment: false,
+    latestRelease: false,
   },
   {
     id: 'release-3',
@@ -48,6 +50,7 @@ export const testReleaseSummaries: ReleaseSummary[] = [
     yearTitle: '2021/22',
     live: true,
     amendment: false,
+    latestRelease: false,
   },
 ];
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationDraftReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationDraftReleases.test.tsx
@@ -40,6 +40,7 @@ describe('PublicationDraftReleases', () => {
     type: 'AdHocStatistics',
     year: 2022,
     yearTitle: '2022/23',
+    latestRelease: false,
   };
 
   const testRelease2: ReleaseSummaryWithPermissions = {

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationPublishedReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationPublishedReleases.test.tsx
@@ -46,6 +46,7 @@ describe('PublicationPublishedReleases', () => {
     type: 'AdHocStatistics',
     year: 2021,
     yearTitle: '2021/22',
+    latestRelease: false,
   };
 
   const testRelease2: ReleaseSummaryWithPermissions = {

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationReleaseAccess.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationReleaseAccess.test.tsx
@@ -37,6 +37,7 @@ describe('PublicationReleaseAccess', () => {
     yearTitle: '2000/01',
     live: false,
     amendment: false,
+    latestRelease: false,
   };
 
   const testContributors: UserReleaseRole[] = [

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationScheduledReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationScheduledReleases.test.tsx
@@ -40,6 +40,7 @@ describe('PublicationScheduledReleases', () => {
       value: 'AY',
     },
     type: 'AdHocStatistics',
+    latestRelease: false,
   };
 
   const testRelease2: ReleaseSummaryWithPermissions = {

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationUnpublishedReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationUnpublishedReleases.test.tsx
@@ -46,6 +46,7 @@ describe('PublicationUnpublishedReleases', () => {
     type: 'NationalStatistics',
     year: 2022,
     yearTitle: '2022/23',
+    latestRelease: false,
   };
 
   const testRelease2: ReleaseSummaryWithPermissions = {
@@ -63,6 +64,7 @@ describe('PublicationUnpublishedReleases', () => {
     type: 'NationalStatistics',
     year: 2024,
     yearTitle: '2024/25',
+    latestRelease: false,
   };
 
   const testRelease3: ReleaseSummaryWithPermissions = {
@@ -80,6 +82,7 @@ describe('PublicationUnpublishedReleases', () => {
     type: 'NationalStatistics',
     year: 2023,
     yearTitle: '2023/24',
+    latestRelease: false,
   };
 
   const testReleasesPage1: PaginatedList<ReleaseSummaryWithPermissions> = {

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -1,6 +1,9 @@
 import { IdTitlePair, ValueLabelPair } from '@admin/services/types/common';
 import client from '@admin/services/utils/service';
-import { ReleaseApprovalStatus } from '@common/services/publicationService';
+import {
+  PublicationSummary,
+  ReleaseApprovalStatus,
+} from '@common/services/publicationService';
 import { ReleaseType } from '@common/services/types/releaseType';
 import { PartialDate } from '@common/utils/date/partialDate';
 
@@ -39,10 +42,6 @@ export interface Release {
   permissions?: ReleasePermissions;
 }
 
-export interface ReleaseWithPermissions extends Release {
-  permissions: ReleasePermissions;
-}
-
 export interface ReleaseSummary {
   id: string;
   title: string;
@@ -57,8 +56,14 @@ export interface ReleaseSummary {
   nextReleaseDate?: PartialDate;
   type: ReleaseType;
   amendment: boolean;
+  latestRelease: boolean;
   previousVersionId?: string;
   permissions?: ReleasePermissions;
+  publication?: PublicationSummary;
+}
+
+export interface DashboardReleaseSummary extends ReleaseSummaryWithPermissions {
+  publication: PublicationSummary;
 }
 
 export interface ReleaseSummaryWithPermissions extends ReleaseSummary {
@@ -228,15 +233,15 @@ const releaseService = {
     return client.delete(`/release/${releaseId}`);
   },
 
-  listDraftReleases(): Promise<Release[]> {
+  listDraftReleases(): Promise<DashboardReleaseSummary[]> {
     return client.get('/releases/draft');
   },
 
-  listScheduledReleases(): Promise<Release[]> {
+  listScheduledReleases(): Promise<DashboardReleaseSummary[]> {
     return client.get('/releases/scheduled');
   },
 
-  listReleasesForApproval(): Promise<Release[]> {
+  listReleasesForApproval(): Promise<DashboardReleaseSummary[]> {
     return client.get('/releases/approvals');
   },
 


### PR DESCRIPTION
This PR:
- takes the work that @ntsim put together on the `ees-4448-summary` branch and completes it, finishing off amending Jest test data and a couple of tweaks to the backend services.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/1fe3855b-5d25-4014-96de-ea3305d5db8f)
  