### PR TITLE
EES-4477 Make contact telephone number optional

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Requests/ContactSaveRequestTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Requests/ContactSaveRequestTests.cs
@@ -3,94 +3,57 @@ using System.ComponentModel.DataAnnotations;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using Xunit;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Requests
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Requests;
+
+public class ContactSaveRequestTests
 {
-    public class ContactSaveRequestTests
+    [Fact]
+    public void ContactSaveRequest_ContactTelNo()
     {
-        [Fact]
-        public void ContactSaveRequest_ContactTelNo()
+        var request = new ContactSaveRequest
         {
-            var request = new ContactSaveRequest
-            {
-                ContactTelNo = "12345678",
-            };
+            ContactTelNo = "01234567",
+        };
 
-            var validationContext = new ValidationContext(request);
+        var validationContext = new ValidationContext(request);
 
-            var results = request.Validate(validationContext);
+        var results = request.Validate(validationContext);
 
-            Assert.Empty(results);
-        }
+        Assert.Empty(results);
+    }
 
-        [Fact]
-        public void ContactSaveRequest_ContactTelNo_Null()
+    [Fact]
+    public void ContactSaveRequest_ContactTelNo_Null()
+    {
+        var request = new ContactSaveRequest
         {
-            var request = new ContactSaveRequest
-            {
-                ContactTelNo = null,
-            };
+            ContactTelNo = null,
+        };
 
-            var validationContext = new ValidationContext(request);
+        var validationContext = new ValidationContext(request);
 
-            var results = request.Validate(validationContext);
+        var results = request.Validate(validationContext);
 
-            Assert.Empty(results);
-        }
+        Assert.Empty(results);
+    }
 
-        [Fact]
-        public void ContactSaveRequest_ContactTelNo_TooShort()
+    [Theory]
+    [InlineData(" 0 3 7 0 0 0 0 2 2 8 8 ")]
+    [InlineData("03700002288")]
+    [InlineData("    0370 000 2288")]
+    [InlineData("037 0000 2288    ")]
+    public void ContactSaveRequest_ContactTelNo_NotDfEEnquiriesNum(string contactTelNo)
+    {
+        var request = new ContactSaveRequest
         {
-            var request = new ContactSaveRequest
-            {
-                ContactTelNo = "1234567",
-            };
+            ContactTelNo = contactTelNo,
+        };
 
-            var validationContext = new ValidationContext(request);
+        var validationContext = new ValidationContext(request);
 
-            var results = request.Validate(validationContext);
+        var results = request.Validate(validationContext);
 
-            var validationResult = Assert.Single(results);
-            Assert.Equal("Contact telephone must have a minimum length of '8'.", validationResult.ErrorMessage);
-        }
-
-        [Theory]
-        [InlineData("abcdefghijk")]
-        [InlineData(@"!&$\*^!\*&)%!")]
-        [InlineData("a12345678")]
-        [InlineData("12345678a")]
-        public void ContactSaveRequest_ContactTelNo_NotNumeric(string contactTelNo)
-        {
-            var request = new ContactSaveRequest
-            {
-                ContactTelNo = contactTelNo,
-            };
-
-            var validationContext = new ValidationContext(request);
-
-            var results = request.Validate(validationContext);
-
-            var validationResult = Assert.Single(results);
-            Assert.Equal("Contact telephone must only contain numbers and spaces", validationResult.ErrorMessage);
-        }
-
-        [Theory]
-        [InlineData(" 0 3 7 0 0 0 0 2 2 8 8 ")]
-        [InlineData("03700002288")]
-        [InlineData("    0370 000 2288")]
-        [InlineData("037 0000 2288    ")]
-        public void ContactSaveRequest_ContactTelNo_NotDfEEnquiriesNum(string contactTelNo)
-        {
-            var request = new ContactSaveRequest
-            {
-                ContactTelNo = contactTelNo,
-            };
-
-            var validationContext = new ValidationContext(request);
-
-            var results = request.Validate(validationContext);
-
-            var validationResult = Assert.Single(results);
-            Assert.Equal("Contact telephone cannot be DfE Enquiries number", validationResult.ErrorMessage);
-        }
+        var validationResult = Assert.Single(results);
+        Assert.Equal("Contact telephone cannot be DfE Enquiries number", validationResult.ErrorMessage);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Requests/ContactSaveRequestTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Requests/ContactSaveRequestTests.cs
@@ -1,0 +1,96 @@
+#nullable enable
+using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Requests
+{
+    public class ContactSaveRequestTests
+    {
+        [Fact]
+        public void ContactSaveRequest_ContactTelNo()
+        {
+            var request = new ContactSaveRequest
+            {
+                ContactTelNo = "12345678",
+            };
+
+            var validationContext = new ValidationContext(request);
+
+            var results = request.Validate(validationContext);
+
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void ContactSaveRequest_ContactTelNo_Null()
+        {
+            var request = new ContactSaveRequest
+            {
+                ContactTelNo = null,
+            };
+
+            var validationContext = new ValidationContext(request);
+
+            var results = request.Validate(validationContext);
+
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void ContactSaveRequest_ContactTelNo_TooShort()
+        {
+            var request = new ContactSaveRequest
+            {
+                ContactTelNo = "1234567",
+            };
+
+            var validationContext = new ValidationContext(request);
+
+            var results = request.Validate(validationContext);
+
+            var validationResult = Assert.Single(results);
+            Assert.Equal("Contact telephone must have a minimum length of '8'.", validationResult.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("abcdefghijk")]
+        [InlineData(@"!&$\*^!\*&)%!")]
+        [InlineData("a12345678")]
+        [InlineData("12345678a")]
+        public void ContactSaveRequest_ContactTelNo_NotNumeric(string contactTelNo)
+        {
+            var request = new ContactSaveRequest
+            {
+                ContactTelNo = contactTelNo,
+            };
+
+            var validationContext = new ValidationContext(request);
+
+            var results = request.Validate(validationContext);
+
+            var validationResult = Assert.Single(results);
+            Assert.Equal("Contact telephone must only contain numbers and spaces", validationResult.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData(" 0 3 7 0 0 0 0 2 2 8 8 ")]
+        [InlineData("03700002288")]
+        [InlineData("    0370 000 2288")]
+        [InlineData("037 0000 2288    ")]
+        public void ContactSaveRequest_ContactTelNo_NotDfEEnquiriesNum(string contactTelNo)
+        {
+            var request = new ContactSaveRequest
+            {
+                ContactTelNo = contactTelNo,
+            };
+
+            var validationContext = new ValidationContext(request);
+
+            var results = request.Validate(validationContext);
+
+            var validationResult = Assert.Single(results);
+            Assert.Equal("Contact telephone cannot be DfE Enquiries number", validationResult.ErrorMessage);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -526,7 +526,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     var service = BuildPublicationService(
                         context: contentDbContext,
                         userService: userService.Object);
-                    return await service.UpdateContact(publication.Id, new Contact());
+                    return await service.UpdateContact(publication.Id, new ContactSaveRequest());
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -26,7 +26,8 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.Validat
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
-using IPublicationRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IPublicationRepository;
+using IPublicationRepository =
+    GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IPublicationRepository;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -623,7 +624,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var publicationService = BuildPublicationService(context,
                     userService: userService.Object);
 
-                var result = (await publicationService.GetPublication(publication.Id, includePermissions: true)).AssertRight();
+                var result = (await publicationService.GetPublication(publication.Id, includePermissions: true))
+                    .AssertRight();
 
                 Assert.Equal(publication.Id, result.Id);
 
@@ -707,7 +709,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var publicationService = BuildPublicationService(context);
 
-                var result = (await publicationService.GetPublication(publication.Id, includePermissions: true)).AssertRight();
+                var result = (await publicationService.GetPublication(publication.Id, includePermissions: true))
+                    .AssertRight();
 
                 Assert.Equal(publication.Id, result.Id);
 
@@ -809,7 +812,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         Title = "Test publication",
                         Summary = "Test summary",
-                        Contact = new ContactSaveViewModel
+                        Contact = new ContactSaveRequest
                         {
                             ContactName = "John Smith",
                             ContactTelNo = "0123456789",
@@ -834,9 +837,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(topic.Theme.Id, publicationViewModel.Theme.Id);
                 Assert.Equal(topic.Theme.Title, publicationViewModel.Theme.Title);
+            }
 
-                // Do an in depth check of the saved release
-                var createdPublication = await context.Publications.FindAsync(publicationViewModel.Id);
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var createdPublication = await context.Publications
+                    .Include(p => p.Contact)
+                    .Include(p => p.Topic)
+                    .FirstAsync(p => p.Title == "Test publication");
 
                 Assert.NotNull(createdPublication);
                 Assert.False(createdPublication!.Live);
@@ -885,7 +893,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         Title = "Test publication",
                         Summary = "Test summary",
-                        Contact = new ContactSaveViewModel
+                        Contact = new ContactSaveRequest
                         {
                             ContactName = "John Smith",
                             ContactTelNo = "",
@@ -901,9 +909,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal("John Smith", publicationViewModel.Contact.ContactName);
                 Assert.Null(publicationViewModel.Contact.ContactTelNo);
+            }
 
-                var createdPublication = await context.Publications.FindAsync(publicationViewModel.Id);
-                Assert.NotNull(createdPublication);
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var createdPublication = await context.Publications
+                    .Include(p => p.Contact)
+                    .FirstAsync(p =>
+                        p.Title == "Test publication");
                 Assert.Equal("John Smith", createdPublication.Contact.ContactName);
                 Assert.Null(createdPublication.Contact.ContactTelNo);
             }
@@ -1006,6 +1019,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
+            var newSupersededById = Guid.NewGuid();
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(Strict);
@@ -1020,8 +1034,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         "New title",
                         "new-title"))
                     .Returns(Task.CompletedTask);
-
-                var newSupersededById = Guid.NewGuid();
 
                 // Service method under test
                 var result = await publicationService.UpdatePublication(
@@ -1046,11 +1058,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(topic.Title, viewModel.Topic.Title);
 
                 Assert.Equal(newSupersededById, viewModel.SupersededById);
+            }
 
-                // Do an in depth check of the saved release
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
                 var updatedPublication = await context.Publications
                     .Include(p => p.Contact)
-                    .SingleAsync(p => p.Id == viewModel.Id);
+                    .Include(p => p.Topic)
+                    .SingleAsync(p => p.Title == "New title");
 
                 Assert.False(updatedPublication.Live);
                 Assert.True(updatedPublication.Updated.HasValue);
@@ -1063,7 +1078,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("0987654321", updatedPublication.Contact.ContactTelNo);
                 Assert.Equal("Old team", updatedPublication.Contact.TeamName);
                 Assert.Equal("old.smith@test.com", updatedPublication.Contact.TeamEmail);
-
 
                 Assert.Equal(topic.Id, updatedPublication.TopicId);
                 Assert.Equal("New topic", updatedPublication.Topic.Title);
@@ -1117,6 +1131,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
+            var newSupersededById = Guid.NewGuid();
+
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(Strict);
@@ -1150,8 +1166,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         "old-title"))
                     .Returns(Task.CompletedTask);
 
-                var newSupersededById = Guid.NewGuid();
-
                 // Service method under test
                 var result = await publicationService.UpdatePublication(
                     publication.Id,
@@ -1177,11 +1191,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(topic.Title, viewModel.Topic.Title);
 
                 Assert.Equal(newSupersededById, viewModel.SupersededById);
+            }
 
-                // Do an in depth check of the saved release
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
                 var updatedPublication = await context.Publications
                     .Include(p => p.Contact)
-                    .SingleAsync(p => p.Id == viewModel.Id);
+                    .Include(p => p.Topic)
+                    .SingleAsync(p => p.Title == "New title");
 
                 Assert.True(updatedPublication.Live);
                 Assert.True(updatedPublication.Updated.HasValue);
@@ -1354,8 +1371,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     publicationCacheService);
 
                 var viewModel = result.AssertRight();
+            }
 
-                var updatedPublication = await context.Publications.FindAsync(viewModel.Id);
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var updatedPublication = await context.Publications.FirstAsync(p => p.Title == "Test title");
                 Assert.NotNull(updatedPublication);
             }
         }
@@ -1557,7 +1577,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     publication.Id,
                     new List<LegacyReleasePartialUpdateViewModel>
                     {
-                        new LegacyReleasePartialUpdateViewModel
+                        new()
                         {
                             Id = publication.LegacyReleases[0].Id,
                             Description = "Updated description 1",
@@ -1680,7 +1700,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal("New external methodology", externalMethodology.Title);
                 Assert.Equal("http://test.external.methodology/new", externalMethodology.Url);
+            }
 
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
                 var dbPublication = contentDbContext.Publications
                     .Single(p => p.Id == publication.Id);
 
@@ -1739,7 +1762,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 VerifyAllMocks(publicationCacheService);
 
                 result.AssertRight();
+            }
 
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
                 var dbPublication = contentDbContext.Publications
                     .Single(p => p.Id == publication.Id);
 
@@ -1843,7 +1869,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var service = BuildPublicationService(context: contentDbContext,
                     publicationCacheService: publicationCacheService.Object);
 
-                var updatedContact = new Contact
+                var updatedContact = new ContactSaveRequest
                 {
                     ContactName = "new contact name",
                     ContactTelNo = "12345 6789",
@@ -1858,15 +1884,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(updatedContact.ContactTelNo, contact.ContactTelNo);
                 Assert.Equal(updatedContact.TeamName, contact.TeamName);
                 Assert.Equal(updatedContact.TeamEmail, contact.TeamEmail);
+            }
 
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
                 var dbPublication = await contentDbContext.Publications
                     .Include(p => p.Contact)
                     .SingleAsync(p => p.Id == publication.Id);
 
-                Assert.Equal(updatedContact.ContactName, dbPublication.Contact.ContactName);
-                Assert.Equal(updatedContact.ContactTelNo, dbPublication.Contact.ContactTelNo);
-                Assert.Equal(updatedContact.TeamName, dbPublication.Contact.TeamName);
-                Assert.Equal(updatedContact.TeamEmail, dbPublication.Contact.TeamEmail);
+                Assert.Equal("new contact name", dbPublication.Contact.ContactName);
+                Assert.Equal("12345 6789", dbPublication.Contact.ContactTelNo);
+                Assert.Equal("new team name", dbPublication.Contact.TeamName);
+                Assert.Equal("new_team@email.com", dbPublication.Contact.TeamEmail);
             }
         }
 
@@ -1900,7 +1929,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var service = BuildPublicationService(context: contentDbContext,
                     publicationCacheService: publicationCacheService.Object);
 
-                var updatedContact = new Contact
+                var updatedContact = new ContactSaveRequest
                 {
                     ContactName = "new contact name",
                     ContactTelNo = "",
@@ -1913,12 +1942,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(updatedContact.ContactName, contact.ContactName);
                 Assert.Null(contact.ContactTelNo);
+            }
 
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
                 var dbPublication = await contentDbContext.Publications
                     .Include(p => p.Contact)
                     .SingleAsync(p => p.Id == publication.Id);
 
-                Assert.Equal(updatedContact.ContactName, dbPublication.Contact.ContactName);
+                Assert.Equal("new contact name", dbPublication.Contact.ContactName);
                 Assert.Null(dbPublication.Contact.ContactTelNo);
             }
         }
@@ -1960,7 +1992,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var service = BuildPublicationService(context: contentDbContext,
                     publicationCacheService: publicationCacheService.Object);
 
-                var updatedContact = new Contact
+                var updatedContact = new ContactSaveRequest
                 {
                     ContactName = "new contact name",
                     ContactTelNo = "12345 6789",
@@ -1975,15 +2007,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(updatedContact.ContactTelNo, contact.ContactTelNo);
                 Assert.Equal(updatedContact.TeamName, contact.TeamName);
                 Assert.Equal(updatedContact.TeamEmail, contact.TeamEmail);
+            }
 
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
                 var dbPublication1 = contentDbContext.Publications
                     .Include(p => p.Contact)
                     .Single(p => p.Id == publication1.Id);
 
-                Assert.Equal(updatedContact.ContactName, dbPublication1.Contact.ContactName);
-                Assert.Equal(updatedContact.ContactTelNo, dbPublication1.Contact.ContactTelNo);
-                Assert.Equal(updatedContact.TeamName, dbPublication1.Contact.TeamName);
-                Assert.Equal(updatedContact.TeamEmail, dbPublication1.Contact.TeamEmail);
+                Assert.Equal("new contact name", dbPublication1.Contact.ContactName);
+                Assert.Equal("12345 6789", dbPublication1.Contact.ContactTelNo);
+                Assert.Equal("new team name", dbPublication1.Contact.TeamName);
+                Assert.Equal("new_team@email.com", dbPublication1.Contact.TeamEmail);
 
                 var dbPublication2 = contentDbContext.Publications
                     .Include(p => p.Contact)
@@ -2004,7 +2039,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var service = BuildPublicationService(context: contentDbContext);
 
             var result = await service.UpdateContact(
-                Guid.NewGuid(), new Contact());
+                Guid.NewGuid(), new ContactSaveRequest());
             result.AssertNotFound();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -88,7 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 
         [HttpPut("api/publication/{publicationId:guid}/contact")]
         public async Task<ActionResult<ContactViewModel>> UpdateContact(
-            Guid publicationId, Contact updatedContact)
+            Guid publicationId, ContactSaveRequest updatedContact)
         {
             return await _publicationService.UpdateContact(publicationId, updatedContact)
                 .HandleFailuresOrOk();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230920145213_EES4477_MakeContactTelNosNullable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230920145213_EES4477_MakeContactTelNosNullable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230920145213_EES4477_MakeContactTelNosNullable")]
+    partial class EES4477_MakeContactTelNosNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -208,8 +210,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.HasIndex("FileId")
                         .IsUnique();
-
-                    SqlServerIndexBuilderExtensions.IncludeProperties(b.HasIndex("FileId"), new[] { "Status" });
 
                     b.HasIndex("MetaFileId")
                         .IsUnique();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230920145213_EES4477_MakeContactTelNosNullable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230920145213_EES4477_MakeContactTelNosNullable.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES4477_MakeContactTelNosNullable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ContactTelNo",
+                table: "Contacts",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.Sql(
+                @"UPDATE [dbo].[Contacts]
+                  SET ContactTelNo = NULL
+                  WHERE TRIM(ContactTelNo) = '03700002288'
+                  OR TRIM(ContactTelNo) = '0370 000 2288'
+                  OR TRIM(ContactTelNo) = '037 0000 2288';");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ContactTelNo",
+                table: "Contacts",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230920145213_EES4477_MakeContactTelNosNullable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230920145213_EES4477_MakeContactTelNosNullable.cs
@@ -19,9 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
             migrationBuilder.Sql(
                 @"UPDATE [dbo].[Contacts]
                   SET ContactTelNo = NULL
-                  WHERE TRIM(ContactTelNo) = '03700002288'
-                  OR TRIM(ContactTelNo) = '0370 000 2288'
-                  OR TRIM(ContactTelNo) = '037 0000 2288';");
+                  WHERE TRIM(ContactTelNo) IN ('03700002288', '0370 000 2288', '037 0000 2288');");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ContactSaveRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ContactSaveRequest.cs
@@ -1,0 +1,46 @@
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+
+public class ContactSaveRequest : IValidatableObject
+{
+    [Required] public string TeamName { get; set; } = string.Empty;
+
+    [Required, EmailAddress] public string TeamEmail { get; set; } = string.Empty;
+
+    [Required] public string ContactName { get; set; } = string.Empty;
+
+    public string? ContactTelNo { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var results = new List<ValidationResult>();
+
+        if (ContactTelNo != null)
+        {
+            if (ContactTelNo.Length < 8)
+            {
+                results.Add(new ValidationResult(
+                    "Contact telephone must have a minimum length of '8'."));
+            }
+
+            if (!Regex.IsMatch(ContactTelNo, @"^[0-9\s]*$"))
+            {
+                results.Add(new ValidationResult(
+                    "Contact telephone must only contain numbers and spaces"));
+            }
+
+            if (Regex.IsMatch(ContactTelNo,
+                    @"^\s*0\s*3\s*7\s*0\s*0\s*0\s*0\s*2\s*2\s*8\s*8\s*$"))
+            {
+                results.Add(new ValidationResult(
+                    "Contact telephone cannot be DfE Enquiries number"));
+            }
+        }
+
+        return results;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ContactSaveRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ContactSaveRequest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
@@ -13,7 +14,7 @@ public class ContactSaveRequest : IValidatableObject
 
     [Required] public string ContactName { get; set; } = string.Empty;
 
-    public string? ContactTelNo { get; set; }
+    [PhoneNumber] public string? ContactTelNo { get; set; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
@@ -21,18 +22,6 @@ public class ContactSaveRequest : IValidatableObject
 
         if (ContactTelNo != null)
         {
-            if (ContactTelNo.Length < 8)
-            {
-                results.Add(new ValidationResult(
-                    "Contact telephone must have a minimum length of '8'."));
-            }
-
-            if (!Regex.IsMatch(ContactTelNo, @"^[0-9\s]*$"))
-            {
-                results.Add(new ValidationResult(
-                    "Contact telephone must only contain numbers and spaces"));
-            }
-
             if (Regex.IsMatch(ContactTelNo,
                     @"^\s*0\s*3\s*7\s*0\s*0\s*0\s*0\s*2\s*2\s*8\s*8\s*$"))
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/PublicationCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/PublicationCreateRequest.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using System;
 using System.ComponentModel.DataAnnotations;
-using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using static System.String;
 
@@ -15,7 +14,7 @@ public record PublicationCreateRequest
 
         [Required] public Guid TopicId { get; set; }
 
-        [Required] public ContactSaveViewModel Contact { get; set; } = null!;
+        [Required] public ContactSaveRequest Contact { get; set; } = null!;
 
         private string _slug = Empty;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationService.cs
@@ -35,7 +35,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId);
 
-        Task<Either<ActionResult, ContactViewModel>> UpdateContact(Guid publicationId, Contact updatedContact);
+        Task<Either<ActionResult, ContactViewModel>> UpdateContact(Guid publicationId, ContactSaveRequest updatedContact);
 
         Task<Either<ActionResult, PaginatedListViewModel<ReleaseSummaryViewModel>>> ListActiveReleasesPaginated(
             Guid publicationId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Util;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -115,7 +116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     var contact = await _context.Contacts.AddAsync(new Contact
                     {
                         ContactName = publication.Contact.ContactName,
-                        ContactTelNo = String.IsNullOrWhiteSpace(publication.Contact.ContactTelNo)
+                        ContactTelNo = string.IsNullOrWhiteSpace(publication.Contact.ContactTelNo)
                             ? null
                             : publication.Contact.ContactTelNo,
                         TeamName = publication.Contact.TeamName,
@@ -326,7 +327,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(publication => _mapper.Map<ContactViewModel>(publication.Contact));
         }
 
-        public async Task<Either<ActionResult, ContactViewModel>> UpdateContact(Guid publicationId, Contact updatedContact)
+        public async Task<Either<ActionResult, ContactViewModel>> UpdateContact(Guid publicationId, ContactSaveRequest updatedContact)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Publication>(publicationId, query =>
@@ -343,7 +344,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     }
 
                     publication.Contact.ContactName = updatedContact.ContactName;
-                    publication.Contact.ContactTelNo = String.IsNullOrWhiteSpace(updatedContact.ContactTelNo)
+                    publication.Contact.ContactTelNo = string.IsNullOrWhiteSpace(updatedContact.ContactTelNo)
                         ? null
                         : updatedContact.ContactTelNo;
                     publication.Contact.TeamName = updatedContact.TeamName;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -115,7 +115,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     var contact = await _context.Contacts.AddAsync(new Contact
                     {
                         ContactName = publication.Contact.ContactName,
-                        ContactTelNo = publication.Contact.ContactTelNo,
+                        ContactTelNo = String.IsNullOrWhiteSpace(publication.Contact.ContactTelNo)
+                            ? null
+                            : publication.Contact.ContactTelNo,
                         TeamName = publication.Contact.TeamName,
                         TeamEmail = publication.Contact.TeamEmail
                     });
@@ -341,7 +343,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     }
 
                     publication.Contact.ContactName = updatedContact.ContactName;
-                    publication.Contact.ContactTelNo = updatedContact.ContactTelNo;
+                    publication.Contact.ContactTelNo = String.IsNullOrWhiteSpace(updatedContact.ContactTelNo)
+                        ? null
+                        : updatedContact.ContactTelNo;
                     publication.Contact.TeamName = updatedContact.TeamName;
                     publication.Contact.TeamEmail = updatedContact.TeamEmail;
                     await _context.SaveChangesAsync();
@@ -349,7 +353,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     // Clear cache because Contact is in Content.Services.ViewModels.PublicationViewModel
                     await _publicationCacheService.UpdatePublication(publication.Slug);
 
-                    return _mapper.Map<ContactViewModel>(updatedContact);
+                    return _mapper.Map<ContactViewModel>(publication.Contact);
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
@@ -220,7 +220,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 }
             }
 
-            if (release.PreReleaseAccessList.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(release.PreReleaseAccessList))
             {
                 warnings.Add(new ReleaseChecklistIssue(ValidationErrorMessages.NoPublicPreReleaseAccessList));
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
@@ -14,14 +14,4 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public string? ContactTelNo { get; set; }
     }
 
-    public class ContactSaveViewModel
-    {
-        [Required] public string TeamName { get; set; } = string.Empty;
-
-        [Required, EmailAddress] public string TeamEmail { get; set; } = string.Empty;
-
-        [Required] public string ContactName { get; set; } = string.Empty;
-
-        public string? ContactTelNo { get; set; }
-    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ContactViewModels.cs
@@ -11,7 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public string ContactName { get; set; } = string.Empty;
 
-        public string ContactTelNo { get; set; } = string.Empty;
+        public string? ContactTelNo { get; set; }
     }
 
     public class ContactSaveViewModel
@@ -22,6 +22,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         [Required] public string ContactName { get; set; } = string.Empty;
 
-        [Required] public string ContactTelNo { get; set; } = string.Empty;
+        public string? ContactTelNo { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationCreateViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationCreateViewModel.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using static System.String;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
@@ -15,7 +14,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public string Slug { get; set; } = Empty;
 
-        public Contact Contact { get; set; } = null!;
+        public ContactViewModel Contact { get; set; } = null!;
 
         public IdTitleViewModel Topic { get; set; } = null!;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ThemeViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ThemeViewModels.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
@@ -20,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public string Slug
         {
-            get => String.IsNullOrEmpty(_slug) ? NamingUtils.SlugFromTitle(Title) : _slug;
+            get => string.IsNullOrEmpty(_slug) ? NamingUtils.SlugFromTitle(Title) : _slug;
             set => _slug = value;
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/TopicViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/TopicViewModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
@@ -27,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public string Slug
         {
-            get => String.IsNullOrEmpty(_slug) ? NamingUtils.SlugFromTitle(Title) : _slug;
+            get => string.IsNullOrEmpty(_slug) ? NamingUtils.SlugFromTitle(Title) : _slug;
             set => _slug = value;
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/PhoneNumberAttributeTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/PhoneNumberAttributeTests.cs
@@ -1,0 +1,65 @@
+#nullable enable
+using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Validators;
+
+public class PhoneNumberAttributeTests
+{
+    [Theory]
+    [InlineData("01234567")]
+    [InlineData("0   123 4567")]
+    [InlineData("0 1 2 3   4 5 6 7      ")]
+    public void AllowedValues_Valid(string value)
+    {
+        var attribute = new PhoneNumberAttribute();
+        var result = attribute.GetValidationResult(value, new ValidationContext(value));
+
+        Assert.Equal(ValidationResult.Success, result);
+    }
+
+    [Fact]
+    public void AllowedValues_Null()
+    {
+        var attribute = new PhoneNumberAttribute();
+        string? value = null;
+        var result = attribute.GetValidationResult(value, new ValidationContext("test")); // Have to give ValidationContext something that isn't null
+
+        Assert.Equal(ValidationResult.Success, result);
+    }
+
+    [Fact]
+    public void DisallowedValues_NotString()
+    {
+        var attribute = new PhoneNumberAttribute();
+        var value = 42;
+        var result = attribute.GetValidationResult(value, new ValidationContext(value));
+
+        Assert.Equal("A phone number must be a string", result?.ErrorMessage);
+    }
+
+    [Fact]
+    public void DisallowedValues_TooShort()
+    {
+        var attribute = new PhoneNumberAttribute();
+        var value = "0123456";
+        var result = attribute.GetValidationResult(value, new ValidationContext(value));
+
+        Assert.Equal("The value must have a minimum length of 8.", result?.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("012  34567a")]
+    [InlineData(@"0!£$%^&*'`()_+=")]
+    [InlineData("1234567890")]
+    [InlineData("a12345678")]
+    [InlineData("0  12345678 !")]
+    public void DisallowedValues_NotNumericOrNotStartWithZero(string value)
+    {
+        var attribute = new PhoneNumberAttribute();
+        var result = attribute.GetValidationResult(value, new ValidationContext(value));
+
+        Assert.Equal("The value must start with a '0' and  contain only numbers or spaces.", result?.ErrorMessage);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/PhoneNumberAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/PhoneNumberAttribute.cs
@@ -1,0 +1,42 @@
+#nullable enable
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field| AttributeTargets.Parameter)]
+public class PhoneNumberAttribute : ValidationAttribute
+{
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value == null)
+        {
+            return ValidationResult.Success;
+        }
+
+        if (value is not string telNo)
+        {
+            return new ValidationResult("A phone number must be a string");
+        }
+
+        if (telNo.Length < 8)
+        {
+            return new ValidationResult(LengthMessage(validationContext));
+        }
+
+        return !Regex.IsMatch(telNo, @"^0[0-9\s]*$")
+            ? new ValidationResult(FormatMessage(validationContext))
+            : ValidationResult.Success;
+    }
+
+    private string LengthMessage(ValidationContext validationContext) =>
+        validationContext?.MemberName is not null
+            ? $"The {validationContext.MemberName} field must have a minimum length of 8."
+            : "The value must have a minimum length of 8.";
+
+    private string FormatMessage(ValidationContext validationContext) =>
+        validationContext?.MemberName is not null
+            ? $"The {validationContext.MemberName} field must start with a '0' and contain only numbers or spaces."
+            : "The value must start with a '0' and  contain only numbers or spaces.";
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Contact.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Contact.cs
@@ -1,18 +1,17 @@
 #nullable enable
 using System;
-using System.ComponentModel.DataAnnotations;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 public class Contact
 {
-    [Key] [Required] public Guid Id { get; set; }
+    public Guid Id { get; set; }
 
-    [Required] public string TeamName { get; set; } = null!;
+    public string TeamName { get; set; } = null!;
 
-    [Required] [EmailAddress] public string TeamEmail { get; set; } = null!;
+    public string TeamEmail { get; set; } = null!;
 
-    [Required] public string ContactName { get; set; } = null!;
+    public string ContactName { get; set; } = null!;
 
     public string? ContactTelNo { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Contact.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Contact.cs
@@ -1,23 +1,18 @@
+#nullable enable
 using System;
 using System.ComponentModel.DataAnnotations;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Model
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+public class Contact
 {
-    public class Contact
-    {
-        [Key] [Required] public Guid Id { get; set; }
+    [Key] [Required] public Guid Id { get; set; }
 
-        [Required]
-        public string TeamName { get; set; }
+    [Required] public string TeamName { get; set; } = null!;
 
-        [Required]
-        [EmailAddress]
-        public string TeamEmail { get; set; }
+    [Required] [EmailAddress] public string TeamEmail { get; set; } = null!;
 
-        [Required]
-        public string ContactName { get; set; }
+    [Required] public string ContactName { get; set; } = null!;
 
-        [Required]
-        public string ContactTelNo { get; set; }
-    }
+    public string? ContactTelNo { get; set; }
 }

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
@@ -173,45 +173,128 @@ describe('PublicationContactPage', () => {
         }),
       ).toBeInTheDocument();
 
-      // NOTE: Contact telephone number is optional, so no validation
+      // NOTE: Contact telephone is optional, so no validation
     });
   });
 
-  test('show validation error when contact tel no is not valid', async () => {
-    publicationService.getContact.mockResolvedValue(testContact);
+  test.each([' abcdefgh ', '1234 4567a', '_12345678', '1234 5678 !'])(
+    'show validation error when contact tel no "%s" contains non-numeric or non-whitespace characters',
+    async telNo => {
+      publicationService.getContact.mockResolvedValue(testContact);
 
-    renderPage(testPublication);
+      renderPage(testPublication);
 
-    await waitFor(() => {
-      expect(
-        screen.getByText('Contact for this publication'),
-      ).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(
+          screen.getByText('Contact for this publication'),
+        ).toBeInTheDocument();
+      });
 
-    userEvent.click(
-      screen.getByRole('button', { name: 'Edit contact details' }),
-    );
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit contact details' }),
+      );
 
-    userEvent.clear(screen.getByLabelText('Contact telephone (optional)'));
+      userEvent.clear(screen.getByLabelText('Contact telephone (optional)'));
 
-    userEvent.type(
-      screen.getByLabelText('Contact telephone (optional)'),
-      ' 0 3 7 0 0 0 0 2 2 8 8 ',
-    );
+      userEvent.type(
+        screen.getByLabelText('Contact telephone (optional)'),
+        telNo,
+      );
 
-    userEvent.tab();
+      userEvent.tab();
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          'The DfE enquiries number is not suitable for use on statistics publications',
-          {
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Contact telephone must only contain numeric or whitespace characters',
+            {
+              selector: '#publicationContactForm-contactTelNo-error',
+            },
+          ),
+        ).toBeInTheDocument();
+      });
+    },
+  );
+
+  test.each([
+    ' 03700002288 ',
+    '0370 000 2288',
+    '037 0000 2288',
+    ' 0 3 7 0 0 0 0 2 2 8 8 ',
+  ])(
+    'show validation error when contact tel no "%s" is DfE enquiries number',
+    async telNo => {
+      publicationService.getContact.mockResolvedValue(testContact);
+
+      renderPage(testPublication);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Contact for this publication'),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit contact details' }),
+      );
+
+      userEvent.clear(screen.getByLabelText('Contact telephone (optional)'));
+
+      userEvent.type(
+        screen.getByLabelText('Contact telephone (optional)'),
+        telNo,
+      );
+
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Contact telephone cannot be the DfE enquiries number',
+            {
+              selector: '#publicationContactForm-contactTelNo-error',
+            },
+          ),
+        ).toBeInTheDocument();
+      });
+    },
+  );
+
+  test.each([' 1234567 ', '1', '123', '1234 67'])(
+    'show validation error when contact tel no "%s" is less than 8 characters',
+    async telNo => {
+      publicationService.getContact.mockResolvedValue(testContact);
+
+      renderPage(testPublication);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Contact for this publication'),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit contact details' }),
+      );
+
+      userEvent.clear(screen.getByLabelText('Contact telephone (optional)'));
+
+      userEvent.type(
+        screen.getByLabelText('Contact telephone (optional)'),
+        telNo,
+      );
+
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Contact telephone must be 8 characters or more', {
             selector: '#publicationContactForm-contactTelNo-error',
-          },
-        ),
-      ).toBeInTheDocument();
-    });
-  });
+          }),
+        ).toBeInTheDocument();
+      });
+    },
+  );
 
   test('show validation error when contact email is not valid', async () => {
     publicationService.getContact.mockResolvedValue(testContact);

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
@@ -88,7 +88,7 @@ describe('PublicationContactPage', () => {
       'john.smith@test.com',
     );
     expect(screen.getByLabelText('Contact name')).toHaveValue('John Smith');
-    expect(screen.getByLabelText('Contact telephone')).toHaveValue(
+    expect(screen.getByLabelText('Contact telephone (optional)')).toHaveValue(
       '0777777777',
     );
     expect(
@@ -150,7 +150,7 @@ describe('PublicationContactPage', () => {
     userEvent.clear(screen.getByLabelText('Team name'));
     userEvent.clear(screen.getByLabelText('Team email'));
     userEvent.clear(screen.getByLabelText('Contact name'));
-    userEvent.clear(screen.getByLabelText('Contact telephone'));
+    userEvent.clear(screen.getByLabelText('Contact telephone (optional)'));
 
     userEvent.tab();
 
@@ -173,10 +173,42 @@ describe('PublicationContactPage', () => {
         }),
       ).toBeInTheDocument();
 
+      // NOTE: Contact telephone number is optional, so no validation
+    });
+  });
+
+  test('show validation error when contact tel no is not valid', async () => {
+    publicationService.getContact.mockResolvedValue(testContact);
+
+    renderPage(testPublication);
+
+    await waitFor(() => {
       expect(
-        screen.getByText('Enter a contact telephone', {
-          selector: '#publicationContactForm-contactTelNo-error',
-        }),
+        screen.getByText('Contact for this publication'),
+      ).toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit contact details' }),
+    );
+
+    userEvent.clear(screen.getByLabelText('Contact telephone (optional)'));
+
+    userEvent.type(
+      screen.getByLabelText('Contact telephone (optional)'),
+      ' 0 3 7 0 0 0 0 2 2 8 8 ',
+    );
+
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'The DfE enquiries number is not suitable for use on statistics publications',
+          {
+            selector: '#publicationContactForm-contactTelNo-error',
+          },
+        ),
       ).toBeInTheDocument();
     });
   });

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
@@ -177,7 +177,7 @@ describe('PublicationContactPage', () => {
     });
   });
 
-  test.each([' abcdefgh ', '1234 4567a', '_12345678', '1234 5678 !'])(
+  test.each([' 0abcdefg ', '01234 4567a', '_12345678', '01234 5678 !'])(
     'show validation error when contact tel no "%s" contains non-numeric or non-whitespace characters',
     async telNo => {
       publicationService.getContact.mockResolvedValue(testContact);
@@ -206,7 +206,7 @@ describe('PublicationContactPage', () => {
       await waitFor(() => {
         expect(
           screen.getByText(
-            'Contact telephone must only contain numeric or whitespace characters',
+            'Contact telephone must start with a "0" and only contain numeric or whitespace characters',
             {
               selector: '#publicationContactForm-contactTelNo-error',
             },
@@ -260,7 +260,7 @@ describe('PublicationContactPage', () => {
     },
   );
 
-  test.each([' 1234567 ', '1', '123', '1234 67'])(
+  test.each([' 0123456 ', '0', '012', '0123 56'])(
     'show validation error when contact tel no "%s" is less than 8 characters',
     async telNo => {
       publicationService.getContact.mockResolvedValue(testContact);

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
@@ -14,7 +14,7 @@ export interface PublicationContactFormValues {
   teamName: string;
   teamEmail: string;
   contactName: string;
-  contactTelNo: string;
+  contactTelNo?: string;
 }
 
 interface Props {
@@ -36,16 +36,17 @@ const PublicationContactForm = ({
       .required('Enter a team email')
       .email('Enter a valid team email'),
     contactName: Yup.string().required('Enter a contact name'),
-    contactTelNo: Yup.string().test({
-      name: 'telephone',
-      message: 'Enter a contact telephone',
-      test: value => {
-        if (!value) {
-          return false;
-        }
-        return true;
-      },
-    }),
+    contactTelNo: Yup.string()
+      .trim()
+      .matches(
+        /^[0-9 \t]*$/,
+        'The telephone number should only contain numeric characters',
+      )
+      .matches(
+        /^(?!^0[ \t]*3[ \t]*7[ \t]*0[ \t]*0[ \t]*0[ \t]*0[ \t]*2[ \t]*2[ \t]*8[ \t]*8$)/,
+        'The DfE enquiries number is not suitable for use on statistics publications',
+      )
+      .min(8, 'The telephone number must be at least 8 characters long'),
   });
 
   return (
@@ -78,7 +79,7 @@ const PublicationContactForm = ({
 
             <FormFieldTextInput<PublicationContactFormValues>
               name="contactTelNo"
-              label="Contact telephone"
+              label="Contact telephone (optional)"
               className="govuk-!-width-one-half"
             />
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
@@ -39,14 +39,14 @@ const PublicationContactForm = ({
     contactTelNo: Yup.string()
       .trim()
       .matches(
-        /^[0-9 \t]*$/,
-        'The telephone number should only contain numeric characters',
+        /^[0-9\s]*$/,
+        'Contact telephone must only contain numeric or whitespace characters',
       )
       .matches(
-        /^(?!^0[ \t]*3[ \t]*7[ \t]*0[ \t]*0[ \t]*0[ \t]*0[ \t]*2[ \t]*2[ \t]*8[ \t]*8$)/,
-        'The DfE enquiries number is not suitable for use on statistics publications',
+        /^(?!^0\s*3\s*7\s*0\s*0\s*0\s*0\s*2\s*2\s*8\s*8$)/,
+        'Contact telephone cannot be the DfE enquiries number',
       )
-      .min(8, 'The telephone number must be at least 8 characters long'),
+      .min(8, 'Contact telephone must be 8 characters or more'),
   });
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
@@ -39,8 +39,8 @@ const PublicationContactForm = ({
     contactTelNo: Yup.string()
       .trim()
       .matches(
-        /^[0-9\s]*$/,
-        'Contact telephone must only contain numeric or whitespace characters',
+        /^0[0-9\s]*$/,
+        'Contact telephone must start with a "0" and only contain numeric or whitespace characters',
       )
       .matches(
         /^(?!^0\s*3\s*7\s*0\s*0\s*0\s*0\s*2\s*2\s*8\s*8$)/,

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
@@ -93,14 +93,14 @@ const PublicationForm = ({
       contactTelNo: Yup.string()
         .trim()
         .matches(
-          /^[0-9 \t]*$/,
-          'The telephone number should only contain numeric characters',
+          /^[0-9\s]*$/,
+          'Contact telephone must only contain numeric or whitespace characters',
         )
         .matches(
-          /^(?!^0[ \t]*3[ \t]*7[ \t]*0[ \t]*0[ \t]*0[ \t]*0[ \t]*2[ \t]*2[ \t]*8[ \t]*8$)/,
-          'The DfE enquiries number is not suitable for use on statistics publications',
+          /^(?!^0\s*3\s*7\s*0\s*0\s*0\s*0\s*2\s*2\s*8\s*8$)/,
+          'Contact telephone cannot be the DfE enquiries number',
         )
-        .min(8, 'The telephone number must be at least 8 characters long'),
+        .min(8, 'Contact telephone must be 8 characters or more'),
       supersededById: Yup.string(),
     });
 
@@ -189,7 +189,7 @@ const PublicationForm = ({
 
             <FormFieldTextInput<FormValues>
               name="contactTelNo"
-              label="Contact telephone number (optional)"
+              label="Contact telephone (optional)"
               width={10}
             />
           </FormFieldset>

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
@@ -25,7 +25,7 @@ export interface FormValues {
   teamName: string;
   teamEmail: string;
   contactName: string;
-  contactTelNo: string;
+  contactTelNo?: string;
   supersededById?: string;
 }
 
@@ -90,7 +90,17 @@ const PublicationForm = ({
         .required('Enter a team email address')
         .email('Enter a valid team email address'),
       contactName: Yup.string().required('Enter a contact name'),
-      contactTelNo: Yup.string().required('Enter a contact telephone number'),
+      contactTelNo: Yup.string()
+        .trim()
+        .matches(
+          /^[0-9 \t]*$/,
+          'The telephone number should only contain numeric characters',
+        )
+        .matches(
+          /^(?!^0[ \t]*3[ \t]*7[ \t]*0[ \t]*0[ \t]*0[ \t]*0[ \t]*2[ \t]*2[ \t]*8[ \t]*8$)/,
+          'The DfE enquiries number is not suitable for use on statistics publications',
+        )
+        .min(8, 'The telephone number must be at least 8 characters long'),
       supersededById: Yup.string(),
     });
 
@@ -179,7 +189,7 @@ const PublicationForm = ({
 
             <FormFieldTextInput<FormValues>
               name="contactTelNo"
-              label="Contact telephone number"
+              label="Contact telephone number (optional)"
               width={10}
             />
           </FormFieldset>

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
@@ -93,8 +93,8 @@ const PublicationForm = ({
       contactTelNo: Yup.string()
         .trim()
         .matches(
-          /^[0-9\s]*$/,
-          'Contact telephone must only contain numeric or whitespace characters',
+          /^0[0-9\s]*$/,
+          'Contact telephone must start with a "0" and only contain numeric or whitespace characters',
         )
         .matches(
           /^(?!^0\s*3\s*7\s*0\s*0\s*0\s*0\s*2\s*2\s*8\s*8$)/,

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
@@ -152,7 +152,7 @@ describe('PublicationForm', () => {
     });
   });
 
-  test.each([' abcdefgh ', '1234 4567a', '_12345678', '1234 5678 !'])(
+  test.each([' 0abcdefg ', '01234 4567a', '_12345678', '01234 5678 !'])(
     'show validation error when contact tel no "%s" contains non-numeric or non-whitespace characters',
     async telNo => {
       render(<PublicationForm onSubmit={noop} />);
@@ -172,7 +172,7 @@ describe('PublicationForm', () => {
       await waitFor(() => {
         expect(
           screen.getByText(
-            'Contact telephone must only contain numeric or whitespace characters',
+            'Contact telephone must start with a "0" and only contain numeric or whitespace characters',
             {
               selector: '#publicationForm-contactTelNo-error',
             },
@@ -217,7 +217,7 @@ describe('PublicationForm', () => {
     },
   );
 
-  test.each([' 1234567 ', '1', '123', '1234 67'])(
+  test.each([' 0123456 ', '0', '012', '0123 56'])(
     'show validation error when contact tel no "%s" is less than 8 characters',
     async telNo => {
       render(<PublicationForm onSubmit={noop} />);

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
@@ -126,7 +126,9 @@ describe('PublicationForm', () => {
     userEvent.click(screen.getByLabelText('Contact name'));
     userEvent.tab();
 
-    userEvent.click(screen.getByLabelText('Contact telephone number'));
+    userEvent.click(
+      screen.getByLabelText('Contact telephone number (optional)'),
+    );
     userEvent.tab();
 
     await waitFor(() => {
@@ -148,10 +150,33 @@ describe('PublicationForm', () => {
         }),
       ).toBeInTheDocument();
 
+      // NOTE: Contact telelphone number is optional, so no validation error
+    });
+  });
+
+  test('show validation error when contact tel no is not valid', async () => {
+    render(<PublicationForm onSubmit={noop} />);
+
+    await waitFor(() => {
       expect(
-        screen.getByText('Enter a contact telephone number', {
-          selector: '#publicationForm-contactTelNo-error',
-        }),
+        screen.getByLabelText('Contact telephone number (optional)'),
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByLabelText('Contact telephone number (optional)'),
+      ' 0 3 7 0 0 0 0 2 2 8 8 ',
+    );
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'The DfE enquiries number is not suitable for use on statistics publications',
+          {
+            selector: '#publicationForm-contactTelNo-error',
+          },
+        ),
       ).toBeInTheDocument();
     });
   });
@@ -224,7 +249,7 @@ describe('PublicationForm', () => {
     );
     await userEvent.type(screen.getByLabelText('Contact name'), 'John Smith');
     await userEvent.type(
-      screen.getByLabelText('Contact telephone number'),
+      screen.getByLabelText('Contact telephone number (optional)'),
       '0123456789',
     );
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
@@ -126,9 +126,7 @@ describe('PublicationForm', () => {
     userEvent.click(screen.getByLabelText('Contact name'));
     userEvent.tab();
 
-    userEvent.click(
-      screen.getByLabelText('Contact telephone number (optional)'),
-    );
+    userEvent.click(screen.getByLabelText('Contact telephone (optional)'));
     userEvent.tab();
 
     await waitFor(() => {
@@ -154,32 +152,97 @@ describe('PublicationForm', () => {
     });
   });
 
-  test('show validation error when contact tel no is not valid', async () => {
-    render(<PublicationForm onSubmit={noop} />);
+  test.each([' abcdefgh ', '1234 4567a', '_12345678', '1234 5678 !'])(
+    'show validation error when contact tel no "%s" contains non-numeric or non-whitespace characters',
+    async telNo => {
+      render(<PublicationForm onSubmit={noop} />);
 
-    await waitFor(() => {
-      expect(
-        screen.getByLabelText('Contact telephone number (optional)'),
-      ).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('Contact telephone (optional)'),
+        ).toBeInTheDocument();
+      });
 
-    await userEvent.type(
-      screen.getByLabelText('Contact telephone number (optional)'),
-      ' 0 3 7 0 0 0 0 2 2 8 8 ',
-    );
-    userEvent.tab();
+      await userEvent.type(
+        screen.getByLabelText('Contact telephone (optional)'),
+        telNo,
+      );
+      userEvent.tab();
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          'The DfE enquiries number is not suitable for use on statistics publications',
-          {
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Contact telephone must only contain numeric or whitespace characters',
+            {
+              selector: '#publicationForm-contactTelNo-error',
+            },
+          ),
+        ).toBeInTheDocument();
+      });
+    },
+  );
+
+  test.each([
+    ' 03700002288 ',
+    '0370 000 2288',
+    '037 0000 2288',
+    ' 0 3 7 0 0 0 0 2 2 8 8 ',
+  ])(
+    'show validation error when contact tel no "%s" is DfE enquiries number',
+    async telNo => {
+      render(<PublicationForm onSubmit={noop} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('Contact telephone (optional)'),
+        ).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText('Contact telephone (optional)'),
+        telNo,
+      );
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Contact telephone cannot be the DfE enquiries number',
+            {
+              selector: '#publicationForm-contactTelNo-error',
+            },
+          ),
+        ).toBeInTheDocument();
+      });
+    },
+  );
+
+  test.each([' 1234567 ', '1', '123', '1234 67'])(
+    'show validation error when contact tel no "%s" is less than 8 characters',
+    async telNo => {
+      render(<PublicationForm onSubmit={noop} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('Contact telephone (optional)'),
+        ).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByLabelText('Contact telephone (optional)'),
+        telNo,
+      );
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Contact telephone must be 8 characters or more', {
             selector: '#publicationForm-contactTelNo-error',
-          },
-        ),
-      ).toBeInTheDocument();
-    });
-  });
+          }),
+        ).toBeInTheDocument();
+      });
+    },
+  );
 
   test('show validation error when contact email is not valid', async () => {
     render(<PublicationForm onSubmit={noop} />);
@@ -249,7 +312,7 @@ describe('PublicationForm', () => {
     );
     await userEvent.type(screen.getByLabelText('Contact name'), 'John Smith');
     await userEvent.type(
-      screen.getByLabelText('Contact telephone number (optional)'),
+      screen.getByLabelText('Contact telephone (optional)'),
       '0123456789',
     );
 

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -21,7 +21,7 @@ export interface Contact {
 
 export interface ContactSave {
   contactName: string;
-  contactTelNo: string;
+  contactTelNo?: string;
   teamEmail: string;
   teamName: string;
 }

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/ContactUsSection.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/ContactUsSection.tsx
@@ -24,10 +24,12 @@ const ContactUsSection = ({
           {publicationContact.teamEmail}
         </a>
       </p>
-      <p>
-        Telephone: {publicationContact.contactName} <br />{' '}
-        {publicationContact.contactTelNo}
-      </p>
+      {publicationContact.contactTelNo && (
+        <p>
+          Telephone: {publicationContact.contactName} <br />{' '}
+          {publicationContact.contactTelNo}
+        </p>
+      )}
       <h4 className="govuk-heading-s govuk-!-margin-bottom-0">Press office</h4>
       <p className="govuk-!-margin-top-0">If you have a media enquiry:</p>
       <p>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolInfo.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolInfo.tsx
@@ -37,7 +37,9 @@ const TableToolInfo = ({
               {contactDetails.teamEmail}
             </a>
           </p>
-          <p>Telephone: {contactDetails.contactTelNo}</p>
+          {contactDetails.contactTelNo && (
+            <p>Telephone: {contactDetails.contactTelNo}</p>
+          )}
         </>
       )}
     </>

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -63,7 +63,7 @@ export interface Contact {
   teamName: string;
   teamEmail: string;
   contactName: string;
-  contactTelNo: string;
+  contactTelNo?: string;
 }
 
 export interface PublicationTitle {

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_owner_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_owner_ui_permissions.robot
@@ -64,7 +64,7 @@ Check Edit publication contact page inputs are correct
     user waits until page contains element    label:Team name
     user waits until page contains element    label:Team email
     user waits until page contains element    label:Contact name
-    user waits until page contains element    label:Contact telephone
+    user waits until page contains element    label:Contact telephone (optional)
 
     user clicks button    Cancel
     user waits until page does not contain button    Cancel

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
@@ -60,7 +60,7 @@ Update publication contact
     user enters text into element    label:Team name    Team name updated
     user enters text into element    label:Team email    email_updated@test.com
     user enters text into element    label:Contact name    Contact name updated
-    user enters text into element    label:Contact telephone    4321 4321
+    user enters text into element    label:Contact telephone (optional)    4321 4321
 
     user clicks button    Update contact details
     ${modal}=    user waits until modal is visible    Confirm contact changes


### PR DESCRIPTION
This PR makes a Contact telephone number optional. It also adds a migration to remove the DfE Enquiries telephone number from existing contacts, and frontend validation to prevent the DfE Enquiries number being added as a contact tel no in the future.

:rotating_light: NOTE: After the migration, to update the caches, we need to hit the `DELETE admin/api/bau/public-cache/publications` endpoint. :rotating_light: 

### Notes

- I checked the Contact tel numbers currently in the Prod DB, and I wrote my migration to cover all cases, as the number was spaced differently in different rows.
- The frontend validation regex is designed to ensure nobody can get around the DfE Enquiries number validation by using spacing.