### PR TITLE
EES-3849 Lowercase API request paths and add Trim to string model binding

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
@@ -86,4 +86,9 @@ public static class HttpResponseMessageTestExtensions
 
         return body;
     }
+
+    public static void AssertPathAndQueryEqualTo(this HttpResponseMessage response, string expected)
+    {
+        Assert.Equal(expected, response.RequestMessage?.RequestUri?.PathAndQuery);
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
@@ -423,6 +423,20 @@ Test
             }
         }
 
+        public class TrimToLowerTests
+        {
+            [Theory]
+            [InlineData("", "")]
+            [InlineData(" ", "")]
+            [InlineData("foo bar")]
+            [InlineData("foo BAR")]
+            [InlineData("  foo BAR  ")]
+            public void TrimToLower(string input, string expected = "foo bar")
+            {
+                Assert.Equal(expected, input.TrimToLower());
+            }
+        }
+
         public class ToMd5HashTests
         {
             [Fact]
@@ -452,7 +466,6 @@ Test
                 var input = "héy";
                 Assert.Equal("f7d6171b6bcfd8923a50b65721064b27", input.ToMd5Hash(Encoding.ASCII));
             }
-
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ModelBinding/TrimStringModelBinderIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ModelBinding/TrimStringModelBinderIntegrationTests.cs
@@ -1,0 +1,127 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.ModelBinding;
+
+public class TrimStringModelBinderIntegrationTests
+    : IClassFixture<TestApplicationFactory<TestStartup>>
+{
+    private readonly WebApplicationFactory<TestStartup> _testApp;
+
+    public TrimStringModelBinderIntegrationTests(TestApplicationFactory<TestStartup> testApp)
+    {
+        _testApp = testApp;
+    }
+
+    [Fact]
+    public async Task RouteValuesAreTrimmed()
+    {
+        var client = SetupApp().CreateClient();
+
+        var response = await client.GetAsync("api/test/  path  ");
+
+        response.AssertOk(new PathResponse("path"));
+    }
+
+    [Fact]
+    public async Task QueryValuesAreTrimmed_SimpleType()
+    {
+        var client = SetupApp().CreateClient();
+
+        var response = await client.GetAsync("api/test?query=  query  ");
+
+        response.AssertOk(new QueryResponse("query"));
+    }
+
+    [Fact]
+    public async Task QuerySourceValuesAreTrimmed_ComplexType()
+    {
+        var client = SetupApp().CreateClient();
+
+        var response = await client.GetAsync("api/test/complex?request.query=  query  ");
+
+        response.AssertOk(new QueryResponse("query"));
+    }
+
+    [Fact]
+    public async Task FormValuesAreTrimmed_SimpleType()
+    {
+        var client = SetupApp().CreateClient();
+
+        var response = await client.PostAsync("api/test",
+            content: new FormUrlEncodedContent(new List<KeyValuePair<string, string>>
+            {
+                new("query", "  query  ")
+            }));
+
+        response.AssertOk(new QueryResponse("query"));
+    }
+
+    [Fact]
+    public async Task FormValuesAreTrimmed_ComplexType()
+    {
+        var client = SetupApp().CreateClient();
+
+        var response = await client.PostAsync("api/test/complex",
+            content: new FormUrlEncodedContent(new List<KeyValuePair<string, string>>
+            {
+                new("request.query", "  query  ")
+            }));
+
+        response.AssertOk(new QueryResponse("query"));
+    }
+
+    private WebApplicationFactory<TestStartup> SetupApp()
+    {
+        return _testApp.WithWebHostBuilder(builder => builder
+            .WithAdditionalControllers(typeof(TestController)));
+    }
+
+    [ApiController]
+    [Route("api/test")]
+    private class TestController : ControllerBase
+    {
+        [HttpGet("{path}")]
+        public ActionResult<PathResponse> FromRoute([FromRoute] string path)
+        {
+            return new PathResponse(path);
+        }
+
+        [HttpGet("")]
+        public ActionResult<QueryResponse> FromQuery([FromQuery] string query)
+        {
+            return new QueryResponse(query);
+        }
+
+        [HttpGet("complex")]
+        public ActionResult<QueryResponse> FromQueryComplex([FromQuery] ComplexRequest request)
+        {
+            return new QueryResponse(request.Query);
+        }
+
+        [HttpPost("")]
+        public ActionResult<QueryResponse> FromForm([FromForm] string query)
+        {
+            return new QueryResponse(query);
+        }
+
+        [HttpPost("complex")]
+        public ActionResult<QueryResponse> FromFormComplex([FromForm] ComplexRequest request)
+        {
+            return new QueryResponse(request.Query);
+        }
+    }
+
+    private record ComplexRequest(string Query);
+
+    private record PathResponse(string Path);
+
+    private record QueryResponse(string Query);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Rules/LowercasePathRuleIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Rules/LowercasePathRuleIntegrationTests.cs
@@ -1,0 +1,77 @@
+﻿#nullable enable
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Rules;
+
+public class LowercasePathRuleIntegrationTests
+    : IClassFixture<TestApplicationFactory<TestStartup>>
+{
+    private readonly WebApplicationFactory<TestStartup> _testApp;
+
+    public LowercasePathRuleIntegrationTests(TestApplicationFactory<TestStartup> testApp)
+    {
+        _testApp = testApp;
+    }
+
+    [Fact]
+    public async Task PathIsLowercased_Get()
+    {
+        var client = SetupApp().CreateClient();
+
+        var response = await client.GetAsync("api/test/Path?query=Query");
+
+        // Client should follow 308 permanent redirect
+        response.AssertOk(new TestResponse(Path: "path", Query: "Query"));
+        response.AssertPathAndQueryEqualTo("/api/test/path?query=Query");
+    }
+
+    [Fact]
+    public async Task PathIsLowercased_Post()
+    {
+        var client = SetupApp().CreateClient();
+
+        var response = await client.PostAsync("api/test/Path?query=Query",
+            content: new JsonNetContent("Body"));
+
+        // Client should follow 308 permanent redirect without changing method from POST to GET
+        response.AssertOk(new TestResponse(Path: "path", Query: "Query", Body: "Body"));
+        response.AssertPathAndQueryEqualTo("/api/test/path?query=Query");
+    }
+
+    private WebApplicationFactory<TestStartup> SetupApp()
+    {
+        return _testApp.WithWebHostBuilder(builder => builder
+            .WithAdditionalControllers(typeof(TestController)));
+    }
+
+    [ApiController]
+    [Route("api/test/{path}")]
+    private class TestController : ControllerBase
+    {
+        [HttpGet("")]
+        public ActionResult<TestResponse> Get(
+            string path,
+            [FromQuery] string query)
+        {
+            return new TestResponse(path, query);
+        }
+
+        [HttpPost("")]
+        public ActionResult<TestResponse> Post(
+            string path,
+            [FromQuery] string query,
+            [FromBody, Required] string body)
+        {
+            return new TestResponse(path, query, body);
+        }
+    }
+
+    private record TestResponse(string Path, string Query, string? Body = null);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Rules/LowercasePathRuleTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Rules/LowercasePathRuleTests.cs
@@ -1,0 +1,136 @@
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Rules;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Rewrite;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Rules;
+
+public class LowercasePathRuleTests
+{
+    private readonly LowercasePathRule _rule;
+
+    public LowercasePathRuleTests()
+    {
+        _rule = new LowercasePathRule();
+    }
+
+    [Fact]
+    public void ApplyRule_PathIsLowercase_DoesNotRedirect()
+    {
+        // Setup a new context with a request path that is already lowercase and should not be redirected
+        var rewriteContext = new RewriteContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Scheme = "https",
+                    Host = new HostString("localhost"),
+                    PathBase = new PathString("/base"),
+                    Path = new PathString("/path"),
+                    QueryString = new QueryString("?query=query")
+                }
+            }
+        };
+
+        _rule.ApplyRule(rewriteContext);
+
+        var response = rewriteContext.HttpContext.Response;
+
+        Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+        Assert.Equal(RuleResult.ContinueRules, rewriteContext.Result);
+        Assert.True(StringValues.IsNullOrEmpty(response.Headers.Location));
+    }
+
+    [Theory]
+    [InlineData("/_configuration/Admin")]
+    [InlineData("/Identity/Account/Login")]
+    [InlineData("/static/js/App.js")]
+    public void ApplyRule_PathIsNotLowercaseButExcluded_DoesNotRedirect(string path)
+    {
+        // Setup a new context with a request path that matches the excluded regex as well as not being lowercase
+        var rewriteContext = new RewriteContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Scheme = "https",
+                    Host = new HostString("localhost"),
+                    PathBase = new PathString("/base"),
+                    Path = new PathString(path),
+                    QueryString = new QueryString("?query=query")
+                }
+            }
+        };
+
+        _rule.ApplyRule(rewriteContext);
+
+        var response = rewriteContext.HttpContext.Response;
+
+        Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+        Assert.Equal(RuleResult.ContinueRules, rewriteContext.Result);
+        Assert.True(StringValues.IsNullOrEmpty(response.Headers.Location));
+    }
+
+    [Fact]
+    public void ApplyRule_PathIsNotLowercase_ResponseIsRedirected()
+    {
+        // Setup a new context with a request path that is not lowercase and should be redirected
+        var rewriteContext = new RewriteContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Scheme = "https",
+                    Host = new HostString("localhost"),
+                    PathBase = new PathString("/base"),
+                    Path = new PathString("/Path"),
+                    QueryString = new QueryString("?query=query")
+                }
+            }
+        };
+
+        _rule.ApplyRule(rewriteContext);
+
+        var response = rewriteContext.HttpContext.Response;
+
+        Assert.Equal(StatusCodes.Status308PermanentRedirect, response.StatusCode);
+        Assert.Equal(RuleResult.EndResponse, rewriteContext.Result);
+        // Path is lowercased
+        Assert.Equal("https://localhost/base/path?query=query", response.Headers.Location);
+    }
+
+    [Fact]
+    public void ApplyRule_PathIsNotLowercase_QueryStringIsNotModified()
+    {
+        // Setup a new context with a request path that is not lowercase and should be redirected,
+        // but which also has a query string that should not be modified
+        var rewriteContext = new RewriteContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Scheme = "https",
+                    Host = new HostString("localhost"),
+                    PathBase = new PathString("/base"),
+                    Path = new PathString("/Path"),
+                    QueryString = new QueryString("?query=Query")
+                }
+            }
+        };
+
+        _rule.ApplyRule(rewriteContext);
+
+        var response = rewriteContext.HttpContext.Response;
+
+        Assert.Equal(StatusCodes.Status308PermanentRedirect, response.StatusCode);
+        Assert.Equal(RuleResult.EndResponse, rewriteContext.Result);
+        // Query string is not modified
+        Assert.Equal("https://localhost/base/path?query=Query", response.Headers.Location);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/FileStoragePathUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/FileStoragePathUtilsTests.cs
@@ -1,24 +1,167 @@
+#nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services;
+
+public class FileStoragePathUtilsTests
 {
-    public class FileStoragePathUtilsTests
+    public class PublicPathTests
     {
-        [Fact]
-        public void TestFilesPath()
+        public static TheoryData<string> PublicationData =
+            new()
+            {
+                "publication-slug",
+                "  publication-SLUG  "
+            };
+
+        public static TheoryData<string, string> PublicationAndReleaseData =
+            new()
+            {
+                { "publication-slug", "release-slug" },
+                { "  publication-SLUG  ", "  release-SLUG  " }
+            };
+
+        public static TheoryData<string, string, Guid> PublicationReleaseAndIdData =
+            new()
+            {
+                { "publication-slug", "release-slug", Guid.NewGuid() },
+                { "  publication-SLUG  ", "  release-SLUG  ", Guid.NewGuid() }
+            };
+
+        [Theory]
+        [MemberData(nameof(PublicationData))]
+        public void PublicContentPublicationPath(string publicationSlug)
         {
-            var rootPath = Guid.NewGuid();
-            Assert.Equal($"{rootPath}/ancillary/", FilesPath(rootPath, Ancillary));
-            Assert.Equal($"{rootPath}/chart/", FilesPath(rootPath, Chart));
-            Assert.Equal($"{rootPath}/data/", FilesPath(rootPath, FileType.Data));
-            Assert.Equal($"{rootPath}/data-zip/", FilesPath(rootPath, DataZip));
-            Assert.Equal($"{rootPath}/image/", FilesPath(rootPath, Image));
-            Assert.Equal($"{rootPath}/data/", FilesPath(rootPath, Metadata));
-            Assert.Equal($"{rootPath}/zip/", FilesPath(rootPath, AllFilesZip));
+            Assert.Equal("publications/publication-slug/publication.json",
+                FileStoragePathUtils.PublicContentPublicationPath(publicationSlug: publicationSlug));
         }
+
+        [Theory]
+        [MemberData(nameof(PublicationData))]
+        public void PublicContentLatestReleasePath(string publicationSlug)
+        {
+            Assert.Equal("publications/publication-slug/latest-release.json",
+                FileStoragePathUtils.PublicContentLatestReleasePath(publicationSlug: publicationSlug));
+
+            Assert.Equal("staging/publications/publication-slug/latest-release.json",
+                FileStoragePathUtils.PublicContentLatestReleasePath(publicationSlug: publicationSlug,
+                    staging: true));
+        }
+
+        [Theory]
+        [MemberData(nameof(PublicationAndReleaseData))]
+        public void PublicContentReleasePath(string publicationSlug,
+            string releaseSlug)
+        {
+            Assert.Equal("publications/publication-slug/releases/release-slug.json",
+                FileStoragePathUtils.PublicContentReleasePath(publicationSlug: publicationSlug,
+                    releaseSlug: releaseSlug));
+
+            Assert.Equal("staging/publications/publication-slug/releases/release-slug.json",
+                FileStoragePathUtils.PublicContentReleasePath(publicationSlug: publicationSlug,
+                    releaseSlug: releaseSlug,
+                    staging: true));
+        }
+
+        [Theory]
+        [MemberData(nameof(PublicationReleaseAndIdData))]
+        public void PublicContentDataBlockPath(string publicationSlug,
+            string releaseSlug,
+            Guid dataBlockId)
+        {
+            Assert.Equal($"publications/publication-slug/releases/release-slug/data-blocks/{dataBlockId}.json",
+                FileStoragePathUtils.PublicContentDataBlockPath(publicationSlug: publicationSlug,
+                    releaseSlug: releaseSlug,
+                    dataBlockId));
+        }
+
+        [Theory]
+        [MemberData(nameof(PublicationAndReleaseData))]
+        public void PublicContentDataBlockParentPath(string publicationSlug,
+            string releaseSlug)
+        {
+            Assert.Equal($"publications/publication-slug/releases/release-slug/data-blocks",
+                FileStoragePathUtils.PublicContentDataBlockParentPath(publicationSlug: publicationSlug,
+                    releaseSlug: releaseSlug));
+        }
+
+        [Theory]
+        [MemberData(nameof(PublicationAndReleaseData))]
+        public void PublicContentReleaseSubjectsPath(string publicationSlug,
+            string releaseSlug)
+        {
+            Assert.Equal($"publications/publication-slug/releases/release-slug/subjects.json",
+                FileStoragePathUtils.PublicContentReleaseSubjectsPath(publicationSlug: publicationSlug,
+                    releaseSlug: releaseSlug));
+        }
+
+        [Theory]
+        [MemberData(nameof(PublicationReleaseAndIdData))]
+        public void PublicContentSubjectMetaPath(string publicationSlug,
+            string releaseSlug,
+            Guid subjectId)
+        {
+            Assert.Equal($"publications/publication-slug/releases/release-slug/subject-meta/{subjectId}.json",
+                FileStoragePathUtils.PublicContentSubjectMetaPath(publicationSlug: publicationSlug,
+                    releaseSlug: releaseSlug,
+                    subjectId));
+        }
+
+        [Theory]
+        [MemberData(nameof(PublicationAndReleaseData))]
+        public void PublicContentSubjectMetaParentPath(string publicationSlug,
+            string releaseSlug)
+        {
+            Assert.Equal($"publications/publication-slug/releases/release-slug/subject-meta",
+                FileStoragePathUtils.PublicContentSubjectMetaParentPath(publicationSlug: publicationSlug,
+                    releaseSlug: releaseSlug));
+        }
+    }
+
+    public class PrivatePathTests
+    {
+        private class TestData : TheoryData<Guid, Guid>
+        {
+            public TestData()
+            {
+                Add(Guid.NewGuid(), Guid.NewGuid());
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(TestData))]
+        public void PrivateContentDataBlockPath(Guid releaseId,
+            Guid dataBlockId)
+        {
+            Assert.Equal($"releases/{releaseId}/data-blocks/{dataBlockId}.json",
+                FileStoragePathUtils.PrivateContentDataBlockPath(releaseId: releaseId,
+                    dataBlockId: dataBlockId));
+        }
+
+        [Theory]
+        [ClassData(typeof(TestData))]
+        public void PrivateContentSubjectMetaPath(Guid releaseId,
+            Guid subjectId)
+        {
+            Assert.Equal($"releases/{releaseId}/subject-meta/{subjectId}.json",
+                FileStoragePathUtils.PrivateContentSubjectMetaPath(releaseId: releaseId,
+                    subjectId: subjectId));
+        }
+    }
+
+    [Fact]
+    public void FilesPath()
+    {
+        var rootPath = Guid.NewGuid();
+        Assert.Equal($"{rootPath}/ancillary/", FileStoragePathUtils.FilesPath(rootPath, FileType.Ancillary));
+        Assert.Equal($"{rootPath}/chart/", FileStoragePathUtils.FilesPath(rootPath, FileType.Chart));
+        Assert.Equal($"{rootPath}/data/", FileStoragePathUtils.FilesPath(rootPath, FileType.Data));
+        Assert.Equal($"{rootPath}/data-zip/", FileStoragePathUtils.FilesPath(rootPath, FileType.DataZip));
+        Assert.Equal($"{rootPath}/image/", FileStoragePathUtils.FilesPath(rootPath, FileType.Image));
+        Assert.Equal($"{rootPath}/data/", FileStoragePathUtils.FilesPath(rootPath, FileType.Metadata));
+        Assert.Equal($"{rootPath}/zip/", FileStoragePathUtils.FilesPath(rootPath, FileType.AllFilesZip));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/TestStartup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/TestStartup.cs
@@ -1,7 +1,9 @@
 #nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Rules;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 
@@ -23,16 +25,18 @@ public class TestStartup
                 options => { options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore; }
             );
 
-        services.AddControllers(
-            options =>
+        services.AddControllers(options =>
             {
-                options.ModelBinderProviders.Insert(0, new SeparatedQueryModelBinderProvider(","));
+                options.AddCommaSeparatedQueryModelBinderProvider();
+                options.AddTrimStringBinderProvider();
             }
         );
     }
 
     public void Configure(IApplicationBuilder app)
     {
+        app.UseRewriter(new RewriteOptions()
+            .Add(new LowercasePathRule()));
         app.UseMvc();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/MvcOptionsExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/MvcOptionsExtensions.cs
@@ -1,0 +1,30 @@
+﻿#nullable enable
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class MvcOptionsExtensions
+{
+    public static void AddCommaSeparatedQueryModelBinderProvider(this MvcOptions options)
+    {
+        options.ModelBinderProviders.Insert(0, new SeparatedQueryModelBinderProvider(","));
+    }
+
+    public static void AddTrimStringBinderProvider(this MvcOptions option)
+    {
+        var simpleTypeModelBinderProvider = option.ModelBinderProviders
+            .FirstOrDefault(x => x.GetType() == typeof(SimpleTypeModelBinderProvider));
+
+        if (simpleTypeModelBinderProvider == null)
+        {
+            return;
+        }
+
+        // The first provider that returns a binder is used, so insert before the SimpleTypeModelBinderProvider
+        var index = option.ModelBinderProviders.IndexOf(simpleTypeModelBinderProvider);
+        option.ModelBinderProviders.Insert(index, new TrimStringModelBinderProvider());
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -62,6 +62,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return firstChar > -1 ? firstChar : value.Length;
         }
 
+        public static string TrimToLower(this string value)
+        {
+            return value.Trim().ToLower(); 
+        }
+
         public static string TrimIndent(this string value)
         {
             var lines = value.ToLines()

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/TrimStringModelBinder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/TrimStringModelBinder.cs
@@ -1,0 +1,53 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+
+public class TrimStringModelBinder : IModelBinder
+{
+    private readonly IModelBinder _baseModelBinder;
+
+    public TrimStringModelBinder(IModelBinder baseModelBinder)
+    {
+        _baseModelBinder = baseModelBinder;
+    }
+
+    public Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        if (bindingContext == null)
+        {
+            throw new ArgumentNullException(nameof(bindingContext));
+        }
+
+        if (bindingContext.ModelType != typeof(string))
+        {
+            throw new ArgumentException("Model type must be a string");
+        }
+
+        var modelName = bindingContext.ModelName;
+        var valueProviderResult = bindingContext.ValueProvider.GetValue(modelName);
+
+        if (valueProviderResult != ValueProviderResult.None)
+        {
+            var value = valueProviderResult.FirstValue;
+            if (!string.IsNullOrEmpty(value))
+            {
+                bindingContext.ModelState.SetModelValue(modelName, valueProviderResult);
+
+                var model = value.Trim();
+                if (bindingContext.ModelMetadata.ConvertEmptyStringToNull && model.Length == 0)
+                {
+                    model = null;
+                }
+
+                bindingContext.Result = ModelBindingResult.Success(model);
+                return Task.CompletedTask;
+            }
+        }
+
+        // Delegate to the built-in binder
+        return _baseModelBinder.BindModelAsync(bindingContext);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/TrimStringModelBinderProvider.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/TrimStringModelBinderProvider.cs
@@ -1,0 +1,27 @@
+﻿#nullable enable
+using System;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+
+public class TrimStringModelBinderProvider : IModelBinderProvider
+{
+    public IModelBinder? GetBinder(ModelBinderProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (!context.Metadata.IsComplexType && context.Metadata.ModelType == typeof(string))
+        {
+            var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
+            return new TrimStringModelBinder(new SimpleTypeModelBinder(context.Metadata.ModelType, loggerFactory));
+        }
+
+        return null;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Rules/LowercasePathRule.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Rules/LowercasePathRule.cs
@@ -1,0 +1,45 @@
+﻿#nullable enable
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Rewrite;
+using Microsoft.Net.Http.Headers;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Rules;
+
+public class LowercasePathRule : IRule
+{
+    private const string ExcludedPathsRegex = "^/(_configuration|identity|static).*$";
+
+    public void ApplyRule(RewriteContext context)
+    {
+        var request = context.HttpContext.Request;
+
+        var scheme = request.Scheme;
+        var pathBase = request.PathBase;
+        var path = request.Path;
+        var host = request.Host;
+        var query = request.QueryString;
+
+        if (IsApplicable(path))
+        {
+            var location = $"{scheme}://{host.Value}{pathBase.Value}{path.Value}".ToLower() + query;
+
+            var response = context.HttpContext.Response;
+            response.StatusCode = StatusCodes.Status308PermanentRedirect;
+            response.Headers[HeaderNames.Location] = location;
+            context.Result = RuleResult.EndResponse;
+        }
+        else
+        {
+            context.Result = RuleResult.ContinueRules;
+        }
+    }
+
+    private static bool IsApplicable(PathString path)
+    {
+        return path.HasValue
+               && !Regex.IsMatch(path, ExcludedPathsRegex, RegexOptions.IgnoreCase)
+               && path.Value.Any(char.IsUpper);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Rules/LowercasePathRule.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Rules/LowercasePathRule.cs
@@ -7,6 +7,22 @@ using Microsoft.Net.Http.Headers;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Rules;
 
+/// <summary>
+/// Rule which is used to redirect any request paths that contain uppercase characters to lowercase.
+/// This excludes any paths that match the regex defined in <see cref="ExcludedPathsRegex"/>.
+/// Examples of requests that we might want to exclude:
+/// <list type="bullet">
+/// <item>
+/// <description>Oidc configuration</description>
+/// </item>
+/// <item>
+/// <description>Identity endpoints</description>
+/// </item>
+/// <item>
+/// <description>Static assets</description>
+/// </item>
+/// </list>
+/// </summary>
 public class LowercasePathRule : IRule
 {
     private const string ExcludedPathsRegex = "^/(_configuration|identity|static).*$";

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -16,19 +16,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public static string PublicContentStagingPath() => "staging";
 
-        private static string PublicContentPublicationParentPath(string slug, bool staging = false)
+        private static string PublicContentPublicationParentPath(string publicationSlug, bool staging = false)
         {
-            return $"{AppendPathSeparator(staging ? PublicContentStagingPath() : null)}publications/{slug}";
+            return
+                $"{AppendPathSeparator(staging ? PublicContentStagingPath() : null)}publications/{publicationSlug.TrimToLower()}";
         }
 
         private static string PublicContentReleaseParentPath(string publicationSlug, string releaseSlug)
         {
-            return $"{PublicContentPublicationParentPath(publicationSlug)}/{ReleasesDirectory}/{releaseSlug}";
+            return
+                $"{PublicContentPublicationParentPath(publicationSlug)}/{ReleasesDirectory}/{releaseSlug.TrimToLower()}";
         }
 
-        public static string PublicContentPublicationPath(string slug)
+        public static string PublicContentPublicationPath(string publicationSlug)
         {
-            return $"{PublicContentPublicationParentPath(slug)}/{PublicationFileName}";
+            return $"{PublicContentPublicationParentPath(publicationSlug)}/{PublicationFileName}";
         }
 
         public static string PublicContentLatestReleasePath(string publicationSlug, bool staging = false)
@@ -38,7 +40,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public static string PublicContentReleasePath(string publicationSlug, string releaseSlug, bool staging = false)
         {
-            return $"{PublicContentPublicationParentPath(publicationSlug, staging)}/{ReleasesDirectory}/{releaseSlug}.json";
+            return
+                $"{PublicContentPublicationParentPath(publicationSlug, staging)}/{ReleasesDirectory}/{releaseSlug.TrimToLower()}.json";
         }
 
         public static string PublicContentDataBlockParentPath(string publicationSlug, string releaseSlug)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/TestStartup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/TestStartup.cs
@@ -1,5 +1,6 @@
 #nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Rules;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils;
@@ -7,6 +8,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
@@ -30,12 +32,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests
                     options => { options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore; }
                 );
 
-            services.AddControllers(
-                options =>
+            services.AddControllers(options =>
                 {
-                    options.ModelBinderProviders.Insert(0, new SeparatedQueryModelBinderProvider(","));
-                }
-            )
+                    options.AddCommaSeparatedQueryModelBinderProvider();
+                    options.AddTrimStringBinderProvider();
+                })
                 .AddApplicationPart(typeof(Startup).Assembly);
 
             services.AddDbContext<StatisticsDbContext>(
@@ -56,6 +57,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests
 
         public void Configure(IApplicationBuilder app)
         {
+            app.UseRewriter(new RewriteOptions()
+                .Add(new LowercasePathRule()));
             app.UseMvc();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/AllMethodologiesCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/AllMethodologiesCacheKey.cs
@@ -6,12 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
 
 public record AllMethodologiesCacheKey : IBlobCacheKey
 {
-    public string Key => GetKey();
-
     public IBlobContainer Container => BlobContainers.PublicContent;
 
-    public static string GetKey()
-    {
-        return "methodology-tree.json";
-    }
+    public string Key => "methodology-tree.json";
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationTreeCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationTreeCacheKey.cs
@@ -2,17 +2,11 @@
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
+
+public record PublicationTreeCacheKey : IBlobCacheKey
 {
-    public record PublicationTreeCacheKey : IBlobCacheKey
-    {
-        public string Key => GetKey();
+    public IBlobContainer Container => BlobContainers.PublicContent;
 
-        public IBlobContainer Container => BlobContainers.PublicContent;
-
-        public static string GetKey()
-        {
-            return "publication-tree.json";
-        }
-    }
+    public string Key => "publication-tree.json";
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/TestStartup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/TestStartup.cs
@@ -1,5 +1,6 @@
 #nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Rules;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils;
@@ -7,6 +8,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
@@ -30,9 +32,11 @@ public class TestStartup
                 options => { options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore; }
             );
 
-        services.AddControllers(
-                options => { options.ModelBinderProviders.Insert(0, new SeparatedQueryModelBinderProvider(",")); }
-            )
+        services.AddControllers(options =>
+            {
+                options.AddCommaSeparatedQueryModelBinderProvider();
+                options.AddTrimStringBinderProvider();
+            })
             .AddApplicationPart(typeof(Startup).Assembly);
 
         services.AddDbContext<StatisticsDbContext>(
@@ -57,6 +61,8 @@ public class TestStartup
 
     public void Configure(IApplicationBuilder app)
     {
+        app.UseRewriter(new RewriteOptions()
+            .Add(new LowercasePathRule()));
         app.UseMvc();
     }
 }


### PR DESCRIPTION
This PR fixes a bug where backend API requests that use the blob cache internally could create additional cache entries for any resources which use string parameters as database and cache keys, by appending trailing spaces and/or by changing the case of those keys in the request path.

These keys are typically captured in route parameters.

E.g. for the public `GetRelease` endpoint `publications/{publication-slug}/releases/{release-slug}` the following variations will all fetch the same resource for the publication slug `pupil-attendance-in-schools` and release slug `2023-week-29`:

```
/api/publications/pupil-attendance-in-schools/releases/2023-week-29%20%20
/api/publications/pupil-attendance-in-schools%20%20/releases/2023-week-29
/api/publications/pupil-attendance-in-schools/releases/2023-Week-29
/api/publications/Pupil-Attendance-In-Schools/releases/2023-Week-29
```

This was bad for the following reasons:

* Unlimited variants of the same resource's URL could be requested by appending a differing number of trailing spaces to the URL and/or by using combinations of mixed case in the URL. Each new unique URL evades the original intended cache entry of the resource. After a cache miss for the new key, the resource is fetched from the database in potentially heavy query(s) that caching was meant to mitigate against.

* Each 'variant' key is added as a new cache entry. As well as wasting storage in the cache, the entries are never invalidated when changes to that resource are made. As an example, a cached release contains publication data which includes the latest published release and other release versions. These are immediately out of date as soon as a new release is published so the cache entry is updated at publishing time. However these 'variant' cache entries now become stale but are still accessible with incorrect data. Public URL's responsible for these 'variants' may have been shared, published on other websites, bookmarked, and indexed by search engines so users end up seeing old data. This was seen in [EES-4496](https://dfedigital.atlassian.net/browse/EES-4496).

This happens because of behaviour in the database when fetching resources after a cache miss.

After a miss on the cache key, the resource is located in the database using string keys as query parameters. These queries find results even though the parameters have trailing space and don't match by case. The SQL Server database collation we use is case-insensitive so there's no exact case matching on string equality. Trailing space doesn't effect string comparison because the ANSI SQL standard for string comparison right-pads strings to be the same length. Try the query `SELECT 'Equal!' WHERE 'abc    ' = 'ABC'` will return one result.

### Considerations for fixing this

* I avoided tackling trailing space in comparisons at a database level because that's an ANSI SQL standard. We could have done something like change every comparison to also compare length, or append some text to the end of both strings but both felt hacky.

* I avoided changing the database collation or some other change like adding an explicit collation to every query because that wouldn't be a solution here either. Adding case sensitivity would prevent all requests using mixed or upper case.
Using upper case in a request path should be ok, we just don't want resources found using mixed case keys to be cached uniquely.

* I considered making a change in `CacheAttribute.GetCacheKey` when constructing a `CacheKey` to lower case all parameters like slugs but it would affect all string parameters used in a `CacheKey` constructor, not just those used by the `CacheKey.Key`.

* I considered making a change in `BlobCacheService` `GetItemAsync` and `SetItemAsync` methods to lowercase `CacheKey.Key` which is used for the blob path but that would mean blob cache key's could never be case-sensitive in any circumstances even if we wanted them to be.

### How this was fixed

* Added new `LowercasePathRule` which rewrites all request paths to lowercase (bar the query string and certain exceptions such as static resources excluded by regex) which guarantees all route parameters captured in paths are lowercase.

* Added new `TrimStringModelBinder` as a replacement for binding primitive type `string` by `SimpleTypeModelBinder`.  `TrimStringModelBinder` does the same thing as `SimpleTypeModelBinder` except for trimming whitespace on the result of model binding.

* I made an additional change to helper methods of `FileStoragePathUtils` which produce all the paths based on slugs to make them safe for whitespace and always return lowercase paths no matter what data source the paths are constructed from.

### Other changes

- Remove unnecessary `GetKey` methods in `PublicationTreeCacheKey` and `AllMethodologiesCacheKey`.
- Add new sets of unit tests in classes `FileStoragePathUtilsTests.PublicPathTests` and `FileStoragePathUtilsTests.PrivatePathTests`.