### PR TITLE
EES-4575 fix PRA email validation

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
@@ -61,10 +61,6 @@ const PreReleaseUserAccessForm = ({
 
   const [invitePlan, setInvitePlan] = useState<PreReleaseInvitePlan>();
 
-  const isValidEmail = (input: string) => {
-    return /^[A-Z0-9.'_%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(input);
-  };
-
   const splitAndTrimLines = (input: string) =>
     input
       .split(/\r\n|\r|\n/)
@@ -141,8 +137,9 @@ const PreReleaseUserAccessForm = ({
                 test(value?: string) {
                   if (value) {
                     const emails = splitAndTrimLines(value);
+                    const schema = Yup.string().email();
                     const indexOfFirstInvalid = emails.findIndex(
-                      email => !isValidEmail(email),
+                      email => !schema.isValidSync(email),
                     );
                     if (indexOfFirstInvalid < 0) {
                       return true;

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/__tests__/PreReleaseUserAccessForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/__tests__/PreReleaseUserAccessForm.test.tsx
@@ -342,7 +342,8 @@ describe('PreReleaseUserAccessForm', () => {
           'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.com{enter}' +
           'test@test.co.uk{enter}' +
           'test@test.uk{enter}' +
-          'test@education.gov.uk',
+          'test@education.gov.uk{enter}' +
+          'test@gov.wales',
       );
       userEvent.tab();
 
@@ -357,6 +358,7 @@ describe('PreReleaseUserAccessForm', () => {
             'test@test.co.uk',
             'test@test.uk',
             'test@education.gov.uk',
+            'test@gov.wales',
           ],
         );
       });


### PR DESCRIPTION
Replaces the custom email validation for PRA users with Yup email validation so that `gov.wales` and other valid TLDs are not rejected.