### PR TITLE
EES-4557 Fix how renderMethodologyLink prop is passed to ReleaseHelpAndSupportSection

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDraftReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDraftReleases.tsx
@@ -4,10 +4,7 @@ import {
   IssuesGuidanceModal,
 } from '@admin/pages/publication/components/PublicationGuidance';
 import { ReleaseSummaryWithPermissions } from '@admin/services/releaseService';
-import ButtonText from '@common/components/ButtonText';
-import InfoIcon from '@common/components/InfoIcon';
 import InsetText from '@common/components/InsetText';
-import useToggle from '@common/hooks/useToggle';
 import React from 'react';
 
 interface Props {

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleases.tsx
@@ -1,4 +1,3 @@
-import { PublishedStatusGuidanceModal } from '@admin/pages/publication/components/PublicationGuidance';
 import PublicationPublishedReleasesTable from '@admin/pages/publication/components/PublicationPublishedReleasesTable';
 import {
   ReleaseRouteParams,
@@ -11,7 +10,6 @@ import releaseService, {
 import ButtonText from '@common/components/ButtonText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
-import useToggle from '@common/hooks/useToggle';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import last from 'lodash/last';
 import React, { MutableRefObject, useEffect, useMemo, useState } from 'react';
@@ -31,9 +29,6 @@ export default function PublicationPublishedReleases({
   const history = useHistory();
 
   const [focusReleaseId, setFocusReleaseId] = useState<string>();
-
-  const [showPublishedStatusGuidance, togglePublishedStatusGuidance] =
-    useToggle(false);
 
   const {
     data: releases,

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -438,7 +438,7 @@ const ReleaseContent = () => {
         renderExternalMethodologyLink={externalMethodology => (
           <Link to={externalMethodology.url}>{externalMethodology.title}</Link>
         )}
-        renderMethodologyLink={methodology => {
+        renderMethodologyLink={methodology => (
           <>
             {editingMode === 'edit' ? (
               <a>{`${methodology.title}`}</a>
@@ -447,8 +447,8 @@ const ReleaseContent = () => {
                 {methodology.title}
               </Link>
             )}
-          </>;
-        }}
+          </>
+        )}
       />
       <PrintThisPage />
     </>

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseHelpAndSupportSection.tsx
@@ -33,7 +33,7 @@ export default function ReleaseHelpAndSupportSection({
         Help and support
       </h2>
 
-      {methodologies.length > 0 && (
+      {(methodologies.length > 0 || externalMethodology) && (
         <>
           <h3>Methodology</h3>
           <p>

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseSummarySection.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseSummarySection.tsx
@@ -8,7 +8,6 @@ import SummaryListItem from '@common/components/SummaryListItem';
 import ButtonText from '@common/components/ButtonText';
 import InfoIcon from '@common/components/InfoIcon';
 import ReleaseTypeSection from '@common/modules/release/components/ReleaseTypeSection';
-import useToggle from '@common/hooks/useToggle';
 import { Release } from '@common/services/publicationService';
 import { ReleaseType, releaseTypes } from '@common/services/types/releaseType';
 import Modal from '@common/components/Modal';
@@ -48,8 +47,6 @@ export default function ReleaseSummarySection({
   renderSubscribeLink,
   onShowReleaseTypeModal,
 }: Props) {
-  const [showReleaseTypeModal, toggleReleaseTypeModal] = useToggle(false);
-
   return (
     <>
       <div className="dfe-flex dfe-align-items--center dfe-justify-content--space-between govuk-!-margin-bottom-3">

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/FiltersMobile.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/FiltersMobile.tsx
@@ -7,7 +7,7 @@ import AdvancedFilters from '@frontend/modules/find-statistics/components/Advanc
 import { FilterChangeHandler } from '@frontend/modules/find-statistics/components/FiltersDesktop';
 import styles from '@frontend/modules/find-statistics/components/FiltersMobile.module.scss';
 import ThemeFilters from '@frontend/modules/find-statistics/components/ThemeFilters';
-import React, { useRef } from 'react';
+import React from 'react';
 
 interface Props {
   releaseType?: ReleaseType;


### PR DESCRIPTION
This PR fixes a bug where methodology links weren't being displayed in the Help and Support section on Admin content pages. This is because the `renderMethodologyLink` prop was being passed to `ReleaseHelpAndSupportSection` incorrectly .

As part of this PR, I've also ensured the Methodology section of `ReleaseHelpAndSupportSection` is displayed if the release only has an external release, and I've also removed various unused variables.