### PR TITLE
EES-4588 Fix missing methodology type modal guidance

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationMethodologyGuidance.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationMethodologyGuidance.tsx
@@ -18,7 +18,7 @@ export function MethodologyStatusGuidanceModal() {
         </ButtonText>
       }
     >
-      <p>A methodology can have various types of status as descibed below:</p>
+      <p>A methodology can have various types of status as described below:</p>
       <SummaryList>
         <SummaryListItem term={<Tag>Draft</Tag>}>
           This is an unpublished draft methodology that can still be edited
@@ -41,6 +41,11 @@ export function MethodologyTypeGuidanceModal() {
       className="govuk-!-width-one-half"
       showClose
       title="Methodology type guidance"
+      triggerButton={
+        <ButtonText>
+          <InfoIcon description="Guidance on methodology types" />
+        </ButtonText>
+      }
     >
       <p>Various types of methodology can be associated to this publication:</p>
       <SummaryList>

--- a/src/explore-education-statistics-common/src/components/Modal.tsx
+++ b/src/explore-education-statistics-common/src/components/Modal.tsx
@@ -1,9 +1,9 @@
 import Button from '@common/components/Button';
 import styles from '@common/components/Modal.module.scss';
 import useToggle from '@common/hooks/useToggle';
+import * as Dialog from '@radix-ui/react-dialog';
 import classNames from 'classnames';
 import React, { ReactNode, useEffect, useRef } from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
 
 export interface ModalProps {
   children: ReactNode;

--- a/src/explore-education-statistics-common/src/components/ModalConfirm.tsx
+++ b/src/explore-education-statistics-common/src/components/ModalConfirm.tsx
@@ -15,9 +15,9 @@ interface Props {
   title: string;
   triggerButton?: ReactNode;
   underlayClass?: string;
-  onCancel?(): void;
-  onConfirm(): void;
-  onExit?(): void;
+  onCancel?(): void | Promise<void>;
+  onConfirm(): void | Promise<void>;
+  onExit?(): void | Promise<void>;
 }
 
 const ModalConfirm = ({
@@ -30,9 +30,9 @@ const ModalConfirm = ({
   title,
   triggerButton,
   underlayClass,
-  onCancel,
-  onConfirm,
   onExit,
+  onCancel = onExit,
+  onConfirm,
 }: Props) => {
   const isMounted = useMountedRef();
   const [isDisabled, toggleDisabled] = useToggle(false);
@@ -42,7 +42,7 @@ const ModalConfirm = ({
     toggleOpen(initialOpen);
   }, [initialOpen, toggleOpen]);
 
-  const handleAction = (callback?: () => void) => async () => {
+  const handleAction = (callback?: () => void | Promise<void>) => async () => {
     if (!callback) {
       toggleOpen.off();
       return;

--- a/src/explore-education-statistics-common/src/components/__tests__/ModalConfirm.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ModalConfirm.test.tsx
@@ -9,6 +9,7 @@ describe('ModalConfirm', () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
+
   describe('confirming', () => {
     test('clicking Confirm button disables all buttons', () => {
       const handleExit = jest.fn();
@@ -116,6 +117,56 @@ describe('ModalConfirm', () => {
   });
 
   describe('cancelling', () => {
+    test('clicking Cancel button calls `onExit` when no `onCancel` set', async () => {
+      const handleExit = jest.fn();
+      const handleConfirm = jest.fn();
+
+      render(
+        <ModalConfirm
+          open
+          title="Test modal"
+          triggerButton={<button type="button">Open</button>}
+          onConfirm={handleConfirm}
+          onExit={handleExit}
+        />,
+      );
+
+      expect(handleExit).not.toHaveBeenCalled();
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => {
+        expect(handleExit).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    test('clicking Cancel button calls `onCancel` when set', async () => {
+      const handleExit = jest.fn();
+      const handleCancel = jest.fn();
+      const handleConfirm = jest.fn();
+
+      render(
+        <ModalConfirm
+          open
+          title="Test modal"
+          triggerButton={<button type="button">Open</button>}
+          onCancel={handleCancel}
+          onConfirm={handleConfirm}
+          onExit={handleExit}
+        />,
+      );
+
+      expect(handleCancel).not.toHaveBeenCalled();
+      expect(handleExit).not.toHaveBeenCalled();
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => {
+        expect(handleCancel).toHaveBeenCalledTimes(1);
+        expect(handleExit).not.toHaveBeenCalled();
+      });
+    });
+
     test('clicking Cancel button disables all buttons', () => {
       const handleExit = jest.fn();
       const handleCancel = jest.fn();


### PR DESCRIPTION
This PR:

- Re-adds the modal button for the methodology type guidance that was accidentally omitted in #4319.
- Fixes `ModalConfirm` not calling `onExit` by default when no `onCancel`. This was causing the `ReleaseStatusForm` submit button to not re-trigger the modal on subsequent submissions after cancelling it once.

