### PR TITLE
EES-4585 Include Contact name in Contact Us section

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/PublicationController.cs
@@ -8,7 +8,6 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/PhoneNumberAttributeTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/PhoneNumberAttributeTests.cs
@@ -11,8 +11,6 @@ public class PhoneNumberAttributeTests
     [InlineData("01234567")]
     [InlineData("0   123 4567")]
     [InlineData("0 1 2 3   4 5 6 7      ")]
-    [InlineData("")]
-    [InlineData("    ")]
     public void AllowedValues_Valid(string value)
     {
         var attribute = new PhoneNumberAttribute();
@@ -41,14 +39,27 @@ public class PhoneNumberAttributeTests
         Assert.Equal("A phone number must be a string", result?.ErrorMessage);
     }
 
-    [Fact]
-    public void DisallowedValues_TooShort()
+    [Theory]
+    [InlineData("0123456        ")]
+    [InlineData("0         ")]
+    [InlineData("     0123456")]
+    public void DisallowedValues_TooShort(string value)
     {
         var attribute = new PhoneNumberAttribute();
-        var value = "0123456";
         var result = attribute.GetValidationResult(value, new ValidationContext(value));
 
         Assert.Equal("The value must have a minimum length of 8.", result?.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("    ")]
+    public void DisallowedValues_EmptyStringOrWhitespace(string value)
+    {
+        var attribute = new PhoneNumberAttribute();
+        var result = attribute.GetValidationResult(value, new ValidationContext(value));
+
+        Assert.Equal("A phone number cannot be an empty string or whitespace", result?.ErrorMessage);
     }
 
     [Theory]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/PhoneNumberAttributeTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/PhoneNumberAttributeTests.cs
@@ -11,6 +11,8 @@ public class PhoneNumberAttributeTests
     [InlineData("01234567")]
     [InlineData("0   123 4567")]
     [InlineData("0 1 2 3   4 5 6 7      ")]
+    [InlineData("")]
+    [InlineData("    ")]
     public void AllowedValues_Valid(string value)
     {
         var attribute = new PhoneNumberAttribute();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/PhoneNumberAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/PhoneNumberAttribute.cs
@@ -2,6 +2,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Validators;
 
@@ -18,6 +19,11 @@ public class PhoneNumberAttribute : ValidationAttribute
         if (value is not string telNo)
         {
             return new ValidationResult("A phone number must be a string");
+        }
+
+        if (telNo.IsNullOrWhitespace())
+        {
+            return ValidationResult.Success;
         }
 
         if (telNo.Length < 8)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/PhoneNumberAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/PhoneNumberAttribute.cs
@@ -21,17 +21,19 @@ public class PhoneNumberAttribute : ValidationAttribute
             return new ValidationResult("A phone number must be a string");
         }
 
-        if (telNo.IsNullOrWhitespace())
+        var trimmedTelNo = telNo.Trim();
+
+        if (trimmedTelNo.IsNullOrWhitespace())
         {
-            return ValidationResult.Success;
+            return new ValidationResult("A phone number cannot be an empty string or whitespace");
         }
 
-        if (telNo.Length < 8)
+        if (trimmedTelNo.Length < 8)
         {
             return new ValidationResult(LengthMessage(validationContext));
         }
 
-        return !Regex.IsMatch(telNo, @"^0[0-9\s]*$")
+        return !Regex.IsMatch(trimmedTelNo, @"^0[0-9\s]*$")
             ? new ValidationResult(FormatMessage(validationContext))
             : ValidationResult.Success;
     }

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationContactPage.tsx
@@ -24,9 +24,13 @@ const PublicationContactPage = () => {
     if (!contact) {
       return;
     }
+    const sanitisedContact = updatedContact;
+    if (!updatedContact.contactTelNo?.trim()) {
+      sanitisedContact.contactTelNo = undefined;
+    }
     const nextContact = await publicationService.updateContact(
       publication.id,
-      updatedContact,
+      sanitisedContact,
     );
 
     setContact({ value: nextContact });

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationCreatePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationCreatePage.tsx
@@ -70,15 +70,19 @@ const PublicationCreatePage = ({
           contactTelNo,
           ...values
         }) => {
+          const contact = {
+            teamName,
+            teamEmail,
+            contactName,
+            contactTelNo,
+          };
+          if (!contact.contactTelNo?.trim()) {
+            contact.contactTelNo = undefined;
+          }
           await publicationService.createPublication({
             ...values,
             topicId: topic.id,
-            contact: {
-              teamName,
-              teamEmail,
-              contactName,
-              contactTelNo,
-            },
+            contact,
           });
 
           history.push(dashboardRoute.path);

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/ContactUsSection.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/ContactUsSection.tsx
@@ -18,23 +18,27 @@ const ContactUsSection = ({
       <h4 className="govuk-heading-s govuk-!-margin-bottom-0">
         {publicationContact.teamName}
       </h4>
-      <p className="govuk-!-margin-top-0">
-        Email <br />
+      <address className="govuk-!-margin-top-0">
+        Email:{' '}
         <a href={`mailto:${publicationContact.teamEmail}`}>
           {publicationContact.teamEmail}
         </a>
-      </p>
-      {publicationContact.contactTelNo && (
-        <p>
-          Telephone: {publicationContact.contactName} <br />{' '}
-          {publicationContact.contactTelNo}
-        </p>
-      )}
+        <br />
+        Contact name: {publicationContact.contactName}
+        {publicationContact.contactTelNo && (
+          <>
+            <br />
+            Telephone:{' '}
+            <a href={`tel:${publicationContact.contactTelNo}`}>
+              {publicationContact.contactTelNo}
+            </a>
+          </>
+        )}
+      </address>
       <h4 className="govuk-heading-s govuk-!-margin-bottom-0">Press office</h4>
       <p className="govuk-!-margin-top-0">If you have a media enquiry:</p>
       <p>
-        Telephone <br />
-        020 7783 8300
+        Telephone: <a href="tel:020 7783 8300">020 7783 8300</a>
       </p>
       <h4 className="govuk-heading-s govuk-!-margin-bottom-0">
         Public enquiries
@@ -44,8 +48,7 @@ const ContactUsSection = ({
         or education:
       </p>
       <p>
-        Telephone <br />
-        037 0000 2288
+        Telephone: <a href="tel:037 0000 2288">037 0000 2288</a>
       </p>
       <p>
         Opening times: <br />

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolInfo.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolInfo.tsx
@@ -27,19 +27,23 @@ const TableToolInfo = ({
           <h3>Contact us</h3>
           <p>
             If you have a question about the data or methods used to create this
-            table contact the named statistician:
+            table, please contact us:
           </p>
           <h3 className="govuk-heading-s">{contactDetails.teamName}</h3>
-          <p>Named statistician: {contactDetails.contactName}</p>
-          <p>
+          <address className="govuk-!-margin-top-0">
             Email:{' '}
             <a href={`mailto:${contactDetails.teamEmail}`}>
               {contactDetails.teamEmail}
             </a>
-          </p>
-          {contactDetails.contactTelNo && (
-            <p>Telephone: {contactDetails.contactTelNo}</p>
-          )}
+            <br />
+            Contact name: {contactDetails.contactName}
+            {contactDetails.contactTelNo && (
+              <>
+                <br />
+                Telephone: {contactDetails.contactTelNo}
+              </>
+            )}
+          </address>
         </>
       )}
     </>

--- a/src/explore-education-statistics-common/src/styles/_typography.scss
+++ b/src/explore-education-statistics-common/src/styles/_typography.scss
@@ -59,6 +59,11 @@ hr {
     %govuk-section-break--visible;
 }
 
+address {
+  @extend %govuk-body-m;
+  font-style: normal;
+}
+
 /* stylelint-disable scss/at-extend-no-missing-placeholder */
 
 blockquote {


### PR DESCRIPTION
This PR includes a publication contact's contact name in the Contact Us sections across the service. It previously wouldn't be present if the contact telephone wasn't present. We've also changed the layout of the contact details:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/44812484/2e5fa8b1-aac3-4914-925c-b468aeae7e15)

### Other notes
- I've used `<a href="tel:[...]">` for other phone numbers in the Contact Us section and used the `Telephone: <telNo>` format so it is aligned with how a publication contact's details are displayed. 
- I also fixed a backend validation issue with `PhoneNumberAttribute`. The validation was failing if the frontend provided an empty string or whitespace - we want to succeed in those cases because the contact telephone is now optional.


