### PR TITLE
Ees 4579 permission error accessing methodology

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/AdoptMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/AdoptMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
@@ -100,8 +100,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             return new AdoptMethodologyForSpecificPublicationAuthorizationHandler(
                 new AuthorizationHandlerResourceRoleService(
                     Mock.Of<IUserReleaseRoleRepository>(Strict),
-                    userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict),
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict)));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/AssignPrereleaseContactsToSpecificReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/AssignPrereleaseContactsToSpecificReleaseAuthorizationHandlerTests.cs
@@ -3,15 +3,12 @@ using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
-using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
-using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -146,8 +143,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             return new AssignPrereleaseContactsToSpecificReleaseAuthorizationHandler(
                 new AuthorizationHandlerResourceRoleService(
                     new UserReleaseRoleRepository(contentDbContext),
-                    new UserPublicationRoleRepository(contentDbContext),
-                    Mock.Of<IPublicationRepository>(Strict))
+                    new UserPublicationRoleRepository(contentDbContext))
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/CreateMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/CreateMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
@@ -249,8 +249,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 context,
                 new AuthorizationHandlerResourceRoleService(
                     Mock.Of<IUserReleaseRoleRepository>(Strict),
-                    userPublicationRoleRepository.Object,
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    userPublicationRoleRepository.Object));
 
             return (handler, userPublicationRoleRepository);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/CreateReleaseForSpecificPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/CreateReleaseForSpecificPublicationAuthorizationHandlerTests.cs
@@ -41,9 +41,7 @@ public class CreateReleaseForSpecificPublicationAuthorizationHandlerTests
             await AuthorizationHandlersTestUtil.ForEachSecurityClaimAsync(async claim =>
             {
                 var (handler,
-                    _,
-                    userPublicationRoleRepository,
-                    _) = CreateHandlerAndDependencies();
+                    userPublicationRoleRepository) = CreateHandlerAndDependencies();
 
                 var user = ClaimsPrincipalUtils.CreateClaimsPrincipal(UserId, claim);
                 var authContext = CreateAuthContext(user, Publication);
@@ -70,10 +68,7 @@ public class CreateReleaseForSpecificPublicationAuthorizationHandlerTests
         {
             await AuthorizationHandlersTestUtil.ForEachSecurityClaimAsync(async claim =>
             {
-                var (handler,
-                    _,
-                    _,
-                    _) = CreateHandlerAndDependencies();
+                var (handler, _) = CreateHandlerAndDependencies();
 
                 var user = ClaimsPrincipalUtils.CreateClaimsPrincipal(UserId, claim);
                 var authContext = CreateAuthContext(user, PublicationArchived);
@@ -93,10 +88,7 @@ public class CreateReleaseForSpecificPublicationAuthorizationHandlerTests
         {
             await AuthorizationHandlersTestUtil.ForEachPublicationRoleAsync(async publicationRole =>
             {
-                var (handler,
-                    _,
-                    userPublicationRoleRepository,
-                    _) = CreateHandlerAndDependencies();
+                var (handler, userPublicationRoleRepository) = CreateHandlerAndDependencies();
 
                 var user = ClaimsPrincipalUtils.CreateClaimsPrincipal(UserId);
                 var authContext = CreateAuthContext(user, Publication);
@@ -117,10 +109,7 @@ public class CreateReleaseForSpecificPublicationAuthorizationHandlerTests
         [Fact]
         public async Task CreateReleaseForSpecificPublicationAuthorizationHandler_FailsWhenArchived()
         {
-            var (handler,
-                _,
-                userPublicationRoleRepository,
-                _) = CreateHandlerAndDependencies();
+            var (handler, userPublicationRoleRepository) = CreateHandlerAndDependencies();
 
             var user = ClaimsPrincipalUtils.CreateClaimsPrincipal(UserId);
             var authContext = CreateAuthContext(user, PublicationArchived);
@@ -146,28 +135,18 @@ public class CreateReleaseForSpecificPublicationAuthorizationHandlerTests
 
     private static
         (CreateReleaseForSpecificPublicationAuthorizationHandler,
-        Mock<IUserReleaseRoleRepository>,
-        Mock<IUserPublicationRoleRepository>,
-        Mock<IPublicationRepository>
-        )
+        Mock<IUserPublicationRoleRepository>)
         CreateHandlerAndDependencies()
     {
         var userReleaseRoleRepository = new Mock<IUserReleaseRoleRepository>(MockBehavior.Strict);
         var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
-        var publicationRepository = new Mock<IPublicationRepository>(MockBehavior.Strict);
 
         var handler = new CreateReleaseForSpecificPublicationAuthorizationHandler(
             new AuthorizationHandlerResourceRoleService(
                 userReleaseRoleRepository.Object,
-                userPublicationRoleRepository.Object,
-                publicationRepository.Object)
+                userPublicationRoleRepository.Object)
         );
 
-        return (
-            handler,
-            userReleaseRoleRepository,
-            userPublicationRoleRepository,
-            publicationRepository
-        );
+        return (handler, userPublicationRoleRepository);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificCommentAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificCommentAuthorizationHandlerTests.cs
@@ -3,13 +3,11 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
-using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -53,8 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     new ReleasePublishingStatusRepository(Mock.Of<IPublisherTableStorageService>()),
                     new AuthorizationHandlerResourceRoleService(
                         new UserReleaseRoleRepository(contentDbContext),
-                        new UserPublicationRoleRepository(contentDbContext),
-                        Mock.Of<IPublicationRepository>(Strict))),
+                        new UserPublicationRoleRepository(contentDbContext))),
                 ReleaseRole.Approver, ReleaseRole.Contributor, ReleaseRole.Lead);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
@@ -20,7 +20,6 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockU
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 using static Moq.MockBehavior;
-using IPublicationRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IPublicationRepository;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -345,8 +344,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 methodologyRepository.Object,
                 new AuthorizationHandlerResourceRoleService(
                     Mock.Of<IUserReleaseRoleRepository>(Strict),
-                    userPublicationRoleRepository.Object,
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    userPublicationRoleRepository.Object));
 
             return (handler, methodologyRepository, userPublicationRoleRepository);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificReleaseAuthorizationHandlerTests.cs
@@ -3,14 +3,11 @@ using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    ReleaseAuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
@@ -188,8 +185,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             return new DeleteSpecificReleaseAuthorizationHandler(
                 new AuthorizationHandlerResourceRoleService(
                     new UserReleaseRoleRepository(contentDbContext),
-                    new UserPublicationRoleRepository(contentDbContext),
-                    Mock.Of<IPublicationRepository>(MockBehavior.Strict)));
+                    new UserPublicationRoleRepository(contentDbContext)));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DropMethodologyLinkAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DropMethodologyLinkAuthorizationHandlerTests.cs
@@ -184,8 +184,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             return new(
                 new AuthorizationHandlerResourceRoleService(
                     Mock.Of<IUserReleaseRoleRepository>(Strict),
-                    userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict),
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict)));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlersTests.cs
@@ -45,8 +45,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 return new ManageLegacyReleasesAuthorizationHandler(
                     new AuthorizationHandlerResourceRoleService(
                         Mock.Of<IUserReleaseRoleRepository>(Strict),
-                        new UserPublicationRoleRepository(contentDbContext),
-                        Mock.Of<IPublicationRepository>(Strict)));
+                        new UserPublicationRoleRepository(contentDbContext)));
             }
         }
 
@@ -83,8 +82,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 return new ViewLegacyReleaseAuthorizationHandler(
                     new AuthorizationHandlerResourceRoleService(
                         Mock.Of<IUserReleaseRoleRepository>(Strict),
-                        new UserPublicationRoleRepository(contentDbContext),
-                        Mock.Of<IPublicationRepository>(Strict)));
+                        new UserPublicationRoleRepository(contentDbContext)));
             }
         }
 
@@ -121,8 +119,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 return new UpdateLegacyReleaseAuthorizationHandler(
                     new AuthorizationHandlerResourceRoleService(
                         Mock.Of<IUserReleaseRoleRepository>(Strict),
-                        new UserPublicationRoleRepository(contentDbContext),
-                        Mock.Of<IPublicationRepository>(Strict)));
+                        new UserPublicationRoleRepository(contentDbContext)));
             }
         }
 
@@ -159,8 +156,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 return new DeleteLegacyReleaseAuthorizationHandler(
                     new AuthorizationHandlerResourceRoleService(
                         Mock.Of<IUserReleaseRoleRepository>(Strict),
-                        new UserPublicationRoleRepository(contentDbContext),
-                        Mock.Of<IPublicationRepository>(Strict)));
+                        new UserPublicationRoleRepository(contentDbContext)));
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfReleaseAuthorizationHandlersTests.cs
@@ -498,8 +498,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             return new MakeAmendmentOfSpecificReleaseAuthorizationHandler(contentDbContext,
                 new AuthorizationHandlerResourceRoleService(
                     Mock.Of<IUserReleaseRoleRepository>(Strict),
-                    new UserPublicationRoleRepository(contentDbContext),
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    new UserPublicationRoleRepository(contentDbContext)));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
@@ -20,7 +20,6 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockU
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 using static Moq.MockBehavior;
-using IPublicationRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IPublicationRepository;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -238,8 +237,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 methodologyRepository.Object,
                 new AuthorizationHandlerResourceRoleService(
                     Mock.Of<IUserReleaseRoleRepository>(Strict),
-                    userPublicationRoleRepository.Object,
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    userPublicationRoleRepository.Object));
 
             return (handler, methodologyRepository, methodologyVersionRepository, userPublicationRoleRepository);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ManageExternalMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ManageExternalMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
@@ -123,8 +123,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             var handler = new ManageExternalMethodologyForSpecificPublicationAuthorizationHandler(
                 new AuthorizationHandlerResourceRoleService(
                     Mock.Of<IUserReleaseRoleRepository>(Strict),
-                    userPublicationRoleRepository.Object,
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    userPublicationRoleRepository.Object));
 
             return (handler, userPublicationRoleRepository);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandlerTests.cs
@@ -16,7 +16,6 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockU
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseRole;
 using static Moq.MockBehavior;
-using IPublicationRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IPublicationRepository;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -47,7 +46,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         handler,
                         _,
                         methodologyVersionRepository,
-                        _,
                         _,
                         _) = CreateHandlerAndDependencies();
 
@@ -85,8 +83,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         methodologyRepository,
                         methodologyVersionRepository,
                         userReleaseRoleRepository,
-                        userPublicationRoleRepository,
-                        publicationRepository
+                        userPublicationRoleRepository
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
@@ -106,9 +103,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                             .ReturnsAsync(new List<PublicationRole>());
 
-                        publicationRepository
-                            .Setup(s => s.GetLatestReleaseForPublication(OwningPublication.Id))
-                            .ReturnsAsync((Release?)null);
+                        userReleaseRoleRepository
+                            .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
+                            .ReturnsAsync(new List<ReleaseRole>());
                     }
 
                     var user = CreateClaimsPrincipal(UserId, claim);
@@ -121,8 +118,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         methodologyRepository,
                         methodologyVersionRepository,
                         userPublicationRoleRepository,
-                        userReleaseRoleRepository,
-                        publicationRepository);
+                        userReleaseRoleRepository);
 
                     Assert.Equal(expectedToPassByClaimAlone, authContext.HasSucceeded);
                 });
@@ -145,8 +141,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         methodologyRepository,
                         methodologyVersionRepository,
                         userReleaseRoleRepository,
-                        userPublicationRoleRepository,
-                        publicationRepository
+                        userPublicationRoleRepository
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
@@ -166,9 +161,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                             .ReturnsAsync(new List<PublicationRole>());
 
-                        publicationRepository
-                            .Setup(s => s.GetLatestReleaseForPublication(OwningPublication.Id))
-                            .ReturnsAsync((Release?)null);
+                        userReleaseRoleRepository
+                            .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
+                            .ReturnsAsync(new List<ReleaseRole>());
                     }
 
                     var user = CreateClaimsPrincipal(UserId, claim);
@@ -181,8 +176,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         methodologyRepository, 
                         methodologyVersionRepository,
                         userReleaseRoleRepository,
-                        userPublicationRoleRepository,
-                        publicationRepository);
+                        userPublicationRoleRepository);
 
                     Assert.Equal(expectedToPassByClaimAlone, authContext.HasSucceeded);
                 });
@@ -204,8 +198,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         methodologyRepository,
                         methodologyVersionRepository,
                         userReleaseRoleRepository,
-                        userPublicationRoleRepository,
-                        publicationRepository
+                        userPublicationRoleRepository
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
@@ -222,9 +215,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
                     if (!expectedToPassByPublicationRole)
                     {
-                        publicationRepository
-                            .Setup(s => s.GetLatestReleaseForPublication(OwningPublication.Id))
-                            .ReturnsAsync((Release?) null);
+                        userReleaseRoleRepository
+                            .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
+                            .ReturnsAsync(new List<ReleaseRole>());
                     }
 
                     var user = CreateClaimsPrincipal(UserId);
@@ -239,8 +232,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         methodologyRepository,
                         methodologyVersionRepository,
                         userReleaseRoleRepository,
-                        userPublicationRoleRepository,
-                        publicationRepository);
+                        userPublicationRoleRepository);
 
                     Assert.Equal(expectedToPassByPublicationRole, authContext.HasSucceeded);
                 });
@@ -250,7 +242,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         public class ReleaseRoleTests
         {
             [Fact]
-            public async Task ApproversOnOwningPublicationsLatestReleaseCanApprove()
+            public async Task ApproversOnAnyOwningPublicationReleaseCanApprove()
             {
                 await ForEachReleaseRoleAsync(async releaseRole =>
                 {
@@ -258,18 +250,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     // Methodology they are allowed to approve it
                     var expectedToPassByReleaseRole = releaseRole == Approver;
 
-                    var latestReleaseForPublication = new Release
-                    {
-                        Id = Guid.NewGuid()
-                    };
-
                     var (
                         handler,
                         methodologyRepository,
                         methodologyVersionRepository,
                         userReleaseRoleRepository,
-                        userPublicationRoleRepository,
-                        publicationRepository
+                        userPublicationRoleRepository
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository.Setup(mock =>
@@ -284,12 +270,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                         .ReturnsAsync(new List<PublicationRole>());
 
-                    publicationRepository
-                        .Setup(s => s.GetLatestReleaseForPublication(OwningPublication.Id))
-                        .ReturnsAsync(latestReleaseForPublication);
-
                     userReleaseRoleRepository
-                        .Setup(s => s.GetAllRolesByUserAndRelease(UserId, latestReleaseForPublication.Id))
+                        .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                         .ReturnsAsync(ListOf(releaseRole));
 
                     var user = CreateClaimsPrincipal(UserId);
@@ -304,28 +286,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         methodologyRepository,
                         methodologyVersionRepository,
                         userReleaseRoleRepository,
-                        userPublicationRoleRepository,
-                        publicationRepository);
+                        userPublicationRoleRepository);
 
                     Assert.Equal(expectedToPassByReleaseRole, authContext.HasSucceeded);
                 });
             }
 
             [Fact]
-            public async Task UsersWithNoRolesOnOwningPublicationsLatestReleaseCannotApprove()
+            public async Task UsersWithNoRolesOnAnyOwningPublicationReleaseCannotApprove()
             {
-                var latestReleaseForPublication = new Release
-                {
-                    Id = Guid.NewGuid()
-                };
-
                 var (
                     handler,
                     methodologyRepository,
                     methodologyVersionRepository,
                     userReleaseRoleRepository,
-                    userPublicationRoleRepository,
-                    publicationRepository
+                    userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
@@ -340,12 +315,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(new List<PublicationRole>());
 
-                publicationRepository
-                    .Setup(s => s.GetLatestReleaseForPublication(OwningPublication.Id))
-                    .ReturnsAsync(latestReleaseForPublication);
-
                 userReleaseRoleRepository
-                    .Setup(s => s.GetAllRolesByUserAndRelease(UserId, latestReleaseForPublication.Id))
+                    .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(new List<ReleaseRole>());
 
                 var user = CreateClaimsPrincipal(UserId);
@@ -359,23 +330,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     methodologyRepository,
                     methodologyVersionRepository,
                     userPublicationRoleRepository,
-                    userReleaseRoleRepository,
-                    publicationRepository);
+                    userReleaseRoleRepository);
 
                 // A user with no role on the owning Publication's latest release is not allowed to approve it
                 Assert.False(authContext.HasSucceeded);
             }
 
             [Fact]
-            public async Task NoLatestReleaseOnOwningPublicationSoCannotApprove()
+            public async Task NoReleaseRolesOnAnyOwningPublicatioReleaseSoCannotApprove()
             {
                 var (
                     handler,
                     methodologyRepository,
                     methodologyVersionRepository,
                     userReleaseRoleRepository,
-                    userPublicationRoleRepository,
-                    publicationRepository
+                    userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
@@ -390,9 +359,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(new List<PublicationRole>());
 
-                publicationRepository
-                    .Setup(s => s.GetLatestReleaseForPublication(OwningPublication.Id))
-                    .ReturnsAsync((Release?) null);
+                userReleaseRoleRepository
+                    .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
+                    .ReturnsAsync(new List<ReleaseRole>());
 
                 var user = CreateClaimsPrincipal(UserId);
 
@@ -405,8 +374,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     methodologyRepository,
                     methodologyVersionRepository,
                     userPublicationRoleRepository,
-                    userReleaseRoleRepository,
-                    publicationRepository);
+                    userReleaseRoleRepository);
 
                 Assert.False(authContext.HasSucceeded);
             }
@@ -417,8 +385,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             Mock<IMethodologyRepository>,
             Mock<IMethodologyVersionRepository>,
             Mock<IUserReleaseRoleRepository>,
-            Mock<IUserPublicationRoleRepository>,
-            Mock<IPublicationRepository>
+            Mock<IUserPublicationRoleRepository>
             )
             CreateHandlerAndDependencies()
         {
@@ -426,15 +393,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(Strict);
             var userReleaseRoleRepository = new Mock<IUserReleaseRoleRepository>(Strict);
             var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
-            var publicationRepository = new Mock<IPublicationRepository>(Strict);
 
             var handler = new MarkMethodologyAsApprovedAuthorizationHandler(
                 methodologyVersionRepository.Object,
                 methodologyRepository.Object,
                 new AuthorizationHandlerResourceRoleService(
                     userReleaseRoleRepository.Object,
-                    userPublicationRoleRepository.Object,
-                    publicationRepository.Object)
+                    userPublicationRoleRepository.Object)
             );
 
             return (
@@ -442,8 +407,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 methodologyRepository,
                 methodologyVersionRepository,
                 userReleaseRoleRepository,
-                userPublicationRoleRepository,
-                publicationRepository
+                userPublicationRoleRepository
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandlerTests.cs
@@ -173,7 +173,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
                     await handler.HandleAsync(authContext);
                     VerifyAllMocks(
-                        methodologyRepository, 
+                        methodologyRepository,
                         methodologyVersionRepository,
                         userReleaseRoleRepository,
                         userPublicationRoleRepository);
@@ -182,7 +182,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 });
             }
         }
-        
+
         public class PublicationRoleTests
         {
             [Fact]
@@ -246,8 +246,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             {
                 await ForEachReleaseRoleAsync(async releaseRole =>
                 {
-                    // If the user has the Approver role on the latest Release of the owning Publication of this
-                    // Methodology they are allowed to approve it
+                    // If the user has the Approver role on any Releases of the owning Publication of this
+                    // Methodology, they are allowed to approve it.
                     var expectedToPassByReleaseRole = releaseRole == Approver;
 
                     var (
@@ -293,51 +293,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
 
             [Fact]
-            public async Task UsersWithNoRolesOnAnyOwningPublicationReleaseCannotApprove()
-            {
-                var (
-                    handler,
-                    methodologyRepository,
-                    methodologyVersionRepository,
-                    userReleaseRoleRepository,
-                    userPublicationRoleRepository
-                    ) = CreateHandlerAndDependencies();
-
-                methodologyVersionRepository.Setup(mock =>
-                        mock.IsLatestPublishedVersion(MethodologyVersion))
-                    .ReturnsAsync(false);
-
-                methodologyRepository
-                    .Setup(s => s.GetOwningPublication(MethodologyVersion.MethodologyId))
-                    .ReturnsAsync(OwningPublication);
-
-                userPublicationRoleRepository
-                    .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
-                    .ReturnsAsync(new List<PublicationRole>());
-
-                userReleaseRoleRepository
-                    .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
-                    .ReturnsAsync(new List<ReleaseRole>());
-
-                var user = CreateClaimsPrincipal(UserId);
-
-                var authContext =
-                    CreateAuthorizationHandlerContext<MarkMethodologyAsApprovedRequirement, MethodologyVersion>
-                        (user, MethodologyVersion);
-
-                await handler.HandleAsync(authContext);
-                VerifyAllMocks(
-                    methodologyRepository,
-                    methodologyVersionRepository,
-                    userPublicationRoleRepository,
-                    userReleaseRoleRepository);
-
-                // A user with no role on the owning Publication's latest release is not allowed to approve it
-                Assert.False(authContext.HasSucceeded);
-            }
-
-            [Fact]
-            public async Task NoReleaseRolesOnAnyOwningPublicatioReleaseSoCannotApprove()
+            public async Task NoReleaseRolesOnAnyOwningPublicationReleaseSoCannotApprove()
             {
                 var (
                     handler,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandlerTests.cs
@@ -126,7 +126,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 });
             }
         }
-        
+
         public class PublicationRoleTests
         {
             [Fact]
@@ -174,9 +174,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             HigherReviewMethodologyVersion);
 
                     await handler.HandleAsync(authContext);
-                    
+
                     VerifyAllMocks(
-                        methodologyRepository, 
+                        methodologyRepository,
                         methodologyVersionRepository,
                         userReleaseRoleRepository,
                         userPublicationRoleRepository);
@@ -283,9 +283,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             HigherReviewMethodologyVersion);
 
                     await handler.HandleAsync(authContext);
-                    
+
                     VerifyAllMocks(
-                        methodologyRepository, 
+                        methodologyRepository,
                         methodologyVersionRepository,
                         userReleaseRoleRepository,
                         userPublicationRoleRepository);
@@ -326,7 +326,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .Setup(mock =>
                             mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                         .ReturnsAsync(ListOf(releaseRole));
-                    
+
                     var user = CreateClaimsPrincipal(UserId);
 
                     var authContext =
@@ -344,46 +344,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
                     Assert.Equal(expectedToPassByReleaseRole, authContext.HasSucceeded);
                 });
-            }
-
-            [Fact]
-            public async Task UsersWithNoRolesOnAnyOwningPublicationReleaseCannotMarkMethodologyAsDraft()
-            {
-                var (
-                    handler,
-                    methodologyRepository,
-                    methodologyVersionRepository,
-                    userReleaseRoleRepository,
-                    userPublicationRoleRepository
-                    ) = CreateHandlerAndDependencies();
-
-                methodologyVersionRepository.Setup(mock =>
-                        mock.IsLatestPublishedVersion(HigherReviewMethodologyVersion))
-                    .ReturnsAsync(false);
-
-                methodologyRepository.Setup(s =>
-                        s.GetOwningPublication(HigherReviewMethodologyVersion.MethodologyId))
-                    .ReturnsAsync(OwningPublication);
-
-                userPublicationRoleRepository
-                    .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
-                    .ReturnsAsync(new List<PublicationRole>());
-
-                userReleaseRoleRepository
-                    .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
-                    .ReturnsAsync(new List<ReleaseRole>());
-
-                var user = CreateClaimsPrincipal(UserId);
-
-                var authContext =
-                    CreateAuthorizationHandlerContext<MarkMethodologyAsDraftRequirement, MethodologyVersion>
-                        (user, HigherReviewMethodologyVersion);
-
-                await handler.HandleAsync(authContext);
-                VerifyAllMocks(methodologyRepository, methodologyVersionRepository, userReleaseRoleRepository);
-
-                // A user with no role on the owning Publication of this Methodology is not allowed to mark it as draft
-                Assert.False(authContext.HasSucceeded);
             }
 
             [Fact]
@@ -421,7 +381,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
                 await handler.HandleAsync(authContext);
                 VerifyAllMocks(
-                    methodologyRepository, 
+                    methodologyRepository,
                     methodologyVersionRepository,
                     userReleaseRoleRepository,
                     userPublicationRoleRepository);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsHigherReviewAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsHigherReviewAuthorizationHandlerTests.cs
@@ -57,7 +57,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     _,
                     _) = CreateHandlerAndDependencies();
 
-                methodologyVersionRepository.Setup(mock => 
+                methodologyVersionRepository.Setup(mock =>
                         mock.IsLatestPublishedVersion(DraftMethodologyVersion))
                     .ReturnsAsync(true);
 
@@ -87,7 +87,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
 
-                methodologyVersionRepository.Setup(mock => 
+                methodologyVersionRepository.Setup(mock =>
                         mock.IsLatestPublishedVersion(DraftMethodologyVersion))
                     .ReturnsAsync(false);
 
@@ -100,12 +100,12 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                         .ReturnsAsync(OwningPublication);
 
                     userPublicationRoleRepository
-                        .Setup(mock => 
+                        .Setup(mock =>
                             mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                         .ReturnsAsync(new List<PublicationRole>());
 
                     userReleaseRoleRepository
-                        .Setup(mock => 
+                        .Setup(mock =>
                             mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                         .ReturnsAsync(new List<ReleaseRole>());
                 }
@@ -117,7 +117,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
 
                 await handler.HandleAsync(authContext);
                 VerifyAllMocks(
-                    methodologyRepository, 
+                    methodologyRepository,
                     methodologyVersionRepository,
                     userReleaseRoleRepository,
                     userPublicationRoleRepository);
@@ -154,14 +154,14 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     .ReturnsAsync(OwningPublication);
 
                 userPublicationRoleRepository
-                    .Setup(mock => 
+                    .Setup(mock =>
                         mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(ListOf(publicationRole));
 
                 if (!expectedToPassByPublicationRole)
                 {
                     userReleaseRoleRepository
-                        .Setup(mock => 
+                        .Setup(mock =>
                             mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                         .ReturnsAsync(new List<ReleaseRole>());
                 }
@@ -217,7 +217,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 if (!expectedToPassByPublicationRole)
                 {
                     userReleaseRoleRepository
-                        .Setup(mock => 
+                        .Setup(mock =>
                             mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                         .ReturnsAsync(new List<ReleaseRole>());
                 }
@@ -272,7 +272,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     .ReturnsAsync(new List<PublicationRole>());
 
                 userReleaseRoleRepository
-                    .Setup(mock => 
+                    .Setup(mock =>
                         mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(new List<ReleaseRole>());
 
@@ -328,7 +328,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     .ReturnsAsync(new List<PublicationRole>());
 
                 userReleaseRoleRepository
-                    .Setup(mock => 
+                    .Setup(mock =>
                         mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(new List<ReleaseRole>());
 
@@ -357,46 +357,6 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
         }
 
         [Fact]
-        public async Task UsersWithNoRolesOnAnyOwningPublicationReleaseCannotMarkMethodologyHigherReview()
-        {
-            var (
-                handler,
-                methodologyRepository,
-                methodologyVersionRepository,
-                userReleaseRoleRepository,
-                userPublicationRoleRepository
-                ) = CreateHandlerAndDependencies();
-
-            methodologyVersionRepository.Setup(mock =>
-                    mock.IsLatestPublishedVersion(DraftMethodologyVersion))
-                .ReturnsAsync(false);
-
-            methodologyRepository.Setup(s =>
-                    s.GetOwningPublication(DraftMethodologyVersion.MethodologyId))
-                .ReturnsAsync(OwningPublication);
-
-            userPublicationRoleRepository
-                .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
-                .ReturnsAsync(new List<PublicationRole>());
-
-            userReleaseRoleRepository
-                .Setup(mock => 
-                    mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
-                .ReturnsAsync(new List<ReleaseRole>());
-
-            var user = CreateClaimsPrincipal(UserId);
-
-            var authContext =
-                CreateAuthorizationHandlerContext<MarkMethodologyAsHigherLevelReviewRequirement, MethodologyVersion>
-                    (user, DraftMethodologyVersion);
-
-            await handler.HandleAsync(authContext);
-            VerifyAllMocks(methodologyRepository, methodologyVersionRepository, userReleaseRoleRepository);
-
-            Assert.False(authContext.HasSucceeded);
-        }
-
-        [Fact]
         public async Task NoReleaseRolesOnOwningPublicationReleasesSoCannotMarkMethodologyHigherReview()
         {
             var (
@@ -420,7 +380,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 .ReturnsAsync(new List<PublicationRole>());
 
             userReleaseRoleRepository
-                .Setup(mock => 
+                .Setup(mock =>
                     mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                 .ReturnsAsync(new List<ReleaseRole>());
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsHigherReviewAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkMethodologyAsHigherReviewAuthorizationHandlerTests.cs
@@ -16,7 +16,6 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Services.Collecti
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 using static Moq.MockBehavior;
-using IPublicationRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IPublicationRepository;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers;
 
@@ -56,7 +55,6 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     _,
                     methodologyVersionRepository,
                     _,
-                    _,
                     _) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock => 
@@ -86,8 +84,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     methodologyRepository,
                     methodologyVersionRepository,
                     userReleaseRoleRepository,
-                    userPublicationRoleRepository,
-                    publicationRepository
+                    userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock => 
@@ -107,10 +104,10 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                             mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                         .ReturnsAsync(new List<PublicationRole>());
 
-                    publicationRepository
+                    userReleaseRoleRepository
                         .Setup(mock => 
-                            mock.GetLatestReleaseForPublication(OwningPublication.Id))
-                        .ReturnsAsync((Release?)null);
+                            mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
+                        .ReturnsAsync(new List<ReleaseRole>());
                 }
 
                 var user = CreateClaimsPrincipal(UserId, claim);
@@ -119,8 +116,11 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                         (user, DraftMethodologyVersion);
 
                 await handler.HandleAsync(authContext);
-                VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
-                    userReleaseRoleRepository);
+                VerifyAllMocks(
+                    methodologyRepository, 
+                    methodologyVersionRepository,
+                    userReleaseRoleRepository,
+                    userPublicationRoleRepository);
 
                 Assert.Equal(expectedToPassByClaimAlone, authContext.HasSucceeded);
             });
@@ -141,9 +141,8 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     handler,
                     methodologyRepository,
                     methodologyVersionRepository,
-                    _,
-                    userPublicationRoleRepository,
-                    publicationRepository
+                    userReleaseRoleRepository,
+                    userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
@@ -161,10 +160,10 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
 
                 if (!expectedToPassByPublicationRole)
                 {
-                    publicationRepository
+                    userReleaseRoleRepository
                         .Setup(mock => 
-                            mock.GetLatestReleaseForPublication(OwningPublication.Id))
-                        .ReturnsAsync((Release?)null);
+                            mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
+                        .ReturnsAsync(new List<ReleaseRole>());
                 }
 
                 var user = CreateClaimsPrincipal(UserId);
@@ -179,8 +178,8 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 VerifyAllMocks(
                     methodologyRepository,
                     methodologyVersionRepository,
-                    userPublicationRoleRepository,
-                    publicationRepository);
+                    userReleaseRoleRepository,
+                    userPublicationRoleRepository);
 
                 Assert.Equal(expectedToPassByPublicationRole, authContext.HasSucceeded);
             });
@@ -198,9 +197,8 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     handler,
                     methodologyRepository,
                     methodologyVersionRepository,
-                    _,
-                    userPublicationRoleRepository,
-                    publicationRepository
+                    userReleaseRoleRepository,
+                    userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
@@ -218,10 +216,10 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
 
                 if (!expectedToPassByPublicationRole)
                 {
-                    publicationRepository
-                        .Setup(mock =>
-                            mock.GetLatestReleaseForPublication(OwningPublication.Id))
-                        .ReturnsAsync((Release?)null);
+                    userReleaseRoleRepository
+                        .Setup(mock => 
+                            mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
+                        .ReturnsAsync(new List<ReleaseRole>());
                 }
 
                 var user = CreateClaimsPrincipal(UserId);
@@ -236,8 +234,8 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 VerifyAllMocks(
                     methodologyRepository,
                     methodologyVersionRepository,
-                    userPublicationRoleRepository,
-                    publicationRepository);
+                    userReleaseRoleRepository,
+                    userPublicationRoleRepository);
 
                 Assert.Equal(expectedToPassByPublicationRole, authContext.HasSucceeded);
             });
@@ -247,24 +245,18 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
     public class ReleaseRoleTests
     {
         [Fact]
-        public async Task ReleaseEditorAndApproverRolesOnOwningPublicationsLatestReleaseCanMarkDraftMethodologyHigherReview()
+        public async Task ReleaseEditorAndApproverRolesOnAnyOwningPublicationReleaseCanMarkDraftMethodologyHigherReview()
         {
             await ForEachReleaseRoleAsync(async releaseRole =>
             {
                 var expectedToPassByReleaseRole = ReleaseEditorAndApproverRoles.Contains(releaseRole);
-
-                var latestReleaseForPublication = new Release
-                {
-                    Id = Guid.NewGuid()
-                };
 
                 var (
                     handler,
                     methodologyRepository,
                     methodologyVersionRepository,
                     userReleaseRoleRepository,
-                    userPublicationRoleRepository,
-                    publicationRepository
+                    userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
@@ -279,12 +271,13 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(new List<PublicationRole>());
 
-                publicationRepository
-                    .Setup(s => s.GetLatestReleaseForPublication(OwningPublication.Id))
-                    .ReturnsAsync(latestReleaseForPublication);
+                userReleaseRoleRepository
+                    .Setup(mock => 
+                        mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
+                    .ReturnsAsync(new List<ReleaseRole>());
 
                 userReleaseRoleRepository
-                    .Setup(s => s.GetAllRolesByUserAndRelease(UserId, latestReleaseForPublication.Id))
+                    .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(ListOf(releaseRole));
 
                 var user = CreateClaimsPrincipal(UserId);
@@ -300,32 +293,25 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     methodologyRepository,
                     methodologyVersionRepository,
                     userReleaseRoleRepository,
-                    userPublicationRoleRepository,
-                    publicationRepository);
+                    userPublicationRoleRepository);
 
                 Assert.Equal(expectedToPassByReleaseRole, authContext.HasSucceeded);
             });
         }
 
         [Fact]
-        public async Task ApproversOnOwningPublicationsLatestReleaseCanMarkApprovedMethodologyHigherReview()
+        public async Task ApproversOnAnyOwningPublicationReleaseCanMarkApprovedMethodologyHigherReview()
         {
             await ForEachReleaseRoleAsync(async releaseRole =>
             {
                 var expectedToPassByReleaseRole = releaseRole == ReleaseRole.Approver;
-
-                var latestReleaseForPublication = new Release
-                {
-                    Id = Guid.NewGuid()
-                };
 
                 var (
                     handler,
                     methodologyRepository,
                     methodologyVersionRepository,
                     userReleaseRoleRepository,
-                    userPublicationRoleRepository,
-                    publicationRepository
+                    userPublicationRoleRepository
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository.Setup(mock =>
@@ -341,14 +327,14 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                         mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(new List<PublicationRole>());
 
-                publicationRepository
-                    .Setup(mock =>
-                        mock.GetLatestReleaseForPublication(OwningPublication.Id))
-                    .ReturnsAsync(latestReleaseForPublication);
+                userReleaseRoleRepository
+                    .Setup(mock => 
+                        mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
+                    .ReturnsAsync(new List<ReleaseRole>());
 
                 userReleaseRoleRepository
                     .Setup(mock =>
-                        mock.GetAllRolesByUserAndRelease(UserId, latestReleaseForPublication.Id))
+                        mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(ListOf(releaseRole));
 
                 var user = CreateClaimsPrincipal(UserId);
@@ -364,23 +350,21 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                     methodologyRepository,
                     methodologyVersionRepository,
                     userReleaseRoleRepository,
-                    userPublicationRoleRepository,
-                    publicationRepository);
+                    userPublicationRoleRepository);
 
                 Assert.Equal(expectedToPassByReleaseRole, authContext.HasSucceeded);
             });
         }
 
         [Fact]
-        public async Task UsersWithNoRolesOnOwningPublicationsLatestReleaseCannotMarkMethodologyHigherReview()
+        public async Task UsersWithNoRolesOnAnyOwningPublicationReleaseCannotMarkMethodologyHigherReview()
         {
             var (
                 handler,
                 methodologyRepository,
                 methodologyVersionRepository,
                 userReleaseRoleRepository,
-                userPublicationRoleRepository,
-                publicationRepository
+                userPublicationRoleRepository
                 ) = CreateHandlerAndDependencies();
 
             methodologyVersionRepository.Setup(mock =>
@@ -395,9 +379,10 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                 .ReturnsAsync(new List<PublicationRole>());
 
-            publicationRepository
-                .Setup(s => s.GetLatestReleaseForPublication(OwningPublication.Id))
-                .ReturnsAsync((Release?)null);
+            userReleaseRoleRepository
+                .Setup(mock => 
+                    mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
+                .ReturnsAsync(new List<ReleaseRole>());
 
             var user = CreateClaimsPrincipal(UserId);
 
@@ -412,15 +397,14 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
         }
 
         [Fact]
-        public async Task NoLatestReleaseForOwningPublicationSoCannotMarkMethodologyHigherReview()
+        public async Task NoReleaseRolesOnOwningPublicationReleasesSoCannotMarkMethodologyHigherReview()
         {
             var (
                 handler,
                 methodologyRepository,
                 methodologyVersionRepository,
-                _,
-                userPublicationRoleRepository,
-                publicationRepository
+                userReleaseRoleRepository,
+                userPublicationRoleRepository
                 ) = CreateHandlerAndDependencies();
 
             methodologyVersionRepository.Setup(mock =>
@@ -435,9 +419,10 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
                 .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                 .ReturnsAsync(new List<PublicationRole>());
 
-            publicationRepository
-                .Setup(s => s.GetLatestReleaseForPublication(OwningPublication.Id))
-                .ReturnsAsync((Release?)null);
+            userReleaseRoleRepository
+                .Setup(mock => 
+                    mock.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
+                .ReturnsAsync(new List<ReleaseRole>());
 
             var user = CreateClaimsPrincipal(UserId);
 
@@ -449,8 +434,8 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
             VerifyAllMocks(
                 methodologyRepository,
                 methodologyVersionRepository,
-                userPublicationRoleRepository,
-                publicationRepository);
+                userReleaseRoleRepository,
+                userPublicationRoleRepository);
 
             Assert.False(authContext.HasSucceeded);
         }
@@ -461,8 +446,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
         Mock<IMethodologyRepository>,
         Mock<IMethodologyVersionRepository>,
         Mock<IUserReleaseRoleRepository>,
-        Mock<IUserPublicationRoleRepository>,
-        Mock<IPublicationRepository>
+        Mock<IUserPublicationRoleRepository>
         )
         CreateHandlerAndDependencies()
     {
@@ -470,15 +454,13 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
         var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(Strict);
         var userReleaseRoleRepository = new Mock<IUserReleaseRoleRepository>(Strict);
         var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
-        var publicationRepository = new Mock<IPublicationRepository>(Strict);
 
         var handler = new MarkMethodologyAsHigherLevelReviewAuthorizationHandler(
             methodologyVersionRepository.Object,
             methodologyRepository.Object,
             new AuthorizationHandlerResourceRoleService(
                 userReleaseRoleRepository.Object,
-                userPublicationRoleRepository.Object,
-                publicationRepository.Object)
+                userPublicationRoleRepository.Object)
         );
 
         return (
@@ -486,8 +468,7 @@ public class MarkMethodologyAsHigherReviewAuthorizationHandlerTests
             methodologyRepository,
             methodologyVersionRepository,
             userReleaseRoleRepository,
-            userPublicationRoleRepository,
-            publicationRepository
+            userPublicationRoleRepository
         );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/PublishSpecificReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/PublishSpecificReleaseAuthorizationHandlerTests.cs
@@ -2,17 +2,13 @@
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    ReleaseAuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseRole;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
-using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -83,8 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             return new PublishSpecificReleaseAuthorizationHandler(
                 new AuthorizationHandlerResourceRoleService(
                     new UserReleaseRoleRepository(contentDbContext),
-                    new UserPublicationRoleRepository(contentDbContext),
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    new UserPublicationRoleRepository(contentDbContext)));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ReleaseStatusAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ReleaseStatusAuthorizationHandlersTests.cs
@@ -825,8 +825,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 releasePublishingStatusRepository, 
                 new AuthorizationHandlerResourceRoleService(
                     userReleaseRoleRepository,
-                    userPublicationRoleRepository,
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    userPublicationRoleRepository));
         }
         
         private static MarkReleaseAsHigherLevelReviewAuthorizationHandler BuildMarkReleaseAsHigherLevelReviewHandler(
@@ -838,8 +837,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 releasePublishingStatusRepository, 
                 new AuthorizationHandlerResourceRoleService(
                     userReleaseRoleRepository,
-                    userPublicationRoleRepository,
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    userPublicationRoleRepository));
         }
 
         private static MarkReleaseAsApprovedAuthorizationHandler BuildMarkReleaseAsApprovedHandler(
@@ -851,8 +849,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 releasePublishingStatusRepository, 
                 new AuthorizationHandlerResourceRoleService(
                     userReleaseRoleRepository,
-                    userPublicationRoleRepository,
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    userPublicationRoleRepository));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateContactAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateContactAuthorizationHandlerTests.cs
@@ -38,8 +38,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             return new UpdateContactAuthorizationHandler(
                 new AuthorizationHandlerResourceRoleService(
                     Mock.Of<IUserReleaseRoleRepository>(Strict),
-                    new UserPublicationRoleRepository(contentDbContext),
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    new UserPublicationRoleRepository(contentDbContext)));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdatePublicationSummaryAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdatePublicationSummaryAuthorizationHandlerTests.cs
@@ -38,8 +38,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             return new UpdatePublicationSummaryAuthorizationHandler(
                 new AuthorizationHandlerResourceRoleService(
                     Mock.Of<IUserReleaseRoleRepository>(Strict),
-                    new UserPublicationRoleRepository(contentDbContext),
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    new UserPublicationRoleRepository(contentDbContext)));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateReleaseRoleAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateReleaseRoleAuthorizationHandlerTests.cs
@@ -63,8 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             return new UpdateReleaseRoleAuthorizationHandler(
                 new AuthorizationHandlerResourceRoleService(
                     Mock.Of<IUserReleaseRoleRepository>(Strict),
-                    new UserPublicationRoleRepository(contentDbContext),
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    new UserPublicationRoleRepository(contentDbContext)));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlerTests.cs
@@ -58,7 +58,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             (user, methodologyVersion);
 
                     await handler.HandleAsync(authContext);
-                    
+
                     Assert.False(authContext.HasSucceeded);
                 });
             }
@@ -101,7 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             (user, MethodologyVersion);
 
                     await handler.HandleAsync(authContext);
-                    
+
                     VerifyAllMocks(
                         methodologyRepository,
                         userReleaseRoleRepository,
@@ -146,7 +146,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             (user, MethodologyVersion);
 
                     await handler.HandleAsync(authContext);
-                    
+
                     VerifyAllMocks(
                         methodologyRepository,
                         userPublicationRoleRepository,
@@ -155,43 +155,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
                     Assert.Equal(expectedReleaseRolesToPass.Contains(releaseRole), authContext.HasSucceeded);
                 });
-            }
-
-            [Fact]
-            public async Task UsersWithNoRolesOnAnyOwningPublicationReleaseCannotUpdateMethodology()
-            {
-                var (
-                    handler,
-                    methodologyRepository,
-                    userPublicationRoleRepository,
-                    userReleaseRoleRepository
-                    ) = CreateHandlerAndDependencies();
-
-                methodologyRepository.Setup(s =>
-                        s.GetOwningPublication(MethodologyVersion.MethodologyId))
-                    .ReturnsAsync(OwningPublication);
-
-                userPublicationRoleRepository
-                    .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
-                    .ReturnsAsync(new List<PublicationRole>());
-
-                userReleaseRoleRepository
-                    .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
-                    .ReturnsAsync(new List<ReleaseRole>());
-
-                var user = CreateClaimsPrincipal(UserId);
-                var authContext =
-                    CreateAuthorizationHandlerContext<UpdateSpecificMethodologyRequirement, MethodologyVersion>
-                        (user, MethodologyVersion);
-
-                await handler.HandleAsync(authContext);
-                
-                VerifyAllMocks(
-                    methodologyRepository,
-                    userPublicationRoleRepository,
-                    userReleaseRoleRepository);
-
-                Assert.False(authContext.HasSucceeded);
             }
 
             [Fact]
@@ -222,7 +185,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         (user, MethodologyVersion);
 
                 await handler.HandleAsync(authContext);
-                
+
                 VerifyAllMocks(
                     methodologyRepository,
                     userPublicationRoleRepository,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlerTests.cs
@@ -347,8 +347,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     releaseStatusRepository.Object,
                     new AuthorizationHandlerResourceRoleService(
                         new UserReleaseRoleRepository(contentDbContext),
-                        new UserPublicationRoleRepository(contentDbContext),
-                        Mock.Of<IPublicationRepository>(MockBehavior.Strict)));
+                        new UserPublicationRoleRepository(contentDbContext)));
             };
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewReleaseStatusHistoryAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewReleaseStatusHistoryAuthorizationHandlerTests.cs
@@ -2,15 +2,11 @@
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    ReleaseAuthorizationHandlersTestUtil;
-using static Moq.MockBehavior;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -68,8 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             return new ViewReleaseStatusHistoryAuthorizationHandler(
                 new AuthorizationHandlerResourceRoleService(
                     new UserReleaseRoleRepository(contentDbContext),
-                    new UserPublicationRoleRepository(contentDbContext),
-                    Mock.Of<IPublicationRepository>(Strict)));
+                    new UserPublicationRoleRepository(contentDbContext)));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewReleaseStatusHistoryAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewReleaseStatusHistoryAuthorizationHandlerTests.cs
@@ -6,7 +6,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
+    ReleaseAuthorizationHandlersTestUtil;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlerTests.cs
@@ -72,7 +72,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         userReleaseRoleRepository
                             .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                             .ReturnsAsync(new List<ReleaseRole>());
-                        
+
                         userReleaseRoleRepository
                             .Setup(s => s.IsUserPrereleaseViewerOnLatestPreReleaseRelease(UserId, OwningPublication.Id))
                             .ReturnsAsync(false);
@@ -115,7 +115,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .ReturnsAsync(OwningPublication);
 
                     var expectedToPassByRole = ListOf(PublicationRole.Owner, PublicationRole.Approver).Contains(publicationRole);
-                    
+
                     userPublicationRoleRepository
                         .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                         .ReturnsAsync(ListOf(publicationRole));
@@ -133,10 +133,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             (user, MethodologyVersion);
 
                     await handler.HandleAsync(authContext);
-                    
+
                     VerifyAllMocks(
-                        methodologyRepository, 
-                        userPublicationRoleRepository, 
+                        methodologyRepository,
+                        userPublicationRoleRepository,
                         publicationRepository);
 
                     // As the user has Publication Owner role on the owning Publication of this Methodology, they are
@@ -195,13 +195,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             (user, MethodologyVersion);
 
                     await handler.HandleAsync(authContext);
-                    
+
                     VerifyAllMocks(
                         methodologyRepository,
                         userPublicationRoleRepository,
                         userReleaseRoleRepository);
 
-                    // As the user has a role on the latest Release of the owning Publication of this Methodology
+                    // As the user has a role on any Release of the owning Publication of this Methodology,
                     // they are allowed to view it.
                     Assert.Equal(expectedToPassByReleaseRole, authContext.HasSucceeded);
                 });
@@ -215,7 +215,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     Id = Guid.NewGuid(),
                     PublicationId = Guid.NewGuid()
                 };
-                
+
                 var (
                     handler,
                     methodologyRepository,
@@ -232,7 +232,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 userPublicationRoleRepository
                     .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(new List<PublicationRole>());
-                
+
                 userReleaseRoleRepository
                     .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(new List<ReleaseRole>());
@@ -244,11 +244,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 userReleaseRoleRepository
                     .Setup(s => s.IsUserPrereleaseViewerOnLatestPreReleaseRelease(UserId, preReleaseForConnectedPublication.PublicationId))
                     .ReturnsAsync(true);
-                
+
                 publicationRepository
                     .Setup(s => s.GetLatestReleaseForPublication(preReleaseForConnectedPublication.PublicationId))
                     .ReturnsAsync(preReleaseForConnectedPublication);
-                
+
                 preReleaseService
                     .Setup(s => s.GetPreReleaseWindowStatus(
                         It.Is<Release>(r => r.Id == preReleaseForConnectedPublication.Id),
@@ -256,13 +256,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     .Returns(new PreReleaseWindowStatus { Access = PreReleaseAccess.Within });
 
                 var user = CreateClaimsPrincipal(UserId);
-                
+
                 var authContext =
                     CreateAuthorizationHandlerContext<ViewSpecificMethodologyRequirement, MethodologyVersion>
                         (user, MethodologyVersion);
 
                 await handler.HandleAsync(authContext);
-                
+
                 VerifyAllMocks(
                     methodologyRepository,
                     userPublicationRoleRepository,
@@ -270,11 +270,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     preReleaseService,
                     publicationRepository);
 
-                // As the user has a role on the latest Release of the owning Publication of this Methodology
+                // As the user has a role on the any Release of the owning Publication of this Methodology,
                 // they are allowed to view it.
                 Assert.True(authContext.HasSucceeded);
             }
-            
+
             [Fact]
             public async Task PrereleaseViewersNoLatestReleasesForOnOwningPublicationCannotViewMethodology()
             {
@@ -283,7 +283,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     Id = Guid.NewGuid(),
                     PublicationId = Guid.NewGuid()
                 };
-                
+
                 var (
                     handler,
                     methodologyRepository,
@@ -300,7 +300,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 userPublicationRoleRepository
                     .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(new List<PublicationRole>());
-                
+
                 userReleaseRoleRepository
                     .Setup(s => s.GetAllRolesByUserAndPublication(UserId, OwningPublication.Id))
                     .ReturnsAsync(new List<ReleaseRole>());
@@ -312,19 +312,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 userReleaseRoleRepository
                     .Setup(s => s.IsUserPrereleaseViewerOnLatestPreReleaseRelease(UserId, preReleaseForConnectedPublication.PublicationId))
                     .ReturnsAsync(true);
-                
+
                 publicationRepository
                     .Setup(s => s.GetLatestReleaseForPublication(preReleaseForConnectedPublication.PublicationId))
                     .ReturnsAsync(null as Release);
-                
+
                 var user = CreateClaimsPrincipal(UserId);
-                
+
                 var authContext =
                     CreateAuthorizationHandlerContext<ViewSpecificMethodologyRequirement, MethodologyVersion>
                         (user, MethodologyVersion);
 
                 await handler.HandleAsync(authContext);
-                
+
                 VerifyAllMocks(
                     methodologyRepository,
                     userPublicationRoleRepository,
@@ -374,7 +374,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         (user, MethodologyVersion);
 
                 await handler.HandleAsync(authContext);
-                
+
                 VerifyAllMocks(
                     methodologyRepository,
                     userPublicationRoleRepository,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificPreReleaseSummaryAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificPreReleaseSummaryAuthorizationHandlersTests.cs
@@ -3,14 +3,11 @@ using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
-using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers;
 
@@ -57,7 +54,6 @@ public class ViewSpecificPreReleaseSummaryAuthorizationHandlersTests
         return new ViewSpecificPreReleaseSummaryAuthorizationHandler(
             new AuthorizationHandlerResourceRoleService(
                 new UserReleaseRoleRepository(contentDbContext),
-                new UserPublicationRoleRepository(contentDbContext),
-                Mock.Of<IPublicationRepository>(Strict)));
+                new UserPublicationRoleRepository(contentDbContext)));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificPublicationAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificPublicationAuthorizationHandlersTests.cs
@@ -48,8 +48,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 new HasOwnerOrApproverRoleOnPublicationAuthorizationHandler(
                     new AuthorizationHandlerResourceRoleService(
                         Mock.Of<IUserReleaseRoleRepository>(Strict),
-                        new UserPublicationRoleRepository(contentDbContext),
-                        Mock.Of<IPublicationRepository>(Strict))),
+                        new UserPublicationRoleRepository(contentDbContext))),
                 Owner, Approver);
         }
 
@@ -115,8 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     context,
                     new AuthorizationHandlerResourceRoleService(
                         Mock.Of<IUserReleaseRoleRepository>(Strict),
-                        new UserPublicationRoleRepository(context),
-                        Mock.Of<IPublicationRepository>(Strict)));
+                        new UserPublicationRoleRepository(context)));
                 
                 var authContext = new AuthorizationHandlerContext(
                     new IAuthorizationRequirement[] {new ViewSpecificPublicationRequirement()},

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificPublicationReleaseTeamAccessAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificPublicationReleaseTeamAccessAuthorizationHandlersTests.cs
@@ -94,7 +94,6 @@ public class ViewSpecificPublicationReleaseTeamAccessAuthorizationHandlersTests
         return new ViewSpecificPublicationReleaseTeamAccessAuthorizationHandler(
             new AuthorizationHandlerResourceRoleService(
                 Mock.Of<IUserReleaseRoleRepository>(Strict),
-                userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict),
-                Mock.Of<IPublicationRepository>(Strict)));
+                userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict)));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
@@ -39,8 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     new HasUnrestrictedViewerRoleOnReleaseAuthorizationHandler(
                         new AuthorizationHandlerResourceRoleService(
                             new UserReleaseRoleRepository(contentDbContext),
-                            new UserPublicationRoleRepository(contentDbContext),
-                            Mock.Of<IPublicationRepository>(Strict))),
+                            new UserPublicationRoleRepository(contentDbContext))),
                 ReleaseRole.Viewer, ReleaseRole.Lead, ReleaseRole.Contributor, ReleaseRole.Approver);
         }
 
@@ -55,8 +54,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 contentDbContext => new HasOwnerOrApproverRoleOnParentPublicationAuthorizationHandler(
                         new AuthorizationHandlerResourceRoleService(
                             Mock.Of<IUserReleaseRoleRepository>(Strict),
-                            new UserPublicationRoleRepository(contentDbContext),
-                            Mock.Of<IPublicationRepository>(Strict))),
+                            new UserPublicationRoleRepository(contentDbContext))),
                 new Release
                 {
                     PublicationId = publication.Id,
@@ -87,8 +85,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         preReleaseService.Object,
                         new AuthorizationHandlerResourceRoleService(
                             new UserReleaseRoleRepository(contentDbContext),
-                            new UserPublicationRoleRepository(contentDbContext),
-                            Mock.Of<IPublicationRepository>(Strict))),
+                            new UserPublicationRoleRepository(contentDbContext))),
                 release,
                 ReleaseRole.PrereleaseViewer);
         }
@@ -144,8 +141,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                                 preReleaseService.Object,
                                 new AuthorizationHandlerResourceRoleService(
                                     new UserReleaseRoleRepository(contentDbContext),
-                                    new UserPublicationRoleRepository(contentDbContext),
-                                    Mock.Of<IPublicationRepository>(Strict))),
+                                    new UserPublicationRoleRepository(contentDbContext))),
                         failureScenario);
                 });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsApprovedAuthorizationHandler.cs
@@ -52,9 +52,9 @@ public class MarkMethodologyAsApprovedAuthorizationHandler :
             await _methodologyRepository.GetOwningPublication(methodologyVersion.MethodologyId);
 
         // If the user is a Publication Approver that owns this Methodology, they can approve it.
-        // Additionally, if they're an Approver for Releases on the owning Publication, they can approve it.
+        // Additionally, if they're an Approver for any Releases on the owning Publication, they can approve it.
         if (await _authorizationHandlerResourceRoleService
-                .HasRolesOnPublicationOrLatestRelease(
+                .HasRolesOnPublicationOrAnyRelease(
                     context.User.GetUserId(),
                     owningPublication.Id,
                     ListOf(PublicationRole.Approver),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsDraftAuthorizationHandler.cs
@@ -61,7 +61,7 @@ public class MarkMethodologyAsDraftAuthorizationHandler : AuthorizationHandler<
             await _methodologyRepository.GetOwningPublication(methodologyVersion.MethodologyId);
 
         if (await _authorizationHandlerResourceRoleService
-                .HasRolesOnPublicationOrLatestRelease(
+                .HasRolesOnPublicationOrAnyRelease(
                     context.User.GetUserId(),
                     owningPublication.Id,
                     allowedPublicationRoles,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsHigherLevelReviewAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkMethodologyAsHigherLevelReviewAuthorizationHandler.cs
@@ -60,7 +60,7 @@ public class MarkMethodologyAsHigherLevelReviewAuthorizationHandler : Authorizat
             await _methodologyRepository.GetOwningPublication(methodologyVersion.MethodologyId);
 
         if (await _authorizationHandlerResourceRoleService
-                .HasRolesOnPublicationOrLatestRelease(
+                .HasRolesOnPublicationOrAnyRelease(
                     context.User.GetUserId(),
                     owningPublication.Id,
                     allowedPublicationRoles,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandler.cs
@@ -47,7 +47,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 await _methodologyRepository.GetOwningPublication(methodologyVersion.MethodologyId);
             
             if (await _authorizationHandlerResourceRoleService
-                    .HasRolesOnPublicationOrLatestRelease(
+                    .HasRolesOnPublicationOrAnyRelease(
                         context.User.GetUserId(),
                         owningPublication.Id,
                         ListOf(PublicationRole.Owner, PublicationRole.Approver),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlers.cs
@@ -57,10 +57,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 await _methodologyRepository.GetOwningPublication(methodologyVersion.MethodologyId);
 
             // If the user is a Publication Owner or Approver of the Publication that owns this Methodology, they can
-            // view it.  Additionally, if the user is an Editor (Contributor, Lead) or an Approver of the latest
+            // view it.  Additionally, if the user is an Editor (Contributor, Lead) or an Approver of any
             // (Live or non-Live) Release of the owning Publication of this Methodology, they can view it.
             if (await _authorizationHandlerResourceRoleService
-                    .HasRolesOnPublicationOrLatestRelease(
+                    .HasRolesOnPublicationOrAnyRelease(
                         context.User.GetUserId(),
                         owningPublication.Id,
                         ListOf(PublicationRole.Owner, PublicationRole.Approver),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserReleaseRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserReleaseRoleRepository.cs
@@ -40,6 +40,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         
         Task<List<ReleaseRole>> GetAllRolesByUserAndRelease(Guid userId,
             Guid releaseId);
+        
+        Task<List<ReleaseRole>> GetAllRolesByUserAndPublication(Guid userId,
+            Guid publicationId);
 
         Task<bool> IsUserPrereleaseViewerOnLatestPreReleaseRelease(Guid userId, Guid publicationId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -437,13 +437,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         public async Task<Either<ActionResult, List<MethodologyVersionViewModel>>> ListUsersMethodologyVersionsForApproval()
         {
             var userId = _userService.GetUserId();
-            
+
             var directPublicationsWithApprovalRole = await _context
                 .UserPublicationRoles
                 .Where(role => role.UserId == userId && role.Role == PublicationRole.Approver)
                 .Select(role => role.PublicationId)
                 .ToListAsync();
-            
+
             var indirectPublicationsWithApprovalRole = await _context
                 .UserReleaseRoles
                 .Where(role => role.UserId == userId && role.Role == ReleaseRole.Approver)
@@ -453,7 +453,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             var publicationIdsForApproval = directPublicationsWithApprovalRole
                 .Concat(indirectPublicationsWithApprovalRole)
                 .Distinct();
-                
+
             var methodologiesToApprove = await _context
                 .MethodologyVersions
                 .Where(methodologyVersion =>
@@ -463,7 +463,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                             publicationMethodology.Owner
                             && publicationIdsForApproval.Contains(publicationMethodology.PublicationId)))
                 .ToListAsync();
-            
+
             return (await methodologiesToApprove
                     .SelectAsync(BuildMethodologyVersionViewModel))
                 .ToList();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -443,7 +443,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 .Where(role => role.UserId == userId && role.Role == PublicationRole.Approver)
                 .Select(role => role.PublicationId)
                 .ToListAsync();
-
+            
             var indirectPublicationsWithApprovalRole = await _context
                 .UserReleaseRoles
                 .Where(role => role.UserId == userId && role.Role == ReleaseRole.Approver)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseRoleRepository.cs
@@ -65,6 +65,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return GetAllResourceRolesByUserAndResource(userId, releaseId);
         }
 
+        public Task<List<ReleaseRole>> GetAllRolesByUserAndPublication(Guid userId, Guid publicationId)
+        {
+            return ContentDbContext
+                .UserReleaseRoles
+                .Where(role => role.UserId == userId && role.Release.PublicationId == publicationId)
+                .Select(role => role.Role)
+                .Distinct()
+                .ToListAsync();
+        }
+
         public async Task<bool> IsUserApproverOnLatestRelease(Guid userId, Guid publicationId)
         {
             return await UserHasAnyOfRolesOnLatestRelease(


### PR DESCRIPTION
This PR:
* updates existing Methodology auth handlers' logic to check for users' Release Roles based upon ANY Release for the Methodology's Owning Publication, rather than just the LATEST Release.

The above change braings this behaviour in line with the logic that determines whether or not to display Higher Review Methodologies on the "Your Approvals" tab, and avoids the performance penalties involved in calculating the Latest Release for large numbers of Publications on the Dashboard.

Also this fits in line with superseding Release Roles with just coarser-grained Publication Roles in the future.

## UI test results

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/4dd5ec7e-9942-4005-ba83-c1cf32eb4e37)
