### PR TITLE
chore: Update pnpm package manager to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "explore-education-statistics",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@8.6.7",
+  "packageManager": "pnpm@8.8.0",
   "engines": {
     "node": "18.17.0",
-    "pnpm": "8.6.7"
+    "pnpm": ">=8.8.0"
   },
   "devDependencies": {
     "@commander-js/extra-typings": "^11.0.0",


### PR DESCRIPTION
This PR changes the required pnpm version from exactly `8.6.7` to `>=8.8.0` to make the project work with the current latest version of pnpm.

As part of this change the `package.json` [packageManager](https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#packagemanager) field is also updated, although I wasn't sure how this could be done without specifying the version to be exact.