### PR TITLE
EES-4599 Fix `HtmlToTextConverter` outputting OS-dependent line endings

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringBuilderExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringBuilderExtensionTests.cs
@@ -1,0 +1,96 @@
+#nullable enable
+using System;
+using System.Text;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class StringBuilderExtensionTests
+{
+    public class AppendCrlfLineTests
+    {
+        [Fact]
+        public void NoArgs()
+        {
+            var builder = new StringBuilder();
+            builder.AppendCrlfLine();
+
+            Assert.Equal("\r\n", builder.ToString());
+        }
+
+        [Fact]
+        public void WithStringArg()
+        {
+            var builder = new StringBuilder();
+            builder.AppendCrlfLine("test");
+
+            Assert.Equal("test\r\n", builder.ToString());
+        }
+    }
+
+    public class SubstringTests
+    {
+        public static TheoryData<string, Range> RangeInsideLengthData => new()
+        {
+            { "al", 1..3 },
+            { "alidating", 1.. },
+            { "alidatin", 1..^1 },
+            { "lidat", 2..^3 },
+            { "idating", 3.. },
+            { "dat", ^6..^3 },
+            { "da", 4..^4 },
+            { "valida", ..^4 },
+        };
+
+        [Theory]
+        [MemberData(nameof(RangeInsideLengthData))]
+        public void RangeInsideLength(string expected, Range range)
+        {
+            var builder = new StringBuilder();
+            builder.Append("validating");
+
+            Assert.Equal(expected, builder.Substring(range));
+        }
+
+        public static TheoryData<string, Range> RangeOutsideLengthData => new()
+        {
+            { "s", ^7..^5 },
+            { "s", ^6..^5 },
+            { "string", ^7.. },
+            { "string", ^6.. },
+            { "string", ..6 },
+            { "string", ..7 },
+            { "g", 5.. },
+            { "g", 5..6 },
+        };
+
+        [Theory]
+        [MemberData(nameof(RangeOutsideLengthData))]
+        public void RangeOutsideLength(string expected, Range range)
+        {
+            var builder = new StringBuilder();
+            builder.Append("string");
+
+            Assert.Equal(expected, builder.Substring(range));
+        }
+
+        public static TheoryData<Range> InvalidRangeData => new()
+        {
+            5..7,
+            7..5,
+            ^5..^6,
+            ^6..^5,
+        };
+
+        [Theory]
+        [MemberData(nameof(InvalidRangeData))]
+        public void InvalidRange_Throws(Range range)
+        {
+            var builder = new StringBuilder();
+            builder.Append("test");
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => builder.Substring(range));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
@@ -109,6 +109,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
         }
 
         [Fact]
+        public async Task HtmlToText_Paragraph_AfterInlineText()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"Something before <p>Test paragraph</p>");
+
+            Assert.Equal("Something before\r\n\r\nTest paragraph", text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_Paragraph_AfterInlineTextWithLineBreak()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"Something before<br/><p>Test paragraph</p>");
+
+            Assert.Equal("Something before\r\n\r\nTest paragraph", text);
+        }
+
+        [Fact]
         public async Task HtmlToText_Link()
         {
             var text = await HtmlToTextUtils.HtmlToText(
@@ -359,6 +377,47 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
                     <h6>Test heading 6</h6>
                     <p>Test paragraph 1</p>
                 </div>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_MultipleElements_MixOfInlineAndBlocks_InlineFirst()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <span>Test span 1</span>
+                <p>Test paragraph 1</p>
+                <strong>Test strong 1</strong>
+                <h1>Test heading 1</h1>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_MultipleElements_MixOfInlineAndBlocks_InlineFirst_InDiv()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <div>
+                    <span>Test span 1</span>
+                    <p>Test paragraph 1</p>
+                    <strong>Test strong 1</strong>
+                    <h1>Test heading 1</h1>
+                </div>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_MultipleElements_MixOfInlineAndBlocks_InlineFirst_WithLineBreakElements()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <span>Test span 1 <br/></span>
+                <p>Test paragraph 1</p>
+                <strong>Test strong 1 <br/></strong>
+                <h1>Test heading 1</h1>");
 
             Snapshot.Match(text);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Snapshooter.Xunit;
 using Xunit;
@@ -39,6 +40,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
             Assert.Empty(await HtmlToTextUtils.HtmlToText("  "));
             Assert.Empty(await HtmlToTextUtils.HtmlToText("  \n  "));
             Assert.Empty(await HtmlToTextUtils.HtmlToText("  \r\n  "));
+        }
+
+        [Fact]
+        public async Task HtmlToText_CrlfLineEndingsOnly()
+        {
+            var text = await HtmlToTextUtils.HtmlToText("<p>Line 1</p><p>Line 2</p>");
+
+            Assert.Equal("Line 1\r\n\r\nLine 2", text);
         }
 
         [Fact]
@@ -202,6 +211,38 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
         }
 
         [Fact]
+        public async Task HtmlToText_MultipleElements_Blocks_CrlfLineEndingsOnly()
+        {
+            var lines = new []
+            {
+                "<h1>Test heading 1</h1>",
+                "<h2>Test heading 2</h2>",
+                "<h3>Test heading 3</h3>",
+                "<h4>Test heading 4</h4>",
+                "<h5>Test heading 5</h5>",
+                "<h6>Test heading 6</h6>",
+                "<p>Test paragraph 1</p>",
+            };
+
+            var text = await HtmlToTextUtils.HtmlToText(lines.JoinToString());
+
+            var expectedLines = new []
+            {
+                "Test heading 1",
+                "Test heading 2",
+                "Test heading 3",
+                "Test heading 4",
+                "Test heading 5",
+                "Test heading 6",
+                "Test paragraph 1",
+            };
+
+            var expected = expectedLines.JoinToString("\r\n\r\n");
+
+            Assert.Equal(expected, text);
+        }
+
+        [Fact]
         public async Task HtmlToText_MultipleElements_Blocks()
         {
             var text = await HtmlToTextUtils.HtmlToText(
@@ -247,7 +288,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
                     </ul>
                 </section>
                 <section>
-                    <h2>Test heading 2<h2>
+                    <h2>Test heading 2</h2>
                 </section>");
             Snapshot.Match(text);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_MultipleElements_MixOfInlineAndBlocks_InlineFirst.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_MultipleElements_MixOfInlineAndBlocks_InlineFirst.snap
@@ -1,0 +1,7 @@
+﻿Test span 1
+
+Test paragraph 1
+
+Test strong 1
+
+Test heading 1

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_MultipleElements_MixOfInlineAndBlocks_InlineFirst_InDiv.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_MultipleElements_MixOfInlineAndBlocks_InlineFirst_InDiv.snap
@@ -1,0 +1,7 @@
+﻿Test span 1
+
+Test paragraph 1
+
+Test strong 1
+
+Test heading 1

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_MultipleElements_MixOfInlineAndBlocks_InlineFirst_WithLineBreakElements.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_MultipleElements_MixOfInlineAndBlocks_InlineFirst_WithLineBreakElements.snap
@@ -1,0 +1,7 @@
+﻿Test span 1
+
+Test paragraph 1
+
+Test strong 1
+
+Test heading 1

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringBuilderExtensions.cs
@@ -1,0 +1,50 @@
+#nullable enable
+using System;
+using System.Text;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class StringBuilderExtensions
+{
+    private const string CrlfLineEnding = "\r\n";
+
+    public static StringBuilder AppendCrlfLine(this StringBuilder builder)
+    {
+        return builder.Append(CrlfLineEnding);
+    }
+
+    public static StringBuilder AppendCrlfLine(this StringBuilder builder, string str)
+    {
+        builder.Append(str);
+
+        return builder.Append(CrlfLineEnding);
+    }
+
+    /// <summary>
+    /// Get a substring from the string builder using a range.
+    /// </summary>
+    /// <remarks>
+    /// If the range starts or ends outside of the string builder's length,
+    /// no <see cref="ArgumentOutOfRangeException"/> will be thrown.
+    /// Instead, we will clamp the range to the length of the string builder.
+    /// </remarks>
+    /// <param name="builder">The current string builder</param>
+    /// <param name="range">The substring range to get from the string builder</param>
+    /// <returns>The substring</returns>
+    public static string Substring(this StringBuilder builder, Range range)
+    {
+        if (range.Start.IsFromEnd && range.Start.Value > builder.Length)
+        {
+            range = ..range.End;
+        }
+        
+        if (!range.End.IsFromEnd && range.End.Value > builder.Length)
+        {
+            range = range.Start..builder.Length;
+        }
+
+        var (offset, length) = range.GetOffsetAndLength(builder.Length);
+
+        return builder.ToString(offset, length);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextConverter.cs
@@ -97,7 +97,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
 
                 case "hr":
                     _builder.AppendLine("---------------");
-                    _builder.AppendLine();
                     break;
 
                 case "table":
@@ -106,7 +105,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
 
                 case "a":
                     ParseLinkElement(element);
-                    AddSpacing(element);
                     break;
 
                 case "br":
@@ -116,7 +114,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
                 case "cite":
                     _builder.Append("— ");
                     ParseChildren(element);
-                    AddSpacing(element);
                     break;
 
                 default:
@@ -130,21 +127,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
                         ParseEdgeNode(element);
                     }
 
-                    AddSpacing(element);
-
                     break;
                 }
             }
+
+            AddSpacing(element);
         }
 
         private void AddSpacing(IElement element)
         {
             var next = element.NextNonWhitespaceSibling();
-
-            if (next is null)
-            {
-                return;
-            }
 
             if (element.IsBlockType() || next is IElement nextElement && nextElement.IsBlockType())
             {
@@ -159,7 +151,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
                     return;
                 }
 
-                _builder.AppendLine();
+                // Don't have a trailing line ending currently, so it
+                // should be safe to add an additional line ending to
+                // provide better spacing with the next block.
+                if (!currentEnding.EndsWith(Environment.NewLine))
+                {
+                    _builder.AppendLine();
+                }
+
                 _builder.AppendLine();
             }
         }
@@ -258,8 +257,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
                         );
                 }
             );
-
-            _builder.AppendLine();
         }
 
         private void ParseDescriptionListElement(IElement element)
@@ -290,8 +287,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
                     }
                 }
             );
-
-            _builder.AppendLine();
         }
 
         private void ParseTableElement(IElement element)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextTableRenderer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextTableRenderer.cs
@@ -13,9 +13,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
         private const string Separator = "  |  ";
         private const string EmptySeparator = "     ";
 
-        private readonly List<List<TableCell>> _headerRows = new List<List<TableCell>>();
-        private readonly List<List<TableCell>> _bodyRows = new List<List<TableCell>>();
-        private readonly List<int> _columnWidths = new List<int>();
+        private readonly List<List<TableCell>> _headerRows = new();
+        private readonly List<List<TableCell>> _bodyRows = new();
+        private readonly List<int> _columnWidths = new();
 
         private class TableCell
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/HtmlToTextUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/HtmlToTextUtils.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System.Threading.Tasks;
-using AngleSharp;
 using AngleSharp.Html.Parser;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils.Html;
 
@@ -10,8 +9,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
     {
         public static async Task<string> HtmlToText(string html)
         {
-            var config = Configuration.Default;
-
             var parser = new HtmlParser();
             var document = await parser.ParseDocumentAsync("");
 


### PR DESCRIPTION
This changes `HtmlToTextConverter` to only output Windows CRLF line endings. We're specifically only using CRLF as this will work best with the most users (who use Windows).