### PR TITLE
EES-4602 Validate slug is unique when creating new methodology

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.NamingUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies
 {
@@ -100,7 +101,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             return _persistenceHelper
                 .CheckEntityExists<Publication>(publicationId)
                 .OnSuccess(_userService.CheckCanCreateMethodologyForPublication)
-                .OnSuccess(() => _methodologyVersionRepository
+                .OnSuccess(publication => ValidateMethodologySlugUnused(publication.Slug))
+                .OnSuccess(_ => _methodologyVersionRepository
                     .CreateMethodologyForPublication(publicationId, _userService.GetUserId())
                 )
                 .OnSuccess(BuildMethodologyVersionViewModel);
@@ -323,13 +325,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 return methodologyVersionToUpdate;
             }
 
+            var newSlug = SlugFromTitle(request.Title);
+
             return await _userService.CheckCanUpdateMethodologyVersion(methodologyVersionToUpdate)
-                // Check that the Methodology will have a unique slug.  It is possible to have a clash in the case where
-                // another Methodology has previously set its AlternativeTitle (and Slug) to something specific and then
-                // this Methodology attempts to set its AlternativeTitle (and Slug) to the same value.  Whilst an
-                // unlikely scenario, it's entirely possible.
-                .OnSuccessDo(methodologyVersion =>
-                    ValidateMethodologySlugUniqueForUpdate(methodologyVersion, request.Slug))
+                .OnSuccessDo(async _ => {
+                    if (newSlug != methodologyVersionToUpdate.Methodology.Slug)
+                    {
+                        // Only need to validate if the slug is changing
+                        return await ValidateMethodologySlugUnused(newSlug);
+                    }
+
+                    return Unit.Instance;
+                })
                 .OnSuccess(async methodologyVersion =>
                 {
                     methodologyVersion.Updated = DateTime.UtcNow;
@@ -347,7 +354,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                         // Slug to change even though its AlternativeTitle can.
                         if (!methodologyVersion.Amendment)
                         {
-                            methodologyVersion.Methodology.Slug = request.Slug;
+                            methodologyVersion.Methodology.Slug = newSlug;
                         }
                     }
 
@@ -511,13 +518,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             return new IdTitleViewModel(publication.Id, publication.Title);
         }
 
-        private async Task<Either<ActionResult, Unit>> ValidateMethodologySlugUniqueForUpdate(
-            MethodologyVersion methodologyVersion, string slug)
+        private async Task<Either<ActionResult, Unit>> ValidateMethodologySlugUnused(string slug)
         {
-            if (await _context
-                    .Methodologies
-                    .AsQueryable()
-                    .AnyAsync(p => p.Slug == slug && p.Id != methodologyVersion.MethodologyId))
+            var methodologyVersion = await _methodologyVersionRepository.GetLatestPublishedVersionBySlug(slug);
+
+            if (methodologyVersion != null)
             {
                 return ValidationActionResult(SlugNotUnique);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyUpdateRequest.cs
@@ -1,14 +1,10 @@
 #nullable enable
 using System.ComponentModel.DataAnnotations;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.NamingUtils;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
+
+public class MethodologyUpdateRequest : MethodologyApprovalUpdateRequest
 {
-    public class MethodologyUpdateRequest : MethodologyApprovalUpdateRequest
-    {
-        // TODO SOW4 EES-2212 - update to AlternativeTitle
-        [Required] public string Title { get; set; } = string.Empty;
-
-        public string Slug => SlugFromTitle(Title);
-    }
+    // TODO SOW4 EES-2212 - update to AlternativeTitle
+    [Required] public string Title { get; set; } = string.Empty;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyVersionRepository.cs
@@ -13,6 +13,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 
         Task<List<MethodologyVersion>> GetLatestVersionByPublication(Guid publicationId);
 
+        Task<MethodologyVersion?> GetLatestPublishedVersionBySlug(string slug);
+
         Task<MethodologyVersion?> GetLatestPublishedVersion(Guid methodologyId);
 
         Task<List<MethodologyVersion>> GetLatestPublishedVersionByPublication(Guid publicationId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
@@ -82,6 +82,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                 .ToList();
         }
 
+        public async Task<MethodologyVersion?> GetLatestPublishedVersionBySlug(string slug)
+        {
+            return await _contentDbContext
+                .MethodologyVersions
+                .Include(mv => mv.Methodology)
+                .Where(mv =>
+                    mv.Slug == slug
+                    && mv.Methodology.LatestPublishedVersionId == mv.Id)
+                .SingleOrDefaultAsync();
+        }
+
         public async Task<MethodologyVersion?> GetLatestPublishedVersion(Guid methodologyId)
         {
             var methodology = await _contentDbContext.Methodologies


### PR DESCRIPTION
This PR adds slug validation when creating a new methodology. It no longer allows a methodology to be created if the slug is already being used.

### Notes
- As the `Create new methodology` button is a button and not a form, I'm not aware of an easy way to feed back the `SlugNotUnique` error from the backend to the user. So if someone did try to create a methodology with a duplicate slug, it now results in "Sorry, something went wrong" page - I figure this is better than a duplicate slug. Ultimately, this bug has been present for a long time and nobody has created a duplicate slug and the redirect work will fix this. So unless there is a quick fix, I'm inclined to leave this as it is for now.
- The code change to `MethodologyService#UpdateDetails`, whereby we only validate a slug if it has changed, cannot currently be hit. This is because currently the title and slug can only be updated in tandem. But I've added this now so it work correctly in theory. I've removed the `Slug` - which was generated via `NamingUtils.SlugFromTitle`, *not* the user - property from `MethodologyUpdateRequest` to make this clearer.