### PR TITLE
EES-4605 Remove telephone number links from contact details

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/ContactUsSection.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/ContactUsSection.tsx
@@ -11,13 +11,16 @@ const ContactUsSection = ({
   return (
     <>
       <h3 id="contact-us">Contact us</h3>
+
       <p>
         If you have a specific enquiry about {publicationTitle} statistics and
         data:
       </p>
+
       <h4 className="govuk-heading-s govuk-!-margin-bottom-0">
         {publicationContact.teamName}
       </h4>
+
       <address className="govuk-!-margin-top-0">
         Email:{' '}
         <a href={`mailto:${publicationContact.teamEmail}`}>
@@ -28,28 +31,25 @@ const ContactUsSection = ({
         {publicationContact.contactTelNo && (
           <>
             <br />
-            Telephone:{' '}
-            <a href={`tel:${publicationContact.contactTelNo}`}>
-              {publicationContact.contactTelNo}
-            </a>
+            Telephone: {publicationContact.contactTelNo}
           </>
         )}
       </address>
+
       <h4 className="govuk-heading-s govuk-!-margin-bottom-0">Press office</h4>
+
       <p className="govuk-!-margin-top-0">If you have a media enquiry:</p>
-      <p>
-        Telephone: <a href="tel:020 7783 8300">020 7783 8300</a>
-      </p>
+      <p>Telephone: 020 7783 8300</p>
+
       <h4 className="govuk-heading-s govuk-!-margin-bottom-0">
         Public enquiries
       </h4>
+
       <p className="govuk-!-margin-top-0">
         If you have a general enquiry about the Department for Education (DfE)
         or education:
       </p>
-      <p>
-        Telephone: <a href="tel:037 0000 2288">037 0000 2288</a>
-      </p>
+      <p>Telephone: 037 0000 2288</p>
       <p>
         Opening times: <br />
         Monday to Friday from 9.30am to 5pm (excluding bank holidays)


### PR DESCRIPTION
This PR converts the telephone number links implemented in #4333, back to plain text. This is based on guidance specified in the GOV.UK Design System.