### PR TITLE
EES-4467 - added additional deletion case for HTML Blocks that have b…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230926093503_EES4467_RemoveOrphanedContentBlocksAndContentSections.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20230926093503_EES4467_RemoveOrphanedContentBlocksAndContentSections.sql
@@ -44,3 +44,12 @@ WHERE NOT EXISTS (
     FROM ReleaseContentSections
     WHERE ReleaseContentSections.ContentSectionId = ContentSections.Id
 );
+
+-- Delete orphaned HTML Blocks - HTML Blocks that belong to no ContentSection and don't even have a way back to their
+-- owning Release via the ReleaseContentBlocks table.
+DELETE FROM ContentBlock
+WHERE [Type] != 'DataBlock'
+AND ContentSectionId IS NULL
+AND NOT EXISTS (
+	SELECT 1 FROM ReleaseContentBlocks WHERE ReleaseContentBlocks.ContentBlockId = ContentBlock.Id
+);


### PR DESCRIPTION
This PR:
- adds an additional scenario to deleting orphaned Release Content, whereby we delete any Html Blocks that no longer belong to any ContentSection.  This was preventing the EES-4467 database migrations from completing successfully.