### PR TITLE
EES-4602 Fix bug preventing methodology creation

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
@@ -312,6 +312,39 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         }
 
         [Fact]
+        public async Task GetLatestPublishedVersionBySlug()
+        {
+            var methodologyVersionId = Guid.NewGuid();
+            var methodologyVersion = new MethodologyVersion
+            {
+                Id = methodologyVersionId,
+                Methodology = new Methodology
+                {
+                    Slug = "methodology-slug",
+                    LatestPublishedVersionId = methodologyVersionId,
+                },
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyVersions.AddAsync(methodologyVersion);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = BuildMethodologyVersionRepository(
+                    contentDbContext: contentDbContext);
+
+                var result = await service.GetLatestPublishedVersionBySlug(methodologyVersion.Slug);
+
+                Assert.NotNull(result);
+                Assert.Equal(methodologyVersionId, result.Id);
+            }
+        }
+
+        [Fact]
         public async Task GetLatestPublishedVersion()
         {
             var previousVersion = new MethodologyVersion

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
@@ -86,9 +86,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
         {
             return await _contentDbContext
                 .MethodologyVersions
-                .Include(mv => mv.Methodology)
                 .Where(mv =>
-                    mv.Slug == slug
+                    mv.Methodology.Slug == slug
                     && mv.Methodology.LatestPublishedVersionId == mv.Id)
                 .SingleOrDefaultAsync();
         }


### PR DESCRIPTION
This fixes a bug that prevents users from creating a methodology.

It happened because EF couldn't translate MethodologyVersion.Slug into SQL, as it actually refers to the version's methodology's slug:
```
public string Slug => Methodology.Slug;
```

I've also written a unit test. I didn't write unit tests previously because I thought the logic was so simple that nothing could go wrong - lesson learned!