### PR TITLE
EES-4607 fix table tool publication form error message

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -97,10 +97,14 @@ const PublicationForm = ({
 
   const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
     return Yup.object({
-      publicationId: Yup.string().required('Choose publication'),
-      themeId: Yup.string(),
+      publicationId: Yup.string().required('Choose a publication'),
+      themeId: Yup.string().test(
+        'theme',
+        'Choose a theme',
+        value => !(!publications.length && !value),
+      ),
     });
-  }, []);
+  }, [publications.length]);
 
   const handleSubmit = async ({ publicationId }: FormValues) => {
     const publication = publications.find(p => p.id === publicationId);

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -430,6 +430,7 @@ export default function TableToolWizard({
                     {...stepProps}
                     initialValues={{
                       publicationId: state.query.publicationId ?? '',
+                      themeId: '',
                     }}
                     themes={themeMeta}
                     onSubmit={handlePublicationFormSubmit}


### PR DESCRIPTION
Fixes a bug on the first step of a table tool where when you clicked 'Next step' without selecting anything you'd get an error message of 'themeId cannot be null'. This has been changed to 'Choose a theme'.