### PR TITLE
EES-4587 update methodology status guidance modal

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationMethodologyGuidance.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationMethodologyGuidance.tsx
@@ -11,7 +11,7 @@ export function MethodologyStatusGuidanceModal() {
     <Modal
       className="govuk-!-width-one-half"
       showClose
-      title="Methodology type guidance"
+      title="Methodology status guidance"
       triggerButton={
         <ButtonText>
           <InfoIcon description="Guidance on methodology statuses" />
@@ -22,6 +22,17 @@ export function MethodologyStatusGuidanceModal() {
       <SummaryList>
         <SummaryListItem term={<Tag>Draft</Tag>}>
           This is an unpublished draft methodology that can still be edited
+        </SummaryListItem>
+        <SummaryListItem term={<Tag>In review</Tag>}>
+          This is a methodology that is ready to be reviewed prior to
+          publication
+        </SummaryListItem>
+        <SummaryListItem term={<Tag>Draft amendment</Tag>}>
+          This is a published methodology that is currently being amended
+        </SummaryListItem>
+        <SummaryListItem term={<Tag>In review amendment</Tag>}>
+          This is a published methodology that has an amendment that is ready to
+          be reviewed prior to publication
         </SummaryListItem>
         <SummaryListItem term={<Tag>Approved</Tag>}>
           This is an approved methodology that can be published at the same time

--- a/src/explore-education-statistics-common/src/components/SummaryList.module.scss
+++ b/src/explore-education-statistics-common/src/components/SummaryList.module.scss
@@ -13,3 +13,10 @@
     width: 15%;
   }
 }
+
+// Vertical alignment is needed because we sometimes
+// use <Tag> elements in the keys which can cause the
+// alignment to be off.
+.key {
+  vertical-align: top;
+}

--- a/src/explore-education-statistics-common/src/components/SummaryListItem.tsx
+++ b/src/explore-education-statistics-common/src/components/SummaryListItem.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import styles from './SummaryList.module.scss';
 
 interface Props {
   actions?: ReactNode;
@@ -15,7 +16,10 @@ const SummaryListItem = ({
 }: Props) => {
   return (
     <div className="govuk-summary-list__row" data-testid={testId}>
-      <dt className="govuk-summary-list__key" data-testid={`${testId}-key`}>
+      <dt
+        className={`govuk-summary-list__key ${styles.key}`}
+        data-testid={`${testId}-key`}
+      >
         {term}
       </dt>
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FiltersForm.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FiltersForm.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`FiltersForm renders a read-only view of selected options when no longer
     data-testid="Indicators"
   >
     <dt
-      class="govuk-summary-list__key"
+      class="govuk-summary-list__key key"
       data-testid="Indicators-key"
     >
       Indicators
@@ -33,7 +33,7 @@ exports[`FiltersForm renders a read-only view of selected options when no longer
     data-testid="School type"
   >
     <dt
-      class="govuk-summary-list__key"
+      class="govuk-summary-list__key key"
       data-testid="School type-key"
     >
       School type
@@ -57,7 +57,7 @@ exports[`FiltersForm renders a read-only view of selected options when no longer
     data-testid="Characteristic"
   >
     <dt
-      class="govuk-summary-list__key"
+      class="govuk-summary-list__key key"
       data-testid="Characteristic-key"
     >
       Characteristic


### PR DESCRIPTION
Updates the methodology status guidance modal to add new statuses for amendments and approvals.

I've also added some CSS to fix an issue with vertical alignment in summary lists when you have a `Tag` as the key and multiple line text in the value. 