### PR TITLE
EES-4392 Attempted fix for SlugNotUnique intermittent UI test failure

### DIFF
--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -10,7 +10,9 @@ import argparse
 import datetime
 import json
 import os
+import random
 import shutil
+import string
 from pathlib import Path
 
 import requests
@@ -342,7 +344,9 @@ if args.tests and "general_public" not in args.tests:
 
     # NOTE(mark): Tests that alter data only occur on local and dev environments
     if args.env in ["local", "dev"]:
-        runIdentifier = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+        # add randomness to prevent multiple simultaneous run_tests.py generating the same runIdentifier value
+        randomStr = "".join([random.choice(string.ascii_letters + string.digits) for n in range(6)])
+        runIdentifier = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S-" + randomStr)
 
         os.environ["RUN_IDENTIFIER"] = runIdentifier
         logger.info(f"Starting tests with RUN_IDENTIFIER: {runIdentifier}")


### PR DESCRIPTION
This attempts to fix a rare intermittent UI test failure we've had with the error "SlugNotUnique".

We believe this is due to the `run_tests.py` script being invoked multiple times at the same time, and two of these runs coincidentally generating the same `runIdentifer` value. If this is correct, this fix should prevent this by adding additional random characters to the end of the `runIdentifier` variable.