### PR TITLE
EES-4629 Alter Dev and Prod content db storage capacities

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -111,7 +111,7 @@
       "value": 2
     },
     "maxContentDbSizeBytes": {
-      "value": 1073741824
+      "value": 2147483648
     },
     "maxStatsDbSizeBytes": {
       "value": 375809638400

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -87,7 +87,7 @@
       "value": 1000000
     },
     "maxContentDbSizeBytes": {
-      "value": 2147483648
+      "value": 4294967296
     },
     "maxStatsDbSizeBytes": {
       "value": 1020054732800


### PR DESCRIPTION
This PR alters the Dev and Prod content database storage capacities.

<html>
<head>

</head>

<body>


Environment | Old capacity (bytes) | Old capacity (Gb) | New capacity (bytes) | New capacity (Gb)
-- | -- | -- | -- | --
Dev | 1073741824 | 1 | 2147483648 | 2
Prod | 2147483648 | 2 | 4294967296 | 4


</body>

</html>

Note: The Prod content database has recently been manually resized from 2Gb to 20Gb so this change will have the effect of reducing it in size from 20Gb to 4Gb when it's deployed.
