### PR TITLE
Update validate snapshots cron schedule

### DIFF
--- a/.github/workflows/validate-snapshots.yml
+++ b/.github/workflows/validate-snapshots.yml
@@ -7,7 +7,7 @@ on:
     # twice a year (at the start and end of daylight saving time) 
     # to account for daylight saving time in the UK
     # This action is intended to run at 9:35AM, 12:35PM & 4:35PM
-    - cron: '35 8,11,15 * * 1-5'
+    - cron: '35 9,12,16 * * 1-5'
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This PR updates the validate snapshots cron schedule intended to run at 9:35AM, 12:35PM & 4:35PM in advance of daylight saving time ending on 29/10/23.

Github Actions have no timezone support.