### PR TITLE
EES-4638 fix server error handling on methodology form

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/components/__tests__/MethodologySummaryForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/components/__tests__/MethodologySummaryForm.test.tsx
@@ -34,7 +34,7 @@ describe('MethodologySummaryForm', () => {
       <MethodologySummaryForm
         id="id"
         initialValues={{
-          title: '',
+          title: 'the publication title',
           titleType: 'default',
         }}
         defaultTitle="the publication title"
@@ -45,7 +45,7 @@ describe('MethodologySummaryForm', () => {
     );
 
     userEvent.click(screen.getByLabelText('Set an alternative title'));
-    userEvent.click(screen.getByLabelText('Enter methodology title'));
+    userEvent.clear(screen.getByLabelText('Enter methodology title'));
     userEvent.tab();
 
     await waitFor(() => {
@@ -63,7 +63,7 @@ describe('MethodologySummaryForm', () => {
       <MethodologySummaryForm
         id="id"
         initialValues={{
-          title: '',
+          title: 'the publication title',
           titleType: 'default',
         }}
         defaultTitle="the publication title"
@@ -74,6 +74,7 @@ describe('MethodologySummaryForm', () => {
     );
 
     userEvent.click(screen.getByLabelText('Set an alternative title'));
+    userEvent.clear(screen.getByLabelText('Enter methodology title'));
     await userEvent.type(
       screen.getByLabelText('Enter methodology title'),
       'an alternative title',
@@ -82,10 +83,7 @@ describe('MethodologySummaryForm', () => {
     userEvent.click(screen.getByRole('button', { name: 'Update methodology' }));
 
     await waitFor(() => {
-      expect(handleSubmit).toHaveBeenCalledWith({
-        title: 'an alternative title',
-        titleType: 'alternative',
-      });
+      expect(handleSubmit).toHaveBeenCalledWith('an alternative title');
     });
   });
 
@@ -95,7 +93,7 @@ describe('MethodologySummaryForm', () => {
       <MethodologySummaryForm
         id="id"
         initialValues={{
-          title: '',
+          title: 'the publication title',
           titleType: 'default',
         }}
         defaultTitle="the publication title"
@@ -108,10 +106,32 @@ describe('MethodologySummaryForm', () => {
     userEvent.click(screen.getByRole('button', { name: 'Update methodology' }));
 
     await waitFor(() => {
-      expect(handleSubmit).toHaveBeenCalledWith({
-        title: 'the publication title',
-        titleType: 'default',
-      });
+      expect(handleSubmit).toHaveBeenCalledWith('the publication title');
+    });
+  });
+
+  test('submits successfully when change back to publication title from an alternative title', async () => {
+    const handleSubmit = jest.fn();
+    render(
+      <MethodologySummaryForm
+        id="id"
+        initialValues={{
+          title: 'the alternative title',
+          titleType: 'alternative',
+        }}
+        defaultTitle="the publication title"
+        submitText="Update methodology"
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    userEvent.click(screen.getByLabelText('Use publication title'));
+
+    userEvent.click(screen.getByRole('button', { name: 'Update methodology' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith('the publication title');
     });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryEditPage.tsx
@@ -1,6 +1,4 @@
-import MethodologySummaryForm, {
-  MethodologySummaryFormValues,
-} from '@admin/pages/methodology/components/MethodologySummaryForm';
+import MethodologySummaryForm from '@admin/pages/methodology/components/MethodologySummaryForm';
 import {
   MethodologyRouteParams,
   methodologySummaryRoute,
@@ -16,7 +14,7 @@ const MethodologySummaryEditPage = ({
   const { methodologyId, methodology, onMethodologyChange } =
     useMethodologyContext();
 
-  const handleSubmit = async ({ title }: MethodologySummaryFormValues) => {
+  const handleSubmit = async (title: string) => {
     if (!methodology) {
       throw new Error('Could not update missing methodology');
     }


### PR DESCRIPTION
Fixes the server error handling on the methodology summary form. Previously if you tried to change the title to one that is already taken you'd get an error page instead of the standard form error. I've converted the form to React Hook Form as part of this work.

![err](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/68ace946-7f1a-42e5-90a6-ae9018996657)
