### PR TITLE
Add Jen and remove Tess as snapshot reviewers

### DIFF
--- a/.github/workflows/validate-snapshots.yml
+++ b/.github/workflows/validate-snapshots.yml
@@ -67,7 +67,7 @@ jobs:
           branch: chore/update-test-snapshots
           add-paths: |
             tests/robot-tests/tests/snapshots
-          reviewers: rmbielby, lauraselby, cjrace, chfoster, twilliams24
+          reviewers: rmbielby, lauraselby, cjrace, chfoster, jen-machin
           title: ${{ steps.vars.outputs.pr_title }}
           body: ${{ steps.vars.outputs.pr_body }}
           draft: false


### PR DESCRIPTION
This updates the reviewers for the snapshots comparison GitHub action to remove Tess (who has now left the DfE) and add Jen (who has recently joined).
