### PR TITLE
EES-4642 Fixing UI tests failures in Admin suite

### DIFF
--- a/tests/robot-tests/tests/admin/analyst/manage_approvals_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/manage_approvals_as_publication_approver.robot
@@ -44,7 +44,7 @@ Sign in as Analyst1 User1 (publication approver)
     user changes to analyst1
 
 Check Approvals warning
-    user checks page contains element    testid:outstanding-approvals-warning
+    user waits until page contains element    testid:outstanding-approvals-warning
 
 Check Analyst can see correct tabs
     user checks element should contain    id:publications-tab    Your publications


### PR DESCRIPTION
Changed a Keyword in the file manage_approvals_as_publication_approver.robot to wait for the publications to load before checking the Approvals warning on Analyst Dashboard
