### PR TITLE
EES-4643 fixing Prod UI test failures in 'general_public' suite

### DIFF
--- a/tests/robot-tests/tests/general_public/glossary_page.robot
+++ b/tests/robot-tests/tests/general_public/glossary_page.robot
@@ -27,11 +27,9 @@ Validate glossary accordion sections
 
 Search for Voluntary repayment
     user verifies accordion is closed    V
-
     user enters text into element    id:pageSearchForm-input    Voluntary repayment
     user waits until element contains    id:pageSearchForm-resultsLabel    Found 1 result
     user clicks element    id:pageSearchForm-option-0
-
     user verifies accordion is open    V
 
     ${section}=    user gets accordion section content element    V

--- a/tests/robot-tests/tests/general_public/glossary_page.robot
+++ b/tests/robot-tests/tests/general_public/glossary_page.robot
@@ -25,19 +25,19 @@ Validate glossary accordion sections
     user checks accordion is in position    D    4
     user checks accordion is in position    Z    26
 
-Search for Pupil referral unit
-    user verifies accordion is closed    P
+Search for Voluntary repayment
+    user verifies accordion is closed    V
 
-    user enters text into element    id:pageSearchForm-input    Pupil referral unit
+    user enters text into element    id:pageSearchForm-input    Voluntary repayment
     user waits until element contains    id:pageSearchForm-resultsLabel    Found 1 result
     user clicks element    id:pageSearchForm-option-0
 
-    user verifies accordion is open    P
+    user verifies accordion is open    V
 
-    ${section}=    user gets accordion section content element    P
+    ${section}=    user gets accordion section content element    V
 
-    user waits until parent contains element    ${section}    id:pupil-referral-unit
-    user checks element is visible    id:pupil-referral-unit
-    user checks element should contain    id:pupil-referral-unit    Pupil referral unit (PRUs)
+    user waits until parent contains element    ${section}    id:voluntary-repayment
+    user checks element is visible    id:voluntary-repayment
+    user checks element should contain    id:voluntary-repayment    Voluntary repayment
     user checks element should contain    ${section}
-    ...    An alternative education provision specifically organised to provide education for children who are not able to attend school and may not otherwise receive a suitable education.
+    ...    A borrower can at any time choose to repay some or all of their loan balance early, in addition to any repayments they are liable to make based on their income.

--- a/tests/robot-tests/tests/general_public/notifications_absence.robot
+++ b/tests/robot-tests/tests/general_public/notifications_absence.robot
@@ -35,5 +35,6 @@ Sign up for email alerts
     user clicks button    Subscribe
 
     # EES-1265
-    user waits until h1 is visible    Subscribed    %{WAIT_LONG}
+    #user waits until h1 is visible    Subscribed    %{WAIT_LONG}
+    user waits until page contains    Subscribed    %{WAIT_SMALL}
     user checks page contains    Thank you. Check your email to confirm your subscription.

--- a/tests/robot-tests/tests/general_public/notifications_absence.robot
+++ b/tests/robot-tests/tests/general_public/notifications_absence.robot
@@ -35,6 +35,5 @@ Sign up for email alerts
     user clicks button    Subscribe
 
     # EES-1265
-    #user waits until h1 is visible    Subscribed    %{WAIT_LONG}
-    user waits until page contains    Subscribed    %{WAIT_SMALL}
+    user waits until page contains    Subscribed    %{WAIT_LONG}
     user checks page contains    Thank you. Check your email to confirm your subscription.

--- a/tests/robot-tests/tests/general_public/permalink_prod_1.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_1.robot
@@ -43,7 +43,7 @@ Validate table
     user checks table cell contains    1    3    148,820
 
 Validate footnotes
-    user checks page contains element    //h3[@class="govuk-heading-m"]
+    user checks page contains element    testid:footnotes
     user checks page contains
     ...    State-funded secondary schools include city technology colleges and all secondary academies, including all-through academies and free schools.
     user checks page contains    x - 1 or 2 pupils, or a percentage based on 1 or 2.

--- a/tests/robot-tests/tests/general_public/permalink_prod_1.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_1.robot
@@ -43,10 +43,10 @@ Validate table
     user checks table cell contains    1    3    148,820
 
 Validate footnotes
-    user checks page contains element
-    ...    xpath://h3[text()="Footnotes"]/../ol/li[text()="State-funded secondary schools include city technology colleges and all secondary academies, including all-through academies and free schools."]
-    user checks page contains element
-    ...    xpath://h3[text()="Footnotes"]/../ol/li[text()="x - 1 or 2 pupils, or a percentage based on 1 or 2."]
+    user checks page contains element    //h3[@class="govuk-heading-m"]
+    user checks page contains
+    ...    State-funded secondary schools include city technology colleges and all secondary academies, including all-through academies and free schools.
+    user checks page contains    x - 1 or 2 pupils, or a percentage based on 1 or 2.
 
 Validate download files
     user checks page contains    Table in ODS format (spreadsheet, with title and footnotes)

--- a/tests/robot-tests/tests/general_public/permalink_prod_2.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_2.robot
@@ -55,10 +55,9 @@ Validate table
     user checks row cell contains text    ${row}    3    7,916,225
 
 Validate footnotes
-    user checks page contains element
-    ...    xpath://h3[text()="Footnotes"]/../ol/li[text()="Includes pupils who are sole or dual main registrations. Includes boarding pupils."]
-    user checks page contains element
-    ...    xpath://h3[text()="Footnotes"]/../ol/li[text()="x - 1 or 2 pupils, or a percentage based on 1 or 2."]
+    user checks page contains element    //h3[@class="govuk-heading-m"]
+    user checks page contains    Includes pupils who are sole or dual main registrations. Includes boarding pupils.
+    user checks page contains    x - 1 or 2 pupils, or a percentage based on 1 or 2.
 
 Validate download files
     user checks page contains    Table in ODS format (spreadsheet, with title and footnotes)

--- a/tests/robot-tests/tests/general_public/permalink_prod_2.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_2.robot
@@ -55,7 +55,7 @@ Validate table
     user checks row cell contains text    ${row}    3    7,916,225
 
 Validate footnotes
-    user checks page contains element    //h3[@class="govuk-heading-m"]
+    user checks page contains element    testid:footnotes
     user checks page contains    Includes pupils who are sole or dual main registrations. Includes boarding pupils.
     user checks page contains    x - 1 or 2 pupils, or a percentage based on 1 or 2.
 

--- a/tests/robot-tests/tests/general_public/permalink_prod_3.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_3.robot
@@ -61,7 +61,7 @@ Validate table
     user checks row cell contains text    ${row}    3    798
 
 Validate footnotes
-    user checks page contains element    //h3[@class="govuk-heading-m"]
+    user checks page contains element    testid:footnotes
     user checks page contains
     ...    The number of fixed period exclusions expressed as a percentage of the number of pupils in January each year.
     user checks page contains    x - 1 or 2 pupils, or a percentage based on 1 or 2.

--- a/tests/robot-tests/tests/general_public/permalink_prod_3.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_3.robot
@@ -61,10 +61,10 @@ Validate table
     user checks row cell contains text    ${row}    3    798
 
 Validate footnotes
-    user checks page contains element
-    ...    xpath://h3[text()="Footnotes"]/../ol/li[text()="The number of fixed period exclusions expressed as a percentage of the number of pupils in January each year."]
-    user checks page contains element
-    ...    xpath://h3[text()="Footnotes"]/../ol/li[text()="x - 1 or 2 pupils, or a percentage based on 1 or 2."]
+    user checks page contains element    //h3[@class="govuk-heading-m"]
+    user checks page contains
+    ...    The number of fixed period exclusions expressed as a percentage of the number of pupils in January each year.
+    user checks page contains    x - 1 or 2 pupils, or a percentage based on 1 or 2.
 
 Validate download files
     user checks page contains    Table in ODS format (spreadsheet, with title and footnotes)


### PR DESCRIPTION
A few UI tests failed due to a mismatch of data from the live environment compared to the seed data for the UI tests. Additionally, a few xpaths are not valid anymore so they got replaced with ID selectors instead.

![Screenshot (564)](https://github.com/dfe-analytical-services/explore-education-statistics/assets/93383553/ff177d5c-393b-4290-a449-f1a8bd9ad61b)
