### PR TITLE
EES-4621/update offical statistics description

### DIFF
--- a/src/explore-education-statistics-common/src/modules/release/components/OfficialStatisticsSection.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/OfficialStatisticsSection.tsx
@@ -33,6 +33,25 @@ export default function OfficialStatisticsSection({
         </a>
         .
       </p>
+      <p>
+        Our statistical practice is regulated by the Office for Statistics
+        Regulation (OSR).
+      </p>
+      <p>
+        OSR sets the standards of trustworthiness, quality and value in the{' '}
+        <a href="https://code.statisticsauthority.gov.uk/the-code/">
+          Code of Practice for Statistics
+        </a>{' '}
+        that all producers of official statistics should adhere to.
+      </p>
+      <p>
+        You are welcome to contact us directly with any comments about how we
+        meet these standards. Alternatively, you can contact OSR by emailing{' '}
+        <a href="mailto:regulation@statistics.gov.uk">
+          regulation@statistics.gov.uk
+        </a>{' '}
+        or via the OSR website.
+      </p>
     </>
   );
 }

--- a/src/explore-education-statistics-common/src/modules/release/components/OfficialStatisticsSection.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/OfficialStatisticsSection.tsx
@@ -50,7 +50,8 @@ export default function OfficialStatisticsSection({
         <a href="mailto:regulation@statistics.gov.uk">
           regulation@statistics.gov.uk
         </a>{' '}
-        or via the OSR website.
+        or via the{' '}
+        <a href="https://osr.statisticsauthority.gov.uk/">OSR website</a>.
       </p>
     </>
   );

--- a/src/explore-education-statistics-common/src/modules/release/components/__tests__/OfficialStatisticsSection.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/__tests__/OfficialStatisticsSection.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import OfficialStatisticsSection from '@common/modules/release/components/OfficialStatisticsSection';
+
+describe('OfficialStatisticsSection', () => {
+  test('renders', () => {
+    render(<OfficialStatisticsSection />);
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Code of Practice for Official Statistics',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('shows the heading if showHeading is true', () => {
+    render(<OfficialStatisticsSection showHeading />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Official statistics' }),
+    ).toBeInTheDocument();
+  });
+
+  test('hides the heading if showHeading is false', () => {
+    render(<OfficialStatisticsSection showHeading={false} />);
+
+    expect(
+      screen.queryByRole('heading', { name: 'Official statistics' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('includes the OSR guidance text', () => {
+    // Introduced because of changes to the National Statistics Designation Review,
+    // Documented in https://dfedigital.atlassian.net/browse/EES-4621
+
+    render(<OfficialStatisticsSection />);
+
+    expect(
+      screen.getByText(
+        'Our statistical practice is regulated by the Office for Statistics Regulation (OSR).',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', { name: 'Code of Practice for Statistics' }),
+    ).toHaveAttribute(
+      'href',
+      'https://code.statisticsauthority.gov.uk/the-code/',
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'regulation@statistics.gov.uk' }),
+    ).toHaveAttribute('href', 'mailto:regulation@statistics.gov.uk');
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/release/components/__tests__/OfficialStatisticsSection.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/__tests__/OfficialStatisticsSection.test.tsx
@@ -51,5 +51,10 @@ describe('OfficialStatisticsSection', () => {
     expect(
       screen.getByRole('link', { name: 'regulation@statistics.gov.uk' }),
     ).toHaveAttribute('href', 'mailto:regulation@statistics.gov.uk');
+
+    expect(screen.getByRole('link', { name: 'OSR website' })).toHaveAttribute(
+      'href',
+      'https://osr.statisticsauthority.gov.uk/',
+    );
   });
 });


### PR DESCRIPTION
This PR expands the Official Statistics Section to include new copy from the OSR. This new copy is documented in https://dfedigital.atlassian.net/browse/EES-4621

Changes:

<img width="1023" alt="EES-4621-changes" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/63285990/c0b5072d-7941-4fd2-931a-d9225766601b">
