### PR TITLE
EES-4623 add OSR line to footer

### DIFF
--- a/src/explore-education-statistics-admin/src/components/PageFooter.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageFooter.tsx
@@ -41,6 +41,16 @@ const PageFooter = ({ wide }: Props) => {
                 </Link>
               </li>
             </ul>
+            <div className="govuk-footer__meta-custom">
+              Our statistical practice is regulated by the{' '}
+              <Link
+                className="govuk-footer__link"
+                to="https://osr.statisticsauthority.gov.uk/what-we-do/"
+              >
+                Office for Statistics Regulation
+              </Link>{' '}
+              (OSR)
+            </div>
             <svg
               role="presentation"
               focusable="false"
@@ -57,13 +67,13 @@ const PageFooter = ({ wide }: Props) => {
             </svg>
             <span className="govuk-footer__licence-description">
               All content is available under the{' '}
-              <a
+              <Link
                 className="govuk-footer__link"
-                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                to="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
                 rel="license"
               >
                 Open Government Licence v3.0
-              </a>
+              </Link>
               , except where otherwise stated
             </span>
 
@@ -77,12 +87,12 @@ const PageFooter = ({ wide }: Props) => {
             )}
           </div>
           <div className="govuk-footer__meta-item">
-            <a
+            <Link
               className="govuk-footer__link govuk-footer__copyright-logo"
-              href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+              to="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
             >
               © Crown copyright
-            </a>
+            </Link>
           </div>
         </div>
       </div>

--- a/src/explore-education-statistics-frontend/src/components/PageFooter.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageFooter.tsx
@@ -72,7 +72,16 @@ const PageFooter = ({ wide }: Props) => (
               </Link>
             </li>
           </ul>
-
+          <div className="govuk-footer__meta-custom">
+            Our statistical practice is regulated by the{' '}
+            <Link
+              className="govuk-footer__link"
+              to="https://osr.statisticsauthority.gov.uk/what-we-do/"
+            >
+              Office for Statistics Regulation
+            </Link>{' '}
+            (OSR)
+          </div>
           <svg
             role="presentation"
             focusable="false"
@@ -89,13 +98,13 @@ const PageFooter = ({ wide }: Props) => (
           </svg>
           <span className="govuk-footer__licence-description">
             All content is available under the{' '}
-            <a
+            <Link
               className="govuk-footer__link"
-              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              to="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
               rel="license"
             >
               Open Government Licence v3.0
-            </a>
+            </Link>
             , except where otherwise stated
           </span>
 
@@ -109,12 +118,12 @@ const PageFooter = ({ wide }: Props) => (
           )}
         </div>
         <div className="govuk-footer__meta-item">
-          <a
+          <Link
             className="govuk-footer__link govuk-footer__copyright-logo"
-            href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+            to="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
           >
             © Crown copyright
-          </a>
+          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adds a line about the OSR to the footer.

![footer](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/e04ebffa-5325-4726-b0e7-2019fc132646)
