### PR TITLE
EES-4654 - hotfix - prevent data blocks being copied to releases from templates

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentSection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentSection.cs
@@ -27,14 +27,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public List<ContentBlock> Content { get; set; } = new();
 
         public Release Release { get; set; }
-        
+
         public Guid ReleaseId { get; set; }
-        
+
         [JsonIgnore] public ContentSectionType Type { get; set; }
 
+        // TODO EES-4639 - rewrite Release Amendment generation code to be localised to
+        // ReleaseAmendmentExtensions.CreateAmendment() or ReleaseService.CreateBasicReleaseAmendment().
         public ContentSection Clone(Release.CloneContext context)
         {
-            var copy = MemberwiseClone() as ContentSection;
+            var copy = MemberwiseClone();
             copy.Id = Guid.NewGuid();
 
             copy.Release = context.NewRelease;
@@ -48,9 +50,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             return copy;
         }
 
+        // TODO EES-4639 - rewrite Methodology Amendment generation code to be localised to
+        // MethodologyVersion.CreateMethodologyAmendment() or MethodologyAmendmentService.CreateAndSaveAmendment().
         public ContentSection Clone(DateTime createdDate)
         {
-            var copy = MemberwiseClone() as ContentSection;
+            var copy = MemberwiseClone();
             copy.Id = Guid.NewGuid();
 
             copy.Content = copy
@@ -60,6 +64,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
             copy.Content?.ForEach(c => c.ContentSectionId = copy.Id);
             return copy;
+        }
+
+        // TODO EES-4639 - adopt straight MemberwiseClone() usage during the generating of Release Amendments,
+        // Methodology Amendments and Releases from templates, then have each call site tailor the resulting
+        // cloned Content tree to their individual requirements, rather than support various Clone() methods in
+        // Release Content entities themselves.
+        public new ContentSection MemberwiseClone()
+        {
+            return base.MemberwiseClone() as ContentSection;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseAmendmentExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseAmendmentExtensions.cs
@@ -185,24 +185,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
                 }
             );
         }
-
-        public static void CreateGenericContentFromTemplate(
-            this Release originalRelease,
-            Release.CloneContext context)
-        {
-            var newRelease = context.NewRelease;
-
-            newRelease.Content = originalRelease.Content
-                .Where(section => section.Type == ContentSectionType.Generic)
-                .ToList();
-
-            newRelease.Content = originalRelease
-                .Content
-                .Select(section => section.Clone(context))
-                .ToList();
-
-            // TODO EES-4467 - we can add the cloning of Data Blocks back in here rather than being doing separately
-            // when the new DataBlock / DataBlockVersion tables are added.
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -200,21 +200,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             return MemberwiseClone() as Release;
         }
 
-        public record CloneContext
+        public record CloneContext(Release NewRelease)
         {
             // Maps old content block references to new content blocks
             // Ideally we want to try and get rid of this completely as we
             // shouldn't have to deal with the same content blocks being
             // referenced in multiple places.
-            // TODO: EES-1306 may be possible to remove this as part of this ticket
             public Dictionary<ContentBlock, ContentBlock> OriginalToAmendmentContentBlockMap { get; } = new();
-
-            public Release NewRelease { get; }
-
-            public CloneContext(Release newRelease)
-            {
-                NewRelease = newRelease;
-            }
         }
     }
 }


### PR DESCRIPTION
This PR:
- Fixes a problem whereby Data Blocks were being copied across into new Releases when they were being created from a template Release.
- Adds additional test steps into unit tests around creating Releases from templates to ensure that no Data Blocks have been copied over.
- Tackles the chunk of EES-4639 relating to creating Releases from templates, which was raised in part to prevent this very scenario from occurring!

This bug was introduced when removing ReleaseContentBlock and ReleaseContentSection from the model.  It was pointed out by @mmyoungman as having been a long-standing risky area of code whereby we were getting away with not copying Content Blocks into a Release generated from a template because we didn't hydrate them whilst pulling the template Release out of the database.  The PR however amended code that then caused this very transfer to happen in a different way!

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/6f3d6ea6-9cf2-44f6-8844-9ebd4b8324f1)
