### PR TITLE
EES-4584 trim whitespace from text inputs

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationContactForm.tsx
@@ -38,7 +38,7 @@ export default function PublicationContactForm({
   const handleSubmit = async (values: FormValues) => {
     const contact = values;
 
-    if (!contact.contactTelNo?.trim()) {
+    if (!contact.contactTelNo) {
       contact.contactTelNo = undefined;
     }
 
@@ -58,7 +58,6 @@ export default function PublicationContactForm({
         .email('Enter a valid team email'),
       contactName: Yup.string().required('Enter a contact name'),
       contactTelNo: Yup.string()
-        .trim()
         .matches(/^0[0-9\s]*$/, {
           excludeEmptyString: true,
           message:

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
@@ -55,7 +55,6 @@ export default function PublicationForm({
         .email('Enter a valid team email address'),
       contactName: Yup.string().required('Enter a contact name'),
       contactTelNo: Yup.string()
-        .trim()
         .matches(/^0[0-9\s]*$/, {
           excludeEmptyString: true,
           message:
@@ -88,7 +87,7 @@ export default function PublicationForm({
       contactTelNo,
     };
 
-    if (!contact.contactTelNo?.trim()) {
+    if (!contact.contactTelNo) {
       contact.contactTelNo = undefined;
     }
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
@@ -42,7 +42,7 @@ const EditableKeyStatDataBlockForm = ({
     async values => {
       await onSubmit({
         ...values,
-        guidanceTitle: values.guidanceTitle.trim(),
+        guidanceTitle: values.guidanceTitle,
         guidanceText: toMarkdown(values.guidanceText),
       });
     },

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
@@ -42,7 +42,7 @@ export default function EditableKeyStatTextForm({
   const handleSubmit = useFormSubmit<KeyStatTextFormValues>(async values => {
     await onSubmit({
       ...values,
-      guidanceTitle: values.guidanceTitle.trim(),
+      guidanceTitle: values.guidanceTitle,
       guidanceText: toMarkdown(values.guidanceText),
     });
   });

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileForm.tsx
@@ -96,7 +96,6 @@ export default function AncillaryFileForm({
       onSubmit={handleSubmit}
       validationSchema={Yup.object<AncillaryFileFormValues>({
         title: Yup.string()
-          .trim()
           .required('Enter a title')
           .test({
             name: 'unique',

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -132,13 +132,13 @@ const ReleaseDataUploadsSection = ({
 
       if (values.uploadType === 'csv') {
         file = await releaseDataFileService.uploadDataFiles(releaseId, {
-          title: values.subjectTitle.trim(),
+          title: values.subjectTitle,
           dataFile: values.dataFile as File,
           metadataFile: values.metadataFile as File,
         });
       } else {
         file = await releaseDataFileService.uploadZipDataFile(releaseId, {
-          title: values.subjectTitle.trim(),
+          title: values.subjectTitle,
           zipFile: values.zipFile as File,
         });
       }
@@ -193,7 +193,6 @@ const ReleaseDataUploadsSection = ({
           validationSchema={baseSchema => {
             return baseSchema.shape({
               subjectTitle: Yup.string()
-                .trim()
                 .required('Enter a subject title')
                 .test({
                   name: 'unique',

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -56,9 +56,9 @@ export default function ReleaseFileUploadsSection({
   const handleSubmit = useCallback(
     async (values: AncillaryFileFormValues) => {
       const newFile = await releaseAncillaryFileService.createFile(releaseId, {
-        title: values.title.trim(),
+        title: values.title,
         file: values.file as File,
-        summary: values.summary.trim(),
+        summary: values.summary,
       });
 
       queryClient.setQueryData(listFilesQuery.queryKey, [...files, newFile]);

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
@@ -47,8 +47,8 @@ const DataBlockDetailsForm = ({
     ({ highlightName, highlightDescription, isHighlight, ...values }) => {
       onSubmit({
         ...values,
-        highlightName: isHighlight ? highlightName.trim() : '',
-        highlightDescription: isHighlight ? highlightDescription.trim() : '',
+        highlightName: isHighlight ? highlightName : '',
+        highlightDescription: isHighlight ? highlightDescription : '',
       });
     },
     [],
@@ -65,7 +65,7 @@ const DataBlockDetailsForm = ({
         isHighlight: Yup.boolean(),
         highlightName: Yup.string().when('isHighlight', {
           is: true,
-          then: s => s.trim().required('Enter a featured table name'),
+          then: s => s.required('Enter a featured table name'),
         }),
         highlightDescription: Yup.string().when('isHighlight', {
           is: true,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -112,7 +112,7 @@ const ChartConfiguration = ({
             // eslint-disable-next-line react/no-this-in-sfc
             const title: string = this.resolve(Yup.ref('title')) ?? '';
 
-            return value.trim() !== title.trim();
+            return value !== title;
           },
         }),
       height: Yup.number()

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/__tests__/PreReleaseUserAccessForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/__tests__/PreReleaseUserAccessForm.test.tsx
@@ -157,7 +157,7 @@ describe('PreReleaseUserAccessForm', () => {
       });
 
       // now exceed the limit
-      await userEvent.type(emailsTextarea, `test@test.com`);
+      await userEvent.type(emailsTextarea, `{enter}test@test.com`);
       userEvent.tab();
 
       await waitFor(() => {

--- a/src/explore-education-statistics-common/src/components/form/FormField.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormField.tsx
@@ -5,6 +5,7 @@ import {
   FieldInputProps,
   FieldMetaProps,
   useField,
+  useFormikContext,
 } from 'formik';
 import React, {
   ChangeEvent,
@@ -28,6 +29,8 @@ export interface FormFieldProps<FormValues = unknown> {
   formGroupClass?: string;
   name: FormValues extends Record<string, unknown> ? keyof FormValues : string;
   showError?: boolean;
+  trimInput?: boolean;
+  trimInputOnEnter?: boolean;
 }
 
 interface FormFieldInputProps<Value> extends FieldInputProps<Value> {
@@ -57,6 +60,8 @@ function FormField<Value, Props = Record<string, unknown>>({
   id: customId,
   name,
   showError = true,
+  trimInput = false,
+  trimInputOnEnter = false,
   type,
   ...props
 }: FormFieldProps & InternalFormFieldProps<Props, Value>) {
@@ -67,6 +72,8 @@ function FormField<Value, Props = Record<string, unknown>>({
     name,
     type,
   });
+
+  const { setFieldValue } = useFormikContext();
 
   const error = showError && meta.error && meta.touched ? meta.error : '';
 
@@ -95,6 +102,12 @@ function FormField<Value, Props = Record<string, unknown>>({
             }
           }}
           onBlur={(event: FocusEvent) => {
+            if (trimInput) {
+              setFieldValue(
+                name,
+                (event.target as HTMLInputElement).value.trim(),
+              );
+            }
             if (typedProps.onBlur) {
               typedProps.onBlur(event);
             }
@@ -103,6 +116,11 @@ function FormField<Value, Props = Record<string, unknown>>({
               field.onBlur(event);
             }
           }}
+          onKeyPress={(event: KeyboardEvent) =>
+            trimInputOnEnter &&
+            event.key === 'Enter' &&
+            (event.currentTarget as HTMLInputElement)?.blur()
+          }
         />
       );
     }
@@ -130,6 +148,9 @@ function FormField<Value, Props = Record<string, unknown>>({
     meta,
     name,
     props,
+    setFieldValue,
+    trimInput,
+    trimInputOnEnter,
   ]);
 
   return formGroup ? (

--- a/src/explore-education-statistics-common/src/components/form/FormFieldTextArea.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldTextArea.tsx
@@ -6,7 +6,10 @@ import FormField, { FormFieldComponentProps } from './FormField';
 type Props<FormValues> = FormFieldComponentProps<FormTextAreaProps, FormValues>;
 
 function FormFieldTextArea<FormValues>(props: Props<FormValues>) {
-  return <FormField {...props} as={FormTextArea} />;
+  const { trimInput } = props;
+  return (
+    <FormField {...props} as={FormTextArea} trimInput={trimInput ?? true} />
+  );
 }
 
 export default FormFieldTextArea;

--- a/src/explore-education-statistics-common/src/components/form/FormFieldTextInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldTextInput.tsx
@@ -10,7 +10,15 @@ type Props<FormValues> = FormFieldComponentProps<
 >;
 
 function FormFieldTextInput<FormValues>(props: Props<FormValues>) {
-  return <FormField {...props} as={FormTextInput} />;
+  const { trimInput } = props;
+  return (
+    <FormField
+      {...props}
+      as={FormTextInput}
+      trimInput={trimInput ?? true}
+      trimInputOnEnter={trimInput ?? true}
+    />
+  );
 }
 
 export default FormFieldTextInput;

--- a/src/explore-education-statistics-common/src/components/form/FormSearchBar.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormSearchBar.tsx
@@ -43,10 +43,11 @@ const FormSearchBar = ({
   }, [initialValue]);
 
   const handleSubmit = () => {
-    if (searchTerm.length >= min) {
+    const trimmed = searchTerm.trim();
+    if (trimmed.length >= min) {
       toggleHasSubmitted.on();
       toggleError.off();
-      onSubmit?.(searchTerm);
+      onSubmit?.(trimmed);
     } else {
       toggleError.on();
     }
@@ -78,8 +79,9 @@ const FormSearchBar = ({
         value={searchTerm}
         onChange={event => {
           setSearchTerm(event.target.value);
-          onChange?.(event.target.value);
-          if (event.target.value.length >= min || !event.target.value.length) {
+          onChange?.(event.target.value.trim());
+          const trimmed = event.target.value.trim();
+          if (trimmed.length >= min || !trimmed.length) {
             toggleError.off();
           }
         }}

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldTextArea.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldTextArea.test.tsx
@@ -1,0 +1,318 @@
+import { Form } from '@common/components/form';
+import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Formik } from 'formik';
+import noop from 'lodash/noop';
+import React from 'react';
+import Yup from '@common/validation/yup';
+
+describe('FormFieldTextArea', () => {
+  test('renders correctly', () => {
+    const { container } = render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextArea name="testField" label="Test field" />
+      </Formik>,
+    );
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders with a hint correctly', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextArea
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testField-hint',
+    );
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testField-hint',
+    );
+  });
+
+  test('renders with correct defaults ids with form', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <Form id="testForm">
+          <FormFieldTextArea
+            name="testField"
+            label="Test field"
+            hint="Test hint"
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testForm-testField',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testForm-testField-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-testField-hint',
+    );
+  });
+
+  test('renders with correct defaults ids without form', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextArea
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testField',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testField-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testField-hint',
+    );
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <Form id="testForm">
+          <FormFieldTextArea
+            id="customId"
+            name="testField"
+            label="Test field"
+            hint="Test hint"
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testForm-customId',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testForm-customId-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-customId-hint',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextArea
+          id="customId"
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'customId',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'customId-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'customId-hint',
+    );
+  });
+
+  test('trims the value on blur by default', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextArea name="testField" label="Test field" />
+      </Formik>,
+    );
+
+    userEvent.type(screen.getByLabelText('Test field'), '  trim me  ');
+    userEvent.tab();
+    expect(screen.getByLabelText('Test field')).toHaveValue('trim me');
+  });
+
+  test('does not trim the value on blur when `trimInput` is false', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextArea
+          name="testField"
+          label="Test field"
+          trimInput={false}
+        />
+      </Formik>,
+    );
+
+    userEvent.type(screen.getByLabelText('Test field'), '  do not trim me  ');
+    userEvent.tab();
+    expect(screen.getByLabelText('Test field')).toHaveValue(
+      '  do not trim me  ',
+    );
+  });
+
+  describe('error messages', () => {
+    test('does not display validation message when untouched', () => {
+      render(
+        <Formik
+          initialValues={{
+            testField: '',
+          }}
+          onSubmit={noop}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <FormFieldTextArea name="testField" label="Test field" />
+        </Formik>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+    });
+
+    test('displays validation message on blur', async () => {
+      render(
+        <Formik
+          initialValues={{
+            testField: '',
+          }}
+          onSubmit={noop}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <FormFieldTextArea name="testField" label="Test field" />
+        </Formik>,
+      );
+
+      userEvent.click(screen.getByLabelText('Test field'));
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).toBeInTheDocument();
+      });
+    });
+
+    test('displays validation message when form is submitted', async () => {
+      render(
+        <Formik
+          initialValues={{ testField: '' }}
+          onSubmit={noop}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          {props => (
+            <form onSubmit={props.handleSubmit}>
+              <FormFieldTextArea name="testField" label="Test field" />
+
+              <button type="submit">Submit</button>
+            </form>
+          )}
+        </Formik>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByText('Submit'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message on blur when `showError` is false', async () => {
+      render(
+        <Formik
+          initialValues={{
+            testField: '',
+          }}
+          onSubmit={noop}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <FormFieldTextArea
+            name="testField"
+            label="Test field"
+            showError={false}
+          />
+        </Formik>,
+      );
+
+      userEvent.click(screen.getByLabelText('Test field'));
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message when `showError` is false and form is submitted', async () => {
+      render(
+        <Formik
+          initialValues={{
+            testField: '',
+          }}
+          onSubmit={noop}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          {props => (
+            <form onSubmit={props.handleSubmit}>
+              <FormFieldTextArea
+                name="testField"
+                label="Test field"
+                showError={false}
+              />
+
+              <button type="submit">Submit</button>
+            </form>
+          )}
+        </Formik>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByText('Submit'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldTextInput.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldTextInput.test.tsx
@@ -1,0 +1,318 @@
+import { Form } from '@common/components/form';
+import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Formik } from 'formik';
+import noop from 'lodash/noop';
+import React from 'react';
+import Yup from '@common/validation/yup';
+
+describe('FormFieldTextInput', () => {
+  test('renders correctly', () => {
+    const { container } = render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextInput name="testField" label="Test field" />
+      </Formik>,
+    );
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders with a hint correctly', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextInput
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testField-hint',
+    );
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testField-hint',
+    );
+  });
+
+  test('renders with correct defaults ids with form', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <Form id="testForm">
+          <FormFieldTextInput
+            name="testField"
+            label="Test field"
+            hint="Test hint"
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testForm-testField',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testForm-testField-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-testField-hint',
+    );
+  });
+
+  test('renders with correct defaults ids without form', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextInput
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testField',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testField-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testField-hint',
+    );
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <Form id="testForm">
+          <FormFieldTextInput
+            id="customId"
+            name="testField"
+            label="Test field"
+            hint="Test hint"
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testForm-customId',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testForm-customId-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-customId-hint',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextInput
+          id="customId"
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'customId',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'customId-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'customId-hint',
+    );
+  });
+
+  test('trims the value on blur by default', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextInput name="testField" label="Test field" />
+      </Formik>,
+    );
+
+    userEvent.type(screen.getByLabelText('Test field'), '  trim me  ');
+    userEvent.tab();
+    expect(screen.getByLabelText('Test field')).toHaveValue('trim me');
+  });
+
+  test('does not trim the value on blur when `trimInput` is false', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={noop}>
+        <FormFieldTextInput
+          name="testField"
+          label="Test field"
+          trimInput={false}
+        />
+      </Formik>,
+    );
+
+    userEvent.type(screen.getByLabelText('Test field'), '  do not trim me  ');
+    userEvent.tab();
+    expect(screen.getByLabelText('Test field')).toHaveValue(
+      '  do not trim me  ',
+    );
+  });
+
+  describe('error messages', () => {
+    test('does not display validation message when untouched', () => {
+      render(
+        <Formik
+          initialValues={{
+            testField: '',
+          }}
+          onSubmit={noop}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <FormFieldTextInput name="testField" label="Test field" />
+        </Formik>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+    });
+
+    test('displays validation message on blur', async () => {
+      render(
+        <Formik
+          initialValues={{
+            testField: '',
+          }}
+          onSubmit={noop}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <FormFieldTextInput name="testField" label="Test field" />
+        </Formik>,
+      );
+
+      userEvent.click(screen.getByLabelText('Test field'));
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).toBeInTheDocument();
+      });
+    });
+
+    test('displays validation message when form is submitted', async () => {
+      render(
+        <Formik
+          initialValues={{ testField: '' }}
+          onSubmit={noop}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          {props => (
+            <form onSubmit={props.handleSubmit}>
+              <FormFieldTextInput name="testField" label="Test field" />
+
+              <button type="submit">Submit</button>
+            </form>
+          )}
+        </Formik>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByText('Submit'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message on blur when `showError` is false', async () => {
+      render(
+        <Formik
+          initialValues={{
+            testField: '',
+          }}
+          onSubmit={noop}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <FormFieldTextInput
+            name="testField"
+            label="Test field"
+            showError={false}
+          />
+        </Formik>,
+      );
+
+      userEvent.click(screen.getByLabelText('Test field'));
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message when `showError` is false and form is submitted', async () => {
+      render(
+        <Formik
+          initialValues={{
+            testField: '',
+          }}
+          onSubmit={noop}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          {props => (
+            <form onSubmit={props.handleSubmit}>
+              <FormFieldTextInput
+                name="testField"
+                label="Test field"
+                showError={false}
+              />
+
+              <button type="submit">Submit</button>
+            </form>
+          )}
+        </Formik>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByText('Submit'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldTextArea.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldTextArea.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormFieldTextArea renders correctly 1`] = `
+<div class="govuk-form-group">
+  <label class="govuk-label"
+         for="testField"
+  >
+    Test field
+  </label>
+  <textarea class="govuk-textarea"
+            id="testField"
+            name="testField"
+            rows="5"
+  >
+  </textarea>
+</div>
+`;

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldTextInput.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldTextInput.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormFieldTextInput renders correctly 1`] = `
+<div class="govuk-form-group">
+  <label class="govuk-label"
+         for="testField"
+  >
+    Test field
+  </label>
+  <input name="testField"
+         class="govuk-input"
+         id="testField"
+         type="text"
+         value
+  >
+</div>
+`;

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormField.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormField.tsx
@@ -38,6 +38,7 @@ export type FormFieldProps<TFormValues> = {
   inputRef?: Ref<Element>;
   name: Path<TFormValues>;
   showError?: boolean;
+  trimInput?: boolean;
   onChange?: ChangeEventHandler;
   onBlur?: FocusEventHandler;
 };
@@ -57,6 +58,7 @@ export default function RHFFormField<
   inputRef,
   name,
   showError = true,
+  trimInput = false,
   onBlur,
   onChange,
   ...props
@@ -70,7 +72,7 @@ export default function RHFFormField<
     ref: fieldRef,
     onBlur: fieldOnBlur,
     onChange: fieldOnChange,
-  } = useRegister(name, register);
+  } = useRegister(name, register, trimInput);
 
   const { fieldId } = useFormIdContext();
 
@@ -111,10 +113,10 @@ export default function RHFFormField<
     customId,
     fieldRef,
     inputRef,
-    onChange,
     fieldOnChange,
-    onBlur,
     fieldOnBlur,
+    onBlur,
+    onChange,
   ]);
 
   return formGroup ? (

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldTextArea.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldTextArea.tsx
@@ -14,5 +14,12 @@ type Props<TFormValues extends FieldValues> = FormFieldComponentProps<
 export default function RHFFormFieldTextArea<TFormValues extends FieldValues>(
   props: Props<TFormValues>,
 ) {
-  return <RHFFormField {...props} as={RHFFormTextArea} />;
+  const { trimInput } = props;
+  return (
+    <RHFFormField
+      {...props}
+      as={RHFFormTextArea}
+      trimInput={trimInput ?? true}
+    />
+  );
 }

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldTextInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldTextInput.tsx
@@ -15,5 +15,8 @@ type Props<TFormValues extends FieldValues> = FormFieldComponentProps<
 export default function RHFFormFieldTextInput<TFormValues extends FieldValues>(
   props: Props<TFormValues>,
 ) {
-  return <RHFFormField {...props} as={FormTextInput} />;
+  const { trimInput } = props;
+  return (
+    <RHFFormField {...props} as={FormTextInput} trimInput={trimInput ?? true} />
+  );
 }

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldTextArea.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldTextArea.test.tsx
@@ -1,0 +1,326 @@
+import RHFFormFieldTextArea from '@common/components/form/rhf/RHFFormFieldTextArea';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import Yup from '@common/validation/yup';
+
+describe('RHFFormFieldTextArea', () => {
+  test('renders correctly', () => {
+    const { container } = render(
+      <FormProvider initialValues={{}}>
+        <RHFFormFieldTextArea name="testField" label="Test field" />
+      </FormProvider>,
+    );
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders with a hint correctly', () => {
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFFormFieldTextArea
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testField-hint',
+    );
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testField-hint',
+    );
+  });
+
+  test('renders with correct defaults ids with form', () => {
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldTextArea
+            name="testField"
+            label="Test field"
+            hint="Test hint"
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testForm-testField',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testForm-testField-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-testField-hint',
+    );
+  });
+
+  test('renders with correct defaults ids without form', () => {
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFFormFieldTextArea
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testField',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testField-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testField-hint',
+    );
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldTextArea
+            id="customId"
+            name="testField"
+            label="Test field"
+            hint="Test hint"
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testForm-customId',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testForm-customId-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-customId-hint',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFFormFieldTextArea
+          id="customId"
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'customId',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'customId-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'customId-hint',
+    );
+  });
+
+  test('trims the value by default when the form is submitted', async () => {
+    const handleSubmit = jest.fn();
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={handleSubmit}>
+          <RHFFormFieldTextArea name="testField" label="Test field" />{' '}
+          <button type="submit">Submit</button>
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    userEvent.type(screen.getByLabelText('Test field'), '  trim me  ');
+    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({ testField: 'trim me' });
+    });
+  });
+
+  test('does not trim the value when the form is submitted when `trimInput` is false', async () => {
+    const handleSubmit = jest.fn();
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={handleSubmit}>
+          <RHFFormFieldTextArea
+            name="testField"
+            label="Test field"
+            trimInput={false}
+          />
+          <button type="submit">Submit</button>
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    userEvent.type(screen.getByLabelText('Test field'), '  do not trim me  ');
+    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        testField: '  do not trim me  ',
+      });
+    });
+  });
+
+  describe('error messages', () => {
+    test('does not display validation message when untouched', () => {
+      render(
+        <FormProvider
+          initialValues={{
+            testField: '',
+          }}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <RHFFormFieldTextArea name="testField" label="Test field" />
+        </FormProvider>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+    });
+
+    test('displays validation message on blur', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            testField: '',
+          }}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <RHFFormFieldTextArea name="testField" label="Test field" />
+        </FormProvider>,
+      );
+
+      userEvent.click(screen.getByLabelText('Test field'));
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).toBeInTheDocument();
+      });
+    });
+
+    test('displays validation message when form is submitted', async () => {
+      render(
+        <FormProvider
+          initialValues={{ testField: '' }}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <RHFForm
+            id="testForm"
+            showErrorSummary={false}
+            onSubmit={Promise.resolve}
+          >
+            <RHFFormFieldTextArea name="testField" label="Test field" />
+
+            <button type="submit">Submit</button>
+          </RHFForm>
+        </FormProvider>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByText('Submit'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message on blur when `showError` is false', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            testField: '',
+          }}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <RHFFormFieldTextArea
+            name="testField"
+            label="Test field"
+            showError={false}
+          />
+        </FormProvider>,
+      );
+
+      userEvent.click(screen.getByLabelText('Test field'));
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message when `showError` is false and form is submitted', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            testField: '',
+          }}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <RHFForm id="testForm" onSubmit={Promise.resolve}>
+            <RHFFormFieldTextArea
+              name="testField"
+              label="Test field"
+              showError={false}
+            />
+
+            <button type="submit">Submit</button>
+          </RHFForm>
+        </FormProvider>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByText('Submit'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldTextInput.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldTextInput.test.tsx
@@ -1,0 +1,326 @@
+import RHFFormFieldTextInput from '@common/components/form/rhf/RHFFormFieldTextInput';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import Yup from '@common/validation/yup';
+
+describe('RHFFormFieldTextInput', () => {
+  test('renders correctly', () => {
+    const { container } = render(
+      <FormProvider initialValues={{}}>
+        <RHFFormFieldTextInput name="testField" label="Test field" />
+      </FormProvider>,
+    );
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders with a hint correctly', () => {
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFFormFieldTextInput
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testField-hint',
+    );
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testField-hint',
+    );
+  });
+
+  test('renders with correct defaults ids with form', () => {
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldTextInput
+            name="testField"
+            label="Test field"
+            hint="Test hint"
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testForm-testField',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testForm-testField-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-testField-hint',
+    );
+  });
+
+  test('renders with correct defaults ids without form', () => {
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFFormFieldTextInput
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testField',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testField-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testField-hint',
+    );
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldTextInput
+            id="customId"
+            name="testField"
+            label="Test field"
+            hint="Test hint"
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'testForm-customId',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'testForm-customId-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-customId-hint',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFFormFieldTextInput
+          id="customId"
+          name="testField"
+          label="Test field"
+          hint="Test hint"
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'id',
+      'customId',
+    );
+
+    expect(screen.getByLabelText('Test field')).toHaveAttribute(
+      'aria-describedby',
+      'customId-hint',
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'customId-hint',
+    );
+  });
+
+  test('trims the value by default when the form is submitted', async () => {
+    const handleSubmit = jest.fn();
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={handleSubmit}>
+          <RHFFormFieldTextInput name="testField" label="Test field" />
+          <button type="submit">Submit</button>
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    userEvent.type(screen.getByLabelText('Test field'), '  trim me  ');
+    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({ testField: 'trim me' });
+    });
+  });
+
+  test('does not trim the value when the form is submitted when `trimInput` is false', async () => {
+    const handleSubmit = jest.fn();
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={handleSubmit}>
+          <RHFFormFieldTextInput
+            name="testField"
+            label="Test field"
+            trimInput={false}
+          />
+          <button type="submit">Submit</button>
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    userEvent.type(screen.getByLabelText('Test field'), '  do not trim me  ');
+    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        testField: '  do not trim me  ',
+      });
+    });
+  });
+
+  describe('error messages', () => {
+    test('does not display validation message when untouched', () => {
+      render(
+        <FormProvider
+          initialValues={{
+            testField: '',
+          }}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <RHFFormFieldTextInput name="testField" label="Test field" />
+        </FormProvider>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+    });
+
+    test('displays validation message on blur', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            testField: '',
+          }}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <RHFFormFieldTextInput name="testField" label="Test field" />
+        </FormProvider>,
+      );
+
+      userEvent.click(screen.getByLabelText('Test field'));
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).toBeInTheDocument();
+      });
+    });
+
+    test('displays validation message when form is submitted', async () => {
+      render(
+        <FormProvider
+          initialValues={{ testField: '' }}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <RHFForm
+            id="testForm"
+            showErrorSummary={false}
+            onSubmit={Promise.resolve}
+          >
+            <RHFFormFieldTextInput name="testField" label="Test field" />
+
+            <button type="submit">Submit</button>
+          </RHFForm>
+        </FormProvider>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByText('Submit'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message on blur when `showError` is false', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            testField: '',
+          }}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <RHFFormFieldTextInput
+            name="testField"
+            label="Test field"
+            showError={false}
+          />
+        </FormProvider>,
+      );
+
+      userEvent.click(screen.getByLabelText('Test field'));
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message when `showError` is false and form is submitted', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            testField: '',
+          }}
+          validationSchema={Yup.object({
+            testField: Yup.string().required('Field required'),
+          })}
+        >
+          <RHFForm id="testForm" onSubmit={Promise.resolve}>
+            <RHFFormFieldTextInput
+              name="testField"
+              label="Test field"
+              showError={false}
+            />
+
+            <button type="submit">Submit</button>
+          </RHFForm>
+        </FormProvider>,
+      );
+
+      expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByText('Submit'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Field required')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/__snapshots__/RHFFormFieldTextArea.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/__snapshots__/RHFFormFieldTextArea.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RHFFormFieldTextArea renders correctly 1`] = `
+<div class="govuk-form-group">
+  <label class="govuk-label"
+         for="testField"
+  >
+    Test field
+  </label>
+  <textarea class="govuk-textarea"
+            id="testField"
+            name="testField"
+            rows="5"
+  >
+  </textarea>
+</div>
+`;

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/__snapshots__/RHFFormFieldTextInput.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/__snapshots__/RHFFormFieldTextInput.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RHFFormFieldTextInput renders correctly 1`] = `
+<div class="govuk-form-group">
+  <label class="govuk-label"
+         for="testField"
+  >
+    Test field
+  </label>
+  <input name="testField"
+         class="govuk-input"
+         id="testField"
+         type="text"
+         value
+  >
+</div>
+`;

--- a/src/explore-education-statistics-common/src/components/form/rhf/hooks/useRegister.ts
+++ b/src/explore-education-statistics-common/src/components/form/rhf/hooks/useRegister.ts
@@ -16,7 +16,14 @@ export default function useRegister<
 >(
   name: TFieldName,
   register: UseFormRegister<TFieldValues>,
+  trimInput = false,
 ): UseFormRegisterReturn<TFieldName> {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useMemo(() => register(name), [name]);
+  return useMemo(
+    () =>
+      register(name, {
+        setValueAs: value => (trimInput ? value.trim() : value),
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [name, trimInput],
+  );
 }


### PR DESCRIPTION
Automatically trims whitespace in the React Hook Form and Formik versions of the `FormFieldTextInput` and `FormFieldTextArea` components .

I've ended up with different implementations for RHF and Formik which isn't ideal but I think the RHF version is better and we'll hopefully be rid of Formik soonish.

RHF:
- uses `setValueAs` on `register` to trim the input, this runs before validation when the form is submitted, see https://react-hook-form.com/docs/useform/register
- it's controlled by an optional `trimInput` param 
- `RHFFormFieldTextInput` and `RHFFormFieldTextArea` set `trimInput` to true by default but it can be overriden

Formik:
- trims the inputs on blur
- it's controlled by an optional `trimInput` param 
- `FormFieldTextInput` and `FormFieldTextArea` set `trimInput` to true by default but it can be overriden
- for inputs it also trims (by blurring the field) when you press Enter, without this the trim won't happen if you submit the form with Enter. This doesn't happen for textareas as Enter adds a new line rather than submitting the form.

Also:
I've added some manual trimming for `FormSearchBar` as it doesn't use the standard `FormFieldX` components.