### PR TITLE
Updating Robot test harness to take non-resized screenshots as well as full-height screenshots

### DIFF
--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -29,7 +29,7 @@ do this on failure
     ${currently_failing_fast}=    current test suite failing fast
 
     IF    "${currently_failing_fast}" == "${FALSE}"
-        capture large screenshot and html
+        capture screenshots and html
 
         # Additionally, mark the current Test Suite as failing if the "FAIL_TEST_SUITES_FAST" option is enabled, and
         # this will cause subsequent tests within this same Test Suite to fail immediately (by virtue of their "Test

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -3,7 +3,6 @@ import datetime
 import json
 import os
 import re
-import time
 from typing import Union
 from urllib.parse import urlparse
 
@@ -249,7 +248,8 @@ def capture_large_screenshot_and_prompt_to_continue():
     prompt_to_continue()
 
 
-def capture_large_screenshot_and_html():
+def capture_screenshots_and_html():
+    visual.capture_screenshot()
     visual.capture_large_screenshot()
     capture_html()
 

--- a/tests/robot-tests/tests/libs/visual.py
+++ b/tests/robot-tests/tests/libs/visual.py
@@ -45,10 +45,19 @@ def highlight_element(element: WebElement):
     sl.driver.execute_script("arguments[0].style.border = 'red 4px solid';", element)
 
 
+def capture_screenshot():
+    screenshot_location = sl.capture_page_screenshot()
+    logger.warn(
+        f"Captured current screenshot at URL '{sl.get_location()}' Screenshot saved to file://{screenshot_location}"
+    )
+
+
 @with_maximised_browser
 def capture_large_screenshot():
     screenshot_location = sl.capture_page_screenshot()
-    logger.warn(f"Captured a screenshot at URL '{sl.get_location()}' Screenshot saved to file://{screenshot_location}")
+    logger.warn(
+        f"Captured enlarged screenshot at URL '{sl.get_location()}' Screenshot saved to file://{screenshot_location}"
+    )
 
 
 @with_no_overflow


### PR DESCRIPTION
This PR:
- allows Robot to take a screenshot of what it was actually seeing at the point that it failed, as well as a full-height version of that page as well.

## Before

Before, if we were getting for example an error whereby a test was not able to click on a Save button, all we were able to get was a full-height screenshot like so, which didn't help too much:

![selenium-screenshot-2](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/c9e30524-66a6-4a68-b2fa-6d6498e9ffe6)

## Now

Now, we will also get a screenshot like this, which is what Robot actually sees at the point of failure and that will hopefully make the debugging process a lot easier:

![selenium-screenshot-1](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/98072cbb-4b9d-4c91-a82b-9baa7deddc29)

Here we can easily see that we can't click on the "Save" button because it is covered over.