### PR TITLE
EES-4544 comments on data and embed blocks

### DIFF
--- a/src/explore-education-statistics-admin/src/components/comments/CommentAddForm.module.scss
+++ b/src/explore-education-statistics-admin/src/components/comments/CommentAddForm.module.scss
@@ -4,10 +4,14 @@
 .container {
   background: govuk-colour('white');
   border: 1px solid govuk-colour('dark-grey');
-  margin-left: -$dfe-comments-gutter/2;
+  margin-bottom: govuk-spacing(2);
   padding: govuk-spacing(2);
-  position: absolute;
-  top: 0;
-  width: $dfe-comments-width;
-  z-index: 9;
+
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: 0;
+    position: absolute;
+    top: 0;
+    z-index: 9;
+    width: $dfe-comments-width - $dfe-comments-gutter;
+  }
 }

--- a/src/explore-education-statistics-admin/src/components/comments/CommentAddForm.tsx
+++ b/src/explore-education-statistics-admin/src/components/comments/CommentAddForm.tsx
@@ -22,7 +22,12 @@ interface Props {
   onSave: () => void;
 }
 
-const CommentAddForm = ({ baseId, containerRef, onCancel, onSave }: Props) => {
+export default function CommentAddForm({
+  baseId,
+  containerRef,
+  onCancel,
+  onSave,
+}: Props) {
   const { addComment, setCurrentInteraction } = useCommentsContext();
 
   const ref = useRef<HTMLDivElement>(null);
@@ -46,7 +51,11 @@ const CommentAddForm = ({ baseId, containerRef, onCancel, onSave }: Props) => {
   };
 
   return (
-    <div className={classNames(styles.container, positionStyle)} ref={ref}>
+    <div
+      className={classNames(styles.container, positionStyle)}
+      data-testid="comment-add-form"
+      ref={ref}
+    >
       <FormProvider
         initialValues={{
           content: '',
@@ -73,6 +82,7 @@ const CommentAddForm = ({ baseId, containerRef, onCancel, onSave }: Props) => {
                 <Button type="submit" disabled={formState.isSubmitting}>
                   Add comment
                 </Button>
+
                 <ButtonText
                   onClick={() => {
                     setCurrentInteraction?.({
@@ -91,6 +101,4 @@ const CommentAddForm = ({ baseId, containerRef, onCancel, onSave }: Props) => {
       </FormProvider>
     </div>
   );
-};
-
-export default CommentAddForm;
+}

--- a/src/explore-education-statistics-admin/src/components/comments/CommentEditForm.tsx
+++ b/src/explore-education-statistics-admin/src/components/comments/CommentEditForm.tsx
@@ -21,7 +21,12 @@ interface Props {
   onSubmit: () => void;
 }
 
-const CommentEditForm = ({ comment, id, onCancel, onSubmit }: Props) => {
+export default function CommentEditForm({
+  comment,
+  id,
+  onCancel,
+  onSubmit,
+}: Props) {
   const { content } = comment;
 
   const { updateComment } = useCommentsContext();
@@ -74,6 +79,4 @@ const CommentEditForm = ({ comment, id, onCancel, onSubmit }: Props) => {
       }}
     </FormProvider>
   );
-};
-
-export default CommentEditForm;
+}

--- a/src/explore-education-statistics-admin/src/components/comments/CommentsList.tsx
+++ b/src/explore-education-statistics-admin/src/components/comments/CommentsList.tsx
@@ -1,17 +1,18 @@
-import Comment from '@admin/components/comments/Comment';
+import Comment, { CommentType } from '@admin/components/comments/Comment';
 import styles from '@admin/components/comments/CommentsList.module.scss';
 import { useCommentsContext } from '@admin/contexts/CommentsContext';
 import Details from '@common/components/Details';
+import { useDesktopMedia } from '@common/hooks/useMedia';
 import sortBy from 'lodash/sortBy';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 interface Props {
   className?: string;
+  type: CommentType;
 }
 
-const CommentsList = ({ className }: Props) => {
+export default function CommentsList({ className, type }: Props) {
   const { comments, markersOrder } = useCommentsContext();
-
   const resolvedComments = comments.filter(comment => comment.resolved);
   const unresolvedComments = sortBy(
     comments.filter(comment => !comment.resolved),
@@ -21,24 +22,44 @@ const CommentsList = ({ className }: Props) => {
   return (
     <div className={className}>
       {unresolvedComments.length > 0 && (
-        <ol className={styles.list} data-testid="unresolvedComments">
-          {unresolvedComments.map(comment => (
-            <Comment key={comment.id} comment={comment} />
-          ))}
-        </ol>
+        <UnresolvedCommentsWrapper total={unresolvedComments.length}>
+          <ol className={styles.list} data-testid="comments-unresolved">
+            {unresolvedComments.map(comment => (
+              <Comment key={comment.id} comment={comment} type={type} />
+            ))}
+          </ol>
+        </UnresolvedCommentsWrapper>
       )}
 
       {resolvedComments.length > 0 && (
         <Details summary={`Resolved comments (${resolvedComments.length})`}>
-          <ol className={styles.list} data-testid="resolvedComments">
+          <ol className={styles.list} data-testid="comments-resolved">
             {resolvedComments.map(comment => (
-              <Comment key={comment.id} comment={comment} />
+              <Comment key={comment.id} comment={comment} type={type} />
             ))}
           </ol>
         </Details>
       )}
     </div>
   );
-};
+}
 
-export default CommentsList;
+function UnresolvedCommentsWrapper({
+  children,
+  total,
+}: {
+  children: ReactNode;
+  total: number;
+}) {
+  const { isMedia: isDesktopMedia } = useDesktopMedia();
+
+  if (isDesktopMedia) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Details open summary={`View comments (${total})`}>
+      {children}
+    </Details>
+  );
+}

--- a/src/explore-education-statistics-admin/src/components/comments/CommentsWrapper.module.scss
+++ b/src/explore-education-statistics-admin/src/components/comments/CommentsWrapper.module.scss
@@ -1,0 +1,43 @@
+@import '~govuk-frontend/govuk/base';
+@import '@admin/styles/variables';
+
+@include govuk-media-query($from: desktop) {
+  .container {
+    display: flex;
+    margin-left: -$dfe-comments-width;
+    position: relative;
+  }
+
+  .sidebar {
+    bottom: 0;
+    margin-right: $dfe-comments-gutter;
+    padding: 2px;
+    position: absolute;
+    top: 0;
+    width: $dfe-comments-width - $dfe-comments-gutter;
+  }
+
+  .list {
+    max-height: calc(100% - 46px);
+    overflow-y: auto;
+
+    &.inline {
+      max-height: 100%;
+    }
+
+    &.formOpen {
+      margin-top: $dfe-comments-form-height;
+      max-height: calc(100% - #{$dfe-comments-form-height});
+    }
+  }
+
+  .block {
+    margin-left: $dfe-comments-width;
+    max-width: calc(100% - #{$dfe-comments-width});
+    width: 100%;
+  }
+
+  .button {
+    width: 100%;
+  }
+}

--- a/src/explore-education-statistics-admin/src/components/comments/CommentsWrapper.tsx
+++ b/src/explore-education-statistics-admin/src/components/comments/CommentsWrapper.tsx
@@ -1,0 +1,104 @@
+import styles from '@admin/components/comments/CommentsWrapper.module.scss';
+import { CommentType } from '@admin/components/comments/Comment';
+import CommentAddForm from '@admin/components/comments/CommentAddForm';
+import CommentsList from '@admin/components/comments/CommentsList';
+import { useCommentsContext } from '@admin/contexts/CommentsContext';
+import React, { ReactNode, useRef } from 'react';
+import classNames from 'classnames';
+import Button from '@common/components/Button';
+import Tooltip from '@common/components/Tooltip';
+
+interface Props {
+  allowComments?: boolean;
+  blockLockedMessage?: string;
+  children: ReactNode;
+  commentType: CommentType;
+  id: string;
+  showCommentAddForm?: boolean;
+  showCommentsList?: boolean;
+  testId?: string;
+  onAdd?: () => void;
+  onAddCancel?: () => void;
+  onAddSave?: () => void;
+  onViewComments?: () => void;
+}
+
+export default function CommentsWrapper({
+  allowComments = true,
+  blockLockedMessage,
+  children,
+  id,
+  commentType,
+  showCommentAddForm,
+  showCommentsList = true,
+  testId,
+  onAdd,
+  onAddCancel,
+  onAddSave,
+  onViewComments,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { comments } = useCommentsContext();
+  const isInline = commentType === 'inline';
+
+  return (
+    <div className={styles.container} ref={containerRef} data-testid={testId}>
+      {allowComments && (
+        <div className={styles.sidebar} data-testid="comments-sidebar">
+          {showCommentAddForm && onAddCancel && onAddSave && (
+            <CommentAddForm
+              baseId={id}
+              containerRef={containerRef}
+              onCancel={onAddCancel}
+              onSave={onAddSave}
+            />
+          )}
+          {!showCommentAddForm && !isInline && (
+            <Button
+              className={`${styles.button} govuk-!-margin-bottom-2`}
+              testId="comment-add-button"
+              variant="secondary"
+              onClick={onAdd}
+            >
+              Add comment
+            </Button>
+          )}
+
+          {!showCommentsList && comments.length > 0 && (
+            <Tooltip text={blockLockedMessage} enabled={!!blockLockedMessage}>
+              {({ ref }) => (
+                <Button
+                  ariaDisabled={!!blockLockedMessage}
+                  className={styles.button}
+                  ref={ref}
+                  testId="view-comments"
+                  variant="secondary"
+                  onClick={onViewComments}
+                >
+                  View comments
+                  <br />
+                  <span className="govuk-!-margin-top-1 govuk-body-s">
+                    {`(${
+                      comments.filter(comment => !comment.resolved).length
+                    } unresolved)`}
+                  </span>
+                </Button>
+              )}
+            </Tooltip>
+          )}
+
+          {showCommentsList && comments.length > 0 && (
+            <CommentsList
+              className={classNames(styles.list, {
+                [styles.inline]: isInline,
+                [styles.formOpen]: showCommentAddForm,
+              })}
+              type={commentType}
+            />
+          )}
+        </div>
+      )}
+      <div className={styles.block}>{children}</div>
+    </div>
+  );
+}

--- a/src/explore-education-statistics-admin/src/components/comments/__tests__/Comment.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/comments/__tests__/Comment.test.tsx
@@ -21,98 +21,203 @@ describe('Comment', () => {
     permissions: {} as GlobalPermissions,
   };
 
-  test('renders an unresolved comment correctly', () => {
-    render(<Comment comment={testComments[2]} />);
+  describe('inline comments', () => {
+    test('renders an unresolved comment correctly', () => {
+      render(<Comment type="inline" comment={testComments[2]} />);
 
-    const comment = screen.getByTestId('comment');
-    expect(comment).toHaveTextContent('Comment 3');
-    expect(comment).toHaveTextContent('User Two');
-    expect(comment).toHaveTextContent('30 Nov 2021, 13:55');
+      const comment = screen.getByTestId('comment');
+      expect(comment).toHaveTextContent('Comment 3');
+      expect(comment).toHaveTextContent('User Two');
+      expect(comment).toHaveTextContent('30 Nov 2021, 13:55');
 
-    expect(screen.getByRole('button', { name: 'Resolve' })).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Unresolve' }),
-    ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Resolve' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Unresolve' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('renders the edit and delete buttons if the user created the comment', () => {
+      render(
+        <AuthContext.Provider
+          value={{
+            user: testUser2,
+          }}
+        >
+          <Comment type="inline" comment={testComments[2]} />,
+        </AuthContext.Provider>,
+      );
+
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Delete' }),
+      ).toBeInTheDocument();
+    });
+
+    test('does not render the edit and delete buttons if the user did not create the comment', () => {
+      render(
+        <AuthContext.Provider
+          value={{
+            user: testUser1,
+          }}
+        >
+          <Comment type="inline" comment={testComments[2]} />,
+        </AuthContext.Provider>,
+      );
+
+      expect(
+        screen.queryByRole('button', { name: 'Edit' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Delete' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('renders an updated comment correctly', () => {
+      const updatedComment = {
+        ...testComments[2],
+        updated: '2021-11-30T14:00',
+      };
+      render(<Comment type="inline" comment={updatedComment} />);
+
+      const comment = screen.getByTestId('comment');
+      expect(comment).toHaveTextContent('Comment 3');
+      expect(comment).toHaveTextContent('30 Nov 2021, 13:55');
+      expect(comment).toHaveTextContent('(Updated 30 Nov 2021, 14:00)');
+    });
+
+    test('renders a resolved comment correctly', () => {
+      render(
+        <AuthContext.Provider
+          value={{
+            user: testUser1,
+          }}
+        >
+          <Comment type="inline" comment={testComments[0]} />
+        </AuthContext.Provider>,
+      );
+
+      const comment = screen.getByTestId('comment');
+      expect(comment).toHaveTextContent('Comment 1');
+      expect(comment).toHaveTextContent('User One');
+      expect(comment).toHaveTextContent('29 Nov 2021, 13:55');
+      expect(comment).toHaveTextContent(
+        'Resolved by User Two on 30 Nov 2021, 13:55',
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'Unresolve' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Resolve' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Edit' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Delete' }),
+      ).not.toBeInTheDocument();
+    });
   });
 
-  test('renders the edit and delete buttons if the user created the comment', () => {
-    render(
-      <AuthContext.Provider
-        value={{
-          user: testUser2,
-        }}
-      >
-        <Comment comment={testComments[2]} />,
-      </AuthContext.Provider>,
-    );
+  describe('block comments', () => {
+    test('renders an unresolved comment correctly', () => {
+      render(<Comment type="block" comment={testComments[2]} />);
 
-    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
-  });
+      const comment = screen.getByTestId('comment');
+      expect(comment).toHaveTextContent('Comment 3');
+      expect(comment).toHaveTextContent('User Two');
+      expect(comment).toHaveTextContent('30 Nov 2021, 13:55');
 
-  test('does not render the edit and delete buttons if the user did not create the comment', () => {
-    render(
-      <AuthContext.Provider
-        value={{
-          user: testUser1,
-        }}
-      >
-        <Comment comment={testComments[2]} />,
-      </AuthContext.Provider>,
-    );
+      expect(
+        screen.getByRole('button', { name: 'Resolve' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Unresolve' }),
+      ).not.toBeInTheDocument();
+    });
 
-    expect(
-      screen.queryByRole('button', { name: 'Edit' }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Delete' }),
-    ).not.toBeInTheDocument();
-  });
+    test('renders the edit and delete buttons if the user created the comment', () => {
+      render(
+        <AuthContext.Provider
+          value={{
+            user: testUser2,
+          }}
+        >
+          <Comment type="block" comment={testComments[2]} />,
+        </AuthContext.Provider>,
+      );
 
-  test('renders an updated comment correctly', () => {
-    const updatedComment = {
-      ...testComments[2],
-      updated: '2021-11-30T14:00',
-    };
-    render(<Comment comment={updatedComment} />);
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Delete' }),
+      ).toBeInTheDocument();
+    });
 
-    const comment = screen.getByTestId('comment');
-    expect(comment).toHaveTextContent('Comment 3');
-    expect(comment).toHaveTextContent(
-      '30 Nov 2021, 13:55(Updated 30 Nov 2021, 14:00)',
-    );
-  });
+    test('does not render the edit and delete buttons if the user did not create the comment', () => {
+      render(
+        <AuthContext.Provider
+          value={{
+            user: testUser1,
+          }}
+        >
+          <Comment type="block" comment={testComments[2]} />,
+        </AuthContext.Provider>,
+      );
 
-  test('renders a resolved comment correctly', () => {
-    render(
-      <AuthContext.Provider
-        value={{
-          user: testUser1,
-        }}
-      >
-        <Comment comment={testComments[0]} />
-      </AuthContext.Provider>,
-    );
+      expect(
+        screen.queryByRole('button', { name: 'Edit' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Delete' }),
+      ).not.toBeInTheDocument();
+    });
 
-    const comment = screen.getByTestId('comment');
-    expect(comment).toHaveTextContent('Comment 1');
-    expect(comment).toHaveTextContent('User One');
-    expect(comment).toHaveTextContent('29 Nov 2021, 13:55');
-    expect(comment).toHaveTextContent(
-      'Resolved by User Two on 30 Nov 2021, 13:55',
-    );
+    test('renders an updated comment correctly', () => {
+      const updatedComment = {
+        ...testComments[2],
+        updated: '2021-11-30T14:00',
+      };
+      render(<Comment type="block" comment={updatedComment} />);
 
-    expect(
-      screen.getByRole('button', { name: 'Unresolve' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Resolve' }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Edit' }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Delete' }),
-    ).not.toBeInTheDocument();
+      const comment = screen.getByTestId('comment');
+      expect(comment).toHaveTextContent('Comment 3');
+      expect(comment).toHaveTextContent('30 Nov 2021, 13:55');
+      expect(comment).toHaveTextContent('(Updated 30 Nov 2021, 14:00)');
+    });
+
+    test('renders a resolved comment correctly', () => {
+      render(
+        <AuthContext.Provider
+          value={{
+            user: testUser1,
+          }}
+        >
+          <Comment type="block" comment={testComments[0]} />
+        </AuthContext.Provider>,
+      );
+
+      const comment = screen.getByTestId('comment');
+      expect(comment).toHaveTextContent('Comment 1');
+      expect(comment).toHaveTextContent('User One');
+      expect(comment).toHaveTextContent('29 Nov 2021, 13:55');
+      expect(comment).toHaveTextContent(
+        'Resolved by User Two on 30 Nov 2021, 13:55',
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'Unresolve' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Resolve' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Edit' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Delete' }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/explore-education-statistics-admin/src/components/comments/__tests__/CommentAddForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/comments/__tests__/CommentAddForm.test.tsx
@@ -47,9 +47,9 @@ describe('CommentAddForm', () => {
     render(
       <CommentsContextProvider
         comments={[]}
-        onDelete={noop}
+        onDelete={() => Promise.resolve()}
         onCreate={handleSaveComment}
-        onUpdate={noop}
+        onUpdate={() => Promise.resolve()}
         onPendingDelete={noop}
         onPendingDeleteUndo={noop}
       >

--- a/src/explore-education-statistics-admin/src/components/comments/__tests__/CommentEditForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/comments/__tests__/CommentEditForm.test.tsx
@@ -107,7 +107,7 @@ describe('CommentEditForm', () => {
     render(
       <CommentsContextProvider
         comments={[]}
-        onDelete={noop}
+        onDelete={() => Promise.resolve()}
         onCreate={jest.fn()}
         onUpdate={handleUpdateComment}
         onPendingDelete={noop}

--- a/src/explore-education-statistics-admin/src/components/comments/__tests__/CommentsList.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/comments/__tests__/CommentsList.test.tsx
@@ -14,18 +14,18 @@ describe('CommentsList', () => {
       <CommentsContextProvider
         comments={testComments}
         markersOrder={testMarkersOrder}
-        onDelete={noop}
+        onDelete={() => Promise.resolve()}
         onCreate={jest.fn()}
-        onUpdate={noop}
+        onUpdate={() => Promise.resolve()}
         onPendingDelete={noop}
         onPendingDeleteUndo={noop}
       >
-        <CommentsList />
+        <CommentsList type="inline" />
       </CommentsContextProvider>,
     );
 
     const unresolvedComments = within(
-      screen.getByTestId('unresolvedComments'),
+      screen.getByTestId('comments-unresolved'),
     ).getAllByTestId('comment');
 
     expect(unresolvedComments).toHaveLength(3);
@@ -39,13 +39,13 @@ describe('CommentsList', () => {
       <CommentsContextProvider
         comments={testComments}
         markersOrder={testMarkersOrder}
-        onDelete={noop}
+        onDelete={() => Promise.resolve()}
         onCreate={jest.fn()}
-        onUpdate={noop}
+        onUpdate={() => Promise.resolve()}
         onPendingDelete={noop}
         onPendingDeleteUndo={noop}
       >
-        <CommentsList />
+        <CommentsList type="inline" />
       </CommentsContextProvider>,
     );
 
@@ -60,7 +60,7 @@ describe('CommentsList', () => {
     ).toBeInTheDocument();
 
     const resolvedComments = within(
-      screen.getByTestId('resolvedComments'),
+      screen.getByTestId('comments-resolved'),
     ).getAllByTestId('comment');
 
     expect(resolvedComments).toHaveLength(2);

--- a/src/explore-education-statistics-admin/src/components/comments/__tests__/CommentsWrapper.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/comments/__tests__/CommentsWrapper.test.tsx
@@ -1,0 +1,332 @@
+import CommentsWrapper from '@admin/components/comments/CommentsWrapper';
+import { testComments } from '@admin/components/comments/__data__/testComments';
+import { CommentsContextProvider } from '@admin/contexts/CommentsContext';
+import { render, screen } from '@testing-library/react';
+import noop from 'lodash/noop';
+import React from 'react';
+
+describe('CommentsWrapper', () => {
+  test('renders the child element', () => {
+    render(
+      <CommentsContextProvider
+        comments={testComments}
+        onDelete={() => Promise.resolve()}
+        onCreate={jest.fn()}
+        onUpdate={() => Promise.resolve()}
+        onPendingDelete={noop}
+        onPendingDeleteUndo={noop}
+      >
+        <CommentsWrapper
+          commentType="inline"
+          id="id"
+          onAdd={noop}
+          onAddCancel={noop}
+          onAddSave={noop}
+        >
+          <p>child block</p>
+        </CommentsWrapper>
+      </CommentsContextProvider>,
+    );
+
+    expect(screen.getByText('child block')).toBeInTheDocument();
+  });
+
+  test('renders the add comment form when `showCommentAddForm` is true', () => {
+    render(
+      <CommentsContextProvider
+        comments={testComments}
+        onDelete={() => Promise.resolve()}
+        onCreate={jest.fn()}
+        onUpdate={() => Promise.resolve()}
+        onPendingDelete={noop}
+        onPendingDeleteUndo={noop}
+      >
+        <CommentsWrapper
+          commentType="inline"
+          id="id"
+          showCommentAddForm
+          onAdd={noop}
+          onAddCancel={noop}
+          onAddSave={noop}
+        >
+          <p>child block</p>
+        </CommentsWrapper>
+      </CommentsContextProvider>,
+    );
+
+    expect(screen.getByTestId('comment-add-form')).toBeInTheDocument();
+  });
+
+  test('does not render the add comment form when `showCommentAddForm` is false', () => {
+    render(
+      <CommentsContextProvider
+        comments={testComments}
+        onDelete={() => Promise.resolve()}
+        onCreate={jest.fn()}
+        onUpdate={() => Promise.resolve()}
+        onPendingDelete={noop}
+        onPendingDeleteUndo={noop}
+      >
+        <CommentsWrapper
+          commentType="inline"
+          id="id"
+          showCommentAddForm={false}
+          onAdd={noop}
+          onAddCancel={noop}
+          onAddSave={noop}
+        >
+          <p>child block</p>
+        </CommentsWrapper>
+      </CommentsContextProvider>,
+    );
+
+    expect(screen.queryByTestId('comment-add-form')).not.toBeInTheDocument();
+  });
+
+  test('renders the comments list when there are comments and `showCommentsList` is true', () => {
+    render(
+      <CommentsContextProvider
+        comments={testComments}
+        onDelete={() => Promise.resolve()}
+        onCreate={jest.fn()}
+        onUpdate={() => Promise.resolve()}
+        onPendingDelete={noop}
+        onPendingDeleteUndo={noop}
+      >
+        <CommentsWrapper
+          commentType="inline"
+          id="id"
+          showCommentsList
+          onAdd={noop}
+          onAddCancel={noop}
+          onAddSave={noop}
+        >
+          <p>child block</p>
+        </CommentsWrapper>
+      </CommentsContextProvider>,
+    );
+
+    expect(screen.getByTestId('comments-unresolved')).toBeInTheDocument();
+  });
+
+  test('does not render the comments list when there are no comments and `showCommentsList` is true', () => {
+    render(
+      <CommentsContextProvider
+        comments={[]}
+        onDelete={() => Promise.resolve()}
+        onCreate={jest.fn()}
+        onUpdate={() => Promise.resolve()}
+        onPendingDelete={noop}
+        onPendingDeleteUndo={noop}
+      >
+        <CommentsWrapper
+          commentType="inline"
+          id="id"
+          showCommentsList
+          onAdd={noop}
+          onAddCancel={noop}
+          onAddSave={noop}
+        >
+          <p>child block</p>
+        </CommentsWrapper>
+      </CommentsContextProvider>,
+    );
+
+    expect(screen.queryByTestId('comments-unresolved')).not.toBeInTheDocument();
+  });
+
+  test('does not render the comments list when there are comments and `showCommentsList` is false', () => {
+    render(
+      <CommentsContextProvider
+        comments={testComments}
+        onDelete={() => Promise.resolve()}
+        onCreate={jest.fn()}
+        onUpdate={() => Promise.resolve()}
+        onPendingDelete={noop}
+        onPendingDeleteUndo={noop}
+      >
+        <CommentsWrapper
+          commentType="inline"
+          id="id"
+          showCommentsList={false}
+          onAdd={noop}
+          onAddCancel={noop}
+          onAddSave={noop}
+        >
+          <p>child block</p>
+        </CommentsWrapper>
+      </CommentsContextProvider>,
+    );
+
+    expect(screen.queryByTestId('comments-unresolved')).not.toBeInTheDocument();
+  });
+
+  test('does not render the sidebar if allow comments is false', () => {
+    render(
+      <CommentsContextProvider
+        comments={testComments}
+        onDelete={() => Promise.resolve()}
+        onCreate={jest.fn()}
+        onUpdate={() => Promise.resolve()}
+        onPendingDelete={noop}
+        onPendingDeleteUndo={noop}
+      >
+        <CommentsWrapper
+          allowComments={false}
+          commentType="inline"
+          id="id"
+          showCommentsList
+          onAdd={noop}
+          onAddCancel={noop}
+          onAddSave={noop}
+        >
+          <p>child block</p>
+        </CommentsWrapper>
+      </CommentsContextProvider>,
+    );
+
+    expect(screen.queryByTestId('comments-sidebar')).not.toBeInTheDocument();
+  });
+
+  describe('inline comments', () => {
+    test('renders the view button when there are comments and `showCommentsList` is false', () => {
+      render(
+        <CommentsContextProvider
+          comments={testComments}
+          onDelete={() => Promise.resolve()}
+          onCreate={jest.fn()}
+          onUpdate={() => Promise.resolve()}
+          onPendingDelete={noop}
+          onPendingDeleteUndo={noop}
+        >
+          <CommentsWrapper
+            commentType="inline"
+            id="id"
+            showCommentsList={false}
+            onAdd={noop}
+            onAddCancel={noop}
+            onAddSave={noop}
+          >
+            <p>child block</p>
+          </CommentsWrapper>
+        </CommentsContextProvider>,
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'View comments (3 unresolved)' }),
+      ).toBeInTheDocument();
+    });
+
+    test('does not render the view button when there are comments and `showCommentsList` is true', () => {
+      render(
+        <CommentsContextProvider
+          comments={testComments}
+          onDelete={() => Promise.resolve()}
+          onCreate={jest.fn()}
+          onUpdate={() => Promise.resolve()}
+          onPendingDelete={noop}
+          onPendingDeleteUndo={noop}
+        >
+          <CommentsWrapper
+            commentType="inline"
+            id="id"
+            showCommentsList
+            onAdd={noop}
+            onAddCancel={noop}
+            onAddSave={noop}
+          >
+            <p>child block</p>
+          </CommentsWrapper>
+        </CommentsContextProvider>,
+      );
+
+      expect(
+        screen.queryByRole('button', { name: 'View comments (3 unresolved)' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('does not render the view button when there are no comments and `showCommentsList` is false', () => {
+      render(
+        <CommentsContextProvider
+          comments={[]}
+          onDelete={() => Promise.resolve()}
+          onCreate={jest.fn()}
+          onUpdate={() => Promise.resolve()}
+          onPendingDelete={noop}
+          onPendingDeleteUndo={noop}
+        >
+          <CommentsWrapper
+            commentType="inline"
+            id="id"
+            showCommentsList={false}
+            onAdd={noop}
+            onAddCancel={noop}
+            onAddSave={noop}
+          >
+            <p>child block</p>
+          </CommentsWrapper>
+        </CommentsContextProvider>,
+      );
+
+      expect(
+        screen.queryByRole('button', { name: 'View comments (3 unresolved)' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('block comments', () => {
+    test('renders the add comment button when `showCommentAddForm` is false', () => {
+      render(
+        <CommentsContextProvider
+          comments={testComments}
+          onDelete={() => Promise.resolve()}
+          onCreate={jest.fn()}
+          onUpdate={() => Promise.resolve()}
+          onPendingDelete={noop}
+          onPendingDeleteUndo={noop}
+        >
+          <CommentsWrapper
+            commentType="block"
+            id="id"
+            showCommentAddForm={false}
+            onAdd={noop}
+            onAddCancel={noop}
+            onAddSave={noop}
+          >
+            <p>child block</p>
+          </CommentsWrapper>
+        </CommentsContextProvider>,
+      );
+
+      expect(screen.getByTestId('comment-add-button')).toBeInTheDocument();
+    });
+
+    test('does not render the add comment button when `showCommentAddForm` is true', () => {
+      render(
+        <CommentsContextProvider
+          comments={testComments}
+          onDelete={() => Promise.resolve()}
+          onCreate={jest.fn()}
+          onUpdate={() => Promise.resolve()}
+          onPendingDelete={noop}
+          onPendingDeleteUndo={noop}
+        >
+          <CommentsWrapper
+            commentType="block"
+            id="id"
+            showCommentAddForm
+            onAdd={noop}
+            onAddCancel={noop}
+            onAddSave={noop}
+          >
+            <p>child block</p>
+          </CommentsWrapper>
+        </CommentsContextProvider>,
+      );
+
+      expect(
+        screen.queryByTestId('comment-add-button'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.module.scss
@@ -45,13 +45,3 @@ $locked-border-width: 4px;
   position: absolute;
   right: -#{$locked-border-width};
 }
-
-.commentsButtonContainer {
-  margin-left: -$dfe-comments-width;
-  position: absolute;
-  width: $dfe-comments-width - $dfe-comments-gutter;
-
-  button {
-    width: 100%;
-  }
-}

--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.tsx
@@ -1,5 +1,6 @@
 import EditableBlockLockedMessage from '@admin/components/editable/EditableBlockLockedMessage';
 import { useCommentsContext } from '@admin/contexts/CommentsContext';
+import CommentsWrapper from '@admin/components/comments/CommentsWrapper';
 import EditableBlockWrapper from '@admin/components/editable/EditableBlockWrapper';
 import EditableContentForm, {
   AltTextWarningMessage,
@@ -12,7 +13,6 @@ import {
   ImageUploadHandler,
 } from '@admin/utils/ckeditor/CustomUploadAdapter';
 import toHtml from '@admin/utils/markdown/toHtml';
-import Button from '@common/components/Button';
 import ContentHtml from '@common/components/ContentHtml';
 import Tooltip from '@common/components/Tooltip';
 import useToggle from '@common/hooks/useToggle';
@@ -160,36 +160,19 @@ const EditableContentBlock = ({
 
   const isEditable = editable && !isLoading && !lockedBy;
 
-  const disabledTooltip = lockedBy
+  const blockLockedMessage = lockedBy
     ? `This block is being edited by ${lockedBy?.displayName}`
     : undefined;
 
   return (
-    <>
-      {allowComments && comments.length > 0 && (
-        <div className={styles.commentsButtonContainer}>
-          <Tooltip text={disabledTooltip} enabled={!!disabledTooltip}>
-            {({ ref }) => (
-              <Button
-                ariaDisabled={!!disabledTooltip}
-                ref={ref}
-                testId="view-comments"
-                variant="secondary"
-                onClick={onEditing}
-              >
-                View comments
-                <br />
-                <span className="govuk-!-margin-top-1 govuk-body-s">
-                  {`(${
-                    comments.filter(comment => !comment.resolved).length
-                  } unresolved)`}
-                </span>
-              </Button>
-            )}
-          </Tooltip>
-        </div>
-      )}
-
+    <CommentsWrapper
+      allowComments={allowComments}
+      commentType="inline"
+      blockLockedMessage={blockLockedMessage}
+      id={id}
+      showCommentsList={false}
+      onViewComments={onEditing}
+    >
       {showAltTextMessage && <AltTextWarningMessage />}
 
       {locked && lockedBy && (
@@ -202,7 +185,7 @@ const EditableContentBlock = ({
         onEdit={editable ? onEditing : undefined}
         onDelete={editable ? onDelete : undefined}
       >
-        <Tooltip enabled={!!lockedBy} followMouse text={disabledTooltip}>
+        <Tooltip enabled={!!lockedBy} followMouse text={blockLockedMessage}>
           {({ ref }) => (
             // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
             <div
@@ -230,7 +213,7 @@ const EditableContentBlock = ({
           )}
         </Tooltip>
       </EditableBlockWrapper>
-    </>
+    </CommentsWrapper>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.module.scss
@@ -1,31 +1,7 @@
 @import '~govuk-frontend/govuk/base';
 @import '@admin/styles/variables';
 
-.container {
-  display: flex;
-  margin-left: -$dfe-comments-width;
-  position: relative;
-}
-
-.commentsList {
-  bottom: 0;
-  margin-right: $dfe-comments-gutter;
-  max-height: 100%;
-  overflow-y: auto;
-  padding: 2px;
-  position: absolute;
-  top: 0;
-  width: $dfe-comments-width - $dfe-comments-gutter;
-
-  &.padTop {
-    margin-top: 200px;
-  }
-}
-
 .form {
-  margin-left: $dfe-comments-width;
-  width: 100%;
-
   // stylelint-disable-next-line selector-no-qualifying-type
   img:not([alt]),
   img[alt=''] {

--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.tsx
@@ -1,4 +1,5 @@
 import { useCommentsContext } from '@admin/contexts/CommentsContext';
+import CommentsWrapper from '@admin/components/comments/CommentsWrapper';
 import styles from '@admin/components/editable/EditableContentForm.module.scss';
 import FormFieldEditor from '@admin/components/form/FormFieldEditor';
 import { Element, Node } from '@admin/types/ckeditor';
@@ -6,8 +7,6 @@ import {
   ImageUploadCancelHandler,
   ImageUploadHandler,
 } from '@admin/utils/ckeditor/CustomUploadAdapter';
-import CommentAddForm from '@admin/components/comments/CommentAddForm';
-import CommentsList from '@admin/components/comments/CommentsList';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import { Form } from '@common/components/form';
@@ -17,7 +16,6 @@ import useToggle from '@common/hooks/useToggle';
 import logger from '@common/services/logger';
 import Yup from '@common/validation/yup';
 import LoadingSpinner from '@common/components/LoadingSpinner';
-import classNames from 'classnames';
 import { Formik, FormikHelpers } from 'formik';
 import React, { useCallback, useRef } from 'react';
 import { useIdleTimer } from 'react-idle-timer';
@@ -61,7 +59,7 @@ const EditableContentForm = ({
   onImageUploadCancel,
   onSubmit,
 }: Props) => {
-  const { comments, clearPendingDeletions } = useCommentsContext();
+  const { clearPendingDeletions } = useCommentsContext();
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [showCommentAddForm, toggleCommentAddForm] = useToggle(false);
@@ -119,27 +117,15 @@ const EditableContentForm = ({
   );
 
   return (
-    <div className={styles.container} ref={containerRef}>
-      {allowComments && (
-        <div data-testid="comments-sidebar">
-          {showCommentAddForm && (
-            <CommentAddForm
-              baseId={id}
-              containerRef={containerRef}
-              onCancel={toggleCommentAddForm.off}
-              onSave={toggleCommentAddForm.off}
-            />
-          )}
-          {comments.length > 0 && (
-            <CommentsList
-              className={classNames(styles.commentsList, {
-                [styles.padTop]: showCommentAddForm,
-              })}
-            />
-          )}
-        </div>
-      )}
-
+    <CommentsWrapper
+      allowComments={allowComments}
+      commentType="inline"
+      id={id}
+      showCommentAddForm={showCommentAddForm}
+      onAddCancel={toggleCommentAddForm.off}
+      onAddSave={toggleCommentAddForm.off}
+      onAdd={toggleCommentAddForm.on}
+    >
       <div className={styles.form}>
         <Formik<FormValues>
           initialValues={{
@@ -195,7 +181,7 @@ const EditableContentForm = ({
           }}
         </Formik>
       </div>
-    </div>
+    </CommentsWrapper>
   );
 };
 export default EditableContentForm;

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableContentBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableContentBlock.test.tsx
@@ -303,9 +303,9 @@ Test paragraph
       render(
         <CommentsContextProvider
           comments={testComments}
-          onDelete={noop}
+          onDelete={() => Promise.resolve()}
           onCreate={jest.fn()}
-          onUpdate={noop}
+          onUpdate={() => Promise.resolve()}
           onPendingDelete={noop}
           onPendingDeleteUndo={noop}
         >
@@ -333,9 +333,9 @@ Test paragraph
       render(
         <CommentsContextProvider
           comments={testComments}
-          onDelete={noop}
+          onDelete={() => Promise.resolve()}
           onCreate={jest.fn()}
-          onUpdate={noop}
+          onUpdate={() => Promise.resolve()}
           onPendingDelete={noop}
           onPendingDeleteUndo={noop}
         >

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableContentForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableContentForm.test.tsx
@@ -223,9 +223,9 @@ describe('EditableContentForm', () => {
       render(
         <CommentsContextProvider
           comments={testComments}
-          onDelete={noop}
+          onDelete={() => Promise.resolve()}
           onCreate={jest.fn()}
-          onUpdate={noop}
+          onUpdate={() => Promise.resolve()}
           onPendingDelete={noop}
           onPendingDeleteUndo={noop}
         >
@@ -241,7 +241,7 @@ describe('EditableContentForm', () => {
       );
 
       const unresolvedComments = within(
-        screen.getByTestId('unresolvedComments'),
+        screen.getByTestId('comments-unresolved'),
       ).getAllByTestId('comment');
 
       expect(unresolvedComments).toHaveLength(3);
@@ -250,7 +250,7 @@ describe('EditableContentForm', () => {
       expect(unresolvedComments[2]).toHaveTextContent('Comment 4 content');
 
       const resolvedComments = within(
-        screen.getByTestId('resolvedComments'),
+        screen.getByTestId('comments-resolved'),
       ).getAllByTestId('comment');
 
       expect(resolvedComments).toHaveLength(2);
@@ -262,9 +262,9 @@ describe('EditableContentForm', () => {
       render(
         <CommentsContextProvider
           comments={testComments}
-          onDelete={noop}
+          onDelete={() => Promise.resolve()}
           onCreate={jest.fn()}
-          onUpdate={noop}
+          onUpdate={() => Promise.resolve()}
           onPendingDelete={noop}
           onPendingDeleteUndo={noop}
         >
@@ -279,9 +279,9 @@ describe('EditableContentForm', () => {
       );
 
       expect(
-        screen.queryByTestId('unresolvedComments'),
+        screen.queryByTestId('comments-unresolved'),
       ).not.toBeInTheDocument();
-      expect(screen.queryByTestId('resolvedComments')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('comments-resolved')).not.toBeInTheDocument();
     });
 
     test('calls `onPendingDelete` handler when a comment delete button is clicked', async () => {
@@ -295,9 +295,9 @@ describe('EditableContentForm', () => {
         >
           <CommentsContextProvider
             comments={testComments}
-            onDelete={noop}
+            onDelete={() => Promise.resolve()}
             onCreate={jest.fn()}
-            onUpdate={noop}
+            onUpdate={() => Promise.resolve()}
             onPendingDelete={handlePendingDelete}
             onPendingDeleteUndo={noop}
           >
@@ -316,7 +316,7 @@ describe('EditableContentForm', () => {
       expect(handlePendingDelete).not.toHaveBeenCalled();
 
       const unresolvedComments = within(
-        screen.getByTestId('unresolvedComments'),
+        screen.getByTestId('comments-unresolved'),
       ).getAllByTestId('comment');
 
       userEvent.click(
@@ -342,7 +342,7 @@ describe('EditableContentForm', () => {
         >
           <CommentsContextProvider
             comments={testComments}
-            onDelete={noop}
+            onDelete={() => Promise.resolve()}
             onCreate={jest.fn()}
             onUpdate={handleUpdate}
             onPendingDelete={noop}
@@ -363,7 +363,7 @@ describe('EditableContentForm', () => {
       expect(handleUpdate).not.toHaveBeenCalled();
 
       const unresolvedComments = within(
-        screen.getByTestId('unresolvedComments'),
+        screen.getByTestId('comments-unresolved'),
       ).getAllByTestId('comment');
 
       const comment = within(unresolvedComments[0]);
@@ -397,7 +397,7 @@ describe('EditableContentForm', () => {
         >
           <CommentsContextProvider
             comments={testComments}
-            onDelete={noop}
+            onDelete={() => Promise.resolve()}
             onCreate={jest.fn()}
             onUpdate={handleUpdate}
             onPendingDelete={noop}
@@ -418,7 +418,7 @@ describe('EditableContentForm', () => {
       expect(handleUpdate).not.toHaveBeenCalled();
 
       const unresolvedComments = within(
-        screen.getByTestId('unresolvedComments'),
+        screen.getByTestId('comments-unresolved'),
       ).getAllByTestId('comment');
 
       const comment = within(unresolvedComments[0]);
@@ -445,7 +445,7 @@ describe('EditableContentForm', () => {
         >
           <CommentsContextProvider
             comments={testComments}
-            onDelete={noop}
+            onDelete={() => Promise.resolve()}
             onCreate={jest.fn()}
             onUpdate={handleUpdate}
             onPendingDelete={noop}
@@ -466,7 +466,7 @@ describe('EditableContentForm', () => {
       expect(handleUpdate).not.toHaveBeenCalled();
 
       const resolvedComments = within(
-        screen.getByTestId('resolvedComments'),
+        screen.getByTestId('comments-resolved'),
       ).getAllByTestId('comment');
 
       const comment = within(resolvedComments[0]);

--- a/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.module.scss
@@ -1,0 +1,9 @@
+@import '~govuk-frontend/govuk/base';
+@import '@admin/styles/variables';
+
+.container {
+  @include govuk-media-query($from: desktop) {
+    margin-left: $dfe-comments-width;
+    margin-right: 0;
+  }
+}

--- a/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
@@ -8,6 +8,7 @@ import {
   ReleaseContentContextState,
   useReleaseContentState,
 } from '@admin/pages/release/content/contexts/ReleaseContentContext';
+import styles from '@admin/pages/release/content/ReleaseContentPage.module.scss';
 import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
 import permissionService from '@admin/services/permissionService';
 import releaseContentService from '@admin/services/releaseContentService';
@@ -67,7 +68,7 @@ const ReleaseContentPageLoaded = () => {
 
             <div
               className={classNames({
-                'govuk-!-margin-right-0': editingMode === 'edit',
+                [styles.container]: editingMode === 'edit',
                 'govuk-width-container': editingMode !== 'table-preview',
               })}
             >

--- a/src/explore-education-statistics-admin/src/styles/_variables.scss
+++ b/src/explore-education-statistics-admin/src/styles/_variables.scss
@@ -2,3 +2,4 @@ $dfe-page-width-wide: 1280px;
 $dfe-page-width-wide-gutter: 15px;
 $dfe-comments-width: 300px;
 $dfe-comments-gutter: 30px;
+$dfe-comments-form-height: 194px;

--- a/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
@@ -12,8 +12,10 @@ Test Setup          fail test fast if required
 ${RELEASE_NAME}=        Academic year Q1 2020/21
 ${PUBLICATION_NAME}=    UI tests - release content authoring %{RUN_IDENTIFIER}
 ${SECTION_1_TITLE}=     First content section
+${SECTION_2_TITLE}=     Second content section
 ${BLOCK_1_CONTENT}=     Block 1 content
 ${BLOCK_2_CONTENT}=     Block 2 content
+${DATABLOCK_NAME}=      Dates data block name
 
 
 *** Test Cases ***
@@ -26,6 +28,18 @@ Create publication
 Create new release
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
     user creates release from publication page    ${PUBLICATION_NAME}    Academic year Q1    2020
+
+Upload a subject
+    user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
+    ...    ${RELEASE_NAME}
+
+    user uploads subject    Dates test subject    dates.csv    dates.meta.csv
+
+Create a data block
+    user creates data block for dates csv
+    ...    Dates test subject
+    ...    ${DATABLOCK_NAME}
+    ...    Data Block 1 title
 
 Give analyst1 publication owner permissions to work on release
     user gives analyst publication owner access    ${PUBLICATION_NAME}
@@ -88,8 +102,8 @@ Switch to bau1 to add review comments for first text block
     user presses keys    CTRL+a
     user adds comment to selected text    ${block}    Test comment 1
 
-    user checks list has x items    testid:unresolvedComments    1    ${block}
-    user checks list item contains    testid:unresolvedComments    1    Test comment 1    ${block}
+    user checks list has x items    testid:comments-unresolved    1    ${block}
+    user checks list item contains    testid:comments-unresolved    1    Test comment 1    ${block}
 
     ${editor}=    get editor    ${block}
     user sets focus to element    ${editor}
@@ -99,9 +113,9 @@ Switch to bau1 to add review comments for first text block
     sleep    0.1    # Prevent intermittent failure where toolbar button is disabled
     user adds comment to selected text    ${block}    Test comment 2
 
-    user checks list has x items    testid:unresolvedComments    2    ${block}
-    user checks list item contains    testid:unresolvedComments    1    Test comment 1    ${block}
-    user checks list item contains    testid:unresolvedComments    2    Test comment 2    ${block}
+    user checks list has x items    testid:comments-unresolved    2    ${block}
+    user checks list item contains    testid:comments-unresolved    1    Test comment 1    ${block}
+    user checks list item contains    testid:comments-unresolved    2    Test comment 2    ${block}
 
     user saves autosaving text block    ${block}
 
@@ -115,8 +129,8 @@ Add review comment for second text block as bau1
     user presses keys    CTRL+a
     user adds comment to selected text    ${block}    Test comment 3
 
-    user checks list has x items    testid:unresolvedComments    1    ${block}
-    user checks list item contains    testid:unresolvedComments    1    Test comment 3    ${block}
+    user checks list has x items    testid:comments-unresolved    1    ${block}
+    user checks list item contains    testid:comments-unresolved    1    Test comment 3    ${block}
 
 Switch to analyst1 to check second text block is locked
     user switches to analyst1 browser
@@ -162,9 +176,9 @@ Switch to analyst1 to resolve comment for first text block
     user switches to analyst1 browser
     ${block}=    get accordion section block    First content section    1    id:releaseMainContent
 
-    user checks list has x items    testid:unresolvedComments    2    ${block}
-    user checks list item contains    testid:unresolvedComments    1    Test comment 1    ${block}
-    user checks list item contains    testid:unresolvedComments    2    Test comment 2    ${block}
+    user checks list has x items    testid:comments-unresolved    2    ${block}
+    user checks list item contains    testid:comments-unresolved    1    Test comment 1    ${block}
+    user checks list item contains    testid:comments-unresolved    2    Test comment 2    ${block}
 
     ${comment}=    user gets unresolved comment    Test comment 1    ${block}
     ${author}=    get child element    ${comment}    testid:comment-author
@@ -181,13 +195,13 @@ Switch to analyst1 to resolve comment for first text block
     ...    ${block}
     ...    testid:Expand Details Section Resolved comments (1)    10
 
-    user checks list has x items    testid:unresolvedComments    1    ${block}
-    user checks list item contains    testid:unresolvedComments    1    Test comment 2    ${block}
+    user checks list has x items    testid:comments-unresolved    1    ${block}
+    user checks list item contains    testid:comments-unresolved    1    Test comment 2    ${block}
 
     user opens details dropdown    Resolved comments (1)    ${block}
 
-    user checks list has x items    testid:resolvedComments    1    ${block}
-    user checks list item contains    testid:resolvedComments    1    Test comment 1    ${block}
+    user checks list has x items    testid:comments-resolved    1    ${block}
+    user checks list item contains    testid:comments-resolved    1    Test comment 1    ${block}
 
     ${comment}=    user gets resolved comment    Test comment 1    ${block}
     user waits until element contains    ${comment}    Resolved by Analyst1 User1
@@ -210,8 +224,8 @@ Switch back to analyst1 to resolve second text block
     # avoid set page view box getting in the way
     user scrolls down    600
 
-    user checks list has x items    testid:unresolvedComments    1    ${block}
-    user checks list item contains    testid:unresolvedComments    1    Test comment 3    ${block}
+    user checks list has x items    testid:comments-unresolved    1    ${block}
+    user checks list item contains    testid:comments-unresolved    1    Test comment 3    ${block}
 
     ${comment}=    user gets unresolved comment    Test comment 3    ${block}
     ${author}=    get child element    ${comment}    testid:comment-author
@@ -225,11 +239,11 @@ Switch back to analyst1 to resolve second text block
     ...    ${block}
     ...    testid:Expand Details Section Resolved comments (1)    10
 
-    user waits until parent does not contain element    ${block}    testid:unresolvedComments
+    user waits until parent does not contain element    ${block}    testid:comments-unresolved
     user opens details dropdown    Resolved comments (1)    ${block}
 
-    user checks list has x items    testid:resolvedComments    1    ${block}
-    user checks list item contains    testid:resolvedComments    1    Test comment 3    ${block}
+    user checks list has x items    testid:comments-resolved    1    ${block}
+    user checks list item contains    testid:comments-resolved    1    Test comment 3    ${block}
 
     ${comment}=    user gets resolved comment    Test comment 3    ${block}
     user waits until element contains    ${comment}    Resolved by Analyst1 User1
@@ -253,9 +267,51 @@ Delete unresolved comment as bau1
     ${block}=    get accordion section block    First content section    1    id:releaseMainContent
     ${comment}=    user gets unresolved comment    Test updated comment 2    ${block}
     user clicks button    Delete    ${comment}
-    user waits until parent does not contain element    ${block}    testid:unresolvedComments
+    user waits until parent does not contain element    ${block}    testid:comments-unresolved
 
     user saves autosaving text block    ${block}
+
+Add second content section as analyst1
+    user switches to analyst1 browser
+    user scrolls to element    xpath://button[text()="Add new section"]
+    user waits until button is enabled    Add new section
+    user clicks button    Add new section
+    user changes accordion section title    2    ${SECTION_2_TITLE}    id:releaseMainContent
+
+Add data block
+    user adds data block to editable accordion section    ${SECTION_2_TITLE}    ${DATABLOCK_NAME}
+    ...    id:releaseMainContent
+    ${block}=    set variable    xpath://*[@data-testid="Data block - ${DATABLOCK_NAME}"]
+    user waits until page contains element    ${block}    %{WAIT_SMALL}
+
+Add review comment for data block as bau1
+    user switches to bau1 browser
+    user reloads page
+    user opens accordion section    ${SECTION_2_TITLE}    id:releaseMainContent
+    ${block}=    set variable    xpath://*[@data-testid="data-block-comments-${DATABLOCK_NAME}"]
+    user adds comment to data block    ${block}    Test data block comment
+
+    user checks list has x items    testid:comments-unresolved    1    ${block}
+    user checks list item contains    testid:comments-unresolved    1    Test data block comment    ${block}
+
+Resolve comment for data block as analyst1
+    user switches to analyst1 browser
+    user reloads page
+    user closes Set Page View box
+    user opens accordion section    ${SECTION_2_TITLE}    id:releaseMainContent
+    user scrolls down    400
+    ${block}=    set variable    xpath://*[@data-testid="data-block-comments-${DATABLOCK_NAME}"]
+    ${comment}=    user gets unresolved comment    Test data block comment    ${block}
+
+    user clicks button    Resolve    ${comment}
+
+    user waits until parent contains element
+    ...    ${block}
+    ...    testid:Expand Details Section Resolved comments (1)    10
+
+    user opens details dropdown    Resolved comments (1)    ${block}
+    user checks list has x items    testid:comments-resolved    1    ${block}
+    user checks list item contains    testid:comments-resolved    1    Test data block comment    ${block}
 
 
 *** Keywords ***
@@ -271,3 +327,9 @@ user adds comment to selected text
     ${textarea}=    get child element    ${comments}    label:Comment
     user enters text into element    ${textarea}    ${text}
     user clicks button    Add comment    ${comments}
+
+user adds comment to data block
+    [Arguments]    ${block}    ${text}
+    user clicks button    Add comment    ${block}
+    user enters text into element    label:Comment    ${text}
+    user clicks button    Add comment    ${block}

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -780,14 +780,14 @@ user waits until modal is not visible
 
 user gets resolved comments
     [Arguments]    ${parent}=css:body
-    user waits until parent contains element    ${parent}    testid:resolvedComments
-    ${comments}=    get child element    ${parent}    testid:resolvedComments
+    user waits until parent contains element    ${parent}    testid:comments-resolved
+    ${comments}=    get child element    ${parent}    testid:comments-resolved
     [Return]    ${comments}
 
 user gets unresolved comments
     [Arguments]    ${parent}=css:body
-    user waits until parent contains element    ${parent}    testid:unresolvedComments
-    ${comments}=    get child element    ${parent}    testid:unresolvedComments
+    user waits until parent contains element    ${parent}    testid:comments-unresolved
+    ${comments}=    get child element    ${parent}    testid:comments-unresolved
     [Return]    ${comments}
 
 user gets unresolved comment


### PR DESCRIPTION
Adds the ability to comment on data blocks and embed blocks. The comments are on the while block, not on specific parts of it.

- there are two types of comment component now - `inline`, which is for inline comments in content blocks and includes the interactions with CKEditor, and `block`, a simpler version for comments on data & embed blocks. They both use a new `BaseComment` component.
- I've added a new `CommentsWrapper` component that's used for all the block types
- I've tidied it up a bit on smaller screens as previously the comments were pushed offscreen
- the UI for comments on content and data / embed blocks is a bit inconsistent as the comments UI always shows for data blocks but only shows when you edit content blocks, due to how it works with CKEditor. I've discussed this with Cam and we decided to leave it like that for now and see what feedback we get about it.

![datablockcomments](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/418f2fb3-c781-4d8a-bb6e-9c5f6167b4b5)

