### PR TITLE
EES-4680 - moved SendPreReleaseUserInviteEmails() from public method …

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServicePermissionTests.cs
@@ -33,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task GetPreReleaseUsers()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheckToFail(_release, CanAssignPrereleaseContactsToSpecificRelease)
+                .SetupResourceCheckToFail(_release, CanAssignPreReleaseUsersToSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -48,7 +48,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task GetPreReleaseUsersInvitePlan()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheckToFail(_release, CanAssignPrereleaseContactsToSpecificRelease)
+                .SetupResourceCheckToFail(_release, CanAssignPreReleaseUsersToSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -66,7 +66,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task InvitePreReleaseUsers()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheckToFail(_release, CanAssignPrereleaseContactsToSpecificRelease)
+                .SetupResourceCheckToFail(_release, CanAssignPreReleaseUsersToSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -84,28 +84,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task RemovePreReleaseUser()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheckToFail(_release, CanAssignPrereleaseContactsToSpecificRelease)
+                .SetupResourceCheckToFail(_release, CanAssignPreReleaseUsersToSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
                         var service = SetupPreReleaseUserService(
                             userService: userService.Object);
                         return service.RemovePreReleaseUser(_release.Id, "test@test.com");
-                    }
-                );
-        }
-
-        [Fact]
-        public async Task SendPreReleaseUserInviteEmails()
-        {
-            await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
-                .AssertForbidden(
-                    userService =>
-                    {
-                        var service = SetupPreReleaseUserService(
-                            userService: userService.Object);
-                        return service.SendPreReleaseUserInviteEmails(_release.Id);
                     }
                 );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServicePermissionTests.cs
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         private readonly Release _release = new()
         {
             Id = Guid.NewGuid(),
-            Publication= new Publication(),
+            Publication = new Publication(),
             Published = DateTime.Now,
             TimePeriodCoverage = TimeIdentifier.April
         };

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServicePermissionTests.cs
@@ -9,7 +9,6 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Manag
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
@@ -17,7 +16,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
-using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 using IReleaseRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseRepository;
 
@@ -25,15 +24,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
     public class ReleaseApprovalServicePermissionTests
     {
-        private static readonly Publication Publication = new()
-        {
-            Id = Guid.NewGuid()
-        };
-
         private readonly Release _release = new()
         {
             Id = Guid.NewGuid(),
-            PublicationId = Publication.Id,
+            Publication= new Publication(),
             Published = DateTime.Now,
             TimePeriodCoverage = TimeIdentifier.April
         };
@@ -42,26 +36,43 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task GetReleaseStatuses()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheckToFail(_release, CanViewReleaseStatusHistory)
-                .AssertForbidden(
-                    userService =>
+                .SetupResourceCheckToFailWithMatcher<Release>(r => r.Id == _release.Id, CanViewReleaseStatusHistory)
+                .AssertForbidden(async userService =>
+                {
+                    var contentDbContextId = Guid.NewGuid().ToString();
+                    await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
                     {
-                        var service = BuildService(userService.Object);
-                        return service.GetReleaseStatuses(_release.Id);
+                        await contentDbContext.AddRangeAsync(_release);
+                        await contentDbContext.SaveChangesAsync();
                     }
-                );
+
+                    await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+                    {
+                        var service = BuildService(contentDbContext: contentDbContext, userService.Object);
+                        return await service.GetReleaseStatuses(_release.Id);
+                    }
+                });
         }
 
         [Fact]
         public async Task UpdateReleaseStatus_Draft()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheckToFail(_release, CanMarkSpecificReleaseAsDraft)
-                .AssertForbidden(
-                    userService =>
+                .SetupResourceCheckToFailWithMatcher<Release>(r => r.Id == _release.Id, CanMarkSpecificReleaseAsDraft)
+                .AssertForbidden(async userService =>
+                {
+                    var contentDbContextId = Guid.NewGuid().ToString();
+                    await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
                     {
-                        var service = BuildService(userService.Object);
-                        return service.CreateReleaseStatus(
+                        await contentDbContext.AddRangeAsync(_release);
+                        await contentDbContext.SaveChangesAsync();
+                    }
+
+                    await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+                    {
+                        var service = BuildService(contentDbContext: contentDbContext, userService.Object);
+
+                        return await service.CreateReleaseStatus(
                             _release.Id,
                             new ReleaseStatusCreateRequest
                             {
@@ -69,25 +80,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             }
                         );
                     }
-                );
+                });
         }
 
         [Fact]
         public async Task UpdateReleaseStatus_HigherLevelReview()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheckToFail(_release, CanSubmitSpecificReleaseToHigherReview)
-                .AssertForbidden(
-                    userService =>
+                .SetupResourceCheckToFailWithMatcher<Release>(r => r.Id == _release.Id, CanSubmitSpecificReleaseToHigherReview)
+                .AssertForbidden(async userService =>
                     {
-                        var service = BuildService(userService.Object);
-                        return service.CreateReleaseStatus(
-                            _release.Id,
-                            new ReleaseStatusCreateRequest
-                            {
-                                ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview
-                            }
-                        );
+                        var contentDbContextId = Guid.NewGuid().ToString();
+                        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+                        {
+                            await contentDbContext.AddRangeAsync(_release);
+                            await contentDbContext.SaveChangesAsync();
+                        }
+
+                        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+                        {
+                            var service = BuildService(contentDbContext: contentDbContext, userService.Object);
+
+                            return await service.CreateReleaseStatus(
+                                _release.Id,
+                                new ReleaseStatusCreateRequest
+                                {
+                                    ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview
+                                }
+                            );
+                        }
                     }
                 );
         }
@@ -96,12 +117,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task UpdateReleaseStatus_Approve()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheckToFail(_release, CanApproveSpecificRelease)
-                .AssertForbidden(
-                    userService =>
+                .SetupResourceCheckToFailWithMatcher<Release>(r => r.Id == _release.Id, CanApproveSpecificRelease)
+                .AssertForbidden(async userService =>
+                {
+                    var contentDbContextId = Guid.NewGuid().ToString();
+                    await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
                     {
-                        var service = BuildService(userService.Object);
-                        return service.CreateReleaseStatus(
+                        await contentDbContext.AddRangeAsync(_release);
+                        await contentDbContext.SaveChangesAsync();
+                    }
+
+                    await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+                    {
+                        var service = BuildService(contentDbContext: contentDbContext, userService.Object);
+                        return await service.CreateReleaseStatus(
                             _release.Id,
                             new ReleaseStatusCreateRequest
                             {
@@ -109,14 +138,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             }
                         );
                     }
-                );
+                });
         }
 
-        private ReleaseApprovalService BuildService(IUserService userService)
+        private ReleaseApprovalService BuildService(ContentDbContext contentDbContext, IUserService userService)
         {
             return new ReleaseApprovalService(
-                Mock.Of<ContentDbContext>(),
-                DefaultPersistenceHelperMock().Object,
+                contentDbContext,
                 new DateTimeProvider(),
                 userService,
                 Mock.Of<IPublishingService>(),
@@ -128,17 +156,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Mock.Of<IReleaseRepository>(),
                 Options.Create(new ReleaseApprovalOptions()),
                 Mock.Of<IUserReleaseRoleService>(),
-                Mock.Of<IEmailTemplateService>()
+                Mock.Of<IEmailTemplateService>(),
+                Mock.Of<IUserRepository>()
             );
-        }
-
-        private Mock<IPersistenceHelper<ContentDbContext>> DefaultPersistenceHelperMock()
-        {
-            var mock = MockPersistenceHelper<ContentDbContext, Release>();
-            SetupCall(mock, _release.Id, _release);
-            SetupCall(mock, Publication.Id, Publication);
-
-            return mock;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
@@ -1468,11 +1468,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .SingleAsync(r => r.Id == release.Id);
 
                 // Assert that the failure to send emails prevented the Release from completing approval.
-                // The Release should remain unchanged from the original Release, as changes to it were rolled back.
+                // The Release should remain unchanged from the original Release.
                 // Additionally, no new ReleaseStatus entries were added.
                 saved.AssertDeepEqualTo(release);
 
-                // Futhermore, we have proven that the Publisher was not informed of the Release change, as it
+                // Furthermore, we have proven that the Publisher was not informed of the Release change, as it
                 // did not complete.
             }
         }
@@ -1583,7 +1583,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .SingleAsync(r => r.Id == release.Id);
 
                 // Assert that the failure to notify the Publisher prevented the Release from completing approval.
-                // The Release should remain unchanged from the original Release, as changes to it were rolled back.
+                // The Release should remain unchanged from the original Release.
                 // Additionally, no new ReleaseStatus entries were added.
                 saved.AssertDeepEqualTo(release);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
@@ -13,12 +13,12 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -636,7 +636,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task 
+        public async Task
             CreateReleaseStatus_Approved_Scheduled_FailsPublishDateCannotBeScheduled_SecondFunctionHasNoOccurrence()
         {
             var release = new Release
@@ -750,10 +750,69 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Version = 0,
             };
 
+            var existingUser1 = new User
+            {
+                Email = "test@test.com",
+            };
+
+            var existingUser1Invite = new UserReleaseInvite
+            {
+                Release = release,
+                Role = ReleaseRole.PrereleaseViewer,
+                Email = existingUser1.Email,
+                EmailSent = false,
+            };
+
+            var existingUser2 = new User
+            {
+                Email = "test2@test.com"
+            };
+
+            var existingUser2SentInvite = new UserReleaseInvite
+            {
+                Release = release,
+                Role = ReleaseRole.PrereleaseViewer,
+                Email = existingUser2.Email,
+                EmailSent = true,
+            };
+
+            var existingUser3 = new User
+            {
+                Email = "test3@test.com",
+            };
+
+            var existingUser3NonPreReleaseInvite = new UserReleaseInvite
+            {
+                Release = release,
+                Role = ReleaseRole.Contributor,
+                Email = existingUser3.Email,
+                EmailSent = false,
+            };
+
+            var nonExistingUserPreReleaseInvite = new UserReleaseInvite
+            {
+                Release = release,
+                Role = ReleaseRole.PrereleaseViewer,
+                Email = "nonexistent1@test.com",
+                EmailSent = false,
+            };
+
+            var nonExistingUserNonPreReleaseInvite = new UserReleaseInvite
+            {
+                Release = release,
+                Role = ReleaseRole.Contributor,
+                Email = "nonexistent2@test.com",
+                EmailSent = false,
+            };
+
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 await context.Releases.AddAsync(release);
+                await context.Users.AddRangeAsync(existingUser1, existingUser2, existingUser3);
+                await context.UserReleaseInvites.AddRangeAsync(
+                    existingUser1Invite, existingUser2SentInvite, existingUser3NonPreReleaseInvite,
+                    nonExistingUserPreReleaseInvite, nonExistingUserNonPreReleaseInvite);
                 await context.SaveChangesAsync();
             }
 
@@ -781,9 +840,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     mock.GetContentBlocks<HtmlBlock>(release.Id))
                 .ReturnsAsync(new List<HtmlBlock>());
 
-            preReleaseUserService.Setup(mock =>
-                    mock.SendPreReleaseUserInviteEmails(release.Id))
+            preReleaseUserService
+                .Setup(mock => mock.SendPreReleaseInviteEmail(
+                    It.Is<Release>(r => r.Id == release.Id),
+                    existingUser1Invite.Email,
+                    false))
                 .ReturnsAsync(Unit.Instance);
+
+            preReleaseUserService
+                .Setup(mock => mock.SendPreReleaseInviteEmail(
+                    It.Is<Release>(r => r.Id == release.Id),
+                    nonExistingUserPreReleaseInvite.Email,
+                    true))
+                .ReturnsAsync(Unit.Instance);
+
+            preReleaseUserService
+                .Setup(mock => mock.MarkInviteEmailAsSent(
+                    It.Is<UserReleaseInvite>(i => i.Email == existingUser1Invite.Email)))
+                .Returns(Task.CompletedTask);
+
+            preReleaseUserService
+                .Setup(mock => mock.MarkInviteEmailAsSent(
+                    It.Is<UserReleaseInvite>(i => i.Email == nonExistingUserPreReleaseInvite.Email)))
+                .Returns(Task.CompletedTask);
 
             var nextReleaseDateEdited = new PartialDate { Month = "12", Year = "2000" };
 
@@ -823,12 +902,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .SingleAsync(r => r.Id == release.Id);
 
                 Assert.Equal(ReleaseApprovalStatus.Approved, saved.ApprovalStatus);
-                
+
                 // PublishScheduled should have been set to the scheduled date specified in the request.
                 Assert.Equal(new DateTime(2051, 6, 29, 23, 0, 0, DateTimeKind.Utc),
                     saved.PublishScheduled);
                 nextReleaseDateEdited.AssertDeepEqualTo(saved.NextReleaseDate);
-               
+
                 // NotifySubscribers should default to true for original releases
                 Assert.True(saved.NotifySubscribers);
                 Assert.False(saved.UpdatePublishedDate);
@@ -840,7 +919,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test note", savedStatus.InternalReleaseNote);
             }
         }
-        
+
         [Fact]
         public async Task CreateReleaseStatus_Approved_Immediately()
         {
@@ -921,10 +1000,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .SingleAsync(r => r.Id == release.Id);
 
                 Assert.Equal(ReleaseApprovalStatus.Approved, saved.ApprovalStatus);
-                
+
                 // PublishScheduled should have been set to "now".
                 saved.PublishScheduled.AssertUtcNow();
-                
+
                 nextReleaseDateEdited.AssertDeepEqualTo(saved.NextReleaseDate);
                 // NotifySubscribers should default to true for original releases
                 Assert.True(saved.NotifySubscribers);
@@ -1281,6 +1360,240 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task CreateReleaseStatus_Approved_Scheduled_FailsSendingPreReleaseInviteEmail()
+        {
+            var release = new Release
+            {
+                ApprovalStatus = ReleaseApprovalStatus.Draft,
+                Type = ReleaseType.AdHocStatistics,
+                Publication = new Publication(),
+                ReleaseName = "2030",
+                Slug = "2030",
+                Version = 0,
+            };
+
+            var invite1 = new UserReleaseInvite
+            {
+                Release = release,
+                Role = ReleaseRole.PrereleaseViewer,
+                Email = "test@test.com",
+                EmailSent = false,
+            };
+
+            var invite2 = new UserReleaseInvite
+            {
+                Release = release,
+                Role = ReleaseRole.PrereleaseViewer,
+                Email = "test2@test.com",
+                EmailSent = false,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                await context.Releases.AddAsync(release);
+                await context.UserReleaseInvites.AddRangeAsync(invite1, invite2);
+                await context.SaveChangesAsync();
+            }
+
+            var releaseChecklistService = new Mock<IReleaseChecklistService>(MockBehavior.Strict);
+            var contentService = new Mock<IContentService>(MockBehavior.Strict);
+            var preReleaseUserService = new Mock<IPreReleaseUserService>(MockBehavior.Strict);
+
+            releaseChecklistService
+                .Setup(s =>
+                    s.GetErrors(It.Is<Release>(r => r.Id == release.Id)))
+                .ReturnsAsync(
+                    new List<ReleaseChecklistIssue>()
+                );
+
+            contentService.Setup(mock =>
+                    mock.GetContentBlocks<HtmlBlock>(release.Id))
+                .ReturnsAsync(new List<HtmlBlock>());
+
+            preReleaseUserService
+                .Setup(mock => mock.SendPreReleaseInviteEmail(
+                    It.Is<Release>(r => r.Id == release.Id),
+                    invite1.Email,
+                    true))
+                .ReturnsAsync(new BadRequestResult());
+
+            preReleaseUserService
+                .Setup(mock => mock.SendPreReleaseInviteEmail(
+                    It.Is<Release>(r => r.Id == release.Id),
+                    invite2.Email,
+                    true))
+                .ReturnsAsync(Unit.Instance);
+
+            preReleaseUserService
+                .Setup(mock => mock.MarkInviteEmailAsSent(
+                    It.Is<UserReleaseInvite>(i => i.Email == invite2.Email)))
+                .Returns(Task.CompletedTask);
+
+            var nextReleaseDateEdited = new PartialDate { Month = "12", Year = "2000" };
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var releaseService = BuildService(contentDbContext: context,
+                    releaseChecklistService: releaseChecklistService.Object,
+                    contentService: contentService.Object,
+                    preReleaseUserService: preReleaseUserService.Object);
+
+                var result = await releaseService
+                    .CreateReleaseStatus(
+                        release.Id,
+                        new ReleaseStatusCreateRequest
+                        {
+                            ApprovalStatus = ReleaseApprovalStatus.Approved,
+                            InternalReleaseNote = "Test note",
+                            PublishMethod = PublishMethod.Scheduled,
+                            PublishScheduled = "2051-06-30",
+                            NextReleaseDate = nextReleaseDateEdited
+                        }
+                    );
+
+                VerifyAllMocks(contentService,
+                    preReleaseUserService,
+                    releaseChecklistService);
+
+                result.AssertLeft();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var saved = await context
+                    .Releases
+                    .HydrateReleaseForChecklist()
+                    .Include(r => r.ReleaseStatuses)
+                    .SingleAsync(r => r.Id == release.Id);
+
+                // Assert that the failure to send emails prevented the Release from completing approval.
+                // The Release should remain unchanged from the original Release, as changes to it were rolled back.
+                // Additionally, no new ReleaseStatus entries were added.
+                saved.AssertDeepEqualTo(release);
+
+                // Futhermore, we have proven that the Publisher was not informed of the Release change, as it
+                // did not complete.
+            }
+        }
+
+        [Fact]
+        public async Task CreateReleaseStatus_Approved_Scheduled_FailsWhileInformingPublisher()
+        {
+            var release = new Release
+            {
+                ApprovalStatus = ReleaseApprovalStatus.Draft,
+                Type = ReleaseType.AdHocStatistics,
+                Publication = new Publication(),
+                ReleaseName = "2030",
+                Slug = "2030",
+                Version = 0,
+            };
+
+            var invite = new UserReleaseInvite
+            {
+                Release = release,
+                Role = ReleaseRole.PrereleaseViewer,
+                Email = "test@test.com",
+                EmailSent = false,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                await context.Releases.AddAsync(release);
+                await context.UserReleaseInvites.AddAsync(invite);
+                await context.SaveChangesAsync();
+            }
+
+            var releaseChecklistService = new Mock<IReleaseChecklistService>(MockBehavior.Strict);
+            var publishingService = new Mock<IPublishingService>(MockBehavior.Strict);
+            var contentService = new Mock<IContentService>(MockBehavior.Strict);
+            var preReleaseUserService = new Mock<IPreReleaseUserService>(MockBehavior.Strict);
+
+            releaseChecklistService
+                .Setup(s =>
+                    s.GetErrors(It.Is<Release>(r => r.Id == release.Id)))
+                .ReturnsAsync(
+                    new List<ReleaseChecklistIssue>()
+                );
+
+            preReleaseUserService
+                .Setup(mock => mock.SendPreReleaseInviteEmail(
+                    It.Is<Release>(r => r.Id == release.Id),
+                    invite.Email,
+                    true))
+                .ReturnsAsync(Unit.Instance);
+
+            preReleaseUserService
+                .Setup(mock => mock.MarkInviteEmailAsSent(
+                    It.Is<UserReleaseInvite>(i => i.Email == invite.Email)))
+                .Returns(Task.CompletedTask);
+
+            publishingService
+                .Setup(s => s.ReleaseChanged(
+                    It.Is<Guid>(g => g == release.Id),
+                    It.IsAny<Guid>(),
+                    It.IsAny<bool>()
+                ))
+                .ReturnsAsync(new BadRequestResult());
+
+            contentService.Setup(mock =>
+                    mock.GetContentBlocks<HtmlBlock>(release.Id))
+                .ReturnsAsync(new List<HtmlBlock>());
+
+            var nextReleaseDateEdited = new PartialDate { Month = "12", Year = "2000" };
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var releaseService = BuildService(contentDbContext: context,
+                    releaseChecklistService: releaseChecklistService.Object,
+                    publishingService: publishingService.Object,
+                    contentService: contentService.Object,
+                    preReleaseUserService: preReleaseUserService.Object);
+
+                var result = await releaseService
+                    .CreateReleaseStatus(
+                        release.Id,
+                        new ReleaseStatusCreateRequest
+                        {
+                            ApprovalStatus = ReleaseApprovalStatus.Approved,
+                            InternalReleaseNote = "Test note",
+                            PublishMethod = PublishMethod.Scheduled,
+                            PublishScheduled = "2051-06-30",
+                            NextReleaseDate = nextReleaseDateEdited
+                        }
+                    );
+
+                VerifyAllMocks(
+                    contentService,
+                    publishingService,
+                    releaseChecklistService,
+                    preReleaseUserService);
+
+                result.AssertLeft();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var saved = await context
+                    .Releases
+                    .HydrateReleaseForChecklist()
+                    .Include(r => r.ReleaseStatuses)
+                    .SingleAsync(r => r.Id == release.Id);
+
+                // Assert that the failure to notify the Publisher prevented the Release from completing approval.
+                // The Release should remain unchanged from the original Release, as changes to it were rolled back.
+                // Additionally, no new ReleaseStatus entries were added.
+                saved.AssertDeepEqualTo(release);
+
+                // We have also shown that unfortunately the invite emails would have been sent out despite the
+                // approval failing, but we have more importantly stopped a Release from only having been partially
+                // approved.
+            }
+        }
+
+        [Fact]
         public async Task GetReleaseStatuses()
         {
             var release = new Release
@@ -1505,7 +1818,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var releaseRepository = new ReleaseRepository(
@@ -1577,6 +1889,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userReleaseRoleService);
 
                 result.AssertRight();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var saved = await context
+                    .Releases
+                    .Include(r => r.ReleaseStatuses)
+                    .SingleAsync(r => r.Id == release.Id);
+
+                // Assert that the Release has moved into Higher Level Review successfully.
+                Assert.Equal(ReleaseApprovalStatus.HigherLevelReview, saved.ApprovalStatus);
+
+                // Assert a new ReleaseStatus entry is included.
+                var savedStatus = Assert.Single(saved.ReleaseStatuses);
+                Assert.Equal(release.Id, savedStatus.ReleaseId);
+                Assert.Equal(ReleaseApprovalStatus.HigherLevelReview, savedStatus.ApprovalStatus);
+                Assert.Equal(_userId, savedStatus.CreatedById);
+                Assert.Equal("Test internal note", savedStatus.InternalReleaseNote);
             }
         }
 
@@ -1654,6 +1984,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 VerifyAllMocks(contentService, userReleaseRoleService, emailTemplateService);
                 result.AssertRight();
             }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var saved = await context
+                    .Releases
+                    .Include(r => r.ReleaseStatuses)
+                    .SingleAsync(r => r.Id == release.Id);
+
+                // Assert that the Release has moved into Higher Level Review successfully.
+                Assert.Equal(ReleaseApprovalStatus.HigherLevelReview, saved.ApprovalStatus);
+
+                // Assert a new ReleaseStatus entry is included.
+                var savedStatus = Assert.Single(saved.ReleaseStatuses);
+                Assert.Equal(release.Id, savedStatus.ReleaseId);
+                Assert.Equal(ReleaseApprovalStatus.HigherLevelReview, savedStatus.ApprovalStatus);
+                Assert.Equal(_userId, savedStatus.CreatedById);
+                Assert.Equal("Test internal note", savedStatus.InternalReleaseNote);
+            }
         }
 
         [Fact]
@@ -1723,6 +2071,115 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 result.AssertRight();
             }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var saved = await context
+                    .Releases
+                    .Include(r => r.ReleaseStatuses)
+                    .SingleAsync(r => r.Id == release.Id);
+
+                // Assert that the Release has moved into Higher Level Review successfully.
+                Assert.Equal(ReleaseApprovalStatus.HigherLevelReview, saved.ApprovalStatus);
+
+                // Assert a new ReleaseStatus entry is included.
+                var savedStatus = Assert.Single(saved.ReleaseStatuses);
+                Assert.Equal(release.Id, savedStatus.ReleaseId);
+                Assert.Equal(ReleaseApprovalStatus.HigherLevelReview, savedStatus.ApprovalStatus);
+                Assert.Equal(_userId, savedStatus.CreatedById);
+                Assert.Equal("Test internal note", savedStatus.InternalReleaseNote);
+            }
+        }
+
+        [Fact]
+        public async Task CreateReleaseStatus_HigherReview_FailsSendingEmail()
+        {
+            var release = new Release
+            {
+                Type = ReleaseType.AdHocStatistics,
+                Publication = new Publication { Title = "Test publication" },
+                ReleaseName = "2030",
+                Slug = "2030",
+                Version = 0,
+            };
+
+            var userReleaseRole1 = new UserReleaseRole
+            {
+                User = new User { Id = Guid.NewGuid(), Email = "test@test.com"},
+                Release = release,
+                Role = ReleaseRole.Approver,
+            };
+
+            var userReleaseRole2 = new UserReleaseRole
+            {
+                User = new User { Id = Guid.NewGuid(), Email = "test2@test.com"},
+                Release = release,
+                Role = ReleaseRole.Approver,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                await context.Releases.AddAsync(release);
+                await context.SaveChangesAsync();
+            }
+
+            var contentService = new Mock<IContentService>(MockBehavior.Strict);
+            var userReleaseRoleService = new Mock<IUserReleaseRoleService>(MockBehavior.Strict);
+            var emailTemplateService = new Mock<IEmailTemplateService>(MockBehavior.Strict);
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                contentService.Setup(mock => mock.GetContentBlocks<HtmlBlock>(release.Id))
+                    .ReturnsAsync(new List<HtmlBlock>());
+
+                userReleaseRoleService.Setup(mock =>
+                        mock.ListUserReleaseRolesByPublication(ReleaseRole.Approver, release.Publication.Id))
+                    .ReturnsAsync(ListOf(userReleaseRole1, userReleaseRole2));
+
+                emailTemplateService.Setup(mock => mock.SendReleaseHigherReviewEmail(userReleaseRole1.User.Email, It.Is<Release>(r => r.Id == release.Id)))
+                    .Returns(Unit.Instance);
+
+                emailTemplateService.Setup(mock => mock.SendReleaseHigherReviewEmail(userReleaseRole2.User.Email, It.Is<Release>(r => r.Id == release.Id)))
+                    .Returns(new BadRequestResult());
+
+                var releaseService = BuildService(
+                    contentDbContext: context,
+                    contentService: contentService.Object,
+                    userReleaseRoleService: userReleaseRoleService.Object,
+                    emailTemplateService: emailTemplateService.Object
+                );
+
+                var result = await releaseService
+                    .CreateReleaseStatus(
+                        release.Id, new ReleaseStatusCreateRequest
+                        {
+                            PublishMethod = PublishMethod.Scheduled,
+                            PublishScheduled = "2051-06-30",
+                            ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview,
+                            InternalReleaseNote = "Test internal note",
+                            NextReleaseDate = new PartialDate { Month = "12", Year = "2077" },
+                        });
+
+                VerifyAllMocks(contentService, userReleaseRoleService, emailTemplateService);
+                result.AssertLeft();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var saved = await context
+                    .Releases
+                    .Include(r => r.ReleaseStatuses)
+                    .SingleAsync(r => r.Id == release.Id);
+
+                // Assert that the failure to send emails prevented the Release from completing moving into Higher
+                // Level Review.
+                Assert.Equal(ReleaseApprovalStatus.Draft, saved.ApprovalStatus);
+
+                // Assert no new ReleaseStatus entries were added.
+                Assert.Empty(saved.ReleaseStatuses);
+            }
         }
 
         private static IOptions<ReleaseApprovalOptions> DefaultReleaseApprovalOptions()
@@ -1756,7 +2213,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             return new ReleaseApprovalService(
                 contentDbContext,
-                new PersistenceHelper<ContentDbContext>(contentDbContext),
                 dateTimeProvider ?? new DateTimeProvider(),
                 userService.Object,
                 publishingService ?? Mock.Of<IPublishingService>(MockBehavior.Strict),
@@ -1768,7 +2224,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 releaseRepository ?? Mock.Of<IReleaseRepository>(MockBehavior.Strict),
                 options ?? DefaultReleaseApprovalOptions(),
                 userReleaseRoleService ?? Mock.Of<IUserReleaseRoleService>(MockBehavior.Strict),
-                emailTemplateService ?? Mock.Of<IEmailTemplateService>(MockBehavior.Strict));
+                emailTemplateService ?? Mock.Of<IEmailTemplateService>(MockBehavior.Strict),
+                new UserRepository(contentDbContext));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
@@ -10,7 +10,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
@@ -674,7 +673,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             return new(
                 contentDbContext,
-                new PersistenceHelper<ContentDbContext>(contentDbContext),
                 dataImportService ?? new Mock<IDataImportService>().Object,
                 userService ?? MockUtils.AlwaysTrueUserService().Object,
                 dataGuidanceService ?? new Mock<IDataGuidanceService>().Object,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -167,7 +167,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     async userService =>
                     {
                         userService
-                            .Setup(s => s.MatchesPolicy(list[0], CanAssignPrereleaseContactsToSpecificRelease))
+                            .Setup(s => s.MatchesPolicy(list[0], CanAssignPreReleaseUsersToSpecificRelease))
                             .ReturnsAsync(true);
 
                         userService
@@ -230,7 +230,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     async userService =>
                     {
                         userService
-                            .Setup(s => s.MatchesPolicy(list[0], CanAssignPrereleaseContactsToSpecificRelease))
+                            .Setup(s => s.MatchesPolicy(list[0], CanAssignPreReleaseUsersToSpecificRelease))
                             .ReturnsAsync(true);
 
                         userService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
@@ -56,8 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
         /**
          * Pre Release management
          */
-        CanViewPrereleaseContacts,
-        CanAssignPrereleaseContactsToSpecificRelease,
+        CanAssignPreReleaseUsersToSpecificRelease,
 
         /**
          * Publication management

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
@@ -134,10 +134,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
                 /**
                  * Pre Release management
                  */
-                options.AddPolicy(SecurityPolicies.CanViewPrereleaseContacts.ToString(), policy =>
-                    policy.RequireClaim(SecurityClaimTypes.CanViewPrereleaseContacts.ToString()));
-
-                options.AddPolicy(SecurityPolicies.CanAssignPrereleaseContactsToSpecificRelease.ToString(), policy =>
+                options.AddPolicy(SecurityPolicies.CanAssignPreReleaseUsersToSpecificRelease.ToString(), policy =>
                     policy.Requirements.Add(new AssignPrereleaseContactsToSpecificReleaseRequirement()));
 
                 /**

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPreReleaseUserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPreReleaseUserService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
@@ -22,6 +23,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, Unit>> RemovePreReleaseUser(Guid releaseId, string email);
 
-        Task<Either<ActionResult, Unit>> SendPreReleaseUserInviteEmails(Guid releaseId);
+        Task<Either<ActionResult, Unit>> SendPreReleaseInviteEmail(
+            Release release,
+            string email,
+            bool isNewUser);
+
+        Task MarkInviteEmailAsSent(UserReleaseInvite invite);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
@@ -278,16 +278,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
             return userService.CheckPolicy(release, SecurityPolicies.CanMakeAmendmentOfSpecificRelease);
         }
 
-        public static Task<Either<ActionResult, Unit>> CheckCanViewPrereleaseContactsList(
-            this IUserService userService)
-        {
-            return userService.CheckPolicy(SecurityPolicies.CanViewPrereleaseContacts);
-        }
-
         public static Task<Either<ActionResult, Release>> CheckCanAssignPrereleaseContactsToRelease(
             this IUserService userService, Release release)
         {
-            return userService.CheckPolicy(release, SecurityPolicies.CanAssignPrereleaseContactsToSpecificRelease);
+            return userService.CheckPolicy(release, SecurityPolicies.CanAssignPreReleaseUsersToSpecificRelease);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanViewPreReleaseSummary(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
@@ -57,8 +57,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return await _contentDbContext
                 .Releases
                 .HydrateReleaseForChecklist()
-                .SingleOrDefaultAsync(r => r.Id == releaseId)
-                .OrNotFound()
+                .SingleOrNotFoundAsync(r => r.Id == releaseId)
                 .OnSuccess(_userService.CheckCanViewRelease)
                 .OnSuccess(
                     async release => new ReleaseChecklistViewModel(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
@@ -10,7 +10,6 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
@@ -25,7 +24,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
     public class ReleaseChecklistService : IReleaseChecklistService
     {
         private readonly ContentDbContext _contentDbContext;
-        private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
         private readonly IDataImportService _dataImportService;
         private readonly IUserService _userService;
         private readonly IDataGuidanceService _dataGuidanceService;
@@ -36,7 +34,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public ReleaseChecklistService(
             ContentDbContext contentDbContext,
-            IPersistenceHelper<ContentDbContext> persistenceHelper,
             IDataImportService dataImportService,
             IUserService userService,
             IDataGuidanceService dataGuidanceService,
@@ -46,7 +43,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IDataBlockService dataBlockService)
         {
             _contentDbContext = contentDbContext;
-            _persistenceHelper = persistenceHelper;
             _dataImportService = dataImportService;
             _userService = userService;
             _dataGuidanceService = dataGuidanceService;
@@ -58,7 +54,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<Either<ActionResult, ReleaseChecklistViewModel>> GetChecklist(Guid releaseId)
         {
-            return await _persistenceHelper.CheckEntityExists<Release>(releaseId, HydrateReleaseForChecklist)
+            return await _contentDbContext
+                .Releases
+                .HydrateReleaseForChecklist()
+                .SingleOrDefaultAsync(r => r.Id == releaseId)
+                .OrNotFound()
                 .OnSuccess(_userService.CheckCanViewRelease)
                 .OnSuccess(
                     async release => new ReleaseChecklistViewModel(
@@ -66,12 +66,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         await GetWarnings(release)
                     )
                 );
-        }
-
-        public static IQueryable<Release> HydrateReleaseForChecklist(IQueryable<Release> query)
-        {
-            return query.Include(r => r.Publication)
-                .Include(r => r.Updates);
         }
 
         public async Task<List<ReleaseChecklistIssue>> GetErrors(Release release)
@@ -248,6 +242,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var dataBlockIds = dataBlocks.Select(dataBlock => dataBlock.Id);
             return await _contentDbContext.FeaturedTables
                 .AnyAsync(ft => dataBlockIds.Contains(ft.DataBlockId));
+        }
+    }
+
+    public static class ReleaseChecklistQueryableExtensions
+    {
+        public static IQueryable<Release> HydrateReleaseForChecklist(this IQueryable<Release> query)
+        {
+            return query.Include(r => r.Publication)
+                .Include(r => r.Updates);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -345,8 +345,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return await _context
                 .Releases
                 .HydrateReleaseForChecklist()
-                .SingleOrDefaultAsync(r => r.Id == releaseId)
-                .OrNotFound()
+                .SingleOrNotFoundAsync(r => r.Id == releaseId)
                 .OnSuccess(_userService.CheckCanUpdateRelease)
                 .OnSuccessDo(async release => await ValidateReleaseSlugUniqueToPublication(request.Slug, release.PublicationId, releaseId))
                 .OnSuccess(async release =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -342,8 +342,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, ReleaseViewModel>> UpdateRelease(
             Guid releaseId, ReleaseUpdateRequest request)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<Release>(releaseId, ReleaseChecklistService.HydrateReleaseForChecklist)
+            return await _context
+                .Releases
+                .HydrateReleaseForChecklist()
+                .SingleOrDefaultAsync(r => r.Id == releaseId)
+                .OrNotFound()
                 .OnSuccess(_userService.CheckCanUpdateRelease)
                 .OnSuccessDo(async release => await ValidateReleaseSlugUniqueToPublication(request.Slug, release.PublicationId, releaseId))
                 .OnSuccess(async release =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
@@ -1652,5 +1652,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model
 
             result.AssertLeft(500);
         }
+
+        [Fact]
+        public void OnSuccessAllReturnVoid()
+        {
+            var either1 = new Either<int, string>("either1");
+            var either2 = new Either<int, string>("either2");
+            var either3 = new Either<int, string>("either3");
+
+            var eitherList = ListOf(either1, either2, either3);
+
+            var results = eitherList.OnSuccessAllReturnVoid();
+
+            Assert.True(results.IsRight);
+            Assert.Equal(Unit.Instance, results.Right);
+        }
+
+        [Fact]
+        public void OnSuccessAllReturnVoid_Left()
+        {
+            var either1 = new Either<int, string>("either1");
+            var either2 = new Either<int, string>(2);
+            var either3 = new Either<int, string>(3);
+
+            var eitherList = ListOf(either1, either2, either3);
+
+            var results = eitherList.OnSuccessAllReturnVoid();
+
+            Assert.True(results.IsLeft);
+            Assert.Equal(2, results.Left);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -66,6 +66,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
     public static class EitherExtensions
     {
+        /// <summary>
+        /// If all Eithers in the provided list are successful, return a list of the successful results. Otherwise,
+        /// return the first failure.
+        /// </summary>
         public static Either<TFailure, List<TSuccess>> OnSuccessAll<TFailure, TSuccess>(
             this IEnumerable<Either<TFailure, TSuccess>> items)
         {
@@ -80,6 +84,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
                 result.Add(either.Right);
             }
             return result;
+        }
+
+        /// <summary>
+        /// If all Eithers in the provided list are successful, return Unit.Instance. Otherwise, return the first
+        /// failure.
+        /// </summary>
+        public static Either<TFailure, Unit> OnSuccessAllReturnVoid<TFailure, TSuccess>(
+            this IEnumerable<Either<TFailure, TSuccess>> items)
+        {
+            return items
+                .OnSuccessAll()
+                .OnSuccessVoid();
         }
 
         public static Either<TFailure, Unit> OnSuccessVoid<TFailure, TSuccess>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -302,10 +302,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 FiltersDifferFromSubject).OnSuccess(_ =>
             {
                 var requestMap = requestFilters.ToDictionary(filter => filter.Id);
-                return filters.Select(filter =>
+                return filters
+                    .Select(filter =>
                         ValidateFilterGroupsForSubject(filter, requestMap[filter.Id].FilterGroups))
-                    .OnSuccessAll()
-                    .OnSuccessVoid();
+                    .OnSuccessAllReturnVoid();
             });
         }
 
@@ -321,13 +321,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 .OnSuccess(_ =>
                 {
                     var requestMap = requestFilterGroups.ToDictionary(filterGroup => filterGroup.Id);
-                    return filter.FilterGroups.Select(filterGroup =>
+                    return filter
+                        .FilterGroups
+                        .Select(filterGroup =>
                             AssertCollectionsAreSameIgnoringOrder(
                                 filterGroup.FilterItems.Select(filterItem => filterItem.Id),
                                 requestMap[filterGroup.Id].FilterItems,
                                 FilterItemsDifferFromSubject))
-                        .OnSuccessAll()
-                        .OnSuccessVoid();
+                        .OnSuccessAllReturnVoid();
                 });
         }
 
@@ -349,8 +350,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                                 indicatorGroup.Indicators.Select(indicator => indicator.Id),
                                 requestMap[indicatorGroup.Id].Indicators,
                                 IndicatorsDifferFromSubject))
-                        .OnSuccessAll()
-                        .OnSuccessVoid();
+                        .OnSuccessAllReturnVoid();
                 });
         }
 

--- a/tests/robot-tests/tests/libs/admin-utilities.py
+++ b/tests/robot-tests/tests/libs/admin-utilities.py
@@ -14,9 +14,9 @@ logger = get_logger(__name__)
 sl = BuiltIn().get_library_instance("SeleniumLibrary")
 
 
-def raise_assertion_error(self, err_msg):
+def raise_assertion_error(err_msg):
     sl.failure_occurred()
-    self.logger.warn(err_msg)
+    logger.warn(err_msg)
     raise AssertionError(err_msg)
 
 


### PR DESCRIPTION
## UI test run update - 17/11/23

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/24064e37-49ea-45fc-bc46-c8a100c2fc8e)

This PR:
- resolves a bug whereby a permission check was failing when attempting to send Pre-Release emails, causing the approval of the Release to silently fail to send the emails.

There were 2 main things to sort out in this PR, and an additional bonus one:
* Stop the permissions issue from occurring.
* Stop silently ignoring errors during Release approval.
* Bonus - prevent the release approval completing if any failures are encountered along the way. 

## Stop the permissions issue from occurring
Upon looking further into it, and given that ReleaseApprovalService was the only caller for SendPreReleaseUserInviteEmails(), I chose to bring that method into ReleaseApprovalService itself, and strip out the permission check as it's already been done in the calling method.

## Stop silently ignoring errors during Release approval
For this, I re-jigged the code to always take into account the return values from sending emails.  I also noticed that we were ignoring potential failures from informing the Publisher of the Release change as well, so I got it to take into account the return values from this call as well.

## Prevent approval from completing if failures occur
It seemed dangerous to allow the Release approval to partially go through if either Pre-Release emails couldn't be sent or the Publisher was not informed of the Release change.  Therefore, I added a basic rollback of the Release updates and the new Release Status that is created just prior to the Publisher being notified.  Removing unused files is NOT rolled back, but it seemed that that was a low priority thing to attempt to roll back.  

I thought initially that we could just delay the updating of the Release and the creation of the new Release Status until after the Publisher was notified of the change, so we didn't need t have anything to roll back, but I was surprised that this actually caused failures.  Given notifying the Publisher was simply a queue message drop, I would have thought there would be no race condition likely between then moving on to saving the Release changes, and the queue message being dealt with, but locally at least, there was!

## Other misc things
* Removed an old unused SecurityPolicy.
* Replaced PersistenceHelper with plain DbContext lookups 
* Raised ticket EES-4681 to investigate why sometimes we're marking emails as sent and sometimes we're not. 