### PR TITLE
EES-4467 - fixing Fast Track link generated in Admin

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
@@ -141,7 +141,7 @@ const ReleaseDataBlockEditPage = ({
                 <SummaryListItem term="Fast track URL">
                   <UrlContainer
                     data-testid="fastTrackUrl"
-                    url={`${config.PublicAppUrl}/data-tables/fast-track/${dataBlockId}`}
+                    url={`${config.PublicAppUrl}/data-tables/fast-track/${dataBlock.dataBlockParentId}`}
                   />
                 </SummaryListItem>
                 {dataBlock.dataSetName && (

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
@@ -41,6 +41,7 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
 describe('ReleaseDataBlockEditPage', () => {
   const testDataBlock: ReleaseDataBlock = {
     id: 'block-1',
+    dataBlockParentId: 'block-1-parent',
     dataSetId: 'data-set-1',
     dataSetName: 'Test data set',
     name: 'Test name 1',
@@ -207,7 +208,7 @@ describe('ReleaseDataBlockEditPage', () => {
 
     expect(screen.queryByTestId('Highlight name')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Url')).toHaveValue(
-      'http://localhost/data-tables/fast-track/block-1',
+      'http://localhost/data-tables/fast-track/block-1-parent',
     );
   });
 
@@ -421,7 +422,7 @@ describe('ReleaseDataBlockEditPage', () => {
         screen.getByTestId('Featured table description'),
       ).toHaveTextContent('Test highlight description 1');
       expect(screen.getByLabelText('Url')).toHaveValue(
-        'http://localhost/data-tables/fast-track/block-1',
+        'http://localhost/data-tables/fast-track/block-1-parent',
       );
     });
 
@@ -450,7 +451,7 @@ describe('ReleaseDataBlockEditPage', () => {
       ).not.toBeInTheDocument();
 
       expect(screen.getByLabelText('Url')).toHaveValue(
-        'http://localhost/data-tables/fast-track/block-1',
+        'http://localhost/data-tables/fast-track/block-1-parent',
       );
     });
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
@@ -29,6 +29,7 @@ describe('DataBlockPageTabs', () => {
     name: 'Test data block',
     heading: 'Test title',
     id: 'block-1',
+    dataBlockParentId: 'block-1-parent',
     dataSetId: 'subject-1',
     dataSetName: 'Test subject',
     source: 'Test source',

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -255,6 +255,7 @@ describe('PreReleaseTableToolPage', () => {
 
   const testDataBlock: ReleaseDataBlock = {
     id: 'block-1',
+    dataBlockParentId: 'block-1-parent',
     dataSetId: 'data-set-1',
     dataSetName: 'Test data set',
     name: 'Test block',

--- a/src/explore-education-statistics-admin/src/services/dataBlockService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataBlockService.ts
@@ -3,10 +3,7 @@ import { DataBlock } from '@common/services/types/blocks';
 import { OmitStrict } from '@common/types';
 import { FeaturedTableBasic } from '@admin/services/featuredTableService';
 
-export type ReleaseDataBlock = OmitStrict<
-  DataBlock,
-  'order' | 'type' | 'dataBlockParentId'
->;
+export type ReleaseDataBlock = OmitStrict<DataBlock, 'order' | 'type'>;
 
 export interface ReleaseDataBlockSummary {
   id: string;


### PR DESCRIPTION
This PR:
* fixes the Fast Track preview URL that is generated for a Data Block when in Admin.

I found during doing a quick test of Admin after the big EES-4467 PR went in that I'd not addressed the Public Fast Track link in Admin when a user creates a Featured Table.  This needs to be using the permanent DataBlockParent Id, rather than the versionable DataBlockVersion Id.

I had no idea that this URL preview was even a thing until now!

## UI tests

All passing saving for the usual Data Catalogue failure that we're currently getting on the dev branch.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/e236437f-5ebb-48ee-aad9-e9b15a857f90)
