### PR TITLE
EES-4660 Part 2 - Begin setting Data Guidance on `ReleaseFile.Summary`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataGuidanceMigrationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataGuidanceMigrationServicePermissionTests.cs
@@ -1,0 +1,41 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+public class DataGuidanceMigrationServicePermissionTests
+{
+    [Fact]
+    public async Task MigrateDataGuidance()
+    {
+        await PolicyCheckBuilder()
+            .SetupCheck(SecurityPolicies.IsBauUser, false)
+            .AssertForbidden(
+                async userService =>
+                {
+                    var service = SetupService(userService: userService.Object);
+                    return await service.MigrateDataGuidance();
+                }
+            );
+    }
+
+    private static DataGuidanceMigrationService SetupService(IUserService userService)
+    {
+        return new DataGuidanceMigrationService(
+            Mock.Of<ContentDbContext>(),
+            Mock.Of<StatisticsDbContext>(),
+            userService
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataGuidanceMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataGuidanceMigrationServiceTests.cs
@@ -1,0 +1,581 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.StatisticsDbUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+public class DataGuidanceMigrationServiceTests
+{
+    private readonly DataFixture _fixture = new();
+
+    [Fact]
+    public async Task MigrateDataGuidance()
+    {
+        // Set up 2 releases with data sets as follows:
+        // Release 1: Data set 1, Data set 2
+        // Release 2: Data set 1, Data set 3
+
+        var statsReleases = _fixture.DefaultStatsRelease()
+            .GenerateList(2);
+        var (statsRelease1, statsRelease2) = statsReleases.ToTuple2();
+
+        var subjects = _fixture.DefaultSubject()
+            .GenerateList(3);
+        var (subject1, subject2, subject3) = subjects.ToTuple3();
+
+        var release1Subjects = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease1)
+            .WithSubjects(ListOf(subject1, subject2))
+            .GenerateList(2);
+        var (release1Subject1, release1Subject2) = release1Subjects.ToTuple2();
+
+        var release2Subjects = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease2)
+            .WithSubjects(ListOf(subject1, subject3))
+            .GenerateList(2);
+        var (release2Subject1, release2Subject3) = release2Subjects.ToTuple2();
+
+        var contentReleases = _fixture.DefaultRelease()
+            .WithIds(statsReleases.Select(r => r.Id))
+            .GenerateList(2);
+        var (contentRelease1, contentRelease2) = contentReleases.ToTuple2();
+
+        var release1Files = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease1,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release1Subject1.SubjectId
+                }
+            },
+            new()
+            {
+                Release = contentRelease1,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release1Subject2.SubjectId
+                }
+            }
+        };
+
+        var release2Files = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease2,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release2Subject1.SubjectId
+                }
+            },
+            new()
+            {
+                Release = contentRelease2,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release2Subject3.SubjectId
+                }
+            }
+        };
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            await statisticsDbContext.Release.AddRangeAsync(statsReleases);
+            await statisticsDbContext.Subject.AddRangeAsync(subjects);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(release1Subjects.Concat(release2Subjects));
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Releases.AddRangeAsync(contentReleases);
+            await contentDbContext.ReleaseFiles.AddRangeAsync(release1Files.Concat(release2Files));
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateDataGuidance(dryRun: false);
+
+            var report = result.AssertRight();
+
+            Assert.False(report.DryRun);
+            Assert.Equal(4, report.ReleaseDataFilesExcludingReplacementsCount);
+            Assert.Empty(report.FileIdsWithNoMatchingSubject);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var actualReleaseFiles = await contentDbContext.ReleaseFiles.ToListAsync();
+
+            Assert.Equal(release1Subject1.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release1Files[0].Id).Summary);
+            Assert.Equal(release1Subject2.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release1Files[1].Id).Summary);
+
+            Assert.Equal(release2Subject1.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release2Files[0].Id).Summary);
+            Assert.Equal(release2Subject3.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release2Files[1].Id).Summary);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateDataGuidance_DryRunMakesNoChanges()
+    {
+        // Set up 2 releases with data sets as follows:
+        // Release 1: Data set 1, Data set 2
+        // Release 2: Data set 1, Data set 3
+
+        var statsReleases = _fixture.DefaultStatsRelease()
+            .GenerateList(2);
+        var (statsRelease1, statsRelease2) = statsReleases.ToTuple2();
+
+        var subjects = _fixture.DefaultSubject()
+            .GenerateList(3);
+        var (subject1, subject2, subject3) = subjects.ToTuple3();
+
+        var release1Subjects = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease1)
+            .WithSubjects(ListOf(subject1, subject2))
+            .GenerateList(2);
+        var (release1Subject1, release1Subject2) = release1Subjects.ToTuple2();
+
+        var release2Subjects = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease2)
+            .WithSubjects(ListOf(subject1, subject3))
+            .GenerateList(2);
+        var (release2Subject1, release2Subject3) = release2Subjects.ToTuple2();
+
+        var contentReleases = _fixture.DefaultRelease()
+            .WithIds(statsReleases.Select(r => r.Id))
+            .GenerateList(2);
+        var (contentRelease1, contentRelease2) = contentReleases.ToTuple2();
+
+        var release1Files = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease1,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release1Subject1.SubjectId
+                }
+            },
+            new()
+            {
+                Release = contentRelease1,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release1Subject2.SubjectId
+                }
+            }
+        };
+
+        var release2Files = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease2,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release2Subject1.SubjectId
+                }
+            },
+            new()
+            {
+                Release = contentRelease2,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release2Subject3.SubjectId
+                }
+            }
+        };
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            await statisticsDbContext.Release.AddRangeAsync(statsReleases);
+            await statisticsDbContext.Subject.AddRangeAsync(subjects);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(release1Subjects.Concat(release2Subjects));
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Releases.AddRangeAsync(contentReleases);
+            await contentDbContext.ReleaseFiles.AddRangeAsync(release1Files.Concat(release2Files));
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateDataGuidance(dryRun: true);
+
+            var report = result.AssertRight();
+            Assert.True(report.DryRun);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var actualReleaseFiles = await contentDbContext.ReleaseFiles.ToListAsync();
+
+            // Release file summaries should be untouched
+            Assert.Equal(release1Files[0].Summary,
+                actualReleaseFiles.Single(rf => rf.Id == release1Files[0].Id).Summary);
+            Assert.Equal(release1Files[1].Summary,
+                actualReleaseFiles.Single(rf => rf.Id == release1Files[1].Id).Summary);
+
+            Assert.Equal(release2Files[0].Summary,
+                actualReleaseFiles.Single(rf => rf.Id == release2Files[0].Id).Summary);
+            Assert.Equal(release2Files[1].Summary,
+                actualReleaseFiles.Single(rf => rf.Id == release2Files[1].Id).Summary);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateDataGuidance_IgnoresNonDataFileTypes()
+    {
+        var statsRelease = _fixture.DefaultStatsRelease().Generate();
+
+        var releaseSubject = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease)
+            .WithSubject(_fixture.DefaultSubject().Generate())
+            .Generate();
+
+        var contentRelease = _fixture.DefaultRelease()
+            .WithId(statsRelease.Id)
+            .Generate();
+
+        var releaseFiles = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = releaseSubject.SubjectId
+                }
+            },
+            // Set up other release file with a non-data file type
+            new()
+            {
+                Release = contentRelease,
+                File = new File
+                {
+                    Type = FileType.Ancillary
+                },
+                Summary = "Ancillary file summary"
+            }
+        };
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            await statisticsDbContext.Release.AddRangeAsync(statsRelease);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Releases.AddRangeAsync(contentRelease);
+            await contentDbContext.ReleaseFiles.AddRangeAsync(releaseFiles);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateDataGuidance(dryRun: false);
+
+            var report = result.AssertRight();
+
+            // Count of release data files should not include the other file
+            Assert.Equal(1, report.ReleaseDataFilesExcludingReplacementsCount);
+            Assert.Empty(report.FileIdsWithNoMatchingSubject);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var actualReleaseFiles = await contentDbContext.ReleaseFiles.ToListAsync();
+
+            Assert.Equal(releaseSubject.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == releaseFiles[0].Id).Summary);
+
+            // Summary of other release file should be untouched
+            Assert.Equal("Ancillary file summary",
+                actualReleaseFiles.Single(rf => rf.Id == releaseFiles[1].Id).Summary);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateDataGuidance_IgnoresFileReplacementsInProgress()
+    {
+        // Set up 2 releases with data sets as follows:
+        // Release 1: Data set 1
+        // Release 2: Data set 1, Data set 2 (replacement of Data set 1 in progress)
+
+        var statsReleases = _fixture.DefaultStatsRelease()
+            .GenerateList(2);
+        var (statsRelease1, statsRelease2) = statsReleases.ToTuple2();
+
+        var subjects = _fixture.DefaultSubject()
+            .GenerateList(2);
+        var (subject1, subject2) = subjects.ToTuple2();
+
+        var release1Subject1 = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease1)
+            .WithSubject(subject1)
+            .Generate();
+
+        var release2Subjects = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease2)
+            .WithSubjects(ListOf(subject1, subject2))
+            .GenerateList(2);
+        var (release2Subject1, release2Subject2) = release2Subjects.ToTuple2();
+
+        var contentReleases = _fixture.DefaultRelease()
+            .WithIds(statsReleases.Select(r => r.Id))
+            .GenerateList(2);
+        var (contentRelease1, contentRelease2) = contentReleases.ToTuple2();
+
+        var release1File1 = new ReleaseFile
+        {
+            Release = contentRelease1,
+            File = new File
+            {
+                Type = FileType.Data,
+                SubjectId = release1Subject1.SubjectId
+            }
+        };
+
+        // Set up the replacement of the data set in release 2
+
+        var release2File1 = new ReleaseFile
+        {
+            Release = contentRelease2,
+            File = new File
+            {
+                Type = FileType.Data,
+                SubjectId = release2Subject1.SubjectId
+            }
+        };
+
+        var release2File2 = new ReleaseFile
+        {
+            Release = contentRelease2,
+            File = new File
+            {
+                Type = FileType.Data,
+                SubjectId = release2Subject2.SubjectId,
+                Replacing = release2File1.File
+            }
+        };
+
+        release2File1.File.ReplacedBy = release2File2.File;
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            await statisticsDbContext.Release.AddRangeAsync(statsReleases);
+            await statisticsDbContext.Subject.AddRangeAsync(subjects);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(release1Subject1, release2Subject1,
+                release2Subject2);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Releases.AddRangeAsync(contentReleases);
+            await contentDbContext.ReleaseFiles.AddRangeAsync(release1File1, release2File1, release2File2);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateDataGuidance(dryRun: false);
+
+            var report = result.AssertRight();
+
+            // Count of release data files should not include the replacement in progress
+            Assert.Equal(2, report.ReleaseDataFilesExcludingReplacementsCount);
+            Assert.Empty(report.FileIdsWithNoMatchingSubject);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var actualReleaseFiles = await contentDbContext.ReleaseFiles.ToListAsync();
+
+            Assert.Equal(release1Subject1.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release1File1.Id).Summary);
+
+            // Release file which is in the process of being replaced should have the data guidance set
+            // from the original release subject
+            Assert.Equal(release2Subject1.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release2File1.Id).Summary);
+
+            // Release file which is the replacement should not have data guidance set
+            // It will be set as a copy of the data guidance from the original file when the replacement is executed
+            Assert.Null(actualReleaseFiles.Single(rf => rf.Id == release2File2.Id).Summary);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateDataGuidance_HandlesFileWithSubjectIdNotFound()
+    {
+        var statsRelease = _fixture.DefaultStatsRelease().Generate();
+
+        var releaseSubject = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease)
+            .WithSubject(_fixture.DefaultSubject().Generate())
+            .WithDataGuidance("Data set guidance")
+            .Generate();
+
+        var contentRelease = _fixture.DefaultRelease()
+            .WithId(statsRelease.Id)
+            .Generate();
+
+        var releaseFiles = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = releaseSubject.SubjectId
+                }
+            },
+            // Set up a release data file with a subject id that doesn't exist in the statistics db
+            new()
+            {
+                Release = contentRelease,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = Guid.NewGuid()
+                }
+            },
+            // Set up a release data file with a subject id is null
+            new()
+            {
+                Release = contentRelease,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = null
+                }
+            }
+        };
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            await statisticsDbContext.Release.AddRangeAsync(statsRelease);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Releases.AddRangeAsync(contentRelease);
+            await contentDbContext.ReleaseFiles.AddRangeAsync(releaseFiles);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateDataGuidance(dryRun: false);
+
+            var report = result.AssertRight();
+
+            Assert.Equal(3, report.ReleaseDataFilesExcludingReplacementsCount);
+
+            // Files with no matching subject should have their id's added to the report
+            Assert.Equal(SetOf(releaseFiles[1].FileId, releaseFiles[2].FileId),
+                report.FileIdsWithNoMatchingSubject);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var actualReleaseFiles = await contentDbContext.ReleaseFiles.ToListAsync();
+
+            Assert.Equal(releaseSubject.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == releaseFiles[0].Id).Summary);
+            Assert.Null(actualReleaseFiles.Single(rf => rf.Id == releaseFiles[1].Id).Summary);
+            Assert.Null(actualReleaseFiles.Single(rf => rf.Id == releaseFiles[2].Id).Summary);
+        }
+    }
+
+    private static DataGuidanceMigrationService SetupService(
+        ContentDbContext? contentDbContext = null,
+        StatisticsDbContext? statisticsDbContext = null,
+        IUserService? userService = null)
+    {
+        return new DataGuidanceMigrationService(
+            contentDbContext ?? Mock.Of<ContentDbContext>(MockBehavior.Strict),
+            statisticsDbContext ?? Mock.Of<StatisticsDbContext>(MockBehavior.Strict),
+            userService ?? MockUtils.AlwaysTrueUserService().Object
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataGuidanceServiceTests.cs
@@ -203,7 +203,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     Filename = "file1.csv",
                     Type = FileType.Data
-                }
+                },
+                Summary = "Data set 1 guidance"
             };
 
             var releaseFile2 = new ReleaseFile
@@ -213,7 +214,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     Filename = "file2.csv",
                     Type = FileType.Data
-                }
+                },
+                Summary = "Data set 2 guidance"
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -255,11 +257,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                // Assert no changes have been made
+                // Assert no changes have been made to the release or any of the data sets
                 var actualRelease = await contentDbContext.Releases
                     .FirstAsync(r => r.Id == release1.Id);
 
                 Assert.Equal("Release 1 guidance", actualRelease.DataGuidance);
+
+                var actualReleaseFile1 = await contentDbContext.ReleaseFiles
+                    .FirstAsync(rf => rf.ReleaseId == release1.Id
+                                      && rf.FileId == releaseFile1.FileId);
+
+                Assert.Equal("Data set 1 guidance", actualReleaseFile1.Summary);
+
+                var actualReleaseFile2 = await contentDbContext.ReleaseFiles
+                    .FirstAsync(rf => rf.ReleaseId == release2.Id
+                                      && rf.FileId == releaseFile2.FileId);
+
+                Assert.Equal("Data set 2 guidance", actualReleaseFile2.Summary);
             }
         }
 
@@ -295,7 +309,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Filename = "file1.csv",
                     Type = FileType.Data,
                     SubjectId = subject1.Id
-                }
+                },
+                Summary = "Data set 1 guidance"
             };
 
             var releaseFile2 = new ReleaseFile
@@ -306,7 +321,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Filename = "file2.csv",
                     Type = FileType.Data,
                     SubjectId = subject2.Id
-                }
+                },
+                Summary = "Data set 2 guidance"
             };
 
             var releaseSubject1 = new ReleaseSubject
@@ -394,16 +410,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal("Data set 1 guidance updated", actualSubject1.DataGuidance);
 
+                var actualReleaseFile1 = await contentDbContext.ReleaseFiles
+                    .FirstAsync(rf => rf.ReleaseId == contentRelease.Id
+                                      && rf.FileId == releaseFile1.FileId);
+
+                Assert.Equal("Data set 1 guidance updated", actualReleaseFile1.Summary);
+
                 var actualSubject2 = await statisticsDbContext.ReleaseSubject
                     .FirstAsync(rs => rs.ReleaseId == statsRelease.Id
                                       && rs.SubjectId == releaseSubject2.Subject.Id);
 
                 Assert.Equal("Data set 2 guidance", actualSubject2.DataGuidance);
+
+                var actualReleaseFile2 = await contentDbContext.ReleaseFiles
+                    .FirstAsync(rf => rf.ReleaseId == contentRelease.Id
+                                      && rf.FileId == releaseFile2.FileId);
+
+                Assert.Equal("Data set 2 guidance", actualReleaseFile2.Summary);
             }
         }
 
         [Fact]
-        public async Task UpdateDataGuidance_WithSubjects_AmendedRelease()
+        public async Task UpdateDataGuidance_WithDataSets_AmendedRelease()
         {
             var contentReleaseVersion1 = new Release
             {
@@ -449,7 +477,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Filename = "file1.csv",
                     Type = FileType.Data,
                     SubjectId = subject1.Id
-                }
+                },
+                Summary = "Version 1 data set 1 guidance"
             };
 
             var releaseVersion2File1 = new ReleaseFile
@@ -460,7 +489,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Filename = "file1.csv",
                     Type = FileType.Data,
                     SubjectId = subject1.Id
-                }
+                },
+                Summary = "Version 2 data set 1 guidance"
             };
 
             var releaseVersion2File2 = new ReleaseFile
@@ -471,7 +501,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Filename = "file2.csv",
                     Type = FileType.Data,
                     SubjectId = subject2.Id
-                }
+                },
+                Summary = "Version 2 data set 2 guidance"
             };
 
             var releaseVersion1Subject1 = new ReleaseSubject
@@ -574,6 +605,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal("Version 1 data set 1 guidance", actualReleaseVersion1Subject1.DataGuidance);
 
+                var actualReleaseVersion1File1 = await contentDbContext.ReleaseFiles
+                    .FirstAsync(rf => rf.ReleaseId == contentReleaseVersion1.Id
+                                      && rf.FileId == releaseVersion1File1.FileId);
+
+                Assert.Equal("Version 1 data set 1 guidance", actualReleaseVersion1File1.Summary);
+
                 // Assert only one data set on version 2 has been updated
                 var actualReleaseVersion2Subject1 = await statisticsDbContext.ReleaseSubject
                     .FirstAsync(rs => rs.ReleaseId == statsReleaseVersion2.Id
@@ -581,11 +618,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal("Version 2 data set 1 guidance updated", actualReleaseVersion2Subject1.DataGuidance);
 
+                var actualReleaseVersion2File1 = await contentDbContext.ReleaseFiles
+                    .FirstAsync(rf => rf.ReleaseId == contentReleaseVersion2.Id
+                                      && rf.FileId == releaseVersion2File1.FileId);
+
+                Assert.Equal("Version 2 data set 1 guidance updated", actualReleaseVersion2File1.Summary);
+
                 var actualReleaseVersion2Subject2 = await statisticsDbContext.ReleaseSubject
                     .FirstAsync(rs => rs.ReleaseId == statsReleaseVersion2.Id
                                       && rs.SubjectId == subject2.Id);
 
                 Assert.Equal("Version 2 data set 2 guidance", actualReleaseVersion2Subject2.DataGuidance);
+
+                var actualReleaseVersion2File2 = await contentDbContext.ReleaseFiles
+                    .FirstAsync(rf => rf.ReleaseId == contentReleaseVersion2.Id
+                                      && rf.FileId == releaseVersion2File2.FileId);
+
+                Assert.Equal("Version 2 data set 2 guidance", actualReleaseVersion2File2.Summary);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataGuidanceMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataGuidanceMigrationController.cs
@@ -1,0 +1,36 @@
+﻿#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+[Route("api")]
+[ApiController]
+[Authorize(Roles = GlobalRoles.RoleNames.BauUser)]
+public class DataGuidanceMigrationController : ControllerBase
+{
+    private readonly IDataGuidanceMigrationService _dataGuidanceMigrationService;
+
+    public DataGuidanceMigrationController(IDataGuidanceMigrationService dataGuidanceMigrationService)
+    {
+        _dataGuidanceMigrationService = dataGuidanceMigrationService;
+    }
+
+    [HttpPatch("bau/migrate-data-guidance")]
+    public async Task<ActionResult<DataGuidanceMigrationReport>> MigrateDataGuidance([FromQuery] bool dryRun = true,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dataGuidanceMigrationService
+            .MigrateDataGuidance(dryRun, cancellationToken)
+            .HandleFailuresOrOk();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataGuidanceMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataGuidanceMigrationService.cs
@@ -1,0 +1,83 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+public class DataGuidanceMigrationService : IDataGuidanceMigrationService
+{
+    private readonly ContentDbContext _contentDbContext;
+    private readonly StatisticsDbContext _statisticsDbContext;
+    private readonly IUserService _userService;
+
+    public DataGuidanceMigrationService(ContentDbContext contentDbContext,
+        StatisticsDbContext statisticsDbContext,
+        IUserService userService)
+    {
+        _contentDbContext = contentDbContext;
+        _statisticsDbContext = statisticsDbContext;
+        _userService = userService;
+    }
+
+    public async Task<Either<ActionResult, DataGuidanceMigrationReport>> MigrateDataGuidance(bool dryRun = true,
+        CancellationToken cancellationToken = default)
+    {
+        return await _userService.CheckIsBauUser()
+            .OnSuccess(async () =>
+            {
+                var releaseDataFilesExcludingReplacements = await _contentDbContext.ReleaseFiles
+                    .Include(rf => rf.File)
+                    .Where(rf => rf.File.Type == FileType.Data
+                                 && rf.File.ReplacingId == null)
+                    .ToListAsync(cancellationToken);
+
+                var fileIdsWithNoMatchingSubject = new HashSet<Guid>();
+
+                await releaseDataFilesExcludingReplacements
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitWithCancellationAsync(async (ReleaseFile rf, CancellationToken ct) =>
+                    {
+                        var releaseSubject = await _statisticsDbContext.ReleaseSubject
+                            .SingleOrDefaultAsync(rs => rs.ReleaseId == rf.ReleaseId
+                                                        && rs.SubjectId == rf.File.SubjectId,
+                                ct);
+
+                        if (releaseSubject == null)
+                        {
+                            fileIdsWithNoMatchingSubject.Add(rf.FileId);
+                        }
+                        else
+                        {
+                            rf.Summary = releaseSubject.DataGuidance;
+                        }
+                    }, cancellationToken);
+
+                if (!dryRun)
+                {
+                    await _contentDbContext.SaveChangesAsync(cancellationToken);
+                }
+
+                return new DataGuidanceMigrationReport(
+                    dryRun,
+                    ReleaseDataFilesExcludingReplacementsCount: releaseDataFilesExcludingReplacements.Count,
+                    fileIdsWithNoMatchingSubject
+                );
+            });
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataGuidanceService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -131,6 +132,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             releaseFiles.ForEach(releaseFile =>
             {
                 var content = updateRequestsByFileId[releaseFile.FileId].Content;
+
+                _contentDbContext.Update(releaseFile);
+                releaseFile.Summary = content;
+
+                // Until we switch over data guidance and data catalogue to use ReleaseFiles as the
+                // source for content, ensure data guidance content is still updated for each corresponding
+                // ReleaseSubject.
+                // TODO EES-4661 Once the change to migrate data guidance from ReleaseSubject to ReleaseFile has been
+                // a success, drop ReleaseSubject.DataGuidance.
 
                 var releaseSubject = releaseSubjectsBySubjectId[releaseFile.File.SubjectId!.Value];
                 _statisticsDbContext.Update(releaseSubject);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataGuidanceMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataGuidanceMigrationService.cs
@@ -1,0 +1,18 @@
+﻿#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+public interface IDataGuidanceMigrationService
+{
+    public Task<Either<ActionResult, DataGuidanceMigrationReport>> MigrateDataGuidance(
+        bool dryRun = true,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -13,7 +13,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
@@ -26,7 +25,6 @@ using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using IReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseService;
-using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
 using Unit = GovUk.Education.ExploreEducationStatistics.Common.Model.Unit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
@@ -42,7 +40,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IFootnoteRepository _footnoteRepository;
         private readonly IReleaseService _releaseService;
         private readonly ITimePeriodService _timePeriodService;
-        private readonly IPersistenceHelper<ContentDbContext> _contentPersistenceHelper;
         private readonly IUserService _userService;
         private readonly ICacheKeyService _cacheKeyService;
         private readonly IBlobCacheService _cacheService;
@@ -58,7 +55,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IFootnoteRepository footnoteRepository,
             IReleaseService releaseService,
             ITimePeriodService timePeriodService,
-            IPersistenceHelper<ContentDbContext> contentPersistenceHelper,
             IUserService userService,
             ICacheKeyService cacheKeyService,
             IBlobCacheService cacheService)
@@ -72,7 +68,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _footnoteRepository = footnoteRepository;
             _releaseService = releaseService;
             _timePeriodService = timePeriodService;
-            _contentPersistenceHelper = contentPersistenceHelper;
             _userService = userService;
             _cacheKeyService = cacheKeyService;
             _cacheService = cacheService;
@@ -83,31 +78,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             Guid originalFileId,
             Guid replacementFileId)
         {
-            return await _contentPersistenceHelper
-                .CheckEntityExists<Release>(releaseId)
+            return await _contentDbContext.Releases
+                .FirstOrNotFoundAsync(r => r.Id == releaseId)
                 .OnSuccess(_userService.CheckCanUpdateRelease)
-                .OnSuccess(() => CheckFileExists(releaseId, originalFileId)
-                    .OnSuccess(async originalFile =>
-                    {
-                        return await CheckFileExists(releaseId, replacementFileId)
-                            .OnSuccess(async replacementFile =>
-                            {
-                                var originalSubjectId = originalFile.SubjectId!.Value;
-                                var replacementSubjectId = replacementFile.SubjectId!.Value;
+                .OnSuccess(() => CheckReleaseFilesExist(releaseId, originalFileId, replacementFileId))
+                .OnSuccess(async releaseFiles =>
+                {
+                    var originalFile = releaseFiles.originalReleaseFile.File;
+                    var replacementFile = releaseFiles.replacementReleaseFile.File;
 
-                                var replacementSubjectMeta = await GetReplacementSubjectMeta(replacementSubjectId);
+                    var originalSubjectId = originalFile.SubjectId!.Value;
+                    var replacementSubjectId = replacementFile.SubjectId!.Value;
 
-                                var dataBlocks = ValidateDataBlocks(releaseId, originalSubjectId,
-                                    replacementSubjectMeta);
-                                var footnotes = await ValidateFootnotes(releaseId, originalSubjectId, replacementSubjectMeta);
+                    var replacementSubjectMeta = await GetReplacementSubjectMeta(replacementSubjectId);
 
-                                return new DataReplacementPlanViewModel(
-                                    dataBlocks,
-                                    footnotes,
-                                    originalSubjectId,
-                                    replacementSubjectId);
-                            });
-                    }));
+                    var dataBlocks = ValidateDataBlocks(releaseId, originalSubjectId,
+                        replacementSubjectMeta);
+                    var footnotes = await ValidateFootnotes(releaseId, originalSubjectId, replacementSubjectMeta);
+
+                    return new DataReplacementPlanViewModel(
+                        dataBlocks,
+                        footnotes,
+                        originalSubjectId,
+                        replacementSubjectId);
+                });
         }
 
         public async Task<Either<ActionResult, Unit>> Replace(
@@ -148,22 +142,40 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
-        private async Task<Either<ActionResult, File>> CheckFileExists(Guid releaseId, Guid fileId)
+        private async Task<Either<ActionResult, (ReleaseFile originalReleaseFile, ReleaseFile replacementReleaseFile)>>
+            CheckReleaseFilesExist(
+                Guid releaseId,
+                Guid originalFileId,
+                Guid replacementFileId)
         {
-            return await _contentPersistenceHelper.CheckEntityExists<ReleaseFile>(
-                    q => q.Include(rf => rf.File)
-                        .Where(rf => rf.ReleaseId == releaseId && rf.FileId == fileId)
-                )
-                .OnSuccess<ActionResult, ReleaseFile, File>(releaseFile =>
-                    {
-                        if (releaseFile.File.Type != FileType.Data)
-                        {
-                            return ValidationActionResult(ReplacementFileTypesMustBeData);
-                        }
+            return await _contentDbContext.ReleaseFiles
+                .Include(rf => rf.File)
+                .FirstOrNotFoundAsync(rf => rf.ReleaseId == releaseId
+                                            && rf.FileId == originalFileId
+                                            && rf.File.Type == FileType.Data)
+                .OnSuccessCombineWith(async _ => await _contentDbContext.ReleaseFiles
+                    .Include(rf => rf.File)
+                    .FirstOrNotFoundAsync(rf => rf.ReleaseId == releaseId
+                                                && rf.FileId == replacementFileId
+                                                && rf.File.Type == FileType.Data))
+                .OnSuccess(releaseFiles =>
+                {
+                    var (originalReleaseFile, replacementReleaseFile) = releaseFiles;
 
-                        return releaseFile.File;
+                    if (originalReleaseFile.File.ReplacedById != replacementFileId)
+                    {
+                        throw new InvalidOperationException(
+                            "Original file has no association with the replacement file");
                     }
-                );
+
+                    if (replacementReleaseFile.File.ReplacingId != originalFileId)
+                    {
+                        throw new InvalidOperationException(
+                            "Replacement file has no association with the original file");
+                    }
+
+                    return releaseFiles.ToValueTuple();
+                });
         }
 
         private async Task<ReplacementSubjectMeta> GetReplacementSubjectMeta(Guid subjectId)
@@ -1101,7 +1113,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 return null;
             }
 
-            var originalFilters = 
+            var originalFilters =
                 await _filterRepository.GetFiltersIncludingItems(originalReleaseSubject.SubjectId);
             var replacementFilters =
                 await _filterRepository.GetFiltersIncludingItems(replacementReleaseSubject.SubjectId);
@@ -1141,28 +1153,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             // First, unlink the original file from the replacement before removing it.
             // Ordinarily, removing a file from a Release deletes any associated replacement
             // so that there's no possibility of abandoned replacements being orphaned from their original files.
-            return await CheckFileExists(releaseId, originalFileId)
-                .OnSuccessVoid(async originalFile =>
+            return await CheckReleaseFilesExist(releaseId, originalFileId, replacementFileId)
+                .OnSuccess(async releaseFiles =>
                 {
-                    await CheckFileExists(releaseId, replacementFileId)
-                        .OnSuccessVoid(
-                            async replacementFile =>
-                            {
-                                if (originalFile.ReplacedById != replacementFile.Id)
-                                {
-                                    throw new InvalidOperationException(
-                                        $"Expected the original file reference to be associated with the replacement but found: {originalFile.ReplacedById}");
-                                }
+                    var originalFile = releaseFiles.originalReleaseFile.File;
+                    var replacementFile = releaseFiles.replacementReleaseFile.File;
 
-                                originalFile.ReplacedById = null;
-                                replacementFile.ReplacingId = null;
-                                _contentDbContext.Update(originalFile);
-                                _contentDbContext.Update(replacementFile);
+                    originalFile.ReplacedById = null;
+                    replacementFile.ReplacingId = null;
 
-                                await _contentDbContext.SaveChangesAsync();
-                            });
-                })
-                .OnSuccess(async _ => await _releaseService.RemoveDataFiles(releaseId, originalFileId));
+                    await _contentDbContext.SaveChangesAsync();
+
+                    return await _releaseService.RemoveDataFiles(releaseId, originalFileId);
+                });
         }
 
         private Task<Either<ActionResult, Unit>> InvalidateDataBlockCachedResults(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -560,6 +560,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IFileUploadsValidatorService, FileUploadsValidatorService>();
             services.AddTransient<IReleaseFileBlobService, PrivateReleaseFileBlobService>();
 
+            services.AddTransient<IDataGuidanceMigrationService, DataGuidanceMigrationService>();
+
             services.AddSingleton<IPrivateBlobStorageService, PrivateBlobStorageService>();
             services.AddSingleton<IPublicBlobStorageService, PublicBlobStorageService>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -75,7 +75,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         MetaFileIsIncorrectlyNamed,
 
         // Data replacement
-        ReplacementFileTypesMustBeData,
         ReplacementMustBeValid,
 
         // Release

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataGuidanceMigrationReport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataGuidanceMigrationReport.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+public record DataGuidanceMigrationReport(
+    bool DryRun,
+    int ReleaseDataFilesExcludingReplacementsCount,
+    HashSet<Guid> FileIdsWithNoMatchingSubject);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
@@ -22,6 +22,16 @@ public static class ReleaseGeneratorExtensions
         Guid id)
         => generator.ForInstance(release => release.SetId(id));
 
+    public static Generator<Release> WithIds(
+        this Generator<Release> generator,
+        IEnumerable<Guid> ids)
+    {
+        ids.ForEach((id, index) =>
+            generator.ForIndex(index, s => s.SetId(id)));
+
+        return generator;
+    }
+
     public static Generator<Release> WithPublication(
         this Generator<Release> generator,
         Publication publication)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/ReleaseSubjectGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/ReleaseSubjectGeneratorExtensions.cs
@@ -18,31 +18,46 @@ public static class ReleaseSubjectGeneratorExtensions
 
     public static Generator<ReleaseSubject> WithSubject(this Generator<ReleaseSubject> generator, Subject subject)
         => generator.ForInstance(s => s.SetSubject(subject));
-    
-    public static Generator<ReleaseSubject> WithReleases(this Generator<ReleaseSubject> generator, IEnumerable<Release> releases)
+
+    public static Generator<ReleaseSubject> WithReleases(this Generator<ReleaseSubject> generator,
+        IEnumerable<Release> releases)
     {
-        releases.ForEach((release, index) => 
+        releases.ForEach((release, index) =>
             generator.ForIndex(index, s => s.SetRelease(release)));
-        
+
         return generator;
     }
 
-    public static Generator<ReleaseSubject> WithSubjects(this Generator<ReleaseSubject> generator, IEnumerable<Subject> subjects)
+    public static Generator<ReleaseSubject> WithSubjects(this Generator<ReleaseSubject> generator,
+        IEnumerable<Subject> subjects)
     {
-        subjects.ForEach((subject, index) => 
+        subjects.ForEach((subject, index) =>
             generator.ForIndex(index, s => s.SetSubject(subject)));
-        
+
         return generator;
     }
-    
+
+    public static Generator<ReleaseSubject> WithDataGuidance(this Generator<ReleaseSubject> generator,
+        string dataGuidance)
+        => generator.ForInstance(rs => rs.SetDataGuidance(dataGuidance));
+
     public static InstanceSetters<ReleaseSubject> SetDefaults(this InstanceSetters<ReleaseSubject> setters)
         => setters
             .SetDefault(rs => rs.ReleaseId)
-            .SetDefault(rs => rs.SubjectId);
-    
-    public static InstanceSetters<ReleaseSubject> SetRelease(this InstanceSetters<ReleaseSubject> setters, Release release)
+            .SetDefault(rs => rs.SubjectId)
+            .SetDefault(rs => rs.DataGuidance);
+
+    public static InstanceSetters<ReleaseSubject> SetRelease(this InstanceSetters<ReleaseSubject> setters,
+        Release release)
         => setters.Set(rs => rs.Release, release);
-    
-    public static InstanceSetters<ReleaseSubject> SetSubject(this InstanceSetters<ReleaseSubject> setters, Subject subject)
-        => setters.Set(rs => rs.Subject, subject);
+
+    public static InstanceSetters<ReleaseSubject> SetSubject(this InstanceSetters<ReleaseSubject> setters,
+        Subject subject)
+        => setters
+            .Set(rs => rs.Subject, subject)
+            .Set(rs => rs.SubjectId, subject.Id);
+
+    public static InstanceSetters<ReleaseSubject> SetDataGuidance(this InstanceSetters<ReleaseSubject> setters,
+        string dataGuidance)
+        => setters.Set(rs => rs.DataGuidance, dataGuidance);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/DataGuidanceDataSetServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/DataGuidanceDataSetServiceTests.cs
@@ -76,14 +76,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 Release = release,
                 Subject = subject1,
-                DataGuidance = "Subject 1 Guidance"
+                DataGuidance = "Data set 1 guidance"
             };
 
             var releaseSubject2 = new ReleaseSubject
             {
                 Release = release,
                 Subject = subject2,
-                DataGuidance = "Subject 2 Guidance"
+                DataGuidance = "Data set 2 guidance"
             };
 
             var subject1Observation1 = new Observation
@@ -281,6 +281,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     Filename = "file1.csv",
                     Type = FileType.Data,
                 },
+                Summary = "Data set 1 guidance"
             };
 
             var releaseFile2 = new ReleaseFile
@@ -293,6 +294,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     Filename = "file2.csv",
                     Type = FileType.Data,
                 },
+                Summary = "Data set 2 guidance"
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -317,7 +319,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal(2, result.Count);
 
                 Assert.Equal(releaseFile1.FileId, result[0].FileId);
-                Assert.Equal("Subject 1 Guidance", result[0].Content);
+                Assert.Equal("Data set 1 guidance", result[0].Content);
                 Assert.Equal("file1.csv", result[0].Filename);
                 Assert.Equal("Subject 1", result[0].Name);
 
@@ -345,7 +347,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal(subject1Footnote3.FootnoteId, result[0].Footnotes[2].Id);
 
                 Assert.Equal(releaseFile2.FileId, result[1].FileId);
-                Assert.Equal("Subject 2 Guidance", result[1].Content);
+                Assert.Equal("Data set 2 guidance", result[1].Content);
                 Assert.Equal("file2.csv", result[1].Filename);
                 Assert.Equal("Subject 2", result[1].Name);
 
@@ -379,20 +381,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var releaseSubject1 = new ReleaseSubject
             {
                 Release = release,
-                Subject = new Subject(),
-                DataGuidance = "Subject 1 Guidance"
+                Subject = new Subject()
             };
             var releaseSubject2 = new ReleaseSubject
             {
                 Release = release,
-                Subject = new Subject(),
-                DataGuidance = "Subject 2 Guidance"
+                Subject = new Subject()
             };
             var releaseSubject3 = new ReleaseSubject
             {
                 Release = release,
-                Subject = new Subject(),
-                DataGuidance = "Subject 3 Guidance"
+                Subject = new Subject()
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -483,22 +482,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var releaseSubject1 = new ReleaseSubject
             {
                 Release = release,
-                Subject = new Subject(),
-                DataGuidance = "Data set 1 guidance"
+                Subject = new Subject()
             };
 
             var releaseSubject2 = new ReleaseSubject
             {
                 Release = release,
-                Subject = new Subject(),
-                DataGuidance = "Data set 2 guidance"
+                Subject = new Subject()
             };
 
             var releaseSubject3 = new ReleaseSubject
             {
                 Release = release,
-                Subject = new Subject(),
-                DataGuidance = "Data set 3 guidance"
+                Subject = new Subject()
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -573,28 +569,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     releaseFile1.FileId, releaseFile3.FileId
                 });
 
-                // Assert only the specified Subjects are returned
+                // Assert only the specified data sets are returned
                 var viewModels = result.AssertRight();
 
                 Assert.Equal(2, viewModels.Count);
 
                 Assert.Equal(releaseFile1.FileId, viewModels[0].FileId);
-                Assert.Equal("Data set 1 guidance", viewModels[0].Content);
-                Assert.Equal("file1.csv", viewModels[0].Filename);
-                Assert.Equal("Data set 1", viewModels[0].Name);
-                Assert.Empty(viewModels[0].TimePeriods.From);
-                Assert.Empty(viewModels[0].TimePeriods.To);
-                Assert.Empty(viewModels[0].GeographicLevels);
-                Assert.Empty(viewModels[0].Variables);
-
                 Assert.Equal(releaseFile3.FileId, viewModels[1].FileId);
-                Assert.Equal("Data set 3 guidance", viewModels[1].Content);
-                Assert.Equal("file3.csv", viewModels[1].Filename);
-                Assert.Equal("Data set 3", viewModels[1].Name);
-                Assert.Empty(viewModels[1].TimePeriods.From);
-                Assert.Empty(viewModels[1].TimePeriods.To);
-                Assert.Empty(viewModels[1].GeographicLevels);
-                Assert.Empty(viewModels[1].Variables);
             }
         }
 
@@ -712,21 +693,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 Release = contentReleaseVersion1,
                 File = file1,
-                Name = "Version 1 data set 1"
+                Name = "Version 1 data set 1",
+                Summary = "Version 1 data set 1 guidance"
             };
 
             var releaseVersion2File1 = new ReleaseFile
             {
                 Release = contentReleaseVersion2,
                 File = file1,
-                Name = "Version 2 data set 1"
+                Name = "Version 2 data set 1",
+                Summary = "Version 2 data set 1 guidance"
             };
 
             var releaseVersion2File2 = new ReleaseFile
             {
                 Release = contentReleaseVersion2,
                 File = file2,
-                Name = "Version 2 data set 2"
+                Name = "Version 2 data set 2",
+                Summary = "Version 2 data set 2 guidance"
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -911,8 +895,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var releaseSubject = new ReleaseSubject
             {
                 Release = release,
-                Subject = subject,
-                DataGuidance = "Subject 1 Guidance"
+                Subject = subject
             };
 
             var subjectObservation1 = new Observation
@@ -985,8 +968,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var releaseSubject = new ReleaseSubject
             {
                 Release = release,
-                Subject = subject,
-                DataGuidance = "Subject 1 Guidance"
+                Subject = subject
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
@@ -35,7 +35,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 Release = statisticsRelease,
                 Subject = new Subject(),
-                DataGuidance = "Guidance 1"
+                DataGuidance = "Data set 1 guidance"
 
             };
 
@@ -43,7 +43,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 Release = statisticsRelease,
                 Subject = new Subject(),
-                DataGuidance = "Guidance 2"
+                DataGuidance = "Data set 2 guidance"
             };
 
             var subject1Filter1 = new Filter
@@ -116,7 +116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var releaseFile1 = new ReleaseFile
             {
                 Release = contentRelease,
-                Name = "Subject 1",
+                Name = "Data set 1",
                 File = new File
                 {
                     Filename = "data1.csv",
@@ -124,19 +124,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     Type = FileType.Data,
                     SubjectId = releaseSubject1.Subject.Id
                 },
+                Summary = "Data set 1 guidance"
             };
 
             var releaseFile2 = new ReleaseFile
             {
                 Release = contentRelease,
-                Name = "Subject 2",
+                Name = "Data set 2",
                 File = new File
                 {
                     Filename = "data2.csv",
                     ContentLength = 20480,
                     Type = FileType.Data,
                     SubjectId = releaseSubject2.Subject.Id,
-                }
+                },
+                Summary = "Data set 2 guidance"
             };
 
             var import1 = new DataImport
@@ -605,7 +607,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 Release = statisticsRelease,
                 Subject = new Subject(),
-                DataGuidance = "Guidance 1",
                 FilterSequence = new List<FilterSequenceEntry>
                 {
                     new (subject1Filter2Id, new List<FilterGroupSequenceEntry>()),
@@ -744,7 +745,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 Release = statisticsRelease,
                 Subject = new Subject(),
-                DataGuidance = "Guidance 1",
                 IndicatorSequence = new List<IndicatorGroupSequenceEntry>
                 {
                     new(Guid.NewGuid(), new List<Guid> { subject1Indicator2.Id, subject1Indicator1.Id, }),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodServiceTests.cs
@@ -124,8 +124,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var releaseSubject = new ReleaseSubject
             {
                 Release = release,
-                Subject = subject,
-                DataGuidance = "Subject 1 Guidance"
+                Subject = subject
             };
 
             var subjectObservation1 = new Observation
@@ -184,8 +183,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var releaseSubject = new ReleaseSubject
             {
                 Release = release,
-                Subject = subject,
-                DataGuidance = "Subject 1 Guidance"
+                Subject = subject
             };
 
             var subjectObservation1 = new Observation
@@ -243,8 +241,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var releaseSubject1 = new ReleaseSubject
             {
                 Release = release,
-                Subject = subject,
-                DataGuidance = "Subject 1 Guidance"
+                Subject = subject
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/DataGuidanceDataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/DataGuidanceDataSetService.cs
@@ -64,6 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                         .ToAsyncEnumerable()
                         .SelectAwait(async releaseFile =>
                         {
+                            // TODO EES-4661 Remove this and switch to using ReleaseFile for content
                             var subjectId = releaseFile.File.SubjectId!.Value;
 
                             var releaseSubject = await _statisticsDbContext.ReleaseSubject
@@ -93,6 +94,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         public async Task<Either<ActionResult, Unit>> Validate(Guid releaseId,
             CancellationToken cancellationToken = default)
         {
+            // TODO EES-4661 Switch to using ReleaseFile once we know the migration of all existing data set guidance
+            // has been a success. Inline this method with the validation that's already in DataGuidanceService 
             var releaseSubjects = _statisticsDbContext
                 .ReleaseSubject
                 .Where(rs => rs.ReleaseId == releaseId);
@@ -159,7 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             return new DataGuidanceDataSetViewModel
             {
                 FileId = releaseFile.FileId,
-                Content = content ?? "",
+                Content = content ?? "", // TODO EES-4661 Update this to be releaseFile.Summary
                 Filename = releaseFile.File.Filename,
                 Order = releaseFile.Order,
                 Name = releaseFile.Name ?? "",

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -51,7 +51,7 @@ Add metadata guidance
     user checks table cell contains    1    2    Admission Numbers    id:dataGuidance-dataFiles
 
     user enters text into element    id:dataGuidanceForm-content    Test metadata guidance content
-    user enters text into element    id:dataGuidanceForm-subjects-0-content    Test file guidance content
+    user enters text into element    id:dataGuidanceForm-dataSets-0-content    Test file guidance content
 
     user clicks button    Save guidance
 

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -52,7 +52,7 @@ Add metadata guidance
     user checks table cell contains    1    2    Admission Numbers    id:dataGuidance-dataFiles
 
     user enters text into element    id:dataGuidanceForm-content    Test metadata guidance content
-    user enters text into element    id:dataGuidanceForm-subjects-0-content    Test file guidance content
+    user enters text into element    id:dataGuidanceForm-dataSets-0-content    Test file guidance content
 
     user clicks button    Save guidance
 


### PR DESCRIPTION
This PR follows on from https://github.com/dfe-analytical-services/explore-education-statistics/pull/4420.

It begins setting data guidance in `ReleaseFile.Summary` for each data set updated in  `DataGuidanceService.UpdateDataGuidance`.

It also changes `ReplacementService` to begin copying data guidance from the original to the replacement `ReleaseFile` during the replace operation.

The current behaviour of setting and replacing data guidance in its original location in `ReleaseSubject.DataGuidance` is retained for now.

This PR will be followed up with a further change to migrate data guidance for all existing data sets from `ReleaseSubject` to `ReleaseFile`.

### Other changes

- Fixes an issue in `ReplacementService.RemoveOriginalSubjectAndFileFromRelease` which would ignore an error if the replacement file is not found.
- Adds a test to ensure `DataGuidanceDataSetService.ListDataSets` ignores data replacements in progress.
- Adds some 'TODO's' in places requiring changes in EES-4661 when `ReleaseSubject.DataGuidance` will be dropped.
- Changes the behaviour of the methods in `ReplacementService` to return not found if the file id's are not `FileType.Data`, removing `ValidationErrorMessages.ReplacementFileTypesMustBeData`.
- Remove setting `ReleaseSubject.DataGuidance` values on tests where its not relevant to the test.

## UI test report

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/4147126/f93ce502-400c-4b03-99df-2ff75967ca07)
