### PR TITLE
EES-4715 suppress jsdom css errors

### DIFF
--- a/src/explore-education-statistics-admin/jest.config.js
+++ b/src/explore-education-statistics-admin/jest.config.js
@@ -32,6 +32,7 @@ const config = {
       '<rootDir>/../explore-education-statistics-common/test/$1',
     '^axios$': '<rootDir>/node_modules/axios/dist/axios.js',
     '^marked$': '<rootDir>/node_modules/marked/lib/marked.umd.js',
+    '^explore-education-statistics-ckeditor$': '<rootDir>/test/EditorStub.js',
   },
   moduleFileExtensions: [
     'web.js',

--- a/src/explore-education-statistics-admin/test/EditorStub.js
+++ b/src/explore-education-statistics-admin/test/EditorStub.js
@@ -1,0 +1,3 @@
+// Stub out CKEditor to prevent errors from its
+// CSS build polluting the test output.
+export default class EditorStub {}


### PR DESCRIPTION
JSDOM doesn't handle CSS well and seems to be particularly objecting to CKEditor, which is causing a ridiculous amount of errors in the log when running the admin tests. ~~As far as I can tell it shouldn't be trying to parse it anyway as all CSS files should be going through the transform we have configured in jest.config.js, but it is so I've just supressed this error.~~

As suggested by @ntsim below, I've stubbed out CKEditor to prevent errors from its CSS build polluting the test output.