### PR TITLE
EES-4660 Part 3 - Migrate existing data guidance to `ReleaseFile.Summary`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataGuidanceMigrationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataGuidanceMigrationServicePermissionTests.cs
@@ -1,0 +1,41 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+public class DataGuidanceMigrationServicePermissionTests
+{
+    [Fact]
+    public async Task MigrateDataGuidance()
+    {
+        await PolicyCheckBuilder()
+            .SetupCheck(SecurityPolicies.IsBauUser, false)
+            .AssertForbidden(
+                async userService =>
+                {
+                    var service = SetupService(userService: userService.Object);
+                    return await service.MigrateDataGuidance();
+                }
+            );
+    }
+
+    private static DataGuidanceMigrationService SetupService(IUserService userService)
+    {
+        return new DataGuidanceMigrationService(
+            Mock.Of<ContentDbContext>(),
+            Mock.Of<StatisticsDbContext>(),
+            userService
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataGuidanceMigrationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataGuidanceMigrationServiceTests.cs
@@ -1,0 +1,581 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.StatisticsDbUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+public class DataGuidanceMigrationServiceTests
+{
+    private readonly DataFixture _fixture = new();
+
+    [Fact]
+    public async Task MigrateDataGuidance()
+    {
+        // Set up 2 releases with data sets as follows:
+        // Release 1: Data set 1, Data set 2
+        // Release 2: Data set 1, Data set 3
+
+        var statsReleases = _fixture.DefaultStatsRelease()
+            .GenerateList(2);
+        var (statsRelease1, statsRelease2) = statsReleases.ToTuple2();
+
+        var subjects = _fixture.DefaultSubject()
+            .GenerateList(3);
+        var (subject1, subject2, subject3) = subjects.ToTuple3();
+
+        var release1Subjects = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease1)
+            .WithSubjects(ListOf(subject1, subject2))
+            .GenerateList(2);
+        var (release1Subject1, release1Subject2) = release1Subjects.ToTuple2();
+
+        var release2Subjects = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease2)
+            .WithSubjects(ListOf(subject1, subject3))
+            .GenerateList(2);
+        var (release2Subject1, release2Subject3) = release2Subjects.ToTuple2();
+
+        var contentReleases = _fixture.DefaultRelease()
+            .WithIds(statsReleases.Select(r => r.Id))
+            .GenerateList(2);
+        var (contentRelease1, contentRelease2) = contentReleases.ToTuple2();
+
+        var release1Files = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease1,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release1Subject1.SubjectId
+                }
+            },
+            new()
+            {
+                Release = contentRelease1,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release1Subject2.SubjectId
+                }
+            }
+        };
+
+        var release2Files = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease2,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release2Subject1.SubjectId
+                }
+            },
+            new()
+            {
+                Release = contentRelease2,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release2Subject3.SubjectId
+                }
+            }
+        };
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            await statisticsDbContext.Release.AddRangeAsync(statsReleases);
+            await statisticsDbContext.Subject.AddRangeAsync(subjects);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(release1Subjects.Concat(release2Subjects));
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Releases.AddRangeAsync(contentReleases);
+            await contentDbContext.ReleaseFiles.AddRangeAsync(release1Files.Concat(release2Files));
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateDataGuidance(dryRun: false);
+
+            var report = result.AssertRight();
+
+            Assert.False(report.DryRun);
+            Assert.Equal(4, report.ReleaseDataFilesExcludingReplacementsCount);
+            Assert.Empty(report.FileIdsWithNoMatchingSubject);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var actualReleaseFiles = await contentDbContext.ReleaseFiles.ToListAsync();
+
+            Assert.Equal(release1Subject1.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release1Files[0].Id).Summary);
+            Assert.Equal(release1Subject2.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release1Files[1].Id).Summary);
+
+            Assert.Equal(release2Subject1.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release2Files[0].Id).Summary);
+            Assert.Equal(release2Subject3.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release2Files[1].Id).Summary);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateDataGuidance_DryRunMakesNoChanges()
+    {
+        // Set up 2 releases with data sets as follows:
+        // Release 1: Data set 1, Data set 2
+        // Release 2: Data set 1, Data set 3
+
+        var statsReleases = _fixture.DefaultStatsRelease()
+            .GenerateList(2);
+        var (statsRelease1, statsRelease2) = statsReleases.ToTuple2();
+
+        var subjects = _fixture.DefaultSubject()
+            .GenerateList(3);
+        var (subject1, subject2, subject3) = subjects.ToTuple3();
+
+        var release1Subjects = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease1)
+            .WithSubjects(ListOf(subject1, subject2))
+            .GenerateList(2);
+        var (release1Subject1, release1Subject2) = release1Subjects.ToTuple2();
+
+        var release2Subjects = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease2)
+            .WithSubjects(ListOf(subject1, subject3))
+            .GenerateList(2);
+        var (release2Subject1, release2Subject3) = release2Subjects.ToTuple2();
+
+        var contentReleases = _fixture.DefaultRelease()
+            .WithIds(statsReleases.Select(r => r.Id))
+            .GenerateList(2);
+        var (contentRelease1, contentRelease2) = contentReleases.ToTuple2();
+
+        var release1Files = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease1,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release1Subject1.SubjectId
+                }
+            },
+            new()
+            {
+                Release = contentRelease1,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release1Subject2.SubjectId
+                }
+            }
+        };
+
+        var release2Files = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease2,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release2Subject1.SubjectId
+                }
+            },
+            new()
+            {
+                Release = contentRelease2,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = release2Subject3.SubjectId
+                }
+            }
+        };
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            await statisticsDbContext.Release.AddRangeAsync(statsReleases);
+            await statisticsDbContext.Subject.AddRangeAsync(subjects);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(release1Subjects.Concat(release2Subjects));
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Releases.AddRangeAsync(contentReleases);
+            await contentDbContext.ReleaseFiles.AddRangeAsync(release1Files.Concat(release2Files));
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateDataGuidance(dryRun: true);
+
+            var report = result.AssertRight();
+            Assert.True(report.DryRun);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var actualReleaseFiles = await contentDbContext.ReleaseFiles.ToListAsync();
+
+            // Release file summaries should be untouched
+            Assert.Equal(release1Files[0].Summary,
+                actualReleaseFiles.Single(rf => rf.Id == release1Files[0].Id).Summary);
+            Assert.Equal(release1Files[1].Summary,
+                actualReleaseFiles.Single(rf => rf.Id == release1Files[1].Id).Summary);
+
+            Assert.Equal(release2Files[0].Summary,
+                actualReleaseFiles.Single(rf => rf.Id == release2Files[0].Id).Summary);
+            Assert.Equal(release2Files[1].Summary,
+                actualReleaseFiles.Single(rf => rf.Id == release2Files[1].Id).Summary);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateDataGuidance_IgnoresNonDataFileTypes()
+    {
+        var statsRelease = _fixture.DefaultStatsRelease().Generate();
+
+        var releaseSubject = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease)
+            .WithSubject(_fixture.DefaultSubject().Generate())
+            .Generate();
+
+        var contentRelease = _fixture.DefaultRelease()
+            .WithId(statsRelease.Id)
+            .Generate();
+
+        var releaseFiles = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = releaseSubject.SubjectId
+                }
+            },
+            // Set up other release file with a non-data file type
+            new()
+            {
+                Release = contentRelease,
+                File = new File
+                {
+                    Type = FileType.Ancillary
+                },
+                Summary = "Ancillary file summary"
+            }
+        };
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            await statisticsDbContext.Release.AddRangeAsync(statsRelease);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Releases.AddRangeAsync(contentRelease);
+            await contentDbContext.ReleaseFiles.AddRangeAsync(releaseFiles);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateDataGuidance(dryRun: false);
+
+            var report = result.AssertRight();
+
+            // Count of release data files should not include the other file
+            Assert.Equal(1, report.ReleaseDataFilesExcludingReplacementsCount);
+            Assert.Empty(report.FileIdsWithNoMatchingSubject);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var actualReleaseFiles = await contentDbContext.ReleaseFiles.ToListAsync();
+
+            Assert.Equal(releaseSubject.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == releaseFiles[0].Id).Summary);
+
+            // Summary of other release file should be untouched
+            Assert.Equal("Ancillary file summary",
+                actualReleaseFiles.Single(rf => rf.Id == releaseFiles[1].Id).Summary);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateDataGuidance_IgnoresFileReplacementsInProgress()
+    {
+        // Set up 2 releases with data sets as follows:
+        // Release 1: Data set 1
+        // Release 2: Data set 1, Data set 2 (replacement of Data set 1 in progress)
+
+        var statsReleases = _fixture.DefaultStatsRelease()
+            .GenerateList(2);
+        var (statsRelease1, statsRelease2) = statsReleases.ToTuple2();
+
+        var subjects = _fixture.DefaultSubject()
+            .GenerateList(2);
+        var (subject1, subject2) = subjects.ToTuple2();
+
+        var release1Subject1 = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease1)
+            .WithSubject(subject1)
+            .Generate();
+
+        var release2Subjects = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease2)
+            .WithSubjects(ListOf(subject1, subject2))
+            .GenerateList(2);
+        var (release2Subject1, release2Subject2) = release2Subjects.ToTuple2();
+
+        var contentReleases = _fixture.DefaultRelease()
+            .WithIds(statsReleases.Select(r => r.Id))
+            .GenerateList(2);
+        var (contentRelease1, contentRelease2) = contentReleases.ToTuple2();
+
+        var release1File1 = new ReleaseFile
+        {
+            Release = contentRelease1,
+            File = new File
+            {
+                Type = FileType.Data,
+                SubjectId = release1Subject1.SubjectId
+            }
+        };
+
+        // Set up the replacement of the data set in release 2
+
+        var release2File1 = new ReleaseFile
+        {
+            Release = contentRelease2,
+            File = new File
+            {
+                Type = FileType.Data,
+                SubjectId = release2Subject1.SubjectId
+            }
+        };
+
+        var release2File2 = new ReleaseFile
+        {
+            Release = contentRelease2,
+            File = new File
+            {
+                Type = FileType.Data,
+                SubjectId = release2Subject2.SubjectId,
+                Replacing = release2File1.File
+            }
+        };
+
+        release2File1.File.ReplacedBy = release2File2.File;
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            await statisticsDbContext.Release.AddRangeAsync(statsReleases);
+            await statisticsDbContext.Subject.AddRangeAsync(subjects);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(release1Subject1, release2Subject1,
+                release2Subject2);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Releases.AddRangeAsync(contentReleases);
+            await contentDbContext.ReleaseFiles.AddRangeAsync(release1File1, release2File1, release2File2);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateDataGuidance(dryRun: false);
+
+            var report = result.AssertRight();
+
+            // Count of release data files should not include the replacement in progress
+            Assert.Equal(2, report.ReleaseDataFilesExcludingReplacementsCount);
+            Assert.Empty(report.FileIdsWithNoMatchingSubject);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var actualReleaseFiles = await contentDbContext.ReleaseFiles.ToListAsync();
+
+            Assert.Equal(release1Subject1.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release1File1.Id).Summary);
+
+            // Release file which is in the process of being replaced should have the data guidance set
+            // from the original release subject
+            Assert.Equal(release2Subject1.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == release2File1.Id).Summary);
+
+            // Release file which is the replacement should not have data guidance set
+            // It will be set as a copy of the data guidance from the original file when the replacement is executed
+            Assert.Null(actualReleaseFiles.Single(rf => rf.Id == release2File2.Id).Summary);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateDataGuidance_HandlesFileWithSubjectIdNotFound()
+    {
+        var statsRelease = _fixture.DefaultStatsRelease().Generate();
+
+        var releaseSubject = _fixture.DefaultReleaseSubject()
+            .WithRelease(statsRelease)
+            .WithSubject(_fixture.DefaultSubject().Generate())
+            .WithDataGuidance("Data set guidance")
+            .Generate();
+
+        var contentRelease = _fixture.DefaultRelease()
+            .WithId(statsRelease.Id)
+            .Generate();
+
+        var releaseFiles = new List<ReleaseFile>
+        {
+            new()
+            {
+                Release = contentRelease,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = releaseSubject.SubjectId
+                }
+            },
+            // Set up a release data file with a subject id that doesn't exist in the statistics db
+            new()
+            {
+                Release = contentRelease,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = Guid.NewGuid()
+                }
+            },
+            // Set up a release data file with a subject id is null
+            new()
+            {
+                Release = contentRelease,
+                File = new File
+                {
+                    Type = FileType.Data,
+                    SubjectId = null
+                }
+            }
+        };
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            await statisticsDbContext.Release.AddRangeAsync(statsRelease);
+            await statisticsDbContext.ReleaseSubject.AddRangeAsync(releaseSubject);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            await contentDbContext.Releases.AddRangeAsync(contentRelease);
+            await contentDbContext.ReleaseFiles.AddRangeAsync(releaseFiles);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupService(contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext);
+
+            var result = await service.MigrateDataGuidance(dryRun: false);
+
+            var report = result.AssertRight();
+
+            Assert.Equal(3, report.ReleaseDataFilesExcludingReplacementsCount);
+
+            // Files with no matching subject should have their id's added to the report
+            Assert.Equal(SetOf(releaseFiles[1].FileId, releaseFiles[2].FileId),
+                report.FileIdsWithNoMatchingSubject);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var actualReleaseFiles = await contentDbContext.ReleaseFiles.ToListAsync();
+
+            Assert.Equal(releaseSubject.DataGuidance,
+                actualReleaseFiles.Single(rf => rf.Id == releaseFiles[0].Id).Summary);
+            Assert.Null(actualReleaseFiles.Single(rf => rf.Id == releaseFiles[1].Id).Summary);
+            Assert.Null(actualReleaseFiles.Single(rf => rf.Id == releaseFiles[2].Id).Summary);
+        }
+    }
+
+    private static DataGuidanceMigrationService SetupService(
+        ContentDbContext? contentDbContext = null,
+        StatisticsDbContext? statisticsDbContext = null,
+        IUserService? userService = null)
+    {
+        return new DataGuidanceMigrationService(
+            contentDbContext ?? Mock.Of<ContentDbContext>(MockBehavior.Strict),
+            statisticsDbContext ?? Mock.Of<StatisticsDbContext>(MockBehavior.Strict),
+            userService ?? MockUtils.AlwaysTrueUserService().Object
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataGuidanceMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataGuidanceMigrationController.cs
@@ -1,0 +1,36 @@
+﻿#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+[Route("api")]
+[ApiController]
+[Authorize(Roles = GlobalRoles.RoleNames.BauUser)]
+public class DataGuidanceMigrationController : ControllerBase
+{
+    private readonly IDataGuidanceMigrationService _dataGuidanceMigrationService;
+
+    public DataGuidanceMigrationController(IDataGuidanceMigrationService dataGuidanceMigrationService)
+    {
+        _dataGuidanceMigrationService = dataGuidanceMigrationService;
+    }
+
+    [HttpPatch("bau/migrate-data-guidance")]
+    public async Task<ActionResult<DataGuidanceMigrationReport>> MigrateDataGuidance([FromQuery] bool dryRun = true,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dataGuidanceMigrationService
+            .MigrateDataGuidance(dryRun, cancellationToken)
+            .HandleFailuresOrOk();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataGuidanceMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataGuidanceMigrationService.cs
@@ -1,0 +1,83 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+public class DataGuidanceMigrationService : IDataGuidanceMigrationService
+{
+    private readonly ContentDbContext _contentDbContext;
+    private readonly StatisticsDbContext _statisticsDbContext;
+    private readonly IUserService _userService;
+
+    public DataGuidanceMigrationService(ContentDbContext contentDbContext,
+        StatisticsDbContext statisticsDbContext,
+        IUserService userService)
+    {
+        _contentDbContext = contentDbContext;
+        _statisticsDbContext = statisticsDbContext;
+        _userService = userService;
+    }
+
+    public async Task<Either<ActionResult, DataGuidanceMigrationReport>> MigrateDataGuidance(bool dryRun = true,
+        CancellationToken cancellationToken = default)
+    {
+        return await _userService.CheckIsBauUser()
+            .OnSuccess(async () =>
+            {
+                var releaseDataFilesExcludingReplacements = await _contentDbContext.ReleaseFiles
+                    .Include(rf => rf.File)
+                    .Where(rf => rf.File.Type == FileType.Data
+                                 && rf.File.ReplacingId == null)
+                    .ToListAsync(cancellationToken);
+
+                var fileIdsWithNoMatchingSubject = new HashSet<Guid>();
+
+                await releaseDataFilesExcludingReplacements
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitWithCancellationAsync(async (ReleaseFile rf, CancellationToken ct) =>
+                    {
+                        var releaseSubject = await _statisticsDbContext.ReleaseSubject
+                            .SingleOrDefaultAsync(rs => rs.ReleaseId == rf.ReleaseId
+                                                        && rs.SubjectId == rf.File.SubjectId,
+                                ct);
+
+                        if (releaseSubject == null)
+                        {
+                            fileIdsWithNoMatchingSubject.Add(rf.FileId);
+                        }
+                        else
+                        {
+                            rf.Summary = releaseSubject.DataGuidance;
+                        }
+                    }, cancellationToken);
+
+                if (!dryRun)
+                {
+                    await _contentDbContext.SaveChangesAsync(cancellationToken);
+                }
+
+                return new DataGuidanceMigrationReport(
+                    dryRun,
+                    ReleaseDataFilesExcludingReplacementsCount: releaseDataFilesExcludingReplacements.Count,
+                    fileIdsWithNoMatchingSubject
+                );
+            });
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataGuidanceMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataGuidanceMigrationService.cs
@@ -1,0 +1,18 @@
+﻿#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+public interface IDataGuidanceMigrationService
+{
+    public Task<Either<ActionResult, DataGuidanceMigrationReport>> MigrateDataGuidance(
+        bool dryRun = true,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -559,6 +559,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IFileUploadsValidatorService, FileUploadsValidatorService>();
             services.AddTransient<IReleaseFileBlobService, PrivateReleaseFileBlobService>();
 
+            services.AddTransient<IDataGuidanceMigrationService, DataGuidanceMigrationService>();
+
             services.AddSingleton<IPrivateBlobStorageService, PrivateBlobStorageService>();
             services.AddSingleton<IPublicBlobStorageService, PublicBlobStorageService>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataGuidanceMigrationReport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataGuidanceMigrationReport.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+
+/// <summary>
+/// TODO EES-4661 Remove after the EES-4660 data guidance migration is successful
+/// </summary>
+public record DataGuidanceMigrationReport(
+    bool DryRun,
+    int ReleaseDataFilesExcludingReplacementsCount,
+    HashSet<Guid> FileIdsWithNoMatchingSubject);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
@@ -20,6 +20,16 @@ public static class ReleaseGeneratorExtensions
         Guid id)
         => generator.ForInstance(release => release.SetId(id));
 
+    public static Generator<Release> WithIds(
+        this Generator<Release> generator,
+        IEnumerable<Guid> ids)
+    {
+        ids.ForEach((id, index) =>
+            generator.ForIndex(index, s => s.SetId(id)));
+
+        return generator;
+    }
+
     public static Generator<Release> WithPublication(
         this Generator<Release> generator,
         Publication publication)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/ReleaseSubjectGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/ReleaseSubjectGeneratorExtensions.cs
@@ -18,31 +18,46 @@ public static class ReleaseSubjectGeneratorExtensions
 
     public static Generator<ReleaseSubject> WithSubject(this Generator<ReleaseSubject> generator, Subject subject)
         => generator.ForInstance(s => s.SetSubject(subject));
-    
-    public static Generator<ReleaseSubject> WithReleases(this Generator<ReleaseSubject> generator, IEnumerable<Release> releases)
+
+    public static Generator<ReleaseSubject> WithReleases(this Generator<ReleaseSubject> generator,
+        IEnumerable<Release> releases)
     {
-        releases.ForEach((release, index) => 
+        releases.ForEach((release, index) =>
             generator.ForIndex(index, s => s.SetRelease(release)));
-        
+
         return generator;
     }
 
-    public static Generator<ReleaseSubject> WithSubjects(this Generator<ReleaseSubject> generator, IEnumerable<Subject> subjects)
+    public static Generator<ReleaseSubject> WithSubjects(this Generator<ReleaseSubject> generator,
+        IEnumerable<Subject> subjects)
     {
-        subjects.ForEach((subject, index) => 
+        subjects.ForEach((subject, index) =>
             generator.ForIndex(index, s => s.SetSubject(subject)));
-        
+
         return generator;
     }
-    
+
+    public static Generator<ReleaseSubject> WithDataGuidance(this Generator<ReleaseSubject> generator,
+        string dataGuidance)
+        => generator.ForInstance(rs => rs.SetDataGuidance(dataGuidance));
+
     public static InstanceSetters<ReleaseSubject> SetDefaults(this InstanceSetters<ReleaseSubject> setters)
         => setters
             .SetDefault(rs => rs.ReleaseId)
-            .SetDefault(rs => rs.SubjectId);
-    
-    public static InstanceSetters<ReleaseSubject> SetRelease(this InstanceSetters<ReleaseSubject> setters, Release release)
+            .SetDefault(rs => rs.SubjectId)
+            .SetDefault(rs => rs.DataGuidance);
+
+    public static InstanceSetters<ReleaseSubject> SetRelease(this InstanceSetters<ReleaseSubject> setters,
+        Release release)
         => setters.Set(rs => rs.Release, release);
-    
-    public static InstanceSetters<ReleaseSubject> SetSubject(this InstanceSetters<ReleaseSubject> setters, Subject subject)
-        => setters.Set(rs => rs.Subject, subject);
+
+    public static InstanceSetters<ReleaseSubject> SetSubject(this InstanceSetters<ReleaseSubject> setters,
+        Subject subject)
+        => setters
+            .Set(rs => rs.Subject, subject)
+            .Set(rs => rs.SubjectId, subject.Id);
+
+    public static InstanceSetters<ReleaseSubject> SetDataGuidance(this InstanceSetters<ReleaseSubject> setters,
+        string dataGuidance)
+        => setters.Set(rs => rs.DataGuidance, dataGuidance);
 }


### PR DESCRIPTION
⚠️ This has an associated faffy deploy task [EES-4724](https://dfedigital.atlassian.net/browse/EES-4724) ⚠️ 

This PR follows on from https://github.com/dfe-analytical-services/explore-education-statistics/pull/4424.

It adds a migration endpoint which copies data guidance from the statistics database to the content database.

This needs to be run before we drop `ReleaseSubject.DataGuidance` in [EES-4661](https://dfedigital.atlassian.net/browse/EES-4661).

For every content database `ReleaseFile` of type `FileType.Data` which is also not a file replacement currently in progress, it copies `DataGuidance` from the corresponding `ReleaseSubject` found in the stattistics database.

## Migration

### Usage
Make a request to the secured BAU endpoint `PATCH /bau/migrate-data-guidance?dryRun={true|false}`.

When option `dryRun=true` no update will be made to the content database. The default value is `true`.

### Report
A report is returned in the response containing the following values:

- `dryRun`: The value of the `dryRun` query parameter indicating whether a dry run took place or not.
- `releaseDataFilesExcludingReplacementsCount`: The count of release data files found in the content database excluding any replacement files for data replacements currently in progress.
- `fileIdsWithNoMatchingSubject`: Set of content database `File` id's where release files were found with no corresponding subject in the statistics database.
