### PR TITLE
EES-4622 Button and Modal Tweaks

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationPublishedReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationPublishedReleases.test.tsx
@@ -1,6 +1,5 @@
 import PublicationPublishedReleases from '@admin/pages/publication/components/PublicationPublishedReleases';
 import _releaseService, {
-  Release,
   ReleaseSummaryWithPermissions,
 } from '@admin/services/releaseService';
 import _publicationService from '@admin/services/publicationService';

--- a/src/explore-education-statistics-common/src/components/InfoIcon.tsx
+++ b/src/explore-education-statistics-common/src/components/InfoIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './InfoIcon.module.scss';
 
 interface Props {
-  description: string;
+  description?: string;
 }
 
 const InfoIcon = ({ description }: Props) => {
@@ -11,7 +11,9 @@ const InfoIcon = ({ description }: Props) => {
       <span className={styles.infoIcon} aria-hidden>
         ?
       </span>
-      <span className="govuk-visually-hidden">{description}</span>
+      {description && (
+        <span className="govuk-visually-hidden">{description}</span>
+      )}
     </>
   );
 };

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolInfo.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolInfo.tsx
@@ -1,9 +1,10 @@
 import React, { ReactNode } from 'react';
 import { Contact } from '@common/services/publicationService';
-import ReleaseTypesModal from '@common/modules/release/components/ReleaseTypesModal';
 import { ReleaseType, releaseTypes } from '@common/services/types/releaseType';
 import ButtonText from '@common/components/ButtonText';
 import InfoIcon from '@common/components/InfoIcon';
+import ReleaseTypeSection from '@common/modules/release/components/ReleaseTypeSection';
+import Modal from '@common/components/Modal';
 
 interface Props {
   contactDetails?: Contact;
@@ -25,14 +26,18 @@ const TableToolInfo = ({
       <ul className="govuk-list">
         {releaseType && (
           <li>
-            Release type: {releaseTypes[releaseType]}{' '}
-            <ReleaseTypesModal
+            Release type:{' '}
+            <Modal
+              showClose
+              title={releaseTypes[releaseType]}
               triggerButton={
                 <ButtonText>
-                  <InfoIcon description="What are release types?" />
+                  {releaseTypes[releaseType]} <InfoIcon />
                 </ButtonText>
               }
-            />
+            >
+              <ReleaseTypeSection showHeading={false} type={releaseType} />
+            </Modal>
           </li>
         )}
         {releaseLink && <li>Publication: {releaseLink}</li>}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolInfo.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolInfo.test.tsx
@@ -17,12 +17,10 @@ describe('TableToolInfo', () => {
 
     render(<TableToolInfo releaseType={testReleaseType} />);
 
-    expect(
-      screen.getByText('Release type: Official statistics'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Release type:')).toBeInTheDocument();
 
     expect(
-      screen.getByRole('button', { name: 'What are release types?' }),
+      screen.getByRole('button', { name: 'Official statistics' }),
     ).toBeInTheDocument();
 
     expect(
@@ -34,7 +32,7 @@ describe('TableToolInfo', () => {
     render(<TableToolInfo releaseType={undefined} />);
 
     expect(
-      screen.queryByRole('button', { name: 'What are release types?' }),
+      screen.queryByRole('button', { name: 'Official statistics' }),
     ).not.toBeInTheDocument();
 
     expect(


### PR DESCRIPTION
Two tweaks to this ticket have been discussed between myself, Nick, Nusrath and Cam:

* Both the release type text itself as well as the info icon are now clickable (previously only the icon was)
* The modal that opens when the button is clicked is now the specific one for that release type (previously it opened the explanatory one which lists all release types)


<img width="1250" alt="Screenshot 2023-11-24 134048" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/63285990/ec215c42-696a-4cd1-8cdd-834a027700b0">

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/63285990/93570d5b-6f83-4429-80de-3a377fd0a6d7)

