### PR TITLE
EES-4117 - add "rerun-attempts" option to enable UI test retries on the pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ src/explore-education-statistics-frontend/*.xml
 !/tests/robot-tests/.env.example
 /tests/robot-tests/IDENTITY_*
 /tests/robot-tests/.pabotsuitenames
+/tests/robot-tests/.failing_suites
 /tests/robot-tests/geckodriver.log
 /tests/robot-tests/debug.log
 **/*/jwt

--- a/azure-pipelines-ui-tests.dfe.yml
+++ b/azure-pipelines-ui-tests.dfe.yml
@@ -32,7 +32,6 @@ jobs:
 
   - task: UsePythonVersion@0
     displayName: Use Python 3.10
-  # retryCountOnTaskFailure: 2
     timeoutInMinutes: 5
     inputs:
       versionSpec: 3.10
@@ -49,19 +48,12 @@ jobs:
     displayName: Public UI tests
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --env "dev" --file "tests/general_public/" --processes 2
+      arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --env "dev" --file "tests/general_public/" --processes 2 --rerun-attempts 3
       workingDirectory: tests/robot-tests
     env:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
-  #- task: PythonScript@0
-  #  displayName: Public UI tests - rerun failed suites
-  #  condition: not(succeeded())
-  #  inputs:
-  #    scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-  #    arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --env "dev" --file "tests/general_public/" --processes 2 --rerun-failed-suites
-  #    workingDirectory: tests/robot-tests
 
   - task: PublishTestResults@2
     displayName: Publish Test Results
@@ -92,7 +84,6 @@ jobs:
 
   - task: UsePythonVersion@0
     displayName: Use Python 3.10
-  # retryCountOnTaskFailure: 2
     timeoutInMinutes: 5
     inputs:
       versionSpec: 3.10
@@ -110,20 +101,13 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public_2" --processes 2
+      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public_2" --processes 2 --rerun-attempts 3
     #  The magic incantation '"$(variable)"'was added by Mark to resolve an issue with Analyst password that contained ampersands.
       workingDirectory: tests/robot-tests
     env:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
-  #- task: PythonScript@0
-  #  displayName: 'Publish release and amend UI tests - rerun failed suites'
-  #  condition: not(succeeded())
-  #  inputs:
-  #    scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-  #    arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public_2" --processes 2 --rerun-failed-suites
-  #    workingDirectory: tests/robot-tests
 
   - task: PublishTestResults@2
     displayName: Publish Test Results
@@ -153,7 +137,6 @@ jobs:
 
   - task: UsePythonVersion@0
     displayName: Use Python 3.10
-  # retryCountOnTaskFailure: 2
     timeoutInMinutes: 5
     inputs:
       versionSpec: 3.10
@@ -171,19 +154,12 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin" --processes 2
+      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin" --processes 2 --rerun-attempts 3
       workingDirectory: tests/robot-tests
     env:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
-  #- task: PythonScript@0
-  #  displayName: Admin UI tests - rerun failed suites
-  #  condition: not(succeeded())
-  #  inputs:
-  #    scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-  #    arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin" --processes 2 --rerun-failed-suites
-  #    workingDirectory: tests/robot-tests
 
   - task: PublishTestResults@2
     displayName: Publish Test Results
@@ -215,7 +191,6 @@ jobs:
 
   - task: UsePythonVersion@0
     displayName: Use Python 3.10
-  # retryCountOnTaskFailure: 2
     timeoutInMinutes: 5
     inputs:
       versionSpec: 3.10
@@ -232,19 +207,12 @@ jobs:
     displayName: Admin public UI tests
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public" --processes 2
+      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public" --processes 2 --rerun-attempts 3
       workingDirectory: tests/robot-tests
     env:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
-  #- task: PythonScript@0
-  #  displayName: Admin public UI tests - rerun failed suites
-  #  condition: not(succeeded())
-  #  inputs:
-  #    scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-  #    arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public" --processes 2 --rerun-failed-suites
-  #    workingDirectory: tests/robot-tests
 
   - task: PublishTestResults@2
     displayName: Publish Test Results

--- a/azure-pipelines-ui-tests.dfe.yml
+++ b/azure-pipelines-ui-tests.dfe.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: Public UI tests
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --env "dev" --file "tests/general_public/" --processes 2 --rerun-attempts 3
+      arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --env "dev" --file "tests/general_public/" --processes 2 --rerun-attempts 5
       workingDirectory: tests/robot-tests
     env:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
@@ -101,7 +101,7 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public_2" --processes 2 --rerun-attempts 3
+      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public_2" --processes 2 --rerun-attempts 5
     #  The magic incantation '"$(variable)"'was added by Mark to resolve an issue with Analyst password that contained ampersands.
       workingDirectory: tests/robot-tests
     env:
@@ -154,7 +154,7 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin" --processes 2 --rerun-attempts 3
+      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin" --processes 2 --rerun-attempts 5
       workingDirectory: tests/robot-tests
     env:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
@@ -207,7 +207,7 @@ jobs:
     displayName: Admin public UI tests
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public" --processes 2 --rerun-attempts 3
+      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public" --processes 2 --rerun-attempts 5
       workingDirectory: tests/robot-tests
     env:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Security/PermissionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Security/PermissionsControllerTests.cs
@@ -12,10 +12,11 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Uti
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Security;
 
+[Collection(CacheServiceTestFixture.CacheServiceTests)]
 public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<TestStartup>>
 {
     private readonly WebApplicationFactory<TestStartup> _testApp;
-    
+
     public PermissionsControllerTests(TestApplicationFactory<TestStartup> testApp)
     {
         _testApp = testApp;
@@ -27,9 +28,9 @@ public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<T
         var client = _testApp
             .SetUser(AuthenticatedUser())
             .CreateClient();
-        
+
         var response = await client.GetAsync("/api/permissions/access");
-        
+
         response.AssertOk(new GlobalPermissionsViewModel(
             CanAccessSystem: true,
             CanAccessAnalystPages: false,
@@ -39,16 +40,16 @@ public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<T
             IsBauUser: false,
             IsApprover: false));
     }
-    
+
     [Fact]
     public async Task GetGlobalPermissions_BauUser()
     {
         var client = _testApp
             .SetUser(BauUser())
             .CreateClient();
-        
+
         var response = await client.GetAsync("/api/permissions/access");
-        
+
         response.AssertOk(new GlobalPermissionsViewModel(
             CanAccessSystem: true,
             CanAccessAnalystPages: true,
@@ -60,7 +61,7 @@ public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<T
             // individual Approver roles on Releases or Publications.
             IsApprover: false));
     }
-    
+
     [Fact]
     public async Task GetGlobalPermissions_AnalystUser_NotReleaseOrPublicationApprover()
     {
@@ -76,7 +77,7 @@ public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<T
                     UserId = user.GetUserId(),
                     Role = ReleaseRole.Contributor
                 });
-                
+
                 // Add test data that gives the user access to a Publication without being an Approver.
                 context.UserPublicationRoles.Add(new UserPublicationRole
                 {
@@ -85,9 +86,9 @@ public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<T
                 });
             })
             .CreateClient();
-        
+
         var response = await client.GetAsync("/api/permissions/access");
-        
+
         response.AssertOk(new GlobalPermissionsViewModel(
             CanAccessSystem: true,
             CanAccessAnalystPages: true,
@@ -98,7 +99,7 @@ public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<T
             // Expect this to be false if the user isn't an approver of any kind
             IsApprover: false));
     }
-    
+
     [Fact]
     public async Task GetGlobalPermissions_AnalystUser_ReleaseApprover()
     {
@@ -115,9 +116,9 @@ public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<T
                 });
             })
             .CreateClient();
-        
+
         var response = await client.GetAsync("/api/permissions/access");
-        
+
         response.AssertOk(new GlobalPermissionsViewModel(
             CanAccessSystem: true,
             CanAccessAnalystPages: true,
@@ -145,9 +146,9 @@ public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<T
                 });
             })
             .CreateClient();
-        
+
         var response = await client.GetAsync("/api/permissions/access");
-        
+
         response.AssertOk(new GlobalPermissionsViewModel(
             CanAccessSystem: true,
             CanAccessAnalystPages: true,
@@ -165,9 +166,9 @@ public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<T
         var client = _testApp
             .SetUser(PreReleaseUser())
             .CreateClient();
-        
+
         var response = await client.GetAsync("/api/permissions/access");
-        
+
         response.AssertOk(new GlobalPermissionsViewModel(
             CanAccessSystem: true,
             CanAccessAnalystPages: false,
@@ -177,7 +178,7 @@ public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<T
             IsBauUser: false,
             IsApprover: false));
     }
-    
+
     [Fact]
     public async Task GetGlobalPermissions_UnauthenticatedUser()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/CacheServiceTestFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/CacheServiceTestFixture.cs
@@ -12,7 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures
     /// </summary>
     public class CacheServiceTestFixture : IDisposable
     {
-        protected const string CacheServiceTests = "Cache service tests";
+        public const string CacheServiceTests = "Cache service tests";
 
         protected static readonly Mock<IBlobCacheService> BlobCacheService = new(MockBehavior.Strict);
         protected static readonly Mock<IBlobCacheService> PublicBlobCacheService = new(MockBehavior.Strict);

--- a/tests/robot-tests/admin_api.py
+++ b/tests/robot-tests/admin_api.py
@@ -1,0 +1,220 @@
+import json
+import os
+from pathlib import Path
+from typing import Tuple
+
+import requests
+from scripts.get_auth_tokens import get_identity_info
+from tests.libs.logger import get_logger
+
+# TODO - there's plenty of duplication between this file and admin_api.py and setup_auth_variables.py in tests/libs.
+# Would be good to attempt to consolidate.
+# There is also a web of dependencies between Python scripts in tests, tests/scripts and tests/libs. Would
+# be good to consolidate these into a better structure.
+
+logger = get_logger(__name__)
+
+test_theme_name = "Test theme"
+
+
+def send_admin_request(method, endpoint, body=None, fail_on_reauthenticate=False):
+    """
+    This method makes an authenticated request to the Admin API.
+
+    If no prior authentication tokens are available when this method is called, they will
+    be obtained using the BAU user's credentials.
+
+    If authentication tokens exist already but are no longer valid, new tokens will be
+    acquired and the requrest retried.
+
+    If an error HTTP status code is encountered, an error will be thrown.
+    """
+
+    assert method and endpoint
+    assert os.getenv("ADMIN_URL") is not None
+
+    if method == "POST":
+        assert body is not None, "POST requests require a body"
+
+    requests.sessions.HTTPAdapter(pool_connections=50, pool_maxsize=50, max_retries=3)
+    session = requests.Session()
+
+    # To prevent InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings()
+
+    response = send_request_with_retry_on_auth_failure(session, method, endpoint, body, fail_on_reauthenticate)
+
+    if response.status_code == 400 and response.text.find("SlugNotUnique") != -1:
+        raise Exception(f"SlugNotUnique for {body}")
+    else:
+        assert response.status_code < 300, f"Admin request responded with {response.status_code} and {response.text}"
+    return response
+
+
+def send_authenticated_api_request(session, method, endpoint, body):
+    """
+    This method makes an request to the Admin API, and requires that authentication tokens
+    have been fetched prior to being called.
+    """
+
+    jwt_token = json.loads(os.getenv("IDENTITY_LOCAL_STORAGE_ADMIN"))["access_token"]
+    return session.request(
+        method,
+        url=f'{os.getenv("ADMIN_URL")}{endpoint}',
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {jwt_token}",
+        },
+        stream=True,
+        json=body,
+        verify=False,
+    )
+
+
+def send_request_with_retry_on_auth_failure(session, method, endpoint, body, fail_on_reauthenticate=True):
+    """
+    This method makes an request to the given Admin API endpoint.
+
+    If no prior authentication tokens are available when this method is called, they will
+    be obtained using the BAU user's credentials.
+
+    If authentication tokens exist already but are no longer valid, new tokens will be
+    acquired and the requrest retried.
+
+    If an error HTTP status code is encountered, an error will be thrown.
+    """
+
+    if os.getenv("IDENTITY_LOCAL_STORAGE_ADMIN") is None:
+        setup_bau_authentication(clear_existing=True)
+
+    response = send_authenticated_api_request(session, method, endpoint, body)
+
+    if response.status_code not in {401, 403}:
+        return response
+
+    logger.info("Attempting re-authentication...")
+
+    # Delete identify files and re-attempt to fetch them
+    setup_bau_authentication(clear_existing=True)
+    response = send_authenticated_api_request(session, method, endpoint, body)
+
+    if fail_on_reauthenticate:
+        assert response.status_code not in {401, 403}, "Failed to reauthenticate."
+
+    return response
+
+
+def get_test_themes():
+    return send_admin_request("GET", "/api/themes")
+
+
+def create_test_theme():
+    return send_admin_request("POST", "/api/themes", {"title": test_theme_name, "summary": "Test theme summary"})
+
+
+def get_test_theme_id():
+    get_themes_resp = get_test_themes()
+
+    for theme in get_themes_resp.json():
+        if theme["title"] == test_theme_name:
+            return theme["id"]
+
+    return None
+
+
+def create_test_topic(run_id: str):
+    test_theme_id = get_test_theme_id()
+
+    if not test_theme_id:
+        create_theme_resp = create_test_theme()
+        test_theme_id = create_theme_resp.json()["id"]
+
+    os.environ["TEST_THEME_NAME"] = test_theme_name
+    os.environ["TEST_THEME_ID"] = test_theme_id
+
+    topic_name = f"UI test topic {run_id}"
+    response = send_admin_request("POST", "/api/topics", {"title": topic_name, "themeId": os.getenv("TEST_THEME_ID")})
+
+    os.environ["TEST_TOPIC_NAME"] = topic_name
+    os.environ["TEST_TOPIC_ID"] = response.json()["id"]
+
+
+def delete_test_topic():
+    if os.getenv("TEST_TOPIC_ID") is not None:
+        send_admin_request("DELETE", f'/api/topics/{os.getenv("TEST_TOPIC_ID")}')
+
+
+def setup_bau_authentication(clear_existing=False):
+    setup_auth_variables(
+        user="ADMIN",
+        email=os.getenv("ADMIN_EMAIL"),
+        password=os.getenv("ADMIN_PASSWORD"),
+        clear_existing=clear_existing,
+        identity_provider=os.getenv("IDENTITY_PROVIDER"),
+    )
+
+
+def setup_analyst_authentication(clear_existing=False):
+    setup_auth_variables(
+        user="ANALYST",
+        email=os.getenv("ANALYST_EMAIL"),
+        password=os.getenv("ANALYST_PASSWORD"),
+        clear_existing=clear_existing,
+        identity_provider=os.getenv("IDENTITY_PROVIDER"),
+    )
+
+
+def setup_auth_variables(
+    user, email, password, identity_provider, clear_existing=False, driver=None
+) -> Tuple[str, str]:
+    assert user, "user param must be set"
+    assert email, "email param must be set"
+    assert password, "password param must be set"
+
+    local_storage_name = f"IDENTITY_LOCAL_STORAGE_{user}"
+    cookie_name = f"IDENTITY_COOKIE_{user}"
+
+    local_storage_file = Path(f"{local_storage_name}.json")
+    cookie_file = Path(f"{cookie_name}.json")
+
+    if clear_existing:
+        local_storage_file.unlink(True)
+        cookie_file.unlink(True)
+
+    admin_url = os.getenv("ADMIN_URL")
+    assert admin_url, "ADMIN_URL env variable must be set"
+
+    authenticated = False
+
+    if local_storage_file.exists() and cookie_file.exists():
+        os.environ[local_storage_name] = local_storage_file.read_text()
+        os.environ[cookie_name] = cookie_file.read_text()
+
+        response = send_admin_request("GET", "/api/permissions/access", fail_on_reauthenticate=False)
+
+        if response.status_code == 200:
+            authenticated = True
+        else:
+            authenticated = False
+            logger.warn("Found invalid authentication information in local files! Attempting to reauthenticate.")
+
+    if not authenticated:
+        logger.info(f"Logging in to obtain {user} authentication information...")
+
+        os.environ[local_storage_name], os.environ[cookie_name] = get_identity_info(
+            url=admin_url, email=email, password=password, driver=driver, identity_provider=identity_provider
+        )
+
+        # Cache auth info to files for efficiency
+        local_storage_file.write_text(os.environ[local_storage_name])
+        cookie_file.write_text(os.environ[cookie_name])
+
+        logger.info("Done!")
+
+    local_storage_token = os.getenv(local_storage_name)
+    cookie_token = os.getenv(cookie_name)
+
+    assert local_storage_token, f"{local_storage_name} env variable was not set"
+    assert cookie_token, f"{cookie_name} env variable was not set"
+
+    return local_storage_token, cookie_token

--- a/tests/robot-tests/args_and_variables.py
+++ b/tests/robot-tests/args_and_variables.py
@@ -1,0 +1,178 @@
+import argparse
+import os
+
+from dotenv import load_dotenv
+
+
+# Create a parser for our CLI arguments.
+def create_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="pipenv run python run_tests.py",
+        description="Use this script to run the UI tests, locally or as part of the CI pipeline, against the environment of your choosing",
+    )
+    parser.add_argument(
+        "-b",
+        "--browser",
+        dest="browser",
+        default="chrome",
+        choices=["chrome", "firefox", "ie"],
+        help="name of the browser you wish to run the tests with (NOTE: Only chromedriver is automatically installed!)",
+    )
+    parser.add_argument(
+        "-i",
+        "--interp",
+        dest="interp",
+        default="pabot",
+        choices=["pabot", "robot"],
+        help="interpreter to use to run the tests",
+    )
+    parser.add_argument(
+        "--processes", dest="processes", help="how many processes should be used when using the pabot interpreter"
+    )
+    parser.add_argument(
+        "-e",
+        "--env",
+        dest="env",
+        default="test",
+        choices=["local", "dev", "test", "preprod", "prod", "ci"],
+        help="the environment to run the tests against",
+    )
+    parser.add_argument(
+        "-f",
+        "--file",
+        dest="tests",
+        metavar="{file/dir}",
+        default="tests/",
+        help="test suite or folder of tests suites you wish to run",
+    )
+    parser.add_argument(
+        "-t", "--tags", dest="tags", nargs="?", metavar="{tag(s)}", help="specify tests you wish to run by tag"
+    )
+    parser.add_argument(
+        "-v", "--visual", dest="visual", action="store_true", help="display browser window that the tests run in"
+    )
+    parser.add_argument(
+        "--ci", dest="ci", action="store_true", help="specify that the test are running as part of the CI pipeline"
+    )
+    parser.add_argument(
+        "--chromedriver",
+        dest="chromedriver_version",
+        metavar="{version}",
+        help="specify which version of chromedriver to use",
+    )
+    parser.add_argument(
+        "--disable-teardown",
+        dest="disable_teardown",
+        help="disable tearing down of any test data after completion",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--rerun-failed-tests",
+        dest="rerun_failed_tests",
+        action="store_true",
+        help="rerun individual failed tests and merge results into original run results",
+    )
+    parser.add_argument(
+        "--rerun-failed-suites",
+        dest="rerun_failed_suites",
+        action="store_true",
+        help="rerun failed test suites and merge results into original run results",
+    )
+    parser.add_argument("--rerun-attempts", dest="rerun_attempts", type=int, default=0, help="Number of rerun attempts")
+    parser.add_argument(
+        "--print-keywords",
+        dest="print_keywords",
+        action="store_true",
+        help="choose to print out keywords as they are started",
+    )
+    parser.add_argument(
+        "--enable-slack-notifications",
+        dest="enable_slack_notifications",
+        action="store_true",
+        help="enable Slack notifications to be sent for test reports",
+    )
+    parser.add_argument(
+        "--prompt-to-continue",
+        dest="prompt_to_continue",
+        action="store_true",
+        help="get prompted to continue with test execution upon a failure",
+    )
+    parser.add_argument("--fail-fast", dest="fail_fast", action="store_true", help="stop test execution on failure")
+    parser.add_argument(
+        "--custom-env",
+        dest="custom_env",
+        default=None,
+        help="load a custom .env file (must be in ~/robot-tests directory)",
+    )
+    parser.add_argument(
+        "--debug",
+        dest="debug",
+        action="store_true",
+        help="get debug-level logging in report.html, including Python tracebacks",
+    )
+
+    """
+    NOTE(mark): The admin and analyst passwords to access the Admin app are
+    stored in the CI pipeline as secret variables, which means they cannot be accessed as normal
+    environment variables, and instead must be passed as an argument to this script.
+    """
+    parser.add_argument("--admin-pass", dest="admin_pass", default=None, help="manually specify the admin password")
+    parser.add_argument(
+        "--analyst-pass", dest="analyst_pass", default=None, help="manually specify the analyst password"
+    )
+    parser.add_argument(
+        "--expiredinvite-pass",
+        dest="expiredinvite_pass",
+        default=None,
+        help="manually specify the expiredinvite user password",
+    )
+
+    return parser
+
+
+def initialise() -> argparse.Namespace:
+    args = create_argument_parser().parse_args()
+    load_environment_variables(args)
+    store_credential_environment_variables(args)
+    return args
+
+
+def load_environment_variables(arguments: argparse.Namespace):
+    if arguments.custom_env:
+        load_dotenv(arguments.custom_env)
+    else:
+        load_dotenv(".env." + arguments.env)
+
+    validate_environment_variables()
+
+
+def validate_environment_variables():
+    required_env_vars = [
+        "TIMEOUT",
+        "IMPLICIT_WAIT",
+        "PUBLIC_URL",
+        "ADMIN_URL",
+        "PUBLIC_AUTH_USER",
+        "PUBLIC_AUTH_PASSWORD",
+        "RELEASE_COMPLETE_WAIT",
+        "WAIT_MEDIUM",
+        "WAIT_LONG",
+        "WAIT_SMALL",
+        "FAIL_TEST_SUITES_FAST",
+        "IDENTITY_PROVIDER",
+        "WAIT_CACHE_EXPIRY",
+        "EXPIRED_INVITE_USER_EMAIL",
+        "PUBLISHER_FUNCTIONS_URL",
+    ]
+
+    for env_var in required_env_vars:
+        assert os.getenv(env_var) is not None, f"Environment variable {env_var} is not set"
+
+
+def store_credential_environment_variables(arguments: argparse.Namespace):
+    if arguments.admin_pass:
+        os.environ["ADMIN_PASSWORD"] = arguments.admin_pass
+    if arguments.analyst_pass:
+        os.environ["ANALYST_PASSWORD"] = arguments.analyst_pass
+    if arguments.expiredinvite_pass:
+        os.environ["EXPIRED_INVITE_USER_PASSWORD"] = arguments.expiredinvite_pass

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -167,12 +167,6 @@ def execute_tests(arguments: argparse.Namespace, rerunning_failures: bool):
         pabot_run_cli(create_robot_arguments(arguments, rerunning_failures))
 
 
-def setup_user_authentication(tests: str):
-    if not tests or f"{os.sep}admin" in tests:
-        admin_api.setup_bau_authentication()
-        admin_api.setup_analyst_authentication()
-
-
 def run():
     args = args_and_variables.initialise()
 
@@ -184,9 +178,6 @@ def run():
         raise Exception(f"Cannot run tests that change data on environment {args.env}")
 
     install_chromedriver(args.chromedriver_version)
-
-    if data_changing_tests:
-        setup_user_authentication(args.tests)
 
     test_run_index = -1
 

--- a/tests/robot-tests/scripts/run_tests_pipeline.py
+++ b/tests/robot-tests/scripts/run_tests_pipeline.py
@@ -30,8 +30,8 @@ def run_tests_pipeline():
 
     run_tests_command = f"pipenv run python run_tests.py --admin-pass {args.admin_pass} --analyst-pass {args.analyst_pass} --expiredinvite-pass {args.expiredinvite_pass} --env {args.env} --file {args.file} --ci --processes {args.processes} --enable-slack-notifications"
 
-    if args.rerun_failed_suites:
-        run_tests_command += " --rerun-failed-suites"
+    if args.rerun_attempts:
+        run_tests_command += f" --rerun-attempts {str(args.rerun_attempts)}"
 
     subprocess.check_call(run_tests_command, shell=True)
 
@@ -58,13 +58,6 @@ if __name__ == "__main__":
 
     parser.add_argument("--processes", dest="processes", help="number of processes to run", required=True)
 
-    parser.add_argument(
-        "--rerun-failed-suites",
-        dest="rerun_failed_suites",
-        help="rerun any failed suites from a previous run",
-        required=False,
-        action="store_true",
-    )
-
+    parser.add_argument("--rerun-attempts", dest="rerun_attempts", type=int, help="Number of rerun attempts")
     args = parser.parse_args()
     run_tests_pipeline()

--- a/tests/robot-tests/tests/libs/admin-utilities.py
+++ b/tests/robot-tests/tests/libs/admin-utilities.py
@@ -2,20 +2,18 @@ import os
 import time
 
 import requests
-from robot.libraries.BuiltIn import BuiltIn
 from selenium.common import NoSuchElementException
 from selenium.webdriver.common.by import By
 from tests.libs.logger import get_logger
+from tests.libs.selenium_elements import sl
 from tests.libs.setup_auth_variables import setup_auth_variables
 from tests.libs.utilities import set_cookie_from_json, set_to_local_storage
 
 logger = get_logger(__name__)
 
-sl = BuiltIn().get_library_instance("SeleniumLibrary")
-
 
 def raise_assertion_error(err_msg):
-    sl.failure_occurred()
+    sl().failure_occurred()
     logger.warn(err_msg)
     raise AssertionError(err_msg)
 
@@ -55,7 +53,7 @@ def user_signs_in_as(user: str):
             user,
             email=os.getenv(f"{user}_EMAIL"),
             password=os.getenv(f"{user}_PASSWORD"),
-            driver=sl.driver,
+            driver=sl().driver,
             identity_provider=os.getenv("IDENTITY_PROVIDER"),
         )
 
@@ -69,13 +67,13 @@ def user_signs_in_as(user: str):
         )
         set_cookie_from_json(cookie_token)
 
-        sl.go_to(admin_url)
+        sl().go_to(admin_url)
     except Exception as e:
         raise_assertion_error(e)
 
 
 def get_theme_id_from_url():
-    url = sl.get_location()
+    url = sl().get_location()
     assert "/themes/" in url, "URL does not contain /themes"
     result = url[len(os.getenv("ADMIN_URL")) :].lstrip("/").split("/")
     assert result[0] == "themes", 'String "themes" should be 1st element in list'
@@ -90,7 +88,7 @@ def get_release_guid_from_release_status_page_url(url):
 
 def data_csv_number_contains_xpath(num, xpath):
     try:
-        elem = sl.driver.find_element(By.XPATH, f'//*[@id="dataFileUploadForm"]/dl[{num}]')
+        elem = sl().driver.find_element(By.XPATH, f'//*[@id="dataFileUploadForm"]/dl[{num}]')
     except BaseException:
         raise_assertion_error(f'Cannot find data file number "{num}"')
     try:
@@ -101,7 +99,7 @@ def data_csv_number_contains_xpath(num, xpath):
 
 def data_file_number_contains_xpath(num, xpath):
     try:
-        elem = sl.driver.find_element(By.XPATH, f'//*[@id="fileUploadForm"]/dl[{num}]')
+        elem = sl().driver.find_element(By.XPATH, f'//*[@id="fileUploadForm"]/dl[{num}]')
     except BaseException:
         raise_assertion_error(f'Cannot find data file number "{num}"')
     try:
@@ -114,23 +112,23 @@ def user_waits_for_release_process_status_to_be(status, timeout):
     max_time = time.time() + int(timeout)
     while time.time() < max_time:
         try:
-            sl.driver.find_element(By.ID, f"release-process-status-Failed")
+            sl().driver.find_element(By.ID, f"release-process-status-Failed")
             raise_assertion_error("Release process status FAILED!")
         except BaseException:
             pass
         try:
-            sl.driver.find_element(By.ID, f"release-process-status-{status}")
+            sl().driver.find_element(By.ID, f"release-process-status-{status}")
             return
         except BaseException:
-            sl.reload_page()  # Necessary if release previously scheduled
+            sl().reload_page()  # Necessary if release previously scheduled
             time.sleep(3)
     raise_assertion_error(f"Release process status wasn't {status} after {timeout} seconds!")
 
 
 def user_checks_dashboard_theme_topic_dropdowns_exist():
     try:
-        sl.driver.find_element(By.ID, "publicationsReleases-themeTopic-themeId")
-        sl.driver.find_element(By.ID, "publicationsReleases-themeTopic-topicId")
+        sl().driver.find_element(By.ID, "publicationsReleases-themeTopic-themeId")
+        sl().driver.find_element(By.ID, "publicationsReleases-themeTopic-topicId")
     except NoSuchElementException:
         return False
 

--- a/tests/robot-tests/tests/libs/fail_fast.py
+++ b/tests/robot-tests/tests/libs/fail_fast.py
@@ -4,17 +4,28 @@ their Tests fails.  If the "fail tests suites fast" option is enabled, this file
 scripts, firstly to record that a test suite is failing, and then again on subsequent Tests starting to see if they
 should continue to run or if they should fail immediately and therefore fail the test suite immediately.
 """
+import os.path
+
 from robot.libraries.BuiltIn import BuiltIn
 from tests.libs.logger import get_logger
+from tests.libs.selenium_elements import sl
 
-sl = BuiltIn().get_library_instance("SeleniumLibrary")
-FAILING_SUITES = set()
+failing_suites_filename = ".failing_suites"
+
 logger = get_logger(__name__)
+
+
+def _get_current_test_suite() -> str:
+    return BuiltIn().get_variable_value("${SUITE SOURCE}")
 
 
 def current_test_suite_failing_fast() -> bool:
     test_suite = _get_current_test_suite()
-    return test_suite in FAILING_SUITES
+    if os.path.isfile(failing_suites_filename):
+        file = open(failing_suites_filename, "r")
+        failing_suites = file.readlines()
+        return test_suite in failing_suites
+    return False
 
 
 def record_failing_test_suite():
@@ -22,7 +33,8 @@ def record_failing_test_suite():
     logger.warn(
         f"Recording test suite '{test_suite}' as failing - subsequent tests will automatically fail in this suite"
     )
-    FAILING_SUITES.add(test_suite)
+    file = open(failing_suites_filename, "w")
+    file.writelines([test_suite])
 
 
 def fail_test_fast_if_required():
@@ -30,10 +42,6 @@ def fail_test_fast_if_required():
         _raise_assertion_error(f"Test suite {_get_current_test_suite()} is already failing.  Failing this test fast.")
 
 
-def _get_current_test_suite() -> str:
-    return BuiltIn().get_variable_value("${SUITE SOURCE}")
-
-
 def _raise_assertion_error(err_msg):
-    sl.failure_occurred()
+    sl().failure_occurred()
     raise AssertionError(err_msg)

--- a/tests/robot-tests/tests/libs/file_operations.py
+++ b/tests/robot-tests/tests/libs/file_operations.py
@@ -2,10 +2,7 @@ import os
 import zipfile
 
 import requests
-from robot.libraries.BuiltIn import BuiltIn
-
-sl = BuiltIn().get_library_instance("SeleniumLibrary")
-
+from tests.libs.selenium_elements import sl
 
 requests.sessions.HTTPAdapter(pool_connections=50, pool_maxsize=50, max_retries=3)
 session = requests.Session()
@@ -14,7 +11,7 @@ session = requests.Session()
 def download_file(link_locator, file_name):
     if not os.path.exists("test-results/downloads"):
         os.makedirs("test-results/downloads")
-    link_url = sl.get_element_attribute(link_locator, "href")
+    link_url = sl().get_element_attribute(link_locator, "href")
     r = session.get(link_url, allow_redirects=True, stream=True)
     with open(f"test-results/downloads/{file_name}", "wb") as f:
         f.write(r.content)

--- a/tests/robot-tests/tests/libs/public-utilities.py
+++ b/tests/robot-tests/tests/libs/public-utilities.py
@@ -1,56 +1,54 @@
 import os
 import re
 
-from robot.libraries.BuiltIn import BuiltIn
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
-
-sl = BuiltIn().get_library_instance("SeleniumLibrary")
+from tests.libs.selenium_elements import sl
 
 
 def raise_assertion_error(err_msg):
-    sl.capture_page_screenshot()
+    sl().capture_page_screenshot()
     raise AssertionError(err_msg)
 
 
 def cookie_should_not_exist(name):
-    for cookie in sl.driver.get_cookies():
+    for cookie in sl().driver.get_cookies():
         if cookie["name"] == name:
             raise_assertion_error(f"Cookie {name} exists when it shouldn't!")
 
 
 def cookie_should_have_value(name, value):
-    for cookie in sl.driver.get_cookies():
+    for cookie in sl().driver.get_cookies():
         if cookie["name"] == name and cookie["value"] == value:
             return
     raise_assertion_error(f"Couldn't find cookie {name} with value {value}")
 
 
 def cookie_names_should_be_on_page():
-    cookies = sl.driver.get_cookies()
+    cookies = sl().driver.get_cookies()
     for cookie in cookies:
         if cookie["name"] in ["_hjIncludedInSample", "_hjid"]:
             continue
         try:
-            sl.page_should_contain(cookie["name"])
+            sl().page_should_contain(cookie["name"])
         except BaseException:
             raise_assertion_error(f"Page should contain text \"{cookie['name']}\"!")
 
 
 def user_checks_number_of_other_releases_is_correct(number):
-    elems = sl.driver.find_elements(By.XPATH, '(.//*[@data-testid="other-release-item"])')
+    elems = sl().driver.find_elements(By.XPATH, '(.//*[@data-testid="other-release-item"])')
     if len(elems) != int(number):
         raise_assertion_error(f'Found "{len(elems)}" other releases, not "{int(number)}"')
 
 
 def user_checks_other_release_is_shown_in_position(release_name, position):
     try:
-        sl.driver.find_element(By.XPATH, f'.//*[@data-testid="other-release-item" and a/text()="{release_name}"]')
+        sl().driver.find_element(By.XPATH, f'.//*[@data-testid="other-release-item" and a/text()="{release_name}"]')
     except BaseException:
         raise_assertion_error(f'No other release "{release_name}" found')
 
     try:
-        elem = sl.driver.find_element(By.XPATH, f'(.//a[../@data-testid="other-release-item"])[{position}]')
+        elem = sl().driver.find_element(By.XPATH, f'(.//a[../@data-testid="other-release-item"])[{position}]')
     except BaseException:
         raise_assertion_error(f"There are less than {position} other releases listed!")
 
@@ -62,7 +60,7 @@ def user_checks_other_release_is_shown_in_position(release_name, position):
 
 # Table tool
 def user_checks_generated_permalink_is_valid():
-    elem = sl.driver.find_element(By.CSS_SELECTOR, '[data-testid="permalink-generated-url"]')
+    elem = sl().driver.find_element(By.CSS_SELECTOR, '[data-testid="permalink-generated-url"]')
     url_without_basic_auth = re.sub(r".*@", "", os.environ["PUBLIC_URL"])
     url_without_http = re.sub(r"^https?:\/\/", "", url_without_basic_auth)
     current_url_without_http = re.sub(r"^https?:\/\/", "", elem.get_attribute("value"))
@@ -77,23 +75,23 @@ def user_reorders_table_headers(drag_selector, drop_selector):
     drop_elem = None
     if drag_selector.startswith("css:"):
         drag_selector = drag_selector[4:]
-        sl.wait_until_page_contains_element(f"css:{drag_selector}")
-        drag_elem = sl.driver.find_element(By.CSS_SELECTOR, drag_selector)
+        sl().wait_until_page_contains_element(f"css:{drag_selector}")
+        drag_elem = sl().driver.find_element(By.CSS_SELECTOR, drag_selector)
     if drop_selector.startswith("css:"):
         drop_selector = drop_selector[4:]
-        sl.wait_until_page_contains_element(f"css:{drop_selector}")
-        drop_elem = sl.driver.find_element(By.CSS_SELECTOR, drop_selector)
+        sl().wait_until_page_contains_element(f"css:{drop_selector}")
+        drop_elem = sl().driver.find_element(By.CSS_SELECTOR, drop_selector)
     if drag_selector.startswith("xpath:"):
         drag_selector = drag_selector[6:]
-        sl.wait_until_page_contains_element(f"xpath:{drag_selector}")
-        drag_elem = sl.driver.find_element(By.XPATH, drag_selector)
+        sl().wait_until_page_contains_element(f"xpath:{drag_selector}")
+        drag_elem = sl().driver.find_element(By.XPATH, drag_selector)
     if drop_selector.startswith("xpath:"):
         drop_selector = drop_selector[6:]
-        sl.wait_until_page_contains_element(f"xpath:{drop_selector}")
-        drop_elem = sl.driver.find_element(By.XPATH, drop_selector)
+        sl().wait_until_page_contains_element(f"xpath:{drop_selector}")
+        drop_elem = sl().driver.find_element(By.XPATH, drop_selector)
 
     # https://github.com/react-dnd/react-dnd/issues/1195#issuecomment-456370983
-    action = ActionChains(sl.driver)
+    action = ActionChains(sl().driver)
     action.click_and_hold(drag_elem).perform()
     action.move_to_element(drop_elem).perform()
     action.move_by_offset(0, 0).pause(0.01).perform()

--- a/tests/robot-tests/tests/libs/selenium_elements.py
+++ b/tests/robot-tests/tests/libs/selenium_elements.py
@@ -1,0 +1,14 @@
+from robot.libraries.BuiltIn import BuiltIn
+from SeleniumLibrary.keywords.waiting import WaitingKeywords
+
+
+def sl():
+    return BuiltIn().get_library_instance("SeleniumLibrary")
+
+
+def element_finder():
+    return sl()._element_finder
+
+
+def waiting():
+    return WaitingKeywords(sl())

--- a/tests/robot-tests/tests/libs/slack.py
+++ b/tests/robot-tests/tests/libs/slack.py
@@ -24,49 +24,38 @@ class SlackService:
             if env_var is None:
                 raise AssertionError(f"{env_var} is not set")
 
-    def _build_attachments(self, env: str, suite: str):
+    def _build_attachments(self, env: str, suites_ran: str, suites_failed: [], run_index: int):
         with open(f"{PATH}{os.sep}output.xml", "rb") as report:
             contents = report.read()
 
         soup = BeautifulSoup(contents, features="xml")
 
-        test = soup.find("total").find("stat")
+        tests = soup.find("total").find("stat")
 
-        failed_tests = int(test["fail"])
-        passed_tests = int(test["pass"])
+        failed_tests = int(tests["fail"])
+        passed_tests = int(tests["pass"])
 
-        failed_tests_field = ({},)
+        failed_test_suites_field = ({},)
 
-        if failed_tests > 0:
-            failed_tests_field = {"title": "Failed tests", "value": failed_tests}
+        if suites_failed:
+            failed_test_suites_field = {"title": "Failed test suites", "value": "\n * ".join(suites_failed)}
         return [
             {
                 "pretext": "All results",
-                "color": "danger" if failed_tests else "good",
-                "mrkdwn_in": ["pretext"],
+                "color": "danger" if suites_failed else "good",
+                "mrkdwn_in": ["pretext", "Failed test suites"],
                 "fields": [
                     {"title": "Environment", "value": env},
-                    {"title": "Suite", "value": suite.replace("tests/", "")},
+                    {"title": "Suite", "value": suites_ran.replace("tests/", "")},
                     {"title": "Total test cases", "value": passed_tests + failed_tests},
-                    failed_tests_field,
+                    {"title": "Total runs", "value": run_index + 1},
+                    failed_test_suites_field,
                 ],
             }
         ]
 
-    def _tests_failed(self):
-        with open(f"{PATH}{os.sep}output.xml", "rb") as report:
-            contents = report.read()
-
-            soup = BeautifulSoup(contents, features="xml")
-            test = soup.find("total").find("stat")
-
-            failed_tests = int(test["fail"])
-
-            if failed_tests > 0:
-                return True
-
-    def send_test_report(self, env: str, suite: str):
-        attachments = self._build_attachments(env, suite)
+    def send_test_report(self, env: str, suites_ran: str, suites_failed: [], run_index: int):
+        attachments = self._build_attachments(env, suites_ran, suites_failed, run_index)
 
         webhook_url = self.report_webhook_url
         slack_bot_token = self.slack_bot_token
@@ -78,12 +67,12 @@ class SlackService:
 
         logger.info("Sent UI test statistics to #build")
 
-        if self._tests_failed():
+        if suites_failed:
             client = WebClient(token=slack_bot_token)
 
             date = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
 
-            report_name = f"UI-test-report-{suite.replace('tests/', '')}-{env}-{date}.zip"
+            report_name = f"UI-test-report-{suites_ran.replace('tests/', '')}-{env}-{date}.zip"
 
             shutil.make_archive(report_name.replace(".zip", ""), "zip", PATH)
             try:

--- a/tests/robot-tests/tests/libs/slack.py
+++ b/tests/robot-tests/tests/libs/slack.py
@@ -38,12 +38,12 @@ class SlackService:
         failed_test_suites_field = ({},)
 
         if suites_failed:
-            failed_test_suites_field = {"title": "Failed test suites", "value": "\n * ".join(suites_failed)}
+            failed_test_suites_field = {"title": "Failed test suites", "value": "\n".join(suites_failed)}
         return [
             {
                 "pretext": "All results",
                 "color": "danger" if suites_failed else "good",
-                "mrkdwn_in": ["pretext", "Failed test suites"],
+                "mrkdwn_in": ["pretext"],
                 "fields": [
                     {"title": "Environment", "value": env},
                     {"title": "Suite", "value": suites_ran.replace("tests/", "")},

--- a/tests/robot-tests/tests/libs/visual.py
+++ b/tests/robot-tests/tests/libs/visual.py
@@ -1,62 +1,61 @@
 import os
 
-from robot.libraries.BuiltIn import BuiltIn
 from selenium.webdriver.remote.webelement import WebElement
 from tests.libs.logger import get_logger
+from tests.libs.selenium_elements import sl
 
-sl = BuiltIn().get_library_instance("SeleniumLibrary")
 logger = get_logger(__name__)
 
 
 def with_no_overflow(func):
     def wrapper(*args, **kwargs):
-        head_html = sl.driver.execute_script("return document.head.innerHTML;")
-        sl.driver.execute_script("document.head.innerHTML += '<style>* {overflow: unset !important}</style>'")
+        head_html = sl().driver.execute_script("return document.head.innerHTML;")
+        sl().driver.execute_script("document.head.innerHTML += '<style>* {overflow: unset !important}</style>'")
 
         try:
             return func(*args, **kwargs)
         finally:
-            sl.driver.execute_script("document.head.innerHTML = arguments[0];", head_html)
+            sl().driver.execute_script("document.head.innerHTML = arguments[0];", head_html)
 
     return wrapper
 
 
 def with_maximised_browser(func):
     def wrapper(*args, **kwargs):
-        currentWindow = sl.get_window_size()
-        page_width = sl.driver.execute_script("return document.documentElement.scrollWidth;") + 100
-        page_height = sl.driver.execute_script("return document.documentElement.scrollHeight;") + 100
+        currentWindow = sl().get_window_size()
+        page_width = sl().driver.execute_script("return document.documentElement.scrollWidth;") + 100
+        page_height = sl().driver.execute_script("return document.documentElement.scrollHeight;") + 100
 
         original_width = currentWindow[0]
         original_height = currentWindow[1]
 
-        sl.set_window_size(page_width, page_height)
+        sl().set_window_size(page_width, page_height)
 
         try:
             return func(*args, **kwargs)
         finally:
-            sl.set_window_size(original_width, original_height)
+            sl().set_window_size(original_width, original_height)
 
     return wrapper
 
 
 def highlight_element(element: WebElement):
-    sl.driver.execute_script("arguments[0].scrollIntoView();", element)
-    sl.driver.execute_script("arguments[0].style.border = 'red 4px solid';", element)
+    sl().driver.execute_script("arguments[0].scrollIntoView();", element)
+    sl().driver.execute_script("arguments[0].style.border = 'red 4px solid';", element)
 
 
 def capture_screenshot():
-    screenshot_location = sl.capture_page_screenshot()
+    screenshot_location = sl().capture_page_screenshot()
     logger.warn(
-        f"Captured current screenshot at URL '{sl.get_location()}' Screenshot saved to file://{screenshot_location}"
+        f"Captured current screenshot at URL '{sl().get_location()}' Screenshot saved to file://{screenshot_location}"
     )
 
 
 @with_maximised_browser
 def capture_large_screenshot():
-    screenshot_location = sl.capture_page_screenshot()
+    screenshot_location = sl().capture_page_screenshot()
     logger.warn(
-        f"Captured enlarged screenshot at URL '{sl.get_location()}' Screenshot saved to file://{screenshot_location}"
+        f"Captured enlarged screenshot at URL '{sl().get_location()}' Screenshot saved to file://{screenshot_location}"
     )
 
 


### PR DESCRIPTION
This PR:
- Adds a new "rerun-attempts" option to `run_tests.py` in order to allow 0 or more retries upon test suite failures.
- Adds some additional details to the UI test Slack messages.
- Does additional cleanup prior to a test run being executed by removing any existing `.pabotsuitenames` file in order to try preventing Pabot bugs when seemingly executing the same suite multiple times.
- Breaks up `run_tests.py` into smaller modules to hopefully make it easier to absorb.

## Adding rerun support

The Robot tests can now be run from the command line with an additional `rerun-attempts` argument - e.g.:

```bash
pipenv run python3 run_tests.py --rerun-attempts=3
```

This example above will rerun any failing suites an additional 3 times prior to marking them as failed.

As well as adding this as a new argument to `run_tests.py`'s argparser and to the UI Pipeline YAML file, some additional changes to the `run_tests` script and other associated Python scripts were necessary to carry out in order to make it re-runnable:

* The SeleniumLibrary and Element Finder instances used by various scripts now grab the *current* instance in real time whenever they need to use it, rather than relying on it having been previously set in their own modules' startup scripts.  They are broken out into a separate `selenium_elements.py` file.
* Unique `run_identifiers` are generated for each (re)run attempt to stop multiple reruns from interfering with each other.
* Each (re)run sets up and tears down its own test Topic in which it houses all of its generated test data.
* The tracking of which test suites are currently failing (to support our fail-fast behaviour) is now file-based, as attempting to track it in a variable and successfully restart it for subsequent reruns was proving very difficult.
* Various other little setup and cleardown tasks that were necessary to support reruns from within a single Python call.

## Breaking run_tests.py into smaller modules

To make it (hopefully) easier to understand and support, `run_tests.py` has been broken into smaller modules, and some key pieces of complexity refactored, such as:

* Not needing to explicitly decide which users to authenticate with at the start of the test run, based on the tests selected.  Instead, we now lazily log in with the necessary users only when we need to do so.  As an example for BAU, this would either be the first time that a Test requires BAU to be logged in, or the first call to an Admin API endpoint, like "create test topic".
* All requests to the Admin API from the test harness will now auto-try again on authentication failure.  There is no mixing and matching of this behaviour now.