### PR TITLE
🐛 EES-4117 Change path separators in `run_tests.py`

### DIFF
--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -173,7 +173,7 @@ def run():
 
     # If running all tests, or admin, admin_and_public or admin_and_public_2 suites, these
     # change data on environments and require test themes, test topics and user authentication.
-    data_changing_tests = args.tests == f"tests{os.sep}" or f"{os.sep}admin" in args.tests
+    data_changing_tests = args.tests == f"tests/" or f"/admin" in args.tests
 
     if data_changing_tests and args.env not in ["local", "dev"]:
         raise Exception(f"Cannot run tests that change data on environment {args.env}")


### PR DESCRIPTION
This PR changes the path separators used in the declaration of the `data_changing_tests` variable in `run_tests.py`.

https://github.com/dfe-analytical-services/explore-education-statistics/blob/97033898811e7d508ff5e8b8879fe241e7f85ea9/tests/robot-tests/run_tests.py#L176

On Windows the value of `os.sep` is `\\`.

`print(f"tests{os.sep}")`  -> `tests\`
`print(f"{os.sep}admin")` ->  `\admin`

This doesn't match the separator in `args.tests` which is always a forward slash so we replace `{os.sep}` with a forward slash.

Without this change, `data_changing_tests` always evaluates to false on Windows, so `create_test_topic` is never run which lots of tests depend on.
