### PR TITLE
Ees 4117 fail jobs on test failures

### DIFF
--- a/azure-pipelines-ui-tests.dfe.yml
+++ b/azure-pipelines-ui-tests.dfe.yml
@@ -54,16 +54,16 @@ jobs:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
-
   - task: PublishTestResults@2
     displayName: Publish Test Results
     condition: succeededOrFailed()
     inputs:
       testResultsFiles: tests/robot-tests/test-results/xunit.xml
-      failTaskOnFailedTests: false
+      failTaskOnFailedTests: true
 
   - task: PublishPipelineArtifact@1
     displayName: Publish Test Pipeline Artifact
+    condition: succeededOrFailed()
     inputs:
       path: tests/robot-tests/test-results/
       artifactName: test-results-public
@@ -108,15 +108,15 @@ jobs:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
-
   - task: PublishTestResults@2
     displayName: Publish Test Results
     inputs:
       testResultsFiles: tests/robot-tests/test-results/xunit.xml
-      failTaskOnFailedTests: false
+      failTaskOnFailedTests: true
 
   - task: PublishPipelineArtifact@1
     displayName: Publish Pipeline Artifact
+    condition: succeededOrFailed()
     inputs:
       path: tests/robot-tests/test-results/
       artifactName: test-results-admin-and-public-2
@@ -160,13 +160,12 @@ jobs:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
-
   - task: PublishTestResults@2
     displayName: Publish Test Results
     condition: succeededOrFailed()
     inputs:
       testResultsFiles: tests/robot-tests/test-results/xunit.xml
-      failTaskOnFailedTests: false
+      failTaskOnFailedTests: true
 
   - task: PublishPipelineArtifact@1
     displayName: Publish Test Pipeline Artifact
@@ -213,14 +212,15 @@ jobs:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
       SLACK_TEST_REPORT_WEBHOOK_URL: $(ees-test-SLACK-TEST-REPORT-WEBHOOK-URL)
 
-
   - task: PublishTestResults@2
     displayName: Publish Test Results
     inputs:
       testResultsFiles: tests/robot-tests/test-results/xunit.xml
+      failTaskOnFailedTests: true
 
   - task: PublishPipelineArtifact@1
     displayName: Publish Test Pipeline Artifact
+    condition: succeededOrFailed()
     inputs:
       path: tests/robot-tests/test-results/
       artifactName: test-results-admin-public

--- a/tests/robot-tests/tests/libs/slack.py
+++ b/tests/robot-tests/tests/libs/slack.py
@@ -47,8 +47,11 @@ class SlackService:
                 "fields": [
                     {"title": "Environment", "value": env},
                     {"title": "Suite", "value": suites_ran.replace("tests/", "")},
-                    {"title": "Total test cases", "value": passed_tests + failed_tests},
                     {"title": "Total runs", "value": run_index + 1},
+                    {"title": "Total test cases", "value": passed_tests + failed_tests},
+                    {"title": "Passed test cases", "value": passed_tests},
+                    {"title": "Failed test cases", "value": failed_tests},
+                    {"title": "Failed test suites", "value": len(suites_failed)},
                     failed_test_suites_field,
                 ],
             }


### PR DESCRIPTION
This PR:
- makes the UI test pipeline fail when any tests fail (which does not include any tests that previously failed but were fixed in a rerun attempt).
- adds back in "Tests passed" into the Slack notification.

## Pipeline failure

We now fail the "Publish Test Results" task on each of the 4 UI test jobs in the pipeline if any of the tests failed the initial run and any rerun attempts.  We configure the next task in the pipeline to run even if this "Publish Test Results" task fails, thus allowing the pipeline to complete regardless of this failure, but report the overall job as failed:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/95d0df98-ac62-4653-93f3-e7493f37b47f)
In this image, we see the "Publish Test Results" task failing.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/5d52cfc8-c0f1-4800-a99a-f4c0a8374d87)
These are the test results that are published in the failed "Publish Test Results" task.

Note the green ticks in the tasks following the failed "Publish Test Results" task, showing that they ran successfully.

## Slack notification

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/966a03ad-2851-4632-a470-d86cbe79f197)
This shows a passing set of tests.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/d4b7c74b-0134-41d9-8c33-b00d0bb80415)
This shows a job with failing tests.

## Future work

At the moment we're having to retain 4 very similar `job` definitions in our pipeline YAML.  We should look into using templates instead to incorporate all of the common stuff and pass in variables, so that we don't have to manually repeat our changes each time we need to make a common change.