### PR TITLE
Allowing Release JSON files of format yyyy.json to be deleted using the /release-json cache clearing endpoint

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
@@ -252,18 +252,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var regex = Assert.IsType<Regex>(options.IncludeRegex);
             Assert.Matches(regex, "publications/publication-1/latest-release.json");
+            Assert.Matches(regex, "publications/publication-1/releases/1234.json");
+            Assert.Matches(regex, "publications/publication-1/releases/1234-q1.json");
             Assert.Matches(regex, "publications/publication-1/releases/1234-56.json");
-            Assert.Matches(regex, "publications/publication-1/releases/1234-56-fy.json");
+            Assert.Matches(regex, "publications/publication-1/releases/1234-56-q1.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/latest-release_json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/1234_json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/1234/data-block-id.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/1234-56_json");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/1234-56/data-block-id.json");
             Assert.DoesNotMatch(regex, "publications/latest-release.json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/1234.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/1234-56.json");
+            Assert.DoesNotMatch(regex, "publications/publication-1/1234-56-q1.json");
+            Assert.DoesNotMatch(regex, "publications/1234.json");
             Assert.DoesNotMatch(regex, "publications/1234-56.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/latest-release.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/12-56.json");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/latest-release.json.bak");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/1234.json.bak");
             Assert.DoesNotMatch(regex, "publications/publication-1/releases/1234-56.json.bak");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/1234-56-q1.json.bak");
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
@@ -33,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
             IPrivateBlobStorageService privateBlobStorageService,
             IPublicBlobStorageService publicBlobStorageService,
             IGlossaryCacheService glossaryCacheService,
-            IMethodologyCacheService methodologyCacheService, 
+            IMethodologyCacheService methodologyCacheService,
             IPublicationCacheService publicationCacheService)
         {
             _privateBlobStorageService = privateBlobStorageService;
@@ -77,15 +77,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
                 await request.CacheEntries
                     .ToAsyncEnumerable()
                     .ForEachAwaitAsync(
-                        
+
                         async entry =>
                         {
                             var allowedPath =
                                 EnumUtil.GetFromString<UpdatePublicCacheTreePathsViewModel.CacheEntry>(entry);
-                            
+
                             switch (allowedPath)
                             {
-                                case UpdatePublicCacheTreePathsViewModel.CacheEntry.MethodologyTree: 
+                                case UpdatePublicCacheTreePathsViewModel.CacheEntry.MethodologyTree:
                                     await _methodologyCacheService.UpdateSummariesTree();
                                     break;
                                 case UpdatePublicCacheTreePathsViewModel.CacheEntry.PublicationTree:
@@ -157,7 +157,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
         public async Task<ActionResult> ClearPublicCachePublicationJson()
         {
             var publicationJsonFilenameRegex = FileStoragePathUtils.PublicationFileName.Replace(".", "\\.");
-            
+
             await _publicBlobStorageService.DeleteBlobs(
                 BlobContainers.PublicContent,
                 options: new DeleteBlobsOptions
@@ -179,12 +179,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
         public async Task<ActionResult> ClearPublicCacheReleaseJson()
         {
             var latestReleaseJsonFilenameRegex = FileStoragePathUtils.LatestReleaseFileName.Replace(".", "\\.");
-            
+
             await _publicBlobStorageService.DeleteBlobs(
                 BlobContainers.PublicContent,
                 options: new DeleteBlobsOptions
                 {
-                    IncludeRegex = new Regex($"^publications/[^/]+/({latestReleaseJsonFilenameRegex}|releases/[0-9]{{4}}-[^/]+\\.json)$")
+                    // Match against patterns:
+                    //
+                    // publications/***/latest-release.json
+                    // publications/***/releases/1234.json
+                    // publications/***/releases/1234-35.json
+                    // publications/***/releases/1234-q1.json
+                    // publications/***/releases/1234-35-q1.json
+                    IncludeRegex = new Regex($"^publications/[^/]+/({latestReleaseJsonFilenameRegex}|releases/[0-9]{{4}}(-[^/]+)?\\.json)$")
                 });
 
             return NoContent();
@@ -197,7 +204,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
                 MethodologyTree,
                 PublicationTree
             }
-            
+
             private static readonly HashSet<string> AllowedCacheEntries = new()
             {
                 CacheEntry.MethodologyTree.ToString(),


### PR DESCRIPTION
This PR:
- adds the `yyyy.json` filename format to the list of formats allowed in deleting Release JSON when using the Release JSON cache-clearing endpoint. 