### PR TITLE
EES-4732 fix slow locations rendering for schools

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.tsx
@@ -20,13 +20,17 @@ export interface FormCheckboxSearchGroupProps extends FormCheckboxGroupProps {
 
 const FormCheckboxSearchGroup = ({
   searchLabel,
+  searchOnly = false,
   ...props
 }: FormCheckboxSearchGroupProps) => {
   const { isMounted } = useMounted();
 
   const [searchTerm, setSearchTerm] = useState('');
 
-  if (!isMounted) {
+  // searchOnly is used when we expect a very large number
+  // of options which would cause very slow rendering
+  // if they were all rendered.
+  if (!isMounted && !searchOnly) {
     return <FormCheckboxGroup {...props} />;
   }
 
@@ -42,7 +46,6 @@ const FormCheckboxSearchGroup = ({
     name,
     options = [],
     searchHelpText,
-    searchOnly = false,
     value = [],
     onFieldsetFocus,
     onFieldsetBlur,
@@ -65,7 +68,6 @@ const FormCheckboxSearchGroup = ({
   let filteredOptions = searchOnly
     ? options.filter(option => value.includes(option.value))
     : options;
-
   if (searchTerm) {
     // Search for URN in the hint field if search term is a number.
     if (searchOnly && !Number.isNaN(Number(searchTerm))) {


### PR DESCRIPTION
Fixes a bug in the table tool where loading school data in the locations step was very slow and could cause the browser tab to crash. 

School data is very large, 28,000+ schools, so we don't render the checkboxes for them until you search and only show a maximum of 500. Or so we thought... it turns out that there's an `!isMounted` check in the component which renders the checkboxes without search that was kicking in first. I'm assuming was added so the component will work without JS enabled (though I'm dubious if you can actually get to anywhere it's used on the site without JS).

This fix adds a check for the `searchOnly` flag to prevent this happening.
