### PR TITLE
EES-4703 - fix caching test clashes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Security/PermissionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Security/PermissionsControllerTests.cs
@@ -21,7 +21,7 @@ public class PermissionsControllerTests : IntegrationTest<TestStartup>
     [Fact]
     public async Task GetGlobalPermissions_AuthenticatedUser()
     {
-        var client = _testApp
+        var client = TestApp
             .SetUser(AuthenticatedUser())
             .CreateClient();
 
@@ -40,7 +40,7 @@ public class PermissionsControllerTests : IntegrationTest<TestStartup>
     [Fact]
     public async Task GetGlobalPermissions_BauUser()
     {
-        var client = _testApp
+        var client = TestApp
             .SetUser(BauUser())
             .CreateClient();
 
@@ -63,7 +63,7 @@ public class PermissionsControllerTests : IntegrationTest<TestStartup>
     {
         var user = AnalystUser();
 
-        var client = _testApp
+        var client = TestApp
             .SetUser(user)
             .AddContentDbTestData(context =>
             {
@@ -101,7 +101,7 @@ public class PermissionsControllerTests : IntegrationTest<TestStartup>
     {
         var user = AnalystUser();
 
-        var client = _testApp
+        var client = TestApp
             .SetUser(user)
             .AddContentDbTestData(context =>
             {
@@ -131,7 +131,7 @@ public class PermissionsControllerTests : IntegrationTest<TestStartup>
     {
         var user = AnalystUser();
 
-        var client = _testApp
+        var client = TestApp
             .SetUser(user)
             .AddContentDbTestData(context =>
             {
@@ -159,7 +159,7 @@ public class PermissionsControllerTests : IntegrationTest<TestStartup>
     [Fact]
     public async Task GetGlobalPermissions_PreReleaseUser()
     {
-        var client = _testApp
+        var client = TestApp
             .SetUser(PreReleaseUser())
             .CreateClient();
 
@@ -178,7 +178,7 @@ public class PermissionsControllerTests : IntegrationTest<TestStartup>
     [Fact]
     public async Task GetGlobalPermissions_UnauthenticatedUser()
     {
-        var response = await _testApp.CreateClient().GetAsync("/api/permissions/access");
+        var response = await TestApp.CreateClient().GetAsync("/api/permissions/access");
         response.AssertUnauthorized();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Security/PermissionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Security/PermissionsControllerTests.cs
@@ -2,25 +2,21 @@
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Security;
 
-[Collection(CacheServiceTestFixture.CacheServiceTests)]
-public class PermissionsControllerTests : IClassFixture<TestApplicationFactory<TestStartup>>
+public class PermissionsControllerTests : IntegrationTest<TestStartup>
 {
-    private readonly WebApplicationFactory<TestStartup> _testApp;
-
-    public PermissionsControllerTests(TestApplicationFactory<TestStartup> testApp)
-    {
-        _testApp = testApp;
-    }
+    public PermissionsControllerTests(TestApplicationFactory<TestStartup> testApp) 
+        : base(testApp)
+    {}
 
     [Fact]
     public async Task GetGlobalPermissions_AuthenticatedUser()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerIntegrationTests.cs
@@ -1,0 +1,138 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Net.Http.Headers;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Statistics
+{
+    public class TableBuilderControllerIntegrationTests : IntegrationTest<TestStartup>
+    {
+        public TableBuilderControllerIntegrationTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
+        {
+        }
+
+        private static readonly Guid ReleaseId = Guid.NewGuid();
+        private static readonly Guid SubjectId = Guid.NewGuid();
+
+        private static readonly ObservationQueryContext ObservationQueryContext = new()
+        {
+            SubjectId = SubjectId,
+            Filters = new List<Guid>(),
+            Indicators = new List<Guid>(),
+            LocationIds = new List<Guid>(),
+            TimePeriod = new TimePeriodQuery
+            {
+                StartYear = 2021,
+                StartCode = CalendarYear,
+                EndYear = 2022,
+                EndCode = CalendarYear
+            }
+        };
+
+        private readonly TableBuilderResultViewModel _tableBuilderResults = new()
+        {
+            SubjectMeta = new SubjectResultMetaViewModel
+            {
+                TimePeriodRange = new List<TimePeriodMetaViewModel>
+                {
+                    new(2020, AcademicYear),
+                    new(2021, AcademicYear),
+                }
+            },
+            Results = new List<ObservationViewModel>
+            {
+                new()
+                {
+                    TimePeriod = "2020_AY"
+                },
+                new()
+                {
+                    TimePeriod = "2021_AY"
+                }
+            },
+        };
+
+        [Fact]
+        public async Task Query()
+        {
+            var tableBuilderService = new Mock<ITableBuilderService>(Strict);
+            tableBuilderService
+                .Setup(s => s.Query(
+                    ReleaseId,
+                    ItIs.DeepEqualTo(ObservationQueryContext),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_tableBuilderResults);
+
+            var client = SetupApp(
+                    tableBuilderService: tableBuilderService.Object)
+                .SetUser(AuthenticatedUser())
+                .CreateClient();
+
+            var response = await client.PostAsync(
+                $"/api/data/tablebuilder/release/{ReleaseId}",
+                new JsonNetContent(ObservationQueryContext));
+
+            VerifyAllMocks(tableBuilderService);
+
+            response.AssertOk(_tableBuilderResults);
+        }
+
+        [Fact]
+        public async Task Query_Csv()
+        {
+            var tableBuilderService = new Mock<ITableBuilderService>(Strict);
+            tableBuilderService
+                .Setup(s => s.QueryToCsvStream(
+                    ReleaseId,
+                    ItIs.DeepEqualTo(ObservationQueryContext),
+                    It.IsAny<Stream>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Unit.Instance)
+                .Callback<Guid, ObservationQueryContext, Stream, CancellationToken>(
+                    (_, _, stream, _) => { stream.WriteText("Test csv"); });
+
+            var client = SetupApp(tableBuilderService: tableBuilderService.Object)
+                .SetUser(AuthenticatedUser())
+                .CreateClient();
+
+            var response = await client.PostAsync(
+                $"/api/data/tablebuilder/release/{ReleaseId}",
+                content: new JsonNetContent(ObservationQueryContext),
+                headers: new Dictionary<string, string>
+                {
+                    { HeaderNames.Accept, ContentTypes.Csv}
+                });
+
+            VerifyAllMocks(tableBuilderService);
+
+            response.AssertOk("Test csv");
+        }
+
+        private WebApplicationFactory<TestStartup> SetupApp(
+            ITableBuilderService? tableBuilderService = null)
+        {
+            return _testApp.ConfigureServices(services =>
+                services.ReplaceService(tableBuilderService ?? Mock.Of<ITableBuilderService>(Strict)));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerIntegrationTests.cs
@@ -131,7 +131,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         private WebApplicationFactory<TestStartup> SetupApp(
             ITableBuilderService? tableBuilderService = null)
         {
-            return _testApp.ConfigureServices(services =>
+            return TestApp.ConfigureServices(services =>
                 services.ReplaceService(tableBuilderService ?? Mock.Of<ITableBuilderService>(Strict)));
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
@@ -1,30 +1,21 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Statistics;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
@@ -32,39 +23,15 @@ using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Statistics
 {
-    [Collection(CacheServiceTests)]
-    public class TableBuilderControllerTests :
-        CacheServiceTestFixture, IClassFixture<TestApplicationFactory<TestStartup>>
+    public class TableBuilderControllerTests : CacheServiceTestFixture
     {
-        private readonly WebApplicationFactory<TestStartup> _testApp;
-
         private readonly DataFixture _fixture = new();
-
-        public TableBuilderControllerTests(TestApplicationFactory<TestStartup> testApp)
-        {
-            _testApp = testApp;
-        }
 
         private static readonly Guid ReleaseId = Guid.NewGuid();
         private static readonly Guid SubjectId = Guid.NewGuid();
-        private readonly Guid _dataBlockId = Guid.NewGuid();
+        private static readonly Guid DataBlockId = Guid.NewGuid();
 
-        private static readonly ObservationQueryContext ObservationQueryContext = new()
-        {
-            SubjectId = SubjectId,
-            Filters = new List<Guid>(),
-            Indicators = new List<Guid>(),
-            LocationIds = new List<Guid>(),
-            TimePeriod = new TimePeriodQuery
-            {
-                StartYear = 2021,
-                StartCode = CalendarYear,
-                EndYear = 2022,
-                EndCode = CalendarYear
-            }
-        };
-
-        private readonly TableBuilderResultViewModel _tableBuilderResults = new()
+        private static readonly TableBuilderResultViewModel TableBuilderResults = new()
         {
             SubjectMeta = new SubjectResultMetaViewModel
             {
@@ -87,66 +54,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             },
         };
 
-        private readonly ObservationQueryContext _query = new()
+        private static readonly ObservationQueryContext Query = new()
         {
             SubjectId = SubjectId,
         };
-
-        [Fact]
-        public async Task Query()
-        {
-            var tableBuilderService = new Mock<ITableBuilderService>(Strict);
-            tableBuilderService
-                .Setup(s => s.Query(
-                    ReleaseId,
-                    ItIs.DeepEqualTo(ObservationQueryContext),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_tableBuilderResults);
-
-            var client = SetupApp(
-                    tableBuilderService: tableBuilderService.Object)
-                .SetUser(AuthenticatedUser())
-                .CreateClient();
-
-            var response = await client.PostAsync(
-                $"/api/data/tablebuilder/release/{ReleaseId}",
-                new JsonNetContent(ObservationQueryContext));
-
-            VerifyAllMocks(tableBuilderService);
-
-            response.AssertOk(_tableBuilderResults);
-        }
-
-        [Fact]
-        public async Task Query_Csv()
-        {
-            var tableBuilderService = new Mock<ITableBuilderService>(Strict);
-            tableBuilderService
-                .Setup(s => s.QueryToCsvStream(
-                    ReleaseId,
-                    ItIs.DeepEqualTo(ObservationQueryContext),
-                    It.IsAny<Stream>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Unit.Instance)
-                .Callback<Guid, ObservationQueryContext, Stream, CancellationToken>(
-                    (_, _, stream, _) => { stream.WriteText("Test csv"); });
-
-            var client = SetupApp(tableBuilderService: tableBuilderService.Object)
-                .SetUser(AuthenticatedUser())
-                .CreateClient();
-
-            var response = await client.PostAsync(
-                $"/api/data/tablebuilder/release/{ReleaseId}",
-                content: new JsonNetContent(ObservationQueryContext),
-                headers: new Dictionary<string, string>
-                {
-                    { HeaderNames.Accept, ContentTypes.Csv}
-                });
-
-            VerifyAllMocks(tableBuilderService);
-
-            response.AssertOk("Test csv");
-        }
 
         [Fact]
         public async Task QueryForDataBlock()
@@ -158,7 +69,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 .WithLatestPublishedVersion(_fixture
                     .DefaultDataBlockVersion()
                     .WithReleaseId(ReleaseId)
-                    .WithQuery(_query))
+                    .WithQuery(Query))
                 .Generate();
 
             var dataBlockVersion = dataBlockParent.LatestPublishedVersion!;
@@ -186,23 +97,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                         s.Query(
                             ReleaseId,
                             It.Is<ObservationQueryContext>(
-                                q => q.SubjectId == _query.SubjectId
+                                q => q.SubjectId == Query.SubjectId
                             ),
                             cancellationToken
                         )
                 )
-                .ReturnsAsync(_tableBuilderResults);
+                .ReturnsAsync(TableBuilderResults);
 
             BlobCacheService
                 .Setup(s => s.SetItemAsync<object>(
                     ItIs.DeepEqualTo(new DataBlockTableResultCacheKey(dataBlockVersion)),
-                    _tableBuilderResults))
+                    TableBuilderResults))
                 .Returns(Task.CompletedTask);
 
             var result = await controller.QueryForDataBlock(ReleaseId, dataBlockVersion.Id, cancellationToken);
             VerifyAllMocks(dataBlockService, tableBuilderService);
 
-            result.AssertOkResult(_tableBuilderResults);
+            result.AssertOkResult(TableBuilderResults);
         }
 
         [Fact]
@@ -211,12 +122,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var dataBlockService = new Mock<IDataBlockService>(Strict);
 
             dataBlockService
-                .Setup(s => s.GetDataBlockVersionForRelease(ReleaseId, _dataBlockId))
+                .Setup(s => s.GetDataBlockVersionForRelease(ReleaseId, DataBlockId))
                 .ReturnsAsync(new NotFoundResult());
 
             var controller = BuildController(dataBlockService: dataBlockService.Object);
 
-            var result = await controller.QueryForDataBlock(ReleaseId, _dataBlockId);
+            var result = await controller.QueryForDataBlock(ReleaseId, DataBlockId);
             VerifyAllMocks(dataBlockService);
 
             result.AssertNotFoundResult();
@@ -225,8 +136,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         [Fact]
         public void TableBuilderResultViewModel_SerializeAndDeserialize()
         {
-            var converted = DeserializeObject<TableBuilderResultViewModel>(SerializeObject(_tableBuilderResults));
-            converted.AssertDeepEqualTo(_tableBuilderResults);
+            var converted = DeserializeObject<TableBuilderResultViewModel>(SerializeObject(TableBuilderResults));
+            converted.AssertDeepEqualTo(TableBuilderResults);
         }
 
         private static TableBuilderController BuildController(
@@ -238,13 +149,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 AlwaysTrueUserService().Object,
                 dataBlockService ?? Mock.Of<IDataBlockService>(Strict)
             );
-        }
-
-        private WebApplicationFactory<TestStartup> SetupApp(
-            ITableBuilderService? tableBuilderService = null)
-        {
-            return _testApp.ConfigureServices(services =>
-                services.ReplaceService(tableBuilderService ?? Mock.Of<ITableBuilderService>(Strict)));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/CacheAspectThreadManagementIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/CacheAspectThreadManagementIntegrationTests.cs
@@ -20,11 +20,7 @@ using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache;
 
-[Collection(CacheTestFixture.CollectionName)]
-public class CacheAspectThreadManagementIntegrationTests : 
-    IClassFixture<TestApplicationFactory<TestStartup>>,
-    IClassFixture<CacheTestFixture>,
-    IDisposable
+public class CacheAspectThreadManagementIntegrationTests : IntegrationTest<TestStartup>
 {
     // An artificial delay that we will add to dummy async sections of our test setup, including getting
     // cached items setting cached items and time spent in Controller methods. 
@@ -39,16 +35,8 @@ public class CacheAspectThreadManagementIntegrationTests :
     // milliseconds.
     private const int TaskDelayErrorToleranceMillis = 15;
 
-    private readonly WebApplicationFactory<TestStartup> _testApp;
-
-    public CacheAspectThreadManagementIntegrationTests(TestApplicationFactory<TestStartup> testApp)
+    public CacheAspectThreadManagementIntegrationTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
     {
-        _testApp = testApp;
-    }
-
-    public void Dispose()
-    {
-        BlobCacheAttribute.ClearServices();
     }
 
     /// <summary>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/CacheAspectThreadManagementIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/CacheAspectThreadManagementIntegrationTests.cs
@@ -400,7 +400,7 @@ public class CacheAspectThreadManagementIntegrationTests : IntegrationTest<TestS
         IBlobCacheService blobCacheService,
         List<Event> events)
     {
-        var app = _testApp
+        var app = TestApp
             .ConfigureServices(services => services
                 .AddSingleton(_ => blobCacheService)
                 .AddSingleton(_ => events)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/CacheServiceTestFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/CacheServiceTestFixture.cs
@@ -3,6 +3,7 @@ using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using Moq;
+using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures
 {
@@ -10,10 +11,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures
     /// Class fixture for enabling/disabling caching and making available various Caching Services
     /// for tests needing to check caching annotations that use these services.
     /// </summary>
+    [Collection(CacheTestFixture.CollectionName)]
     public class CacheServiceTestFixture : IDisposable
     {
-        public const string CacheServiceTests = "Cache service tests";
-
         protected static readonly Mock<IBlobCacheService> BlobCacheService = new(MockBehavior.Strict);
         protected static readonly Mock<IBlobCacheService> PublicBlobCacheService = new(MockBehavior.Strict);
         protected static readonly Mock<IMemoryCacheService> MemoryCacheService = new(MockBehavior.Strict);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/IntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/IntegrationTest.cs
@@ -10,10 +10,10 @@ public abstract class IntegrationTest<TStartup> :
     IClassFixture<TestApplicationFactory<TStartup>>,
     IClassFixture<CacheTestFixture> where TStartup : class
 {
-    protected readonly WebApplicationFactory<TStartup> _testApp;
+    protected readonly WebApplicationFactory<TStartup> TestApp;
 
     protected IntegrationTest(TestApplicationFactory<TStartup> testApp)
     {
-        _testApp = testApp;
+        TestApp = testApp;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/IntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/IntegrationTest.cs
@@ -1,0 +1,19 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests;
+
+[Collection(CacheTestFixture.CollectionName)]
+public abstract class IntegrationTest<TStartup> :
+    CacheServiceTestFixture,
+    IClassFixture<TestApplicationFactory<TStartup>>,
+    IClassFixture<CacheTestFixture> where TStartup : class
+{
+    protected readonly WebApplicationFactory<TStartup> _testApp;
+
+    protected IntegrationTest(TestApplicationFactory<TStartup> testApp)
+    {
+        _testApp = testApp;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ModelBinding/TrimStringModelBinderIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ModelBinding/TrimStringModelBinderIntegrationTests.cs
@@ -10,14 +10,10 @@ using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.ModelBinding;
 
-public class TrimStringModelBinderIntegrationTests
-    : IClassFixture<TestApplicationFactory<TestStartup>>
+public class TrimStringModelBinderIntegrationTests : IntegrationTest<TestStartup>
 {
-    private readonly WebApplicationFactory<TestStartup> _testApp;
-
-    public TrimStringModelBinderIntegrationTests(TestApplicationFactory<TestStartup> testApp)
+    public TrimStringModelBinderIntegrationTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
     {
-        _testApp = testApp;
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ModelBinding/TrimStringModelBinderIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ModelBinding/TrimStringModelBinderIntegrationTests.cs
@@ -76,7 +76,7 @@ public class TrimStringModelBinderIntegrationTests : IntegrationTest<TestStartup
 
     private WebApplicationFactory<TestStartup> SetupApp()
     {
-        return _testApp.WithWebHostBuilder(builder => builder
+        return TestApp.WithWebHostBuilder(builder => builder
             .WithAdditionalControllers(typeof(TestController)));
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Rules/LowercasePathRuleIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Rules/LowercasePathRuleIntegrationTests.cs
@@ -10,14 +10,10 @@ using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Rules;
 
-public class LowercasePathRuleIntegrationTests
-    : IClassFixture<TestApplicationFactory<TestStartup>>
+public class LowercasePathRuleIntegrationTests : IntegrationTest<TestStartup>
 {
-    private readonly WebApplicationFactory<TestStartup> _testApp;
-
-    public LowercasePathRuleIntegrationTests(TestApplicationFactory<TestStartup> testApp)
+    public LowercasePathRuleIntegrationTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
     {
-        _testApp = testApp;
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Rules/LowercasePathRuleIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Rules/LowercasePathRuleIntegrationTests.cs
@@ -43,7 +43,7 @@ public class LowercasePathRuleIntegrationTests : IntegrationTest<TestStartup>
 
     private WebApplicationFactory<TestStartup> SetupApp()
     {
-        return _testApp.WithWebHostBuilder(builder => builder
+        return TestApp.WithWebHostBuilder(builder => builder
             .WithAdditionalControllers(typeof(TestController)));
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheAspect.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheAspect.cs
@@ -7,7 +7,7 @@ using Aspects.Universal.Aspects;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
 {
-    [Aspect(Scope.Global)]
+    [Aspect(Scope.PerInstance)]
     public class CacheAspect : BaseUniversalWrapperAspect
     {
         private const BindingFlags ConstructorBindingFlags =

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerCachingTests.cs
@@ -19,7 +19,6 @@ using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers;
 
-[Collection(CacheServiceTests)]
 public class ReleaseControllerCachingTests : CacheServiceTestFixture
 {
     private const string PublicationSlug = "publication-a";
@@ -50,7 +49,7 @@ public class ReleaseControllerCachingTests : CacheServiceTestFixture
 
         publicationCacheService.Setup(mock => mock.GetPublication(PublicationSlug))
             .ReturnsAsync(publicationCacheViewModel);
-        
+
         releaseCacheService.Setup(mock => mock.GetRelease(PublicationSlug, null))
             .ReturnsAsync(releaseCacheViewModel);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers
 {
-    [Collection(CacheServiceTests)]
     public class ReleaseControllerTests : CacheServiceTestFixture
     {
         private const string PublicationSlug = "publication-a";

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
@@ -24,20 +25,17 @@ using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers
 {
-    public class ReleaseFileControllerTests : IClassFixture<TestApplicationFactory<TestStartup>>
+    public class ReleaseFileControllerTests : IntegrationTest<TestStartup>
     {
-        private readonly WebApplicationFactory<TestStartup> _testApp;
+        public ReleaseFileControllerTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
+        {
+        }
 
         private readonly Release _release = new()
         {
             Id = Guid.NewGuid(),
             Publication = new Publication()
         };
-
-        public ReleaseFileControllerTests(TestApplicationFactory<TestStartup> testApp)
-        {
-            _testApp = testApp;
-        }
 
         [Fact]
         public async Task Stream()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerTests.cs
@@ -134,7 +134,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
 
         private WebApplicationFactory<TestStartup> SetupApp(IReleaseFileService? releaseFileService = null)
         {
-            return _testApp
+            return TestApp
                 .ResetDbContexts()
                 .ConfigureServices(
                     services =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerCachingTests.cs
@@ -21,18 +21,17 @@ using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers;
 
-[Collection(CacheServiceTests)]
 public class ThemeControllerCachingTests : CacheServiceTestFixture
 {
     private readonly IList<ThemeViewModel> _themes = ListOf(
         new ThemeViewModel(Guid.NewGuid(), "slug1", "title1", "summary1"),
         new ThemeViewModel(Guid.NewGuid(), "slug2", "title2", "summary2"));
-    
+
     [Fact]
     public async Task ListThemes_NoCachedEntryExists()
     {
         var themeService = new Mock<IThemeService>(Strict);
-        
+
         MemoryCacheService
             .Setup(s => s.GetItem(
                 new ListThemesCacheKey(),
@@ -41,27 +40,27 @@ public class ThemeControllerCachingTests : CacheServiceTestFixture
 
         var expectedCacheConfiguration = new MemoryCacheConfiguration(
             10, CrontabSchedule.Parse(HalfHourlyExpirySchedule));
-        
+
         MemoryCacheService
             .Setup(s => s.SetItem<object>(
                 new ListThemesCacheKey(),
                 _themes,
                 ItIs.DeepEqualTo(expectedCacheConfiguration),
                 null));
-        
+
         themeService
             .Setup(s => s.ListThemes())
             .ReturnsAsync(_themes);
-        
+
         var controller = BuildController(themeService.Object);
 
         var result = await controller.ListThemes();
-        
+
         VerifyAllMocks(MemoryCacheService, themeService);
 
         Assert.Equal(_themes, result);
     }
-    
+
     [Fact]
     public async Task ListThemes_CachedEntryExists()
     {
@@ -70,16 +69,16 @@ public class ThemeControllerCachingTests : CacheServiceTestFixture
                 new ListThemesCacheKey(),
                 typeof(IList<ThemeViewModel>)))
             .Returns(_themes);
-        
+
         var controller = BuildController();
 
         var result = await controller.ListThemes();
-        
+
         VerifyAllMocks(MemoryCacheService);
 
         Assert.Equal(_themes, result);
     }
-    
+
     [Fact]
     public void ThemeViewModelList_SerializeAndDeserialize()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/GlossaryCacheServiceTests.cs
@@ -14,7 +14,6 @@ using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cache;
 
-[Collection(CacheServiceTests)]
 public class GlossaryCacheServiceTests : CacheServiceTestFixture
 {
     private readonly List<GlossaryCategoryViewModel> _glossary = new()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/MethodologyCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/MethodologyCacheServiceTests.cs
@@ -19,7 +19,6 @@ using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cache;
 
-[Collection(CacheServiceTests)]
 public class MethodologyCacheServiceTests : CacheServiceTestFixture
 {
     private readonly List<AllMethodologiesThemeViewModel> _methodologyTree = ListOf(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -20,7 +20,6 @@ using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cache;
 
-[Collection(CacheServiceTests)]
 public class PublicationCacheServiceTests : CacheServiceTestFixture
 {
     private const string PublicationSlug = "publication-slug";

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/ReleaseCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/ReleaseCacheServiceTests.cs
@@ -19,7 +19,6 @@ using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Cache;
 
-[Collection(CacheServiceTests)]
 public class ReleaseCacheServiceTests : CacheServiceTestFixture
 {
     private const string PublicationSlug = "publication-slug";

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PermalinkControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PermalinkControllerTests.cs
@@ -186,7 +186,7 @@ public class PermalinkControllerTests : IntegrationTest<TestStartup>
 
     private WebApplicationFactory<TestStartup> SetupApp(IPermalinkService? permalinkService = null)
     {
-        return _testApp.ConfigureServices(
+        return TestApp.ConfigureServices(
             services =>
             {
                 services.AddTransient(_ => permalinkService ?? Mock.Of<IPermalinkService>(MockBehavior.Strict));

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PermalinkControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PermalinkControllerTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
@@ -22,13 +23,10 @@ using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers;
 
-public class PermalinkControllerTests : IClassFixture<TestApplicationFactory<TestStartup>>
+public class PermalinkControllerTests : IntegrationTest<TestStartup>
 {
-    private readonly WebApplicationFactory<TestStartup> _testApp;
-
-    public PermalinkControllerTests(TestApplicationFactory<TestStartup> testApp)
+    public PermalinkControllerTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
     {
-        _testApp = testApp;
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -22,7 +22,6 @@ using static Newtonsoft.Json.JsonConvert;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 {
-    [Collection(CacheServiceTests)]
     public class PublicationControllerTests : CacheServiceTestFixture
     {
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
@@ -9,6 +9,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -35,9 +37,7 @@ using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 {
-    [Collection(CacheServiceTests)]
-    public class TableBuilderControllerTests : CacheServiceTestFixture,
-        IClassFixture<TestApplicationFactory<TestStartup>>
+    public class TableBuilderControllerTests : IntegrationTest<TestStartup>
     {
         private static readonly DataFixture Fixture = new();
 
@@ -131,11 +131,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             },
         };
 
-        private readonly WebApplicationFactory<TestStartup> _testApp;
-
-        public TableBuilderControllerTests(TestApplicationFactory<TestStartup> testApp)
+        public TableBuilderControllerTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
         {
-            _testApp = testApp;
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
@@ -575,7 +575,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             IReleaseRepository? releaseRepository = null,
             ITableBuilderService? tableBuilderService = null)
         {
-            return _testApp
+            return TestApp
                 .ResetDbContexts()
                 .ConfigureServices(
                     services =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderMetaControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderMetaControllerTests.cs
@@ -24,7 +24,6 @@ using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 {
-    [Collection(CacheServiceTests)]
     public class TableBuilderMetaControllerTests : CacheServiceTestFixture
     {
         private static readonly Guid ReleaseId = Guid.NewGuid();


### PR DESCRIPTION
This PR:
- fixes clashes between CacheServiceTestFixture tests and Integration Tests which, when running in parallel, can cause intermittent unit test failures on the pipeline by virtue of both types of tests injecting their own BlobCacheService into the static BlobCacheAttribute.Services field.

Historically, we've seen problems when multiple tests that enable the CacheAspect (by setting `CacheAspect.Enabled` to true) run in parallel, as they tend to interfere with each other in various ways e.g. they will set `CacheAspect.Enabled` back to false at in their teardowns, thus making the caching behaviour unreliable for other caching tests.

We've overcome this in the past by stopping them from running in parallel, by specifying a `Collection` to which these test suites belong.  When this is in place, anything marked with a particular Collection will never run in parallel with another test class that's annotated with that same Collection.

We now have scenarios however where the `TestStartup.cs` process, as used by Integration Tests, is setting its own mocked out Cache services (by virtue of it extending the production `Startup.cs`, which does this also).  This, when allowed to run in parallel with other unit tests that apply changes to the static fields `CacheAspect.Enabled` and `BlobCacheAttribute`, then causes more unstable interactions.

The solution in this PR is to ensure that the Integration Tests don't run in parallel with other caching tests, or indeed with each other.  This will make it stable again.

Longer term, we need to find ways to break away from the static nature of working with the Aspects and the Attributes with caching, but unfortunately this seems to be a fundamental limitation with Aspect Injector.  There's a brief discussion about this on ticket https://dfedigital.atlassian.net/browse/EES-4703.

Although this PR is quite small, it's broken into 2 main commits:
- Commit 1 does the main restructuring work to ensure all integration tests and caching tests are set to not run in parallel.
- Commit 2 does a rename of `_testApp` to `TestApp` to adhere to naming conventions.