### PR TITLE
EES-4222 - enabling alerts for all Azure environments

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -80,9 +80,6 @@
     "capacityStatisticsDb": {
       "value": 6
     },
-    "enableAlerts": {
-      "value": true
-    },
     "tableBuilderMaxTableCellsAllowed": {
       "value": 1000000
     },

--- a/infrastructure/templates/datafactory/template.json
+++ b/infrastructure/templates/datafactory/template.json
@@ -47,9 +47,6 @@
     "actionGroupAlerts": {
       "type": "string"
     },
-    "enableAlerts": {
-      "type": "bool"
-    }
   },
   "variables":{
     "templateBaseUrl": "[concat('https://raw.githubusercontent.com/dfe-analytical-services/explore-education-statistics/', parameters('branch'), '/infrastructure/templates/')]"
@@ -100,7 +97,6 @@
       "properties": {
         "description": "Data Factory - Activity Failures",
         "severity": 3,
-        "enabled": "[parameters('enableAlerts')]",
         "scopes": [
           "[resourceId('Microsoft.DataFactory/factories', parameters('dataFactoryName'))]"
         ],

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -679,10 +679,6 @@
       "type": "int",
       "defaultValue": 268435456000
     },
-    "enableAlerts": {
-      "type": "bool",
-      "defaultValue": false
-    },
     "slackWebhook": {
       "type": "string",
       "metadata": {
@@ -3523,9 +3519,6 @@
           "actionGroupAlerts": {
             "value": "[variables('actionGroupAlerts')]"
           },
-          "enableAlerts": {
-            "value": "[parameters('enableAlerts')]"
-          }
         }
       },
       "dependsOn": [
@@ -4101,7 +4094,6 @@
       "location": "global",
       "properties": {
         "groupShortName": "alertAG",
-        "enabled": "[parameters('enableAlerts')]",
         "logicAppReceivers": [
           {
             "name": "[variables('logicAppSlackAlerts')]",
@@ -4128,7 +4120,6 @@
       "properties": {
         "description": "[variables('metricAlerts')[copyIndex()].description]",
         "severity": 3,
-        "enabled": "[parameters('enableAlerts')]",
         "scopes": ["[variables('metricAlerts')[copyIndex()].resourceId]"],
         "evaluationFrequency": "PT1M",
         "windowSize": "PT5M",


### PR DESCRIPTION
This PR is part 1 of EES-4222, where we are adding support to receive alerts from *all* environments, each with their own Slack channel.

This PR simply removes the `enableAlerts` flag from ARM templates altogether (previously only ever enabled for Prod).  I'd considered keeping it and simply setting its default to true, but there didn't seem to be any point, as anyone who's not interested in a given channel's alerts can simply not join or mute the channel.

This has been done in conjunction with setting up new webhook URLs for posting messages to a separate channel for each environment (#alerts-dev, #alerts-test, #alerts-preprod), and updating the "Slack Webhook" secret in each environment's Key Vault with the new URL.

Note that we are being told also that the way we have Slack alerts configured at the moment is deprecated and we should start moving to Slack Apps rather than Incoming Webhooks.

![Uploading image.png…]()
