### PR TITLE
EES-4675 add chart subtitles

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
@@ -40,6 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
     public abstract class Chart : IChart
     {
         public string? Title { get; set; }
+        public string? Subtitle { get; set; }
         public string Alt { get; set; }
         public int Height { get; set; }
         public int? Width { get; set; }

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -120,6 +120,10 @@ const ChartConfiguration = ({
         .positive('Chart height must be positive'),
       width: Yup.number().positive('Chart width must be positive'),
       includeNonNumericData: Yup.boolean(),
+      subtitle: Yup.string().max(
+        160,
+        'Subtitle must be 160 characters or less',
+      ),
     });
 
     if (definition.capabilities.stackable) {
@@ -279,30 +283,40 @@ const ChartConfiguration = ({
                 accept="image/*"
               />
             )}
+            <div className="govuk-!-width-three-quarters">
+              <FormFieldRadioGroup<FormValues>
+                hint="Communicate the headline message of the chart. For example 'Increase in number of people living alone'."
+                legend="Chart title"
+                legendSize="s"
+                name="titleType"
+                order={[]}
+                options={[
+                  {
+                    label: 'Use table title',
+                    value: 'default',
+                  },
+                  {
+                    label: 'Set an alternative title',
+                    value: 'alternative',
+                    conditional: (
+                      <FormFieldTextInput<FormValues>
+                        label="Enter chart title"
+                        name="title"
+                        hint="Use a concise descriptive title that summarises the main message in the chart."
+                      />
+                    ),
+                  },
+                ]}
+              />
 
-            <FormFieldRadioGroup<FormValues>
-              legend="Chart title"
-              legendSize="s"
-              name="titleType"
-              order={[]}
-              options={[
-                {
-                  label: 'Use table title',
-                  value: 'default',
-                },
-                {
-                  label: 'Set an alternative title',
-                  value: 'alternative',
-                  conditional: (
-                    <FormFieldTextInput<FormValues>
-                      label="Enter chart title"
-                      name="title"
-                      hint="Use a concise descriptive title that summarises the main message in the chart."
-                    />
-                  ),
-                },
-              ]}
-            />
+              <FormFieldTextInput<FormValues>
+                label="Subtitle"
+                name="subtitle"
+                hint="The statistical subtitle should say what the data is, the geography the data relates to and the time period shown. 
+                For example, 'Figure 1: Number of people living in one person households, England, 1991 to 2021'."
+                maxLength={160}
+              />
+            </div>
 
             <FormFieldTextArea<FormValues>
               className="govuk-!-width-three-quarters"

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartConfiguration.test.tsx
@@ -127,6 +127,7 @@ describe('ChartConfiguration', () => {
     height: 600,
     includeNonNumericData: true,
     showDataLabels: true,
+    subtitle: 'This is the subtitle',
     titleType: 'default',
     width: 400,
   };
@@ -161,6 +162,7 @@ describe('ChartConfiguration', () => {
     expect(
       screen.getByRole('group', { name: 'Chart title' }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText('Subtitle')).toBeInTheDocument();
     expect(screen.getByLabelText('Alt text')).toBeInTheDocument();
     expect(screen.getByLabelText('Height (pixels)')).toBeInTheDocument();
     expect(screen.getByLabelText('Width (pixels)')).toBeInTheDocument();
@@ -185,6 +187,7 @@ describe('ChartConfiguration', () => {
     expect(
       screen.getByRole('group', { name: 'Chart title' }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText('Subtitle')).toBeInTheDocument();
     expect(screen.getByLabelText('Alt text')).toBeInTheDocument();
     expect(screen.getByLabelText('Stacked bars')).toBeInTheDocument();
     expect(screen.getByLabelText('Height (pixels)')).toBeInTheDocument();
@@ -211,6 +214,7 @@ describe('ChartConfiguration', () => {
     expect(
       screen.getByRole('group', { name: 'Chart title' }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText('Subtitle')).toBeInTheDocument();
     expect(screen.getByLabelText('Alt text')).toBeInTheDocument();
     expect(screen.getByLabelText('Stacked bars')).toBeInTheDocument();
     expect(screen.getByLabelText('Height (pixels)')).toBeInTheDocument();
@@ -237,6 +241,7 @@ describe('ChartConfiguration', () => {
     expect(
       screen.getByRole('group', { name: 'Chart title' }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText('Subtitle')).toBeInTheDocument();
     expect(screen.getByLabelText('Alt text')).toBeInTheDocument();
     expect(screen.getByLabelText('Height (pixels)')).toBeInTheDocument();
     expect(screen.getByLabelText('Width (pixels)')).toBeInTheDocument();
@@ -281,6 +286,7 @@ describe('ChartConfiguration', () => {
       </ChartBuilderFormsContextProvider>,
     );
 
+    userEvent.type(screen.getByLabelText('Subtitle'), 'This is the subtitle');
     userEvent.type(screen.getByLabelText('Alt text'), 'This is the alt text');
     userEvent.type(screen.getByLabelText('Width (pixels)'), '500');
 
@@ -294,6 +300,7 @@ describe('ChartConfiguration', () => {
         boundaryLevel: undefined,
         dataLabelPosition: 'above',
         height: 300,
+        subtitle: 'This is the subtitle',
         title: '',
         titleType: 'default',
         width: 500,
@@ -340,6 +347,9 @@ describe('ChartConfiguration', () => {
       </ChartBuilderFormsContextProvider>,
     );
 
+    expect(screen.getByLabelText('Subtitle')).toHaveValue(
+      'This is the subtitle',
+    );
     expect(screen.getByLabelText('Alt text')).toHaveValue(
       'This is the alt text',
     );

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
@@ -82,6 +82,7 @@ describe('chartBuilderReducer', () => {
       axes: {},
       options: {
         height: 300,
+        subtitle: '',
         title: '',
         titleType: 'default',
         alt: '',
@@ -107,6 +108,7 @@ describe('chartBuilderReducer', () => {
 
       expect(nextState.options).toEqual<ChartOptions>({
         height: 300,
+        subtitle: '',
         title: '',
         titleType: 'default',
         alt: '',
@@ -132,6 +134,7 @@ describe('chartBuilderReducer', () => {
         ...initialState,
         options: {
           height: 400,
+          subtitle: 'Some subtitle',
           title: 'Some title',
           titleType: 'alternative',
           alt: 'Some alt',
@@ -164,6 +167,7 @@ describe('chartBuilderReducer', () => {
       expect(nextState.options).toEqual<ChartOptions>({
         // Height is set to the definition default
         height: 300,
+        subtitle: 'Some subtitle',
         title: 'Some title',
         titleType: 'alternative',
         alt: 'Some alt',
@@ -351,6 +355,7 @@ describe('chartBuilderReducer', () => {
       definition: testChartDefinition,
       options: {
         height: 300,
+        subtitle: '',
         title: '',
         titleType: 'default',
         alt: '',
@@ -363,6 +368,7 @@ describe('chartBuilderReducer', () => {
         payload: {
           height: 500,
           width: 400,
+          subtitle: 'Test subtitle',
           title: 'Test title',
           titleType: 'alternative',
           alt: 'Test alt',
@@ -374,6 +380,7 @@ describe('chartBuilderReducer', () => {
       expect(nextState.options).toEqual<ChartOptions>({
         height: 500,
         width: 400,
+        subtitle: 'Test subtitle',
         title: 'Test title',
         titleType: 'alternative',
         alt: 'Test alt',
@@ -385,6 +392,7 @@ describe('chartBuilderReducer', () => {
         ...initialState,
         options: {
           height: 300,
+          subtitle: '',
           title: '',
           titleType: 'default',
           alt: '',
@@ -397,6 +405,7 @@ describe('chartBuilderReducer', () => {
         payload: {
           height: 500,
           width: 400,
+          subtitle: '',
           title: '',
           titleType: 'default',
           alt: '',
@@ -411,6 +420,7 @@ describe('chartBuilderReducer', () => {
       expect(nextState.options).toEqual<ChartOptions>({
         height: 500,
         width: 400,
+        subtitle: '',
         title: '',
         titleType: 'default',
         alt: '',
@@ -424,6 +434,7 @@ describe('chartBuilderReducer', () => {
         options: {
           height: 300,
           width: 400,
+          subtitle: '',
           title: '',
           titleType: 'default',
           alt: '',
@@ -435,6 +446,7 @@ describe('chartBuilderReducer', () => {
         payload: {
           height: 300,
           width: undefined,
+          subtitle: '',
           title: '',
           titleType: 'default',
           alt: '',
@@ -448,6 +460,7 @@ describe('chartBuilderReducer', () => {
 
       expect(nextState.options).toEqual<ChartOptions>({
         height: 300,
+        subtitle: '',
         title: '',
         titleType: 'default',
         alt: '',

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
@@ -62,10 +62,11 @@ export type ChartBuilderActions =
     };
 
 const defaultOptions: ChartOptions = {
+  alt: '',
   height: 300,
+  subtitle: '',
   title: '',
   titleType: 'default',
-  alt: '',
 };
 
 const defaultLegend: LegendConfiguration = {

--- a/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
@@ -25,6 +25,7 @@ export interface FormBaseInputProps
   inputMode?: HTMLAttributes<HTMLInputElement>['inputMode'];
   inputRef?: Ref<HTMLInputElement>;
   list?: string;
+  maxLength?: number;
   name: string;
   trimValue?: boolean;
   width?: 20 | 10 | 5 | 4 | 3 | 2;
@@ -52,6 +53,7 @@ function FormBaseInput({
   inputRef,
   label,
   labelSize,
+  maxLength,
   trimValue = true,
   width,
   type = 'text',
@@ -92,6 +94,7 @@ function FormBaseInput({
         classNames({
           [`${id}-error`]: !!error,
           [`${id}-hint`]: !!hint,
+          [`${id}-info`]: !!maxLength,
         }) || undefined
       }
       className={classNames('govuk-input', className, {

--- a/src/explore-education-statistics-common/src/components/form/FormTextInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormTextInput.tsx
@@ -1,6 +1,8 @@
 import FormBaseInput, {
   FormBaseInputProps,
 } from '@common/components/form/FormBaseInput';
+import FormCharacterCount from '@common/components/form/FormCharacterCount';
+import FormGroup from '@common/components/form/FormGroup';
 import React from 'react';
 
 export interface FormTextInputProps extends FormBaseInputProps {
@@ -9,6 +11,26 @@ export interface FormTextInputProps extends FormBaseInputProps {
   value?: string;
 }
 
-export default function FormTextInput({ value, ...props }: FormTextInputProps) {
-  return <FormBaseInput {...props} value={value} />;
+export default function FormTextInput({
+  id,
+  maxLength,
+  value,
+  ...props
+}: FormTextInputProps) {
+  if (!!maxLength && maxLength > 0) {
+    return (
+      <div className="govuk-character-count">
+        <FormGroup>
+          <FormBaseInput
+            {...props}
+            id={id}
+            maxLength={maxLength}
+            value={value}
+          />
+          <FormCharacterCount id={id} maxLength={maxLength} value={value} />
+        </FormGroup>
+      </div>
+    );
+  }
+  return <FormBaseInput id={id} {...props} value={value} />;
 }

--- a/src/explore-education-statistics-common/src/modules/charts/components/ChartRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/ChartRenderer.tsx
@@ -46,7 +46,7 @@ function ChartRenderer({
   id,
   ...props
 }: ChartRendererProps & ChartRendererInternalProps) {
-  const { data, meta, title, type } = props;
+  const { data, meta, subtitle, title, type } = props;
 
   const chart = useMemo(() => {
     switch (props.type) {
@@ -86,7 +86,17 @@ function ChartRenderer({
 
     return (
       <figure className="govuk-!-margin-0" id={id} data-testid={id}>
-        {title && <figcaption className="govuk-heading-s">{title}</figcaption>}
+        {title && (
+          <figcaption>
+            <p
+              className="govuk-heading-s govuk-!-margin-bottom-1"
+              data-testid="chart-title"
+            >
+              {title}
+            </p>
+            {subtitle && <p data-testid="chart-subtitle">{subtitle}</p>}
+          </figcaption>
+        )}
 
         {chart}
 

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -120,6 +120,7 @@ export interface ChartProps {
   includeNonNumericData?: boolean;
   showDataLabels?: boolean;
   map?: MapConfig;
+  subtitle?: string;
 }
 
 export interface StackedBarProps extends ChartProps {
@@ -147,6 +148,7 @@ export interface ChartDefinitionOptions {
   height: number;
   width?: number;
   barThickness?: number;
+  subtitle?: string;
   title?: string;
   titleType: TitleType;
   alt: string;

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -439,6 +439,7 @@ Configure basic line chart
     user clicks button    Line
     user clicks radio    Set an alternative title
     user enters text into element    label:Enter chart title    Test chart title
+    user enters text into element    label:Subtitle    Test chart subtitle
     user enters text into element    label:Alt text    Test chart alt
     user enters text into element    label:Height (pixels)    400
     user enters text into element    label:Width (pixels)    900
@@ -490,6 +491,7 @@ Validate basic line chart preview
     user waits until element contains line chart    id:chartBuilderPreview
 
     user checks chart title contains    id:chartBuilderPreview    Test chart title
+    user checks chart subtitle contains    id:chartBuilderPreview    Test chart subtitle
     user checks chart legend item contains    id:chartBuilderPreview    1    Admission Numbers (Nailsea Youngwood)
 
     user checks chart height    id:chartBuilderPreview    400
@@ -565,6 +567,7 @@ Validate line chart embeds correctly
     user waits until element contains line chart    ${datablock}
 
     user checks chart title contains    ${datablock}    Test chart title
+    user checks chart subtitle contains    ${datablock}    Test chart subtitle
     user checks chart legend item contains    ${datablock}    1    Admission Numbers (Nailsea Youngwood)
 
     user checks chart height    ${datablock}    400

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -226,13 +226,13 @@ Verify data block is updated correctly
     #checking if data block cache has been invalidated by verifying the updates on the block
     user scrolls to accordion section    Dates data block    id:releaseMainContent
     user opens accordion section    Dates data block    id:releaseMainContent
-    ${section}=    user gets accordion section content element    Dates data block    id:releaseMainContent
+    ${datablock}=    set variable    testid:Data block - ${DATABLOCK_NAME}
 
-    user checks chart title contains    ${section}    Updated dates table title
-    user clicks link by visible text    Table    ${section}
-    user waits until parent contains element    ${section}
+    user checks chart title contains    ${datablock}    Updated dates table title
+    user clicks link by visible text    Table    ${datablock}
+    user waits until parent contains element    ${datablock}
     ...    xpath:.//*[@data-testid="dataTableCaption" and text()="Updated dates table title"]
-    user waits until parent contains element    ${section}    xpath:.//*[.="Source: Updated dates source"]
+    user waits until parent contains element    ${datablock}    xpath:.//*[.="Source: Updated dates source"]
     user closes accordion section    Dates data block    id:releaseMainContent
 
 Add public prerelease access list
@@ -427,7 +427,6 @@ Verify Dates data block table has footnotes
     ...    ${data_block_table}
 
 Verify Dates data block Fast Track page
-
     ${release_url}=    user gets url
 
     user clicks link by visible text    Explore data    testid:Data block - Dates data block name-table-tab
@@ -912,7 +911,6 @@ Verify amendment Dates data block table has footnotes
     ...    ${data_block_table}
 
 Verify amendment Dates data block Fast Track page
-
     ${release_url}=    user gets url
 
     user clicks link by visible text    Explore data    testid:Data block - Dates data block name-table-tab
@@ -1037,4 +1035,4 @@ Validate next update date
 
 Verify that the Dates data block is no longer available
     go to    ${FAST_TRACK_URL}
-    user waits until page contains title   Page not found
+    user waits until page contains title    Page not found

--- a/tests/robot-tests/tests/libs/charts.robot
+++ b/tests/robot-tests/tests/libs/charts.robot
@@ -45,7 +45,13 @@ user waits until element does not contain chart tooltip
 
 user checks chart title contains
     [Arguments]    ${locator}    ${text}
-    user waits until parent contains element    ${locator}    xpath:.//figcaption[text()="${text}"]
+    ${element}=    get child element    ${locator}    testid:chart-title
+    user waits until element contains    ${element}    ${text}
+
+user checks chart subtitle contains
+    [Arguments]    ${locator}    ${text}
+    ${element}=    get child element    ${locator}    testid:chart-subtitle
+    user waits until element contains    ${element}    ${text}
 
 user checks chart height
     [Arguments]    ${locator}    ${height}


### PR DESCRIPTION
Adds an optional subtitle to charts:
- the subtitle has a max length of 160 characters (this required adding a `maxLength` option to the `FormTextInput` component
- hint text has been added for title and subtitle
- the subtitle displays in the `figcaption` below the title

I haven't changed the form to use React Hook Form as part of this as having had a try I think it will require wider refactoring of the chart builder forms, see comment on https://dfedigital.atlassian.net/browse/EES-4534

![subtitle](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/742506b2-4024-4c73-ac86-734fd6a2aa00)
![subtitle-form](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/62c576b6-704b-403d-a53a-ad5be36c0b11)
