### PR TITLE
EES-4117 - additional UI test pipeline tweaks

### DIFF
--- a/azure-pipelines-ui-tests.dfe.yml
+++ b/azure-pipelines-ui-tests.dfe.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: Public UI tests
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --env "dev" --file "tests/general_public/" --processes 2 --rerun-attempts 5
+      arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --env "dev" --file "tests/general_public/" --processes 4 --rerun-attempts 3
       workingDirectory: tests/robot-tests
     env:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
@@ -101,7 +101,7 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public_2" --processes 2 --rerun-attempts 5
+      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public_2" --processes 4 --rerun-attempts 3
     #  The magic incantation '"$(variable)"'was added by Mark to resolve an issue with Analyst password that contained ampersands.
       workingDirectory: tests/robot-tests
     env:
@@ -154,7 +154,7 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin" --processes 2 --rerun-attempts 5
+      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin" --processes 4 --rerun-attempts 3
       workingDirectory: tests/robot-tests
     env:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)
@@ -206,7 +206,7 @@ jobs:
     displayName: Admin public UI tests
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public" --processes 2 --rerun-attempts 5
+      arguments: --admin-pass  '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass  '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --env "dev" --file "tests/admin_and_public" --processes 4 --rerun-attempts 3
       workingDirectory: tests/robot-tests
     env:
       SLACK_BOT_TOKEN: $(ees-test-SLACK-BOT-TOKEN)

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -61,6 +61,8 @@ def create_robot_arguments(arguments: argparse.Namespace, rerunning_failed: bool
         "BootstrapData",
         "--exclude",
         "VisualTesting",
+        "--xunit",
+        "xunit",
     ]
     robot_args += ["-v", f"timeout:{os.getenv('TIMEOUT')}", "-v", f"implicit_wait:{os.getenv('IMPLICIT_WAIT')}"]
     if arguments.fail_fast:
@@ -70,7 +72,6 @@ def create_robot_arguments(arguments: argparse.Namespace, rerunning_failed: bool
     if arguments.print_keywords:
         robot_args += ["--listener", "listeners/KeywordListener.py"]
     if arguments.ci:
-        robot_args += ["--xunit", "xunit"]
         # NOTE(mark): Ensure secrets aren't visible in CI logs/reports
         robot_args += ["--removekeywords", "name:operatingsystem.environment variable should be set"]
         robot_args += ["--removekeywords", "name:common.user goes to url"]  # To hide basic auth credentials
@@ -135,6 +136,8 @@ def merge_test_reports():
         f"{results_foldername}/",
         "-o",
         "output.xml",
+        "--xunit",
+        "xunit.xml",
         "--prerebotmodifier",
         "report-modifiers/CheckForAtLeastOnePassingRunPrerebotModifier.py",
         "--merge",

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -201,49 +201,50 @@ def run():
     try:
         # Run tests
         while args.rerun_attempts is None or test_run_index < args.rerun_attempts:
-            test_run_index += 1
+            try:
+                test_run_index += 1
 
-            # Ensure all SeleniumLibrary elements and keywords are updated to use a branch new
-            # Selenium instance for every test (re)run.
-            if test_run_index > 0:
-                selenium_elements.clear_instances()
+                # Ensure all SeleniumLibrary elements and keywords are updated to use a branch new
+                # Selenium instance for every test (re)run.
+                if test_run_index > 0:
+                    selenium_elements.clear_instances()
 
-            rerunning_failed_suites = args.rerun_failed_suites or test_run_index > 0
+                rerunning_failed_suites = args.rerun_failed_suites or test_run_index > 0
 
-            # Perform any cleanup before the test run.
-            clear_files_before_test_run(rerunning_failed_suites)
+                # Perform any cleanup before the test run.
+                clear_files_before_test_run(rerunning_failed_suites)
 
-            if not Path(f"{results_foldername}/downloads").exists():
-                os.makedirs(f"{results_foldername}/downloads")
+                if not Path(f"{results_foldername}/downloads").exists():
+                    os.makedirs(f"{results_foldername}/downloads")
 
-            # Create a unique run identifier so that this test run's data will be unique.
-            run_identifier = create_run_identifier()
-            os.environ["RUN_IDENTIFIER"] = run_identifier
+                # Create a unique run identifier so that this test run's data will be unique.
+                run_identifier = create_run_identifier()
+                os.environ["RUN_IDENTIFIER"] = run_identifier
 
-            # Create a Test Topic under which all of this test run's data will be created.
-            if data_changing_tests:
-                admin_api.create_test_topic(run_identifier)
+                # Create a Test Topic under which all of this test run's data will be created.
+                if data_changing_tests:
+                    admin_api.create_test_topic(run_identifier)
 
-            # Run the tests.
-            logger.info(f"Performing test run {test_run_index + 1} with unique identifier {run_identifier}")
-            execute_tests(args, rerunning_failed_suites)
+                # Run the tests.
+                logger.info(f"Performing test run {test_run_index + 1} with unique identifier {run_identifier}")
+                execute_tests(args, rerunning_failed_suites)
 
-            # If we're rerunning failures, merge the former run's results with this run's
-            # results.
-            if rerunning_failed_suites:
-                logger.info(f"Merging results from test run {test_run_index + 1} with previous run's report")
-                merge_test_reports()
+                # If we're rerunning failures, merge the former run's results with this run's
+                # results.
+                if rerunning_failed_suites:
+                    logger.info(f"Merging results from test run {test_run_index + 1} with previous run's report")
+                    merge_test_reports()
 
-            # Tear down any data created by this test run unless we've disabled teardown.
-            if data_changing_tests and not args.disable_teardown:
-                logger.info("Tearing down test data...")
-                admin_api.delete_test_topic()
+            finally:
+                # Tear down any data created by this test run unless we've disabled teardown.
+                if data_changing_tests and not args.disable_teardown:
+                    logger.info("Tearing down test data...")
+                    admin_api.delete_test_topic()
 
             # If all tests passed, return early.
             if not get_failing_suites():
                 break
 
-    finally:
         logger.info(f"Log available at: file://{os.getcwd()}{os.sep}{results_foldername}{os.sep}log.html")
         logger.info(f"Report available at: file://{os.getcwd()}{os.sep}{results_foldername}{os.sep}report.html")
 
@@ -260,6 +261,12 @@ def run():
         if args.enable_slack_notifications:
             slack_service = SlackService()
             slack_service.send_test_report(args.env, args.tests, failing_suites, test_run_index)
+
+    except Exception as ex:
+        if args.enable_slack_notifications:
+            slack_service = SlackService()
+            slack_service.send_exception_details(args.env, args.tests, test_run_index, ex)
+        raise ex
 
 
 current_dir = Path(__file__).absolute().parent


### PR DESCRIPTION
This PR fixes a couple of outstanding issues with the UI tests running in the pipeline.

## Overall pipeline marked as failed despite all tests passing

### The problem

After the `rerun-attempts` work was put into the pipeline, the tests are very stable now in the pipeline, but often require an additional rerun or two in order to get a full set of greens on the test run.

If a rerun is necessary, the pipeline reports itself as failed, because the `xunit.xml` file contains test failure information in it, despite all tests finally passing.

### The solution

The solution was to explicitly regenerate the `xunit.xml` file when merging rerun results from `rerun.xml` back into `output.xml` using Rebot.  [This commit](https://github.com/dfe-analytical-services/explore-education-statistics/pull/4451/commits/1624fecf1532bb7d06081950d6f7b8d3332f1c3a) specifies the generating of the `xunit.xml` file during the Rebot test result merge, so that it reflects the latest "total" test results rather than just the first run's results.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/977e191a-8fd6-4a35-88d9-ec00ae0613ad)

The above image is a result of a test run with one rerun attempt.  This is now showing all passes whereas before it would have reported several errors from the first run.

## Non-test failures during running of tests not reporting to Slack

### The problem

Whilst executing the main test runs in the UI test pipeline, errors were not being reported to Slack if they occurred outside of the actual running of the tests.  Examples of these types of failures would include things like logging in as BAU1 in order to set up a Test Topic, failing to correctly tear down data at the end of the tests etc.  Instead, we just never got any indication that the tests even tried to run.

### The solution

Now we have a "try-except" statement around each test run attempt in [this commit](https://github.com/dfe-analytical-services/explore-education-statistics/pull/4451/commits/12fa9199e665d602c97a46d054c50fe6bd9890ed), which will report any unexpected Exceptions thrown during the main script run to Slack, and then rethrow the original error.  An example would look like:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/350fdf7c-51d9-42e0-b923-0e53ac7c8c57)