### PR TITLE
EES-4222 - parameterising the Slack channel to which Azure alerts are…

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -23,6 +23,9 @@
     "skuPublisher": {
       "value": "B1 Basic"
     },
+    "slackAlertsChannel": {
+      "value": "#alerts-dev"
+    },
     "publishReleasesCronSchedule": {
       "value": "0 0 * * * *"
     },

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -26,6 +26,9 @@
     "skuPublisher": {
       "value": "S1 Standard"
     },
+    "slackAlertsChannel": {
+      "value": "#alerts-preprod"
+    },
     "useSubnets": {
       "value": true
     },

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -26,6 +26,9 @@
     "skuPublisher": {
       "value": "S1 Standard"
     },
+    "slackAlertsChannel": {
+      "value": "#alerts"
+    },
     "publicAppBasicAuth": {
       "value": "false"
     },

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -23,6 +23,9 @@
     "skuPublisher": {
       "value": "B1 Basic"
     },
+    "slackAlertsChannel": {
+      "value": "#alerts-test"
+    },
     "publishReleasesCronSchedule": {
       "value": "0 0 * * * *"
     },

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -685,6 +685,12 @@
         "description": "Slack webhook URI for alerts"
       }
     },
+    "slackAlertsChannel": {
+      "type": "string",
+      "metadata": {
+        "description": "Slack channel to post Azure alerts to"
+      }
+    },
     "dataFactoryConcurrency": {
       "type": "int",
       "defaultValue": 1
@@ -4072,7 +4078,7 @@
                   "body": {
                     "username": "Alertbot",
                     "icon_emoji": ":face_with_monocle",
-                    "channel": "#alerts",
+                    "channel": "[parameters('slackAlertsChannel')]",
                     "text": "Alert @{triggerBody()?['data']?['essentials']?['monitorCondition']}!\n@{triggerBody()?['data']?['essentials']?['alertRule']}\n@{triggerBody()?['data']?['essentials']?['description']}"
                   },
                   "method": "POST",


### PR DESCRIPTION
This PR:
- allows each environment to specify which channel it will post its Azure alerts to.

This parameter is used to configure the Logic App which forwards Azure alerts to Slack. 