### PR TITLE
EES-4222 - adding success and failure Slack reporting to Data Factory jobs

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -13,6 +13,18 @@
       "metadata": {
         "description": "The name of the key vault"
       }
+    },
+    "slackWebhook": {
+      "type": "string",
+      "metadata": {
+        "description": "Slack webhook URI for alerts"
+      }
+    },
+    "slackAlertsChannel": {
+      "type": "string",
+      "metadata": {
+        "description": "Slack channel to post Azure alerts to"
+      }
     }
   },
   "variables": {
@@ -92,6 +104,111 @@
               "referenceName": "ls_sql_statistics",
               "type": "LinkedServiceReference"
             }
+          },
+          {
+            "name": "Report success",
+            "type": "WebActivity",
+            "dependsOn": [
+              {
+                "activity": "sp_rebuild_indexes",
+                "dependencyConditions": [
+                  "Succeeded"
+                ]
+              }
+            ],
+            "policy": {
+              "timeout": "0.12:00:00",
+              "retry": 0,
+              "retryIntervalInSeconds": 30,
+              "secureOutput": false,
+              "secureInput": false
+            },
+            "userProperties": [],
+            "typeProperties": {
+              "url": "[parameters('slackWebhook')]",
+              "method": "POST",
+              "body": {
+                "channel": "[parameters('slackAlertsChannel')]",
+                "icon_emoji": ":smile",
+                "text": "Data Factory Success!",
+                "username": "Alertbot",
+                "attachments": [{
+                  "color": "good",
+                  "fields": [{
+                    "title": "Data Factory",
+                    "value": "@{pipeline().DataFactory}",
+                    "short": true
+                  },
+                  {
+                    "title": "Pipeline",
+                    "value": "@{pipeline().Pipeline}",
+                    "short": true
+                  },
+                  {
+                    "title": "Duration",
+                    "value": "@{activity('sp_rebuild_indexes').Duration}",
+                    "short": true
+                  }]
+                }]
+              }
+            }
+          },
+          {
+            "name": "Report failure",
+            "type": "WebActivity",
+            "dependsOn": [
+              {
+                "activity": "sp_rebuild_indexes",
+                "dependencyConditions": [
+                  "Failed"
+                ]
+              }
+            ],
+            "policy": {
+              "timeout": "0.12:00:00",
+              "retry": 0,
+              "retryIntervalInSeconds": 30,
+              "secureOutput": false,
+              "secureInput": false
+            },
+            "userProperties": [],
+            "typeProperties": {
+              "url": "[parameters('slackWebhook')]",
+              "method": "POST",
+              "body": {
+                "channel": "[parameters('slackAlertsChannel')]",
+                "icon_emoji": ":face_vomiting",
+                "text": "Data Factory Failure!",
+                "username": "Alertbot",
+                "attachments": [
+                  {
+                    "color": "warning",
+                    "fields": [
+                      {
+                        "title": "Data Factory",
+                        "value": "@{pipeline().DataFactory}",
+                        "short": true
+                      },
+                      {
+                        "title": "Pipeline",
+                        "value": "@{pipeline().Pipeline}",
+                        "short": true
+                      },
+                      {
+                        "title": "Error",
+                        "value": "@{activity('sp_rebuild_indexes').Error.message}",
+                        "short": true
+                      },
+                      {
+                        "title": "Duration",
+                        "value": "@{activity('sp_rebuild_indexes').Duration}",
+                        "short": true
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
           }
         ],
         "parameters": {
@@ -154,6 +271,111 @@
             "linkedServiceName": {
               "referenceName": "ls_sql_statistics",
               "type": "LinkedServiceReference"
+            }
+          },
+          {
+            "name": "Report success",
+            "type": "WebActivity",
+            "dependsOn": [
+              {
+                "activity": "sp_remove_soft_deleted_subjects",
+                "dependencyConditions": [
+                  "Succeeded"
+                ]
+              }
+            ],
+            "policy": {
+              "timeout": "0.12:00:00",
+              "retry": 0,
+              "retryIntervalInSeconds": 30,
+              "secureOutput": false,
+              "secureInput": false
+            },
+            "userProperties": [],
+            "typeProperties": {
+              "url": "[parameters('slackWebhook')]",
+              "method": "POST",
+              "body": {
+                "channel": "[parameters('slackAlertsChannel')]",
+                "icon_emoji": ":smile",
+                "text": "Data Factory Success!",
+                "username": "Alertbot",
+                "attachments": [{
+                  "color": "good",
+                  "fields": [{
+                    "title": "Data Factory",
+                    "value": "@{pipeline().DataFactory}",
+                    "short": true
+                  },
+                    {
+                      "title": "Pipeline",
+                      "value": "@{pipeline().Pipeline}",
+                      "short": true
+                    },
+                    {
+                      "title": "Duration",
+                      "value": "@{activity('sp_remove_soft_deleted_subjects').Duration}",
+                      "short": true
+                    }]
+                }]
+              }
+            }
+          },
+          {
+            "name": "Report failure",
+            "type": "WebActivity",
+            "dependsOn": [
+              {
+                "activity": "sp_remove_soft_deleted_subjects",
+                "dependencyConditions": [
+                  "Failed"
+                ]
+              }
+            ],
+            "policy": {
+              "timeout": "0.12:00:00",
+              "retry": 0,
+              "retryIntervalInSeconds": 30,
+              "secureOutput": false,
+              "secureInput": false
+            },
+            "userProperties": [],
+            "typeProperties": {
+              "url": "[parameters('slackWebhook')]",
+              "method": "POST",
+              "body": {
+                "channel": "[parameters('slackAlertsChannel')]",
+                "icon_emoji": ":face_vomiting",
+                "text": "Data Factory Failure!",
+                "username": "Alertbot",
+                "attachments": [
+                  {
+                    "color": "warning",
+                    "fields": [
+                      {
+                        "title": "Data Factory",
+                        "value": "@{pipeline().DataFactory}",
+                        "short": true
+                      },
+                      {
+                        "title": "Pipeline",
+                        "value": "@{pipeline().Pipeline}",
+                        "short": true
+                      },
+                      {
+                        "title": "Error",
+                        "value": "@{activity('sp_remove_soft_deleted_subjects').Error.message}",
+                        "short": true
+                      },
+                      {
+                        "title": "Duration",
+                        "value": "@{activity('sp_remove_soft_deleted_subjects').Duration}",
+                        "short": true
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           }
         ],

--- a/infrastructure/templates/datafactory/template.json
+++ b/infrastructure/templates/datafactory/template.json
@@ -46,6 +46,18 @@
     },
     "actionGroupAlerts": {
       "type": "string"
+    },
+    "slackWebhook": {
+      "type": "string",
+      "metadata": {
+        "description": "Slack webhook URI for alerts"
+      }
+    },
+    "slackAlertsChannel": {
+      "type": "string",
+      "metadata": {
+        "description": "Slack channel to post Azure alerts to"
+      }
     }
   },
   "variables":{
@@ -79,6 +91,12 @@
           },
           "keyVaultName": {
             "value": "[parameters('keyVaultName')]"
+          },
+          "slackWebhook": {
+            "value": "[parameters('slackWebhook')]"
+          },
+          "slackAlertsChannel": {
+            "value": "[parameters('slackAlertsChannel')]"
           }
         }
       },

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -3524,6 +3524,12 @@
           },
           "actionGroupAlerts": {
             "value": "[variables('actionGroupAlerts')]"
+          },
+          "slackWebhook": {
+            "value": "[parameters('slackWebhook')]"
+          },
+          "slackAlertsChannel": {
+            "value": "[parameters('slackAlertsChannel')]"
           }
         }
       },


### PR DESCRIPTION
This PR:
- adds success and failure messaging to Slack to each of our Data Factory pipelines.
- adds generic failure reporting for Data Factory activities.

## Specific success and failure messages for Pipelines

Each main Data Factory job now has Success and Failure activities that follow on from the main activity.  Each success and failure is a new Web activity, and linked to the "Success" and "Failure" output paths from the main activity.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/1a211657-d6b9-439a-8337-28907c44341c)

The image above shows specific success and failure messages from the "Remove Soft Deleted Subjects" Pipeline.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/5560f25f-19aa-42ad-aba5-eca4238b57c5)

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/aa858057-eb16-4358-8e17-b14036b811ff)

The above 2 images show success and failure messages from the "Rebuild Indexes" Pipeline.

## Generic Data Factory activity failure messages

This was added in a previous PR that is already on dev, but including details here.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/50b9036d-fc1a-455b-8683-fd8edad1c076)

The message above will be shown if any Data Factory errors occur. This will happen in conjunction with the specific success and failure messages above, but may also be raised if something stops the specific success and failure messages from being sent out at all.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/b004578a-b269-4bc9-9a0b-b4f0acbdaedb)

The message above will be shown when Data Factory activity errors stop occurring.