### PR TITLE
EES-4608 make all location filter checkboxes small

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -234,6 +234,7 @@ const LocationFiltersForm = ({
                               ? 'Search by school name or unique reference number (URN), and select at least one option before continuing to the next step.'
                               : 'Search above and select at least one option before continuing to the next step.'
                           }
+                          small
                         />
                       );
                     })}


### PR DESCRIPTION
Currently in the table tool location step if the locations group doesn't have search the checkboxes are larger than if it does, e.g. the England option is larger than Regions etc. This sets them to always be small.