### PR TITLE
EES-4726 Adding LatestVersionId to the DataSet entity

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSet.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSet.cs
@@ -18,6 +18,8 @@ public class DataSet : ICreatedUpdatedTimestamps<DateTimeOffset, DateTimeOffset?
 
     public Guid? LatestVersionId { get; set; }
 
+    public DataSetVersion? LatestVersion { get; set; }
+
     public List<DataSetVersion> Versions { get; set; } = new();
 
     public DateTimeOffset? Published { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
@@ -24,6 +24,11 @@ public class PublicDataDbContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<DataSet>()
+            .HasOne(ds => ds.LatestVersion)
+            .WithOne(dsv => dsv.DataSet)
+            .HasForeignKey<DataSet>(ds => ds.LatestVersionId);
+
+        modelBuilder.Entity<DataSet>()
             .Property(ds => ds.Status)
             .HasConversion<string>();
 
@@ -44,9 +49,7 @@ public class PublicDataDbContext : DbContext
                             .HasConversion(new EnumToEnumValueConverter<TimeIdentifier>());
                     });
                 });
-            });
-
-        modelBuilder.Entity<DataSetVersion>()
+            })
             .Property(dsv => dsv.Status)
             .HasConversion<string>();
 
@@ -72,9 +75,7 @@ public class PublicDataDbContext : DbContext
             {
                 m.ToJson();
                 m.OwnsMany(lm => lm.Options);
-            });
-
-        modelBuilder.Entity<DataSetMeta>()
+            })
             .Property(m => m.GeographicLevels)
             .HasColumnType("text[]");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20231207163314_InitialMigration.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20231207163314_InitialMigration.Designer.cs
@@ -14,7 +14,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
 {
     [DbContext(typeof(PublicDataDbContext))]
-    [Migration("20231207152611_InitialMigration")]
+    [Migration("20231207163314_InitialMigration")]
     partial class InitialMigration
     {
         /// <inheritdoc />
@@ -173,6 +173,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("LatestVersionId")
+                        .IsUnique();
 
                     b.HasIndex("SupersedingDataSetId");
 
@@ -774,9 +777,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", b =>
                 {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "LatestVersion")
+                        .WithOne("DataSet")
+                        .HasForeignKey("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", "LatestVersionId");
+
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", "SupersedingDataSet")
                         .WithMany()
                         .HasForeignKey("SupersedingDataSetId");
+
+                    b.Navigation("LatestVersion");
 
                     b.Navigation("SupersedingDataSet");
                 });
@@ -985,7 +994,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", b =>
                 {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", "DataSet")
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", null)
                         .WithMany("Versions")
                         .HasForeignKey("DataSetId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -1080,8 +1089,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                                 .IsRequired();
                         });
 
-                    b.Navigation("DataSet");
-
                     b.Navigation("MetaSummary")
                         .IsRequired();
                 });
@@ -1093,6 +1100,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", b =>
                 {
+                    b.Navigation("DataSet")
+                        .IsRequired();
+
                     b.Navigation("FilterChanges");
 
                     b.Navigation("FilterOptionChanges");

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20231207163314_InitialMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20231207163314_InitialMigration.cs
@@ -12,6 +12,100 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
+                name: "ChangeSetFilterOptions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Changes = table.Column<string>(type: "jsonb", nullable: true),
+                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChangeSetFilterOptions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ChangeSetFilters",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Changes = table.Column<string>(type: "jsonb", nullable: true),
+                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChangeSetFilters", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ChangeSetIndicators",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Changes = table.Column<string>(type: "jsonb", nullable: true),
+                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChangeSetIndicators", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ChangeSetLocations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Changes = table.Column<string>(type: "jsonb", nullable: true),
+                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChangeSetLocations", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ChangeSetTimePeriods",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Changes = table.Column<string>(type: "jsonb", nullable: true),
+                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChangeSetTimePeriods", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DataSetMeta",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Filters = table.Column<string>(type: "jsonb", nullable: true),
+                    Indicators = table.Column<string>(type: "jsonb", nullable: true),
+                    Locations = table.Column<string>(type: "jsonb", nullable: true),
+                    GeographicLevels = table.Column<string[]>(type: "text[]", nullable: false),
+                    TimePeriods = table.Column<string>(type: "jsonb", nullable: true),
+                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataSetMeta", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "DataSets",
                 columns: table => new
                 {
@@ -52,7 +146,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     Published = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
                     Unpublished = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
                     Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
                 },
                 constraints: table =>
                 {
@@ -61,136 +155,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         name: "FK_DataSetVersions_DataSets_DataSetId",
                         column: x => x.DataSetId,
                         principalTable: "DataSets",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "ChangeSetFilterOptions",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    Changes = table.Column<string>(type: "jsonb", nullable: true),
-                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_ChangeSetFilterOptions", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_ChangeSetFilterOptions_DataSetVersions_DataSetVersionId",
-                        column: x => x.DataSetVersionId,
-                        principalTable: "DataSetVersions",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "ChangeSetFilters",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    Changes = table.Column<string>(type: "jsonb", nullable: true),
-                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_ChangeSetFilters", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_ChangeSetFilters_DataSetVersions_DataSetVersionId",
-                        column: x => x.DataSetVersionId,
-                        principalTable: "DataSetVersions",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "ChangeSetIndicators",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    Changes = table.Column<string>(type: "jsonb", nullable: true),
-                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_ChangeSetIndicators", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_ChangeSetIndicators_DataSetVersions_DataSetVersionId",
-                        column: x => x.DataSetVersionId,
-                        principalTable: "DataSetVersions",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "ChangeSetLocations",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    Changes = table.Column<string>(type: "jsonb", nullable: true),
-                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_ChangeSetLocations", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_ChangeSetLocations_DataSetVersions_DataSetVersionId",
-                        column: x => x.DataSetVersionId,
-                        principalTable: "DataSetVersions",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "ChangeSetTimePeriods",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    Changes = table.Column<string>(type: "jsonb", nullable: true),
-                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_ChangeSetTimePeriods", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_ChangeSetTimePeriods_DataSetVersions_DataSetVersionId",
-                        column: x => x.DataSetVersionId,
-                        principalTable: "DataSetVersions",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "DataSetMeta",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    Filters = table.Column<string>(type: "jsonb", nullable: true),
-                    Indicators = table.Column<string>(type: "jsonb", nullable: true),
-                    Locations = table.Column<string>(type: "jsonb", nullable: true),
-                    GeographicLevels = table.Column<string[]>(type: "text[]", nullable: false),
-                    TimePeriods = table.Column<string>(type: "jsonb", nullable: true),
-                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_DataSetMeta", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_DataSetMeta_DataSetVersions_DataSetVersionId",
-                        column: x => x.DataSetVersionId,
-                        principalTable: "DataSetVersions",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
@@ -227,6 +191,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                 unique: true);
 
             migrationBuilder.CreateIndex(
+                name: "IX_DataSets_LatestVersionId",
+                table: "DataSets",
+                column: "LatestVersionId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
                 name: "IX_DataSets_SupersedingDataSetId",
                 table: "DataSets",
                 column: "SupersedingDataSetId");
@@ -235,11 +205,70 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                 name: "IX_DataSetVersions_DataSetId",
                 table: "DataSetVersions",
                 column: "DataSetId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ChangeSetFilterOptions_DataSetVersions_DataSetVersionId",
+                table: "ChangeSetFilterOptions",
+                column: "DataSetVersionId",
+                principalTable: "DataSetVersions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ChangeSetFilters_DataSetVersions_DataSetVersionId",
+                table: "ChangeSetFilters",
+                column: "DataSetVersionId",
+                principalTable: "DataSetVersions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ChangeSetIndicators_DataSetVersions_DataSetVersionId",
+                table: "ChangeSetIndicators",
+                column: "DataSetVersionId",
+                principalTable: "DataSetVersions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ChangeSetLocations_DataSetVersions_DataSetVersionId",
+                table: "ChangeSetLocations",
+                column: "DataSetVersionId",
+                principalTable: "DataSetVersions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ChangeSetTimePeriods_DataSetVersions_DataSetVersionId",
+                table: "ChangeSetTimePeriods",
+                column: "DataSetVersionId",
+                principalTable: "DataSetVersions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DataSetMeta_DataSetVersions_DataSetVersionId",
+                table: "DataSetMeta",
+                column: "DataSetVersionId",
+                principalTable: "DataSetVersions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DataSets_DataSetVersions_LatestVersionId",
+                table: "DataSets",
+                column: "LatestVersionId",
+                principalTable: "DataSetVersions",
+                principalColumn: "Id");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.DropForeignKey(
+                name: "FK_DataSets_DataSetVersions_LatestVersionId",
+                table: "DataSets");
+
             migrationBuilder.DropTable(
                 name: "ChangeSetFilterOptions");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
@@ -171,6 +171,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
                     b.HasKey("Id");
 
+                    b.HasIndex("LatestVersionId")
+                        .IsUnique();
+
                     b.HasIndex("SupersedingDataSetId");
 
                     b.ToTable("DataSets");
@@ -771,9 +774,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", b =>
                 {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "LatestVersion")
+                        .WithOne("DataSet")
+                        .HasForeignKey("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", "LatestVersionId");
+
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", "SupersedingDataSet")
                         .WithMany()
                         .HasForeignKey("SupersedingDataSetId");
+
+                    b.Navigation("LatestVersion");
 
                     b.Navigation("SupersedingDataSet");
                 });
@@ -982,7 +991,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", b =>
                 {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", "DataSet")
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", null)
                         .WithMany("Versions")
                         .HasForeignKey("DataSetId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -1077,8 +1086,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                                 .IsRequired();
                         });
 
-                    b.Navigation("DataSet");
-
                     b.Navigation("MetaSummary")
                         .IsRequired();
                 });
@@ -1090,6 +1097,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", b =>
                 {
+                    b.Navigation("DataSet")
+                        .IsRequired();
+
                     b.Navigation("FilterChanges");
 
                     b.Navigation("FilterOptionChanges");


### PR DESCRIPTION
Adding `LatestVersionId` to the `DataSet` entity; and the corresponding column to the `DataSets` table. This will allow us to more efficiently query the `DataSetVersions` table for the latest version.