### PR TITLE
EES-4589 reduce map tooltip width and make sticky to mouse pointer

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -333,32 +333,37 @@ export default function MapBlockInternal({
           featureLayer as MapFeatureProperties['layer'];
       }
 
-      featureLayer.bindTooltip(() => {
-        if (feature.properties.dataSets[selectedDataSetKey]) {
-          const dataSetValue = formatPretty(
-            feature.properties.dataSets[selectedDataSetKey].value,
-            selectedDataSetConfig.dataSet.indicator.unit,
-            selectedDataSetConfig.dataSet.indicator.decimalPlaces,
-          );
-          const content = `${selectedDataSetConfig.config.label}: ${dataSetValue}`;
+      featureLayer.bindTooltip(
+        () => {
+          if (feature.properties.dataSets[selectedDataSetKey]) {
+            const dataSetValue = formatPretty(
+              feature.properties.dataSets[selectedDataSetKey].value,
+              selectedDataSetConfig.dataSet.indicator.unit,
+              selectedDataSetConfig.dataSet.indicator.decimalPlaces,
+            );
+            const content = `${selectedDataSetConfig.config.label}: ${dataSetValue}`;
 
-          const mapWidth = mapRef.current?.container?.clientWidth;
+            const mapWidth = mapRef.current?.container?.clientWidth;
 
-          // Not ideal, we would want to use `max-width` instead.
-          // Unfortunately it doesn't seem to work with the tooltip
-          // for some reason (maybe due to the pane styling).
-          const tooltipStyle = mapWidth ? `width: ${mapWidth / 2}px` : '';
+            // Not ideal, we would want to use `max-width` instead.
+            // Unfortunately it doesn't seem to work with the tooltip
+            // for some reason (maybe due to the pane styling).
+            const tooltipStyle = mapWidth
+              ? `width: ${mapWidth / 2 - 20}px`
+              : '';
 
-          return (
-            `<div class="${styles.tooltip}" style="${tooltipStyle}">` +
-            `<p><strong data-testid="chartTooltip-label">${feature.properties.name}</strong></p>` +
-            `<p class="${styles.tooltipContent}" data-testid="chartTooltip-contents">${content}</p>` +
-            `</div>`
-          );
-        }
+            return (
+              `<div class="${styles.tooltip}" style="${tooltipStyle}">` +
+              `<p><strong data-testid="chartTooltip-label">${feature.properties.name}</strong></p>` +
+              `<p class="${styles.tooltipContent}" data-testid="chartTooltip-contents">${content}</p>` +
+              `</div>`
+            );
+          }
 
-        return '';
-      });
+          return '';
+        },
+        { sticky: true },
+      );
     },
     [dataSetCategoryConfigs, selectedDataSetKey],
   );


### PR DESCRIPTION
Changes to the tooltip when you hover over areas on maps to make it more likely that the tooltip content will be visible:
- slightly reduced the width 
- made the tooltip 'sticky' - anchors the tooltip to the mouse pointer instead of it always being fixed in the middle of the area.

Videos to demonstrate the differences - in both of these I'm selecting Sheffield from the dropdown, then hovering over Sheffield, Derbyshire and Staffordshire.

Before:
https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/6c66a3f0-547f-4545-96e9-ca57a80b38d2

After:
https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/adcc625b-488f-4fb1-a773-0e7e5fa35f28

