### PR TITLE
EES-4636 prevent modal icon wrapping in table headers

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTable.tsx
@@ -86,12 +86,14 @@ const DraftReleasesTable = ({
                     >
                       Publication / Release period
                     </th>
-                    <th>
+                    <th className="dfe-white-space--nowrap">
                       Status <DraftStatusGuidanceModal />
                     </th>
                     {/* Don't render the issues for BAU users to prevent performance problems. */}
                     {!isBauUser && (
-                      <th className={styles.issuesColumn}>
+                      <th
+                        className={`${styles.issuesColumn} dfe-white-space--nowrap`}
+                      >
                         Issues <IssuesGuidanceModal />
                       </th>
                     )}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
@@ -64,10 +64,10 @@ const ScheduledReleasesTable = ({ releases }: ScheduledReleasesTableProps) => {
                 <thead>
                   <tr>
                     <th>Publication / Release period</th>
-                    <th>
+                    <th className="dfe-white-space--nowrap">
                       Status <ScheduledStatusGuidanceModal />
                     </th>
-                    <th className="govuk-!-width-one-quarter">
+                    <th className="govuk-!-width-one-quarter dfe-white-space--nowrap">
                       Stages checklist <ScheduledStagesGuidanceModal />
                     </th>
                     <th>Scheduled publish date</th>

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationMethodologiesPage.tsx
@@ -110,10 +110,10 @@ const PublicationMethodologiesPage = () => {
           <thead>
             <tr>
               <th>Methodology</th>
-              <th>
+              <th className="dfe-white-space--nowrap">
                 Type <MethodologyTypeGuidanceModal />
               </th>
-              <th>
+              <th className="dfe-white-space--nowrap">
                 Status <MethodologyStatusGuidanceModal />
               </th>
               <th>Published date</th>

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDraftReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDraftReleases.tsx
@@ -30,13 +30,13 @@ const PublicationDraftReleases = ({
       <thead>
         <tr>
           <th className="govuk-!-width-one-third">Release period</th>
-          <th>
+          <th className="dfe-white-space--nowrap">
             Status <DraftStatusGuidanceModal />
           </th>
-          <th>
+          <th className="dfe-white-space--nowrap">
             Errors <IssuesGuidanceModal />
           </th>
-          <th>
+          <th className="dfe-white-space--nowrap">
             Warnings <IssuesGuidanceModal />
           </th>
           <th>Actions</th>

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
@@ -46,7 +46,7 @@ export default function PublicationPublishedReleasesTable({
       <thead>
         <tr>
           <th className="govuk-!-width-one-third">Release period</th>
-          <th className={styles.statusColumn}>
+          <th className={`${styles.statusColumn} dfe-white-space--nowrap`}>
             Status <PublishedStatusGuidanceModal />
           </th>
           <th>Published date</th>

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationScheduledReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationScheduledReleases.tsx
@@ -23,10 +23,10 @@ const PublicationScheduledReleases = ({ publicationId, releases }: Props) => {
       <thead>
         <tr>
           <th className="govuk-!-width-one-third">Release period</th>
-          <th className={styles.statusColumn}>
+          <th className={`${styles.statusColumn} dfe-white-space--nowrap`}>
             Status <ScheduledStatusGuidanceModal />
           </th>
-          <th className="govuk-!-width-one-quarter">
+          <th className="govuk-!-width-one-quarter dfe-white-space--nowrap">
             Stages checklist <ScheduledStagesGuidanceModal />
           </th>
           <th>Publish date</th>

--- a/src/explore-education-statistics-common/src/styles/utils/_text.scss
+++ b/src/explore-education-statistics-common/src/styles/utils/_text.scss
@@ -1,3 +1,7 @@
+.dfe-white-space--nowrap {
+  white-space: nowrap;
+}
+
 .dfe-white-space--pre-wrap {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
Prevents the modal icon in table headers from wrapping under the text in the following places:

- Dashboard - Draft releases - status column
- Dashboard - Scheduled releases - status and stages columns
- Publication - Methodologies - status and type columns
- Publication - Draft releases - status, errors and warnings columns
- Publication - Published releases - status column
- Publication - Scheduled releases - status and stages columns