### PR TITLE
EES-4641 prevent table tool step tag wrapping

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.tsx
@@ -24,7 +24,7 @@ const WizardStepHeading = ({
       })}
     >
       <span
-        className={classNames('govuk-tag', {
+        className={classNames('govuk-tag', 'dfe-white-space--nowrap', {
           'govuk-tag--turquoise govuk-!-margin-right-2': isActive,
           'govuk-tag govuk-tag--grey': !isActive,
         })}

--- a/src/explore-education-statistics-common/src/styles/utils/_text.scss
+++ b/src/explore-education-statistics-common/src/styles/utils/_text.scss
@@ -1,3 +1,7 @@
+.dfe-white-space--nowrap {
+  white-space: nowrap;
+}
+
 .dfe-white-space--pre-wrap {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
Prevents the 'Step X' tags on the table tool wrapping onto two lines on small screens.