### PR TITLE
EES-4748 Add API versioning with Swashbuckle integration

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/HelloWorldControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/HelloWorldControllerTests.cs
@@ -13,7 +13,7 @@ public class HelloWorldControllerTests : IntegrationTestFixture
     {
         var client = TestApp.CreateClient();
 
-        var response = await client.GetAsync("/HelloWorld");
+        var response = await client.GetAsync("/api/v1/HelloWorld");
 
         var content = await response.Content.ReadAsStringAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Config/SwaggerConfig.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Config/SwaggerConfig.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using Asp.Versioning.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Config;
+
+public class SwaggerConfig(IApiVersionDescriptionProvider provider) : IConfigureOptions<SwaggerGenOptions>
+{
+    public void Configure(SwaggerGenOptions options)
+    {
+        options.OperationFilter<SwaggerDefaultValues>();
+
+        var fileName = typeof(Program).Assembly.GetName().Name + ".xml";
+        var filePath = Path.Combine(AppContext.BaseDirectory, fileName);
+
+        options.IncludeXmlComments(filePath);
+        options.UseAllOfForInheritance();
+        options.UseOneOfForPolymorphism();
+        options.CustomOperationIds(apiDesc =>
+            {
+                var actionDescriptor = apiDesc.ActionDescriptor;
+
+                return actionDescriptor.AttributeRouteInfo?.Name
+                       ?? actionDescriptor.EndpointMetadata
+                               .OfType<IEndpointNameMetadata>()
+                               .LastOrDefault()
+                               ?.EndpointName
+                       ?? (apiDesc.TryGetMethodInfo(out var methodInfo) ? methodInfo.Name : null);
+            }
+        );
+
+        foreach (var description in provider.ApiVersionDescriptions)
+        {
+            options.SwaggerDoc(
+                description.GroupName,
+                new OpenApiInfo
+                {
+                    Title = "Explore education statistics - Public Data API",
+                    Version = description.ApiVersion.ToString(),
+                    Contact = new OpenApiContact
+                    {
+                        Name = "Explore education statistics",
+                        Email = "explore.statistics@education.gov.uk",
+                        Url = new Uri("https://explore-education-statistics.service.gov.uk")
+                    },
+                }
+            );
+        }
+    }
+
+    private class SwaggerDefaultValues : IOperationFilter
+    {
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            var apiDescription = context.ApiDescription;
+
+            operation.Deprecated |= apiDescription.IsDeprecated();
+
+            foreach (var responseType in context.ApiDescription.SupportedResponseTypes)
+            {
+                var responseKey = responseType.IsDefaultResponse
+                    ? "default"
+                    : responseType.StatusCode.ToString();
+                var response = operation.Responses[responseKey];
+
+                foreach (var contentType in response.Content.Keys)
+                {
+                    if (responseType.ApiResponseFormats.All(x => x.MediaType != contentType))
+                    {
+                        response.Content.Remove(contentType);
+                    }
+                }
+            }
+
+            if (operation.Parameters == null)
+            {
+                return;
+            }
+
+            foreach (var parameter in operation.Parameters)
+            {
+                var description = apiDescription.ParameterDescriptions
+                    .First(p => p.Name == parameter.Name);
+
+                parameter.Description ??= description.ModelMetadata?.Description;
+
+                if (parameter.Schema.Default == null && description.DefaultValue != null)
+                {
+                    var json = JsonSerializer.Serialize(
+                        description.DefaultValue,
+                        description.ModelMetadata!.ModelType
+                    );
+                    parameter.Schema.Default = OpenApiAnyFactory.CreateFromJson(json);
+                }
+
+                parameter.Required |= description.IsRequired;
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/HelloWorldController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/HelloWorldController.cs
@@ -1,22 +1,75 @@
+using Asp.Versioning;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Controllers;
 
+[ApiVersion(1.0)]
+[ApiVersion(2.0)]
 [ApiController]
-[Route("/HelloWorld")]
+[Route("api/v{version:apiVersion}/HelloWorld")]
 public class HelloWorldController(PublicDataDbContext publicDataDbContext) : ControllerBase
 {
+    /// <summary>
+    /// List v1
+    /// </summary>
+    /// <remarks>
+    /// Test the API can list with `GET` in v1.
+    /// </remarks>
     [HttpGet]
-    public async Task<ActionResult<string>> Get()
+    [SwaggerResponse(200, "The list of things", typeof(string))]
+    public async Task<ActionResult<string>> List()
     {
         return await Task.FromResult("Hello World");
     }
 
-    [HttpPost]
+    /// <summary>
+    /// List v2
+    /// </summary>
+    /// <remarks>
+    /// Tests the API can list with `GET` in v2.
+    /// </remarks>
+    [MapToApiVersion(2.0)]
+    [HttpGet]
+    [SwaggerResponse(200, "The list of things", typeof(string))]
+    public async Task<ActionResult<string>> ListV2()
+    {
+        return await Task.FromResult("Hello World v2");
+    }
+
+    /// <summary>
+    /// Get by ID
+    /// </summary>
+    /// <remarks>
+    /// Tests the API can get by ID with `GET` v1 and v2.
+    /// </remarks>
+    [HttpGet("{id}", Name = "GetById")]
+    [SwaggerResponse(200, "The specific thing", typeof(string))]
+    [SwaggerResponse(404, "Thing could not be found")]
+    public async Task<ActionResult<string>> Get(
+        [SwaggerParameter("The ID of the thing")] string id)
+    {
+        if (id.IsNullOrEmpty())
+        {
+            return NotFound();
+        }
+
+        return await Task.FromResult("Hello World v1 and v2");
+    }
+
+    /// <summary>
+    /// Create
+    /// </summary>
+    /// <remarks>
+    /// Tests the API can create with `POST` in v1 and v2.
+    /// </remarks>
+    [HttpPost(Name = "CreateCustomId")]
+    [SwaggerResponse(201, "Thing was created")]
     public async Task<DataSet> Create()
     {
         var dataSetId = Guid.NewGuid();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
@@ -5,9 +5,17 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace>GovUk.Education.ExploreEducationStatistics.Public.Data.Api</RootNamespace>
+
+        <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+        <!-- Disable build warnings for undocumented methods -->
+        <NoWarn>1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Asp.Versioning.Mvc" Version="8.0.0" />
+        <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
         <PackageReference Include="AspectInjector" Version="2.8.2" />
         <PackageReference Include="DuckDB.NET.Data.Full" Version="0.9.2" />
         <PackageReference Include="FluentValidation" Version="11.8.1" />
@@ -15,8 +23,8 @@
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
-                <PrivateAssets>all</PrivateAssets>
-             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.0" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
@@ -27,8 +35,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
-      <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Public.Data.Model\GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj" />
+        <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
+        <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Public.Data.Model\GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR:

- Adds API versioning in the form of the [ASP.NET API Versioning](https://github.com/dotnet/aspnet-api-versioning) package.
- Integrates the API versioning with Swashbuckle.
- Reconfigures Swashbuckle to gather documentation from XML docblocks. This is better for formatting summaries and descriptions in a nice way.

## Note

These changes splits out all Swashbuckle config into `Program`, instead of `Startup`. 

This is necessary to get access to some of the extensions on `WebApplication` (in the newer minimal API format), but also streamlines the configuration in `Startup` and avoids having this configuration in integration tests.