### PR TITLE
EES-4753 RHF methodology forms

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/adopt-methodology/components/AdoptMethodologyForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/adopt-methodology/components/AdoptMethodologyForm.tsx
@@ -1,5 +1,4 @@
-import Form from '@common/components/form/Form';
-import FormFieldRadioSearchGroup from '@common/components/form/FormFieldRadioSearchGroup';
+import RHFFormFieldRadioSearchGroup from '@common/components/form/rhf/RHFFormFieldRadioSearchGroup';
 import { mapFieldErrors } from '@common/validation/serverValidations';
 import Button from '@common/components/Button';
 import Details from '@common/components/Details';
@@ -8,15 +7,16 @@ import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
+import getMethodologyApprovalStatusLabel from '@admin/pages/methodology/utils/getMethodologyApprovalStatusLabel';
 import { MethodologyVersion } from '@admin/services/methodologyService';
 import Tag from '@common/components/Tag';
 import TagGroup from '@common/components/TagGroup';
-import useFormSubmit from '@common/hooks/useFormSubmit';
 import { RadioOption } from '@common/components/form/FormRadioGroup';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
 import Yup from '@common/validation/yup';
-import { Formik } from 'formik';
 import React, { useMemo } from 'react';
-import getMethodologyApprovalStatusLabel from '@admin/pages/methodology/utils/getMethodologyApprovalStatusLabel';
+import { ObjectSchema } from 'yup';
 
 const errorMappings = [
   mapFieldErrors<FormValues>({
@@ -74,22 +74,23 @@ const AdoptMethodologyForm = ({ methodologies, onCancel, onSubmit }: Props) => {
     [methodologies],
   );
 
-  const handleSubmit = useFormSubmit(async (values: FormValues) => {
-    await onSubmit(values);
-  }, errorMappings);
+  const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
+    return Yup.object({
+      methodologyId: Yup.string().required(
+        'Select a published methodology to adopt',
+      ),
+    });
+  }, []);
 
   return (
-    <Formik<FormValues>
+    <FormProvider
+      enableReinitialize
+      errorMappings={errorMappings}
       initialValues={{ methodologyId: '' }}
-      onSubmit={handleSubmit}
-      validationSchema={Yup.object<FormValues>({
-        methodologyId: Yup.string().required(
-          'Select a published methodology to adopt',
-        ),
-      })}
+      validationSchema={validationSchema}
     >
-      <Form id="adoptMethodologyForm">
-        <FormFieldRadioSearchGroup
+      <RHFForm id="adoptMethodologyForm" onSubmit={onSubmit}>
+        <RHFFormFieldRadioSearchGroup
           id="selectMethodology"
           legend="Select a published methodology"
           name="methodologyId"
@@ -100,8 +101,8 @@ const AdoptMethodologyForm = ({ methodologies, onCancel, onSubmit }: Props) => {
           <Button type="submit">Save</Button>
           <ButtonText onClick={onCancel}>Cancel</ButtonText>
         </ButtonGroup>
-      </Form>
-    </Formik>
+      </RHFForm>
+    </FormProvider>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesAddForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesAddForm.tsx
@@ -1,0 +1,48 @@
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import RHFFormFieldTextArea from '@common/components/form/rhf/RHFFormFieldTextArea';
+import Yup from '@common/validation/yup';
+import React, { useMemo } from 'react';
+import { ObjectSchema } from 'yup';
+
+interface FormValues {
+  content: string;
+}
+
+interface Props {
+  onCancel: () => void;
+  onSubmit: (values: FormValues) => void;
+}
+
+export default function MethodologyNotesAddForm({ onCancel, onSubmit }: Props) {
+  const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
+    return Yup.object({
+      content: Yup.string().required('Methodology note must be provided'),
+    });
+  }, []);
+
+  return (
+    <FormProvider
+      enableReinitialize
+      initialValues={{ content: '' }}
+      validationSchema={validationSchema}
+    >
+      <RHFForm id="createMethodologyNoteForm" onSubmit={onSubmit}>
+        <RHFFormFieldTextArea<FormValues>
+          label="New methodology note"
+          name="content"
+          rows={3}
+        />
+
+        <ButtonGroup>
+          <Button type="submit">Save note</Button>
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+        </ButtonGroup>
+      </RHFForm>
+    </FormProvider>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesEditForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesEditForm.tsx
@@ -1,0 +1,63 @@
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import RHFFormFieldDateInput from '@common/components/form/rhf/RHFFormFieldDateInput';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import RHFFormFieldTextArea from '@common/components/form/rhf/RHFFormFieldTextArea';
+import Yup from '@common/validation/yup';
+import React, { useMemo } from 'react';
+import { ObjectSchema } from 'yup';
+
+interface FormValues {
+  id: string;
+  content: string;
+  displayDate: Date;
+}
+
+interface Props {
+  initialValues: FormValues;
+  onCancel: () => void;
+  onSubmit: (values: FormValues) => void;
+}
+
+export default function MethodologyNotesEditForm({
+  initialValues,
+  onCancel,
+  onSubmit,
+}: Props) {
+  const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
+    return Yup.object({
+      id: Yup.string().required(),
+      displayDate: Yup.date().required('Enter a valid edit date'),
+      content: Yup.string().required('Methodology note must be provided'),
+    });
+  }, []);
+
+  return (
+    <FormProvider
+      enableReinitialize
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+    >
+      <RHFForm id="editMethodologyNoteForm" onSubmit={onSubmit}>
+        <RHFFormFieldDateInput<FormValues>
+          name="displayDate"
+          legend="Edit date"
+          legendSize="s"
+        />
+        <RHFFormFieldTextArea<FormValues>
+          label="Edit methodology note"
+          name="content"
+          rows={3}
+        />
+
+        <ButtonGroup>
+          <Button type="submit">Update note</Button>
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+        </ButtonGroup>
+      </RHFForm>
+    </FormProvider>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusEditPage.tsx
@@ -1,26 +1,20 @@
 import methodologyService, {
   MethodologyVersion,
-  MethodologyApprovalStatus,
 } from '@admin/services/methodologyService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
-import MethodologyStatusForm from '@admin/pages/methodology/edit-methodology/status/components/MethodologyStatusForm';
+import MethodologyStatusForm, {
+  MethodologyStatusFormValues,
+} from '@admin/pages/methodology/edit-methodology/status/components/MethodologyStatusForm';
 import React from 'react';
 import { MethodologyStatusPermissions } from '@admin/services/permissionService';
-
-interface FormValues {
-  status: MethodologyApprovalStatus;
-  latestInternalReleaseNote: string;
-  publishingStrategy?: 'WithRelease' | 'Immediately';
-  withReleaseId?: string;
-}
 
 interface Props {
   methodology: MethodologyVersion;
   statusPermissions?: MethodologyStatusPermissions;
   onCancel: () => void;
-  onSubmit: (values: FormValues) => void;
+  onSubmit: (values: MethodologyStatusFormValues) => void;
 }
 
 const MethodologyStatusEditPage = ({

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -1,8 +1,6 @@
 import StatusBlock from '@admin/components/StatusBlock';
 import { useConfig } from '@admin/contexts/ConfigContext';
-import methodologyService, {
-  MethodologyApprovalStatus,
-} from '@admin/services/methodologyService';
+import methodologyService from '@admin/services/methodologyService';
 import Button from '@common/components/Button';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
@@ -12,19 +10,13 @@ import { useMethodologyContext } from '@admin/pages/methodology/contexts/Methodo
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import MethodologyStatusEditPage from '@admin/pages/methodology/edit-methodology/status/MethodologyStatusEditPage';
+import { MethodologyStatusFormValues } from '@admin/pages/methodology/edit-methodology/status/components/MethodologyStatusForm';
 import React from 'react';
 import UrlContainer from '@common/components/UrlContainer';
 import FormattedDate from '@common/components/FormattedDate';
 import { useQuery } from '@tanstack/react-query';
 import methodologyQueries from '@admin/queries/methodologyQueries';
 import permissionQueries from '@admin/queries/permissionQueries';
-
-interface FormValues {
-  status: MethodologyApprovalStatus;
-  latestInternalReleaseNote: string;
-  publishingStrategy?: 'WithRelease' | 'Immediately';
-  withReleaseId?: string;
-}
 
 const statusMap: Dictionary<string> = {
   Draft: 'In Draft',
@@ -59,7 +51,7 @@ const MethodologyStatusPage = () => {
     publishingStrategy,
     status,
     withReleaseId,
-  }: FormValues) => {
+  }: MethodologyStatusFormValues) => {
     if (!currentMethodology) {
       return;
     }

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodologyStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodologyStatusForm.tsx
@@ -2,6 +2,7 @@ import {
   MethodologyVersion,
   MethodologyPublishingStrategy,
   MethodologyApprovalStatus,
+  UpdateMethodology,
 } from '@admin/services/methodologyService';
 import { MethodologyStatusPermissions } from '@admin/services/permissionService';
 import { IdTitlePair } from '@admin/services/types/common';
@@ -18,12 +19,7 @@ import Yup from '@common/validation/yup';
 import React, { useMemo } from 'react';
 import { ObjectSchema } from 'yup';
 
-export interface FormValues {
-  status: MethodologyApprovalStatus;
-  latestInternalReleaseNote?: string;
-  publishingStrategy?: MethodologyPublishingStrategy;
-  withReleaseId?: string;
-}
+export type MethodologyStatusFormValues = Omit<UpdateMethodology, 'title'>;
 
 interface Props {
   isPublished?: string;
@@ -31,7 +27,7 @@ interface Props {
   statusPermissions?: MethodologyStatusPermissions;
   unpublishedReleases: IdTitlePair[];
   onCancel: () => void;
-  onSubmit: (values: FormValues) => void;
+  onSubmit: (values: MethodologyStatusFormValues) => void;
 }
 
 const MethodologyStatusForm = ({
@@ -42,7 +38,9 @@ const MethodologyStatusForm = ({
   onCancel,
   onSubmit,
 }: Props) => {
-  const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
+  const validationSchema = useMemo<
+    ObjectSchema<MethodologyStatusFormValues>
+  >(() => {
     return Yup.object({
       status: Yup.string()
         .oneOf<MethodologyApprovalStatus>([
@@ -85,7 +83,7 @@ const MethodologyStatusForm = ({
           <RHFForm id="methodologyStatusForm" onSubmit={onSubmit}>
             <h2>Edit methodology status</h2>
 
-            <RHFFormFieldRadioGroup<FormValues>
+            <RHFFormFieldRadioGroup<MethodologyStatusFormValues>
               legend="Status"
               hint={
                 isPublished &&
@@ -111,7 +109,7 @@ const MethodologyStatusForm = ({
               ]}
               order={[]}
             />
-            <RHFFormFieldTextArea<FormValues>
+            <RHFFormFieldTextArea<MethodologyStatusFormValues>
               name="latestInternalReleaseNote"
               className="govuk-!-width-one-half"
               label="Internal note"
@@ -119,7 +117,7 @@ const MethodologyStatusForm = ({
               rows={2}
             />
             {status === 'Approved' && (
-              <RHFFormFieldRadioGroup<FormValues>
+              <RHFFormFieldRadioGroup<MethodologyStatusFormValues>
                 name="publishingStrategy"
                 legend="When to publish"
                 legendSize="m"
@@ -130,7 +128,7 @@ const MethodologyStatusForm = ({
                     label: 'With a specific release',
                     value: 'WithRelease',
                     conditional: (
-                      <RHFFormFieldSelect<FormValues>
+                      <RHFFormFieldSelect<MethodologyStatusFormValues>
                         label="Select release"
                         name="withReleaseId"
                         order={FormSelect.unordered}

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
@@ -1,5 +1,5 @@
 import MethodologyStatusForm, {
-  FormValues,
+  MethodologyStatusFormValues,
 } from '@admin/pages/methodology/edit-methodology/status/components/MethodologyStatusForm';
 import { IdTitlePair } from '@admin/services/types/common';
 import { render, screen, waitFor, within } from '@testing-library/react';
@@ -305,7 +305,7 @@ describe('MethodologyStatusForm', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Update status' }));
 
-    const expectedValues: FormValues = {
+    const expectedValues: MethodologyStatusFormValues = {
       latestInternalReleaseNote: 'Test release note',
       status: 'Approved',
       publishingStrategy: 'WithRelease',

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
@@ -313,10 +313,7 @@ describe('MethodologyStatusForm', () => {
     };
 
     await waitFor(() => {
-      expect(handleSubmit).toHaveBeenCalledWith(
-        expectedValues,
-        expect.anything(),
-      );
+      expect(handleSubmit).toHaveBeenCalledWith(expectedValues);
     });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/components/ExternalMethodologyForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/components/ExternalMethodologyForm.tsx
@@ -1,12 +1,12 @@
 import { FormFieldset, FormGroup } from '@common/components/form';
-import Form from '@common/components/form/Form';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
 import ButtonGroup from '@common/components/ButtonGroup';
 import Button from '@common/components/Button';
-import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import { ExternalMethodology } from '@admin/services/publicationService';
 import Yup from '@common/validation/yup';
-import { Formik } from 'formik';
 import React, { useMemo } from 'react';
+import RHFFormFieldTextInput from '@common/components/form/rhf/RHFFormFieldTextInput';
 
 interface Props {
   initialValues?: ExternalMethodology;
@@ -41,7 +41,7 @@ const ExternalMethodologyForm = ({
   }, []);
 
   return (
-    <Formik<ExternalMethodology>
+    <FormProvider
       enableReinitialize
       initialValues={
         initialValues ?? {
@@ -49,47 +49,41 @@ const ExternalMethodologyForm = ({
           url: 'https://',
         }
       }
-      onSubmit={values => {
-        onSubmit(values);
-      }}
       validationSchema={validationSchema}
     >
-      {form => (
-        <Form id="methodology-external">
-          <FormFieldset
-            id="methodology-external-fieldset"
-            legend="Link to an externally hosted methodology"
-            legendHidden
-          >
-            <FormGroup>
-              <FormFieldTextInput
-                label="Link title"
-                name="title"
-                className="govuk-!-width-two-thirds"
-              />
-              <FormFieldTextInput
-                label="URL"
-                name="url"
-                className="govuk-!-width-two-thirds"
-              />
-            </FormGroup>
-            <ButtonGroup>
-              <Button type="submit">Save</Button>
-              <Button
-                type="reset"
-                variant="secondary"
-                onClick={() => {
-                  form.resetForm();
-                  onCancel();
-                }}
-              >
-                Cancel
-              </Button>
-            </ButtonGroup>
-          </FormFieldset>
-        </Form>
-      )}
-    </Formik>
+      <RHFForm id="methodology-external" onSubmit={onSubmit}>
+        <FormFieldset
+          id="methodology-external-fieldset"
+          legend="Link to an externally hosted methodology"
+          legendHidden
+        >
+          <FormGroup>
+            <RHFFormFieldTextInput
+              label="Link title"
+              name="title"
+              className="govuk-!-width-two-thirds"
+            />
+            <RHFFormFieldTextInput
+              label="URL"
+              name="url"
+              className="govuk-!-width-two-thirds"
+            />
+          </FormGroup>
+          <ButtonGroup>
+            <Button type="submit">Save</Button>
+            <Button
+              type="reset"
+              variant="secondary"
+              onClick={() => {
+                onCancel();
+              }}
+            >
+              Cancel
+            </Button>
+          </ButtonGroup>
+        </FormFieldset>
+      </RHFForm>
+    </FormProvider>
   );
 };
 

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldDateInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldDateInput.tsx
@@ -1,0 +1,160 @@
+import { useFormIdContext } from '@common/components/form/contexts/FormIdContext';
+import FormFieldset from '@common/components/form/FormFieldset';
+import FormNumberInput from '@common/components/form/FormNumberInput';
+import { FormGroup } from '@common/components/form/index';
+import { PartialDate } from '@common/utils/date/partialDate';
+import parseNumber from '@common/utils/number/parseNumber';
+import { isValid, parse } from 'date-fns';
+import last from 'lodash/last';
+import React, { ChangeEvent, useCallback, useState } from 'react';
+import {
+  FieldValues,
+  Path,
+  PathValue,
+  useFormContext,
+  useWatch,
+} from 'react-hook-form';
+import getErrorMessage from './util/getErrorMessage';
+
+interface Props<TFormValues> {
+  hint?: string;
+  id?: string;
+  legend: string;
+  legendSize?: 'xl' | 'l' | 'm' | 's';
+  name: Path<TFormValues>;
+  partialDateType?: 'dayMonthYear' | 'monthYear';
+  showError?: boolean;
+  type?: 'date' | 'partialDate';
+}
+
+export default function RHFFormFieldDateInput<TFormValues extends FieldValues>({
+  id: customId,
+  name,
+  showError = true,
+  hint,
+  legend,
+  legendSize = 'l',
+  partialDateType = 'dayMonthYear',
+  type = 'date',
+}: Props<TFormValues>) {
+  const { fieldId } = useFormIdContext();
+  const id = fieldId(name as string, customId);
+
+  const {
+    formState: { errors },
+    setValue,
+    trigger,
+  } = useFormContext<TFormValues>();
+
+  const value = useWatch({ name });
+
+  const [values, setValues] = useState<Partial<PartialDate>>(() => {
+    const dateValue = value as Date;
+    if (value && typeof dateValue.getDate === 'function') {
+      return {
+        day: dateValue.getDate(),
+        month:
+          typeof dateValue.getMonth() === 'number'
+            ? dateValue.getMonth() + 1
+            : undefined,
+        year: dateValue.getFullYear(),
+      };
+    }
+
+    const partialDateValue = value as PartialDate;
+
+    return {
+      day: partialDateValue?.day,
+      month: partialDateValue?.month,
+      year: partialDateValue?.year,
+    };
+  });
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const key = last(event.target.name.split('.')) as keyof PartialDate;
+
+      if (!['day', 'month', 'year'].includes(key)) {
+        throw new Error(`Invalid key for day/month/year field: ${key}`);
+      }
+
+      const inputValue = parseNumber(event.target.value);
+
+      const day = key === 'day' ? inputValue : values.day;
+      const month = key === 'month' ? inputValue : values.month;
+      const year = key === 'year' ? inputValue : values.year;
+
+      if (type === 'date') {
+        const date = parse(`${year}-${month}-${day}Z`, 'yyyy-M-dX', new Date());
+
+        const newDateValue = isValid(date) ? date : undefined;
+
+        setValue(
+          name,
+          newDateValue as PathValue<TFormValues, Path<TFormValues>>,
+          { shouldTouch: true },
+        );
+      } else {
+        setValue(
+          name,
+          { day, month, year } as PathValue<TFormValues, Path<TFormValues>>,
+          { shouldTouch: true },
+        );
+      }
+
+      setValues({
+        ...values,
+        [key]: inputValue,
+      });
+
+      trigger(name);
+    },
+    [name, setValue, trigger, type, values],
+  );
+
+  return (
+    <FormFieldset
+      id={id}
+      legend={legend}
+      legendSize={legendSize}
+      hint={hint}
+      error={getErrorMessage(errors, name, showError)}
+      useFormId={false}
+    >
+      {(partialDateType === 'dayMonthYear' || type === 'date') && (
+        <FormGroup className="govuk-date-input__item">
+          <FormNumberInput
+            id={`${id}-day`}
+            name={`${name as string}.day`}
+            label="Day"
+            width={2}
+            value={parseNumber(values.day)}
+            onChange={handleChange}
+          />
+        </FormGroup>
+      )}
+
+      <FormGroup className="govuk-date-input__item">
+        <FormNumberInput
+          id={`${id}-month`}
+          name={`${name as string}.month`}
+          label="Month"
+          width={2}
+          value={parseNumber(values.month)}
+          onChange={handleChange}
+        />
+      </FormGroup>
+
+      <FormGroup className="govuk-date-input__item">
+        <FormNumberInput
+          id={`${id}-year`}
+          name={`${name as string}.year`}
+          label="Year"
+          width={4}
+          value={parseNumber(values.year)}
+          onChange={handleChange}
+        />
+      </FormGroup>
+    </FormFieldset>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldRadioSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldRadioSearchGroup.tsx
@@ -1,0 +1,46 @@
+import FormRadioSearchGroup, {
+  FormRadioSearchGroupProps,
+} from '@common/components/form/FormRadioSearchGroup';
+import { useFormIdContext } from '@common/components/form/contexts/FormIdContext';
+import useRegister from '@common/components/form/rhf/hooks/useRegister';
+import React from 'react';
+import { FieldValues, Path, useFormContext, useWatch } from 'react-hook-form';
+
+export interface RHFFormFieldRadioSearchGroupProps<
+  TFormValues extends FieldValues,
+> extends Omit<FormRadioSearchGroupProps, 'name' | 'value' | 'id'> {
+  name: Path<TFormValues>;
+  id?: string;
+  showError?: boolean;
+}
+
+export default function RHFFormFieldRadioSearchGroup<
+  TFormValues extends FieldValues,
+>({
+  name,
+  id: customId,
+  ...props
+}: RHFFormFieldRadioSearchGroupProps<TFormValues>) {
+  const { register } = useFormContext<TFormValues>();
+  const { ref: inputRef, ...field } = useRegister(name, register);
+  const { fieldId } = useFormIdContext();
+  const id = fieldId(name, customId);
+  const selectedValue = useWatch({ name });
+  const { onChange } = props;
+
+  return (
+    <FormRadioSearchGroup
+      {...props}
+      {...field}
+      id={id}
+      inputRef={inputRef}
+      value={selectedValue}
+      onChange={(event, option) => {
+        onChange?.(event, option);
+        if (!event.isDefaultPrevented()) {
+          field.onChange(event);
+        }
+      }}
+    />
+  );
+}

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldDateInput.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldDateInput.test.tsx
@@ -1,0 +1,494 @@
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import RHFFormFieldDateInput from '@common/components/form/rhf/RHFFormFieldDateInput';
+import { PartialDate } from '@common/utils/date/partialDate';
+import Yup from '@common/validation/yup';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import React from 'react';
+
+describe('RHFFormFieldDateInput', () => {
+  test('renders correctly', () => {
+    const { container } = render(
+      <FormProvider initialValues={{}}>
+        <RHFFormFieldDateInput
+          legend="Start date"
+          id="startDate"
+          name="startDate"
+        />
+      </FormProvider>,
+    );
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders an error message correctly', async () => {
+    render(
+      <FormProvider
+        initialValues={{}}
+        validationSchema={Yup.object({
+          startDate: Yup.date().required('Select a date'),
+        })}
+      >
+        <RHFFormFieldDateInput
+          legend="Start date"
+          id="startDate"
+          name="startDate"
+        />
+      </FormProvider>,
+    );
+
+    userEvent.tab();
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Select a date')).toHaveAttribute(
+        'id',
+        'startDate-error',
+      );
+    });
+
+    expect(screen.getByRole('group')).toHaveAttribute(
+      'aria-describedby',
+      'startDate-error',
+    );
+  });
+
+  test('renders with a hint correctly', () => {
+    render(
+      <FormProvider initialValues={{}}>
+        <RHFFormFieldDateInput
+          legend="Start date"
+          hint="Test hint"
+          id="startDate"
+          name="startDate"
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute(
+      'aria-describedby',
+      'startDate-hint',
+    );
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'startDate-hint',
+    );
+  });
+
+  test('renders with correct defaults ids with form', async () => {
+    render(
+      <FormProvider
+        initialValues={{}}
+        validationSchema={Yup.object({
+          startDate: Yup.date().required('Select a date'),
+        })}
+      >
+        <RHFForm id="testForm" onSubmit={noop}>
+          <RHFFormFieldDateInput
+            legend="Start date"
+            hint="Test hint"
+            name="startDate"
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    const group = within(screen.getByRole('group'));
+
+    expect(group.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-startDate-hint',
+    );
+
+    expect(group.getByLabelText('Day')).toHaveAttribute(
+      'id',
+      'testForm-startDate-day',
+    );
+    expect(group.getByLabelText('Month')).toHaveAttribute(
+      'id',
+      'testForm-startDate-month',
+    );
+    expect(group.getByLabelText('Year')).toHaveAttribute(
+      'id',
+      'testForm-startDate-year',
+    );
+
+    userEvent.tab();
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(group.getByText('Select a date')).toHaveAttribute(
+        'id',
+        'testForm-startDate-error',
+      );
+    });
+  });
+
+  test('renders with correct defaults ids without form', async () => {
+    render(
+      <FormProvider
+        initialValues={{}}
+        validationSchema={Yup.object({
+          startDate: Yup.date().required('Select a date'),
+        })}
+      >
+        <RHFFormFieldDateInput
+          legend="Start date"
+          hint="Test hint"
+          name="startDate"
+        />
+      </FormProvider>,
+    );
+
+    const group = within(screen.getByRole('group'));
+
+    expect(group.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'startDate-hint',
+    );
+
+    expect(group.getByLabelText('Day')).toHaveAttribute('id', 'startDate-day');
+    expect(group.getByLabelText('Month')).toHaveAttribute(
+      'id',
+      'startDate-month',
+    );
+    expect(group.getByLabelText('Year')).toHaveAttribute(
+      'id',
+      'startDate-year',
+    );
+
+    userEvent.tab();
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(group.getByText('Select a date')).toHaveAttribute(
+        'id',
+        'startDate-error',
+      );
+    });
+  });
+
+  test('renders with correct custom ids with form', async () => {
+    render(
+      <FormProvider
+        initialValues={{}}
+        validationSchema={Yup.object({
+          startDate: Yup.date().required('Select a date'),
+        })}
+      >
+        <RHFForm id="testForm" onSubmit={noop}>
+          <RHFFormFieldDateInput
+            legend="Start date"
+            hint="Test hint"
+            name="startDate"
+            id="customId"
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    const group = within(screen.getByRole('group'));
+
+    expect(group.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-customId-hint',
+    );
+
+    expect(group.getByLabelText('Day')).toHaveAttribute(
+      'id',
+      'testForm-customId-day',
+    );
+    expect(group.getByLabelText('Month')).toHaveAttribute(
+      'id',
+      'testForm-customId-month',
+    );
+    expect(group.getByLabelText('Year')).toHaveAttribute(
+      'id',
+      'testForm-customId-year',
+    );
+
+    userEvent.tab();
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(group.getByText('Select a date')).toHaveAttribute(
+        'id',
+        'testForm-customId-error',
+      );
+    });
+  });
+
+  test('renders with correct custom ids without form', async () => {
+    render(
+      <FormProvider
+        initialValues={{}}
+        validationSchema={Yup.object({
+          startDate: Yup.date().required('Select a date'),
+        })}
+      >
+        <RHFFormFieldDateInput
+          legend="Start date"
+          hint="Test hint"
+          name="startDate"
+          id="customId"
+        />
+      </FormProvider>,
+    );
+
+    const group = within(screen.getByRole('group'));
+
+    expect(group.getByLabelText('Day')).toHaveAttribute('id', 'customId-day');
+    expect(group.getByLabelText('Month')).toHaveAttribute(
+      'id',
+      'customId-month',
+    );
+    expect(group.getByLabelText('Year')).toHaveAttribute('id', 'customId-year');
+
+    userEvent.tab();
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(group.getByText('Select a date')).toHaveAttribute(
+        'id',
+        'customId-error',
+      );
+    });
+  });
+
+  test('sets a valid UTC date as a form value', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <FormProvider<{ startDate?: Date }> initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={handleSubmit}>
+          <RHFFormFieldDateInput
+            legend="Start date"
+            id="startDate"
+            name="startDate"
+          />
+          <button type="submit">Submit</button>
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    await userEvent.type(screen.getByLabelText('Day'), '10');
+    await userEvent.type(screen.getByLabelText('Month'), '12');
+    await userEvent.type(screen.getByLabelText('Year'), '2020');
+
+    expect(screen.getByLabelText('Day')).toHaveValue(10);
+    expect(screen.getByLabelText('Month')).toHaveValue(12);
+    expect(screen.getByLabelText('Year')).toHaveValue(2020);
+
+    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        startDate: new Date('2020-12-10T00:00:00.000Z'),
+      });
+    });
+  });
+
+  test('does not set an invalid date as a form value', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <FormProvider<{ startDate?: Date }> initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={handleSubmit}>
+          <RHFFormFieldDateInput
+            legend="Start date"
+            id="startDate"
+            name="startDate"
+          />
+          <button type="submit">Submit</button>
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    await userEvent.type(screen.getByLabelText('Day'), '32');
+    await userEvent.type(screen.getByLabelText('Month'), '12');
+    await userEvent.type(screen.getByLabelText('Year'), '2020');
+
+    expect(screen.getByLabelText('Day')).toHaveValue(32);
+    expect(screen.getByLabelText('Month')).toHaveValue(12);
+    expect(screen.getByLabelText('Year')).toHaveValue(2020);
+
+    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({ startDate: undefined });
+    });
+  });
+
+  test('does not set a partial date as a form value', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <FormProvider<{ startDate?: Date }> initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={handleSubmit}>
+          <RHFFormFieldDateInput
+            legend="Start date"
+            id="startDate"
+            name="startDate"
+          />
+          <button type="submit">Submit</button>
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    await userEvent.type(screen.getByLabelText('Day'), '10');
+
+    expect(screen.getByLabelText('Day')).toHaveValue(10);
+
+    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({ startDate: undefined });
+    });
+  });
+
+  test('can hide day field when `type = partialDate` and `partialDateType = monthYear`', () => {
+    render(
+      <FormProvider<{ startDate?: PartialDate }> initialValues={{}}>
+        <RHFFormFieldDateInput
+          legend="Start date"
+          id="startDate"
+          name="startDate"
+          type="partialDate"
+          partialDateType="monthYear"
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.queryByLabelText('Day')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Month')).toBeInTheDocument();
+    expect(screen.getByLabelText('Year')).toBeInTheDocument();
+  });
+
+  test('does not hide day field when `type = date` and `partialDateType = monthYear`', () => {
+    render(
+      <FormProvider<{ startDate?: PartialDate }> initialValues={{}}>
+        <RHFFormFieldDateInput
+          legend="Start date"
+          id="startDate"
+          name="startDate"
+          type="date"
+          partialDateType="monthYear"
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Day')).toBeInTheDocument();
+    expect(screen.getByLabelText('Month')).toBeInTheDocument();
+    expect(screen.getByLabelText('Year')).toBeInTheDocument();
+  });
+
+  test('can set a full PartialDate as a form value when `type = partialDate`', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <FormProvider<{ startDate?: PartialDate }> initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={handleSubmit}>
+          <RHFFormFieldDateInput
+            legend="Start date"
+            id="startDate"
+            name="startDate"
+            type="partialDate"
+          />
+          <button type="submit">Submit</button>
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    await userEvent.type(screen.getByLabelText('Day'), '15');
+    await userEvent.type(screen.getByLabelText('Month'), '6');
+    await userEvent.type(screen.getByLabelText('Year'), '2020');
+
+    expect(screen.getByLabelText('Day')).toHaveValue(15);
+    expect(screen.getByLabelText('Month')).toHaveValue(6);
+    expect(screen.getByLabelText('Year')).toHaveValue(2020);
+
+    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        startDate: {
+          day: 15,
+          month: 6,
+          year: 2020,
+        },
+      });
+    });
+  });
+
+  test('can set only a day for a form value when `type = partialDate`', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <FormProvider<{ startDate?: PartialDate }> initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={handleSubmit}>
+          <RHFFormFieldDateInput
+            legend="Start date"
+            id="startDate"
+            name="startDate"
+            type="partialDate"
+          />{' '}
+          <button type="submit">Submit</button>
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    await userEvent.type(screen.getByLabelText('Day'), '15');
+
+    expect(screen.getByLabelText('Day')).toHaveValue(15);
+
+    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        startDate: {
+          day: 15,
+        },
+      });
+    });
+  });
+
+  test('can set an invalid PartialDate as a form value when `type = partialDate`', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <FormProvider<{ startDate?: PartialDate }> initialValues={{}}>
+        <RHFForm id="testForm" onSubmit={handleSubmit}>
+          <RHFFormFieldDateInput
+            legend="Start date"
+            id="startDate"
+            name="startDate"
+            type="partialDate"
+          />{' '}
+          <button type="submit">Submit</button>
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    await userEvent.type(screen.getByLabelText('Day'), '32');
+    await userEvent.type(screen.getByLabelText('Month'), '6');
+    await userEvent.type(screen.getByLabelText('Year'), '2020');
+
+    expect(screen.getByLabelText('Day')).toHaveValue(32);
+    expect(screen.getByLabelText('Month')).toHaveValue(6);
+    expect(screen.getByLabelText('Year')).toHaveValue(2020);
+
+    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        startDate: {
+          day: 32,
+          month: 6,
+          year: 2020,
+        },
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldRadioSearchGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldRadioSearchGroup.test.tsx
@@ -1,0 +1,364 @@
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import RHFFormFieldRadioSearchGroup from '@common/components/form/rhf/RHFFormFieldRadioSearchGroup';
+import Yup from '@common/validation/yup';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import noop from 'lodash/noop';
+import React from 'react';
+
+jest.mock('lodash/debounce');
+
+describe('RHFFormFieldRadioSearchGroup', () => {
+  test('renders with correctly without form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: '',
+        }}
+      >
+        <RHFFormFieldRadioSearchGroup
+          id="test-group"
+          name="test"
+          legend="Test radios"
+          options={[
+            { value: '1', label: 'Radio 1' },
+            { value: '2', label: 'Radio 2' },
+            { value: '3', label: 'Radio 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'test-group');
+    expect(screen.getByLabelText('Radio 1')).toHaveAttribute(
+      'id',
+      'test-group-1',
+    );
+    expect(screen.getByLabelText('Radio 2')).toHaveAttribute(
+      'id',
+      'test-group-2',
+    );
+    expect(screen.getByLabelText('Radio 3')).toHaveAttribute(
+      'id',
+      'test-group-3',
+    );
+  });
+
+  test('renders with correctly with form', () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: '',
+        }}
+      >
+        <RHFForm id="testForm" onSubmit={noop}>
+          <RHFFormFieldRadioSearchGroup
+            id="test-group"
+            name="test"
+            legend="Test radios"
+            options={[
+              { value: '1', label: 'Radio 1' },
+              { value: '2', label: 'Radio 2' },
+              { value: '3', label: 'Radio 3' },
+            ]}
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute(
+      'id',
+      'testForm-test-group',
+    );
+    expect(screen.getByLabelText('Radio 1')).toHaveAttribute(
+      'id',
+      'testForm-test-group-1',
+    );
+    expect(screen.getByLabelText('Radio 2')).toHaveAttribute(
+      'id',
+      'testForm-test-group-2',
+    );
+    expect(screen.getByLabelText('Radio 3')).toHaveAttribute(
+      'id',
+      'testForm-test-group-3',
+    );
+  });
+
+  test('checking an option checks it', async () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: '',
+        }}
+      >
+        <RHFFormFieldRadioSearchGroup
+          id="test-group"
+          name="test"
+          legend="Test radios"
+          options={[
+            { id: 'radio-1', value: '1', label: 'Radio 1' },
+            { id: 'radio-2', value: '2', label: 'Radio 2' },
+            { id: 'radio-3', value: '3', label: 'Radio 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const radio = screen.getByLabelText('Radio 1') as HTMLInputElement;
+
+    expect(radio.checked).toBe(false);
+
+    userEvent.click(radio);
+
+    expect(radio.checked).toBe(true);
+  });
+
+  test('checking another option un-checks the currently checked option', async () => {
+    render(
+      <FormProvider
+        initialValues={{
+          test: '1',
+        }}
+      >
+        <RHFFormFieldRadioSearchGroup
+          id="test-group"
+          name="test"
+          legend="Test radios"
+          options={[
+            { id: 'radio-1', value: '1', label: 'Radio 1' },
+            { id: 'radio-2', value: '2', label: 'Radio 2' },
+            { id: 'radio-3', value: '3', label: 'Radio 3' },
+          ]}
+        />
+      </FormProvider>,
+    );
+
+    const radio1 = screen.getByLabelText('Radio 1') as HTMLInputElement;
+    const radio2 = screen.getByLabelText('Radio 2') as HTMLInputElement;
+    const radio3 = screen.getByLabelText('Radio 3') as HTMLInputElement;
+
+    expect(radio1.checked).toBe(true);
+    expect(radio2.checked).toBe(false);
+    expect(radio3.checked).toBe(false);
+
+    userEvent.click(radio2);
+
+    expect(radio1.checked).toBe(false);
+    expect(radio2.checked).toBe(true);
+    expect(radio3.checked).toBe(false);
+  });
+
+  describe('error messages', () => {
+    test('displays validation message when form is submitted', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: '',
+          }}
+          validationSchema={Yup.object({
+            test: Yup.string().required('Select an option'),
+          })}
+        >
+          <RHFForm id="testForm" onSubmit={noop}>
+            <RHFFormFieldRadioSearchGroup
+              id="test-group"
+              name="test"
+              legend="Test radios"
+              options={[
+                { id: 'radio-1', value: '1', label: 'Radio 1' },
+                { id: 'radio-2', value: '2', label: 'Radio 2' },
+                { id: 'radio-3', value: '3', label: 'Radio 3' },
+              ]}
+            />
+
+            <button type="submit">Submit</button>
+          </RHFForm>
+        </FormProvider>,
+      );
+
+      expect(screen.queryByText('Select an option')).toBeNull();
+
+      userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Select an option')).toBeInTheDocument();
+      });
+    });
+
+    test('displays validation message when radios have been touched', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: '',
+          }}
+          validationSchema={Yup.object({
+            test: Yup.string().required('Select an option'),
+          })}
+        >
+          <RHFForm id="testForm" onSubmit={noop}>
+            <RHFFormFieldRadioSearchGroup
+              id="test-group"
+              name="test"
+              legend="Test radios"
+              options={[
+                { id: 'radio-1', value: '1', label: 'Radio 1' },
+                { id: 'radio-2', value: '2', label: 'Radio 2' },
+                { id: 'radio-3', value: '3', label: 'Radio 3' },
+              ]}
+            />
+          </RHFForm>
+        </FormProvider>,
+      );
+
+      userEvent.tab();
+      userEvent.tab();
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(screen.getByText('Select an option')).toBeInTheDocument();
+      });
+    });
+
+    test('does not display validation message when radios are untouched', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: '',
+          }}
+          validationSchema={Yup.object({
+            test: Yup.string().required('Select an option'),
+          })}
+        >
+          <RHFFormFieldRadioSearchGroup
+            id="test-group"
+            name="test"
+            legend="Test radios"
+            options={[
+              { id: 'radio-1', value: '1', label: 'Radio 1' },
+              { id: 'radio-2', value: '2', label: 'Radio 2' },
+              { id: 'radio-3', value: '3', label: 'Radio 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      expect(screen.queryByText('Select an option')).toBeNull();
+    });
+
+    test('does not display validation message when `showError` is false', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: '',
+          }}
+          validationSchema={Yup.object({
+            test: Yup.string().required('Select an option'),
+          })}
+        >
+          <RHFForm id="testForm" onSubmit={noop}>
+            <RHFFormFieldRadioSearchGroup
+              id="test-group"
+              name="test"
+              legend="Test radios"
+              showError={false}
+              options={[
+                { id: 'radio-1', value: '1', label: 'Radio 1' },
+                { id: 'radio-2', value: '2', label: 'Radio 2' },
+                { id: 'radio-3', value: '3', label: 'Radio 3' },
+              ]}
+            />
+
+            <button type="submit">Submit</button>
+          </RHFForm>
+        </FormProvider>,
+      );
+
+      const radio = screen.getByLabelText('Radio 1') as HTMLInputElement;
+
+      expect(radio.checked).toBe(false);
+      expect(screen.queryByText('Select an option')).toBeNull();
+
+      userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      expect(radio.checked).toBe(false);
+      expect(screen.queryByText('Select an option')).toBeNull();
+    });
+  });
+
+  describe('search', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    test('providing a search term filters the radios', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: '',
+          }}
+        >
+          <RHFFormFieldRadioSearchGroup
+            name="test"
+            id="test-group"
+            legend="Test radios"
+            options={[
+              { id: 'radio-1', value: '1', label: 'Radio 1' },
+              { id: 'radio-2', value: '2', label: 'Radio 2' },
+              { id: 'radio-3', value: '3', label: 'Radio 3' },
+              { id: 'radio-22', value: '22', label: 'Radio 22' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      const searchInput = screen.getByLabelText('Search') as HTMLInputElement;
+
+      await userEvent.type(searchInput, '2');
+
+      jest.runAllTimers();
+      const radios = screen.getAllByRole('radio');
+      expect(radios).toHaveLength(2);
+      expect(radios[0]).toHaveAttribute('value', '2');
+      expect(radios[1]).toHaveAttribute('value', '22');
+    });
+
+    test('providing a search term does not remove a radio that has already been checked', async () => {
+      render(
+        <FormProvider
+          initialValues={{
+            test: '',
+          }}
+        >
+          <RHFFormFieldRadioSearchGroup
+            name="test"
+            id="test-group"
+            legend="Test radios"
+            options={[
+              { id: 'radio-1', value: '1', label: 'Radio 1' },
+              { id: 'radio-2', value: '2', label: 'Radio 2' },
+              { id: 'radio-3', value: '3', label: 'Radio 3' },
+            ]}
+          />
+        </FormProvider>,
+      );
+
+      const searchInput = screen.getByLabelText('Search') as HTMLInputElement;
+
+      const radio1 = screen.getByLabelText('Radio 1') as HTMLInputElement;
+      const radio2 = screen.getByLabelText('Radio 2') as HTMLInputElement;
+
+      userEvent.click(radio1);
+      expect(radio1.checked).toBe(true);
+
+      await userEvent.type(searchInput, '2');
+
+      jest.runAllTimers();
+      expect(screen.getAllByRole('radio')).toHaveLength(2);
+      expect(radio1.checked).toBe(true);
+      expect(radio2.checked).toBe(false);
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/__snapshots__/RHFFormFieldDateInput.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/__snapshots__/RHFFormFieldDateInput.test.tsx.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RHFFormFieldDateInput renders correctly 1`] = `
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset"
+            id="startDate"
+  >
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      Start date
+    </legend>
+    <div class="govuk-form-group govuk-date-input__item">
+      <label class="govuk-label"
+             for="startDate-day"
+      >
+        Day
+      </label>
+      <input name="startDate.day"
+             class="govuk-input govuk-input--width-2"
+             id="startDate-day"
+             type="number"
+             value
+      >
+    </div>
+    <div class="govuk-form-group govuk-date-input__item">
+      <label class="govuk-label"
+             for="startDate-month"
+      >
+        Month
+      </label>
+      <input name="startDate.month"
+             class="govuk-input govuk-input--width-2"
+             id="startDate-month"
+             type="number"
+             value
+      >
+    </div>
+    <div class="govuk-form-group govuk-date-input__item">
+      <label class="govuk-label"
+             for="startDate-year"
+      >
+        Year
+      </label>
+      <input name="startDate.year"
+             class="govuk-input govuk-input--width-4"
+             id="startDate-year"
+             type="number"
+             value
+      >
+    </div>
+  </fieldset>
+</div>
+`;


### PR DESCRIPTION
Converts the following forms to React Hook Form:

- Adopt Methodology Form
- Add and Edit Methodology Notes Forms (these have been split out from the `MethodologyNotesSection` component)
- Edit Methodology Status Form
- Add External Methodology Form

Two new RHF form components have been added as part of this:
- RHFFormFieldDateInput
- RHFFormFieldRadioSearchGroup

The tests for these are duplicated from the Formik versions to make sure they have featured parity, but we could probably tidy these up later on as there's a lot of duplcation across the form component tests.