### PR TITLE
EES-4761 Update Azurite to 3.27.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   data-storage:
-    image: mcr.microsoft.com/azure-storage/azurite:3.24.0
+    image: mcr.microsoft.com/azure-storage/azurite:3.27.0
     ports:
       - "10000:10000"
       - "10001:10001"


### PR DESCRIPTION
This PR updates Azurite to 3.27.0. This is done to make it work with tables with newer versions of Azure Storage Explorer.

See https://github.com/microsoft/AzureStorageExplorer/issues/7485