### PR TITLE
EES-4227 Add file name length validation to file uploads

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
@@ -465,6 +465,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task ValidateDataArchiveEntriesForUpload_DataFilenameTooLong()
+        {
+            var (service, _) = BuildService();
+
+            var archiveFile = CreateDataArchiveFileMock("LoremipsumdolorsitametconsecteturadipiscingelitInsitametelitaccumsanbibendumlacusutmattismaurisCrasvehiculaaccumsaneratidelementumaugueposuereatNuncege.csv", "test.meta.csv").Object;
+
+            var result = await service.ValidateDataArchiveEntriesForUpload(Guid.NewGuid(),
+                archiveFile);
+
+            result.AssertBadRequest(DataFilenameTooLong);
+        }
+
+        [Fact]
+        public async Task ValidateDataArchiveEntriesForUpload_MetaFilenameTooLong()
+        {
+            var (service, _) = BuildService();
+
+            var archiveFile = CreateDataArchiveFileMock("test.csv", "LoremipsumdolorsitametconsecteturadipiscingelitInsitametelitaccumsanbibendumlacusutmattismaurisCrasvehiculaaccumsaneratidelementumaugueposuereatNuncege.meta.csv").Object;
+
+            var result = await service.ValidateDataArchiveEntriesForUpload(Guid.NewGuid(),
+                archiveFile);
+
+            result.AssertBadRequest(MetaFilenameTooLong);
+        }
+
+        [Fact]
         public async Task ValidateDataArchiveEntriesForUpload_DataFileIsEmpty()
         {
             var (service, _) = BuildService();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
 {
     public enum ValidationErrorMessages
@@ -61,11 +61,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         FileTypeMustBeData,
         FileIdsShouldBeDistinct,
         IncorrectNumberOfFileIds,
+        DataFilenameTooLong,
 
         // Data zip file
         DataZipMustBeZipFile,
         DataZipFileCanOnlyContainTwoFiles,
         DataZipFileDoesNotContainCsvFiles,
+        DataZipFilenameTooLong,
+        DataZipContentFilenamesTooLong,
 
         // Meta file
         MetadataFileCannotBeEmpty,
@@ -73,6 +76,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         UnableToFindMetadataFileToDelete,
         MetaFilenameCannotContainSpacesOrSpecialCharacters,
         MetaFileIsIncorrectlyNamed,
+        MetaFilenameTooLong,
 
         // Data replacement
         ReplacementMustBeValid,

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -23,6 +23,8 @@ export interface DataFileUploadFormValues {
   zipFile: File | null;
 }
 
+const MAX_FILENAME_SIZE = 150;
+
 function baseErrorMappings<FormValues extends DataFileUploadFormValues>(
   values: FormValues,
 ): FieldMessageMapper<FormValues>[] {
@@ -37,6 +39,10 @@ function baseErrorMappings<FormValues extends DataFileUploadFormValues>(
           DataZipFileDoesNotContainCsvFiles:
             'ZIP file does not contain any CSV files',
           DataFilenameNotUnique: 'Choose a unique ZIP data file name',
+          DataZipFilenameTooLong: `Maximum ZIP data filename cannot exceed ${MAX_FILENAME_SIZE} characters`,
+          DataFilenameTooLong: `Maximum data filename cannot exceed ${MAX_FILENAME_SIZE} characters`,
+          MetaFilenameTooLong: `Maximum metadata filename cannot exceed ${MAX_FILENAME_SIZE} characters`,
+          DataZipContentFilenamesTooLong: `Maximum data and metadata filenames cannot exceed ${MAX_FILENAME_SIZE} characters`,
           DataAndMetadataFilesCannotHaveTheSameName:
             'ZIP data and metadata filenames cannot be the same',
           DataFileCannotBeEmpty: 'Choose a ZIP data file that is not empty',
@@ -64,6 +70,7 @@ function baseErrorMappings<FormValues extends DataFileUploadFormValues>(
         DataFileMustBeCsvFile: 'Data file must be a CSV with UTF-8 encoding',
         DataFilenameCannotContainSpacesOrSpecialCharacters:
           'Data filename cannot contain spaces or special characters',
+        DataFilenameTooLong: `Maximum data filename cannot exceed ${MAX_FILENAME_SIZE} characters`,
       },
     }),
     mapFieldErrors<FormValues>({
@@ -75,6 +82,7 @@ function baseErrorMappings<FormValues extends DataFileUploadFormValues>(
         MetaFilenameCannotContainSpacesOrSpecialCharacters:
           'Metadata filename cannot contain spaces or special characters',
         MetaFileIsIncorrectlyNamed: 'Metadata filename is incorrectly named',
+        MetaFilenameTooLong: `Maximum metadata filename cannot exceed ${MAX_FILENAME_SIZE} characters`,
       },
     }),
   ];
@@ -183,6 +191,7 @@ export default function DataFileUploadForm<
             <FormFieldRadioGroup<DataFileUploadFormValues>
               name="uploadType"
               legend="Choose upload method"
+              hint={`Filenames must be under ${MAX_FILENAME_SIZE} characters in length`}
               options={[
                 {
                   label: 'CSV files',


### PR DESCRIPTION
Limit the number of characters file names can have when uploading individual files and archives, and provide feedback to the user if their files exceed this limit.

This protects end users from hitting errors from having file names that are too long, for example there have been examples in the past where users can’t unzip files as the path is too long.