### PR TITLE
EES-4730 Send release published notification emails to superseded pub…

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -325,6 +325,20 @@
         "description": "Gov UK Notify service template Id for amended release notification"
       }
     },
+    "releaseEmailSupersededSubscribersTemplateId": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Gov UK Notify service template Id for new release for superseded subscribers notification"
+      }
+    },
+    "releaseAmendmentEmailSupersededSubscribersTemplateId": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Gov UK Notify service template Id for amended release for superseded subscribers notification"
+      }
+    },
     "subscriptionConfirmationEmailTemplateId": {
       "type": "securestring",
       "defaultValue": "",
@@ -425,7 +439,7 @@
       "type": "string",
       "defaultValue": "Unknown",
       "metadata": {
-        "description": "Tag Value - Enter the name of the Service or Application Owner in the SURNAME, Firstname format e.g. SINCLAIR, Paul / SHELBY, Laura"
+        "description": "Tag Value - Enter the name of the Service or Application Owner in the SURNAME, Firstname format e.g. SINCLAIR, Paul / SELBY, Laura"
       }
     },
     "dateProvisioned": {
@@ -2896,6 +2910,8 @@
         "VerificationEmailTemplateId": "[parameters('verificationEmailTemplateId')]",
         "ReleaseEmailTemplateId": "[parameters('releaseEmailTemplateId')]",
         "ReleaseAmendmentEmailTemplateId": "[parameters('releaseAmendmentEmailTemplateId')]",
+        "ReleaseEmailSupersededSubscribersTemplateId": "[parameters('releaseEmailSupersededSubscribersTemplateId')]",
+        "ReleaseAmendmentEmailSupersededSubscribersTemplateId": "[parameters('releaseAmendmentEmailSupersededSubscribersTemplateId')]",
         "SubscriptionConfirmationEmailTemplateId": "[parameters('subscriptionConfirmationEmailTemplateId')]",
         "TableStorageConnString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-notifications')).secretUriWithVersion, ')')]"
       }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ReleaseNotificationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ReleaseNotificationMessage.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model
 {
@@ -14,5 +15,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model
 
         public bool Amendment { get; init; }
         public string UpdateNote { get; init; } = string.Empty;
+
+        public List<Guid>  SupersededPublicationIds { get; init; } = new();
+        public List<string> SupersededPublicationTitles { get; init; } = new();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Utils/ConfigKeys.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Utils/ConfigKeys.cs
@@ -19,5 +19,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier.Utils
             "ReleaseEmailTemplateId";
         public const string ReleaseAmendmentEmailTemplateIdName =
             "ReleaseAmendmentEmailTemplateId";
+        public const string ReleaseEmailSupersededSubscribersTemplateIdName =
+            "ReleaseEmailSupersededSubscribersTemplateId";
+        public const string ReleaseAmendmentSupersededSubscribersEmailTemplateIdName =
+            "ReleaseAmendmentEmailSupersededSubscribersTemplateId";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/local.settings.json
@@ -7,6 +7,8 @@
     "VerificationEmailTemplateId": "change-me",
     "ReleaseEmailTemplateId": "change-me",
     "ReleaseAmendmentEmailTemplateId": "change-me",
+    "ReleaseEmailSupersededSubscribersTemplateId": "change-me",
+    "ReleaseAmendmentEmailSupersededSubscribersTemplateId": "change-me",
     "SubscriptionConfirmationEmailTemplateId": "change-me",
     "TokenSecretKey": "change-me",
     "BaseUrl": "http://localhost:7073/api/publication/",

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/NotifyChangeFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/NotifyChangeFunction.cs
@@ -5,7 +5,6 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleasePublishingStatusOverallStage;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleasePublishingStatusStates;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/NotificationsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/NotificationsService.cs
@@ -67,6 +67,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 latestUpdateNoteReason = latestUpdateNote.Reason;
             }
 
+            var supersededPublications = _context.Publications
+                .Where(p => p.SupersededById == release.PublicationId)
+                .Select(p => new { p.Id, p.Title })
+                .ToList();
 
             return new ReleaseNotificationMessage
             {
@@ -77,6 +81,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 ReleaseSlug = release.Slug,
                 Amendment = release.Version > 0,
                 UpdateNote = latestUpdateNoteReason,
+                SupersededPublicationIds = supersededPublications.Select(p => p.Id).ToList(),
+                SupersededPublicationTitles = supersededPublications.Select(p => p.Title).ToList(),
             };
         }
     }


### PR DESCRIPTION
…lication subscribers

This PR makes changes to who is emailed when a release is published. We now send emails to subscribers of any publications superseded by the publication of the release being published.

### Notes

- There is some faffy deploy steps that are covered by ticket EES-4764 - specifically adding the new template IDs to the infra release pipeline's override template parameters before this is deployed. This cannot be done in advance, as the infra release pipeline would fail until this work is deployed.

- I tested this by sending 10,000 fake emails locally  - I didn't find any issues. This was mainly done to ensure there are no issues around the `sentToEmailAddresses` HashSet if it grew large.

- While publication's on the service aren't expected to supersede more than one other publication, the service supports having multiple publications supersede a publication. This is why we need to pass the array `SupersededPublicationIds ` to `Notifier`.