### PR TITLE
EES-4751 Various public data API schema updates

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/HelloWorldController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/HelloWorldController.cs
@@ -136,12 +136,14 @@ public class HelloWorldController(PublicDataDbContext publicDataDbContext) : Con
                                 {
                                     new()
                                     {
-                                        Identifier = "123",
+                                        PublicId = "123",
+                                        PrivateId = 123,
                                         Label = "Primary"
                                     },
                                     new()
                                     {
-                                        Identifier = "345",
+                                        PublicId = "345",
+                                        PrivateId = 345,
                                         Label = "Secondary"
                                     }
                                 },
@@ -173,13 +175,15 @@ public class HelloWorldController(PublicDataDbContext publicDataDbContext) : Con
                                 {
                                     new()
                                     {
-                                        Identifier = "1",
+                                        PublicId = "1",
+                                        PrivateId = 1,
                                         Label = "Barnsley",
                                         Code = "E00001"
                                     },
                                     new()
                                     {
-                                        Identifier = "2",
+                                        PublicId = "2",
+                                        PrivateId = 2,
                                         Label = "Sheffield",
                                         Code = "E00002"
                                     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -59,7 +59,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
 
         services.AddDbContext<PublicDataDbContext>(options =>
         {
-            var dataSourceBuilder = new NpgsqlDataSourceBuilder(configuration.GetConnectionString("PublicDataDbContext"));
+            var dataSourceBuilder = new NpgsqlDataSourceBuilder(configuration.GetConnectionString("PublicDataDb"));
             dataSourceBuilder.MapEnum<GeographicLevel>();
 
             options

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "PublicDataDbContext": "Host=db;Username=postgres;Password=password;Database=public_data"
+    "PublicDataDb": "Host=db;Username=postgres;Password=password;Database=public_data"
   },
   "Logging": {
     "LogLevel": {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Change.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Change.cs
@@ -1,10 +1,7 @@
-using System.Text.Json.Serialization;
-
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 public class Change<TState>
 {
-    [JsonPropertyName("Id")]
     public Guid Identifier { get; set; } = Guid.NewGuid();
 
     public required ChangeType Type { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSet.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSet.cs
@@ -22,7 +22,7 @@ public class DataSet : ICreatedUpdatedTimestamps<DateTimeOffset, DateTimeOffset?
 
     public DataSetVersion? LatestVersion { get; set; }
 
-    public List<DataSetVersion> Versions { get; set; } = new();
+    public List<DataSetVersion> Versions { get; set; } = [];
 
     public DateTimeOffset? Published { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -22,7 +22,7 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public required string Notes { get; set; }
 
-    public DataSetVersionMetaSummary MetaSummary { get; set; } = null!;
+    public required DataSetVersionMetaSummary MetaSummary { get; set; }
 
     public DataSetMeta Meta { get; set; } = null!;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -26,6 +26,8 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public DataSetMeta Meta { get; set; } = null!;
 
+    public long TotalResults { get; set; }
+
     public List<ChangeSetFilters> FilterChanges { get; set; } = [];
 
     public List<ChangeSetFilterOptions> FilterOptionChanges { get; set; } = [];

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -26,15 +26,15 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public DataSetMeta Meta { get; set; } = null!;
 
-    public List<ChangeSetFilters> FilterChanges { get; set; } = new();
+    public List<ChangeSetFilters> FilterChanges { get; set; } = [];
 
-    public List<ChangeSetFilterOptions> FilterOptionChanges { get; set; } = new();
+    public List<ChangeSetFilterOptions> FilterOptionChanges { get; set; } = [];
 
-    public List<ChangeSetIndicators> IndicatorChanges { get; set; } = new();
+    public List<ChangeSetIndicators> IndicatorChanges { get; set; } = [];
 
-    public List<ChangeSetLocations> LocationChanges { get; set; } = new();
+    public List<ChangeSetLocations> LocationChanges { get; set; } = [];
 
-    public List<ChangeSetTimePeriods> TimePeriodChanges { get; set; } = new();
+    public List<ChangeSetTimePeriods> TimePeriodChanges { get; set; } = [];
 
     public DateTimeOffset? Published { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
@@ -57,11 +57,13 @@ public class PublicDataDbContext : DbContext
             .OwnsMany(m => m.Filters, m =>
             {
                 m.ToJson();
+                m.Property(fm => fm.Identifier).HasJsonPropertyName("Id");
                 m.OwnsMany(fm => fm.Options);
             })
             .OwnsMany(m => m.Indicators, m =>
             {
                 m.ToJson();
+                m.Property(im => im.Identifier).HasJsonPropertyName("Id");
                 m.Property(im => im.Unit)
                     .HasConversion(new EnumToEnumValueConverter<IndicatorUnit>());
             })
@@ -83,6 +85,7 @@ public class PublicDataDbContext : DbContext
             .OwnsMany(cs => cs.Changes, cs =>
             {
                 cs.ToJson();
+                cs.Property(c => c.Identifier).HasJsonPropertyName("Id");
                 cs.Property(c => c.Type).HasConversion<string>();
                 cs.OwnsOne(c => c.CurrentState);
                 cs.OwnsOne(c => c.PreviousState);
@@ -92,6 +95,7 @@ public class PublicDataDbContext : DbContext
             .OwnsMany(cs => cs.Changes, cs =>
             {
                 cs.ToJson();
+                cs.Property(c => c.Identifier).HasJsonPropertyName("Id");
                 cs.Property(c => c.Type).HasConversion<string>();
                 cs.OwnsOne(c => c.CurrentState);
                 cs.OwnsOne(c => c.PreviousState);
@@ -101,6 +105,7 @@ public class PublicDataDbContext : DbContext
             .OwnsMany(cs => cs.Changes, cs =>
             {
                 cs.ToJson();
+                cs.Property(c => c.Identifier).HasJsonPropertyName("Id");
                 cs.Property(c => c.Type).HasConversion<string>();
                 cs.OwnsOne(c => c.CurrentState, s =>
                 {
@@ -118,6 +123,7 @@ public class PublicDataDbContext : DbContext
             .OwnsMany(cs => cs.Changes, cs =>
             {
                 cs.ToJson();
+                cs.Property(c => c.Identifier).HasJsonPropertyName("Id");
                 cs.Property(c => c.Type).HasConversion<string>();
                 cs.OwnsOne(c => c.CurrentState, s =>
                 {
@@ -130,6 +136,7 @@ public class PublicDataDbContext : DbContext
             .OwnsMany(cs => cs.Changes, cs =>
             {
                 cs.ToJson();
+                cs.Property(c => c.Identifier).HasJsonPropertyName("Id");
                 cs.Property(c => c.Type).HasConversion<string>();
                 cs.OwnsOne(c => c.CurrentState, s =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/FilterMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/FilterMeta.cs
@@ -1,10 +1,7 @@
-using System.Text.Json.Serialization;
-
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 public class FilterMeta
 {
-    [JsonPropertyName("Id")]
     public required string Identifier { get; set; }
 
     public required string Label { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/FilterOptionMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/FilterOptionMeta.cs
@@ -1,11 +1,10 @@
-using System.Text.Json.Serialization;
-
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 public class FilterOptionMeta
 {
-    [JsonPropertyName("Id")]
-    public required string Identifier { get; set; }
+    public required string PublicId { get; set; }
+
+    public required int PrivateId { get; set; }
 
     public required string Label { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/IndicatorMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/IndicatorMeta.cs
@@ -1,11 +1,9 @@
-using System.Text.Json.Serialization;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 public class IndicatorMeta
 {
-    [JsonPropertyName("Id")]
     public required string Identifier { get; set; }
 
     public required string Label { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/LocationOptionMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/LocationOptionMeta.cs
@@ -1,11 +1,10 @@
-using System.Text.Json.Serialization;
-
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 public class LocationOptionMeta
 {
-    [JsonPropertyName("Id")]
-    public required string Identifier { get; set; }
+    public required string PublicId { get; set; }
+
+    public required int PrivateId { get; set; }
 
     public required string Label { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20231221125422_InitialMigration.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20231221125422_InitialMigration.Designer.cs
@@ -14,7 +14,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
 {
     [DbContext(typeof(PublicDataDbContext))]
-    [Migration("20231213161446_InitialMigration")]
+    [Migration("20231221125422_InitialMigration")]
     partial class InitialMigration
     {
         /// <inheritdoc />
@@ -242,6 +242,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasColumnType("text");
+
+                    b.Property<long>("TotalResults")
+                        .HasColumnType("bigint");
 
                     b.Property<DateTimeOffset?>("Unpublished")
                         .HasColumnType("timestamp with time zone");
@@ -871,15 +874,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                                         .ValueGeneratedOnAdd()
                                         .HasColumnType("integer");
 
-                                    b2.Property<string>("Identifier")
-                                        .IsRequired()
-                                        .HasColumnType("text")
-                                        .HasAnnotation("Relational:JsonPropertyName", "Id");
-
                                     b2.Property<bool?>("IsAggregate")
                                         .HasColumnType("boolean");
 
                                     b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<int>("PrivateId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("PublicId")
                                         .IsRequired()
                                         .HasColumnType("text");
 
@@ -965,12 +970,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                                         .IsRequired()
                                         .HasColumnType("text");
 
-                                    b2.Property<string>("Identifier")
-                                        .IsRequired()
-                                        .HasColumnType("text")
-                                        .HasAnnotation("Relational:JsonPropertyName", "Id");
-
                                     b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<int>("PrivateId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("PublicId")
                                         .IsRequired()
                                         .HasColumnType("text");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20231221125422_InitialMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20231221125422_InitialMigration.cs
@@ -144,6 +144,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     VersionMinor = table.Column<int>(type: "integer", nullable: false),
                     Notes = table.Column<string>(type: "text", nullable: false),
                     MetaSummary = table.Column<string>(type: "jsonb", nullable: false),
+                    TotalResults = table.Column<long>(type: "bigint", nullable: false),
                     Published = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
                     Unpublished = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
                     Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
@@ -240,6 +240,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         .IsRequired()
                         .HasColumnType("text");
 
+                    b.Property<long>("TotalResults")
+                        .HasColumnType("bigint");
+
                     b.Property<DateTimeOffset?>("Unpublished")
                         .HasColumnType("timestamp with time zone");
 
@@ -868,15 +871,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                                         .ValueGeneratedOnAdd()
                                         .HasColumnType("integer");
 
-                                    b2.Property<string>("Identifier")
-                                        .IsRequired()
-                                        .HasColumnType("text")
-                                        .HasAnnotation("Relational:JsonPropertyName", "Id");
-
                                     b2.Property<bool?>("IsAggregate")
                                         .HasColumnType("boolean");
 
                                     b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<int>("PrivateId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("PublicId")
                                         .IsRequired()
                                         .HasColumnType("text");
 
@@ -962,12 +967,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                                         .IsRequired()
                                         .HasColumnType("text");
 
-                                    b2.Property<string>("Identifier")
-                                        .IsRequired()
-                                        .HasColumnType("text")
-                                        .HasAnnotation("Relational:JsonPropertyName", "Id");
-
                                     b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<int>("PrivateId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("PublicId")
                                         .IsRequired()
                                         .HasColumnType("text");
 


### PR DESCRIPTION
This PR makes various tweaks to the `PublicDataDbContext` used by the public data API:

- New `PrivateId` and `PublicatId` properties added to location and filter option meta for use in querying Parquet data more efficiently
- `DataSetVersion.MetaSummary` is now required
- New `TotalResults` column added to `DataSetVersion`
- Renamed connection string name to `PublicDataDb`