### PR TITLE
EES-4671 When removing content block, delete associated comments

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ContentService.cs
@@ -238,6 +238,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                     await _contentBlockService.DeleteContentBlockAndReorder(blockToRemove.Id);
 
                     _context.ContentSections.Update(section);
+
+                    var comments = _context.Comment
+                        .Where(c => c.ContentBlockId == blockToRemove.Id);
+                    _context.RemoveRange(comments);
+
                     await _context.SaveChangesAsync();
                     return OrderedContentBlocks(section);
                 });


### PR DESCRIPTION
This PR fixes an issue where comments would reappear if a data block was attached to release content, removed, and then reattached. It does this by removing all comments associated with a content block when that content block is removed.