### PR TITLE
EES-3503: Increase max file upload size to 2GB

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
@@ -27,6 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly ContentDbContext _context;
 
         private const int MaxFilenameSize = 150;
+        private const int MaxFileSize = int.MaxValue; // 2GB
 
         public FileUploadsValidatorService(IFileTypeService fileTypeService,
             ContentDbContext context)
@@ -73,6 +74,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             if (file.Length == 0)
             {
                 return ValidationActionResult(FileCannotBeEmpty);
+            }
+            
+            if (file.Length > MaxFileSize)
+            {
+                return ValidationActionResult(FileSizeLimitExceeded);
             }
 
             if (!await _fileTypeService.HasMatchingMimeType(file, AllowedMimeTypesByFileType[type]))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -49,6 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         CannotOverwriteFile,
         FileCannotBeEmpty,
         FileTypeInvalid,
+        FileSizeLimitExceeded,
 
         // Data file
         SubjectTitleCannotBeEmpty,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
@@ -7,8 +7,8 @@
       </customHeaders>
     </httpProtocol>
     <security>
-      <requestFiltering removeServerHeader="True">
-        <requestLimits maxAllowedContentLength="104857600" />
+      <requestFiltering removeServerHeader="true">
+        <requestLimits maxAllowedContentLength="2147483647" />
       </requestFiltering>
     </security>
     <applicationInitialization doAppInitAfterRestart="true">

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileForm.tsx
@@ -37,6 +37,7 @@ const errorMappings = [
       FileTypeInvalid: 'Choose a file of an allowed format',
       FilenameCannotContainSpacesOrSpecialCharacters:
         'Filename cannot contain spaces or special characters',
+      FileSizeLimitExceeded: 'Choose a file that is under 2GB',
     },
   }),
 ];
@@ -74,6 +75,8 @@ export default function AncillaryFileForm({
     },
     errorMappings,
   );
+
+  const MAX_FILE_SIZE = 2147483647; // 2GB
 
   return (
     <Formik<AncillaryFileFormValues>
@@ -113,6 +116,7 @@ export default function AncillaryFileForm({
         summary: Yup.string().required('Enter a summary'),
         file: Yup.file()
           .minSize(0, 'Choose a file that is not empty')
+          .maxSize(MAX_FILE_SIZE, 'Choose a file that is under 2GB')
           .notRequired(),
       }).concat(validationSchema ?? Yup.object().notRequired())}
     >
@@ -134,7 +138,7 @@ export default function AncillaryFileForm({
 
           <FormFieldFileInput<AncillaryFileFormValues>
             disabled={form.isSubmitting}
-            hint={initialValues?.file?.name}
+            hint="Maximum file size 2GB"
             label={fileFieldLabel}
             name="file"
           />

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -67,6 +67,8 @@ export default function ReleaseFileUploadsSection({
     [files, listFilesQuery.queryKey, queryClient, releaseId],
   );
 
+  const MAX_FILE_SIZE = 2147483647; // 2GB
+
   return (
     <>
       <h2>Add file to release</h2>
@@ -115,7 +117,8 @@ export default function ReleaseFileUploadsSection({
           validationSchema={Yup.object<Partial<AncillaryFileFormValues>>({
             file: Yup.file()
               .required('Choose a file')
-              .minSize(0, 'Choose a file that is not empty'),
+              .minSize(0, 'Choose a file that is not empty')
+              .maxSize(MAX_FILE_SIZE, 'Choose a file that is under 2GB'),
           })}
           onSubmit={handleSubmit}
         />

--- a/src/explore-education-statistics-common/src/validation/yup/file.ts
+++ b/src/explore-education-statistics-common/src/validation/yup/file.ts
@@ -22,7 +22,7 @@ export default class FileSchema extends Yup.MixedSchema<File> {
   minSize(minBytes: number, message?: string): FileSchema {
     return this.test({
       name: 'minSize',
-      message: message || 'File must be larger than 0 bytes',
+      message: message ?? 'File must be larger than 0 bytes',
       exclusive: true,
 
       test(value) {
@@ -31,6 +31,21 @@ export default class FileSchema extends Yup.MixedSchema<File> {
         }
 
         return value.size > minBytes;
+      },
+    });
+  }
+
+  maxSize(maxBytes: number, message?: string): FileSchema {
+    return this.test({
+      name: 'maxSize',
+      message: message ?? `File must be smaller than ${maxBytes} bytes`,
+      exclusive: true,
+
+      test(value) {
+        if (!value) {
+          return true;
+        }
+        return value.size < maxBytes;
       },
     });
   }


### PR DESCRIPTION
The file limit of 100mb was found too restrictive for certain users when uploading ancillary data. These changes increase the limit to 2GB, and provide helpful messaging for information and validation.

- Client-side validation halts submission of files exceeding the limit before any transfer takes place
- If client validation were to fail, a file upload which exceeds the web server limit would result in a HTTP 400 (Bad Request), due to the endpoint restriction of int.MaxValue, which is ~2GB in bytes
- If the web server limit is increased (and the controller attributes removed, or the limit increased), and a file larger than 2GB is uploaded, the custom server-side validation will kick in and provide similar error feedback to the UI.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/77351705/2527b3f7-6329-42f3-98cb-85b7b282230b)

File streaming and chunking were considered as options, but due to the infrequency of large file uploads, were deemed excessive as the work would require quite substantial refactoring of various validation mechanisms.