### PR TITLE
EES-4775 Speculative fix for UI test redirect blank page issue

### DIFF
--- a/src/explore-education-statistics-frontend/src/middleware.ts
+++ b/src/explore-education-statistics-frontend/src/middleware.ts
@@ -2,7 +2,7 @@ import redirectPages from '@frontend/middleware/pages/redirectPages';
 import type { NextRequest } from 'next/server';
 
 export default async function middleware(request: NextRequest) {
-  return redirectPages(request);
+  await redirectPages(request);
 }
 
 // Restrict to release and methodology pages.


### PR DESCRIPTION
This is a speculative fix to a UI test failure we saw in `publish_publication_update.robot`'s `Validate publication redirect works` test case. 

The test case failed in all three pipeline UI test reruns, and all instances had a screenshot of a blank page - not a 404 or release page as we'd expect. 

We haven't seen this issue in any other case, whether running the UI tests locally or during manual testing.