### PR TITLE
Revert "EES-4775 Speculative fix for UI test redirect blank page issue"

### DIFF
--- a/src/explore-education-statistics-frontend/src/middleware.ts
+++ b/src/explore-education-statistics-frontend/src/middleware.ts
@@ -2,7 +2,7 @@ import redirectPages from '@frontend/middleware/pages/redirectPages';
 import type { NextRequest } from 'next/server';
 
 export default async function middleware(request: NextRequest) {
-  await redirectPages(request);
+  return redirectPages(request);
 }
 
 // Restrict to release and methodology pages.


### PR DESCRIPTION
This reverts commit d07fe6e5b5642fefdca59fe138a65e0b894daf7e. Awaiting the redirectPages function lead to 404s when a page should have been redirected.