### PR TITLE
Revert "EES-4775 Move redirectPages code into middleware.ts"

### DIFF
--- a/src/explore-education-statistics-frontend/src/middleware.ts
+++ b/src/explore-education-statistics-frontend/src/middleware.ts
@@ -1,73 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
-import redirectService, {
-  Redirects,
-  RedirectType,
-} from '@frontend/services/redirectService';
-
-interface CachedRedirects {
-  redirects: Redirects;
-  fetchedAt: number;
-}
-
-// Cache the redirect paths for 2 seconds on Local,
-// 10 seconds on Development, and 60 seconds in all other
-// environments.
-function getCacheTime(): number {
-  switch (process.env.APP_ENV) {
-    case 'Local':
-      return 2_000;
-    case 'Development':
-      return 10_000;
-    default:
-      return 60_000;
-  }
-}
+import redirectPages from '@frontend/middleware/pages/redirectPages';
+import type { NextRequest } from 'next/server';
 
 export default async function middleware(request: NextRequest) {
-  // The middleware only runs on paths defined in the config
-  // in middleware.ts, that will also need to be
-  // updated if any other paths are added here.
-  const redirectPaths = {
-    methodologies: '/methodology',
-    publications: '/find-statistics',
-  };
-
-  let cachedRedirects: CachedRedirects | undefined;
-  const cacheTime = getCacheTime();
-
-  const shouldRefetch =
-    !cachedRedirects || cachedRedirects.fetchedAt + cacheTime < Date.now();
-
-  if (shouldRefetch) {
-    cachedRedirects = {
-      redirects: await redirectService.list(),
-      fetchedAt: Date.now(),
-    };
-  }
-
-  const redirectUrl = Object.keys(redirectPaths).reduce((acc, key) => {
-    const redirectType = key as RedirectType;
-    if (request.nextUrl.pathname.startsWith(redirectPaths[redirectType])) {
-      const pathSegments = request.nextUrl.pathname.split('/');
-
-      const rewriteRule = cachedRedirects?.redirects[redirectType]?.find(
-        ({ fromSlug }) => pathSegments[2] === fromSlug,
-      );
-
-      if (rewriteRule) {
-        return pathSegments
-          .map(segment =>
-            segment === rewriteRule?.fromSlug ? rewriteRule?.toSlug : segment,
-          )
-          .join('/');
-      }
-    }
-    return acc;
-  }, '');
-
-  if (redirectUrl) {
-    return NextResponse.redirect(new URL(redirectUrl, request.url));
-  }
-
-  return NextResponse.next();
+  return redirectPages(request);
 }
+
+// Restrict to release and methodology pages.
+export const config = {
+  matcher: ['/find-statistics/:path/:path*', '/methodology/:path*'],
+};

--- a/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
@@ -1,0 +1,255 @@
+import _redirectService, {
+  Redirects,
+} from '@frontend/services/redirectService';
+import redirectPages from '@frontend/middleware/pages/redirectPages';
+import { NextResponse, NextRequest } from 'next/server';
+
+jest.mock('@frontend/services/redirectService');
+const redirectService = _redirectService as jest.Mocked<
+  typeof _redirectService
+>;
+
+describe('redirectPages', () => {
+  const redirectSpy = jest.spyOn(NextResponse, 'redirect');
+  const nextSpy = jest.spyOn(NextResponse, 'next');
+
+  const testRedirects: Redirects = {
+    methodologies: [
+      { fromSlug: 'original-slug-1', toSlug: 'updated-slug-1' },
+      { fromSlug: 'original-slug-2', toSlug: 'updated-slug-2' },
+    ],
+    publications: [
+      { fromSlug: 'original-slug-3', toSlug: 'updated-slug-3' },
+      { fromSlug: 'original-slug-4', toSlug: 'updated-slug-4' },
+    ],
+  };
+
+  test('does not re-request the list of redirects once it has been fetched', async () => {
+    redirectService.list.mockResolvedValue(testRedirects);
+    const req = new NextRequest(
+      new Request('https://my-env/methodology/original-slug'),
+    );
+    await redirectPages(req);
+
+    expect(redirectService.list).toHaveBeenCalledTimes(1);
+
+    const req2 = new NextRequest(
+      new Request('https://my-env/methodology/another-slug'),
+    );
+    await redirectPages(req2);
+
+    expect(redirectService.list).toHaveBeenCalledTimes(1);
+  });
+
+  describe('redirect methodology pages', () => {
+    test('redirects the request when the slug for the requested page has changed', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request('https://my-env/methodology/original-slug-1'),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).toHaveBeenCalledTimes(1);
+      expect(redirectSpy).toHaveBeenCalledWith(
+        new URL('https://my-env/methodology/updated-slug-1'),
+      );
+      expect(nextSpy).not.toHaveBeenCalled();
+    });
+
+    test('does not redirect when the slug for the requested page has not changed', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request('https://my-env/methodology/my-methodology'),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not redirect if the `fromSlug` only partially matches', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request('https://my-env/methodology/original'),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalledTimes(1);
+
+      const req2 = new NextRequest(
+        new Request('https://my-env/methodology/original-slug-and-something'),
+      );
+      await redirectPages(req2);
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('redirects child pages', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request('https://my-env/methodology/original-slug-1/child-page'),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).toHaveBeenCalledTimes(1);
+      expect(redirectSpy).toHaveBeenCalledWith(
+        new URL('https://my-env/methodology/updated-slug-1/child-page'),
+      );
+      expect(nextSpy).not.toHaveBeenCalled();
+    });
+
+    test('redirects with anchor links', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request('https://my-env/methodology/original-slug-1#anchor-link'),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).toHaveBeenCalledTimes(1);
+      expect(redirectSpy).toHaveBeenCalledWith(
+        new URL('https://my-env/methodology/updated-slug-1#anchor-link'),
+      );
+      expect(nextSpy).not.toHaveBeenCalled();
+    });
+
+    test('redirects with query params', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request(
+          'https://my-env/methodology/original-slug-1?search=something',
+        ),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).toHaveBeenCalledTimes(1);
+      expect(redirectSpy).toHaveBeenCalledWith(
+        new URL('https://my-env/methodology/updated-slug-1?search=something'),
+      );
+      expect(nextSpy).not.toHaveBeenCalled();
+    });
+
+    test('does not redirect when the slug matches a `fromSlug` in a different page type', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request('https://my-env/methodology/original-slug-4'),
+      );
+
+      await redirectPages(req);
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('redirect publication pages', () => {
+    test('redirects the request when the slug for the requested page has changed', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request('https://my-env/find-statistics/original-slug-3'),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).toHaveBeenCalledTimes(1);
+      expect(redirectSpy).toHaveBeenCalledWith(
+        new URL('https://my-env/find-statistics/updated-slug-3'),
+      );
+      expect(nextSpy).not.toHaveBeenCalled();
+    });
+
+    test('does not redirect when the slug for the requested page has not changed', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request('https://my-env/find-statistics/my-publication'),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not redirect if the `fromSlug` only partially matches', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request('https://my-env/find-statistics/original'),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalledTimes(1);
+
+      const req2 = new NextRequest(
+        new Request(
+          'https://my-env/find-statistics/original-slug-and-something',
+        ),
+      );
+      await redirectPages(req2);
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('redirects child pages', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request(
+          'https://my-env/find-statistics/original-slug-3/child-page',
+        ),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).toHaveBeenCalledTimes(1);
+      expect(redirectSpy).toHaveBeenCalledWith(
+        new URL('https://my-env/find-statistics/updated-slug-3/child-page'),
+      );
+      expect(nextSpy).not.toHaveBeenCalled();
+    });
+
+    test('redirects with anchor links', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request(
+          'https://my-env/find-statistics/original-slug-3#anchor-link',
+        ),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).toHaveBeenCalledTimes(1);
+      expect(redirectSpy).toHaveBeenCalledWith(
+        new URL('https://my-env/find-statistics/updated-slug-3#anchor-link'),
+      );
+      expect(nextSpy).not.toHaveBeenCalled();
+    });
+
+    test('redirects with query params', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request(
+          'https://my-env/find-statistics/original-slug-3?search=something',
+        ),
+      );
+      await redirectPages(req);
+
+      expect(redirectSpy).toHaveBeenCalledTimes(1);
+      expect(redirectSpy).toHaveBeenCalledWith(
+        new URL(
+          'https://my-env/find-statistics/updated-slug-3?search=something',
+        ),
+      );
+      expect(nextSpy).not.toHaveBeenCalled();
+    });
+
+    test('does not redirect when the slug matches a `fromSlug` in a different page type', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      const req = new NextRequest(
+        new Request('https://my-env/find-statistics/original-slug-1'),
+      );
+
+      await redirectPages(req);
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
@@ -1,0 +1,75 @@
+import redirectService, {
+  Redirects,
+  RedirectType,
+} from '@frontend/services/redirectService';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+interface CachedRedirects {
+  redirects: Redirects;
+  fetchedAt: number;
+}
+
+const cacheTime = getCacheTime();
+
+let cachedRedirects: CachedRedirects | undefined;
+
+// The middleware only runs on paths defined in the config
+// in middleware.ts, that will also need to be
+// updated if any other paths are added here.
+const redirectPaths = {
+  methodologies: '/methodology',
+  publications: '/find-statistics',
+};
+
+export default async function redirectPages(request: NextRequest) {
+  const shouldRefetch =
+    !cachedRedirects || cachedRedirects.fetchedAt + cacheTime < Date.now();
+
+  if (shouldRefetch) {
+    cachedRedirects = {
+      redirects: await redirectService.list(),
+      fetchedAt: Date.now(),
+    };
+  }
+
+  const redirectUrl = Object.keys(redirectPaths).reduce((acc, key) => {
+    const redirectType = key as RedirectType;
+    if (request.nextUrl.pathname.startsWith(redirectPaths[redirectType])) {
+      const pathSegments = request.nextUrl.pathname.split('/');
+
+      const rewriteRule = cachedRedirects?.redirects[redirectType]?.find(
+        ({ fromSlug }) => pathSegments[2] === fromSlug,
+      );
+
+      if (rewriteRule) {
+        return pathSegments
+          .map(segment =>
+            segment === rewriteRule?.fromSlug ? rewriteRule?.toSlug : segment,
+          )
+          .join('/');
+      }
+    }
+    return acc;
+  }, '');
+
+  if (redirectUrl) {
+    return NextResponse.redirect(new URL(redirectUrl, request.url));
+  }
+
+  return NextResponse.next();
+}
+
+// Cache the redirect paths for 2 seconds on Local,
+// 10 seconds on Development, and 60 seconds in all other
+// environments.
+function getCacheTime(): number {
+  switch (process.env.APP_ENV) {
+    case 'Local':
+      return 2_000;
+    case 'Development':
+      return 10_000;
+    default:
+      return 60_000;
+  }
+}


### PR DESCRIPTION
This reverts commit bfe390ac68404b4417faa5bac17408a492562a00. Moving the code into the `middleware` function didn't solve the UI test failure.
