### PR TITLE
EES-4751 Add seed data script for public data API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin
 obj
 /data/ees-mssql
 /data/public-api-db
+/data/public-api-parquet
 dfe-meta.db
 
 ## CSharp

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/AssemblyExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/AssemblyExtensionTests.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Reflection;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class AssemblyExtensionTests
+{
+    public class DirectoryTests
+    {
+        [Fact]
+        public void GetDirectory()
+        {
+            var directory = Assembly.GetExecutingAssembly().GetDirectory();
+            var expectedPath = Path.Combine(
+                "src", "GovUk.Education.ExploreEducationStatistics.Common.Tests", "bin");
+
+            Assert.Contains(expectedPath, directory.ToString());
+            Assert.True(directory.Exists);
+        }
+
+        [Fact]
+        public void GetDirectoryName()
+        {
+            var path = Assembly.GetExecutingAssembly().GetDirectoryPath();
+            var expectedPath = Path.Combine(
+                "src", "GovUk.Education.ExploreEducationStatistics.Common.Tests", "bin");
+
+            Assert.Contains(expectedPath, path);
+            Assert.True(Directory.Exists(path));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/PathUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/PathUtilsTests.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System.IO;
+using System.Reflection;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class PathUtilsTests
+{
+    public class ProjectRootPathTests
+    {
+        [Fact]
+        public void ProjectRootPath()
+        {
+            Assert.True(Directory.Exists(PathUtils.ProjectRootPath));
+            Assert.StartsWith(PathUtils.ProjectRootPath, Assembly.GetExecutingAssembly().Location);
+
+            Assert.True(Directory.Exists(Path.Combine(PathUtils.ProjectRootPath, "src")));
+            Assert.True(File.Exists(Path.Combine(PathUtils.ProjectRootPath, "README.md")));
+            Assert.True(File.Exists(Path.Combine(PathUtils.ProjectRootPath, "LICENSE")));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/GeographicLevelUtilTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/GeographicLevelUtilTests.cs
@@ -1,0 +1,67 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+
+public static class GeographicLevelUtilTests
+{
+    public class CsvColumnTests
+    {
+        [Fact]
+        public void CsvColumns()
+        {
+            var columns = GeographicLevel.Country.CsvColumns();
+
+            Assert.Equal("country_code", columns.Code);
+            Assert.Equal("country_name", columns.Name);
+        }
+
+        [Fact]
+        public void CsvNameColumn()
+        {
+            Assert.Equal("country_name", GeographicLevel.Country.CsvNameColumn());
+        }
+
+        [Fact]
+        public void CsvCodeColumn()
+        {
+            Assert.Equal("country_code", GeographicLevel.Country.CsvCodeColumn());
+        }
+
+        [Fact]
+        public void CsvOtherColumns()
+        {
+            var columns = GeographicLevel.LocalAuthority.CsvOtherColumns();
+
+            Assert.Single(columns);
+            Assert.Equal("old_la_code", columns[0]);
+        }
+
+        [Theory]
+        [MemberData(nameof(GeographicLevelColumns))]
+        public void CsvColumnsToGeographicLevel(string column, GeographicLevel level)
+        {
+            Assert.Equal(level, GeographicLevelUtils.CsvColumnsToGeographicLevel[column]);
+        }
+
+        public static IEnumerable<object[]> GeographicLevelColumns()
+        {
+            return EnumUtil.GetEnumValues<GeographicLevel>()
+                .SelectMany(
+                    level =>
+                    {
+                        var columns = new List<string> { level.CsvCodeColumn(), level.CsvNameColumn() };
+
+                        columns.AddRange(level.CsvOtherColumns());
+
+                        return columns.Select(column => new object[] { column, level });
+                    }
+                );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/EnumToEnumLabelConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/EnumToEnumLabelConverter.cs
@@ -21,12 +21,12 @@ public class EnumToEnumLabelConverter<TEnum> : ValueConverter<TEnum, string> whe
     {
     }
 
-    private static string ToProvider(TEnum value)
+    public static string ToProvider(TEnum value)
     {
         return value.GetEnumLabel();
     }
 
-    private static TEnum FromProvider(string label)
+    public static TEnum FromProvider(string label)
     {
         if (label == null)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/EnumToEnumValueConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/EnumToEnumValueConverter.cs
@@ -21,12 +21,12 @@ public class EnumToEnumValueConverter<TEnum> : ValueConverter<TEnum, string> whe
     {
     }
 
-    private static string ToProvider(TEnum value)
+    public static string ToProvider(TEnum value)
     {
         return value.GetEnumValue();
     }
 
-    private static TEnum FromProvider(string value)
+    public static TEnum FromProvider(string value)
     {
         if (Lookup.TryGetValue(value, out var enumVal))
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/AssemblyExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/AssemblyExtensions.cs
@@ -1,0 +1,14 @@
+#nullable enable
+using System.IO;
+using System.Reflection;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class AssemblyExtensions
+{
+    public static string GetDirectoryPath(this Assembly assembly)
+        => Path.GetDirectoryName(assembly.Location)!;
+
+    public static DirectoryInfo GetDirectory(this Assembly assembly)
+        => new(assembly.GetDirectoryPath());
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/GeographicLevelUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/GeographicLevelUtils.cs
@@ -1,0 +1,179 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public static class GeographicLevelUtils
+{
+    private static readonly Lazy<IReadOnlyDictionary<GeographicLevel, GeographicCsvColumns>> GeographicLevelCsvColumns =
+        new(() => new Dictionary<GeographicLevel, GeographicCsvColumns>
+        {
+            {
+                GeographicLevel.Country,
+                new GeographicCsvColumns(
+                    Code: "country_code",
+                    Name: "country_name"
+                )
+            },
+            {
+                GeographicLevel.EnglishDevolvedArea,
+                new GeographicCsvColumns(
+                    Code: "english_devolved_area_code",
+                    Name: "english_devolved_area_name"
+                )
+            },
+            {
+                GeographicLevel.Institution,
+                new GeographicCsvColumns(
+                    Code: "institution_id",
+                    Name: "institution_name"
+                )
+            },
+            {
+                GeographicLevel.LocalAuthority,
+                new GeographicCsvColumns(
+                    Code: "new_la_code",
+                    Name: "la_name",
+                    Other: new[] { "old_la_code" }
+                )
+            },
+            {
+                GeographicLevel.LocalAuthorityDistrict,
+                new GeographicCsvColumns(
+                    Code: "lad_code",
+                    Name: "lad_name"
+                )
+            },
+            {
+                GeographicLevel.LocalEnterprisePartnership,
+                new GeographicCsvColumns(
+                    Code: "local_enterprise_partnership_code",
+                    Name: "local_enterprise_partnership_name"
+                )
+            },
+            {
+                GeographicLevel.LocalSkillsImprovementPlanArea,
+                new GeographicCsvColumns(
+                    Code: "lsip_code",
+                    Name: "lsip_name"
+                )
+            },
+            {
+                GeographicLevel.MayoralCombinedAuthority,
+                new GeographicCsvColumns(
+                    Code: "mayoral_combined_authority_code",
+                    Name: "mayoral_combined_authority_name"
+                )
+            },
+            {
+                GeographicLevel.MultiAcademyTrust,
+                new GeographicCsvColumns(
+                    Code: "trust_id",
+                    Name: "trust_name"
+                )
+            },
+            {
+                GeographicLevel.OpportunityArea,
+                new GeographicCsvColumns(
+                    Code: "opportunity_area_code",
+                    Name: "opportunity_area_name"
+                )
+            },
+            {
+                GeographicLevel.ParliamentaryConstituency,
+                new GeographicCsvColumns(
+                    Code: "pcon_code",
+                    Name: "pcon_name"
+                )
+            },
+            {
+                GeographicLevel.PlanningArea,
+                new GeographicCsvColumns(
+                    Code: "planning_area_code",
+                    Name: "planning_area_name"
+                )
+            },
+            {
+                GeographicLevel.Provider,
+                new GeographicCsvColumns(
+                    Code: "provider_ukprn",
+                    Name: "provider_name"
+                )
+            },
+            {
+                GeographicLevel.Region,
+                new GeographicCsvColumns(
+                    Code: "region_code",
+                    Name: "region_name"
+                )
+            },
+            {
+                GeographicLevel.RscRegion,
+                new GeographicCsvColumns(
+                    Code: "rsc_region_code",
+                    Name: "rsc_region_name"
+                )
+            },
+            {
+                GeographicLevel.School,
+                new GeographicCsvColumns(
+                    Code: "school_urn",
+                    Name: "school_name",
+                    Other: new[] { "school_laestab" }
+                )
+            },
+            {
+                GeographicLevel.Sponsor,
+                new GeographicCsvColumns(
+                    Code: "sponsor_id",
+                    Name: "sponsor_name"
+                )
+            },
+            {
+                GeographicLevel.Ward,
+                new GeographicCsvColumns(
+                    Code: "ward_code",
+                    Name: "ward_name"
+                )
+            },
+        }
+    );
+
+    private static readonly Lazy<IReadOnlyDictionary<string, GeographicLevel>> CsvColumnsToGeographicLevelLazy = new(
+        () => GeographicLevelCsvColumns.Value.Aggregate(
+            new Dictionary<string, GeographicLevel>(),
+            (acc, pair) =>
+            {
+                var columns = new List<string> { pair.Value.Code, pair.Value.Name };
+
+                columns.AddRange(pair.Value.Other);
+
+                foreach (var column in columns)
+                {
+                    acc[column] = pair.Key;
+                }
+
+                return acc;
+            }
+        )
+    );
+
+    public static GeographicCsvColumns CsvColumns(this GeographicLevel level) => GeographicLevelCsvColumns.Value[level];
+
+    public static string CsvCodeColumn(this GeographicLevel level) => level.CsvColumns().Code;
+
+    public static string CsvNameColumn(this GeographicLevel level) => level.CsvColumns().Name;
+
+    public static IReadOnlyList<string> CsvOtherColumns(this GeographicLevel level) => level.CsvColumns().Other;
+
+    public static IReadOnlyDictionary<string, GeographicLevel> CsvColumnsToGeographicLevel
+        => CsvColumnsToGeographicLevelLazy.Value;
+
+    public record GeographicCsvColumns(string Code, string Name, IReadOnlyList<string>? Other = null)
+    {
+        public readonly IReadOnlyList<string> Other = Other ?? new List<string>();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/PathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/PathUtils.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using System;
+using System.Reflection;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public static class PathUtils
+{
+    private const string SolutionFilename = "GovUk.Education.ExploreEducationStatistics.sln";
+
+    private static readonly Lazy<string> ProjectRootPathLazy = new(
+        () =>
+        {
+            var directory = Assembly.GetExecutingAssembly().GetDirectory();
+
+            while (directory is not null && directory.GetFiles(SolutionFilename).Length == 0)
+            {
+                directory = directory.Parent;
+            }
+
+            if (directory?.Parent is null)
+            {
+                throw new Exception("Could not detect project root");
+            }
+
+            return directory.Parent.FullName;
+        }
+    );
+
+    public static string ProjectRootPath => ProjectRootPathLazy.Value;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
@@ -1,0 +1,603 @@
+using System.Diagnostics;
+using System.Reflection;
+using CliFx;
+using CliFx.Attributes;
+using CliFx.Infrastructure;
+using Dapper;
+using DuckDB.NET.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.Models;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.Seeds;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.Utils;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.Commands;
+
+[Command("seed:data", Description = "Generate seed data for the public API database")]
+public class SeedDataCommand : ICommand
+{
+    private const string DbConnectionString = "Host=db;Username=postgres;Password=password;Database=public_data";
+
+    public async ValueTask ExecuteAsync(IConsole console)
+    {
+        var cancellationToken = console.RegisterCancellationHandler();
+
+        await using var dbContext = await SetUpPublicDataDbContext(cancellationToken);
+
+        // Set current directory to the assembly's directory to simplify pathing
+        Directory.SetCurrentDirectory(Assembly.GetExecutingAssembly().GetDirectoryPath());
+
+        // Match CSV columns with underscores
+        DefaultTypeMap.MatchNamesWithUnderscores = true;
+
+        var dataSetSeeds = new List<DataSetSeed>
+        {
+            DataSetSeed.AbsenceRatesCharacteristic,
+            DataSetSeed.AbsenceRatesGeographicLevel,
+            DataSetSeed.AbsenceRatesGeographicLevelSchool,
+            DataSetSeed.SpcEthnicityLanguage,
+            DataSetSeed.SpcYearGroupGender,
+            DataSetSeed.Nat01,
+            DataSetSeed.Qua01,
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+
+        await console.Output.WriteLineAsync($"Started seeding data for {dataSetSeeds.Count} data sets");
+
+        foreach (var seed in dataSetSeeds)
+        {
+            await using var duckDb = new DuckDBConnection("DataSource=:memory:");
+            await duckDb.OpenAsync(cancellationToken);
+
+            var seeder = new Seeder(
+                seed: seed,
+                dbContext: dbContext,
+                duckDb: duckDb,
+                console: console,
+                cancellationToken: cancellationToken
+            );
+
+            await seeder.Generate();
+
+            await duckDb.CloseAsync();
+        }
+
+        stopwatch.Stop();
+
+        await console.Output.WriteLineAsync($"Done! Finished all seeding in {stopwatch.Elapsed.TotalSeconds} seconds!");
+    }
+
+    private static async Task<PublicDataDbContext> SetUpPublicDataDbContext(CancellationToken cancellationToken)
+    {
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(DbConnectionString);
+        dataSourceBuilder.MapEnum<GeographicLevel>();
+
+        var options = new DbContextOptionsBuilder<PublicDataDbContext>()
+            .UseNpgsql(dataSourceBuilder.Build())
+            .Options;
+
+        var dbContext = new PublicDataDbContext(options);
+
+        dbContext.Database.SetCommandTimeout(300);
+        await dbContext.Database.MigrateAsync(cancellationToken: cancellationToken);
+
+        var tables = dbContext.Model.GetEntityTypes()
+            .Select(type => type.GetTableName())
+            .Distinct()
+            .Cast<string>()
+            .ToList();
+
+        // Clear any tables in case we're re-running the command
+        foreach (var table in tables)
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                $"""TRUNCATE TABLE "{table}" RESTART IDENTITY CASCADE;""",
+                cancellationToken: cancellationToken);
+        }
+
+        return dbContext;
+    }
+
+    private class Seeder
+    {
+        private static int _idSeedNumber;
+
+        private readonly DataSetSeed _seed;
+        private readonly PublicDataDbContext _dbContext;
+        private readonly DuckDBConnection _duckDb;
+        private readonly IConsole _console;
+        private readonly CancellationToken _cancellationToken;
+
+        private readonly ShortId _shortId;
+        private readonly string _dataFilePath;
+        private readonly string _metaFilePath;
+
+        public Seeder(
+            DataSetSeed seed,
+            PublicDataDbContext dbContext,
+            DuckDBConnection duckDb,
+            IConsole console,
+            CancellationToken cancellationToken)
+        {
+            _seed = seed;
+            _dbContext = dbContext;
+            _duckDb = duckDb;
+            _console = console;
+            _cancellationToken = cancellationToken;
+
+            _idSeedNumber += 1;
+            _shortId = new ShortId(_idSeedNumber, checkCollisions: true);
+
+            _dataFilePath = Path.Combine("SeedFiles", $"{_seed.Filename}.csv");
+            _metaFilePath = Path.Combine("SeedFiles", $"{_seed.Filename}.meta.csv");
+
+            if (!File.Exists(_dataFilePath))
+            {
+                throw new FileNotFoundException($"Could not find data file: '{_dataFilePath}'");
+            }
+
+            if (!File.Exists(_metaFilePath))
+            {
+                throw new FileNotFoundException($"Could not find meta file: '{_metaFilePath}'");
+            }
+        }
+
+        public async Task Generate()
+        {
+            await _console.Output.WriteLineAsync($"Seeding '{_seed.DataSet.Title}' {_seed.DataSet.Id}");
+
+            var stopwatch = Stopwatch.StartNew();
+
+            stopwatch.Start();
+
+            await _console.Output.WriteLineAsync("=> Started seeding meta");
+
+            var columns = _duckDb.Query<(string ColumnName, string ColumnType)>(
+                    $"DESCRIBE SELECT * FROM '{_dataFilePath}'"
+                )
+                .Select(row => row.ColumnName)
+                .ToList();
+
+            var allowedColumns = columns.ToHashSet();
+
+            var metaFileRows = (await _duckDb.QueryAsync<MetaFileRow>(
+                    new CommandDefinition(
+                        $"SELECT * FROM '{_metaFilePath}'",
+                        cancellationToken: _cancellationToken
+                    )
+                ))
+                .ToList();
+
+            await using var transaction = await _dbContext.Database.BeginTransactionAsync(_cancellationToken);
+
+            await _dbContext.DataSets.AddAsync(_seed.DataSet, _cancellationToken);
+
+            var dataSetVersion = await CreateDataSetVersion(metaFileRows, allowedColumns);
+            var dataSetMeta = await CreateDataSetMeta(metaFileRows, allowedColumns);
+
+            await transaction.CommitAsync(_cancellationToken);
+
+            stopwatch.Stop();
+
+            await _console.Output.WriteLineAsync(
+                $"=> Finished seeding meta in {stopwatch.Elapsed.TotalSeconds} seconds"
+            );
+
+            stopwatch.Restart();
+
+            await _console.Output.WriteLineAsync("=> Started seeding Parquet data");
+
+            await SeedParquetData(dataSetMeta, dataSetVersion.TotalResults);
+
+            stopwatch.Stop();
+
+            await _console.Output.WriteLineAsync($"=> Finished seeding Parquet data in {stopwatch.Elapsed.TotalSeconds} seconds");
+        }
+
+        private async Task<DataSetVersion> CreateDataSetVersion(
+            IList<MetaFileRow> metaFileRows,
+            HashSet<string> allowedColumns)
+        {
+            var totalResults = await _duckDb.QuerySingleAsync<int>($"SELECT COUNT(*) FROM '{_dataFilePath}'");
+
+            var timePeriods = (await _duckDb.QueryAsync<(int TimePeriod, string TimeIdentifier)>(
+                    new CommandDefinition(
+                        $"""
+                         SELECT DISTINCT time_period, time_identifier
+                         FROM '{_dataFilePath}'
+                         ORDER BY time_period
+                         """,
+                        cancellationToken: _cancellationToken
+                    )
+                ))
+                .Select(row => (
+                    Year: row.TimePeriod,
+                    TimeIdentifier: EnumToEnumLabelConverter<TimeIdentifier>.FromProvider(row.TimeIdentifier)
+                ))
+                .OrderBy(tuple => tuple.Year)
+                .ThenBy(tuple => tuple.TimeIdentifier)
+                .ToList();
+
+            var dataSetVersion = new DataSetVersion
+            {
+                Id = _seed.DataSetVersionId,
+                VersionMajor = 1,
+                VersionMinor = 0,
+                Status = DataSetVersionStatus.Published,
+                Notes = string.Empty,
+                ParquetFilename = string.Empty,
+                CsvFileId = Guid.NewGuid(),
+                DataSetId = _seed.DataSet.Id,
+                TotalResults = totalResults,
+                MetaSummary = new DataSetVersionMetaSummary
+                {
+                    TimePeriodRange = new TimePeriodRange
+                    {
+                        Start = new TimePeriodMeta
+                        {
+                            Year = timePeriods[0].Year,
+                            Code = timePeriods[0].TimeIdentifier
+                        },
+                        End = new TimePeriodMeta
+                        {
+                            Year = timePeriods[^1].Year,
+                            Code = timePeriods[^1].TimeIdentifier
+                        },
+                    },
+                    Filters = metaFileRows
+                        .Where(row => row.ColType == MetaFileRow.ColumnType.Filter
+                                      && allowedColumns.Contains(row.ColName))
+                        .OrderBy(row => row.Label)
+                        .Select(row => row.Label)
+                        .ToList(),
+                    Indicators = metaFileRows
+                        .Where(
+                            row => row.ColType == MetaFileRow.ColumnType.Indicator
+                                   && allowedColumns.Contains(row.ColName)
+                        )
+                        .OrderBy(row => row.Label)
+                        .Select(row => row.Label)
+                        .ToList(),
+                    GeographicLevels = ListGeographicLevels(allowedColumns)
+                },
+                Published = _seed.DataSet.Published,
+            };
+
+            await _dbContext.DataSetVersions.AddAsync(dataSetVersion, _cancellationToken);
+            await _dbContext.SaveChangesAsync(_cancellationToken);
+
+            return dataSetVersion;
+        }
+
+        private async Task<DataSetMeta> CreateDataSetMeta(
+            IList<MetaFileRow> metaFileRows,
+            IReadOnlySet<string> allowedColumns)
+        {
+            var geographicLevels = ListGeographicLevels(allowedColumns);
+
+            var dataSetMeta = new DataSetMeta
+            {
+                Id = _seed.DataSetMetaId,
+                DataSetVersionId = _seed.DataSetVersionId,
+                Filters = await ListFilterMeta(metaFileRows, allowedColumns),
+                Indicators = ListIndicatorMeta(metaFileRows, allowedColumns),
+                TimePeriods = await ListTimePeriodMeta(),
+                Locations = await ListLocationMeta(geographicLevels),
+                GeographicLevels = geographicLevels
+            };
+
+            await _dbContext.DataSetMeta.AddAsync(dataSetMeta, _cancellationToken);
+            await _dbContext.SaveChangesAsync(_cancellationToken);
+
+            return dataSetMeta;
+        }
+
+        private List<IndicatorMeta> ListIndicatorMeta(
+            IEnumerable<MetaFileRow> metaFileRows,
+            IReadOnlySet<string> allowedColumns)
+        {
+            return metaFileRows
+                .Where(row => row.ColType == MetaFileRow.ColumnType.Indicator
+                              && allowedColumns.Contains(row.ColName))
+                .OrderBy(row => row.Label)
+                .Select(
+                    row => new IndicatorMeta
+                    {
+                        Identifier = row.ColName,
+                        Label = row.Label,
+                        Unit = row.IndicatorUnit,
+                        DecimalPlaces = row.IndicatorDp
+                    }
+                )
+                .ToList();
+        }
+
+        private async Task<List<FilterMeta>> ListFilterMeta(
+            IEnumerable<MetaFileRow> metaFileRows,
+            IReadOnlySet<string> allowedColumns)
+        {
+            return await metaFileRows
+                .Where(row => row.ColType == MetaFileRow.ColumnType.Filter
+                              && allowedColumns.Contains(row.ColName))
+                .OrderBy(row => row.Label)
+                .ToAsyncEnumerable()
+                .SelectAwait(async row =>
+                {
+                    var options = (await _duckDb.QueryAsync<string>(
+                            new CommandDefinition(
+                                $"""
+                                 SELECT DISTINCT "{row.ColName}"
+                                 FROM '{_dataFilePath}' AS data
+                                 WHERE "{row.ColName}" != ''
+                                 ORDER BY "{row.ColName}"
+                                 """,
+                                cancellationToken: _cancellationToken
+                            )
+                        ))
+                        .Select(
+                            (label, index) => new FilterOptionMeta
+                            {
+                                PublicId = _shortId.Generate(),
+                                PrivateId = index + 1,
+                                Label = label
+                            }
+                        )
+                        .ToList();
+
+                    return new FilterMeta
+                    {
+                        Identifier = row.ColName,
+                        Label = row.Label,
+                        Hint = row.FilterHint ?? string.Empty,
+                        Options = options
+                    };
+                })
+                .ToListAsync(_cancellationToken);
+        }
+
+        private async Task<List<LocationMeta>> ListLocationMeta(List<GeographicLevel> geographicLevels)
+        {
+            return await geographicLevels
+                .ToAsyncEnumerable()
+                .SelectAwait(async level =>
+                {
+                    var cols = level.CsvColumns();
+                    var options = (await _duckDb.QueryAsync<(string Code, string Name)>(
+                            new CommandDefinition(
+                                $"""
+                                 SELECT {cols.Code}, {cols.Name}
+                                 FROM '{_dataFilePath}'
+                                 WHERE {cols.Name} != ''
+                                 GROUP BY {cols.Code}, {cols.Name}
+                                 ORDER BY {cols.Name}, {cols.Code}
+                                 """,
+                                cancellationToken: _cancellationToken
+                            )
+                        ))
+                        .Select(
+                            (tuple, index) => new LocationOptionMeta
+                            {
+                                PublicId = _shortId.Generate(),
+                                PrivateId = index + 1,
+                                Code = tuple.Code,
+                                Label = tuple.Name
+                            }
+                        )
+                        .ToList();
+
+                    return new LocationMeta
+                    {
+                        Level = level,
+                        Options = options
+                    };
+                })
+                .ToListAsync(_cancellationToken);
+        }
+
+        private static List<GeographicLevel> ListGeographicLevels(IReadOnlySet<string> allowedColumns)
+        {
+            return allowedColumns
+                .Where(col => GeographicLevelUtils.CsvColumnsToGeographicLevel.ContainsKey(col))
+                .Select(col => GeographicLevelUtils.CsvColumnsToGeographicLevel[col])
+                .Distinct()
+                .OrderBy(EnumToEnumLabelConverter<GeographicLevel>.ToProvider)
+                .ToList();
+        }
+
+        private async Task<List<TimePeriodMeta>> ListTimePeriodMeta()
+        {
+            return (await _duckDb.QueryAsync<(int TimePeriod, string TimeIdentifier)>(
+                    new CommandDefinition(
+                        $"""
+                         SELECT DISTINCT time_period, time_identifier
+                         FROM '{_dataFilePath}'
+                         ORDER BY time_period
+                         """,
+                        cancellationToken: _cancellationToken
+                    )
+                ))
+                .Select(
+                    tuple => new TimePeriodMeta
+                    {
+                        Year = tuple.TimePeriod,
+                        Code = EnumToEnumLabelConverter<TimeIdentifier>.FromProvider(tuple.TimeIdentifier)
+                    }
+                )
+                .OrderBy(meta => meta.Year)
+                .ThenBy(meta => meta.Code)
+                .ToList();
+        }
+
+        private async Task SeedParquetData(DataSetMeta meta, long totalRows)
+        {
+            await _console.Output.WriteLineAsync($"=> Processing {totalRows} rows");
+
+            // Create temporary meta tables in DuckDB to allow us to do data transform
+            // in DuckDB itself (i.e. changing all the filters and locations to normalised IDs).
+            // Trying to transform the data via using Appender API in C# is slower
+            // and seems to regularly cause DuckDB crashes for larger data sets.
+            await CreateDuckDbMetaTables(meta);
+
+            await _duckDb.ExecuteAsync("CREATE SEQUENCE data_seq START 1");
+
+            string[] columns =
+            [
+                "id UINTEGER PRIMARY KEY",
+                "time_period VARCHAR",
+                "time_identifier VARCHAR",
+                "geographic_level VARCHAR",
+                ..meta.Locations.Select(location => $"\"{location.Level}\" INTEGER"),
+                ..meta.Filters.Select(filter => $"\"{filter.Identifier}\" INTEGER"),
+                ..meta.Indicators.Select(indicator => $"\"{indicator.Identifier}\" VARCHAR"),
+            ];
+
+            await _duckDb.ExecuteAsync($"CREATE TABLE data({columns.JoinToString(",\n")})");
+
+            string[] insertColumns =
+            [
+                "nextval('data_seq') AS id",
+                "data_source.time_period",
+                "data_source.time_identifier",
+                "data_source.geographic_level",
+                ..meta.Locations.Select(location => $"{location.Level}.id AS {location.Level}"),
+                ..meta.Filters.Select(filter => $"{filter.Identifier}.id AS \"{filter.Identifier}\""),
+                ..meta.Indicators.Select(indicator => $"\"{indicator.Identifier}\""),
+            ];
+
+            string[] insertJoins =
+            [
+                ..meta.Locations.Select(location => $"""
+                     LEFT JOIN locations AS {location.Level}
+                     ON {location.Level}.level = '{location.Level}'
+                     AND {location.Level}.code = data_source.{location.Level.CsvCodeColumn()}
+                     AND {location.Level}.name = data_source.{location.Level.CsvNameColumn()}
+                     """
+                ),
+                ..meta.Filters.Select(filter => $"""
+                     LEFT JOIN filters AS "{filter.Identifier}"
+                     ON "{filter.Identifier}".type = '{filter.Identifier}'
+                     AND "{filter.Identifier}".label = data_source."{filter.Identifier}"
+                     """
+                )
+            ];
+
+            await _duckDb.ExecuteAsync(new CommandDefinition(
+                $"""
+                 INSERT INTO data
+                 SELECT 
+                    {insertColumns.JoinToString(",\n")}
+                 FROM read_csv_auto('{_dataFilePath}', ALL_VARCHAR = true) AS data_source
+                 {insertJoins.JoinToString('\n')}
+                 ORDER BY 
+                     data_source.geographic_level ASC, 
+                     data_source.time_period DESC
+                 """,
+                cancellationToken: _cancellationToken
+            ));
+
+            // Finish up by outputting Parquet file
+
+            var projectRootPath = PathUtils.ProjectRootPath;
+            var parquetDir = Path.Combine(projectRootPath, "data", "public-api-parquet");
+
+            if (!Path.Exists(parquetDir))
+            {
+                Directory.CreateDirectory(parquetDir);
+            }
+
+            var dataSetDir = Path.Combine(parquetDir, _seed.DataSet.Id.ToString());
+
+            if (Path.Exists(dataSetDir))
+            {
+                // Make sure data set directory is empty before exporting
+                Directory.Delete(dataSetDir, recursive: true);
+
+                // Deletion can be asynchronous (at OS level), meaning
+                // we have to do this to make sure the directory has
+                // actually been removed before proceeding...
+                while (Directory.Exists(dataSetDir))
+                {
+                    Thread.Sleep(100);
+                }
+            }
+
+            Directory.CreateDirectory(dataSetDir);
+
+            var versionDir = Path.Combine(dataSetDir, "v1.0");
+
+            Directory.CreateDirectory(versionDir);
+
+            var outputPath = Path.Combine(versionDir, "data.parquet");
+
+            await _duckDb.ExecuteAsync(new CommandDefinition(
+                $"COPY data TO '{outputPath}' (FORMAT PARQUET, COMPRESSION ZSTD)",
+                cancellationToken: _cancellationToken
+            ));
+        }
+
+        private async Task CreateDuckDbMetaTables(DataSetMeta meta)
+        {
+            await _duckDb.ExecuteAsync(
+                """
+                 CREATE TABLE locations(
+                     id INTEGER,
+                     code VARCHAR,
+                     name VARCHAR,
+                     level VARCHAR
+                 )
+                 """
+            );
+
+            foreach (var location in meta.Locations)
+            {
+                using var appender = _duckDb.CreateAppender(table: "locations");
+
+                foreach (var option in location.Options)
+                {
+                    var insertRow = appender.CreateRow();
+
+                    insertRow.AppendValue(option.PrivateId);
+                    insertRow.AppendValue(option.Code);
+                    insertRow.AppendValue(option.Label);
+                    insertRow.AppendValue(location.Level.ToString());
+
+                    insertRow.EndRow();
+                }
+            }
+
+            await _duckDb.ExecuteAsync(
+                """
+                 CREATE TABLE filters(
+                     id INTEGER,
+                     label VARCHAR,
+                     type VARCHAR
+                 )
+                 """
+            );
+
+            foreach (var filter in meta.Filters)
+            {
+                using var appender = _duckDb.CreateAppender(table: "filters");
+
+                foreach (var option in filter.Options)
+                {
+                    var insertRow = appender.CreateRow();
+
+                    insertRow.AppendValue(option.PrivateId);
+                    insertRow.AppendValue(option.Label);
+                    insertRow.AppendValue(filter.Identifier);
+
+                    insertRow.EndRow();
+                }
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="CliFx" Version="2.3.5" />
+      <PackageReference Include="Dapper" Version="2.1.24" />
+      <PackageReference Include="DuckDB.NET.Data.Full" Version="0.9.2" />
+      <PackageReference Include="Nanoid" Version="3.0.0" />
+      <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Public.Data.Model\GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None CopyToOutputDirectory="PreserveNewest" Include="SeedFiles\*" />
+    </ItemGroup>
+    
+</Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Models/MetaFileRow.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Models/MetaFileRow.cs
@@ -1,0 +1,34 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.Models;
+
+public record MetaFileRow
+{
+    public required string ColName { get; init; }
+
+    public ColumnType ColType { get; init; }
+
+    public required string Label { get; init; }
+
+    public string? IndicatorGrouping { get; init; }
+
+    private string? _indicatorUnit { get; init; }
+
+    public IndicatorUnit? IndicatorUnit =>
+        _indicatorUnit is not null
+            ? EnumToEnumValueConverter<IndicatorUnit>.FromProvider(_indicatorUnit)
+            : null;
+
+    public byte? IndicatorDp { get; init; }
+
+    public string? FilterGroupingColumn { get; init; }
+
+    public string? FilterHint { get; init; }
+
+    public enum ColumnType
+    {
+        Indicator,
+        Filter,
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Program.cs
@@ -1,0 +1,6 @@
+﻿using CliFx;
+
+await new CliApplicationBuilder()
+    .AddCommandsFromThisAssembly()
+    .Build()
+    .RunAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/README.md
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/README.md
@@ -1,0 +1,35 @@
+# Public Data scripts
+
+This project contains various useful scripts for the Public Data API.
+
+To run any of these scripts, you can either:
+
+1. Run directly via Rider. Set different script commands via 'Program arguments' in the run configuration.
+2. Via the CLI e.g.
+
+   ```bash
+   dotnet run -- seed:data
+   ```
+
+## Seed data - `seed:data`
+
+Data for the public data API can be seeded using this command. To run, simply:
+
+```bash
+dotnet run -- seed:data
+```
+
+### Prerequisites
+
+Before using this command, you will first need to place any required seed CSVs in the `SeedFiles` directory. The seed 
+CSVs can be found in Google Drive.
+
+Once you have done this, ensure the public API Docker database is running:
+
+```bash
+# Via Docker Compose
+docker-compose up -d public-api-db
+
+# Via project start script
+pnpm start publicApiDb
+```

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/SeedFiles/.gitignore
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/SeedFiles/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Seeds/DataSetSeed.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Seeds/DataSetSeed.cs
@@ -1,0 +1,136 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.Seeds;
+
+public record DataSetSeed(string Filename, DataSet DataSet, Guid DataSetMetaId, Guid DataSetVersionId)
+{
+    private static readonly Guid SpcPublicationId = new("a91d9e05-be82-474c-85ae-4913158406d0");
+    private static readonly Guid PupilAbsencePublicationId = new("cbbd299f-8297-44bc-92ac-558bcf51f8ad");
+    private static readonly Guid _16To18PerformancePublicationId = new("cbbd299f-8297-44bc-92ac-558bcf51f8ad");
+
+    public static DataSetSeed SpcEthnicityLanguage => new(
+        Filename: nameof(SpcEthnicityLanguage),
+        DataSet: new DataSet
+        {
+            Id = new Guid("018c68f3-51af-70ff-b6b5-719cff3d869e"),
+            Title = "Pupil characteristics - Ethnicity and Language",
+            Summary =
+                "Number of pupils in state-funded nursery, primary, secondary and special schools, non-maintained special schools and pupil referral units by language and ethnicity.",
+            Status = DataSetStatus.Published,
+            PublicationId = SpcPublicationId,
+            Published = DateTimeOffset.Parse("2023-06-15T09:30:00+00:00"),
+            Created = DateTimeOffset.Parse("2023-06-01T12:00:00+00:00"),
+            Updated = DateTimeOffset.Parse("2023-06-15T09:30:00+00:00"),
+        },
+        DataSetMetaId: new Guid("018c8da0-06fc-7b7c-99d7-0849ec885917"),
+        DataSetVersionId: new Guid("018c7db8-d7bb-77e8-8ee7-147a705c1e3e")
+    );
+
+    public static DataSetSeed SpcYearGroupGender => new(
+        Filename: nameof(SpcYearGroupGender),
+        DataSet: new DataSet
+        {
+            Id = new Guid("018c68f3-7aa0-7e1e-895e-6a9587ee31d0"),
+            Title = "Pupil characteristics - Year group and Gender",
+            Summary =
+                "Number of pupils in state-funded nursery, primary, secondary and special schools, non-maintained special schools, pupil referral units and independent schools by national curriculum year and gender.",
+            Status = DataSetStatus.Published,
+            PublicationId = SpcPublicationId,
+            Published = DateTimeOffset.Parse("2023-06-16T09:30:00+00:00"),
+            Created = DateTimeOffset.Parse("2023-06-02T12:00:00+00:00"),
+            Updated = DateTimeOffset.Parse("2023-06-16T09:30:00+00:00"),
+        },
+        DataSetMetaId: new Guid("018c8da0-2791-7209-bfcd-40cfb0addd00"),
+        DataSetVersionId: new Guid("018c7db9-3418-7b58-aa76-6a55d0d7b146")
+    );
+
+    public static DataSetSeed AbsenceRatesCharacteristic => new(
+        Filename: nameof(AbsenceRatesCharacteristic),
+        DataSet: new DataSet
+        {
+            Id = new Guid("018c696b-9ebb-7a62-ae29-2dc3ff52b02a"),
+            Title = "Absence rates by pupil characteristic - full academic years",
+            Summary =
+                "Absence information for the full academic year, by pupil characteristics including SEN, FSM, language, year group, gender and ethnicity for England.",
+            Status = DataSetStatus.Published,
+            PublicationId = PupilAbsencePublicationId,
+            Published = DateTimeOffset.Parse("2023-09-01T09:30:00+00:00"),
+            Created = DateTimeOffset.Parse("2023-08-15T12:00+00:00"),
+            Updated = DateTimeOffset.Parse("2023-09-01T09:30:00+00:00"),
+        },
+        DataSetMetaId: new Guid("018c8da0-8a93-7bb6-82b0-9d53fcf028a3"),
+        DataSetVersionId: new Guid("018c7db9-6a8f-77e1-a789-2eb0f071ef33")
+    );
+
+    public static DataSetSeed AbsenceRatesGeographicLevel => new(
+        Filename: nameof(AbsenceRatesGeographicLevel),
+        DataSet: new DataSet
+        {
+            Id = new Guid("018c696b-b93e-7f43-8b93-88de6cace1cd"),
+            Title = "Absence rates by geographic level - full academic years",
+            Summary =
+                "Absence information for full academic years for all enrolments in state-funded primary, secondary and special schools including information on overall absence, persistent absence and reason for absence for pupils aged 5-15.",
+            Status = DataSetStatus.Published,
+            PublicationId = PupilAbsencePublicationId,
+            Published = DateTimeOffset.Parse("2023-09-02T09:30:00+00:00"),
+            Created = DateTimeOffset.Parse("2023-08-16T12:00+00:00"),
+            Updated = DateTimeOffset.Parse("2023-09-02T09:30:00+00:00"),
+        },
+        DataSetMetaId: new Guid("018c8da0-a962-7124-af9e-b71ad621b89e"),
+        DataSetVersionId: new Guid("018c7db9-c6e5-70b6-869f-2b177b8ad324")
+    );
+
+    public static DataSetSeed AbsenceRatesGeographicLevelSchool => new(
+        Filename: nameof(AbsenceRatesGeographicLevelSchool),
+        DataSet: new DataSet
+        {
+            Id = new Guid("018c696b-c8ea-7376-ba7b-9817339f12d8"),
+            Title = "Absence rates by geographic level - school level - full academic years",
+            Summary =
+                "Absence information for full academic years for all enrolments in state-funded primary, secondary and special schools including information on overall absence, persistent absence and reason for absence for pupils aged 5-15. Includes school level data.",
+            Status = DataSetStatus.Published,
+            PublicationId = PupilAbsencePublicationId,
+            Published = DateTimeOffset.Parse("2023-09-03T09:30:00+00:00"),
+            Created = DateTimeOffset.Parse("2023-08-17T12:00+00:00"),
+            Updated = DateTimeOffset.Parse("2023-09-03T09:30:00+00:00"),
+        },
+        DataSetMetaId: new Guid("018c8da0-bc77-7b52-b8b8-c22a5b14c953"),
+        DataSetVersionId: new Guid("018c7db9-f885-7897-af0a-8f62ac55d0f4")
+    );
+
+    public static DataSetSeed Qua01 => new(
+        Filename: nameof(Qua01),
+        DataSet: new DataSet
+        {
+            Id = new Guid("018c696c-ac3d-74f1-88b6-b6e78d4fc18b"),
+            Title = "Destinations by qualification title, provision and sector subject area (QUA01)",
+            Summary =
+                "Reports on the employment, and learning destinations of adult FE & Skills learners, all age apprentices that achieved their learning aim, and Traineeship learners that completed their aim. Destination rates are calculated as a proportion of learners for whom a match was found in the LEO data.",
+            Status = DataSetStatus.Published,
+            PublicationId = _16To18PerformancePublicationId,
+            Published = DateTimeOffset.Parse("2023-12-01T09:30:00+00:00"),
+            Created = DateTimeOffset.Parse("2023-11-01T09:30:00+00:00"),
+            Updated = DateTimeOffset.Parse("2023-12-01T09:30:00+00:00"),
+        },
+        DataSetMetaId: new Guid("018c8da0-d84f-7fb4-8979-d214d3270c46"),
+        DataSetVersionId: new Guid("018c7dba-1821-747b-9a7c-c91169543a81")
+    );
+
+    public static DataSetSeed Nat01 => new(
+        Filename: nameof(Nat01),
+        DataSet: new DataSet
+        {
+            Id = new Guid("018c696d-333b-775a-a943-29082f7fe894"),
+            Title = "Destinations by demographics and provision (NAT01)",
+            Summary =
+                "Reports on the employment and learning destinations of adult FE & skills learners, all age apprentices that achieved their learning aim, and traineeship learners that completed their aim. Destination rates are calculated as a proportion of learners for whom a match was found in the LEO data.",
+            Status = DataSetStatus.Published,
+            PublicationId = _16To18PerformancePublicationId,
+            Published = DateTimeOffset.Parse("2023-12-02T09:30:00+00:00"),
+            Created = DateTimeOffset.Parse("2023-11-02T09:30:00+00:00"),
+            Updated = DateTimeOffset.Parse("2023-12-02T09:30:00+00:00"),
+        },
+        DataSetMetaId: new Guid("018c8da0-ed73-7b18-b10b-c6407c63e96a"),
+        DataSetVersionId: new Guid("018c7dba-582f-7a22-8e01-67e0a6b43603")
+    );
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Utils/ShortId.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Utils/ShortId.cs
@@ -1,0 +1,43 @@
+using NanoidDotNet;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.Utils;
+
+public class ShortId
+{
+    private const string Alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private const byte Size = 10;
+
+    private readonly Random _random;
+
+    private readonly HashSet<string> _existingIds = [];
+    private readonly bool _checkCollisions;
+
+    public ShortId(
+        int? seed = null,
+        bool checkCollisions = false)
+    {
+        _checkCollisions = checkCollisions;
+        _random = seed is not null ? new Random(seed.Value) : new CryptoRandom();
+    }
+
+    private string NextId() => Nanoid.Generate(random: _random, alphabet: Alphabet, size: Size);
+    
+    public string Generate()
+    {
+        var id = NextId();
+
+        if (!_checkCollisions)
+        {
+            return id;
+        }
+
+        while (_existingIds.Contains(id))
+        {
+            id = NextId();
+        }
+
+        _existingIds.Add(id);
+
+        return id;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.sln
+++ b/src/GovUk.Education.ExploreEducationStatistics.sln
@@ -61,6 +61,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEduc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Public.Data.Model", "GovUk.Education.ExploreEducationStatistics.Public.Data.Model\GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj", "{E37D154B-49E6-4012-A299-CD321C41F014}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts", "GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts\GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.csproj", "{65A141C6-EA38-40E7-844A-4EAA24AD17E1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -419,6 +421,18 @@ Global
 		{E37D154B-49E6-4012-A299-CD321C41F014}.Release|x64.Build.0 = Release|Any CPU
 		{E37D154B-49E6-4012-A299-CD321C41F014}.Release|x86.ActiveCfg = Release|Any CPU
 		{E37D154B-49E6-4012-A299-CD321C41F014}.Release|x86.Build.0 = Release|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Debug|x64.Build.0 = Debug|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Debug|x86.Build.0 = Debug|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Release|x64.ActiveCfg = Release|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Release|x64.Build.0 = Release|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Release|x86.ActiveCfg = Release|Any CPU
+		{65A141C6-EA38-40E7-844A-4EAA24AD17E1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
:warning: Depends on #4489 and #4486 :warning: 

---

This PR adds a seed data script for the public data API. This script will seed data sets for the following publications:

- Schools, pupils and their characteristics
  - Pupil characteristics - Ethnicity and Language
  - Pupil characteristics - Year group and Gender

- Pupil absence in schools in England:
  - Absence rates by pupil characteristic - full academic years
  - Absence rates by geographic level - full academic years
  - Absence rates by geographic level - school level - full academic years

- 16 to 18 school and college performance tables
  - Destinations by qualification title, provision and sector subject area (QUA01)
  - Destinations by demographics and provision (NAT01)

Note that the QUA01 and NAT01 data sets don't really belong in the '16 to 18 school and college performance tables' publication. This is just for convenience instead of creating a new publication as we only need them for performance testing.

## Usage

Via CLI:

1. Go to subproject.
2. Run `dotnet run -- seed:data`

Via Rider:

1. Run the project with `seed:data` as a 'Program argument' (in run config).