### PR TITLE
EES-4553: Add Slack notification for "Validate snapshots" workflow failures

### DIFF
--- a/.github/workflows/validate-snapshots.yml
+++ b/.github/workflows/validate-snapshots.yml
@@ -71,3 +71,20 @@ jobs:
           title: ${{ steps.vars.outputs.pr_title }}
           body: ${{ steps.vars.outputs.pr_body }}
           draft: false
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ always() && (needs.test.result == 'failure' || needs.test.result == 'timed_out') }}
+    needs:
+      - test
+    
+    steps:
+      - uses: actions/checkout@v2
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: Alertbot
+          SLACK_ICON_EMOJI: ':x:'
+          SLACK_COLOR: '#a30200'
+          SLACK_TITLE: Workflow ${{ needs.test.result }}
+          MSG_MINIMAL: actions url
+          SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
**Change**
Add a job to run in the event of a snapshot validation workflow failure, which sends a notification to the applicable Slack channel.

**Motivation**
To ensure workflow failures can be picked up and resolved in a timely manner.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/77351705/54bf2ab8-35af-4e7a-8758-aa25a95b6f95)