### PR TITLE
EES-4775 - swapped "go to" keyword for equivalent public page keyword that includes basic auth support

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
@@ -82,7 +82,7 @@ Check publication is updated on dashboard
     user waits until page contains link    ${PUBLICATION_NAME_UPDATED}
 
 Validate publication redirect works
-    go to    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}${ACADEMIC_YEAR}
+    user navigates to public frontend    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}${ACADEMIC_YEAR}
     user waits until h1 is visible    ${PUBLICATION_NAME_UPDATED}
     user checks url contains    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}-updated${ACADEMIC_YEAR}
 


### PR DESCRIPTION
This PR:
- replaces standard Selenium keyword "go to" with basic auth-supporting equivalent keyword "user navigates to public frontend"

This stops the navigation of the failing test from becoming stuck on the basic auth popup when run against Dev, where basic auth access is enforced.