### PR TITLE
EES-4759: Replace "superseded by" link component with anchor

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
@@ -15,7 +15,6 @@ import tableBuilderService, {
   Subject,
 } from '@common/services/tableBuilderService';
 import { Dictionary } from '@common/types';
-import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
 import DownloadStep, {
   DownloadFormSubmitHandler,
@@ -167,12 +166,12 @@ const DataCataloguePage: NextPage<Props> = ({
                 state.query.publication.supersededBy ? (
                   <WarningMessage testId="superseded-warning">
                     This publication has been superseded by{' '}
-                    <Link
-                      testId="superseded-by-link"
-                      to={`/data-catalogue?publicationSlug=${state.query.publication.supersededBy.slug}`}
+                    <a
+                      data-testid="superseded-by-link"
+                      href={`/data-catalogue?publicationSlug=${state.query.publication.supersededBy.slug}`}
                     >
                       {state.query.publication.supersededBy.title}
-                    </Link>
+                    </a>
                   </WarningMessage>
                 ) : null
               }


### PR DESCRIPTION
**Changes**
Replace "superseded by" React-style `<Link>` component with a standard HTML anchor tag.

**Motivation**
Resolve a state issue whereby superseded links didn't update other components on the page to match the newly-selected publication.

**Tradeoffs**
More complex work would be required to refactor the state management aspect of the multi-step form in order to get this working with the existing `Link` component. Changing the element to an anchor triggers a full page refresh, which isn't the ideal or preferred solution, but is still fast enough to be barely perceivable.

This solution was chosen as a quick, temporary fix due to the data catalogue section currently undergoing a full rewrite.