### PR TITLE
EES-4777 Get publications via releaseIds, not PublicationSlugs

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -108,14 +108,11 @@ public class PublishingCompletionService : IPublishingCompletionService
                 }
             });
 
-        var publicationSlugs = prePublishingStagesComplete
-            .Select(status => status.PublicationSlug)
-            .Distinct();
-
         var directlyRelatedPublicationIds = await _contentDbContext
-            .Publications
-            .Where(p => publicationSlugs.Contains(p.Slug))
-            .Select(p => p.Id)
+            .Releases
+            .Where(r => releaseIdsToUpdate.Contains(r.Id))
+            .Select(r => r.PublicationId)
+            .Distinct()
             .ToListAsync();
 
         await directlyRelatedPublicationIds


### PR DESCRIPTION
This PR fixes a bug where if you schedule a release to be published, then change its publication's slug while it's scheduled, the publication's `LatestPublishedReleaseId` won't get updated when the release is published. This leads to the latest release incorrectly saying it's not the latest data on the public release page.

This happens because the Azure Storage `ReleaseStatus` table has a column called `PublicationSlug` that isn't updated when the Content DBs Publication table Slug is updated. `PublishingCompletionService#CompletePublishingIfAllPriorStagesComplete` used the `ReleaseStatus` table's out-of-date slug to determine what publication's `LatestPublishedReleaseId`s needed updating. So `LatestPublishedReleaseId` was not updated.

I decided against ensuring `ReleaseStatus`'s `PublicationSlug` column was correct. There will probably already be a lot of slugs that are wrong and need fixing there, and even just fixing it for new slugs would be time consuming. There is precedence for treating slugs stored in Azure Storage tables as unreliable in `Notifier`'s Azure Storage `Subscription` and `PendingSubscription` tables, and we're also intending to rework the publishing code. So the quick fix seems like the way to go.