### PR TITLE
EES-4760 Remove associated Azure Storage ReleaseStatus rows when remo…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServicePermissionTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
@@ -100,16 +101,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         private TopicService SetupTopicService(
-            ContentDbContext contentContext = null,
-            StatisticsDbContext statisticsContext = null,
-            PersistenceHelper<ContentDbContext> persistenceHelper = null,
-            IMapper mapper = null,
-            IUserService userService = null,
-            IReleaseSubjectRepository releaseSubjectRepository = null,
-            IReleaseDataFileService releaseDataFileService = null,
-            IReleaseFileService releaseFileService = null,
-            IPublishingService publishingService = null,
-            IMethodologyService methodologyService = null)
+            ContentDbContext? contentContext = null,
+            StatisticsDbContext? statisticsContext = null,
+            PersistenceHelper<ContentDbContext>? persistenceHelper = null,
+            IMapper? mapper = null,
+            IUserService? userService = null,
+            IReleaseSubjectRepository? releaseSubjectRepository = null,
+            IReleaseDataFileService? releaseDataFileService = null,
+            IReleaseFileService? releaseFileService = null,
+            IPublishingService? publishingService = null,
+            IMethodologyService? methodologyService = null,
+            IReleasePublishingStatusRepository? releasePublishingStatusRepository = null)
         {
             return new TopicService(
                 Mock.Of<IConfiguration>(),
@@ -123,7 +125,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 releaseFileService ?? Mock.Of<IReleaseFileService>(),
                 publishingService ?? Mock.Of<IPublishingService>(),
                 methodologyService ?? Mock.Of<IMethodologyService>(),
-                Mock.Of<IBlobCacheService>()
+                Mock.Of<IBlobCacheService>(),
+                releasePublishingStatusRepository ?? Mock.Of<IReleasePublishingStatusRepository>()
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
@@ -413,6 +413,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var methodologyService = new Mock<IMethodologyService>(Strict);
             var publishingService = new Mock<IPublishingService>(Strict);
             var cacheService = new Mock<IBlobCacheService>(Strict);
+            var releasePublishingStatusRepository = new Mock<IReleasePublishingStatusRepository>(Strict);
 
             await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
             await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
@@ -425,7 +426,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseSubjectRepository: releaseSubjectRepository.Object,
                     methodologyService: methodologyService.Object,
                     publishingService: publishingService.Object,
-                    cacheService: cacheService.Object);
+                    cacheService: cacheService.Object,
+                    releasePublishingStatusRepository: releasePublishingStatusRepository.Object);
 
                 releaseDataFileService
                     .Setup(s => s.DeleteAll(releaseId, true))
@@ -452,13 +454,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             ItIs.DeepEqualTo(new PrivateReleaseContentFolderCacheKey(releaseId))))
                     .Returns(Task.CompletedTask);
 
+                releasePublishingStatusRepository.Setup(mock =>
+                        mock.RemovePublisherReleaseStatuses(new List<Guid>{ release.Id }))
+                    .Returns(Task.CompletedTask);
+
                 var result = await service.DeleteTopic(topic.Id);
                 VerifyAllMocks(releaseDataFileService,
                     releaseFileService,
                     releaseSubjectRepository,
                     methodologyService,
                     publishingService,
-                    cacheService);
+                    cacheService,
+                    releasePublishingStatusRepository);
 
                 result.AssertRight();
 
@@ -558,6 +565,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var releaseSubjectRepository = new Mock<IReleaseSubjectRepository>(Strict);
             var publishingService = new Mock<IPublishingService>(Strict);
             var cacheService = new Mock<IBlobCacheService>(Strict);
+            var releasePublishingStatusRepository = new Mock<IReleasePublishingStatusRepository>(Strict);
 
             await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
             await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
@@ -569,7 +577,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object,
                     releaseSubjectRepository: releaseSubjectRepository.Object,
                     publishingService: publishingService.Object,
-                    cacheService: cacheService.Object);
+                    cacheService: cacheService.Object,
+                    releasePublishingStatusRepository: releasePublishingStatusRepository.Object);
 
                 var releaseDataFileDeleteSequence = new MockSequence();
 
@@ -608,13 +617,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 publishingService.Setup(s => s.TaxonomyChanged())
                     .ReturnsAsync(Unit.Instance);
 
+                releasePublishingStatusRepository.Setup(mock =>
+                        mock.RemovePublisherReleaseStatuses(releaseIdsInExpectedDeleteOrder))
+                    .Returns(Task.CompletedTask);
+
                 var result = await service.DeleteTopic(topicId);
                 VerifyAllMocks(
                     releaseDataFileService,
                     releaseFileService,
                     releaseSubjectRepository,
                     publishingService,
-                    cacheService);
+                    cacheService,
+                    releasePublishingStatusRepository);
 
                 result.AssertRight();
 
@@ -872,6 +886,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var methodologyService = new Mock<IMethodologyService>(Strict);
             var publishingService = new Mock<IPublishingService>(Strict);
             var cacheService = new Mock<IBlobCacheService>(Strict);
+            var releasePublishingStatusRepository = new Mock<IReleasePublishingStatusRepository>(Strict);
 
             await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
             await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
@@ -884,7 +899,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseSubjectRepository: releaseSubjectRepository.Object,
                     methodologyService: methodologyService.Object,
                     publishingService: publishingService.Object,
-                    cacheService: cacheService.Object);
+                    cacheService: cacheService.Object,
+                    releasePublishingStatusRepository: releasePublishingStatusRepository.Object);
 
                 releaseDataFileService
                     .Setup(s => s.DeleteAll(releaseId, true))
@@ -911,13 +927,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             ItIs.DeepEqualTo(new PrivateReleaseContentFolderCacheKey(releaseId))))
                     .Returns(Task.CompletedTask);
 
+                releasePublishingStatusRepository.Setup(mock =>
+                        mock.RemovePublisherReleaseStatuses(new List<Guid>{ releaseId }))
+                    .Returns(Task.CompletedTask);
+
                 var result = await service.DeleteTopic(topic.Id);
                 VerifyAllMocks(releaseDataFileService,
                     releaseFileService,
                     releaseSubjectRepository,
                     methodologyService,
                     publishingService,
-                    cacheService);
+                    cacheService,
+                    releasePublishingStatusRepository);
 
                 result.AssertRight();
 
@@ -942,6 +963,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IPublishingService? publishingService = null,
             IMethodologyService? methodologyService = null,
             IBlobCacheService? cacheService = null,
+            IReleasePublishingStatusRepository? releasePublishingStatusRepository = null,
             bool enableThemeDeletion = true)
         {
             var configuration =
@@ -959,7 +981,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 releaseFileService ?? Mock.Of<IReleaseFileService>(Strict),
                 publishingService ?? Mock.Of<IPublishingService>(Strict),
                 methodologyService ?? Mock.Of<IMethodologyService>(Strict),
-                cacheService ?? Mock.Of<IBlobCacheService>(Strict)
+                cacheService ?? Mock.Of<IBlobCacheService>(Strict),
+                releasePublishingStatusRepository ?? Mock.Of<IReleasePublishingStatusRepository>(Strict)
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleasePublishingStatusRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleasePublishingStatusRepository.cs
@@ -8,5 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     public interface IReleasePublishingStatusRepository
     {
         Task<IEnumerable<ReleasePublishingStatus>> GetAllByOverallStage(Guid releaseId, params ReleasePublishingStatusOverallStage[] overallStages);
+
+        Task RemovePublisherReleaseStatuses(List<Guid> releaseIds);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleasePublishingStatusRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleasePublishingStatusRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using Microsoft.Azure.Cosmos.Table;
@@ -46,6 +47,39 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             var query = new TableQuery<ReleasePublishingStatus>().Where(filter);
             return _publisherTableStorageService.ExecuteQueryAsync(PublisherReleaseStatusTableName, query);
+        }
+
+        public async Task RemovePublisherReleaseStatuses(List<Guid> releaseIds)
+        {
+            if (releaseIds.IsNullOrEmpty())
+            {
+                // If filter is string.Empty, the query returns all table entities
+                return;
+            }
+
+            var filter = string.Empty;
+            foreach (var releaseId in releaseIds)
+            {
+                var newFilter = TableQuery.GenerateFilterCondition(nameof(ReleasePublishingStatus.PartitionKey),
+                    QueryComparisons.Equal, releaseId.ToString());
+                if (filter == string.Empty)
+                {
+                    filter = newFilter;
+                }
+                else
+                {
+                    filter = TableQuery.CombineFilters(filter, TableOperators.Or, newFilter);
+                }
+            }
+
+            var cloudTable = _publisherTableStorageService.GetTable(PublisherReleaseStatusTableName);
+            var query = new TableQuery<ReleasePublishingStatus>().Where(filter);
+            var releaseStatusesToRemove = cloudTable.ExecuteQuery(query);
+
+            foreach (var releaseStatus in releaseStatusesToRemove)
+            {
+                await cloudTable.ExecuteAsync(TableOperation.Delete(releaseStatus));
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleasePublishingStatusRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleasePublishingStatusRepository.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using Microsoft.Azure.Cosmos.Table;
 using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
@@ -53,7 +54,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             if (releaseIds.IsNullOrEmpty())
             {
-                // If filter is string.Empty, the query returns all table entities
+                // Return early as we want to do nothing in this case - without this,
+                // `filter` will be string.Empty and the query returns all table entities
                 return;
             }
 
@@ -62,14 +64,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             {
                 var newFilter = TableQuery.GenerateFilterCondition(nameof(ReleasePublishingStatus.PartitionKey),
                     QueryComparisons.Equal, releaseId.ToString());
-                if (filter == string.Empty)
-                {
-                    filter = newFilter;
-                }
-                else
-                {
-                    filter = TableQuery.CombineFilters(filter, TableOperators.Or, newFilter);
-                }
+
+                filter = filter == string.Empty
+                    ? newFilter
+                    : TableQuery.CombineFilters(filter, TableOperators.Or, newFilter);
             }
 
             var cloudTable = _publisherTableStorageService.GetTable(PublisherReleaseStatusTableName);


### PR DESCRIPTION
…ving topic

This PR ensures that entries to the Azure Storage Publisher `ReleaseStatus` table are removed as part of removing a theme or topic. This was necessary because we were seeing alerts like this against the dev environment:
![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/21970718/313bd535-9b30-4827-907e-fdabb494ad95)

After investigating the reason for this alert, it was found that if a release is scheduled for publication, but then removed as part of the UI tests test data teardown, then the `ReleaseStatus` entry remained. Because we had this entry for a scheduled release that no longer exists in the Content or Statistics DBs, when it was staged as part of the midnight publishing step, it caused an alert.

As we now remove these entries from `ReleaseStatus`, this should no longer happen.

# Additional notes

- With `Microsoft.Azure.Cosmos.Table`, it isn't possible to batch delete table entities, and it also is necessary to get entities before removing them. Hence why I fetch all relevant entries first, and then remove them one by one. This can be done more efficiently when we migrate to Azure.Data.Tables as part of EES-4771: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tables/Azure.Data.Tables/MigrationGuide.md#delete-table-entities

- This new code gets called in `TopicService#DeleteTopic` as part of the UI tests test data teardown, and `ThemeService#DeleteTheme` which is used by the UI test suite `themes_and_topics.robot`