### PR TITLE
EES-4754 change page view controls

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.module.scss
@@ -1,27 +1,45 @@
 @import '~govuk-frontend/govuk/base';
+@import '@admin/styles/variables';
 
-.toggle {
+// scroll-padding to ensure the sticky bar doesn't
+// obscure keyboard focus.
+:global(:root) {
+  scroll-padding-top: 180px;
+
+  @include govuk-media-query($from: tablet) {
+    scroll-padding-top: 100px;
+  }
+}
+
+.container {
   background: $govuk-brand-colour;
-  bottom: 0;
-  left: 0;
-  max-width: 390px;
-  padding: 6px;
-  position: fixed;
-  width: 100%;
-  z-index: 10000;
+  margin: -#{govuk-spacing(6)} 0 govuk-spacing(6) -#{govuk-spacing(3)};
+  max-width: $dfe-page-width-wide;
+  padding: govuk-spacing(1) govuk-spacing(4);
+  position: sticky;
+  top: 0;
+  width: calc(100% + #{govuk-spacing(6)});
+  z-index: 999;
 
-  @media print {
-    display: none;
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(9);
+    margin-left: 0;
+    width: 100%;
   }
 
-  :global(.govuk-radios) {
-    background: govuk-colour('white');
-    min-height: 100px;
-    padding: 6px 6px 0;
+  :global(.govuk-fieldset) {
+    align-items: center;
+    display: flex;
   }
 
-  &.open {
-    border-top: 0;
+  :global(.govuk-fieldset__legend) {
+    color: govuk-colour('white');
+    float: left;
+    margin: 0 govuk-spacing(4) 1px 0;
+  }
+
+  :global(.govuk-label) {
+    color: govuk-colour('white');
   }
 }
 
@@ -34,7 +52,7 @@
   display: flex;
   justify-content: space-between;
   font-size: 1.5rem;
-  font-weight: 700;
+  font-weight: $govuk-font-weight-bold;
   line-height: 1.25;
   margin: 0;
   padding: 0;
@@ -46,20 +64,5 @@
   &:focus-visible {
     border-color: govuk-colour('yellow');
     outline: none;
-  }
-}
-
-.open {
-  .button {
-    margin-bottom: 6px;
-  }
-}
-
-.content {
-  background-color: govuk-colour('white');
-  display: none;
-
-  .open & {
-    display: block;
   }
 }

--- a/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.tsx
@@ -1,73 +1,85 @@
 import { EditingMode, useEditingContext } from '@admin/contexts/EditingContext';
+import styles from '@admin/components/editable/EditablePageModeToggle.module.scss';
 import FormRadioGroup from '@common/components/form/FormRadioGroup';
+import { useMobileMedia } from '@common/hooks/useMedia';
 import useToggle from '@common/hooks/useToggle';
 import React from 'react';
 import classNames from 'classnames';
-import styles from './EditablePageModeToggle.module.scss';
 
 interface Props {
   canUpdateRelease?: boolean;
   previewLabel?: string;
   showTablePreviewOption?: boolean;
 }
-const EditablePageModeToggle = ({
+
+export default function EditablePageModeToggle({
   canUpdateRelease = true,
   previewLabel = 'Preview content',
   showTablePreviewOption = false,
-}: Props) => {
+}: Props) {
   const { editingMode, setEditingMode } = useEditingContext();
   const [isOpen, toggleOpen] = useToggle(true);
+  const { isMedia: isMobileMedia } = useMobileMedia();
 
-  const previewOption = {
-    label: previewLabel,
-    value: 'preview',
-  };
+  const options = [
+    ...(canUpdateRelease
+      ? [
+          {
+            label: 'Edit content',
+            value: 'edit',
+          },
+        ]
+      : []),
+    {
+      label: previewLabel,
+      value: 'preview',
+    },
 
-  const options = [previewOption];
-
-  if (canUpdateRelease) {
-    options.push({
-      label: 'Edit content',
-      value: 'edit',
-    });
-  }
-
-  if (showTablePreviewOption) {
-    options.push({
-      label: 'Preview table tool',
-      value: 'table-preview',
-    });
-  }
+    ...(showTablePreviewOption
+      ? [
+          {
+            label: 'Preview table tool',
+            value: 'table-preview',
+          },
+        ]
+      : []),
+  ];
 
   return (
-    <div
-      className={classNames(styles.toggle, {
-        [styles.open]: isOpen,
-      })}
-    >
-      <button
-        type="button"
-        id="pageViewToggleButton"
-        onClick={toggleOpen}
-        className={styles.button}
-        aria-expanded={isOpen}
+    <div className={styles.container}>
+      {isMobileMedia && (
+        <button
+          type="button"
+          id="pageViewToggleButton"
+          onClick={toggleOpen}
+          className={styles.button}
+          aria-expanded={isOpen}
+        >
+          Change page view
+          <span
+            className={classNames('govuk-accordion-nav__chevron', {
+              'govuk-accordion-nav__chevron--down': isOpen,
+            })}
+            aria-hidden
+          />
+        </button>
+      )}
+
+      <div
+        aria-labelledby="pageViewToggleButton"
+        className={classNames({
+          'dfe-js-hidden': isMobileMedia && !isOpen,
+        })}
       >
-        Set page view
-        <span
-          className={classNames('govuk-accordion-nav__chevron', {
-            'govuk-accordion-nav__chevron--down': isOpen,
-          })}
-          aria-hidden
-        />
-      </button>
-      <div aria-labelledby="pageViewToggleButton" className={styles.content}>
         <FormRadioGroup
           id="editingMode"
+          inline
           name="editingMode"
           className={styles.fieldset}
           value={editingMode}
-          legend="Set page view"
-          legendHidden
+          legend="Change page view"
+          legendHidden={isMobileMedia}
+          legendSize="s"
           small
           options={options}
           onChange={event => {
@@ -77,6 +89,4 @@ const EditablePageModeToggle = ({
       </div>
     </div>
   );
-};
-
-export default EditablePageModeToggle;
+}

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditablePageModeToggle.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditablePageModeToggle.test.tsx
@@ -1,0 +1,69 @@
+import EditablePageModeToggle from '@admin/components/editable/EditablePageModeToggle';
+import render from '@common-test/render';
+import { screen, within } from '@testing-library/react';
+
+let mockIsMedia = false;
+jest.mock('@common/hooks/useMedia', () => ({
+  useMobileMedia: () => {
+    return {
+      isMedia: mockIsMedia,
+    };
+  },
+}));
+
+describe('EditablePageModeToggle', () => {
+  test('renders the default options', () => {
+    render(<EditablePageModeToggle />);
+
+    const group = screen.getByRole('group', { name: 'Change page view' });
+    const options = within(group).getAllByRole('radio');
+    expect(options).toHaveLength(2);
+    expect(options[0]).toEqual(screen.getByLabelText('Edit content'));
+    expect(options[1]).toEqual(screen.getByLabelText('Preview content'));
+  });
+
+  test('deso not render the edit content option when canUpdateRelease is false', () => {
+    render(<EditablePageModeToggle canUpdateRelease={false} />);
+
+    const group = screen.getByRole('group', { name: 'Change page view' });
+    const options = within(group).getAllByRole('radio');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toEqual(screen.getByLabelText('Preview content'));
+  });
+
+  test('renders the preview table tool option when showTablePreviewOption is true', () => {
+    render(<EditablePageModeToggle showTablePreviewOption />);
+
+    const group = screen.getByRole('group', { name: 'Change page view' });
+    const options = within(group).getAllByRole('radio');
+    expect(options).toHaveLength(3);
+    expect(options[0]).toEqual(screen.getByLabelText('Edit content'));
+    expect(options[1]).toEqual(screen.getByLabelText('Preview content'));
+    expect(options[2]).toEqual(screen.getByLabelText('Preview table tool'));
+  });
+
+  test('renders the mobile version', async () => {
+    mockIsMedia = true;
+
+    render(<EditablePageModeToggle />);
+
+    expect(
+      screen.getByRole('button', { name: 'Change page view' }),
+    ).toBeInTheDocument();
+    const group = screen.getByRole('group', { name: 'Change page view' });
+    expect(group).toBeVisible();
+
+    const options = within(group).getAllByRole('radio');
+    expect(options).toHaveLength(2);
+    expect(options[0]).toEqual(screen.getByLabelText('Edit content'));
+    expect(options[1]).toEqual(screen.getByLabelText('Preview content'));
+
+    mockIsMedia = false;
+  });
+
+  test('renders the desktop version', () => {
+    expect(
+      screen.queryByRole('button', { name: 'Change page view' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
@@ -434,11 +434,11 @@ describe('ReleaseContentPage', () => {
     });
 
     expect(
-      screen.getByRole('button', { name: 'Set page view' }),
+      screen.getByRole('button', { name: 'Change page view' }),
     ).toBeInTheDocument();
 
     const radios = within(
-      screen.getByRole('group', { name: 'Set page view' }),
+      screen.getByRole('group', { name: 'Change page view' }),
     ).getAllByRole('radio');
     expect(radios).toHaveLength(3);
     expect(radios[0]).toEqual(screen.getByLabelText('Edit content'));

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -275,7 +275,6 @@ Validate data block is in list again
 Embed data block into release content
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
-    user closes Set Page View box
     user creates new content section    1    ${CONTENT_SECTION_NAME}
     user clicks button    Add data block
     user chooses and embeds data block    ${DATABLOCK_NAME}

--- a/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
@@ -149,7 +149,6 @@ Remove a Content Section from the Amendment
     user deletes editable accordion section    Methodology annex section 1    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
 
 Remove an image from a Content Block
-    user closes Set Page View box
     user opens accordion section    Methodology annex section 2    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
     user removes image from accordion section text block    Methodology annex section 2    2
     ...    Alt text for the uploaded annex image 3    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}    Save
@@ -163,6 +162,7 @@ Remove a Content Block from a Content Section
     ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
 
 Add a new Content Block to an existing Content Section and include a new image
+    user scrolls up    400
     user opens accordion section    Methodology content section 1    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
     user adds text block to editable accordion section    Methodology content section 1
     ...    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -57,7 +57,6 @@ Navigate to 'Content' page
     user waits until h2 is visible    ${PUBLICATION_NAME}
 
 Add summary content to release
-    user closes Set Page View box
     user adds summary text block
     user adds content to summary text block    Test intro text for ${PUBLICATION_NAME}
 

--- a/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
@@ -54,8 +54,6 @@ Navigate to content section as analyst1
     user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
 
 Add first content section
-    user closes Set Page View box
-    user scrolls down    400
     user scrolls to element    xpath://button[text()="Add new section"]
     user waits until button is enabled    Add new section
     user clicks button    Add new section
@@ -78,7 +76,6 @@ Switch to bau1 to view release
 
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
-    user closes Set Page View box
 
 Check second text block is locked as bau1
     ${block}=    get accordion section block    First content section    2    id:releaseMainContent
@@ -97,8 +94,6 @@ Switch to bau1 to add review comments for first text block
     ${block}=    user starts editing accordion section text block    First content section    1
     ...    id:releaseMainContent
 
-    # ensure 'Set page view' box doesn't intercept button click
-    user scrolls down    150
     user presses keys    CTRL+a
     user adds comment to selected text    ${block}    Test comment 1
 
@@ -124,8 +119,6 @@ Add review comment for second text block as bau1
     ${block}=    user starts editing accordion section text block    First content section    2
     ...    id:releaseMainContent
 
-    # ensure 'Set page view' box doesn't intercept button click
-    user scrolls down    100
     user presses keys    CTRL+a
     user adds comment to selected text    ${block}    Test comment 3
 
@@ -161,9 +154,6 @@ Switch to analyst1 to start resolving comments
     ...    Analyst1 User1 (ees-test.analyst1@education.gov.uk) is currently editing this block
     user checks element does not contain    ${block}    Analyst1 User1 is editing
 
-    # avoid set page view box getting in the way
-    user scrolls down    600
-
 Switch to bau1 to check first text block is locked
     user switches to bau1 browser
     ${block}=    get accordion section block    First content section    1    id:releaseMainContent
@@ -183,10 +173,6 @@ Switch to analyst1 to resolve comment for first text block
     ${comment}=    user gets unresolved comment    Test comment 1    ${block}
     ${author}=    get child element    ${comment}    testid:comment-author
     user waits until element contains    ${author}    Bau1 User1
-
-    # avoid clicking the 'set page view' span
-    user scrolls to element    ${comment}
-    user scrolls down    200
 
     # resolve the comment left by bau1
     user clicks button    Resolve    ${comment}
@@ -221,8 +207,6 @@ Switch back to analyst1 to resolve second text block
     ${block}=    get accordion section block    First content section    2    id:releaseMainContent
 
     user clicks button    View comments    ${block}
-    # avoid set page view box getting in the way
-    user scrolls down    600
 
     user checks list has x items    testid:comments-unresolved    1    ${block}
     user checks list item contains    testid:comments-unresolved    1    Test comment 3    ${block}
@@ -287,7 +271,6 @@ Add data block
 Add review comment for data block as bau1
     user switches to bau1 browser
     user reloads page
-    user closes Set Page View box
     user opens accordion section    ${SECTION_2_TITLE}    id:releaseMainContent
     user scrolls down    400
     ${block}=    set variable    xpath://*[@data-testid="data-block-comments-${DATABLOCK_NAME}"]
@@ -299,7 +282,6 @@ Add review comment for data block as bau1
 Resolve comment for data block as analyst1
     user switches to analyst1 browser
     user reloads page
-    user closes Set Page View box
     user opens accordion section    ${SECTION_2_TITLE}    id:releaseMainContent
     user scrolls down    400
     ${block}=    set variable    xpath://*[@data-testid="data-block-comments-${DATABLOCK_NAME}"]

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -808,10 +808,6 @@ user gets resolved comment
     ...    xpath:./li[.//*[@data-testid="comment-content" and text()="${comment_text}"]]
     [Return]    ${result}
 
-user closes Set Page View box
-    user clicks element    id:pageViewToggleButton
-    user waits until element is not visible    id:editingMode    %{WAIT_SMALL}
-
 # This keyword will work for any URL containing the pattern release/<guid>, and will return the guid segment of the URL.
 # For example, in the URL https://localhost/publication/<publication id>/release/<release id>/status, this
 # keyword would return the <release id> segment of the URL.

--- a/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
+++ b/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
@@ -25,7 +25,7 @@ user cannot see edit controls for release content
     [Arguments]    ${publication}
     user clicks link    Content
     user waits until h2 is visible    ${publication}
-    user waits until page does not contain button    Set page view
+    user waits until page does not contain button    Change page view
     user waits until page does not contain button    Add note
     user waits until page does not contain button    Add related page link
     user waits until page does not contain button    Add secondary stats


### PR DESCRIPTION
Changes the page view controls on release and methodology content pages to be in a sticky bar at the top of the page (once you've scrolled past it).

Removes the `user closes Set Page View box` keyword from the UI tests as it's no longer needed.

Desktop:
![desktop](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/6783ac16-fe4e-4689-b8ff-a9f0a03f33a3)

Mobile:
![mobile](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/19456099-7eba-4021-b8dd-3164938a8816)

