### PR TITLE
EES-4737 show error if get data file replacement plan fails

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacementCompletePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacementCompletePage.tsx
@@ -22,7 +22,11 @@ const ReleaseDataFileReplacementCompletePage = ({
 
   // Run the replacement plan against itself so we can just get the
   // data blocks and footnotes in a convenient way.
-  const { value: plan, isLoading } = useAsyncRetry(
+  const {
+    value: plan,
+    isLoading,
+    error,
+  } = useAsyncRetry(
     () => dataReplacementService.getReplacementPlan(releaseId, fileId, fileId),
     [releaseId, fileId],
   );
@@ -35,6 +39,19 @@ const ReleaseDataFileReplacementCompletePage = ({
       fileId,
     },
   );
+
+  if (error) {
+    return (
+      <>
+        <WarningMessage>
+          There was a problem with the data replacement.
+        </WarningMessage>
+        <Link back className="govuk-!-margin-bottom-6" to={dataFilePath}>
+          Back
+        </Link>
+      </>
+    );
+  }
 
   return (
     <>
@@ -103,7 +120,9 @@ const ReleaseDataFileReplacementCompletePage = ({
                           },
                         )}
                       >
-                        {sanitizeHtml(footnote.content, { allowedTags: [] })}
+                        {sanitizeHtml(footnote.content, {
+                          allowedTags: [],
+                        })}
                       </Link>
                     </li>
                   ))}

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacementCompletePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacementCompletePage.test.tsx
@@ -1,0 +1,76 @@
+import ReleaseDataFileReplacementCompletePage from '@admin/pages/release/data/ReleaseDataFileReplacementCompletePage';
+import {
+  releaseDataFileReplacementCompleteRoute,
+  ReleaseDataFileRouteParams,
+} from '@admin/routes/releaseRoutes';
+import _dataReplacementService, {
+  DataReplacementPlan,
+} from '@admin/services/dataReplacementService';
+import { render, screen, waitFor } from '@testing-library/react';
+import { createMemoryHistory, MemoryHistory } from 'history';
+import React from 'react';
+import { generatePath, Route, Router } from 'react-router-dom';
+
+jest.mock('@admin/services/dataReplacementService');
+
+const dataReplacementService = _dataReplacementService as jest.Mocked<
+  typeof _dataReplacementService
+>;
+
+describe('ReleaseDataFilePage', () => {
+  const testValidReplacementPlan: DataReplacementPlan = {
+    dataBlocks: [],
+    footnotes: [],
+    originalSubjectId: 'subject-1',
+    replacementSubjectId: 'subject-2',
+    valid: true,
+  };
+
+  test('renders the page when successfully loads the replacement plan', async () => {
+    dataReplacementService.getReplacementPlan.mockResolvedValue(
+      testValidReplacementPlan,
+    );
+
+    await renderPage();
+
+    expect(
+      screen.getByRole('heading', { name: 'Data replacement complete' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders error message if there is an error loading replacement plan', async () => {
+    dataReplacementService.getReplacementPlan.mockRejectedValue(
+      new Error('Something went wrong'),
+    );
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('There was a problem with the data replacement.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  async function renderPage(history: MemoryHistory = createMemoryHistory()) {
+    history.push(
+      generatePath<ReleaseDataFileRouteParams>(
+        releaseDataFileReplacementCompleteRoute.path,
+        {
+          publicationId: 'publication-1',
+          releaseId: 'release-1',
+          fileId: 'file-1',
+        },
+      ),
+    );
+
+    render(
+      <Router history={history}>
+        <Route
+          path={releaseDataFileReplacementCompleteRoute.path}
+          component={ReleaseDataFileReplacementCompletePage}
+        />
+      </Router>,
+    );
+  }
+});


### PR DESCRIPTION
Shows an error message if `getReplacementPlan` fails on the data plan replacement complete page.