### PR TITLE
EES-4798 Customise validation problem responses from APIs

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/PublicationControllerTests.cs
@@ -79,7 +79,7 @@ public class PublicationControllerTests
             TopicId = topicId
         });
 
-        result.Result!.AssertBadRequest(SlugNotUnique);
+        result.Result!.AssertValidationProblem(SlugNotUnique);
     }
     
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -110,7 +110,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             VerifyAllMocks(releaseDataFileService);
 
-            result.AssertBadRequest(CannotOverwriteFile);
+            result.AssertValidationProblem(CannotOverwriteFile);
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var result = await controller.DeleteDataFiles(_releaseId, fileId);
             VerifyAllMocks(releaseService);
 
-            result.AssertBadRequest(UnableToFindMetadataFileToDelete);
+            result.AssertValidationProblem(UnableToFindMetadataFileToDelete);
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -460,7 +460,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 VerifyAllMocks(methodologyVersionRepository);
 
-                actionResult.AssertBadRequest(MethodologySlugNotUnique);
+                actionResult.AssertValidationProblem(MethodologySlugNotUnique);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
@@ -681,7 +681,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.InviteUser(inviteRequest);
 
                 var actionResult = result.AssertLeft();
-                actionResult.AssertBadRequest(ValidationErrorMessages.UserAlreadyExists);
+                actionResult.AssertValidationProblem(ValidationErrorMessages.UserAlreadyExists);
             }
         }
         
@@ -884,7 +884,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var result = await service.InviteUser(inviteRequest);
 
             var actionResult = result.AssertLeft();
-            actionResult.AssertBadRequest(ValidationErrorMessages.InvalidUserRole);
+            actionResult.AssertValidationProblem(ValidationErrorMessages.InvalidUserRole);
         }
 
         [Fact]
@@ -1013,7 +1013,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var service = SetupUserManagementService();
                 var result = await service.CancelInvite("test@test.com");
                 var actionResult = result.AssertLeft();
-                actionResult.AssertBadRequest(ValidationErrorMessages.InviteNotFound);
+                actionResult.AssertValidationProblem(ValidationErrorMessages.InviteNotFound);
         }
 
         private static UserManagementService SetupUserManagementService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -58,6 +58,7 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.SignalR;
@@ -169,6 +170,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                 {
                     options.Filters.Add(new AuthorizeFilter(SecurityPolicies.CanAccessSystem.ToString()));
                     options.Filters.Add(new OperationCancelledExceptionFilter());
+                    options.Filters.Add(new ProblemDetailsResultFilter());
                     options.EnableEndpointRouting = false;
                     options.AllowEmptyInputInBodyModelBinding = true;
                 })

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/PartialDateValidator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/PartialDateValidator.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using ValidationResult = System.ComponentModel.DataAnnotations.ValidationResult;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
@@ -16,7 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
                 return ValidationResult.Success;
             }
 
-            return ValidationResult(PartialDateNotValid);
+            return new ValidationResult(PartialDateNotValid.ToString());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -1,37 +1,20 @@
 #nullable enable
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
 {
     public static class ValidationUtils
     {
-        // TODO EES-919 - return ActionResults rather than ValidationResults
-        public static ValidationResult ValidationResult(ValidationErrorMessages message)
-        {
-            return new ValidationResult(message.ToString());
-        }
-
-        // TODO EES-919 - return ActionResults rather than ValidationResults - as this work is done,
-        // rename this to "ValidationResult"
-        public static ActionResult ValidationActionResult(ValidationErrorMessages message)
+        public static BadRequestObjectResult ValidationActionResult(ValidationErrorMessages message)
         {
             return Common.Validators.ValidationUtils.ValidationResult(message);
         }
 
-        public static ActionResult ValidationActionResult(IEnumerable<ValidationErrorMessages> messages)
+        public static BadRequestObjectResult ValidationActionResult(IEnumerable<ValidationErrorMessages> messages)
         {
-            ModelStateDictionary errors = new ModelStateDictionary();
-
-            foreach (var message in messages)
-            {
-                errors.AddModelError(string.Empty, message.ToString());
-            }
-
-            return new BadRequestObjectResult(new ValidationProblemDetails(errors));
+            return Common.Validators.ValidationUtils.ValidationResult(messages);
         }
 
         public static Either<ActionResult, T> NotFound<T>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Config/FluentValidationActionFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Config/FluentValidationActionFilterTests.cs
@@ -1,0 +1,471 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.WebUtilities;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Config;
+
+public class FluentValidationActionFilterTests : IntegrationTest<TestStartup>
+{
+    private const string NotEmptyCode = "NotEmpty";
+    private const string NotEmptyMessage = "Must not be empty.";
+
+    private FluentValidationActionFilterTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
+    {
+    }
+
+    public class TestClassTests : FluentValidationActionFilterTests
+    {
+        public TestClassTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
+        {
+        }
+
+        [Fact]
+        public async Task Body_Valid()
+        {
+            var body = new TestClass { Name = "Test name" };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsJsonAsync(nameof(TestController.TestClassBody), body);
+
+            response.AssertOk();
+        }
+
+        [Fact]
+        public async Task Body_Invalid()
+        {
+            var body = new TestClass { Name = "" };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsJsonAsync(nameof(TestController.TestClassBody), body);
+
+            var details = response.AssertValidationProblem();
+
+            var errors = details.Errors;
+
+            Assert.Single(errors);
+
+            Assert.Equal("name", errors[0].Path);
+            Assert.Equal(NotEmptyCode, errors[0].Code);
+            Assert.Equal(NotEmptyMessage, errors[0].Message);
+            Assert.Null(errors[0].Detail);
+        }
+
+        [Fact]
+        public async Task BodyNested_Valid()
+        {
+            var body = new TestClass
+            {
+                Name = "Test name",
+                TestAddresses = new List<TestAddress>
+                {
+                    new()
+                    {
+                        Line1 = "Test line 1"
+                    }
+                }
+            };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsJsonAsync(nameof(TestController.TestClassBody), body);
+
+            response.AssertOk();
+        }
+
+        [Fact]
+        public async Task BodyNested_Invalid()
+        {
+            var body = new TestClass
+            {
+                Name = "",
+                TestAddresses = new List<TestAddress>
+                {
+                    new()
+                    {
+                        Line1 = ""
+                    }
+                }
+            };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsJsonAsync(nameof(TestController.TestClassBody), body);
+
+            var details = response.AssertValidationProblem();
+
+            var errors = details.Errors;
+
+            Assert.Equal(2, errors.Count);
+
+            Assert.Equal("name", errors[0].Path);
+            Assert.Equal(NotEmptyCode, errors[0].Code);
+            Assert.Equal(NotEmptyMessage, errors[0].Message);
+            Assert.Null(errors[0].Detail);
+
+            Assert.Equal("testAddresses[0].line1", errors[1].Path);
+            Assert.Equal("MinimumLength", errors[1].Code);
+            Assert.Equal("Must be at least 10 characters (was 0).", errors[1].Message);
+
+            // Assert.Equal(3, errors[1].Detail!.Count);
+            // var minLength = Assert.IsType<JsonElement>(errors[1].Detail!["MinLength"]);
+            // Assert.Equal(10, minLength.GetInt32());
+        }
+
+        [Fact]
+        public async Task Form_Valid()
+        {
+            var form = new FormUrlEncodedContent(
+                new Dictionary<string, string>
+                {
+                    { "name", "Test name" },
+                }
+            );
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsync(nameof(TestController.TestClassForm), form);
+
+            response.AssertOk();
+        }
+
+        [Fact]
+        public async Task Form_Invalid()
+        {
+            var form = new FormUrlEncodedContent(
+                new Dictionary<string, string>
+                {
+                    { "name", "" },
+                }
+            );
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsync(nameof(TestController.TestClassForm), form);
+
+            var details = response.AssertValidationProblem();
+
+            var errors = details.Errors;
+
+            Assert.Single(errors);
+
+            Assert.Equal("name", errors[0].Path);
+            Assert.Equal(NotEmptyCode, errors[0].Code);
+            Assert.Equal(NotEmptyMessage, errors[0].Message);
+            Assert.Null(errors[0].Detail);
+        }
+
+        [Fact]
+        public async Task Query_Valid()
+        {
+            var query = new Dictionary<string, string?>
+            {
+                { "name", "Test name" },
+            };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.GetAsync(
+                QueryHelpers.AddQueryString(nameof(TestController.TestClassQuery), query));
+
+            response.AssertOk();
+        }
+
+        [Fact]
+        public async Task Query_Invalid()
+        {
+            var query = new Dictionary<string, string?>
+            {
+                { "name", "" },
+            };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.GetAsync(
+                QueryHelpers.AddQueryString(nameof(TestController.TestClassQuery), query));
+
+            var details = response.AssertValidationProblem();
+
+            var errors = details.Errors;
+
+            Assert.Single(errors);
+
+            Assert.Equal("name", errors[0].Path);
+            Assert.Equal(NotEmptyCode, errors[0].Code);
+            Assert.Equal(NotEmptyMessage, errors[0].Message);
+            Assert.Null(errors[0].Detail);
+        }
+
+        [Fact]
+        public async Task NoAttribute_Valid()
+        {
+            var body = new TestClass { Name = "Test name" };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsJsonAsync(nameof(TestController.TestClassNoAttribute), body);
+
+            response.AssertOk();
+        }
+
+        [Fact]
+        public async Task NoAttribute_Invalid()
+        {
+            var body = new TestClass { Name = "" };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsJsonAsync(nameof(TestController.TestClassNoAttribute), body);
+
+            var details = response.AssertValidationProblem();
+
+            var errors = details.Errors;
+
+            Assert.Single(errors);
+
+            Assert.Equal("name", errors[0].Path);
+            Assert.Equal(NotEmptyCode, errors[0].Code);
+            Assert.Equal(NotEmptyMessage, errors[0].Message);
+            Assert.Null(errors[0].Detail);
+        }
+    }
+
+    public class TestRecordTests : FluentValidationActionFilterTests
+    {
+        public TestRecordTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
+        {
+        }
+
+        [Fact]
+        public async Task Valid()
+        {
+            var body = new TestRecord { Name = "Test name" };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsJsonAsync(nameof(TestController.TestRecordBody), body);
+
+            response.AssertOk();
+        }
+
+        [Fact]
+        public async Task Invalid()
+        {
+            var body = new TestRecord { Name = "" };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsJsonAsync(nameof(TestController.TestRecordBody), body);
+
+            var details = response.AssertValidationProblem();
+
+            var errors = details.Errors;
+
+            Assert.Single(errors);
+
+            Assert.Equal("name", errors[0].Path);
+            Assert.Equal(NotEmptyCode, errors[0].Code);
+            Assert.Equal(NotEmptyMessage, errors[0].Message);
+            Assert.Null(errors[0].Detail);
+        }
+
+        [Fact]
+        public async Task InvalidWithStatePrimitive()
+        {
+            var body = new TestRecord { Name = "Test", Person = "" };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsJsonAsync(nameof(TestController.TestRecordBody), body);
+
+            var details = response.AssertValidationProblem();
+
+            var errors = details.Errors;
+
+            Assert.Single(errors);
+
+            Assert.Equal("person", errors[0].Path);
+            Assert.Equal(NotEmptyCode, errors[0].Code);
+            Assert.Equal(NotEmptyMessage, errors[0].Message);
+
+            var errorDetailJson = Assert.IsType<JsonElement>(errors[0].Detail);
+            var errorDetail = errorDetailJson.Deserialize<Dictionary<string, JsonElement>>();
+
+            Assert.Equal(1234, errorDetail!["state"].GetInt32());
+        }
+
+        [Fact]
+        public async Task InvalidWithStateObject()
+        {
+            var body = new TestRecord { Name = "Test", Role = "" };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsJsonAsync(nameof(TestController.TestRecordBody), body);
+
+            var details = response.AssertValidationProblem();
+
+            var errors = details.Errors;
+
+            Assert.Single(errors);
+
+            Assert.Equal("role", errors[0].Path);
+            Assert.Equal(NotEmptyCode, errors[0].Code);
+            Assert.Equal(NotEmptyMessage, errors[0].Message);
+
+            var errorDetailJson = Assert.IsType<JsonElement>(errors[0].Detail);
+            var errorDetail = errorDetailJson.Deserialize<Dictionary<string, JsonElement>>();
+
+            Assert.Single(errorDetail!);
+            Assert.Equal("Some allowed value", errorDetail!["allowed"].GetString());
+        }
+
+        [Fact]
+        public async Task InvalidWithPlaceholderValuesAndState()
+        {
+            var body = new TestRecord { Name = "Test", Location = "" };
+
+            var client = BuildApp().CreateClient();
+            var response = await client.PostAsJsonAsync(nameof(TestController.TestRecordBody), body);
+
+            var details = response.AssertValidationProblem();
+
+            var errors = details.Errors;
+
+            Assert.Single(errors);
+
+            Assert.Equal("location", errors[0].Path);
+            Assert.Equal("MinimumLength", errors[0].Code);
+            Assert.Equal("Must be at least 2 characters (was 0).", errors[0].Message);
+
+            var errorDetailJson = Assert.IsType<JsonElement>(errors[0].Detail);
+            var errorDetail = errorDetailJson.Deserialize<Dictionary<string, JsonElement>>();
+
+            Assert.Equal(4, errorDetail!.Count);
+            Assert.Equal(2, errorDetail["minLength"].GetInt32());
+            Assert.Equal(-1, errorDetail["maxLength"].GetInt32());
+            Assert.Equal(0, errorDetail["totalLength"].GetInt32());
+            Assert.Equal("Some reason", errorDetail["reason"].GetString());
+        }
+    }
+
+    [ApiController]
+    private class TestController : ControllerBase
+    {
+        [HttpPost(nameof(TestClassBody))]
+        public ActionResult TestClassBody([FromBody] TestClass testClass)
+        {
+            return Ok(testClass.Name);
+        }
+
+        [HttpPost(nameof(TestClassForm))]
+        public ActionResult TestClassForm([FromForm] TestClass testClass)
+        {
+            return Ok(testClass.Name);
+        }
+
+        [HttpGet(nameof(TestClassQuery))]
+        public ActionResult TestClassQuery([FromQuery] TestClass testClass)
+        {
+            return Ok(testClass.Name);
+        }
+
+        [HttpPost(nameof(TestClassNoAttribute))]
+        public ActionResult TestClassNoAttribute(TestClass testClass)
+        {
+            return Ok(testClass.Name);
+        }
+
+        [HttpPost(nameof(TestRecordBody))]
+        public ActionResult TestRecordBody([FromBody] TestRecord testRecord)
+        {
+            return Ok(testRecord.Name);
+        }
+    }
+
+    public class TestClass
+    {
+        public string? Name { get; init; }
+
+        public List<TestAddress>? TestAddresses { get; init; }
+
+        public class Validator : AbstractValidator<TestClass>
+        {
+            public Validator()
+            {
+                RuleFor(c => c.Name).NotEmpty();
+                When(
+                    c => c.TestAddresses is not null,
+                    () =>
+                        RuleForEach(c => c.TestAddresses)
+                            .SetValidator(new TestAddress.Validator())
+                );
+            }
+        }
+    }
+
+    public class TestAddress
+    {
+        public string? Line1 { get; init; }
+
+        public class Validator : AbstractValidator<TestAddress>
+        {
+            public Validator()
+            {
+                RuleFor(c => c.Line1).MinimumLength(10);
+            }
+        }
+    }
+
+    public class TestRecord
+    {
+        public string? Name { get; init; }
+
+        public string? Role { get; init; }
+
+        public string? Location { get; init; }
+
+        public string? Person { get; init; }
+
+        public class Validator : AbstractValidator<TestRecord>
+        {
+            public Validator()
+            {
+                RuleFor(c => c.Name).NotEmpty();
+                When(
+                    c => c.Role is not null,
+                    () => RuleFor(c => c.Role)
+                        .NotEmpty()
+                        .WithState(_ => new
+                        {
+                            Allowed = "Some allowed value"
+                        })
+                );
+                When(
+                    c => c.Location is not null,
+                    () => RuleFor(c => c.Location)
+                        .MinimumLength(2)
+                        .WithState(_ => new
+                        {
+                            Reason = "Some reason"
+                        })
+                );
+                When(
+                    c => c.Person is not null,
+                    () => RuleFor(c => c.Person)
+                        .NotEmpty()
+                        .WithState(_ => 1234)
+                );
+            }
+        }
+    }
+
+    private WebApplicationFactory<TestStartup> BuildApp()
+    {
+        return TestApp
+            .WithWebHostBuilder(
+                builder => { builder.WithAdditionalControllers(typeof(TestController)); }
+            )
+            .ConfigureServices(
+                services => { services.AddFluentValidation(); }
+            );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Config/ProblemDetailsResultFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Config/ProblemDetailsResultFilterTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
@@ -27,6 +28,7 @@ public class ProblemDetailsResultFilterTests : IntegrationTest<TestStartup>
 
         Assert.Equal(400, problemDetails.Status);
         Assert.Equal("Bad Request", problemDetails.Title);
+        Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.1", problemDetails.Type);
     }
 
     [Fact]
@@ -39,6 +41,7 @@ public class ProblemDetailsResultFilterTests : IntegrationTest<TestStartup>
 
         Assert.Equal(500, problemDetails.Status);
         Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.6.1", problemDetails.Type);
     }
 
     [Fact]
@@ -51,6 +54,7 @@ public class ProblemDetailsResultFilterTests : IntegrationTest<TestStartup>
 
         Assert.Equal(400, validationProblem.Status);
         Assert.Equal("One or more validation errors occurred.", validationProblem.Title);
+        Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.1", validationProblem.Type);
 
         var errors = validationProblem.Errors;
 
@@ -74,6 +78,7 @@ public class ProblemDetailsResultFilterTests : IntegrationTest<TestStartup>
 
         Assert.Equal(400, validationProblem.Status);
         Assert.Equal("One or more validation errors occurred.", validationProblem.Title);
+        Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.1", validationProblem.Type);
 
         var errors = validationProblem.Errors;
 
@@ -93,6 +98,7 @@ public class ProblemDetailsResultFilterTests : IntegrationTest<TestStartup>
 
         Assert.Equal(400, validationProblem.Status);
         Assert.Equal("One or more validation errors occurred.", validationProblem.Title);
+        Assert.Equal("https://tools.ietf.org/html/rfc7231#section-6.5.1", validationProblem.Type);
 
         var errors = validationProblem.Errors;
 
@@ -135,7 +141,10 @@ public class ProblemDetailsResultFilterTests : IntegrationTest<TestStartup>
         [HttpGet(nameof(TestValidationResult))]
         public ActionResult TestValidationResult()
         {
-            return ValidationUtils.ValidationResult("A global error");
+            return ValidationUtils.ValidationResult(new ErrorViewModel
+            {
+                Message = "A global error"
+            });
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Config/ProblemDetailsResultFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Config/ProblemDetailsResultFilterTests.cs
@@ -1,0 +1,154 @@
+#nullable enable
+using System.ComponentModel.DataAnnotations;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Config;
+
+public class ProblemDetailsResultFilterTests : IntegrationTest<TestStartup>
+{
+    public ProblemDetailsResultFilterTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
+    {
+    }
+
+    [Fact]
+    public async Task BadRequest_Returns400ProblemDetails()
+    {
+        var client = BuildApp().CreateClient();
+        var response = await client.GetAsync(nameof(TestController.TestBadRequest));
+
+        var problemDetails = response.AssertBadRequest();
+
+        Assert.Equal(400, problemDetails.Status);
+        Assert.Equal("Bad Request", problemDetails.Title);
+    }
+
+    [Fact]
+    public async Task ServerError_Returns500ProblemDetails()
+    {
+        var client = BuildApp().CreateClient();
+        var response = await client.GetAsync(nameof(TestController.TestServerError));
+
+        var problemDetails = response.AssertInternalServerError();
+
+        Assert.Equal(500, problemDetails.Status);
+        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+    }
+
+    [Fact]
+    public async Task ValidationProblemWithModelState_Returns400ValidationProblem()
+    {
+        var client = BuildApp().CreateClient();
+        var response = await client.GetAsync(nameof(TestController.TestValidationProblemWithModelState));
+
+        var validationProblem = response.AssertValidationProblem();
+
+        Assert.Equal(400, validationProblem.Status);
+        Assert.Equal("One or more validation errors occurred.", validationProblem.Title);
+
+        var errors = validationProblem.Errors;
+
+        Assert.Equal(2, errors.Count);
+
+        Assert.Null(errors[0].Path);
+        Assert.Equal("A global error", errors[0].Message);
+
+        Assert.Equal("Test", errors[1].Path);
+        Assert.Equal("A field error", errors[1].Message);
+    }
+
+    [Fact]
+    public async Task ValidationProblemWithAttributes_Returns400ValidationProblem()
+    {
+        var client = BuildApp().CreateClient();
+        var response = await client.PostAsJsonAsync(
+            nameof(TestController.TestValidationProblemWithAttributes), new TestClass());
+
+        var validationProblem = response.AssertValidationProblem();
+
+        Assert.Equal(400, validationProblem.Status);
+        Assert.Equal("One or more validation errors occurred.", validationProblem.Title);
+
+        var errors = validationProblem.Errors;
+
+        Assert.Single(errors);
+
+        Assert.Equal("Name", errors[0].Path);
+        Assert.Equal("The Name field is required.", errors[0].Message);
+    }
+
+    [Fact]
+    public async Task ValidationResult_Returns400ValidationProblem()
+    {
+        var client = BuildApp().CreateClient();
+        var response = await client.GetAsync(nameof(TestController.TestValidationResult));
+
+        var validationProblem = response.AssertValidationProblem();
+
+        Assert.Equal(400, validationProblem.Status);
+        Assert.Equal("One or more validation errors occurred.", validationProblem.Title);
+
+        var errors = validationProblem.Errors;
+
+        Assert.Single(errors);
+
+        Assert.Null(errors[0].Path);
+        Assert.Equal("A global error", errors[0].Message);
+    }
+
+    [ApiController]
+    private class TestController : ControllerBase
+    {
+        [HttpGet(nameof(TestBadRequest))]
+        public ActionResult TestBadRequest()
+        {
+            return BadRequest();
+        }
+
+        [HttpGet(nameof(TestServerError))]
+        public ActionResult TestServerError()
+        {
+            return StatusCode(500);
+        }
+
+        [HttpPost(nameof(TestValidationProblemWithAttributes))]
+        public ActionResult TestValidationProblemWithAttributes(TestClass testClass)
+        {
+            return Ok(testClass.Name);
+        }
+
+        [HttpGet(nameof(TestValidationProblemWithModelState))]
+        public ActionResult TestValidationProblemWithModelState()
+        {
+            ModelState.AddModelError("", "A global error");
+            ModelState.AddModelError("Test", "A field error");
+
+            return ValidationProblem();
+        }
+
+        [HttpGet(nameof(TestValidationResult))]
+        public ActionResult TestValidationResult()
+        {
+            return ValidationUtils.ValidationResult("A global error");
+        }
+    }
+
+    private class TestClass
+    {
+        [Required] public string? Name { get; init; }
+    }
+
+    private WebApplicationFactory<TestStartup> BuildApp()
+    {
+        return TestApp
+            .WithWebHostBuilder(
+                builder => { builder.WithAdditionalControllers(typeof(TestController)); }
+            );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
@@ -1,6 +1,8 @@
 #nullable enable
 using System;
+using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
@@ -19,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
                 Assert.Equal(expectedValue, result.Value);
             }
 
-            return result.Value;
+            return result.Value!;
         }
 
         public static void AssertNotFoundResult<T>(this ActionResult<T> result) where T : class
@@ -47,17 +49,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             Assert.IsAssignableFrom<AcceptedResult>(result);
         }
 
-        public static void AssertBadRequest<T>(this ActionResult<T> result, params Enum[] expectedValidationErrors)
+        public static void AssertValidationProblem<T>(this ActionResult<T> result, params Enum[] expectedErrorCodes)
         {
-            AssertBadRequestWithValidationErrors(result.Result, expectedValidationErrors);
+            Assert.NotNull(result.Result);
+            AssertBadRequestWithValidationErrors(result.Result, expectedErrorCodes);
         }
 
-        public static void AssertBadRequest(this ActionResult result, params Enum[] expectedValidationErrors)
+        public static void AssertValidationProblem(this ActionResult result, params Enum[] expectedErrorCodes)
         {
-            AssertBadRequestWithValidationErrors(result, expectedValidationErrors);
+            AssertBadRequestWithValidationErrors(result, expectedErrorCodes);
         }
 
-        public static void AssertBadRequest(this ActionResult result, string expectedError)
+        public static void AssertValidationProblem(this ActionResult result, string expectedError)
         {
             var badRequest = Assert.IsAssignableFrom<BadRequestObjectResult>(result);
             var error = Assert.IsAssignableFrom<string>(badRequest.Value);
@@ -70,20 +73,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             Assert.Equal(StatusCodes.Status304NotModified, statusCodeResult.StatusCode);
         }
 
-        private static void AssertBadRequestWithValidationErrors(this object result, params Enum[] expectedValidationErrors)
+        private static void AssertBadRequestWithValidationErrors(this object result, params Enum[] expectedErrorCodes)
         {
             var badRequest = Assert.IsAssignableFrom<BadRequestObjectResult>(result);
-            var validationProblem = Assert.IsAssignableFrom<ValidationProblemDetails>(badRequest.Value);
+            var validationProblem = Assert.IsAssignableFrom<ValidationProblemViewModel>(badRequest.Value);
 
             Assert.NotNull(validationProblem);
-            Assert.True(validationProblem.Errors.ContainsKey(string.Empty));
 
-            var globalErrors = validationProblem.Errors[string.Empty];
+            var errorCodes = validationProblem.Errors
+                .Select(error => error.Code)
+                .ToList();
 
-            Assert.Equal(expectedValidationErrors.Length, globalErrors.Length);
+            Assert.Equal(expectedErrorCodes.Length, errorCodes.Count);
 
-            expectedValidationErrors.ForEach(message =>
-                Assert.Contains(message.ToString(), globalErrors));
+            expectedErrorCodes.ForEach(errorCode =>
+                Assert.Contains(errorCode.ToString(), errorCodes));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTestExtensions.cs
@@ -76,7 +76,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             params Enum[] expectedValidationErrors)
         {
             var badRequest = either.AssertActionResultOfType<BadRequestObjectResult, TRight>();
-            badRequest.AssertBadRequest(expectedValidationErrors);
+            badRequest.AssertValidationProblem(expectedValidationErrors);
             return either.Left;
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
@@ -3,6 +3,8 @@ using System;
 using System.Net.Http;
 using System.Text.Json;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using Microsoft.AspNetCore.Mvc;
 using Xunit;
 using static System.Net.HttpStatusCode;
 
@@ -24,15 +26,6 @@ public static class HttpResponseMessageTestExtensions
         return Assert.IsType<T>(body);
     }
 
-    private static T? Deserialize<T>(this HttpResponseMessage message, bool useSystemJson)
-    {
-        return useSystemJson
-            ? JsonSerializer.Deserialize<T>(
-                message.Content.ReadAsStream().ReadToEnd(), 
-                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
-            : message.Content.ReadFromJson<T>();
-    }
-
     public static string AssertOk(this HttpResponseMessage message, string expectedBody)
     {
         Assert.Equal(OK, message.StatusCode);
@@ -45,7 +38,11 @@ public static class HttpResponseMessageTestExtensions
         return message.AssertBodyEqualTo(expectedBody, useSystemJson);
     }
 
-    public static T AssertCreated<T>(this HttpResponseMessage message, T expectedBody, string expectedLocation, bool useSystemJson = false)
+    public static T AssertCreated<T>(
+        this HttpResponseMessage message,
+        T expectedBody,
+        string expectedLocation,
+        bool useSystemJson = false)
     {
         Assert.Equal(Created, message.StatusCode);
         Assert.Equal(new Uri(expectedLocation), message.Headers.Location);
@@ -78,6 +75,45 @@ public static class HttpResponseMessageTestExtensions
         Assert.Equal(NotModified, message.StatusCode);
     }
 
+    public static ProblemDetails AssertBadRequest(this HttpResponseMessage message)
+    {
+        Assert.Equal(BadRequest, message.StatusCode);
+
+        return message.AssertBodyIsProblemDetails();
+    }
+
+    public static ValidationProblemViewModel AssertValidationProblem(this HttpResponseMessage message)
+    {
+        Assert.Equal(BadRequest, message.StatusCode);
+
+        return message.AssertBodyIsValidationProblem();
+    }
+
+    public static ProblemDetails AssertInternalServerError(this HttpResponseMessage message)
+    {
+        Assert.Equal(InternalServerError, message.StatusCode);
+
+        return message.AssertBodyIsProblemDetails();
+    }
+
+    public static ProblemDetails AssertBodyIsProblemDetails(this HttpResponseMessage message)
+    {
+        var details = Deserialize<ProblemDetails>(message, useSystemJson: true);
+
+        Assert.NotNull(details);
+
+        return details;
+    }
+
+    public static ValidationProblemViewModel AssertBodyIsValidationProblem(this HttpResponseMessage message)
+    {
+        var details = Deserialize<ValidationProblemViewModel>(message, useSystemJson: true);
+
+        Assert.NotNull(details);
+
+        return details;
+    }
+
     public static string AssertBodyEqualTo(this HttpResponseMessage message, string expected)
     {
         var actual = message.Content.ReadAsStream().ReadToEnd();
@@ -100,5 +136,14 @@ public static class HttpResponseMessageTestExtensions
     public static void AssertPathAndQueryEqualTo(this HttpResponseMessage response, string expected)
     {
         Assert.Equal(expected, response.RequestMessage?.RequestUri?.PathAndQuery);
+    }
+
+    private static T? Deserialize<T>(this HttpResponseMessage message, bool useSystemJson)
+    {
+        return useSystemJson
+            ? JsonSerializer.Deserialize<T>(
+                message.Content.ReadAsStream().ReadToEnd(),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+            : message.Content.ReadFromJson<T>();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ObjectExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ObjectExtensionsTests.cs
@@ -1,0 +1,162 @@
+#nullable enable
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class ObjectExtensionsTests
+{
+    public class ToDictionaryTests
+    {
+        [Fact]
+        public void AnonymousObjectWithPrimitives()
+        {
+            var obj = new
+            {
+                String = "Test",
+                Int = 123,
+                Bool = true,
+                Null = (object?)null
+            };
+
+            var dictionary = obj.ToDictionary();
+
+            Assert.Equal(4, dictionary.Count);
+            Assert.Equal("Test", dictionary["String"]);
+            Assert.Equal(123, dictionary["Int"]);
+            Assert.Equal(true, dictionary["Bool"]);
+            Assert.Null(dictionary["Null"]);
+        }
+
+        [Fact]
+        public void AnonymousObjectWithComplexTypes()
+        {
+            var anonymousObj = new
+            {
+                Field = "Test 1"
+            };
+
+            var classObj = new TestClassWithPrimitives();
+
+            var list = new List<object>
+            {
+                "Test 2",
+                new { Field = "Test 3" }
+            };
+
+            var obj = new
+            {
+                Anonymous = anonymousObj,
+                Class = classObj,
+                List = list
+            };
+
+            var dictionary = obj.ToDictionary();
+
+            Assert.Equal(3, dictionary.Count);
+            Assert.Equal(anonymousObj, dictionary["Anonymous"]);
+            Assert.Equal(classObj, dictionary["Class"]);
+            Assert.Equal(list, dictionary["List"]);
+        }
+
+        [Fact]
+        public void TestClassWithPrimitivesObject()
+        {
+            var obj = new TestClassWithPrimitives
+            {
+                String = "Test",
+                Int = 123,
+                Bool = true,
+                Null = null
+            };
+
+            var dictionary = obj.ToDictionary();
+
+            Assert.Equal(4, dictionary.Count);
+            Assert.Equal("Test", dictionary["String"]);
+            Assert.Equal(123, dictionary["Int"]);
+            Assert.Equal(true, dictionary["Bool"]);
+            Assert.Null(dictionary["Null"]);
+        }
+
+        [Fact]
+        public void TestClassWithHiddenPropertiesObject()
+        {
+            var obj = new TestClassWithHiddenProperties
+            {
+                Field = "Test",
+            };
+
+            var dictionary = obj.ToDictionary();
+
+            Assert.Single(dictionary);
+            Assert.Equal("Test", dictionary["Field"]);
+        }
+
+        [Fact]
+        public void TestClassWithComplexTypesObject()
+        {
+            var anonymousObj = new
+            {
+                Field = "Test 1"
+            };
+
+            var classObj = new TestClassWithPrimitives();
+
+            var list = new List<object>
+            {
+                "Test 2",
+                new { Field = "Test 3" }
+            };
+
+            var obj = new TestClassWithComplexTypes
+            {
+                Anonymous = anonymousObj,
+                Class = classObj,
+                List = list
+            };
+
+            var dictionary = obj.ToDictionary();
+
+            Assert.Equal(3, dictionary.Count);
+            Assert.Equal(anonymousObj, dictionary["Anonymous"]);
+            Assert.Equal(classObj, dictionary["Class"]);
+            Assert.Equal(list, dictionary["List"]);
+        }
+
+        private class TestClassWithPrimitives
+        {
+            public string String { get; init; } = string.Empty;
+
+            public int Int { get; init; }
+
+            public bool Bool { get; init; }
+
+            public object? Null { get; init; }
+        }
+
+        private class TestClassWithHiddenProperties
+        {
+            public string Field { get; init; } = string.Empty;
+
+            protected string? ProtectedHidden { get; init; } = null;
+
+            private string? PrivateHidden { get; init; } = null;
+
+            public string SomeMethod()
+            {
+                return "Test";
+            }
+        }
+
+        private class TestClassWithComplexTypes
+        {
+            public object Anonymous { get; init; }
+
+            public TestClassWithPrimitives Class { get; init; }
+
+            public List<object> List { get; init; }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
@@ -1,0 +1,217 @@
+#nullable enable
+using System;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class ValidationProblemViewModelTestExtensions
+{
+    public static ErrorViewModel AssertHasEmailError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.EmailValidator
+        );
+
+    public static ErrorViewModel AssertHasGreaterThanOrEqualError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.GreaterThanOrEqualValidator
+        );
+
+    public static ErrorViewModel AssertHasGreaterThanError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.GreaterThanValidator
+        );
+
+    public static ErrorViewModel AssertHasLengthError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.LengthValidator
+        );
+
+    public static ErrorViewModel AssertHasMinimumLengthError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.MinimumLengthValidator
+        );
+
+    public static ErrorViewModel AssertHasMaximumLengthError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.MaximumLengthValidator
+        );
+
+    public static ErrorViewModel AssertHasLessThanOrEqualError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.LessThanOrEqualValidator
+        );
+
+    public static ErrorViewModel AssertHasLessThanError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.LessThanValidator
+        );
+
+    public static ErrorViewModel AssertHasNotEqualError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.NotEqualValidator
+        );
+
+    public static ErrorViewModel AssertHasNotEmptyError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.NotEmptyValidator
+        );
+
+    public static ErrorViewModel AssertHasNotNullError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.NotNullValidator
+        );
+
+    public static ErrorViewModel AssertHasPredicateError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.PredicateValidator
+        );
+
+    public static ErrorViewModel AssertHasAsyncPredicateError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.AsyncPredicateValidator
+        );
+
+    public static ErrorViewModel AssertHasRegularExpressionError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.RegularExpressionValidator
+        );
+
+    public static ErrorViewModel AssertHasEqualError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.EqualValidator
+        );
+
+    public static ErrorViewModel AssertHasExactLengthError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.ExactLengthValidator
+        );
+
+    public static ErrorViewModel AssertHasInclusiveBetweenError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.InclusiveBetweenValidator
+        );
+
+    public static ErrorViewModel AssertHasExclusiveBetweenError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.ExclusiveBetweenValidator
+        );
+
+    public static ErrorViewModel AssertHasCreditCardError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.CreditCardValidator
+        );
+
+    public static ErrorViewModel AssertHasScalePrecisionError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.ScalePrecisionValidator
+        );
+
+    public static ErrorViewModel AssertHasEmptyError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.EmptyValidator
+        );
+
+    public static ErrorViewModel AssertHasNullError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.NullValidator
+        );
+
+    public static ErrorViewModel AssertHasEnumError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: FluentValidationKeys.EnumValidator
+        );
+
+    public static ErrorViewModel AssertHasError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath,
+        string expectedCode)
+    {
+        Predicate<ErrorViewModel> predicate = error => error.Path == expectedPath && error.Code == expectedCode;
+
+        Assert.Contains(validationProblem.Errors, predicate);
+
+        return validationProblem.Errors.First(new Func<ErrorViewModel, bool>(predicate));
+    }
+
+    private static ErrorViewModel AssertHasFluentValidationError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath,
+        string expectedKey)
+    {
+        var expectedCode = expectedKey.Replace("Validator", "");
+
+        return AssertHasError(validationProblem, expectedPath, expectedCode);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/TestStartup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/TestStartup.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Rules;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
@@ -27,6 +28,8 @@ public class TestStartup
 
         services.AddControllers(options =>
             {
+                options.Filters.Add(new ProblemDetailsResultFilter());
+
                 options.AddCommaSeparatedQueryModelBinderProvider();
                 options.AddTrimStringBinderProvider();
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cancellation/OperationCancelledExceptionFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cancellation/OperationCancelledExceptionFilter.cs
@@ -1,4 +1,5 @@
 using System;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using Microsoft.AspNetCore.Mvc.Filters;
 using static GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
 
@@ -14,7 +15,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Cancellation
             if (context.Exception is OperationCanceledException)
             {
                 context.ExceptionHandled = true;
-                context.Result = ValidationResult("RequestCancelled");
+                context.Result = ValidationResult(new ErrorViewModel
+                {
+                    Code = "RequestCancelled"
+                });
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Config/FluentValidationActionFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Config/FluentValidationActionFilter.cs
@@ -1,0 +1,164 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentValidation;
+using FluentValidation.Results;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Config;
+
+/// <summary>
+/// <para>
+/// A lot of this has been cribbed from the SharpGrip.FluentValidation.AutoValidation package.
+/// It has been tidied up and importantly provides support for more details in validation errors.
+/// </para>
+/// <para>
+/// We may want to swap back to SharpGrip's implementation once it supports the
+/// <a href="https://github.com/SharpGrip/FluentValidation.AutoValidation/issues/12">required functionality</a>.
+/// </para>
+/// </summary>
+public class FluentValidationActionFilter : IAsyncActionFilter
+{
+    private static readonly HashSet<string> IgnoredMessagePlaceholders = new()
+    {
+        "PropertyName",
+        "PropertyPath",
+        "PropertyValue",
+        "CollectionIndex"
+    };
+
+    public async Task OnActionExecutionAsync(
+        ActionExecutingContext context,
+        ActionExecutionDelegate next)
+    {
+        if (context.Controller is not ControllerBase controllerBase)
+        {
+            await next();
+
+            return;
+        }
+
+        var errors = new List<ErrorViewModel>();
+
+        foreach (var parameter in context.ActionDescriptor.Parameters)
+        {
+            if (!context.ActionArguments.TryGetValue(parameter.Name, out var subject))
+            {
+                continue;
+            }
+
+            if (subject == null || !IsValidParameter(parameter))
+            {
+                continue;
+            }
+
+            if (GetValidator(context.HttpContext.RequestServices, parameter) is not IValidator validator)
+            {
+                continue;
+            }
+
+            var validationContext = new ValidationContext<object>(subject);
+
+            var validationResult = await validator.ValidateAsync(
+                validationContext,
+                context.HttpContext.RequestAborted
+            );
+
+            if (validationResult.IsValid)
+            {
+                continue;
+            }
+
+            errors.AddRange(
+                validationResult.Errors.Select(failure => CreateErrorViewModel(failure))
+            );
+        }
+
+        if (errors.Count != 0)
+        {
+            var details = controllerBase.ProblemDetailsFactory.CreateValidationProblemDetails(
+                context.HttpContext,
+                new ModelStateDictionary()
+            );
+
+            context.Result = new BadRequestObjectResult(ValidationProblemViewModel.Create(details, errors));
+
+            return;
+        }
+
+        await next();
+    }
+
+    private static object? GetValidator(IServiceProvider serviceProvider, ParameterDescriptor parameter)
+    {
+        return serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(parameter.ParameterType));
+    }
+
+    private static bool IsValidParameter(ParameterDescriptor parameter)
+    {
+        var type = parameter.ParameterType;
+        var bindingSource = parameter.BindingInfo?.BindingSource;
+
+        return type is { IsClass: true, IsPrimitive: false, IsEnum: false, IsValueType: false }
+               && HasValidBindingSource(bindingSource);
+    }
+
+    private static bool HasValidBindingSource(BindingSource? bindingSource)
+    {
+        return bindingSource == BindingSource.Body ||
+               bindingSource == BindingSource.Form ||
+               bindingSource == BindingSource.Query;
+    }
+
+    private static ErrorViewModel CreateErrorViewModel(ValidationFailure failure)
+    {
+        var detail = GetErrorDetail(failure);
+
+        return new ErrorViewModel
+        {
+            Path = failure.PropertyName,
+            Code = failure.ErrorCode.Replace("Validator", ""),
+            Message = failure.ErrorMessage,
+            Detail = detail.Count > 0 ? detail : null
+        };
+    }
+
+    private static IDictionary<string, object?> GetErrorDetail(ValidationFailure failure)
+    {
+        var detail = failure.FormattedMessagePlaceholderValues
+            .Where(kv => !IgnoredMessagePlaceholders.Contains(kv.Key))
+            .ToDictionary(kv => kv.Key.CamelCase(), kv => kv.Value)
+            as Dictionary<string, object?>;
+
+        if (failure.CustomState is null)
+        {
+            return detail;
+        }
+
+        var type = failure.CustomState.GetType();
+
+        if (type is { IsClass: true, IsPrimitive: false, IsEnum: false, IsValueType: false })
+        {
+            detail.AddRange(
+                failure.CustomState
+                    .ToDictionary()
+                    .ToDictionary(
+                        kv => kv.Key.CamelCase(),
+                        kv => kv.Value)
+            );
+        }
+        else
+        {
+            detail["state"] = failure.CustomState;
+        }
+
+        return detail;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Config/FluentValidationLanguageManager.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Config/FluentValidationLanguageManager.cs
@@ -1,0 +1,76 @@
+#nullable enable
+using System.Collections.Generic;
+using FluentValidation.Resources;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Config;
+
+public class FluentValidationLanguageManager : LanguageManager
+{
+    public FluentValidationLanguageManager()
+    {
+        foreach (var translation in Translations)
+        {
+            AddTranslation("en", translation.Key, translation.Message);
+            AddTranslation("en-GB", translation.Key, translation.Message);
+            AddTranslation("en-US", translation.Key, translation.Message);
+        }
+    }
+
+    private static IEnumerable<Translation> Translations => new List<Translation>
+    {
+        new(Key: FluentValidationKeys.EmailValidator, Message: "Must be a valid email address."),
+        new(
+            Key: FluentValidationKeys.GreaterThanOrEqualValidator,
+            Message: "Must be greater than or equal to '{ComparisonValue}'."
+        ),
+        new(Key: FluentValidationKeys.GreaterThanValidator, Message: "Must be greater than '{ComparisonValue}'."),
+        new(
+            Key: FluentValidationKeys.LengthValidator,
+            Message: "Must be between {MinLength} and {MaxLength} characters (was {TotalLength})."
+        ),
+        new(
+            Key: FluentValidationKeys.MinimumLengthValidator,
+            Message: "Must be at least {MinLength} characters (was {TotalLength})."
+        ),
+        new(
+            Key: FluentValidationKeys.MaximumLengthValidator,
+            Message: "Must be {MaxLength} characters or fewer (was {TotalLength})."
+        ),
+        new(
+            Key: FluentValidationKeys.LessThanOrEqualValidator,
+            Message: "Must be less than or equal to '{ComparisonValue}'."
+        ),
+        new(Key: FluentValidationKeys.LessThanValidator, Message: "Must be less than '{ComparisonValue}'."),
+        new(Key: FluentValidationKeys.NotEmptyValidator, Message: "Must not be empty."),
+        new(Key: FluentValidationKeys.NotEqualValidator, Message: "Must not be equal to '{ComparisonValue}'."),
+        new(Key: FluentValidationKeys.NotNullValidator, Message: "Must not be empty."),
+        new(Key: FluentValidationKeys.PredicateValidator, Message: "Must meet required condition."),
+        new(Key: FluentValidationKeys.AsyncPredicateValidator, Message: "Must meet required condition."),
+        new(Key: FluentValidationKeys.RegularExpressionValidator, Message: "Must be in correct format."),
+        new(Key: FluentValidationKeys.EqualValidator, Message: "Must be equal to '{ComparisonValue}'."),
+        new(
+            Key: FluentValidationKeys.ExactLengthValidator,
+            Message: "Must be {MaxLength} characters in length (was {TotalLength})."
+        ),
+        new(
+            Key: FluentValidationKeys.InclusiveBetweenValidator,
+            Message: "Must be between {From} and {To} (inclusive)."
+        ),
+        new(
+            Key: FluentValidationKeys.ExclusiveBetweenValidator,
+            Message: "Must be between {From} and {To} (exclusive)."
+        ),
+        new(Key: FluentValidationKeys.CreditCardValidator, Message: "Must be a valid credit card number."),
+        new(
+            Key: FluentValidationKeys.ScalePrecisionValidator,
+            Message:
+            "Must not be more than {ExpectedPrecision} digits in total, with allowance for {ExpectedScale} decimals. {Digits} digits and {ActualScale)} decimals were found."
+        ),
+        new(Key: FluentValidationKeys.EmptyValidator, Message: "Must be empty."),
+        new(Key: FluentValidationKeys.NullValidator, Message: "Must be empty."),
+        new(Key: FluentValidationKeys.EnumValidator, Message: "Must be one of an allowed range of values."),
+    };
+
+    public record Translation(string Key, string Message);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Config/ProblemDetailsResultFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Config/ProblemDetailsResultFilter.cs
@@ -1,0 +1,45 @@
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Config;
+
+/// <summary>
+/// A filter that handles conversion of any problem details to our customised view models.
+/// </summary>
+public class ProblemDetailsResultFilter : IResultFilter
+{
+    public void OnResultExecuting(ResultExecutingContext context)
+    {
+        if (context.Result is not ObjectResult result)
+        {
+            return;
+        }
+
+        if (result.Value is not ProblemDetails problemDetails)
+        {
+            return;
+        }
+
+        // If for some reason, there is a mismatch with the
+        // HTTP status code, make sure these are aligned.
+        problemDetails.Status = result.StatusCode;
+
+        if (problemDetails is not ValidationProblemDetails validationProblemDetails)
+        {
+            return;
+        }
+
+        // Result is already the right view model type, don't need to do anything else.
+        if (problemDetails is ValidationProblemViewModel)
+        {
+            return;
+        }
+
+        result.Value = ValidationProblemViewModel.Create(validationProblemDetails);
+    }
+
+    public void OnResultExecuted(ResultExecutedContext context)
+    {
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/FluentValidationServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/FluentValidationServiceCollectionExtensions.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.Json;
+using FluentValidation;
+using FluentValidation.Internal;
+using GovUk.Education.ExploreEducationStatistics.Common.Config;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class FluentValidationServiceCollectionExtensions
+{
+    public static IServiceCollection AddFluentValidation(this IServiceCollection services)
+    {
+        return AddFluentValidation(services, Assembly.GetCallingAssembly());
+    }
+
+    private static IServiceCollection AddFluentValidation(IServiceCollection services, Assembly assembly)
+    {
+        ValidatorOptions.Global.LanguageManager = new FluentValidationLanguageManager();
+
+        ValidatorOptions.Global.PropertyNameResolver = (_, memberInfo, expression) =>
+            JsonNamingPolicy.CamelCase.ConvertName(ResolvePropertyName(memberInfo, expression));
+
+        services.AddValidatorsFromAssembly(assembly);
+
+        services.Configure<MvcOptions>(options =>
+        {
+            options.Filters.Add<FluentValidationActionFilter>();
+        });
+
+        return services;
+    }
+
+    private static string ResolvePropertyName(MemberInfo? memberInfo, LambdaExpression? expression)
+    {
+        if (expression is not null)
+        {
+            var chain = PropertyChain.FromExpression(expression);
+
+            if (chain.Count > 0)
+            {
+                return chain.ToString();
+            }
+        }
+
+        if (memberInfo is not null)
+        {
+            return memberInfo.Name;
+        }
+
+        return string.Empty;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ObjectExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ObjectExtensions.cs
@@ -1,0 +1,18 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class ObjectExtensions
+{
+    public static Dictionary<string, object?> ToDictionary(this object obj)
+    {
+        var properties = obj.GetType().GetProperties();
+
+        return properties.ToDictionary(
+            property => property.Name,
+            property => property.GetValue(obj)
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ServiceProviderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ServiceProviderExtensions.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class ServiceProviderExtensions
+{
+    public static JsonOptions GetSystemTextJsonOptions(this IServiceProvider provider)
+    {
+        return provider.GetRequiredService<IOptions<JsonOptions>>().Value;
+    }
+
+    public static JsonSerializerOptions GetSystemTextJsonSerializerOptions(this IServiceProvider provider)
+    {
+        return provider.GetSystemTextJsonOptions().SerializerOptions;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -12,6 +12,8 @@
         <PackageReference Include="AutoMapper" Version="9.0.0" />
         <PackageReference Include="Azure.Storage.Blobs" Version="12.17.0" />
         <PackageReference Include="CsvHelper" Version="30.0.1" />
+        <PackageReference Include="FluentValidation" Version="11.9.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
         <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
         <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/FluentValidationKeys.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/FluentValidationKeys.cs
@@ -1,0 +1,28 @@
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators;
+
+public static class FluentValidationKeys
+{
+    public const string EmailValidator = "EmailValidator";
+    public const string GreaterThanOrEqualValidator = "GreaterThanOrEqualValidator";
+    public const string GreaterThanValidator = "GreaterThanValidator";
+    public const string LengthValidator = "LengthValidator";
+    public const string MinimumLengthValidator = "MinimumLengthValidator";
+    public const string MaximumLengthValidator = "MaximumLengthValidator";
+    public const string LessThanOrEqualValidator = "LessThanOrEqualValidator";
+    public const string LessThanValidator = "LessThanValidator";
+    public const string NotEmptyValidator = "NotEmptyValidator";
+    public const string NotEqualValidator = "NotEqualValidator";
+    public const string NotNullValidator = "NotNullValidator";
+    public const string PredicateValidator = "PredicateValidator";
+    public const string AsyncPredicateValidator = "AsyncPredicateValidator";
+    public const string RegularExpressionValidator = "RegularExpressionValidator";
+    public const string EqualValidator = "EqualValidator";
+    public const string ExactLengthValidator = "ExactLengthValidator";
+    public const string InclusiveBetweenValidator = "InclusiveBetweenValidator";
+    public const string ExclusiveBetweenValidator = "ExclusiveBetweenValidator";
+    public const string CreditCardValidator = "CreditCardValidator";
+    public const string ScalePrecisionValidator = "ScalePrecisionValidator";
+    public const string EmptyValidator = "EmptyValidator";
+    public const string NullValidator = "NullValidator";
+    public const string EnumValidator = "EnumValidator";
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationUtils.cs
@@ -1,36 +1,42 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Validators
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators;
+
+public static class ValidationUtils
 {
-    public static class ValidationUtils
+    public static BadRequestObjectResult ValidationResult<TEnum>(params TEnum[] codes) where TEnum : Enum
     {
-        public static ActionResult ValidationResult(params Enum[] errors)
-        {
-            return ValidationResult(errors.Select(error => error.ToString()).ToArray());
-        }
-        
-        public static ActionResult ValidationResult(params string[] errors)
-        {
-            var problemDetails = new ValidationProblemDetails(
-                errors.ToDictionary(
-                    _ => string.Empty,
-                    error => new[] {error}))
+        return ValidationResult(codes.ToList());
+    }
+
+    public static BadRequestObjectResult ValidationResult<TEnum>(IEnumerable<TEnum> codes) where TEnum : Enum
+    {
+        return ValidationResult(
+            codes.Select(code => new ErrorViewModel
             {
-                Status = (int) HttpStatusCode.BadRequest,
-                Detail = "Please refer to the errors property for additional details"
-            };
+                // For now, we just output the code, but in the future,
+                // it would be good to provide default messages as well.
+                Code = code.ToString()
+            })
+        );
+    }
 
-            return new BadRequestObjectResult(problemDetails);
-        }
+    public static BadRequestObjectResult ValidationResult(params ErrorViewModel[] errors)
+    {
+        return ValidationResult(errors.ToList());
+    }
 
-        public static Either<ActionResult, T> ValidationResult<T>(Enum error)
+    public static BadRequestObjectResult ValidationResult(IEnumerable<ErrorViewModel> errors)
+    {
+        return new BadRequestObjectResult(new ValidationProblemViewModel
         {
-            return ValidationResult(error);
-        }
+            Errors = errors.ToList()
+        });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ErrorViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ErrorViewModel.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+
+public record ErrorViewModel
+{
+    /// <summary>
+    /// The error message.
+    /// </summary>
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The path to the property on the request that the error relates to.
+    /// May be omitted or be empty if no specific property of the
+    /// request relates to the error (it is a 'global' error).
+    /// </summary>
+    public string? Path { get; init; }
+
+    /// <summary>
+    /// The error's machine-readable code. Can be used for further
+    /// processing of the error before presenting to users.
+    /// May be omitted if there is none.
+    /// </summary>
+    public string? Code { get; init; }
+
+    /// <summary>
+    /// Additional detail about the error that can be used to provide
+    /// more context to users. May be omitted if there is none.
+    /// </summary>
+    public object? Detail { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ValidationProblemViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ValidationProblemViewModel.cs
@@ -22,6 +22,23 @@ public class ValidationProblemViewModel : ValidationProblemDetails
     /// </summary>
     public new IReadOnlyList<ErrorViewModel> Errors { get; set; } = new List<ErrorViewModel>();
 
+    public static ValidationProblemViewModel Create(ValidationProblemDetails problemDetails)
+    {
+        var errors = problemDetails.Errors
+            .SelectMany(errorEntry =>
+                errorEntry.Value.Select(
+                    message => new ErrorViewModel
+                    {
+                        Path = errorEntry.Key.IsNullOrEmpty() ? null : errorEntry.Key,
+                        Message = message
+                    }
+                )
+            )
+            .ToList();
+
+        return Create(problemDetails, errors);
+    }
+
     public static ValidationProblemViewModel Create(
         ValidationProblemDetails problemDetails,
         IEnumerable<ErrorViewModel> errors)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ValidationProblemViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ValidationProblemViewModel.cs
@@ -1,0 +1,42 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+
+/// <summary>
+/// A validation problem that has occurred with the API request.
+/// This type of response will be composed of one or more errors
+/// relating to the request and its properties.
+/// </summary>
+public class ValidationProblemViewModel : ValidationProblemDetails
+{
+    /// <inheritdoc cref="ValidationProblemDetails.Status" />
+    public new int Status => StatusCodes.Status400BadRequest;
+
+    /// <summary>
+    /// Additional errors that are related to the validation problem.
+    /// </summary>
+    public new IReadOnlyList<ErrorViewModel> Errors { get; set; } = new List<ErrorViewModel>();
+
+    public static ValidationProblemViewModel Create(
+        ValidationProblemDetails problemDetails,
+        IEnumerable<ErrorViewModel> errors)
+    {
+        var viewModel = new ValidationProblemViewModel
+        {
+            Title = problemDetails.Title,
+            Type = problemDetails.Type,
+            Detail = problemDetails.Detail,
+            Instance = problemDetails.Instance,
+            Errors = errors.ToList(),
+        };
+
+        viewModel.Extensions.AddRange(problemDetails.Extensions);
+
+        return viewModel;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ValidationProblemViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ValidationProblemViewModel.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -21,6 +22,10 @@ public class ValidationProblemViewModel : ValidationProblemDetails
     /// Additional errors that are related to the validation problem.
     /// </summary>
     public new IReadOnlyList<ErrorViewModel> Errors { get; set; } = new List<ErrorViewModel>();
+
+    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public ValidationProblemDetails? OriginalDetails { get; init; }
 
     public static ValidationProblemViewModel Create(ValidationProblemDetails problemDetails)
     {
@@ -50,6 +55,7 @@ public class ValidationProblemViewModel : ValidationProblemDetails
             Detail = problemDetails.Detail,
             Instance = problemDetails.Instance,
             Errors = errors.ToList(),
+            OriginalDetails = problemDetails,
         };
 
         viewModel.Extensions.AddRange(problemDetails.Extensions);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/TestStartup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/TestStartup.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Rules;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
@@ -27,7 +28,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvcCore(options => { options.EnableEndpointRouting = false; })
+            services.AddMvcCore(options =>
+                {
+                    options.Filters.Add(new ProblemDetailsResultFilter());
+                    options.EnableEndpointRouting = false;
+                })
                 .AddNewtonsoftJson(
                     options => { options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore; }
                 );

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -68,6 +68,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             services.AddMvc(options =>
                 {
                     options.Filters.Add(new OperationCancelledExceptionFilter());
+                    options.Filters.Add(new ProblemDetailsResultFilter());
                     options.EnableEndpointRouting = false;
                 })
                 .AddNewtonsoftJson(options =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/TestStartup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/TestStartup.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Rules;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
@@ -27,7 +28,12 @@ public class TestStartup
 {
     public void ConfigureServices(IServiceCollection services)
     {
-        services.AddMvcCore(options => { options.EnableEndpointRouting = false; })
+        services.AddMvcCore(
+                options =>
+                {
+                    options.Filters.Add(new ProblemDetailsResultFilter());
+                    options.EnableEndpointRouting = false;
+                })
             .AddNewtonsoftJson(
                 options => { options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore; }
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -74,6 +74,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
             services.AddMvc(options =>
                 {
                     options.Filters.Add(new OperationCancelledExceptionFilter());
+                    options.Filters.Add(new ProblemDetailsResultFilter());
                     options.RespectBrowserAcceptHeader = true;
                     options.ReturnHttpNotAcceptable = true;
                     options.EnableEndpointRouting = false;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
@@ -7,9 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
-using System.Net;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Services;
-using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Controllers;
 
@@ -116,7 +114,11 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
 
             var response = await ListPublications(client, page, 1);
 
-            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasGreaterThanOrEqualError("page");
         }
 
         [Theory]
@@ -129,7 +131,11 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
 
             var response = await ListPublications(client, 1, pageSize);
 
-            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasInclusiveBetweenError("pageSize");
         }
 
         [Theory]
@@ -141,7 +147,11 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
 
             var response = await ListPublications(client, null, null, searchTerm);
 
-            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasMinimumLengthError("search");
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
@@ -19,8 +19,6 @@
         <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
         <PackageReference Include="AspectInjector" Version="2.8.2" />
         <PackageReference Include="DuckDB.NET.Data.Full" Version="0.9.2" />
-        <PackageReference Include="FluentValidation" Version="11.8.1" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.1" />
         <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.0.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
@@ -31,7 +29,6 @@
         <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.0" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
         <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
-        <PackageReference Include="SharpGrip.FluentValidation.AutoValidation.Mvc" Version="1.3.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/PublicationsListRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/PublicationsListRequest.cs
@@ -31,8 +31,7 @@ public record PublicationsListRequest
             RuleFor(request => request.Page)
                 .GreaterThanOrEqualTo(1);
             RuleFor(request => request.PageSize)
-                .GreaterThanOrEqualTo(1)
-                .LessThanOrEqualTo(40);
+                .InclusiveBetween(1, 40);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -58,6 +58,7 @@ public class Startup
         services
             .AddControllers(options =>
             {
+                options.Filters.Add(new ProblemDetailsResultFilter());
                 options.AddCommaSeparatedQueryModelBinderProvider();
                 options.AddTrimStringBinderProvider();
             })

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using AngleSharp.Io;
-using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
 using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -15,7 +14,6 @@ using MicroElements.Swashbuckle.FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
-using SharpGrip.FluentValidation.AutoValidation.Mvc.Extensions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api;
 
@@ -57,11 +55,17 @@ public class Startup
             options.SerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
         });
 
-        services.AddControllers(options =>
-        {
-            options.AddCommaSeparatedQueryModelBinderProvider();
-            options.AddTrimStringBinderProvider();
-        });
+        services
+            .AddControllers(options =>
+            {
+                options.AddCommaSeparatedQueryModelBinderProvider();
+                options.AddTrimStringBinderProvider();
+            })
+            .ConfigureApiBehaviorOptions(options =>
+            {
+                // Disables default model validation. Use FluentValidation instead.
+                options.SuppressModelStateInvalidFilter = true;
+            });
 
         services.AddProblemDetails();
         services.AddApiVersioning().AddMvc().AddApiExplorer();
@@ -89,9 +93,7 @@ public class Startup
 
         // Services
 
-        services.AddValidatorsFromAssemblyContaining<Startup>();
-        services.AddFluentValidationAutoValidation();
-
+        services.AddFluentValidation();
         services.AddFluentValidationRulesToSwagger();
 
         services.AddHttpClient<IContentApiClient, ContentApiClient>(httpClient =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="DuckDB.NET.Data.Full" Version="0.9.2" />
-        <PackageReference Include="FluentValidation" Version="11.8.1" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.1" />
+        <PackageReference Include="FluentValidation" Version="11.9.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.20.1" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.1" />

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -607,7 +607,9 @@ describe('ReleaseStatusForm', () => {
       'shows checklist error message `%s` after failed submit',
       async checklistError => {
         const handleSubmit = jest.fn().mockImplementation(() => {
-          throw createServerValidationErrorMock([checklistError]);
+          throw createServerValidationErrorMock([
+            { code: checklistError, message: '' },
+          ]);
         });
 
         render(
@@ -638,7 +640,9 @@ describe('ReleaseStatusForm', () => {
 
     test('shows generic server validation error message for `approvalStatus` after failed submit', async () => {
       const handleSubmit = jest.fn().mockImplementation(() => {
-        throw createServerValidationErrorMock(['UnexpectedError']);
+        throw createServerValidationErrorMock([
+          { code: 'UnexpectedError', message: '' },
+        ]);
       });
 
       render(
@@ -801,7 +805,9 @@ describe('ReleaseStatusForm', () => {
 
     test('shows error modal when submitted with publish date that could not be scheduled', async () => {
       const handleSubmit = jest.fn().mockImplementation(() => {
-        throw createServerValidationErrorMock(['PublishDateCannotBeScheduled']);
+        throw createServerValidationErrorMock([
+          { code: 'PublishDateCannotBeScheduled', message: '' },
+        ]);
       });
 
       render(

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
@@ -45,11 +45,9 @@ import {
   TableDataResult,
 } from '@common/services/tableBuilderService';
 import { Chart } from '@common/services/types/blocks';
+import { ValidationProblemDetails } from '@common/services/types/problemDetails';
 import parseNumber from '@common/utils/number/parseNumber';
-import {
-  isServerValidationError,
-  ServerValidationErrorResponse,
-} from '@common/validation/serverValidations';
+import { isServerValidationError } from '@common/validation/serverValidations';
 import { produce } from 'immer';
 import omit from 'lodash/omit';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
@@ -134,8 +132,7 @@ const ChartBuilder = ({
 
   const getChartFile = useGetChartFile(releaseId);
 
-  const [submitError, setSubmitError] =
-    useState<ServerValidationErrorResponse>();
+  const [submitError, setSubmitError] = useState<ValidationProblemDetails>();
 
   const dataSetsUnits = useMemo(
     () =>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -23,11 +23,11 @@ import {
   barChartDataLabelPositions,
   lineChartDataLabelPositions,
 } from '@common/modules/charts/util/chartUtils';
+import { ValidationProblemDetails } from '@common/services/types/problemDetails';
 import parseNumber from '@common/utils/number/parseNumber';
 import {
   convertServerFieldErrors,
   mapFieldErrors,
-  ServerValidationErrorResponse,
 } from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
@@ -63,7 +63,7 @@ interface Props {
   chartOptions: ChartOptions;
   definition: ChartDefinition;
   legendPosition?: LegendPosition;
-  submitError?: ServerValidationErrorResponse;
+  submitError?: ValidationProblemDetails;
   onChange: (chartOptions: ChartOptions) => void;
   onSubmit: (chartOptions: ChartOptions) => void;
 }
@@ -312,7 +312,7 @@ const ChartConfiguration = ({
               <FormFieldTextInput<FormValues>
                 label="Subtitle"
                 name="subtitle"
-                hint="The statistical subtitle should say what the data is, the geography the data relates to and the time period shown. 
+                hint="The statistical subtitle should say what the data is, the geography the data relates to and the time period shown.
                 For example, 'Figure 1: Number of people living in one person households, England, 1991 to 2021'."
                 maxLength={160}
               />

--- a/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
@@ -414,9 +414,9 @@ describe('Form', () => {
           firstName: Yup.string().defined(),
         })}
         onSubmit={() => {
-          throw createServerValidationErrorMock([], {
-            firstName: ['Invalid first name'],
-          });
+          throw createServerValidationErrorMock([
+            { path: 'firstName', message: 'Invalid first name' },
+          ]);
         }}
       >
         <Form id="test-form">
@@ -438,9 +438,9 @@ describe('Form', () => {
 
   test('removes mapped server validation errors when form can be submitted successfully', async () => {
     const onSubmit = jest.fn(() => {
-      throw createServerValidationErrorMock([], {
-        firstName: ['Invalid first name'],
-      });
+      throw createServerValidationErrorMock([
+        { path: 'firstName', message: 'Invalid first name' },
+      ]);
     });
 
     render(
@@ -486,9 +486,9 @@ describe('Form', () => {
           firstName: Yup.string().defined(),
         })}
         onSubmit={() => {
-          throw createServerValidationErrorMock([], {
-            firstName: ['Invalid first name'],
-          });
+          throw createServerValidationErrorMock([
+            { path: 'firstName', message: 'Invalid first name' },
+          ]);
         }}
       >
         {formik => (
@@ -526,9 +526,9 @@ describe('Form', () => {
           firstName: Yup.string().required(),
         })}
         onSubmit={() => {
-          throw createServerValidationErrorMock([], {
-            firstName: ['Invalid first name'],
-          });
+          throw createServerValidationErrorMock([
+            { path: 'firstName', message: 'Invalid first name' },
+          ]);
         }}
       >
         <Form id="test-form">
@@ -563,10 +563,12 @@ describe('Form', () => {
           firstName: Yup.string().defined(),
         })}
         onSubmit={() => {
-          throw createServerValidationErrorMock(['Global error'], {
-            field1: ['Invalid field 1'],
-            'nested.field2': ['Invalid field 2'],
-          });
+          throw createServerValidationErrorMock([
+            { message: 'Global error' },
+            { code: 'UnmappedCode', message: '' },
+            { path: 'field1', message: 'Invalid field 1' },
+            { path: 'nested.field2', message: 'Invalid field 2' },
+          ]);
         }}
       >
         {({ submitCount }) => (
@@ -583,7 +585,13 @@ describe('Form', () => {
     await waitFor(() => {
       expect(screen.getByText('The form is submitted')).toBeInTheDocument();
 
+      expect(
+        screen.getByText(
+          'The form submission is invalid and could not be processed',
+        ),
+      ).toBeInTheDocument();
       expect(screen.queryByText('Global error')).not.toBeInTheDocument();
+      expect(screen.queryByText('UnmappedCode')).not.toBeInTheDocument();
       expect(screen.queryByText('Invalid field 1')).not.toBeInTheDocument();
       expect(screen.queryByText('Invalid field 2')).not.toBeInTheDocument();
     });

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFForm.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFForm.test.tsx
@@ -408,9 +408,9 @@ describe('Form', () => {
         <RHFForm
           id="test-form"
           onSubmit={() => {
-            throw createServerValidationErrorMock([], {
-              firstName: ['Invalid first name'],
-            });
+            throw createServerValidationErrorMock([
+              { path: 'firstName', message: 'Invalid first name' },
+            ]);
           }}
         >
           The form
@@ -428,9 +428,9 @@ describe('Form', () => {
 
   test('removes mapped server validation errors when form can be submitted successfully', async () => {
     const onSubmit = jest.fn(() => {
-      throw createServerValidationErrorMock([], {
-        firstName: ['Invalid first name'],
-      });
+      throw createServerValidationErrorMock([
+        { path: 'firstName', message: 'Invalid first name' },
+      ]);
     });
 
     render(
@@ -479,9 +479,9 @@ describe('Form', () => {
           <RHFForm
             id="test-form"
             onSubmit={() => {
-              throw createServerValidationErrorMock([], {
-                firstName: ['Invalid first name'],
-              });
+              throw createServerValidationErrorMock([
+                { path: 'firstName', message: 'Invalid first name' },
+              ]);
             }}
           >
             The form
@@ -526,9 +526,9 @@ describe('Form', () => {
           <RHFForm
             id="test-form"
             onSubmit={() => {
-              throw createServerValidationErrorMock([], {
-                firstName: ['Invalid first name'],
-              });
+              throw createServerValidationErrorMock([
+                { path: 'firstName', message: 'Invalid first name' },
+              ]);
             }}
           >
             The form
@@ -572,10 +572,12 @@ describe('Form', () => {
           <RHFForm
             id="test-form"
             onSubmit={() => {
-              throw createServerValidationErrorMock(['Global error'], {
-                field1: ['Invalid field 1'],
-                'nested.field2': ['Invalid field 2'],
-              });
+              throw createServerValidationErrorMock([
+                { message: 'Global error' },
+                { code: 'UnmappedCode', message: '' },
+                { path: 'field1', message: 'Invalid field 1' },
+                { path: 'nested.field2', message: 'Invalid field 2' },
+              ]);
             }}
           >
             {formState.isSubmitted ? 'The form is submitted' : 'The form'}
@@ -590,7 +592,13 @@ describe('Form', () => {
     await waitFor(() => {
       expect(screen.getByText('The form is submitted')).toBeInTheDocument();
 
+      expect(
+        screen.getByText(
+          'The form submission is invalid and could not be processed',
+        ),
+      ).toBeInTheDocument();
       expect(screen.queryByText('Global error')).not.toBeInTheDocument();
+      expect(screen.queryByText('UnmappedCode')).not.toBeInTheDocument();
       expect(screen.queryByText('Invalid field 1')).not.toBeInTheDocument();
       expect(screen.queryByText('Invalid field 2')).not.toBeInTheDocument();
     });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -21,7 +21,7 @@ import { Subject, SubjectMeta } from '@common/services/tableBuilderService';
 import { Dictionary } from '@common/types';
 import createRHFErrorHelper from '@common/components/form/rhf/validation/createRHFErrorHelper';
 import {
-  getErrorMessage,
+  getErrorCode,
   hasErrorMessage,
   isServerValidationError,
 } from '@common/validation/serverValidations';
@@ -134,7 +134,7 @@ export default function FiltersForm({
         throw error;
       }
 
-      const errorCode = getErrorMessage(error);
+      const errorCode = getErrorCode<TableQueryErrorCode>(error);
 
       if (onTableQueryError) {
         if (errorCode) {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FiltersForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FiltersForm.test.tsx
@@ -643,7 +643,7 @@ describe('FiltersForm', () => {
 
   test('shows table size error when the correct error response is returned from the API', async () => {
     const errorResponse = createServerValidationErrorMock<TableQueryErrorCode>([
-      'QueryExceedsMaxAllowableTableSize',
+      { code: 'QueryExceedsMaxAllowableTableSize', message: '' },
     ]);
     const onSubmit = jest.fn(() => Promise.reject(errorResponse));
 
@@ -690,7 +690,7 @@ describe('FiltersForm', () => {
 
   test('shows table timeout error when the correct error response is returned from the API', async () => {
     const errorResponse = createServerValidationErrorMock<TableQueryErrorCode>([
-      'RequestCancelled',
+      { code: 'RequestCancelled', message: '' },
     ]);
     const onSubmit = jest.fn(() => Promise.reject(errorResponse));
 

--- a/src/explore-education-statistics-common/src/services/types/problemDetails.ts
+++ b/src/explore-education-statistics-common/src/services/types/problemDetails.ts
@@ -1,0 +1,50 @@
+export interface ProblemDetails {
+  /**
+   * A short, human-readable summary of the problem type.
+   */
+  title: string;
+  /**
+   * A URI reference [RFC3986] that identifies the problem type.
+   */
+  type: string;
+  /**
+   * The HTTP status code.
+   */
+  status: number;
+  /**
+   * A human-readable explanation specific to this occurrence of the problem.
+   */
+  detail?: string;
+}
+
+export interface ValidationProblemDetails<TCode extends string = string>
+  extends ProblemDetails {
+  /**
+   * Errors associated with the validation problem.
+   */
+  errors: ValidationProblemError<TCode>[];
+}
+
+export interface ValidationProblemError<TCode extends string = string> {
+  /**
+   * The error message.
+   */
+  message: string;
+  /**
+   * The path to the property on the request that the error relates to.
+   * May be omitted or be empty if no specific property of the
+   * request relates to the error (it is a 'global' error).
+   */
+  path?: string;
+  /**
+   * The error's machine-readable code. Use this for localisation
+   * or general processing when presenting the error to users.
+   * May be omitted if there is none.
+   */
+  code?: TCode;
+  /**
+   * Additional detail about the error that can be used to provide
+   * more context to users. May be omitted if there is none.
+   */
+  detail?: unknown;
+}

--- a/src/explore-education-statistics-common/test/createAxiosErrorMock.ts
+++ b/src/explore-education-statistics-common/test/createAxiosErrorMock.ts
@@ -1,5 +1,8 @@
+import {
+  ValidationProblemDetails,
+  ValidationProblemError,
+} from '@common/services/types/problemDetails';
 import { Dictionary } from '@common/types';
-import { ServerValidationErrorResponse } from '@common/validation/serverValidations';
 import { AxiosError, AxiosHeaders } from 'axios';
 
 interface CreateAxiosErrorOptions<T> {
@@ -37,19 +40,16 @@ export default function createAxiosErrorMock<T>(
   };
 }
 
-export function createServerValidationErrorMock<T extends string = string>(
-  globalErrors: T[],
-  fieldErrors: Dictionary<T[]> = {},
-): AxiosError<ServerValidationErrorResponse<T>> {
+export function createServerValidationErrorMock<TCode extends string = string>(
+  errors: ValidationProblemError<TCode>[],
+): AxiosError<ValidationProblemDetails<TCode>> {
   return createAxiosErrorMock({
     status: 400,
     data: {
-      errors: {
-        ...fieldErrors,
-        '': globalErrors,
-      },
+      errors,
       status: 400,
       title: 'One or more validation errors occurred.',
+      type: 'https://tools.ietf.org/html/rfc9110#section-15.5.1',
     },
   });
 }


### PR DESCRIPTION
This PR updates the validation problem responses across the various project APIs to include a custom `errors` property. This contains the list of validation errors, and provides more detail about each in the format of:

```json
{
  "path": "theFieldPath",
  "code": "TheErrorCode",
  "message": "A default error message",
  "details": {}
}
```

Where `details` is an optional free-form object that can provide additional context about the validation error.

With our standard validation using `ValidationResult` or `ValidationActionResult` utils (throughout the service layer), we should typically expect really basic errors like:

```cs
{
  "code": "DataFileCannotBeEmpty",
  "message": ""
}
```

In the future, it'd be nice to fill these errors out more. For now, these essentially work the same as current and will be mapped into any form fields if mappings have been configured.

Importantly, this work now enables richer error responses using FluentValidation, which provides richer error details out of the box. We're hoping that this will work well with validating public API endpoints, particularly for querying.

Unfortunately, it's unlikely we'll be able to achieve a similar thing using attribute-based validation as these only provide a `path` and `message`. We should ideally switch to FluentValidation entirely, although this is unlikely to happen any time soon.