### PR TITLE
EES-4754 fix page mode bar covering ckeditor toolbar

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.module.scss
@@ -19,10 +19,9 @@
   position: sticky;
   top: 0;
   width: calc(100% + #{govuk-spacing(6)});
-  z-index: 999;
+  z-index: 9999; // z-index has to be higher than ckeditor sticky toolbar.
 
   @include govuk-media-query($from: tablet) {
-    margin-bottom: govuk-spacing(9);
     margin-left: 0;
     width: 100%;
   }

--- a/src/explore-education-statistics-admin/src/components/form/FormEditor.module.scss
+++ b/src/explore-education-statistics-admin/src/components/form/FormEditor.module.scss
@@ -26,6 +26,15 @@ $active-colour: lighten(govuk-colour('orange'), 10);
     text-align: left;
     width: 100%;
   }
+
+  // Adjust the sticky toolbar so it isn't obscured by the page mode bar.
+  // stylelint-disable-next-line selector-class-pattern
+  :global(.ck-sticky-panel .ck-sticky-panel__content_sticky) {
+    padding-top: 48px;
+    @include govuk-media-query($from: tablet) {
+      padding-top: 54px;
+    }
+  }
 }
 
 .focused {

--- a/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
@@ -54,6 +54,14 @@ const ReleaseContentPageLoaded = () => {
               </BrowserWarning>
             )}
 
+            {canPreviewRelease && (
+              <EditablePageModeToggle
+                canUpdateRelease={canUpdateRelease}
+                previewLabel="Preview release page"
+                showTablePreviewOption
+              />
+            )}
+
             {canUpdateRelease && (
               <>
                 {totalUnsavedBlocks > 0 && (
@@ -73,13 +81,6 @@ const ReleaseContentPageLoaded = () => {
               </>
             )}
 
-            {canPreviewRelease && (
-              <EditablePageModeToggle
-                canUpdateRelease={canUpdateRelease}
-                previewLabel="Preview release page"
-                showTablePreviewOption
-              />
-            )}
             <div
               className={classNames({
                 [styles.container]: editingMode === 'edit',


### PR DESCRIPTION
Fixes a couple of spacing issues with the new 'Change page view' bar:
- prevents it from covering the sticky toolbar in CKEditor
- moves the warnings about unresolved comments and unsaved changes to below the bar. 