### PR TITLE
EES-4754 remove unneeded aria-labelledby on desktop

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.tsx
@@ -66,7 +66,7 @@ export default function EditablePageModeToggle({
       )}
 
       <div
-        aria-labelledby="pageViewToggleButton"
+        aria-labelledby={isMobileMedia ? 'pageViewToggleButton' : undefined}
         className={classNames({
           'dfe-js-hidden': isMobileMedia && !isOpen,
         })}


### PR DESCRIPTION
Fixes an accessibility issue spotted by @N-moh. 

The `pageViewToggleButton` is only shown on mobile (where the page controls can be expanded / collapsed) so the aria-labelledby tag is not needed on desktop.