### PR TITLE
EES-3986 Extend PRA into Publish Day until Release is actually Published

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -514,6 +514,13 @@
         "description": "Prerelease end time as number of minutes before a release is scheduled to be published"
       }
     },
+    "MinutesIntoPublishDayByWhichPublishingHasOccurred": {
+      "type": "int",
+      "defaultValue": 570,
+      "metadata": {
+        "description": "How many minutes into a day, on which a Release is scheduled to be published, its PreRelease should still be viewable"
+      }
+    },
     "blobDeleteRetentionEnabled": {
       "defaultValue": true,
       "type": "bool",
@@ -1774,6 +1781,7 @@
         "PublisherStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher'), '2018-02-14').secretUriWithVersion, ')')]",
         "PreReleaseAccess:AccessWindow:MinutesBeforeReleaseTimeStart": "[parameters('preReleaseMinutesBeforeStart')]",
         "PreReleaseAccess:AccessWindow:MinutesBeforeReleaseTimeEnd": "[parameters('preReleaseMinutesBeforeEnd')]",
+        "PreReleaseAccess:AccessWindow:MinutesIntoPublishDayByWhichPublishingHasOccurred": "[parameters('preReleaseMinutesIntoPublishDayByWhichPublishingHasOccurred')]",
         "enableSwagger": "[parameters('enableSwagger')]",
         "enableThemeDeletion": "[parameters('enableThemeDeletion')]",
         "ReleaseApproval:PublishReleasesCronSchedule": "[parameters('publishReleasesCronSchedule')]",

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -507,20 +507,6 @@
         "description": "Prerelease start time as number of minutes before a release is scheduled to be published"
       }
     },
-    "preReleaseMinutesBeforeEnd": {
-      "type": "int",
-      "defaultValue": 1,
-      "metadata": {
-        "description": "Prerelease end time as number of minutes before a release is scheduled to be published"
-      }
-    },
-    "MinutesIntoPublishDayByWhichPublishingHasOccurred": {
-      "type": "int",
-      "defaultValue": 570,
-      "metadata": {
-        "description": "How many minutes into a day, on which a Release is scheduled to be published, its PreRelease should still be viewable"
-      }
-    },
     "blobDeleteRetentionEnabled": {
       "defaultValue": true,
       "type": "bool",
@@ -1780,8 +1766,6 @@
         "PublicStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public')).secretUriWithVersion, ')')]",
         "PublisherStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher'), '2018-02-14').secretUriWithVersion, ')')]",
         "PreReleaseAccess:AccessWindow:MinutesBeforeReleaseTimeStart": "[parameters('preReleaseMinutesBeforeStart')]",
-        "PreReleaseAccess:AccessWindow:MinutesBeforeReleaseTimeEnd": "[parameters('preReleaseMinutesBeforeEnd')]",
-        "PreReleaseAccess:AccessWindow:MinutesIntoPublishDayByWhichPublishingHasOccurred": "[parameters('preReleaseMinutesIntoPublishDayByWhichPublishingHasOccurred')]",
         "enableSwagger": "[parameters('enableSwagger')]",
         "enableThemeDeletion": "[parameters('enableThemeDeletion')]",
         "ReleaseApproval:PublishReleasesCronSchedule": "[parameters('publishReleasesCronSchedule')]",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
@@ -137,47 +137,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
 
             [Fact]
-            public async Task PreReleaseUser_WithinPreReleaseAccessLenienceWindow()
-            {
-                var userId = Guid.NewGuid();
-
-                var successScenario = new ReleaseHandlerTestScenario
-                {
-                    Entity = Release,
-                    User = ClaimsPrincipalUtils.CreateClaimsPrincipal(userId),
-                    UserReleaseRoles = new List<UserReleaseRole>
-                    {
-                        new()
-                        {
-                            ReleaseId = Release.Id,
-                            UserId = userId,
-                            Role = ReleaseRole.PrereleaseViewer
-                        }
-                    },
-                    ExpectedToPass = true,
-                    UnexpectedFailMessage =
-                        "Expected the test to succeed because the Pre Release window is currently within publish day lenience"
-                };
-
-                var preReleaseService = new Mock<IPreReleaseService>(Strict);
-
-                preReleaseService
-                    .Setup(s => s.GetPreReleaseWindowStatus(Release, It.IsAny<DateTime>()))
-                    .Returns(new PreReleaseWindowStatus
-                    {
-                        Access = PreReleaseAccess.WithinPublishDayLenience
-                    });
-
-                // Assert that a User who specifically has the Pre Release role will cause this handler to succeed
-                // if the Pre Release window is currently in the leniency period.
-                await AssertReleaseHandlerHandlesScenarioSuccessfully<ViewReleaseRequirement>(
-                    contentDbContext => CreateHandler(contentDbContext, preReleaseService.Object),
-                    successScenario);
-
-                VerifyAllMocks(preReleaseService);
-            }
-
-            [Fact]
             public async Task PreReleaseUser_OutsidePreReleaseAccessWindow()
             {
                 var userId = Guid.NewGuid();
@@ -202,7 +161,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 };
 
                 await GetEnumValues<PreReleaseAccess>()
-                    .Where(value => value != PreReleaseAccess.Within && value != PreReleaseAccess.WithinPublishDayLenience)
+                    .Where(value => value != PreReleaseAccess.Within)
                     .ToList()
                     .ToAsyncEnumerable()
                     .ForEachAwaitAsync(async access =>
@@ -246,9 +205,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         {
                             AccessWindow = new AccessWindowOptions
                             {
-                                MinutesBeforeReleaseTimeEnd = 100,
                                 MinutesBeforeReleaseTimeStart = 200,
-                                MinutesIntoPublishDayByWhichPublishingHasOccurred = 50,
                             }
                         }
                     }))));

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
@@ -202,7 +202,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 };
 
                 await GetEnumValues<PreReleaseAccess>()
-                    .Where(value => value != PreReleaseAccess.Within)
+                    .Where(value => value != PreReleaseAccess.Within && value != PreReleaseAccess.WithinPublishDayLenience)
                     .ToList()
                     .ToAsyncEnumerable()
                     .ForEachAwaitAsync(async access =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
@@ -137,6 +137,47 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
 
             [Fact]
+            public async Task PreReleaseUser_WithinPreReleaseAccessLenienceWindow()
+            {
+                var userId = Guid.NewGuid();
+
+                var successScenario = new ReleaseHandlerTestScenario
+                {
+                    Entity = Release,
+                    User = ClaimsPrincipalUtils.CreateClaimsPrincipal(userId),
+                    UserReleaseRoles = new List<UserReleaseRole>
+                    {
+                        new()
+                        {
+                            ReleaseId = Release.Id,
+                            UserId = userId,
+                            Role = ReleaseRole.PrereleaseViewer
+                        }
+                    },
+                    ExpectedToPass = true,
+                    UnexpectedFailMessage =
+                        "Expected the test to succeed because the Pre Release window is currently within publish day lenience"
+                };
+
+                var preReleaseService = new Mock<IPreReleaseService>(Strict);
+
+                preReleaseService
+                    .Setup(s => s.GetPreReleaseWindowStatus(Release, It.IsAny<DateTime>()))
+                    .Returns(new PreReleaseWindowStatus
+                    {
+                        Access = PreReleaseAccess.WithinPublishDayLenience
+                    });
+
+                // Assert that a User who specifically has the Pre Release role will cause this handler to succeed
+                // if the Pre Release window is currently in the leniency period.
+                await AssertReleaseHandlerHandlesScenarioSuccessfully<ViewReleaseRequirement>(
+                    contentDbContext => CreateHandler(contentDbContext, preReleaseService.Object),
+                    successScenario);
+
+                VerifyAllMocks(preReleaseService);
+            }
+
+            [Fact]
             public async Task PreReleaseUser_OutsidePreReleaseAccessWindow()
             {
                 var userId = Guid.NewGuid();
@@ -207,7 +248,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             {
                                 MinutesBeforeReleaseTimeEnd = 100,
                                 MinutesBeforeReleaseTimeStart = 200,
-                                MinutesIntoPublishDayByWhichPublishingHasOccurred = 50, // TODO: Ensure this value occurs in a test or two
+                                MinutesIntoPublishDayByWhichPublishingHasOccurred = 50,
                             }
                         }
                     }))));

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
@@ -207,6 +207,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             {
                                 MinutesBeforeReleaseTimeEnd = 100,
                                 MinutesBeforeReleaseTimeStart = 200,
+                                MinutesIntoPublishDayByWhichPublishingHasOccurred = 50, // TODO: Ensure this value occurs in a test or two
                             }
                         }
                     }))));

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseServiceTests.cs
@@ -30,13 +30,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             }
         }));
 
-        private readonly Release _testRelease = new()
-        {
-            PublishScheduled = DefaultScheduledPublishDate,
-            Published = null,
-            ApprovalStatus = ReleaseApprovalStatus.Approved
-        };
-
 
         [Theory]
         [InlineData("2003-11-10T00:00:00.00Z", false, PreReleaseAccess.Before)]
@@ -68,9 +61,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void CalculatesAllAccessRangeFieldsAsExpected()
+        public void CalculatesStartAndScheduledPublishDatesAsExpected()
         {
-            var result = _sut.GetPreReleaseWindowStatus(_testRelease, DateTime.Parse("2003-11-14T10:24:00.00Z", styles: DateTimeStyles.AdjustToUniversal));
+            var testRelease = new Release()
+            {
+                PublishScheduled = DefaultScheduledPublishDate,
+                Published = null,
+                ApprovalStatus = ReleaseApprovalStatus.Approved
+            };
+
+            var result = _sut.GetPreReleaseWindowStatus(testRelease, DateTime.Parse("2003-11-14T10:24:00.00Z", styles: DateTimeStyles.AdjustToUniversal));
 
             Assert.Equal(PreReleaseAccess.Within, result.Access);
             Assert.Equal(DateTime.Parse("2003-11-14T00:00:00.00Z", styles: DateTimeStyles.AdjustToUniversal), result.Start);
@@ -80,28 +80,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void AccessIsNoneSetIfPublishedScheduleIsStillInReview()
         {
-            var releaseWithNoInformation = new Release()
+            var testReleaseInReview = new Release()
             {
                 PublishScheduled = DefaultScheduledPublishDate,
                 Published = null,
                 ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview
             };
 
-            var preReleaseWindowStatus = _sut.GetPreReleaseWindowStatus(releaseWithNoInformation, DateWithinPreReleaseAccessWindow);
+            var preReleaseWindowStatus = _sut.GetPreReleaseWindowStatus(testReleaseInReview, DateWithinPreReleaseAccessWindow);
             Assert.Equal(PreReleaseAccess.NoneSet, preReleaseWindowStatus.Access);
         }
 
         [Fact]
         public void AccessIsNoneSetIfPublishedScheduleIsStillInDraft()
         {
-            var releaseWithNoInformation = new Release()
+            var testReleaseInDraft = new Release()
             {
                 PublishScheduled = DefaultScheduledPublishDate,
                 Published = null,
                 ApprovalStatus = ReleaseApprovalStatus.Draft
             };
 
-            var preReleaseWindowStatus = _sut.GetPreReleaseWindowStatus(releaseWithNoInformation, DateWithinPreReleaseAccessWindow);
+            var preReleaseWindowStatus = _sut.GetPreReleaseWindowStatus(testReleaseInDraft, DateWithinPreReleaseAccessWindow);
             Assert.Equal(PreReleaseAccess.NoneSet, preReleaseWindowStatus.Access);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseServiceTests.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using Microsoft.Extensions.Options;
+using Xunit;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using System.Globalization;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+{
+    public class PreReleaseServiceTests
+    {
+        private static readonly DateTime DefaultScheduledPublishDate =
+            DateTime.Parse("2003-11-15T00:00:00.00Z", styles: DateTimeStyles.AdjustToUniversal);
+
+        private static readonly DateTime DefaultActuallyPublishedDate =
+            DateTime.Parse("2003-11-15T09:30:00.00Z", styles: DateTimeStyles.AdjustToUniversal);
+
+        private static readonly DateTime DateWithinPreReleaseAccessWindow =
+            DateTime.Parse("2003-11-14T10:24:00.00Z", styles: DateTimeStyles.AdjustToUniversal);
+
+        private readonly PreReleaseService _sut = new (Options.Create(new PreReleaseOptions
+        {
+            PreReleaseAccess = new PreReleaseAccessOptions
+            {
+                AccessWindow = new AccessWindowOptions
+                {
+                    MinutesBeforeReleaseTimeEnd = 1,
+                    MinutesBeforeReleaseTimeStart = 1440,
+                    MinutesIntoPublishDayByWhichPublishingHasOccurred = 570,
+                }
+            }
+        }));
+
+        private readonly Release _testRelease = new()
+        {
+            PublishScheduled = DefaultScheduledPublishDate,
+            Published = DefaultActuallyPublishedDate,
+            ApprovalStatus = ReleaseApprovalStatus.Approved
+        };
+
+
+        [Theory]
+        [InlineData("2003-11-10T00:00:00.00Z", PreReleaseAccess.Before)]
+        [InlineData("2003-11-13T23:59:00.00Z", PreReleaseAccess.Before)]
+        [InlineData("2003-11-14T00:00:00.00Z", PreReleaseAccess.Within)]
+        [InlineData("2003-11-14T10:24:00.00Z", PreReleaseAccess.Within)]
+        [InlineData("2003-11-14T23:58:00.00Z", PreReleaseAccess.Within)]
+        [InlineData("2003-11-14T23:59:00.00Z", PreReleaseAccess.WithinPublishDayLenience)]
+        [InlineData("2003-11-15T00:00:00.00Z", PreReleaseAccess.WithinPublishDayLenience)]
+        [InlineData("2003-11-15T02:30:00.00Z", PreReleaseAccess.WithinPublishDayLenience)]
+        [InlineData("2003-11-15T08:45:00.00Z", PreReleaseAccess.WithinPublishDayLenience)]
+        [InlineData("2003-11-15T09:32:00.00Z", PreReleaseAccess.After)]
+        public void CalculatesAccessRangeAsExpected(string referenceTimeString, PreReleaseAccess expectedAccess)
+        {
+            var referenceTime = DateTime.Parse(referenceTimeString, styles: DateTimeStyles.AdjustToUniversal);
+
+            var result = _sut.GetPreReleaseWindowStatus(_testRelease, referenceTime);
+
+            Assert.Equal(expectedAccess, result.Access);
+        }
+
+        [Fact]
+        public void CalculatesAllAccessRangeFieldsAsExpected()
+        {
+            var result = _sut.GetPreReleaseWindowStatus(_testRelease, DateTime.Parse("2003-11-14T10:24:00.00Z", styles: DateTimeStyles.AdjustToUniversal));
+
+            Assert.Equal(PreReleaseAccess.Within, result.Access);
+            Assert.Equal(DateTime.Parse("2003-11-14T00:00:00.00Z", styles: DateTimeStyles.AdjustToUniversal), result.Start);
+            Assert.Equal(DateTime.Parse("2003-11-14T23:59:00.00Z", styles: DateTimeStyles.AdjustToUniversal), result.End);
+            Assert.Equal(DateTime.Parse("2003-11-15T09:30:00.00Z", styles: DateTimeStyles.AdjustToUniversal), result.PublishDayLenienceDeadline);
+        }
+
+        [Fact]
+        public void CalculatesLeniencePeriodWhenDateIsBST()
+        {
+            var testReleaseWithBSTTimes = new Release()
+            {
+                PublishScheduled = DateTime.Parse("2003-07-15T00:00:00.00Z", styles: DateTimeStyles.AdjustToUniversal),
+                Published = DateTime.Parse("2003-07-15T09:30:00.00Z", styles: DateTimeStyles.AdjustToUniversal),
+                ApprovalStatus = ReleaseApprovalStatus.Approved
+            };
+
+            var result = _sut.GetPreReleaseWindowStatus(testReleaseWithBSTTimes, DateTime.Parse("2003-07-14T10:24:00.00Z", styles: DateTimeStyles.AdjustToUniversal));
+
+            Assert.Equal(PreReleaseAccess.Within, result.Access);
+            Assert.Equal(DateTime.Parse("2003-07-14T00:00:00.00Z", styles: DateTimeStyles.AdjustToUniversal), result.Start);
+            Assert.Equal(DateTime.Parse("2003-07-14T23:59:00.00Z", styles: DateTimeStyles.AdjustToUniversal), result.End);
+            Assert.Equal(DateTime.Parse("2003-07-15T08:30:00.00Z", styles: DateTimeStyles.AdjustToUniversal), result.PublishDayLenienceDeadline);
+        }
+
+        [Fact]
+        public void DoesNotMoveIntoNegativeTimeIfLenienceOffsetIsBelow60Minutes()
+        {
+            var sut = new PreReleaseService(Options.Create(new PreReleaseOptions
+            {
+                PreReleaseAccess = new PreReleaseAccessOptions
+                {
+                    AccessWindow = new AccessWindowOptions
+                    {
+                        MinutesBeforeReleaseTimeEnd = 1,
+                        MinutesBeforeReleaseTimeStart = 1440,
+                        MinutesIntoPublishDayByWhichPublishingHasOccurred = 30,
+                    }
+                }
+            }));
+
+            var testReleaseWithBSTTimes = new Release()
+            {
+                PublishScheduled = DateTime.Parse("2003-07-15T00:00:00.00Z", styles: DateTimeStyles.AdjustToUniversal),
+                Published = DateTime.Parse("2003-07-15T09:30:00.00Z", styles: DateTimeStyles.AdjustToUniversal),
+                ApprovalStatus = ReleaseApprovalStatus.Approved
+            };
+
+            var result = sut.GetPreReleaseWindowStatus(testReleaseWithBSTTimes, DateTime.Parse("2003-07-14T10:24:00.00Z", styles: DateTimeStyles.AdjustToUniversal));
+
+            Assert.Equal(PreReleaseAccess.Within, result.Access);
+            Assert.Equal(DateTime.Parse("2003-07-14T00:00:00.00Z", styles: DateTimeStyles.AdjustToUniversal), result.Start);
+            Assert.Equal(DateTime.Parse("2003-07-14T23:59:00.00Z", styles: DateTimeStyles.AdjustToUniversal), result.End);
+            Assert.Equal(DateTime.Parse("2003-07-15T00:00:00.00Z", styles: DateTimeStyles.AdjustToUniversal), result.PublishDayLenienceDeadline);
+        }
+
+        [Fact]
+        public void AccessIsNoneSetIfPublishedScheduleIsStillInReview()
+        {
+            var releaseWithNoInformation = new Release()
+            {
+                PublishScheduled = DefaultScheduledPublishDate,
+                Published = DefaultActuallyPublishedDate,
+                ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview
+            };
+
+            var preReleaseWindowStatus = _sut.GetPreReleaseWindowStatus(releaseWithNoInformation, DateWithinPreReleaseAccessWindow);
+            Assert.Equal(PreReleaseAccess.NoneSet, preReleaseWindowStatus.Access);
+        }
+
+        [Fact]
+        public void AccessIsNoneSetIfPublishedScheduleIsStillInDraft()
+        {
+            var releaseWithNoInformation = new Release()
+            {
+                PublishScheduled = DefaultScheduledPublishDate,
+                Published = DefaultActuallyPublishedDate,
+                ApprovalStatus = ReleaseApprovalStatus.Draft
+            };
+
+            var preReleaseWindowStatus = _sut.GetPreReleaseWindowStatus(releaseWithNoInformation, DateWithinPreReleaseAccessWindow);
+            Assert.Equal(PreReleaseAccess.NoneSet, preReleaseWindowStatus.Access);
+        }
+
+        [Fact]
+        public void AccessIsAfterIfReleaseIsLiveButPublishedScheduleHasNoValue()
+        {
+            var releaseWithNoScheduledPublishDate = new Release()
+            {
+                PublishScheduled = null,
+                Published = DefaultActuallyPublishedDate
+            };
+
+            var preReleaseWindowStatus = _sut.GetPreReleaseWindowStatus(releaseWithNoScheduledPublishDate, DateTime.UtcNow);
+
+            Assert.Equal(PreReleaseAccess.After, preReleaseWindowStatus.Access);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
@@ -1765,7 +1765,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     new PreReleaseWindow
                     {
                         Start = DateTime.Parse("2020-09-08T08:30:00.00Z", styles: DateTimeStyles.AdjustToUniversal),
-                        End = DateTime.Parse("2020-09-08T22:59:59.00Z", styles: DateTimeStyles.AdjustToUniversal)
+                        ScheduledPublishDate = DateTime.Parse("2020-09-09T00:00:00.00Z", styles: DateTimeStyles.AdjustToUniversal)
                     }
                 );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/appsettings.IntegrationTest.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/appsettings.IntegrationTest.json
@@ -12,7 +12,8 @@
   "PreReleaseAccess": {
     "AccessWindow": {
       "MinutesBeforeReleaseTimeStart": 1440,
-      "MinutesBeforeReleaseTimeEnd": 1
+      "MinutesBeforeReleaseTimeEnd": 1,
+      "MinutesIntoPublishDayByWhichPublishingHasOccurred": 570
     }
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/appsettings.IntegrationTest.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/appsettings.IntegrationTest.json
@@ -11,9 +11,7 @@
   },
   "PreReleaseAccess": {
     "AccessWindow": {
-      "MinutesBeforeReleaseTimeStart": 1440,
-      "MinutesBeforeReleaseTimeEnd": 1,
-      "MinutesIntoPublishDayByWhichPublishingHasOccurred": 570
+      "MinutesBeforeReleaseTimeStart": 1440
     }
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindow.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindow.cs
@@ -6,6 +6,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
     {
         public DateTime Start { get; set; }
 
-        public DateTime End { get; set; }
+        public DateTime ScheduledPublishDate { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindowStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindowStatus.cs
@@ -12,6 +12,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
         public DateTime Start { get; set; }
 
         public DateTime End { get; set; }
+
+        public DateTime PublishDayLenienceDeadline { get; set; }
     }
 
     public enum PreReleaseAccess
@@ -19,6 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
         NoneSet,
         Before,
         Within,
-        After
+        After,
+        WithinPublishDayLenience,
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindowStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindowStatus.cs
@@ -11,9 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
 
         public DateTime Start { get; set; }
 
-        public DateTime End { get; set; }
-
-        public DateTime PublishDayLenienceDeadline { get; set; }
+        public DateTime ScheduledPublishDate { get; set; }
     }
 
     public enum PreReleaseAccess
@@ -22,6 +20,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
         Before,
         Within,
         After,
-        WithinPublishDayLenience,
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindowStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindowStatus.cs
@@ -19,6 +19,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
         NoneSet,
         Before,
         Within,
-        After,
+        After
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/AuthorizationHandlerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/AuthorizationHandlerService.cs
@@ -172,7 +172,7 @@ public class AuthorizationHandlerService
                     ReleaseRole.PrereleaseViewer))
         {
             var windowStatus = _preReleaseService.GetPreReleaseWindowStatus(release, DateTime.UtcNow);
-            if (windowStatus.Access is PreReleaseAccess.Within or PreReleaseAccess.WithinPublishDayLenience)
+            if (windowStatus.Access == PreReleaseAccess.Within)
             {
                 return true;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/AuthorizationHandlerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/AuthorizationHandlerService.cs
@@ -172,7 +172,7 @@ public class AuthorizationHandlerService
                     ReleaseRole.PrereleaseViewer))
         {
             var windowStatus = _preReleaseService.GetPreReleaseWindowStatus(release, DateTime.UtcNow);
-            if (windowStatus.Access == PreReleaseAccess.Within)
+            if (windowStatus.Access is PreReleaseAccess.Within or PreReleaseAccess.WithinPublishDayLenience)
             {
                 return true;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseService.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
@@ -33,31 +34,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public PreReleaseWindowStatus GetPreReleaseWindowStatus(Release release, DateTime referenceTime)
         {
-            if (release.Live)
-            {
-                return new PreReleaseWindowStatus
-                {
-                    Access = PreReleaseAccess.After
-                };             
-            }
-            
             if (!release.PublishScheduled.HasValue)
             {
                 return new PreReleaseWindowStatus
                 {
-                    Access = PreReleaseAccess.NoneSet
+                    Access = release.Live ? PreReleaseAccess.After : PreReleaseAccess.NoneSet
                 };
             }
 
             var publishScheduled = release.PublishScheduled.Value;
             var startTime = GetStartTime(publishScheduled);
             var endTime = GetEndTime(publishScheduled);
+            var publishDayEndTime = GetPublishDayLenienceDeadline(publishScheduled);
 
             return new PreReleaseWindowStatus
             {
                 Start = startTime,
                 End = endTime,
-                Access = GetAccess(release, startTime, endTime, referenceTime)
+                PublishDayLenienceDeadline = publishDayEndTime,
+                Access = GetAccess(release, startTime, endTime, publishDayEndTime, referenceTime)
             };
         }
 
@@ -71,10 +66,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return publishScheduled.AddMinutes(-_preReleaseOptions.MinutesBeforeReleaseTimeEnd);
         }
 
+        private DateTime GetPublishDayLenienceDeadline(DateTime publishScheduled)
+        {
+            var ukTimeZone = DateTimeExtensions.GetUkTimeZone();
+
+            // The Azure Functions which publish releases will do so at 9:30 in the current timezone (BST in summer, GMT otherwise)
+            //      (^ for reasons explained in the CheckPublishDateCanBeScheduled method in the ReleaseApprovalService).
+            // This means that during winter, these jobs will actually run at 8:30 UTC.
+            // These date calculations are done in UTC, so in summer we only want to add 510 minutes onto midnight rather than 570.
+            //      (^ Assuming the default publishing time of 09:30am)
+            if (ukTimeZone.IsDaylightSavingTime(publishScheduled))
+            {
+                var adjustedMinutes = Math.Max(_preReleaseOptions.MinutesIntoPublishDayByWhichPublishingHasOccurred - 60, 0);
+                return publishScheduled.AddMinutes(adjustedMinutes);
+            }
+
+            return publishScheduled.AddMinutes(_preReleaseOptions.MinutesIntoPublishDayByWhichPublishingHasOccurred);
+        }
+
         private static PreReleaseAccess GetAccess(
             Release release,
             DateTime startTime,
             DateTime endTime,
+            DateTime publishDayLenienceDeadline,
             DateTime referenceTime)
         {
             if (!release.PublishScheduled.HasValue || release.ApprovalStatus != ReleaseApprovalStatus.Approved)
@@ -82,17 +96,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 return PreReleaseAccess.NoneSet;
             }
 
-            if (referenceTime.CompareTo(startTime) < 0)
+            if (referenceTime.IsBefore(startTime))
             {
                 return PreReleaseAccess.Before;
             }
 
-            if (referenceTime.CompareTo(endTime) >= 0)
+            if (referenceTime.IsBefore(endTime))
             {
-                return PreReleaseAccess.After;
+                return PreReleaseAccess.Within;
             }
 
-            return PreReleaseAccess.Within;
+            if (referenceTime.IsAfterInclusive(endTime) && referenceTime.IsBefore(publishDayLenienceDeadline))
+            {
+                return PreReleaseAccess.WithinPublishDayLenience;
+            }
+
+            return PreReleaseAccess.After;
         }
     }
 
@@ -106,6 +125,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public int MinutesBeforeReleaseTimeStart { get; set; }
 
         public int MinutesBeforeReleaseTimeEnd { get; set; }
+
+        public int MinutesIntoPublishDayByWhichPublishingHasOccurred { get; set; }
     }
 
     public class PreReleaseAccessOptions

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -41,9 +41,7 @@
   },
   "PreReleaseAccess": {
     "AccessWindow": {
-      "MinutesBeforeReleaseTimeStart": 1440,
-      "MinutesBeforeReleaseTimeEnd": 1,
-      "MinutesIntoPublishDayByWhichPublishingHasOccurred": 570
+      "MinutesBeforeReleaseTimeStart": 1440
     }
   },
   "ReleaseApproval": {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -42,7 +42,8 @@
   "PreReleaseAccess": {
     "AccessWindow": {
       "MinutesBeforeReleaseTimeStart": 1440,
-      "MinutesBeforeReleaseTimeEnd": 1
+      "MinutesBeforeReleaseTimeEnd": 1,
+      "MinutesIntoPublishDayByWhichPublishingHasOccurred": 570
     }
   },
   "ReleaseApproval": {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeExtensions.cs
@@ -30,5 +30,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return TimeZoneInfo.FindSystemTimeZoneById(
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "GMT Standard Time" : "Europe/London");
         }
+
+        public static bool IsBefore(this DateTime subject, DateTime target)
+        {
+            return subject.CompareTo(target) < 0;
+        }
+
+        public static bool IsAfterInclusive(this DateTime subject, DateTime target)
+        {
+            return subject.CompareTo(target) >= 0;
+        }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -120,7 +120,7 @@ const PreReleasePageContainer = ({
             )} at ${format(start, 'HH:mm')} until it is published on ${format(
               scheduledPublishDate,
               'd MMMM yyyy',
-            )}`}
+            )}.`}
           </p>
 
           <p>

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -132,7 +132,7 @@ const PreReleasePageContainer = ({
       );
     }
 
-    if (access === 'Within') {
+    if (access === 'Within' || access === 'WithinPublishDayLenience') {
       return (
         <>
           <NotificationBanner

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -68,7 +68,7 @@ const PreReleasePageContainer = ({
     }
 
     const {
-      preReleaseWindowStatus: { access, start, end },
+      preReleaseWindowStatus: { access, start, scheduledPublishDate },
       preReleaseSummary: {
         contactEmail,
         contactTeam,
@@ -117,10 +117,10 @@ const PreReleasePageContainer = ({
             {`Pre-release access will be available from ${format(
               start,
               'd MMMM yyyy',
-            )} at ${format(start, 'HH:mm')} until ${format(
-              end,
+            )} at ${format(start, 'HH:mm')} until it is published on ${format(
+              scheduledPublishDate,
               'd MMMM yyyy',
-            )} at ${format(end, 'HH:mm')}.`}
+            )}`}
           </p>
 
           <p>
@@ -132,7 +132,7 @@ const PreReleasePageContainer = ({
       );
     }
 
-    if (access === 'Within' || access === 'WithinPublishDayLenience') {
+    if (access === 'Within') {
       return (
         <>
           <NotificationBanner

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
@@ -37,6 +37,7 @@ describe('PreReleasePageContainer', () => {
       access: 'After',
       start: new Date('2018-12-12T09:00:00Z'),
       end: new Date('2018-12-13T00:00:00Z'),
+      publishDayLenienceDeadline: new Date('2018-12-14T09:30:00Z'),
     });
 
     preReleaseService.getPreReleaseSummary.mockResolvedValue(
@@ -64,6 +65,7 @@ describe('PreReleasePageContainer', () => {
       access: 'Before',
       start: new Date('3000-12-12T09:00:00Z'),
       end: new Date('3000-12-13T00:00:00Z'),
+      publishDayLenienceDeadline: new Date('2018-12-14T09:30:00Z'),
     });
 
     preReleaseService.getPreReleaseSummary.mockResolvedValue(
@@ -98,6 +100,7 @@ describe('PreReleasePageContainer', () => {
       access: 'Within',
       start: subHours(now, 6),
       end: addHours(now, 18),
+      publishDayLenienceDeadline: addHours(now, 27.5),
     });
 
     preReleaseService.getPreReleaseSummary.mockResolvedValue(
@@ -121,6 +124,48 @@ describe('PreReleasePageContainer', () => {
 
       expect(
         screen.queryByRole('heading', { name: 'Pre-release access has ended' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', {
+          name: 'Pre-release access is not yet available',
+        }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('renders correctly when within release day lenience window', async () => {
+    const now = new Date(); // 2am on Publish Day
+
+    permissionService.getPreReleaseWindowStatus.mockResolvedValue({
+      access: 'WithinPublishDayLenience',
+      start: subHours(now, 26),
+      end: subHours(now, 2),
+      publishDayLenienceDeadline: addHours(now, 7.5),
+    });
+
+    preReleaseService.getPreReleaseSummary.mockResolvedValue(
+      testPreReleaseSummary,
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      const banner = within(screen.getByRole('region', { name: 'Contact' }));
+      expect(
+        banner.getByText('If you have an enquiry about this release contact:'),
+      ).toBeInTheDocument();
+
+      expect(banner.getByText('Test team:')).toBeInTheDocument();
+      expect(
+        banner.getByRole('link', { name: 'test@test.com' }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByRole('link', { name: 'Content' })).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('heading', {
+          name: 'Pre-release access has ended',
+        }),
       ).not.toBeInTheDocument();
       expect(
         screen.queryByRole('heading', {

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
@@ -44,19 +44,22 @@ describe('PreReleasePageContainer', () => {
     );
 
     renderPage();
-
     await waitFor(() => {
       expect(
-        screen.getByRole('heading', { name: 'Pre-release access has ended' }),
+        screen.getByText('Pre-release access has ended'),
       ).toBeInTheDocument();
-
-      expect(
-        screen.getByRole('link', { name: 'View this release' }),
-      ).toHaveAttribute(
-        'href',
-        'http://localhost/find-statistics/test-publication/2018',
-      );
     });
+
+    expect(
+      screen.getByRole('heading', { name: 'Pre-release access has ended' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', { name: 'View this release' }),
+    ).toHaveAttribute(
+      'href',
+      'http://localhost/find-statistics/test-publication/2018',
+    );
   });
 
   test('renders correctly when pre-release has not started', async () => {
@@ -71,24 +74,27 @@ describe('PreReleasePageContainer', () => {
     );
 
     renderPage();
-
     await waitFor(() => {
       expect(
-        screen.getByRole('heading', {
-          name: 'Pre-release access is not yet available',
-        }),
+        screen.getByText('Pre-release access is not yet available'),
       ).toBeInTheDocument();
-
-      expect(
-        screen.getByText(
-          'Pre-release access will be available from 12 December 3000 at 09:00 until it is published on 13 December 3000.',
-        ),
-      ).toBeInTheDocument();
-
-      expect(
-        screen.queryByRole('heading', { name: 'Pre-release access has ended' }),
-      ).not.toBeInTheDocument();
     });
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Pre-release access is not yet available',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        'Pre-release access will be available from 12 December 3000 at 09:00 until it is published on 13 December 3000.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('heading', { name: 'Pre-release access has ended' }),
+    ).not.toBeInTheDocument();
   });
 
   test('renders correctly when within pre-release window', async () => {
@@ -105,29 +111,32 @@ describe('PreReleasePageContainer', () => {
     );
 
     renderPage();
-
     await waitFor(() => {
-      const banner = within(screen.getByRole('region', { name: 'Contact' }));
       expect(
-        banner.getByText('If you have an enquiry about this release contact:'),
+        screen.getByText('If you have an enquiry about this release contact:'),
       ).toBeInTheDocument();
-
-      expect(banner.getByText('Test team:')).toBeInTheDocument();
-      expect(
-        banner.getByRole('link', { name: 'test@test.com' }),
-      ).toBeInTheDocument();
-
-      expect(screen.getByRole('link', { name: 'Content' })).toBeInTheDocument();
-
-      expect(
-        screen.queryByRole('heading', { name: 'Pre-release access has ended' }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('heading', {
-          name: 'Pre-release access is not yet available',
-        }),
-      ).not.toBeInTheDocument();
     });
+
+    const banner = within(screen.getByRole('region', { name: 'Contact' }));
+    expect(
+      banner.getByText('If you have an enquiry about this release contact:'),
+    ).toBeInTheDocument();
+
+    expect(banner.getByText('Test team:')).toBeInTheDocument();
+    expect(
+      banner.getByRole('link', { name: 'test@test.com' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('link', { name: 'Content' })).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('heading', { name: 'Pre-release access has ended' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Pre-release access is not yet available',
+      }),
+    ).not.toBeInTheDocument();
   });
 
   test('renders correctly when on release day but release is yet to be published', async () => {
@@ -144,35 +153,38 @@ describe('PreReleasePageContainer', () => {
     );
 
     renderPage();
-
     await waitFor(() => {
-      const banner = within(screen.getByRole('region', { name: 'Contact' }));
       expect(
-        banner.getByText('If you have an enquiry about this release contact:'),
+        screen.getByText('If you have an enquiry about this release contact:'),
       ).toBeInTheDocument();
-
-      expect(banner.getByText('Test team:')).toBeInTheDocument();
-      expect(
-        banner.getByRole('link', { name: 'test@test.com' }),
-      ).toBeInTheDocument();
-
-      expect(screen.getByRole('link', { name: 'Content' })).toBeInTheDocument();
-
-      expect(
-        screen.queryByRole('heading', {
-          name: 'Pre-release access has ended',
-        }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('heading', {
-          name: 'Pre-release access is not yet available',
-        }),
-      ).not.toBeInTheDocument();
     });
+
+    const banner = within(screen.getByRole('region', { name: 'Contact' }));
+    expect(
+      banner.getByText('If you have an enquiry about this release contact:'),
+    ).toBeInTheDocument();
+
+    expect(banner.getByText('Test team:')).toBeInTheDocument();
+    expect(
+      banner.getByRole('link', { name: 'test@test.com' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('link', { name: 'Content' })).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Pre-release access has ended',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Pre-release access is not yet available',
+      }),
+    ).not.toBeInTheDocument();
   });
 
   const renderPage = () => {
-    return render(
+    render(
       <TestConfigContextProvider>
         <MemoryRouter
           initialEntries={[

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
@@ -7,7 +7,7 @@ import _preReleaseService, {
   PreReleaseSummary,
 } from '@admin/services/preReleaseService';
 import { render, screen, waitFor, within } from '@testing-library/react';
-import { addHours, subHours } from 'date-fns';
+import { subHours } from 'date-fns';
 import React from 'react';
 import { generatePath, MemoryRouter } from 'react-router';
 import { Route } from 'react-router-dom';

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
@@ -81,7 +81,7 @@ describe('PreReleasePageContainer', () => {
 
       expect(
         screen.getByText(
-          'Pre-release access will be available from 12 December 3000 at 09:00 until it is published on 13 December 3000',
+          'Pre-release access will be available from 12 December 3000 at 09:00 until it is published on 13 December 3000.',
         ),
       ).toBeInTheDocument();
 

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
@@ -43,12 +43,7 @@ describe('PreReleasePageContainer', () => {
       testPreReleaseSummary,
     );
 
-    renderPage();
-    await waitFor(() => {
-      expect(
-        screen.getByText('Pre-release access has ended'),
-      ).toBeInTheDocument();
-    });
+    await renderPageAndAwaitForText('Pre-release access has ended');
 
     expect(
       screen.getByRole('heading', { name: 'Pre-release access has ended' }),
@@ -73,12 +68,7 @@ describe('PreReleasePageContainer', () => {
       testPreReleaseSummary,
     );
 
-    renderPage();
-    await waitFor(() => {
-      expect(
-        screen.getByText('Pre-release access is not yet available'),
-      ).toBeInTheDocument();
-    });
+    await renderPageAndAwaitForText('Pre-release access is not yet available');
 
     expect(
       screen.getByRole('heading', {
@@ -110,12 +100,9 @@ describe('PreReleasePageContainer', () => {
       testPreReleaseSummary,
     );
 
-    renderPage();
-    await waitFor(() => {
-      expect(
-        screen.getByText('If you have an enquiry about this release contact:'),
-      ).toBeInTheDocument();
-    });
+    await renderPageAndAwaitForText(
+      'If you have an enquiry about this release contact:',
+    );
 
     const banner = within(screen.getByRole('region', { name: 'Contact' }));
     expect(
@@ -152,12 +139,9 @@ describe('PreReleasePageContainer', () => {
       testPreReleaseSummary,
     );
 
-    renderPage();
-    await waitFor(() => {
-      expect(
-        screen.getByText('If you have an enquiry about this release contact:'),
-      ).toBeInTheDocument();
-    });
+    await renderPageAndAwaitForText(
+      'If you have an enquiry about this release contact:',
+    );
 
     const banner = within(screen.getByRole('region', { name: 'Contact' }));
     expect(
@@ -183,7 +167,7 @@ describe('PreReleasePageContainer', () => {
     ).not.toBeInTheDocument();
   });
 
-  const renderPage = () => {
+  const renderPageAndAwaitForText = async (textToWaitFor: string) => {
     render(
       <TestConfigContextProvider>
         <MemoryRouter
@@ -201,5 +185,9 @@ describe('PreReleasePageContainer', () => {
         </MemoryRouter>
       </TestConfigContextProvider>,
     );
+
+    await waitFor(() => {
+      expect(screen.getByText(textToWaitFor)).toBeInTheDocument();
+    });
   };
 });

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
@@ -36,8 +36,7 @@ describe('PreReleasePageContainer', () => {
     permissionService.getPreReleaseWindowStatus.mockResolvedValue({
       access: 'After',
       start: new Date('2018-12-12T09:00:00Z'),
-      end: new Date('2018-12-13T00:00:00Z'),
-      publishDayLenienceDeadline: new Date('2018-12-14T09:30:00Z'),
+      scheduledPublishDate: new Date('2018-12-13T00:00:00Z'),
     });
 
     preReleaseService.getPreReleaseSummary.mockResolvedValue(
@@ -64,8 +63,7 @@ describe('PreReleasePageContainer', () => {
     permissionService.getPreReleaseWindowStatus.mockResolvedValue({
       access: 'Before',
       start: new Date('3000-12-12T09:00:00Z'),
-      end: new Date('3000-12-13T00:00:00Z'),
-      publishDayLenienceDeadline: new Date('2018-12-14T09:30:00Z'),
+      scheduledPublishDate: new Date('3000-12-13T00:00:00Z'),
     });
 
     preReleaseService.getPreReleaseSummary.mockResolvedValue(
@@ -83,7 +81,7 @@ describe('PreReleasePageContainer', () => {
 
       expect(
         screen.getByText(
-          'Pre-release access will be available from 12 December 3000 at 09:00 until 13 December 3000 at 00:00.',
+          'Pre-release access will be available from 12 December 3000 at 09:00 until it is published on 13 December 3000',
         ),
       ).toBeInTheDocument();
 
@@ -94,13 +92,12 @@ describe('PreReleasePageContainer', () => {
   });
 
   test('renders correctly when within pre-release window', async () => {
-    const now = new Date();
+    const now = new Date('2018-12-12T14:32:00Z');
 
     permissionService.getPreReleaseWindowStatus.mockResolvedValue({
       access: 'Within',
       start: subHours(now, 6),
-      end: addHours(now, 18),
-      publishDayLenienceDeadline: addHours(now, 27.5),
+      scheduledPublishDate: new Date('2018-12-13T00:00:00Z'),
     });
 
     preReleaseService.getPreReleaseSummary.mockResolvedValue(
@@ -133,14 +130,13 @@ describe('PreReleasePageContainer', () => {
     });
   });
 
-  test('renders correctly when within release day lenience window', async () => {
+  test('renders correctly when on release day but release is yet to be published', async () => {
     const now = new Date(); // 2am on Publish Day
 
     permissionService.getPreReleaseWindowStatus.mockResolvedValue({
-      access: 'WithinPublishDayLenience',
+      access: 'Within',
       start: subHours(now, 26),
-      end: subHours(now, 2),
-      publishDayLenienceDeadline: addHours(now, 7.5),
+      scheduledPublishDate: subHours(now, 2),
     });
 
     preReleaseService.getPreReleaseSummary.mockResolvedValue(

--- a/src/explore-education-statistics-admin/src/services/permissionService.ts
+++ b/src/explore-education-statistics-admin/src/services/permissionService.ts
@@ -28,18 +28,12 @@ export interface DataFilePermissions {
   canCancelImport: boolean;
 }
 
-export type PreReleaseAccess =
-  | 'Before'
-  | 'After'
-  | 'Within'
-  | 'NoneSet'
-  | 'WithinPublishDayLenience';
+export type PreReleaseAccess = 'Before' | 'After' | 'Within' | 'NoneSet';
 
 export interface PreReleaseWindowStatus {
   access: PreReleaseAccess;
   start: Date;
-  end: Date;
-  publishDayLenienceDeadline: Date;
+  scheduledPublishDate: Date;
 }
 
 const permissionService = {
@@ -78,14 +72,12 @@ const permissionService = {
       .get<{
         access: PreReleaseAccess;
         start: string;
-        end: string;
-        publishDayLenienceDeadline: string;
+        scheduledPublishDate: string;
       }>(`/permissions/release/${releaseId}/prerelease/status`)
       .then(status => ({
         access: status.access,
         start: parseISO(status.start),
-        end: parseISO(status.end),
-        publishDayLenienceDeadline: parseISO(status.publishDayLenienceDeadline),
+        scheduledPublishDate: parseISO(status.scheduledPublishDate),
       }));
   },
   getDataFilePermissions(

--- a/src/explore-education-statistics-admin/src/services/permissionService.ts
+++ b/src/explore-education-statistics-admin/src/services/permissionService.ts
@@ -28,12 +28,18 @@ export interface DataFilePermissions {
   canCancelImport: boolean;
 }
 
-export type PreReleaseAccess = 'Before' | 'After' | 'Within' | 'NoneSet';
+export type PreReleaseAccess =
+  | 'Before'
+  | 'After'
+  | 'Within'
+  | 'NoneSet'
+  | 'WithinPublishDayLenience';
 
 export interface PreReleaseWindowStatus {
   access: PreReleaseAccess;
   start: Date;
   end: Date;
+  publishDayLenienceDeadline: Date;
 }
 
 const permissionService = {
@@ -73,11 +79,13 @@ const permissionService = {
         access: PreReleaseAccess;
         start: string;
         end: string;
+        publishDayLenienceDeadline: string;
       }>(`/permissions/release/${releaseId}/prerelease/status`)
       .then(status => ({
         access: status.access,
         start: parseISO(status.start),
         end: parseISO(status.end),
+        publishDayLenienceDeadline: parseISO(status.publishDayLenienceDeadline),
       }));
   },
   getDataFilePermissions(

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -145,8 +145,9 @@ Validate prerelease has not started
     ${month}=    get current datetime    %m    1
     ${year}=    get current datetime    %Y    1
     ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}T23:59:00    %-d %B %Y at %H:%M
-    user checks page contains    Pre-release access will be available from ${time_start} until ${time_end}.
+    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}    %-d %B %Y
+    user checks page contains
+    ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 
 Go to prerelease access page
     user navigates to admin frontend    ${RELEASE_URL}/prerelease-access
@@ -251,8 +252,9 @@ Validate prerelease has not started for Analyst user
     ${month}=    get current datetime    %m    1
     ${year}=    get current datetime    %Y    1
     ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}T23:59:00    %-d %B %Y at %H:%M
-    user checks page contains    Pre-release access will be available from ${time_start} until ${time_end}.
+    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}    %-d %B %Y
+    user checks page contains
+    ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 
 Start prerelease
     user changes to bau1

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -145,7 +145,7 @@ Validate prerelease has not started
     ${month}=    get current datetime    %m    1
     ${year}=    get current datetime    %Y    1
     ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}    %-d %B %Y
+    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 
@@ -252,7 +252,7 @@ Validate prerelease has not started for Analyst user
     ${month}=    get current datetime    %m    1
     ${year}=    get current datetime    %Y    1
     ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}    %-d %B %Y
+    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -141,17 +141,11 @@ Validate prerelease has not started
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
 
-    ${day}=    get current datetime    %d    1
-    ${month}=    get current datetime    %m    1
-    ${year}=    get current datetime    %Y    1
+    ${tomorrow}=    get current datetime    %Y-%m-%dT00:00:00    1
+    ${day_after_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    2
 
-    ${tomorrows_day}=    get current datetime    %d    2
-    ${tomorrows_month}=    get current datetime    %m    2
-    ${tomorrows_year}=    get current datetime    %Y    2
-
-    ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${tomorrows_year}-${tomorrows_month}-${tomorrows_day}T00:00:00
-    ...    %-d %B %Y
+    ${time_start}=    format uk to local datetime    ${tomorrow}    %-d %B %Y at %H:%M
+    ${time_end}=    format uk to local datetime    ${day_after_tomorrow}    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 
@@ -254,17 +248,11 @@ Validate prerelease has not started for Analyst user
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
 
-    ${day}=    get current datetime    %d    1
-    ${month}=    get current datetime    %m    1
-    ${year}=    get current datetime    %Y    1
+    ${tomorrow}=    get current datetime    %Y-%m-%dT00:00:00    1
+    ${day_after_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    2
 
-    ${tomorrows_day}=    get current datetime    %d    2
-    ${tomorrows_month}=    get current datetime    %m    2
-    ${tomorrows_year}=    get current datetime    %Y    2
-
-    ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${tomorrows_year}-${tomorrows_month}-${tomorrows_day}T00:00:00
-    ...    %-d %B %Y
+    ${time_start}=    format uk to local datetime    ${tomorrow}    %-d %B %Y at %H:%M
+    ${time_end}=    format uk to local datetime    ${day_after_tomorrow}    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -144,8 +144,14 @@ Validate prerelease has not started
     ${day}=    get current datetime    %d    1
     ${month}=    get current datetime    %m    1
     ${year}=    get current datetime    %Y    1
+
+    ${tomorrows_day}=    get current datetime    %d    2
+    ${tomorrows_month}=    get current datetime    %m    2
+    ${tomorrows_year}=    get current datetime    %Y    2
+
     ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y
+    ${time_end}=    format uk to local datetime    ${tomorrows_year}-${tomorrows_month}-${tomorrows_day}T00:00:00
+    ...    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 
@@ -251,8 +257,14 @@ Validate prerelease has not started for Analyst user
     ${day}=    get current datetime    %d    1
     ${month}=    get current datetime    %m    1
     ${year}=    get current datetime    %Y    1
+
+    ${tomorrows_day}=    get current datetime    %d    2
+    ${tomorrows_month}=    get current datetime    %m    2
+    ${tomorrows_year}=    get current datetime    %Y    2
+
     ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y
+    ${time_end}=    format uk to local datetime    ${tomorrows_year}-${tomorrows_month}-${tomorrows_day}T00:00:00
+    ...    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -238,17 +238,11 @@ Validate prerelease window is not yet open for Analyst user
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
 
-    ${day}=    get current datetime    %d    1
-    ${month}=    get current datetime    %m    1
-    ${year}=    get current datetime    %Y    1
+    ${tomorrow}=    get current datetime    %Y-%m-%dT00:00:00    1
+    ${day_after_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    2
 
-    ${tomorrows_day}=    get current datetime    %d    2
-    ${tomorrows_month}=    get current datetime    %m    2
-    ${tomorrows_year}=    get current datetime    %Y    2
-
-    ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${tomorrows_year}-${tomorrows_month}-${tomorrows_day}T00:00:00
-    ...    %-d %B %Y
+    ${time_start}=    format uk to local datetime    ${tomorrow}    %-d %B %Y at %H:%M
+    ${time_end}=    format uk to local datetime    ${day_after_tomorrow}    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -241,8 +241,14 @@ Validate prerelease window is not yet open for Analyst user
     ${day}=    get current datetime    %d    1
     ${month}=    get current datetime    %m    1
     ${year}=    get current datetime    %Y    1
+
+    ${tomorrows_day}=    get current datetime    %d    2
+    ${tomorrows_month}=    get current datetime    %m    2
+    ${tomorrows_year}=    get current datetime    %Y    2
+
     ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y
+    ${time_end}=    format uk to local datetime    ${tomorrows_year}-${tomorrows_month}-${tomorrows_day}T00:00:00
+    ...    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -242,8 +242,9 @@ Validate prerelease window is not yet open for Analyst user
     ${month}=    get current datetime    %m    1
     ${year}=    get current datetime    %Y    1
     ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}T23:59:00    %-d %B %Y at %H:%M
-    user checks page contains    Pre-release access will be available from ${time_start} until ${time_end}.
+    ${time_end}=    format uk to local datetime    ${year}-${month}-${day} %-d %B %Y
+    user checks page contains
+    ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 
 Start prerelease
     user changes to bau1

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -242,7 +242,7 @@ Validate prerelease window is not yet open for Analyst user
     ${month}=    get current datetime    %m    1
     ${year}=    get current datetime    %Y    1
     ${time_start}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${year}-${month}-${day} %-d %B %Y
+    ${time_end}=    format uk to local datetime    ${year}-${month}-${day}T00:00:00    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 


### PR DESCRIPTION
When scheduling a Release, the user is prompted to enter a date sans time, which is saved as its floor (midnight beginning of Publish Day). 
The Pre-Release Access period is calculated using config values, but typically runs from 1440 minutes before that midnight (= the previous midnight) through to 1 minute before. 
However the Release itself isn't available until 9:30 that day, and attempting to access it between midnight and 9:30 will yield a message saying the PRA period has ended. This PR aims to extend the PRA such that Releases are still viewable up to their actual release. 

The simpler route might be to simply change the calculation for the PRA end time. This is fraught with danger however as these are existing config values, and this period might be used for other calculations elsewhere in the codebase. To maintain safety I propose to introduce the new concept of the `Publish Day PRA Lenience Period`, calculated by the delta between midnight and when the Cron job occurs to complete the Release. 

This is further complicated by when those Cron jobs occur - they have been normalised to always occur at 9:30 local time. This means we have to calculate a different offset during GMT and BST respectively.

This diagram is intended as a visual aid to the status quo, and the proposed change:
![PreRelease Dates](https://github.com/dfe-analytical-services/explore-education-statistics/assets/63285990/ef83ea2a-5709-4e5d-b256-475f0c72b38c)
