### PR TITLE
Revert "EES-4522 Use RIGHT JOIN instead of IN in generated query"

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ObservationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ObservationServiceTests.cs
@@ -230,8 +230,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             const string expectedSql = @"
                   INSERT INTO #MatchedObservation 
                   SELECT o.id FROM Observation o
-                  JOIN #LocationTempTable ON #LocationTempTable.Id = o.LocationId 
                   WHERE o.SubjectId = @subjectId
+                  AND (o.LocationId IN (SELECT Id FROM #LocationTempTable)) 
                   ORDER BY o.Id;";
             
             Assert.Equal(FormatSql(expectedSql), FormatSql(sql));
@@ -539,13 +539,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 const string expectedSql = @"
                       INSERT INTO #MatchedObservation 
                       SELECT o.id FROM Observation o
-                      JOIN #LocationTempTable ON #LocationTempTable.Id = o.LocationId 
                       WHERE o.SubjectId = @subjectId 
                       AND (
                         (o.TimeIdentifier = 'AY' AND o.Year = 2015) OR 
                         (o.TimeIdentifier = 'AY' AND o.Year = 2016) OR 
                         (o.TimeIdentifier = 'AY' AND o.Year = 2017)
                       ) 
+                      AND (o.LocationId IN (SELECT Id FROM #LocationTempTable)) 
                       AND (
                           EXISTS (SELECT 1 FROM ObservationFilterItem ofi 
                                   WHERE ofi.ObservationId = o.id 


### PR DESCRIPTION
This reverts commit c57be670ad40b19a52b26a186858224ae4dc59af.

I want to another get_datablock_responses run with the previous set up to help validate any difference we're seeing.

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

Before submitting a pull request, please make sure the following is done:

1. Clone [the repository](https://github.com/dfe-analytical-services/explore-education-statistics) and create your branch from `dev`.
2. Run `npm ci && npm run bootstrap` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suites pass. 
   - Frontend tests can be run using `npm test` from the project root.
   - Backend tests can be run using `dotnet test` from `src` directory.
   - UI tests should be run from `tests/robot-tests`
-->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

You might also want to think about the following:

- How did you solve complex parts of the problem? Other contributors may benefit from knowing more about your solution.
- Are there any potential tradeoffs that need mentioning, or edge cases that have not been covered?
- Have you added a reusable piece of functionality? Consider including some code snippets to better illustrate its usage.

## Related changes

Are there any changes that were closely related to this change but not directly part of the main work e.g. refactoring, fixes, etc?

## Screenshots

Are there any screenshots that help illustrate the change made?
