### PR TITLE
EES-4606 specify redirect paths

### DIFF
--- a/src/explore-education-statistics-frontend/src/middleware.ts
+++ b/src/explore-education-statistics-frontend/src/middleware.ts
@@ -4,3 +4,19 @@ import type { NextRequest } from 'next/server';
 export default async function middleware(request: NextRequest) {
   return redirectPages(request);
 }
+
+// Only run the middleware on the specified paths below.
+// Ideally we'd just exclude build files and run it on all routes,
+// e.g. '/((?!api|_next/static|_next/image|favicon.ico|assets).*)'
+// But a bug in NextJS v12 causes problems for the back button
+// in the table tool (see https://github.com/vercel/next.js/pull/43919).
+export const config = {
+  matcher: [
+    '/cookies/:path*',
+    '/find-statistics/:path*/:path*',
+    '/data-tables',
+    '/data-catalogue',
+    '/methodology/:path*',
+    '/subscriptions',
+  ],
+};


### PR DESCRIPTION
Fixes two bugs caused by https://github.com/dfe-analytical-services/explore-education-statistics/pull/4540:
- it was trying to redirect build files because they weren't lower case
- it broke the back button handling we have in the table tool