### PR TITLE
EES-4820 allow direct linking to superseded publications in the table tool

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -292,7 +292,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
     }
 
     [Fact]
-    public async Task GetPublicationTree_DataTables_SupersededPublicationWithDataOnLatestRelease_Excluded()
+    public async Task GetPublicationTree_DataTables_SupersededPublicationWithDataOnLatestRelease_Included()
     {
         var publicationTree = new PublicationTreeThemeViewModel
         {
@@ -312,7 +312,7 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
             }
         };
 
-        await AssertPublicationTreeEmpty(publicationTree, PublicationTreeFilter.DataTables);
+        await AssertPublicationTreeUnfiltered(publicationTree, PublicationTreeFilter.DataTables);
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
@@ -128,8 +128,7 @@ public class PublicationCacheService : IPublicationCacheService
         switch (filter)
         {
             case PublicationTreeFilter.DataTables:
-                return publication.LatestReleaseHasData
-                       && !publication.IsSuperseded;
+                return publication.LatestReleaseHasData;
             case PublicationTreeFilter.DataCatalogue:
             case PublicationTreeFilter.FastTrack:
                 return publication.AnyLiveReleaseHasData;

--- a/src/explore-education-statistics-admin/src/prototypes/components/PrototypeTableToolWizard.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/components/PrototypeTableToolWizard.tsx
@@ -151,6 +151,7 @@ const PrototypeTableToolWizard = ({
       draft.query.publicationId = publication.id;
       draft.selectedPublication = {
         id: publication.id,
+        isSuperseded: false,
         slug: publication.slug,
         title: publication.title,
         selectedRelease: {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -36,6 +36,7 @@ const formId = 'publicationForm';
 
 interface Props extends InjectedWizardProps {
   initialValues?: FormValues;
+  showSupersededPublications?: boolean;
   themes: Theme[];
   onSubmit: PublicationFormSubmitHandler;
   renderSummaryAfter?: ReactNode;
@@ -46,6 +47,7 @@ const PublicationForm = ({
     publicationId: '',
     themeId: '',
   },
+  showSupersededPublications = false,
   themes,
   onSubmit,
   renderSummaryAfter,
@@ -61,19 +63,29 @@ const PublicationForm = ({
       return (
         themes
           .find(theme => theme.id === selectedThemeId)
-          ?.topics.flatMap(topic => topic.publications) ?? []
+          ?.topics.flatMap(topic => topic.publications)
+          .filter(publication =>
+            showSupersededPublications
+              ? publication
+              : !publication.isSuperseded,
+          ) ?? []
       );
     }
     if (searchTerm) {
       return themes
         .flatMap(theme => theme.topics.flatMap(topic => topic.publications))
         .filter(publication =>
-          publication.title.toLowerCase().includes(searchTerm.toLowerCase()),
+          showSupersededPublications
+            ? publication.title.toLowerCase().includes(searchTerm.toLowerCase())
+            : !publication.isSuperseded &&
+              publication.title
+                .toLowerCase()
+                .includes(searchTerm.toLowerCase()),
         );
     }
 
     return [];
-  }, [themes, searchTerm, selectedThemeId]);
+  }, [themes, searchTerm, selectedThemeId, showSupersededPublications]);
 
   const getThemeForPublication = (publicationId: string) => {
     return themes.find(theme =>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -38,6 +38,7 @@ import tableBuilderService, {
 } from '@common/services/tableBuilderService';
 import React, { ReactElement, ReactNode, useMemo, useState } from 'react';
 import { useImmer } from 'use-immer';
+import WarningMessage from '@common/components/WarningMessage';
 
 export interface InitialTableToolState {
   initialStep: number;
@@ -158,9 +159,7 @@ export default function TableToolWizard({
       draft.query.releaseId = undefined;
       draft.query.publicationId = publication.id;
       draft.selectedPublication = {
-        id: publication.id,
-        slug: publication.slug,
-        title: publication.title,
+        ...publication,
         selectedRelease: {
           id: latestRelease.id,
           latestData: latestRelease.latestRelease,
@@ -434,6 +433,20 @@ export default function TableToolWizard({
                       themeId: '',
                     }}
                     themes={themeMeta}
+                    renderSummaryAfter={
+                      state.selectedPublication?.isSuperseded &&
+                      state.selectedPublication.supersededBy ? (
+                        <WarningMessage testId="superseded-warning">
+                          This publication has been superseded by{' '}
+                          <a
+                            data-testid="superseded-by-link"
+                            href={`/find-statistics/${state.selectedPublication.supersededBy.slug}`}
+                          >
+                            {state.selectedPublication.supersededBy.title}
+                          </a>
+                        </WarningMessage>
+                      ) : null
+                    }
                     onSubmit={handlePublicationFormSubmit}
                   />
                 )}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -38,6 +38,38 @@ describe('TableToolWizard', () => {
     },
   ];
 
+  const testThemeWithSupercededPublication: Theme = {
+    id: 'theme-5',
+    title: 'Theme 5',
+    summary: '',
+    topics: [
+      {
+        id: 'topic-11',
+        title: 'Topic 11',
+        summary: '',
+        publications: [
+          {
+            id: 'publication-11',
+            title: 'Publication 11',
+            slug: 'publication-slug-11',
+            isSuperseded: true,
+            supersededBy: {
+              id: 'superseding-publication',
+              slug: 'superseding-publication-slug',
+              title: 'Superseding publication',
+            },
+          },
+          {
+            id: 'publication-12',
+            title: 'Publication 12',
+            slug: 'publication-slug-12',
+            isSuperseded: false,
+          },
+        ],
+      },
+    ],
+  };
+
   const testSubjects: Subject[] = [
     {
       id: 'subject-1',
@@ -214,6 +246,51 @@ describe('TableToolWizard', () => {
       expect(screen.getByLabelText('Subject 1')).toBeInTheDocument();
       expect(screen.getByLabelText('Subject 2')).toBeInTheDocument();
     });
+  });
+
+  test('shows a warning when the selected publication is superseded', async () => {
+    render(
+      <TableToolWizard
+        themeMeta={[...testThemeMeta, testThemeWithSupercededPublication]}
+        initialState={{
+          initialStep: 2,
+          subjects: testSubjects,
+          query: {
+            publicationId: 'publication-11',
+            subjectId: '',
+            locationIds: [],
+            filters: [],
+            indicators: [],
+          },
+          selectedPublication: {
+            ...testThemeWithSupercededPublication.topics[0].publications[0],
+            selectedRelease: {
+              id: 'selected-release',
+              latestData: false,
+              slug: 'selected-release-slug',
+              title: 'Selected release',
+              type: 'AdHocStatistics',
+            },
+            latestRelease: { title: 'Latest release title' },
+          },
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText('This publication has been superseded by'),
+    ).toBeInTheDocument();
+
+    const supersededWarningLink = within(
+      screen.getByTestId('superseded-warning'),
+    ).getByRole('link', {
+      name: 'Superseding publication',
+    });
+
+    expect(supersededWarningLink).toHaveAttribute(
+      'href',
+      '/find-statistics/superseding-publication-slug',
+    );
   });
 
   test('does not render publication step if instructed to hide it', async () => {

--- a/src/explore-education-statistics-common/src/modules/table-tool/types/selectedPublication.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/types/selectedPublication.ts
@@ -1,10 +1,7 @@
+import { PublicationTreeSummary } from '@common/services/publicationService';
 import { ReleaseType } from '@common/services/types/releaseType';
 
-// TODO: EES-4312 Cleanup this type - use PublicationTreeSummary
-export interface SelectedPublication {
-  id: string;
-  title: string;
-  slug: string;
+export interface SelectedPublication extends PublicationTreeSummary {
   selectedRelease: SelectedRelease;
   latestRelease: {
     title: string;

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
@@ -159,6 +159,7 @@ const DataCataloguePage: NextPage<Props> = ({
               initialValues={{
                 publicationId: state.query.publication?.id ?? '',
               }}
+              showSupersededPublications
               onSubmit={handlePublicationFormSubmit}
               themes={themes}
               renderSummaryAfter={

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -287,9 +287,7 @@ export const getServerSideProps: GetServerSideProps<
     props: {
       themeMeta,
       selectedPublication: {
-        id: selectedPublication.id,
-        slug: selectedPublication.slug,
-        title: selectedPublication.title,
+        ...selectedPublication,
         selectedRelease: {
           id: selectedRelease.id,
           latestData: selectedRelease.latestRelease,

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
@@ -325,6 +325,7 @@ describe('TableToolPage', () => {
 
   const testSelectedPublicationWithLatestRelease: SelectedPublication = {
     id: testPublicationId,
+    isSuperseded: false,
     title: 'Test Publication',
     slug: 'test-publication',
     selectedRelease: {
@@ -341,6 +342,7 @@ describe('TableToolPage', () => {
 
   const testSelectedPublicationWithNonLatestRelease: SelectedPublication = {
     id: testPublicationId,
+    isSuperseded: false,
     title: 'Test Publication',
     slug: 'test-publication',
     selectedRelease: {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
@@ -204,6 +204,7 @@ export const testTableHeaders: TableHeadersConfig = {
 
 export const testSelectedPublicationWithLatestRelease: SelectedPublication = {
   id: '536154f5-7f82-4dc7-060a-08d9097c1945',
+  isSuperseded: false,
   title: 'Test publication',
   slug: 'test-publication',
   selectedRelease: {
@@ -221,6 +222,7 @@ export const testSelectedPublicationWithLatestRelease: SelectedPublication = {
 export const testSelectedPublicationWithNonLatestRelease: SelectedPublication =
   {
     id: '536154f5-7f82-4dc7-060a-08d9097c1945',
+    isSuperseded: false,
     title: 'Test publication',
     slug: 'test-publication',
     selectedRelease: {

--- a/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[dataBlockParentId].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[dataBlockParentId].tsx
@@ -57,9 +57,7 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> =
         fastTrack,
         featuredTables,
         selectedPublication: {
-          id: selectedPublication.id,
-          title: selectedPublication.title,
-          slug: selectedPublication.slug,
+          ...selectedPublication,
           selectedRelease: {
             id: fastTrack.releaseId,
             slug: fastTrack.releaseSlug,

--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -236,7 +236,7 @@ Check public data tables page contains superseding-publication's subject
 
     user clicks radio    %{TEST_THEME_NAME}
 
-    user checks page does not contain    ${PUBLICATION_NAME_ARCHIVE}
+    user checks page does not contain element    label:${PUBLICATION_NAME_ARCHIVE}
 
     user clicks radio    ${PUBLICATION_NAME_SUPERSEDE}
     user clicks element    id:publicationForm-submit


### PR DESCRIPTION
Fixes direct links to the table tool for superseded publications:
- the superseded publication is selected
- a warning is shown
- you can progress through the table tool as usual
- step 1 of the table tool does not list superseded publications (as currently)

![tt](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/e0aa3bf4-0d67-4161-af27-500395067187)
