### PR TITLE
🐛 Fix test data generator bug in `Generator.ForRange` when range is empty

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/Generator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/Generator.cs
@@ -269,7 +269,7 @@ public class Generator<T> where T : class
             var rangeEnd = rangeOffset + rangeLength;
 
             // Ranges are not inclusive of the end index
-            if (rangeLength > 0 && (index < rangeOffset || index >= rangeEnd))
+            if (rangeEnd == 0 || rangeLength > 0 && (index < rangeOffset || index >= rangeEnd))
             {
                 continue;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/GeneratorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/GeneratorTests.cs
@@ -424,6 +424,19 @@ public class GeneratorTests
     }
 
     [Fact]
+    public void Generate_ForRange_EmptyRange_RangeIsNotApplied()
+    {
+        var items = new Generator<Test>()
+            .ForRange(..0, s => s
+                .Set(t => t.FirstName, "John")
+                .Set(t => t.LastName, "Doe"))
+            .GenerateArray(2);
+
+        Assert.All(items, item => Assert.Equal("", item.FirstName));
+        Assert.All(items, item => Assert.Equal("", item.LastName));
+    }
+
+    [Fact]
     public void Generate_ForRange_RangeOutOfBoundsThrows()
     {
         Assert.Throws<ArgumentOutOfRangeException>(


### PR DESCRIPTION
This PR fixes a bug using `Generator.ForRange` when the range is empty.

For example, in the following test data setup, the range setter for range `[..0]` should not be applied:

```csharp
            _fixture
                .DefaultTheme()
                .ForRange(..0, s => s.SetTitle("Theme title"))
                .GenerateArray(2);
```

Without this fix we find that the range setter is applied to the first element in the array.

While we wouldn't normally have any reason to define a range with upper bound (exclusive) equal to zero, it's still possible that a zero value can be encountered when the upper bound is a calculated expression.