### PR TITLE
EES-4667 Add new `ReleaseParent` test data generator options and add unit tests for `ReleaseRepository`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Xunit;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/MethodologyFileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/MethodologyFileExtensionTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseExtensionTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using Xunit;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseFileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseFileExtensionTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ContentSectionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ContentSectionGeneratorExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataBlockParentGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataBlockParentGeneratorExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataBlockVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataBlockVersionGeneratorExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataImportGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataImportGeneratorExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FeaturedTableGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FeaturedTableGeneratorExtensions.cs
@@ -1,8 +1,4 @@
-#nullable enable
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/HtmlBlockGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/HtmlBlockGeneratorExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyGeneratorExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyVersionGeneratorExtensions.cs
@@ -1,7 +1,4 @@
-#nullable enable
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
@@ -27,6 +27,16 @@ public static class PublicationGeneratorExtensions
         Release release)
         => generator.ForInstance(s => s.SetLatestPublishedRelease(release));
 
+    public static Generator<Publication> WithReleaseParents(
+        this Generator<Publication> generator,
+        IEnumerable<ReleaseParent> releaseParents)
+        => generator.ForInstance(s => s.SetReleaseParents(releaseParents));
+
+    public static Generator<Publication> WithReleaseParents(
+        this Generator<Publication> generator,
+        Func<SetterContext, IEnumerable<ReleaseParent>> releaseParents)
+        => generator.ForInstance(s => s.SetReleaseParents(releaseParents.Invoke));
+
     public static Generator<Publication> WithReleases(
         this Generator<Publication> generator,
         IEnumerable<Release> releases)
@@ -54,8 +64,14 @@ public static class PublicationGeneratorExtensions
 
     public static InstanceSetters<Publication> SetLatestPublishedRelease(
         this InstanceSetters<Publication> setters,
-        Release release)
-        => setters.Set(p => p.LatestPublishedRelease, release);
+        Release? release)
+        => setters.Set(p => p.LatestPublishedRelease, release)
+            .SetLatestPublishedReleaseId(release?.Id);
+
+    public static InstanceSetters<Publication> SetLatestPublishedReleaseId(
+        this InstanceSetters<Publication> setters,
+        Guid? latestPublishedReleaseId)
+        => setters.Set(p => p.LatestPublishedReleaseId, latestPublishedReleaseId);
 
     public static Generator<Publication> WithTopics(this Generator<Publication> generator,
         IEnumerable<Topic> topics)
@@ -65,6 +81,65 @@ public static class PublicationGeneratorExtensions
 
         return generator;
     }
+
+    public static InstanceSetters<Publication> SetReleaseParents(
+        this InstanceSetters<Publication> setters,
+        IEnumerable<ReleaseParent> releaseParents)
+        => setters.SetReleaseParents(_ => releaseParents);
+
+    private static InstanceSetters<Publication> SetReleaseParents(
+        this InstanceSetters<Publication> setters,
+        Func<SetterContext, IEnumerable<ReleaseParent>> releaseParents)
+        => setters.Set(
+                p => p.Releases,
+                (_, publication, context) =>
+                {
+                    var list = releaseParents.Invoke(context).ToList();
+
+                    var releases = list.SelectMany(rp => rp.Releases)
+                        .ToList();
+
+                    releases.ForEach(release =>
+                    {
+                        release.Publication = publication;
+                        release.PublicationId = publication.Id;
+                    });
+
+                    return releases;
+                }
+            )
+            .Set(p => p.LatestPublishedRelease, (_, publication, _) =>
+            {
+                var publishedVersions = publication.Releases
+                    .Where(release => release.Published.HasValue)
+                    .ToList();
+
+                if (publishedVersions.Count == 0)
+                {
+                    return null;
+                }
+
+                if (publishedVersions.Count == 1)
+                {
+                    return publishedVersions[0];
+                }
+
+                return publishedVersions
+                    .GroupBy(release => release.ReleaseParentId)
+                    .Select(groupedReleases =>
+                        new
+                        {
+                            ReleaseParentId = groupedReleases.Key,
+                            Version = groupedReleases.Max(release => release.Version)
+                        })
+                    .Join(publishedVersions,
+                        maxVersion => maxVersion,
+                        release => new { release.ReleaseParentId, release.Version },
+                        (_, release) => release)
+                    .OrderByDescending(release => release.Year)
+                    .ThenByDescending(release => release.TimePeriodCoverage)
+                    .FirstOrDefault();
+            });
 
     public static InstanceSetters<Publication> SetReleases(
         this InstanceSetters<Publication> setters,
@@ -89,7 +164,7 @@ public static class PublicationGeneratorExtensions
     private static InstanceSetters<Publication> SetContact(
         this InstanceSetters<Publication> setters,
         Contact contact)
-        => setters.Set(m => m.Contact, contact);
+        => setters.Set(p => p.Contact, contact);
 
     private static InstanceSetters<Publication> SetTopicId(
         this InstanceSetters<Publication> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseFileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseFileGeneratorExtensions.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
@@ -103,6 +103,11 @@ public static class ReleaseGeneratorExtensions
         PartialDate nextReleaseDate)
         => generator.ForInstance(release => release.SetNextReleaseDate(nextReleaseDate));
 
+    public static Generator<Release> WithPreviousVersion(
+        this Generator<Release> generator,
+        Release previousVersion)
+        => generator.ForInstance(release => release.SetPreviousVersion(previousVersion));
+
     public static Generator<Release> WithPreviousVersionId(
         this Generator<Release> generator,
         Guid previousVersionId)
@@ -187,8 +192,10 @@ public static class ReleaseGeneratorExtensions
         => setters
             .SetDefault(p => p.Id)
             .SetDefault(p => p.Slug)
-            .SetDefault(p => p.Title)
             .SetDefault(p => p.DataGuidance)
+            .SetDefault(p => p.Type)
+            .SetApprovalStatus(ReleaseApprovalStatus.Draft)
+            .SetTimePeriodCoverage(TimeIdentifier.AcademicYear)
             .Set(p => p.ReleaseName, (_, _, context) => $"{2000 + context.Index}");
 
     public static InstanceSetters<Release> SetId(
@@ -284,9 +291,15 @@ public static class ReleaseGeneratorExtensions
         return setters;
     }
 
+    public static InstanceSetters<Release> SetPreviousVersion(
+        this InstanceSetters<Release> setters,
+        Release? previousVersion)
+        => setters.Set(release => release.PreviousVersion, previousVersion)
+            .SetPreviousVersionId(previousVersion?.Id);
+
     public static InstanceSetters<Release> SetPreviousVersionId(
         this InstanceSetters<Release> setters,
-        Guid previousVersionId)
+        Guid? previousVersionId)
         => setters.Set(release => release.PreviousVersionId, previousVersionId);
 
     public static InstanceSetters<Release> SetYear(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseParentGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseParentGeneratorExtensions.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseStatusGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseStatusGeneratorExtensions.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ThemeGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ThemeGeneratorExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/TopicGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/TopicGeneratorExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserPublicationRoleGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserPublicationRoleGeneratorExtensions.cs
@@ -1,6 +1,4 @@
-#nullable enable
 using System.Collections.Generic;
-using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserReleaseRoleGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserReleaseRoleGeneratorExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <LangVersion>10.0</LangVersion>
         <IsPackable>false</IsPackable>
+        <Nullable>enable</Nullable>
         <RootNamespace>GovUk.Education.ExploreEducationStatistics.Content.Model.Tests</RootNamespace>
     </PropertyGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
@@ -1,9 +1,5 @@
-#nullable enable
 using System;
-using System.Collections.Generic;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Xunit;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyNoteRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyNoteRepositoryTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyVersionRepositoryTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/PublicationRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/PublicationRepositoryTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/ReleaseRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/ReleaseRepositoryTests.cs
@@ -1,0 +1,773 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Utils.ComparerUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Repository;
+
+public class ReleaseRepositoryTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    public class GetLatestPublishedReleaseVersionTests : ReleaseRepositoryTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_ => ListOf<ReleaseParent>(
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 0, draftVersion: true, year: 2022),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2, draftVersion: true, year: 2021),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2, year: 2020)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            var result = await repository.GetLatestPublishedReleaseVersion(publications[0].Id);
+
+            // Expect the result to be the latest published version taken from releases of the specified publication in
+            // reverse chronological order
+            var expectedReleaseVersion = publications[0].Releases
+                .Single(r => r is { Published: not null, Year: 2021, Version: 1 });
+
+            Assert.NotNull(result);
+            Assert.Equal(expectedReleaseVersion.Id, result.Id);
+        }
+
+        [Fact]
+        public async Task PublicationHasNoPublishedReleaseVersions_ReturnsNull()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                // Index 0 has an unpublished release version
+                // Index 1 has a published release version
+                .ForIndex(0, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 0, draftVersion: true)
+                    .Generate(1)))
+                .ForIndex(1, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Null(await repository.GetLatestPublishedReleaseVersion(publications[0].Id));
+        }
+
+        [Fact]
+        public async Task PublicationHasNoReleaseVersions_ReturnsNull()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                // Index 0 has no release versions
+                // Index 1 has a published release version
+                .ForIndex(1, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Null(await repository.GetLatestPublishedReleaseVersion(publications[0].Id));
+        }
+
+        [Fact]
+        public async Task PublicationDoesNotExist_ReturnsNull()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Null(await repository.GetLatestPublishedReleaseVersion(Guid.NewGuid()));
+        }
+
+        [Fact]
+        public async Task SpecificReleaseSlug_Success()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_ => ListOf<ReleaseParent>(
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 1, year: 2022),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2, draftVersion: true, year: 2021)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            var result = await repository.GetLatestPublishedReleaseVersion(publications[0].Id, "2021-22");
+
+            // Expect the result to be the latest published version for the 2021-22 release of the specified publication
+            var expectedReleaseVersion = publications[0].Releases
+                .Single(r => r is { Published: not null, Year: 2021, Version: 1 });
+
+            Assert.NotNull(result);
+            Assert.Equal(expectedReleaseVersion.Id, result.Id);
+        }
+
+        [Fact]
+        public async Task SpecificReleaseSlug_PublicationHasNoPublishedReleaseVersions_ReturnsNull()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                // Index 0 has an unpublished release version
+                // Index 1 has a published release version
+                .ForIndex(0, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 0, draftVersion: true, year: 2021)
+                    .Generate(1)))
+                .ForIndex(1, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1, year: 2021)
+                    .Generate(1)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Null(await repository.GetLatestPublishedReleaseVersion(publications[0].Id, "2021-22"));
+        }
+
+        [Fact]
+        public async Task SpecificReleaseSlug_PublicationHasNoPublishedReleaseVersionsMatchingSlug_ReturnsNull()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1, year: 2020)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Null(await repository.GetLatestPublishedReleaseVersion(publication.Id, "2021-22"));
+        }
+
+        [Fact]
+        public async Task SpecificReleaseSlug_PublicationHasNoReleaseVersions_ReturnsNull()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                // Index 0 has no release versions
+                // Index 1 has a published release version
+                .ForIndex(1, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1, year: 2021)
+                    .Generate(1)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Null(await repository.GetLatestPublishedReleaseVersion(publications[0].Id, "2021-22"));
+        }
+
+        [Fact]
+        public async Task SpecificReleaseSlug_PublicationDoesNotExist_ReturnsNull()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1, year: 2021)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Null(await repository.GetLatestPublishedReleaseVersion(Guid.NewGuid(), "2021-22"));
+        }
+    }
+
+    public class GetLatestReleaseVersionTests : ReleaseRepositoryTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_ => ListOf<ReleaseParent>(
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 0, draftVersion: true, year: 2022),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2, draftVersion: true, year: 2021),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2, year: 2020)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            var result = await repository.GetLatestReleaseVersion(publications[0].Id);
+
+            // Expect the result to be the latest version taken from releases of the specified publication in
+            // reverse chronological order
+            var expectedReleaseVersion = publications[0].Releases
+                .Single(r => r is { Year: 2022, Version: 0 });
+
+            Assert.NotNull(result);
+            Assert.Equal(expectedReleaseVersion.Id, result.Id);
+        }
+
+        [Fact]
+        public async Task PublicationHasNoReleaseVersions_ReturnsNull()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                // Index 0 has no release versions
+                // Index 1 has a release version
+                .ForIndex(1, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Null(await repository.GetLatestReleaseVersion(publications[0].Id));
+        }
+
+        [Fact]
+        public async Task PublicationDoesNotExist_ReturnsNull()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Null(await repository.GetLatestReleaseVersion(Guid.NewGuid()));
+        }
+    }
+
+    public class IsLatestPublishedReleaseVersionTests : ReleaseRepositoryTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 2, draftVersion: true)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            var releaseVersions = publication.Releases;
+
+            // Expect only the highest published version of the release to be the latest
+            Assert.False(await repository.IsLatestPublishedReleaseVersion(releaseVersions[0].Id));
+            Assert.True(await repository.IsLatestPublishedReleaseVersion(releaseVersions[1].Id));
+            Assert.False(await repository.IsLatestPublishedReleaseVersion(releaseVersions[2].Id));
+        }
+
+        [Fact]
+        public async Task ReleaseHasNoPublishedReleaseVersions_ReturnsFalse()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 0, draftVersion: true)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            var releaseVersion = publication.Releases.Single();
+
+            Assert.False(await repository.IsLatestPublishedReleaseVersion(releaseVersion.Id));
+        }
+
+        [Fact]
+        public async Task ReleaseVersionDoesNotExist_ReturnsFalse()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.False(await repository.IsLatestPublishedReleaseVersion(Guid.NewGuid()));
+        }
+    }
+
+    public class IsLatestReleaseVersionTests : ReleaseRepositoryTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 2, draftVersion: true)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            var releaseVersions = publication.Releases;
+
+            // Expect only the highest version of the release to be the latest
+            Assert.False(await repository.IsLatestReleaseVersion(releaseVersions[0].Id));
+            Assert.False(await repository.IsLatestReleaseVersion(releaseVersions[1].Id));
+            Assert.True(await repository.IsLatestReleaseVersion(releaseVersions[2].Id));
+        }
+
+        [Fact]
+        public async Task ReleaseVersionDoesNotExist_ReturnsFalse()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.False(await repository.IsLatestReleaseVersion(Guid.NewGuid()));
+        }
+    }
+
+    public class ListLatestPublishedReleaseVersionIdsTests : ReleaseRepositoryTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_ => ListOf<ReleaseParent>(
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 0, draftVersion: true),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2, draftVersion: true),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            var result = await repository.ListLatestPublishedReleaseVersionIds(publications[0].Id);
+
+            // Expect the result to contain the highest published version of each release for the specified publication
+            AssertIdsAreEqualIgnoringOrder(new[]
+            {
+                publications[0].Releases[2].Id,
+                publications[0].Releases[5].Id
+            }, result);
+        }
+
+        [Fact]
+        public async Task PublicationHasNoPublishedReleaseVersions_ReturnsEmpty()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                // Index 0 has an unpublished release version
+                // Index 1 has a published release version
+                .ForIndex(0, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 0, draftVersion: true)
+                    .Generate(1)))
+                .ForIndex(1, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestPublishedReleaseVersionIds(publications[0].Id));
+        }
+
+        [Fact]
+        public async Task PublicationHasNoReleaseVersions_ReturnsEmpty()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                .ForIndex(1, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestPublishedReleaseVersionIds(publications[0].Id));
+        }
+
+        [Fact]
+        public async Task PublicationDoesNotExist_ReturnsEmpty()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestPublishedReleaseVersionIds(Guid.NewGuid()));
+        }
+    }
+
+    public class ListLatestPublishedReleaseVersionsTests : ReleaseRepositoryTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_ => ListOf<ReleaseParent>(
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 0, draftVersion: true),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2, draftVersion: true),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            var result = await repository.ListLatestPublishedReleaseVersions(publications[0].Id);
+
+            // Expect the result to contain the highest published version of each release for the specified publication
+            AssertIdsAreEqualIgnoringOrder(new[]
+            {
+                publications[0].Releases[2].Id,
+                publications[0].Releases[5].Id
+            }, result);
+        }
+
+        [Fact]
+        public async Task PublicationHasNoPublishedReleaseVersions_ReturnsEmpty()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                // Index 0 has an unpublished release version
+                // Index 1 has a published release version
+                .ForIndex(0, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 0, draftVersion: true)
+                    .Generate(1)))
+                .ForIndex(1, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestPublishedReleaseVersions(publications[0].Id));
+        }
+
+        [Fact]
+        public async Task PublicationHasNoReleaseVersions_ReturnsEmpty()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                // Index 0 has no release versions
+                // Index 1 has a published release version
+                .ForIndex(1, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestPublishedReleaseVersions(publications[0].Id));
+        }
+
+        [Fact]
+        public async Task PublicationDoesNotExist_ReturnsEmpty()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestPublishedReleaseVersions(Guid.NewGuid()));
+        }
+    }
+
+    public class ListLatestReleaseVersionIdsTests : ReleaseRepositoryTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_ => ListOf<ReleaseParent>(
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 0, draftVersion: true),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2, draftVersion: true),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            var result = await repository.ListLatestReleaseVersionIds(publications[0].Id);
+
+            // Expect the result to contain the highest version of each release for the specified publication
+            AssertIdsAreEqualIgnoringOrder(new[]
+            {
+                publications[0].Releases[0].Id,
+                publications[0].Releases[3].Id,
+                publications[0].Releases[5].Id
+            }, result);
+        }
+
+        [Fact]
+        public async Task PublicationHasNoReleaseVersions_ReturnsEmpty()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                // Index 0 has no release versions
+                // Index 1 has a published release version
+                .ForIndex(1, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestReleaseVersionIds(publications[0].Id));
+        }
+
+        [Fact]
+        public async Task PublicationDoesNotExist_ReturnsEmpty()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestReleaseVersionIds(Guid.NewGuid()));
+        }
+    }
+
+    public class ListLatestReleaseVersionsTests : ReleaseRepositoryTests
+    {
+        [Fact]
+        public async Task AllPublications_Success()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_ => ListOf<ReleaseParent>(
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 0, draftVersion: true),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2, draftVersion: true),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            var result = await repository.ListLatestReleaseVersions();
+
+            // Expect the result to contain the highest version of each release for each publication
+            AssertIdsAreEqualIgnoringOrder(new[]
+            {
+                publications[0].Releases[0].Id,
+                publications[0].Releases[3].Id,
+                publications[0].Releases[5].Id,
+                publications[1].Releases[0].Id,
+                publications[1].Releases[3].Id,
+                publications[1].Releases[5].Id
+            }, result);
+        }
+
+        [Fact]
+        public async Task AllPublications_PublicationsHaveNoReleaseVersions_ReturnsEmpty()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestReleaseVersions());
+        }
+
+        [Fact]
+        public async Task AllPublications_NoPublicationsExist_ReturnsEmpty()
+        {
+            await using var contentDbContext = InMemoryContentDbContext();
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestReleaseVersions());
+        }
+
+        [Fact]
+        public async Task SpecificPublication_Success()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_ => ListOf<ReleaseParent>(
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 0, draftVersion: true),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2, draftVersion: true),
+                    _dataFixture
+                        .DefaultReleaseParent(publishedVersions: 2)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            var result = await repository.ListLatestReleaseVersions(publications[0].Id);
+
+            // Expect the result to contain the highest version of each release for the specified publication
+            AssertIdsAreEqualIgnoringOrder(new[]
+            {
+                publications[0].Releases[0].Id,
+                publications[0].Releases[3].Id,
+                publications[0].Releases[5].Id
+            }, result);
+        }
+
+        [Fact]
+        public async Task SpecificPublication_PublicationHasNoReleaseVersions_ReturnsEmpty()
+        {
+            var publications = _dataFixture
+                .DefaultPublication()
+                // Index 0 has no release versions
+                // Index 1 has a published release version
+                .ForIndex(1, p => p.SetReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1)))
+                .GenerateList(2);
+
+            var contextId = await AddTestData(publications);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestReleaseVersions(publications[0].Id));
+        }
+
+        [Fact]
+        public async Task SpecificPublication_PublicationDoesNotExist_ReturnsEmpty()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleaseParents(_dataFixture
+                    .DefaultReleaseParent(publishedVersions: 1)
+                    .Generate(1));
+
+            var contextId = await AddTestData(publication);
+            await using var contentDbContext = InMemoryContentDbContext(contextId);
+            var repository = BuildRepository(contentDbContext);
+
+            Assert.Empty(await repository.ListLatestReleaseVersions(Guid.NewGuid()));
+        }
+    }
+
+    private static void AssertIdsAreEqualIgnoringOrder(IReadOnlyCollection<Guid> expectedIds,
+        IReadOnlyCollection<Release> actualReleases)
+    {
+        Assert.Equal(expectedIds.Count, actualReleases.Count);
+        Assert.True(SequencesAreEqualIgnoringOrder(expectedIds, actualReleases.Select(r => r.Id)));
+    }
+
+    private static void AssertIdsAreEqualIgnoringOrder(IReadOnlyCollection<Guid> expectedIds,
+        IReadOnlyCollection<Guid> actualIds)
+    {
+        Assert.Equal(expectedIds.Count, actualIds.Count);
+        Assert.True(SequencesAreEqualIgnoringOrder(expectedIds, actualIds));
+    }
+
+    private static async Task<string> AddTestData(params Publication[] publications)
+    {
+        return await AddTestData(publications.ToList());
+    }
+
+    private static async Task<string> AddTestData(IReadOnlyCollection<Publication> publications)
+    {
+        var contextId = Guid.NewGuid().ToString();
+        await using var contentDbContext = InMemoryContentDbContext(contextId);
+
+        contentDbContext.Publications.AddRange(publications);
+        await contentDbContext.SaveChangesAsync();
+
+        return contextId;
+    }
+
+    private static ReleaseRepository BuildRepository(
+        ContentDbContext contentDbContext)
+    {
+        return new ReleaseRepository(
+            contentDbContext: contentDbContext
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Utils/ContentDbUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Utils/ContentDbUtils.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Utils/ContentFilterUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Utils/ContentFilterUtilsTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Text.RegularExpressions;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Utils;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Utils/GlossaryUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Utils/GlossaryUtilsTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;


### PR DESCRIPTION
This PR makes 4 changes:

### (1) Enable nullable reference types in `GovUk.Education.ExploreEducationStatistics.Content.Model.Tests`

We've now reached a stage where the majority of files in the `Content.Model.Tests` project have the `#nullable enable` pragma, and the few that don't have no nullable warnings. This PR removes the `#nullable enable` pragma from the files.

### (2) Add new `ReleaseParent` test data generator options

This PR introduces a new override of `ReleaseParentGeneratorExtensions.DefaultReleaseParent` providing options for generating a `ReleaseParent` with a specified number of published release versions, and a draft version. Year can also be provided to override the generated year that's otherwise applied to every version.

Typically we see unit test data setup as follows with variations in the naming e.g. `originalRelease/amendmentRelease` , `previousVersion/latestVersion` etc...

```csharp
        var previousVersion = new Release
        {
            Id = Guid.NewGuid(),
            Publication = publication,
            Published = DateTime.UtcNow
        };

        var latestVersion = new Release
        {
            Id = Guid.NewGuid(),
            Publication = publication,
            PreviousVersionId = previousVersion.Id,
            ApprovalStatus = Draft
        };
```

In this type of setup, one version needs to be declared first so that the following version can reference the id to set `PreviousVersionId`, and both versions might be given identical years to differentiate them from versions belonging to other releases.

If this code was swapped to be generated with the test release data generator using `ReleaseGeneratorExtensions.DefaultRelease`, then out-of-the-box they would have different generated years which would be wrong, since year is normally always derived from the previous version. They would also all have `Version = 0` which is wrong.

With the new extension override in this PR this kind of code can be swapped out with the following to generate a release parent with any number of published release versions, followed optionally by a draft version.

```csharp
    ReleaseParent releaseParent = _dataFixture.DefaultReleaseParent(publishedVersions: 1, draftVersion: true);
```

* Published release versions will be approved by default, and have a default published date later than any preceding published version.
* All versions will automatically have `PreviousVersionId` set to their preceding version's id.
* All versions in the same release parent will have a consistent generated year.
* All versions in the same release parent will have a generated `Version` sequence.

Year can be overridden where we want to make the year declaration explicit, e.g.

```csharp
    ReleaseParent releaseParent = _dataFixture.DefaultReleaseParent(publishedVersions: 2, draftVersion: true, year: 2022)
```

### (3) Add new `WithReleaseParents` method to publication test data generator

Although `Publication` has no direct relationship with `ReleaseParents` (yet!), I've added this to the publication test data generator to allow declaring a publication with release parents and their release versions.

```csharp
    Publication publication = _dataFixture
        .DefaultPublication()
        .WithReleaseParents(_dataFixture
            .DefaultReleaseParent(publishedVersions: 1)
            .Generate(1));
```

This code will automatically set the bidirectional relationship between the publication and release versions.

Given a list of release parents it will also automatically set `Publication.LatestPublishedRelease` to be the latest published version taken from all versions in reverse chronological order of the releases.

This avoids another pattern we typically see a lot in the unit test code where a release is declared separately to a publication to set `LatestPublishedRelease`:

```csharp
    var releaseA = new Release
    {
        Id = Guid.NewGuid()
    };

    var publicationA = new()
    {
        Title = "Publication A",
        LatestPublishedRelease = releaseA
    };
```

### (4) Add unit tests for `ReleaseRepsository`

Before we start making any changes to `ReleaseRepsository` in EES-4667 I wanted to add unit tests for this class. After #4541 it's being relied on for anything related to working out latest release versions. It's already tested indirectly via other tests but they won't necessarily be covering all permutations such as no existing data and I won't be able to make the changes I want to without exhaustive tests.

The tests make use of the new test data generator methods in this PR.

I deliberately didn't test `ListLatestPublishedReleaseVersionIds()` which is marked for removal by EES-4336.
