### PR TITLE
EES-4792 Create PublicationUpdateConfirmModal

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/NamingUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/NamingUtils.cs
@@ -9,6 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
     {
         public static string SlugFromTitle(string title)
         {
+            // NOTE: If you change anything here, you should also update `slugFromTitle.ts` in the frontend
             var replaceNonAlphaNumericWithSpace = ReplaceNonAlphaNumericWithSpaceAndTrim(title);
             var toLower = new string(replaceNonAlphaNumericWithSpace.Select(ToLower).ToArray());
             var removeMultipleSpaces = Regex.Replace(toLower, @"\s+", " ");

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationDetailsPage.tsx
@@ -60,6 +60,7 @@ const PublicationDetailsPage = () => {
             topicId: topic.id,
           }}
           publicationId={id}
+          publicationSlug={publication.slug}
           onCancel={toggleReadOnly.on}
           onSubmit={onReload}
         />

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import noop from 'lodash/noop';
 import userEvent from '@testing-library/user-event';
+import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
 
 jest.mock('@admin/services/themeService');
 const themeService = _themeService as jest.Mocked<typeof _themeService>;
@@ -394,7 +395,100 @@ describe('PublicationDetailsPage', () => {
       );
     });
 
-    test('successfullly submits with updated values', async () => {
+    test('confirmation modal mentions title change', async () => {
+      renderPage({
+        ...testPublication,
+        title: 'Publication 1',
+        slug: 'publication-1-updated', // to prevent URL change text in modal from displaying
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Publication details')).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit publication details' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+      });
+
+      userEvent.clear(screen.getByLabelText('Publication title'));
+      userEvent.type(
+        screen.getByLabelText('Publication title'),
+        'Publication 1 updated',
+      );
+
+      expect(publicationService.updatePublication).not.toHaveBeenCalled();
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Update publication details' }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Confirm publication changes'),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText('The URL for this publication will change from'),
+      ).not.toBeInTheDocument();
+
+      expect(screen.getByRole('dialog')).toHaveTextContent(
+        'The publication title will change from Publication 1 to Publication 1 updated',
+      );
+    });
+
+    test('confirmation modal mentions URL change', async () => {
+      renderPage({
+        ...testPublication,
+        title: 'Publication 1 updated',
+        slug: 'publication-1', // even with no changes by the user, slug will be changed to match title
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Publication details')).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit publication details' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+      });
+
+      expect(publicationService.updatePublication).not.toHaveBeenCalled();
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Update publication details' }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Confirm publication changes'),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText('The publication title will change from'),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.getByText('The URL for this publication will change from'),
+      ).toBeInTheDocument();
+
+      expect(screen.getByTestId('before-url')).toHaveValue(
+        'http://localhost/find-statistics/publication-1',
+      );
+      expect(screen.getByTestId('after-url')).toHaveValue(
+        'http://localhost/find-statistics/publication-1-updated',
+      );
+    });
+
+    test('successfully submits with updated values', async () => {
       renderPage(testPublication);
 
       await waitFor(() => {
@@ -453,13 +547,15 @@ describe('PublicationDetailsPage', () => {
 function renderPage(publication: PublicationWithPermissions) {
   render(
     <MemoryRouter>
-      <PublicationContextProvider
-        publication={publication}
-        onPublicationChange={noop}
-        onReload={noop}
-      >
-        <PublicationDetailsPage />
-      </PublicationContextProvider>
+      <TestConfigContextProvider>
+        <PublicationContextProvider
+          publication={publication}
+          onPublicationChange={noop}
+          onReload={noop}
+        >
+          <PublicationDetailsPage />
+        </PublicationContextProvider>
+      </TestConfigContextProvider>
     </MemoryRouter>,
   );
 }

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
@@ -395,7 +395,7 @@ describe('PublicationDetailsPage', () => {
       );
     });
 
-    test('confirmation modal mentions title change', async () => {
+    test('confirmation modal renders correctly when title is changed to match the slug', async () => {
       renderPage({
         ...testPublication,
         title: 'Publication 1',
@@ -441,7 +441,7 @@ describe('PublicationDetailsPage', () => {
       );
     });
 
-    test('confirmation modal mentions URL change', async () => {
+    test('confirmation modal renders correctly when a publication title remains the same, but the slug is changed to match the title', async () => {
       renderPage({
         ...testPublication,
         title: 'Publication 1 updated',
@@ -475,6 +475,59 @@ describe('PublicationDetailsPage', () => {
       expect(
         screen.queryByText('The publication title will change from'),
       ).not.toBeInTheDocument();
+
+      expect(
+        screen.getByText('The URL for this publication will change from'),
+      ).toBeInTheDocument();
+
+      expect(screen.getByTestId('before-url')).toHaveValue(
+        'http://localhost/find-statistics/publication-1',
+      );
+      expect(screen.getByTestId('after-url')).toHaveValue(
+        'http://localhost/find-statistics/publication-1-updated',
+      );
+    });
+
+    test('confirmation modal renders correctly when title and slug are changed', async () => {
+      renderPage({
+        ...testPublication,
+        title: 'Publication 1',
+        slug: 'publication-1',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Publication details')).toBeInTheDocument();
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Edit publication details' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+      });
+
+      userEvent.clear(screen.getByLabelText('Publication title'));
+      userEvent.type(
+        screen.getByLabelText('Publication title'),
+        'Publication 1 updated',
+      );
+
+      expect(publicationService.updatePublication).not.toHaveBeenCalled();
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Update publication details' }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Confirm publication changes'),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('dialog')).toHaveTextContent(
+        'The publication title will change from Publication 1 to Publication 1 updated',
+      );
 
       expect(
         screen.getByText('The URL for this publication will change from'),

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
@@ -161,9 +161,9 @@ export default function PublicationDetailsForm({
 
               {showConfirmModal && (
                 <PublicationUpdateConfirmModal
-                  title={initialValues.title}
-                  slug={publicationSlug}
-                  newTitle={form.getValues().title}
+                  initialPublicationTitle={initialValues.title}
+                  initialPublicationSlug={publicationSlug}
+                  newPublicationTitle={form.getValues().title}
                   onConfirm={async () => {
                     await form.handleSubmit(handleSubmit)();
                   }}

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
@@ -11,12 +11,12 @@ import RHFFormFieldSelect from '@common/components/form/rhf/RHFFormFieldSelect';
 import RHFFormFieldTextArea from '@common/components/form/rhf/RHFFormFieldTextArea';
 import RHFFormFieldTextInput from '@common/components/form/rhf/RHFFormFieldTextInput';
 import LoadingSpinner from '@common/components/LoadingSpinner';
-import ModalConfirm from '@common/components/ModalConfirm';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import useToggle from '@common/hooks/useToggle';
 import Yup from '@common/validation/yup';
 import React, { useMemo } from 'react';
 import { ObjectSchema } from 'yup';
+import PublicationUpdateConfirmModal from '@admin/pages/publication/components/PublicationUpdateConfirmModal';
 
 const id = 'publicationDetailsForm';
 
@@ -32,6 +32,7 @@ interface Props {
   canUpdatePublicationSummary?: boolean;
   initialValues: FormValues;
   publicationId: string;
+  publicationSlug: string;
   onCancel: () => void;
   onSubmit: () => void | Promise<void>;
 }
@@ -41,6 +42,7 @@ export default function PublicationDetailsForm({
   canUpdatePublicationSummary = false,
   initialValues,
   publicationId,
+  publicationSlug,
   onCancel,
   onSubmit,
 }: Props) {
@@ -157,21 +159,18 @@ export default function PublicationDetailsForm({
                 </ButtonGroup>
               </RHFForm>
 
-              <ModalConfirm
-                title="Confirm publication changes"
-                onConfirm={async () => {
-                  await form.handleSubmit(handleSubmit)();
-                }}
-                onExit={toggleConfirmModal.off}
-                onCancel={toggleConfirmModal.off}
-                open={showConfirmModal}
-              >
-                <p>
-                  Any changes made here will appear on the public site
-                  immediately.
-                </p>
-                <p>Are you sure you want to save the changes?</p>
-              </ModalConfirm>
+              {showConfirmModal && (
+                <PublicationUpdateConfirmModal
+                  title={initialValues.title}
+                  slug={publicationSlug}
+                  newTitle={form.getValues().title}
+                  onConfirm={async () => {
+                    await form.handleSubmit(handleSubmit)();
+                  }}
+                  onExit={toggleConfirmModal.off}
+                  onCancel={toggleConfirmModal.off}
+                />
+              )}
             </>
           );
         }}

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationUpdateConfirmModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationUpdateConfirmModal.tsx
@@ -1,0 +1,66 @@
+import ModalConfirm from '@common/components/ModalConfirm';
+import React from 'react';
+import { useConfig } from '@admin/contexts/ConfigContext';
+import UrlContainer from '@common/components/UrlContainer';
+import slugFromTitle from '@common/utils/slugFromTitle';
+
+interface Props {
+  title: string;
+  slug: string;
+  newTitle: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  onExit: () => void;
+}
+
+const PublicationUpdateConfirmModal = ({
+  title,
+  slug,
+  newTitle,
+  onConfirm,
+  onCancel,
+  onExit,
+}: Props) => {
+  const newSlug = slugFromTitle(newTitle);
+
+  const titleHasChanged = title !== newTitle;
+  const slugHasChanged = slug !== newSlug;
+
+  const { PublicAppUrl } = useConfig();
+
+  return (
+    <ModalConfirm
+      title="Confirm publication changes"
+      open
+      onConfirm={onConfirm}
+      onExit={onExit}
+      onCancel={onCancel}
+    >
+      <p>Any changes will appear on the public site immediately.</p>
+      {titleHasChanged && (
+        <p>
+          The publication title will change from <strong>{title}</strong> to{' '}
+          <strong>{newTitle}</strong>
+        </p>
+      )}
+      {slugHasChanged && (
+        <>
+          <p>The URL for this publication will change from</p>
+          <UrlContainer
+            data-testid="before-url"
+            url={`${PublicAppUrl}/find-statistics/${slug}`}
+          />{' '}
+          to{' '}
+          <UrlContainer
+            data-testid="after-url"
+            url={`${PublicAppUrl}/find-statistics/${newSlug}`}
+          />
+        </>
+      )}
+
+      <p>Are you sure you want to save the changes?</p>
+    </ModalConfirm>
+  );
+};
+
+export default PublicationUpdateConfirmModal;

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationUpdateConfirmModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationUpdateConfirmModal.tsx
@@ -5,26 +5,26 @@ import UrlContainer from '@common/components/UrlContainer';
 import slugFromTitle from '@common/utils/slugFromTitle';
 
 interface Props {
-  title: string;
-  slug: string;
-  newTitle: string;
+  initialPublicationTitle: string;
+  initialPublicationSlug: string;
+  newPublicationTitle: string;
   onConfirm: () => void;
   onCancel: () => void;
   onExit: () => void;
 }
 
-const PublicationUpdateConfirmModal = ({
-  title,
-  slug,
-  newTitle,
+export default function PublicationUpdateConfirmModal({
+  initialPublicationTitle,
+  initialPublicationSlug,
+  newPublicationTitle,
   onConfirm,
   onCancel,
   onExit,
-}: Props) => {
-  const newSlug = slugFromTitle(newTitle);
+}: Props) {
+  const newPublicationSlug = slugFromTitle(newPublicationTitle);
 
-  const titleHasChanged = title !== newTitle;
-  const slugHasChanged = slug !== newSlug;
+  const titleHasChanged = initialPublicationTitle !== newPublicationTitle;
+  const slugHasChanged = initialPublicationSlug !== newPublicationSlug;
 
   const { PublicAppUrl } = useConfig();
 
@@ -39,8 +39,9 @@ const PublicationUpdateConfirmModal = ({
       <p>Any changes will appear on the public site immediately.</p>
       {titleHasChanged && (
         <p>
-          The publication title will change from <strong>{title}</strong> to{' '}
-          <strong>{newTitle}</strong>
+          The publication title will change from{' '}
+          <strong>{initialPublicationTitle}</strong> to{' '}
+          <strong>{newPublicationTitle}</strong>
         </p>
       )}
       {slugHasChanged && (
@@ -48,19 +49,19 @@ const PublicationUpdateConfirmModal = ({
           <p>The URL for this publication will change from</p>
           <UrlContainer
             data-testid="before-url"
-            url={`${PublicAppUrl}/find-statistics/${slug}`}
+            url={`${PublicAppUrl}/find-statistics/${initialPublicationSlug}`}
           />{' '}
           to{' '}
           <UrlContainer
             data-testid="after-url"
-            url={`${PublicAppUrl}/find-statistics/${newSlug}`}
+            url={`${PublicAppUrl}/find-statistics/${newPublicationSlug}`}
           />
         </>
       )}
 
-      <p>Are you sure you want to save the changes?</p>
+      <p className="govuk-!-margin-top-4">
+        Are you sure you want to save the changes?
+      </p>
     </ModalConfirm>
   );
-};
-
-export default PublicationUpdateConfirmModal;
+}

--- a/src/explore-education-statistics-common/src/utils/__tests__/slugFromTitle.test.tsx
+++ b/src/explore-education-statistics-common/src/utils/__tests__/slugFromTitle.test.tsx
@@ -1,0 +1,51 @@
+import slugFromTitle from '../slugFromTitle';
+
+describe('slugFromTitle', () => {
+  test('converts calendar year', () => {
+    expect(slugFromTitle('calendar year 2019')).toEqual('calendar-year-2019');
+  });
+
+  test('converts non-calendar year', () => {
+    expect(slugFromTitle('tax year 2019/20')).toEqual('tax-year-2019-20');
+  });
+
+  test('no changes', () => {
+    expect(slugFromTitle('title')).toEqual('title');
+  });
+
+  test('lowercase characters', () => {
+    expect(slugFromTitle('TITLE')).toEqual('title');
+  });
+
+  test('converts a sentence with spaces', () => {
+    expect(slugFromTitle('A sentence with spaces')).toEqual(
+      'a-sentence-with-spaces',
+    );
+  });
+
+  test('converts a sentence with non alphanumeric characters', () => {
+    expect(
+      slugFromTitle("A sentence with !@£('\\) non alpha numeric characters"),
+    ).toEqual('a-sentence-with-non-alpha-numeric-characters');
+  });
+
+  test('converts a sentence with non alphanumeric characters at the end', () => {
+    expect(
+      slugFromTitle(
+        "A sentence with non alpha numeric characters at the end !@£('\\)",
+      ),
+    ).toEqual('a-sentence-with-non-alpha-numeric-characters-at-the-end');
+  });
+
+  test('converts a sentence with big spaces', () => {
+    expect(slugFromTitle('A sentence with     big      spaces      ')).toEqual(
+      'a-sentence-with-big-spaces',
+    );
+  });
+
+  test('converts a sentence with numbers', () => {
+    expect(slugFromTitle('A sentence with numbers 1 2 3 and 4')).toEqual(
+      'a-sentence-with-numbers-1-2-3-and-4',
+    );
+  });
+});

--- a/src/explore-education-statistics-common/src/utils/slugFromTitle.ts
+++ b/src/explore-education-statistics-common/src/utils/slugFromTitle.ts
@@ -1,0 +1,12 @@
+/**
+ * Converts a title string into a slug.
+ *
+ * Duplicates NamingUtils#SlugFromTitle in the backend
+ */
+export default function slugFromTitle(title: string) {
+  return title
+    .replace(/[^\w-]+/g, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-');
+}


### PR DESCRIPTION
This PR adds extra details to the update publication confirmation modal in Admin.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/21970718/ed29c72f-ce10-44dc-8608-60931a51215e)

When a publication is updated, it's possible that the title and slug are different. Currently, when a user updates a publication, the title and slug are always brought into alignment. 

Currently, users can only specify the title they want and the slug is generated from that title. In the future, it may be possible for users to also specify the particular slug they want - this work has been done with this potential future change in mind.

### Additional notes
- `slugFromTitle` is a copy of the backend's `NamingUtils#SlugFromTitle`. The tests for `slugFromTitle` also also copied from the backend.