### PR TITLE
EES-4667 EES-4487 EES-4549 Simplify methods of determining latest release versions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -156,8 +156,9 @@ public class PublishingCompletionService : IPublishingCompletionService
         var publication = await _contentDbContext.Publications
             .SingleAsync(p => p.Id == publicationId);
 
-        var publishedReleasesIds = await _releaseRepository.ListLatestPublishedReleaseVersionIds(publicationId);
-        publication.LatestPublishedReleaseId = publishedReleasesIds.First();
+        var latestPublishedReleaseVersion = await _releaseRepository.GetLatestPublishedReleaseVersion(publicationId);
+        publication.LatestPublishedReleaseId = latestPublishedReleaseVersion!.Id;
+
         _contentDbContext.Update(publication);
         await _contentDbContext.SaveChangesAsync();
     }


### PR DESCRIPTION
This PR simplifies the methods of determining latest release versions to use the new `ReleaseParent` which was added by #4558.

In #4541 we gathered all the current methods of determining latest release versions into a new common location in `IReleaseRepository`.

Those methods relied on loading all releases for a publication (or from a releases own publication if starting from a release) and then iterating through the releases to eliminate all but those which had no other release with `PreviousVersionId` equal to their own id.

This PR switches those methods to determining latest release versions based on the max version id for versions related to the same parent.

It's the final part of the implementation of the database queries originally proposed by @Dancemammal in [EES-4487](https://dfedigital.atlassian.net/browse/EES-4487).

Note there are no unit test changes on this PR. All unit tests for `ReleaseRepository` were added by #4568 and since the expected  behaviour of the methods hasn't changed, no updates were necessary. 🙂 

Unit test data is impacted by this change as any methods which depend on determining latest release versions must have release version data set up with release parents. This was pre-empted by the unit test changes made in #4571.