### PR TITLE
Remove preReleaseMinutesBeforeEnd from dev parameters

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -35,9 +35,6 @@
     "preReleaseMinutesBeforeStart": {
       "value": 1440
     },
-    "preReleaseMinutesBeforeEnd": {
-      "value": 1
-    },
     "useSubnets": {
       "value": true
     },


### PR DESCRIPTION
All references to the `preReleaseMinutesBeforeEnd` parameter should have been removed as part of 
https://github.com/dfe-analytical-services/explore-education-statistics/pull/4543
but this one was missed