### PR TITLE
EES-4708 Adding an endpoint to retrieve a summary for a single Data Set

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -22,12 +22,14 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
         {
         }
 
-        [Fact]
-        public async Task DataSetIsPublished_Returns200()
+        [Theory]
+        [InlineData(DataSetStatus.Published)]
+        [InlineData(DataSetStatus.Deprecated)]
+        public async Task DataSetIsAvailable_Returns200(DataSetStatus dataSetStatus)
         {
             var dataSet = DataFixture
                 .DefaultDataSet()
-                .WithStatus(DataSetStatus.Published)
+                .WithStatus(dataSetStatus)
                 .Generate();
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
@@ -80,17 +82,19 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
             Assert.Equal(dataSetVersion.MetaSummary.Indicators, content.LatestVersion.Indicators);
         }
 
-        [Fact]
-        public async Task DataSetNotPublished_Returns404()
+        [Theory]
+        [InlineData(DataSetStatus.Staged)]
+        [InlineData(DataSetStatus.Unpublished)]
+        public async Task DataSetNotAvailable_Returns404(DataSetStatus dataSetStatus)
         {
-            var unpublishedDataSet = DataFixture
+            var dataSet = DataFixture
                 .DefaultDataSet()
-                .WithStatus(DataSetStatus.Unpublished)
+                .WithStatus(dataSetStatus)
                 .Generate();
 
-            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(unpublishedDataSet));
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
 
-            var response = await GetDataSet(unpublishedDataSet.Id);
+            var response = await GetDataSet(dataSet.Id);
 
             response.AssertNotFound();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -27,14 +27,13 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
         [InlineData(DataSetStatus.Deprecated)]
         public async Task DataSetIsAvailable_Returns200(DataSetStatus dataSetStatus)
         {
-            var dataSet = DataFixture
+            DataSet dataSet = DataFixture
                 .DefaultDataSet()
-                .WithStatus(dataSetStatus)
-                .Generate();
+                .WithStatus(dataSetStatus);
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
 
-            var dataSetVersion = DataFixture
+            DataSetVersion dataSetVersion = DataFixture
                 .DefaultDataSetVersion(
                     filters: 1,
                     indicators: 1,
@@ -42,8 +41,7 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
                     timePeriods: 3)
                 .WithStatusPublished()
                 .WithDataSet(dataSet)
-                .FinishWith(dsv => dataSet.LatestVersion = dsv)
-                .Generate();
+                .FinishWith(dsv => dataSet.LatestVersion = dsv);
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -87,10 +85,9 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
         [InlineData(DataSetStatus.Unpublished)]
         public async Task DataSetNotAvailable_Returns404(DataSetStatus dataSetStatus)
         {
-            var dataSet = DataFixture
+            DataSet dataSet = DataFixture
                 .DefaultDataSet()
-                .WithStatus(dataSetStatus)
-                .Generate();
+                .WithStatus(dataSetStatus);
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -1,0 +1,115 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Fixture;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Controllers;
+
+public abstract class DataSetsControllerTests : IntegrationTestFixture
+{
+    private const string BaseUrl = "api/v1/data-sets";
+
+    public DataSetsControllerTests(TestApplicationFactory testApp) : base(testApp)
+    {
+    }
+
+    public class GetDataSetTests : DataSetsControllerTests
+    {
+        public GetDataSetTests(TestApplicationFactory testApp) : base(testApp)
+        {
+        }
+
+        [Fact]
+        public async Task DataSetIsPublished_Returns200()
+        {
+            var dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatus(DataSetStatus.Published)
+                .Generate();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            var dataSetVersion = DataFixture
+                .DefaultDataSetVersion(
+                    filters: 1,
+                    indicators: 1,
+                    locations: 1,
+                    timePeriods: 3)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dataSet.LatestVersion = dsv)
+                .Generate();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var response = await GetDataSet(dataSet.Id);
+
+            var content = response.AssertOk<DataSetViewModel>(useSystemJson: true);
+
+            Assert.NotNull(content);
+            Assert.Equal(dataSet.Id, content.Id);
+            Assert.Equal(dataSet.Title, content.Title);
+            Assert.Equal(dataSet.Summary, content.Summary);
+            Assert.Equal(dataSet.Status, content.Status);
+            Assert.Equal(dataSet.SupersedingDataSetId, content.SupersedingDataSetId);
+            Assert.Equal(dataSetVersion!.Version, content.LatestVersion.Number);
+            Assert.Equal(
+                dataSetVersion.Published!.Value.ToUnixTimeSeconds(),
+                content.LatestVersion.Published.ToUnixTimeSeconds()
+            ); 
+            Assert.Equal(dataSetVersion.TotalResults, content.LatestVersion.TotalResults);
+            Assert.Equal(
+                TimePeriodFormatter.Format(
+                    dataSetVersion.MetaSummary.TimePeriodRange.Start.Year,
+                    dataSetVersion.MetaSummary.TimePeriodRange.Start.Code),
+                content.LatestVersion.TimePeriods.Start);
+            Assert.Equal(
+                TimePeriodFormatter.Format(
+                    dataSetVersion.MetaSummary.TimePeriodRange.End.Year,
+                    dataSetVersion.MetaSummary.TimePeriodRange.End.Code),
+                content.LatestVersion.TimePeriods.End);
+            Assert.Equal(dataSetVersion.MetaSummary.GeographicLevels, content.LatestVersion.GeographicLevels);
+            Assert.Equal(dataSetVersion.MetaSummary.Filters, content.LatestVersion.Filters);
+            Assert.Equal(dataSetVersion.MetaSummary.Indicators, content.LatestVersion.Indicators);
+        }
+
+        [Fact]
+        public async Task DataSetNotPublished_Returns404()
+        {
+            var unpublishedDataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatus(DataSetStatus.Unpublished)
+                .Generate();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(unpublishedDataSet));
+
+            var response = await GetDataSet(unpublishedDataSet.Id);
+
+            response.AssertNotFound();
+        }
+
+        [Fact]
+        public async Task DataSetDoesNotExist_Returns404()
+        {
+            var response = await GetDataSet(Guid.NewGuid());
+
+            response.AssertNotFound();
+        }
+
+        private async Task<HttpResponseMessage> GetDataSet(Guid dataSetId)
+        {
+            var client = TestApp.CreateClient();
+
+            var uri = new Uri($"{BaseUrl}/{dataSetId}", UriKind.Relative);
+
+            return await client.GetAsync(uri);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
@@ -12,7 +12,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixture
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Azure.Documents.SystemFunctions;
 using Moq;
 using PublicationSummaryViewModel = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels.PublicationSummaryViewModel;
 
@@ -115,15 +114,14 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
         {
             var publicationId = Guid.NewGuid();
 
-            var dataSet = DataFixture
+            DataSet dataSet = DataFixture
                 .DefaultDataSet()
                 .WithStatusPublished()
-                .WithPublicationId(publicationId)
-                .Generate();
+                .WithPublicationId(publicationId);
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
 
-            var publication = DataFixture
+            PublicationSearchResultViewModel publication = DataFixture
                 .Generator<PublicationSearchResultViewModel>()
                 .ForInstance(s => s
                     .SetDefault(p => p.Title)
@@ -132,8 +130,7 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
                     .SetDefault(p => p.Theme)
                     .Set(p => p.Published, p => p.Date.Past())
                     .Set(p => p.Type, ReleaseType.OfficialStatistics)
-                    .Set(p => p.Id, publicationId))
-                .Generate();
+                    .Set(p => p.Id, publicationId));
 
             var contentApiClient = new Mock<IContentApiClient>();
             contentApiClient
@@ -290,15 +287,14 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
         [Fact]
         public async Task PublicationExists_Returns200()
         {
-            var publication = DataFixture
+            PublishedPublicationSummaryViewModel publication = DataFixture
                 .Generator<PublishedPublicationSummaryViewModel>()
                 .ForInstance(s => s
                     .SetDefault(f => f.Id)
                     .SetDefault(f => f.Title)
                     .SetDefault(f => f.Slug)
                     .SetDefault(f => f.Summary)
-                    .Set(f => f.Published, f => f.Date.Past()))
-                .Generate();
+                    .Set(f => f.Published, f => f.Date.Past()));
 
             var contentApiClient = new Mock<IContentApiClient>();
             contentApiClient
@@ -397,8 +393,7 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
             return DataFixture
                 .DefaultDataSet()
                 .WithStatus(DataSetStatus.Published)
-                .WithPublicationId(publicationId)
-                .Generate();
+                .WithPublicationId(publicationId);
         }
 
         private static async Task<HttpResponseMessage> GetPublication(HttpClient client, Guid publicationId)
@@ -502,15 +497,14 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
         {
             var publicationId = Guid.NewGuid();
 
-            var dataSet = DataFixture
+            DataSet dataSet = DataFixture
                 .DefaultDataSet()
                 .WithStatus(dataSetStatus)
-                .WithPublicationId(publicationId)
-                .Generate();
+                .WithPublicationId(publicationId);
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
 
-            var dataSetVersion = DataFixture
+            DataSetVersion dataSetVersion = DataFixture
                 .DefaultDataSetVersion(
                     filters: 1,
                     indicators: 1,
@@ -518,8 +512,7 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
                     timePeriods: 3)
                 .WithStatusPublished()
                 .WithDataSet(dataSet)
-                .FinishWith(dsv => dataSet.LatestVersion = dsv)
-                .Generate();
+                .FinishWith(dsv => dataSet.LatestVersion = dsv);
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -576,22 +569,20 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
             var publicationId1 = Guid.NewGuid();
             var publicationId2 = Guid.NewGuid();
 
-            var publication1DataSet = DataFixture
+            DataSet publication1DataSet = DataFixture
                 .DefaultDataSet()
                 .WithStatusPublished()
-                .WithPublicationId(publicationId1)
-                .Generate();
+                .WithPublicationId(publicationId1);
 
-            var publication2DataSet = DataFixture
+            DataSet publication2DataSet = DataFixture
                 .DefaultDataSet()
                 .WithStatusPublished()
-                .WithPublicationId(publicationId2)
-                .Generate();
+                .WithPublicationId(publicationId2);
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
                 context.DataSets.AddRange(publication1DataSet, publication2DataSet));
 
-            var publication1DataSetVersion = DataFixture
+            DataSetVersion publication1DataSetVersion = DataFixture
                 .DefaultDataSetVersion(
                     filters: 1,
                     indicators: 1,
@@ -599,10 +590,9 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
                     timePeriods: 3)
                 .WithStatusPublished()
                 .WithDataSet(publication1DataSet)
-                .FinishWith(dsv => publication1DataSet.LatestVersion = dsv)
-                .Generate();
+                .FinishWith(dsv => publication1DataSet.LatestVersion = dsv);
 
-            var publication2DataSetVersion = DataFixture
+            DataSetVersion publication2DataSetVersion = DataFixture
                 .DefaultDataSetVersion(
                     filters: 1,
                     indicators: 1,
@@ -610,8 +600,7 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
                     timePeriods: 3)
                 .WithStatusPublished()
                 .WithDataSet(publication2DataSet)
-                .FinishWith(dsv => publication2DataSet.LatestVersion = dsv)
-                .Generate();
+                .FinishWith(dsv => publication2DataSet.LatestVersion = dsv);
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -644,15 +633,14 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
         {
             var publicationId = Guid.NewGuid();
 
-            var dataSet = DataFixture
+            DataSet dataSet = DataFixture
                 .DefaultDataSet()
                 .WithStatus(dataSetStatus)
-                .WithPublicationId(publicationId)
-                .Generate();
+                .WithPublicationId(publicationId);
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
 
-            var dataSetVersion = DataFixture
+            DataSetVersion dataSetVersion = DataFixture
                 .DefaultDataSetVersion(
                     filters: 1,
                     indicators: 1,
@@ -660,8 +648,7 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
                     timePeriods: 3)
                 .WithStatusPublished()
                 .WithDataSet(dataSet)
-                .FinishWith(dsv => dataSet.LatestVersion = dsv)
-                .Generate();
+                .FinishWith(dsv => dataSet.LatestVersion = dsv);
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
@@ -415,49 +415,15 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
         {
         }
 
-        public static IEnumerable<object[]> AvailableDataSetPaginationCombinations()
-        {
-            var dataSetStatuses = new HashSet<DataSetStatus>()
-            {
-                DataSetStatus.Published,
-                DataSetStatus.Deprecated,
-            };
-
-            var paginationCombinations = new List<(
-                int page, 
-                int pageSize, 
-                int numberOfAvailableDataSets, 
-                int numberOfUnpublishedDataSets)>()
-            {
-                ( 1, 2, 2, 0 ),
-                ( 1, 2, 2, 1 ),
-                ( 1, 2, 2, 10 ),
-                ( 1, 2, 9, 1 ),
-                ( 2, 2, 9, 1 ),
-                ( 1, 2, 9, 10 ),
-                ( 1, 3, 2, 1 ),
-            };
-
-            foreach (var dataSetStatus in dataSetStatuses)
-            {
-                foreach (var paginationCombination in paginationCombinations)
-                {
-                    yield return new object[]
-                    {
-                        dataSetStatus,
-                        paginationCombination.page,
-                        paginationCombination.pageSize,
-                        paginationCombination.numberOfAvailableDataSets,
-                        paginationCombination.numberOfUnpublishedDataSets
-                    };
-                }
-            }
-        }
-
         [Theory]
-        [MemberData(nameof(AvailableDataSetPaginationCombinations))]
+        [InlineData(1, 2, 2, 0)]
+        [InlineData(1, 2, 2, 1)]
+        [InlineData(1, 2, 2, 10)]
+        [InlineData(1, 2, 9, 1)]
+        [InlineData(2, 2, 9, 1)]
+        [InlineData(1, 2, 9, 10)]
+        [InlineData(1, 3, 2, 1)]
         public async Task MultipleDataSetsAvailableForRequestedPublication_Returns200(
-            DataSetStatus availableDataSetStatus,
             int page,
             int pageSize,
             int numberOfAvailableDataSets,
@@ -467,7 +433,7 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
 
             var availableDataSets = DataFixture
                 .DefaultDataSet()
-                .WithStatus(availableDataSetStatus)
+                .WithStatusPublished()
                 .WithPublicationId(publicationId)
                 .GenerateList(numberOfAvailableDataSets);
 
@@ -532,7 +498,7 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
         [Theory]
         [InlineData(DataSetStatus.Published)]
         [InlineData(DataSetStatus.Deprecated)]
-        public async Task ReturnsCorrectViewModel(DataSetStatus dataSetStatus)
+        public async Task DataSetIsAvailable_Returns200_CorrectViewModel(DataSetStatus dataSetStatus)
         {
             var publicationId = Guid.NewGuid();
 
@@ -604,23 +570,21 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
             Assert.Equal(dataSetVersion.MetaSummary.Indicators, result.LatestVersion.Indicators);
         }
 
-        [Theory]
-        [InlineData(DataSetStatus.Published)]
-        [InlineData(DataSetStatus.Deprecated)]
-        public async Task DataSetAvailableForOtherPublication_Returns200_OnlyRequestedPublicationDataSet(DataSetStatus dataSetStatus)
+        [Fact]
+        public async Task DataSetAvailableForOtherPublication_Returns200_OnlyRequestedPublicationDataSet()
         {
             var publicationId1 = Guid.NewGuid();
             var publicationId2 = Guid.NewGuid();
 
             var publication1DataSet = DataFixture
                 .DefaultDataSet()
-                .WithStatus(dataSetStatus)
+                .WithStatusPublished()
                 .WithPublicationId(publicationId1)
                 .Generate();
 
             var publication2DataSet = DataFixture
                 .DefaultDataSet()
-                .WithStatus(dataSetStatus)
+                .WithStatusPublished()
                 .WithPublicationId(publicationId2)
                 .Generate();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -1,0 +1,40 @@
+using Asp.Versioning;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Controllers;
+
+[ApiVersion(1.0)]
+[ApiController]
+[Route("api/v{version:apiVersion}/data-sets")]
+public class DataSetsController : ControllerBase
+{
+    private readonly IDataSetService _dataSetService;
+
+    public DataSetsController(IDataSetService dataSetService)
+    {
+        _dataSetService = dataSetService;
+    }
+
+    /// <summary>
+    /// Get a data set’s summary
+    /// </summary>
+    /// <remarks>
+    /// Gets a specific data set’s summary details.
+    /// </remarks>
+    [HttpGet("{dataSetId:guid}")]
+    [Produces("application/json")]
+    [SwaggerResponse(200, "The requested data-set summary", type: typeof(DataSetViewModel))]
+    [SwaggerResponse(400)]
+    [SwaggerResponse(404)]
+    public async Task<ActionResult<DataSetViewModel>> GetDataSet(
+        [SwaggerParameter("The ID of the data-set.")] Guid dataSetId)
+    {
+        return await _dataSetService
+            .GetDataSet(dataSetId)
+            .HandleFailuresOrOk();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -27,11 +27,11 @@ public class DataSetsController : ControllerBase
     /// </remarks>
     [HttpGet("{dataSetId:guid}")]
     [Produces("application/json")]
-    [SwaggerResponse(200, "The requested data-set summary", type: typeof(DataSetViewModel))]
+    [SwaggerResponse(200, "The requested data set summary", type: typeof(DataSetViewModel))]
     [SwaggerResponse(400)]
     [SwaggerResponse(404)]
     public async Task<ActionResult<DataSetViewModel>> GetDataSet(
-        [SwaggerParameter("The ID of the data-set.")] Guid dataSetId)
+        [SwaggerParameter("The ID of the data set.")] Guid dataSetId)
     {
         return await _dataSetService
             .GetDataSet(dataSetId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
@@ -52,16 +53,12 @@ internal class DataSetService : IDataSetService
 
     private async Task<Either<ActionResult, DataSet>> CheckDataSetExists(Guid dataSetId)
     {
-        var dataSet = await _publicDataDbContext.DataSets
+        return await _publicDataDbContext.DataSets
             .Include(ds => ds.LatestVersion)
             .Where(ds => ds.Id == dataSetId)
             .Where(ds => ds.Status == DataSetStatus.Published
                 || ds.Status == DataSetStatus.Deprecated)
-            .SingleOrDefaultAsync();
-
-        return dataSet is null
-            ? new NotFoundResult()
-            : dataSet;
+            .SingleOrNotFound();
     }
 
     private static DataSetViewModel MapDataSet(DataSet dataSet)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -32,7 +32,8 @@ internal class DataSetService : IDataSetService
         var queryable = _publicDataDbContext.DataSets
             .Include(ds => ds.LatestVersion)
             .Where(ds => ds.PublicationId == publicationId)
-            .Where(ds => ds.Status == DataSetStatus.Published);
+            .Where(ds => ds.Status == DataSetStatus.Published 
+                || ds.Status == DataSetStatus.Deprecated);
 
         var totalResults = await queryable.CountAsync();
 
@@ -54,7 +55,8 @@ internal class DataSetService : IDataSetService
         var dataSet = await _publicDataDbContext.DataSets
             .Include(ds => ds.LatestVersion)
             .Where(ds => ds.Id == dataSetId)
-            .Where(ds => ds.Status == DataSetStatus.Published)
+            .Where(ds => ds.Status == DataSetStatus.Published
+                || ds.Status == DataSetStatus.Deprecated)
             .SingleOrDefaultAsync();
 
         return dataSet is null

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetService.cs
@@ -6,6 +6,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.In
 
 public interface IDataSetService
 {
+    Task<Either<ActionResult, DataSetViewModel>> GetDataSet(Guid dataSetId);
+
     Task<Either<ActionResult, DataSetPaginatedListViewModel>> ListDataSets(
         int page,
         int pageSize, 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PublicationService.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using PublicationSummaryViewModel = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels.PublicationSummaryViewModel;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
@@ -74,11 +75,11 @@ internal class PublicationService : IPublicationService
         };
     }
 
-    private Either<ActionResult, Unit> CheckPublicationIsPublished(Guid publicationId)
+    private async Task<Either<ActionResult, Unit>> CheckPublicationIsPublished(Guid publicationId)
     {
-        var publicationIsPublished = _publicDataDbContext.DataSets
+        var publicationIsPublished = await _publicDataDbContext.DataSets
             .Where(ds => ds.PublicationId == publicationId)
-            .Any(ds => ds.Status == DataSetStatus.Published);
+            .AnyAsync(ds => ds.Status == DataSetStatus.Published);
 
         if (publicationIsPublished)
         {


### PR DESCRIPTION
Adding an endpoint for retrieving the details of a single data-set via the Public API. 

The endpoint lives at `api/v1/data-sets/{dataSetId}`.

The endpoint returns the following status codes:
- 200
- 404

And returns the following JSON response when the response is a 200 OK:

```json
{
  "id": "string(uuid)",
  "title": "string",
  "summary": "string",
  "status": "string",
  "latestVersion": {
    "number": "string",
    "published": "string(datetime)",
    "totalResults": 0,
    "timePeriods": {
      "start": "string",
      "end": "string"
    },
    "geographicLevels": [
      "string"
    ],
    "filters": [
      "string"
    ],
    "indicators": [
      "string"
    ]
  },
  "supersedingDataSetId": "string"
}
```