### PR TITLE
EES-4743 Adding endpoint to retrieve a single Data Set Version

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/VersionUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/VersionUtilsTests.cs
@@ -1,4 +1,5 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Semver;
 using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
@@ -19,11 +20,11 @@ public abstract class VersionUtilsTests
         [InlineData("2", 2)]
         public void ValidVersion_SuccessfullyParsed(string versionString, int expectedMajor, int expectedMinor = default, int expectedPatch = default)
         {
-            Assert.True(VersionUtils.TryParse(versionString, out int major, out int minor, out int patch));
+            Assert.True(VersionUtils.TryParse(versionString, out SemVersion version));
 
-            Assert.Equal(expectedMajor, major);
-            Assert.Equal(expectedMinor, minor);
-            Assert.Equal(expectedPatch, patch);
+            Assert.Equal(expectedMajor, version.Major);
+            Assert.Equal(expectedMinor, version.Minor);
+            Assert.Equal(expectedPatch, version.Patch);
         }
 
         [Theory]
@@ -32,11 +33,11 @@ public abstract class VersionUtilsTests
         [InlineData(" 1.1.1 ", 1, 1, 1)]
         public void VersionWithEmptySpaces_SuccessfullyParsed(string versionString, int expectedMajor, int expectedMinor = default, int expectedPatch = default)
         {
-            Assert.True(VersionUtils.TryParse(versionString, out int major, out int minor, out int patch));
+            Assert.True(VersionUtils.TryParse(versionString, out SemVersion version));
 
-            Assert.Equal(expectedMajor, major);
-            Assert.Equal(expectedMinor, minor);
-            Assert.Equal(expectedPatch, patch);
+            Assert.Equal(expectedMajor, version.Major);
+            Assert.Equal(expectedMinor, version.Minor);
+            Assert.Equal(expectedPatch, version.Patch);
         }
 
         [Theory]
@@ -51,7 +52,7 @@ public abstract class VersionUtilsTests
 
         public void InvalidVersion_FailsToParse(string versionString)
         {
-            Assert.False(VersionUtils.TryParse(versionString, out int _, out int _, out int _));
+            Assert.False(VersionUtils.TryParse(versionString, out SemVersion _));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/VersionUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/VersionUtilsTests.cs
@@ -20,7 +20,7 @@ public abstract class VersionUtilsTests
         [InlineData("2", 2)]
         public void ValidVersion_SuccessfullyParsed(string versionString, int expectedMajor, int expectedMinor = default, int expectedPatch = default)
         {
-            Assert.True(VersionUtils.TryParse(versionString, out SemVersion version));
+            Assert.True(VersionUtils.TryParse(versionString, out var version));
 
             Assert.Equal(expectedMajor, version.Major);
             Assert.Equal(expectedMinor, version.Minor);
@@ -33,7 +33,7 @@ public abstract class VersionUtilsTests
         [InlineData(" 1.1.1 ", 1, 1, 1)]
         public void VersionWithEmptySpaces_SuccessfullyParsed(string versionString, int expectedMajor, int expectedMinor = default, int expectedPatch = default)
         {
-            Assert.True(VersionUtils.TryParse(versionString, out SemVersion version));
+            Assert.True(VersionUtils.TryParse(versionString, out var version));
 
             Assert.Equal(expectedMajor, version.Major);
             Assert.Equal(expectedMinor, version.Minor);
@@ -52,7 +52,7 @@ public abstract class VersionUtilsTests
 
         public void InvalidVersion_FailsToParse(string versionString)
         {
-            Assert.False(VersionUtils.TryParse(versionString, out SemVersion _));
+            Assert.False(VersionUtils.TryParse(versionString, out var _));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/VersionUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/VersionUtilsTests.cs
@@ -1,0 +1,57 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+
+public abstract class VersionUtilsTests
+{
+    public class TryParseTests : VersionUtilsTests
+    {
+        [Theory]
+        [InlineData("1.0.0", 1, 0, 0)]
+        [InlineData("1.1.0", 1, 1, 0)]
+        [InlineData("1.1.1", 1, 1, 1)]
+        [InlineData("2.0.0", 2, 0, 0)]
+        [InlineData("1.0", 1, 0)]
+        [InlineData("1.1", 1, 1)]
+        [InlineData("2.0", 2, 0)]
+        [InlineData("1", 1)]
+        [InlineData("2", 2)]
+        public void ValidVersion_SuccessfullyParsed(string versionString, int expectedMajor, int expectedMinor = default, int expectedPatch = default)
+        {
+            Assert.True(VersionUtils.TryParse(versionString, out int major, out int minor, out int patch));
+
+            Assert.Equal(expectedMajor, major);
+            Assert.Equal(expectedMinor, minor);
+            Assert.Equal(expectedPatch, patch);
+        }
+
+        [Theory]
+        [InlineData(" 1.1.1", 1, 1, 1)]
+        [InlineData("1.1.1 ", 1, 1, 1)]
+        [InlineData(" 1.1.1 ", 1, 1, 1)]
+        public void VersionWithEmptySpaces_SuccessfullyParsed(string versionString, int expectedMajor, int expectedMinor = default, int expectedPatch = default)
+        {
+            Assert.True(VersionUtils.TryParse(versionString, out int major, out int minor, out int patch));
+
+            Assert.Equal(expectedMajor, major);
+            Assert.Equal(expectedMinor, minor);
+            Assert.Equal(expectedPatch, patch);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("a")]
+        [InlineData("1.a")]
+        [InlineData("1.")]
+        [InlineData("a 1")]
+        [InlineData("1 a")]
+        [InlineData("1.1.1.1")]
+
+        public void InvalidVersion_FailsToParse(string versionString)
+        {
+            Assert.False(VersionUtils.TryParse(versionString, out int _, out int _, out int _));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -29,6 +29,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
         <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />
+        <PackageReference Include="Semver" Version="2.3.0" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
         <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
         <PackageReference Include="Mime" Version="3.5.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/VersionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/VersionUtils.cs
@@ -4,25 +4,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
 
 public static class VersionUtils
 {
-    public static bool TryParse(string versionString, out int major, out int minor, out int patch)
+    public static bool TryParse(string versionString, out SemVersion version)
     {
-        if (!SemVersion.TryParse(
+        var successful = SemVersion.TryParse(
             versionString,
             SemVersionStyles.OptionalMinorPatch
                 | SemVersionStyles.AllowWhitespace,
-            out SemVersion version))
-        {
-            major = default;
-            minor = default;
-            patch = default;
+            out SemVersion sv);
 
-            return false;
-        }
+        version = sv;
 
-        major = version.Major;
-        minor = version.Minor;
-        patch = version.Patch;
-
-        return true;
+        return successful;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/VersionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/VersionUtils.cs
@@ -1,4 +1,3 @@
-using SemanticVersioning;
 using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -10,8 +9,7 @@ public static class VersionUtils
         if (!SemVersion.TryParse(
             versionString,
             SemVersionStyles.OptionalMinorPatch
-                | SemVersionStyles.AllowWhitespace
-                | SemVersionStyles.AllowLeadingWhitespace,
+                | SemVersionStyles.AllowWhitespace,
             out SemVersion version))
         {
             major = default;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/VersionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/VersionUtils.cs
@@ -10,7 +10,7 @@ public static class VersionUtils
             versionString,
             SemVersionStyles.OptionalMinorPatch
                 | SemVersionStyles.AllowWhitespace,
-            out SemVersion sv);
+            out var sv);
 
         version = sv;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/VersionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/VersionUtils.cs
@@ -1,0 +1,30 @@
+using SemanticVersioning;
+using Semver;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public static class VersionUtils
+{
+    public static bool TryParse(string versionString, out int major, out int minor, out int patch)
+    {
+        if (!SemVersion.TryParse(
+            versionString,
+            SemVersionStyles.OptionalMinorPatch
+                | SemVersionStyles.AllowWhitespace
+                | SemVersionStyles.AllowLeadingWhitespace,
+            out SemVersion version))
+        {
+            major = default;
+            minor = default;
+            patch = default;
+
+            return false;
+        }
+
+        major = version.Major;
+        minor = version.Minor;
+        patch = version.Patch;
+
+        return true;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -554,7 +554,7 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
 
             Assert.NotNull(content);
             Assert.Equal(dataSetVersion.Version, content.Number);
-            Assert.Equal(dataSetVersion.VersionType(), content.Type);
+            Assert.Equal(dataSetVersion.VersionType, content.Type);
             Assert.Equal(dataSetVersion.Status, content.Status);
             Assert.Equal(
                 dataSetVersion.Published!.Value.ToUnixTimeSeconds(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -639,7 +639,38 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
         [Fact]
         public async Task VersionDoesNotExist_Returns404()
         {
-            var response = await GetVersion(Guid.NewGuid(), "1.0");
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusPublished();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            var response = await GetVersion(dataSet.Id, "1.0");
+
+            response.AssertNotFound();
+        }
+
+        [Fact]
+        public async Task DataSetDoesNotExist_Returns404()
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusPublished();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion(
+                    filters: 1,
+                    indicators: 1,
+                    locations: 1,
+                    timePeriods: 3)
+                .WithStatusPublished()
+                .WithDataSetId(dataSet.Id);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
+
+            var response = await GetVersion(Guid.NewGuid(), dataSetVersion.Version);
 
             response.AssertNotFound();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -39,6 +39,25 @@ public class DataSetsController : ControllerBase
     }
 
     /// <summary>
+    /// Get a data set version
+    /// </summary>
+    /// <remarks>
+    /// Get a data set version, including a full list of its changes.
+    /// </remarks>
+    [HttpGet("{dataSetId:guid}/versions/{dataSetVersion}")]
+    [Produces("application/json")]
+    [SwaggerResponse(200, "The requested data set version", type: typeof(DataSetVersionViewModel))]
+    [SwaggerResponse(404)]
+    public async Task<ActionResult<DataSetVersionViewModel>> GetVersion(
+        [SwaggerParameter("The ID of the data set.")] Guid dataSetId,
+        [SwaggerParameter("The data set version.")] string dataSetVersion)
+    {
+        return await _dataSetService
+            .GetVersion(dataSetId, dataSetVersion)
+            .HandleFailuresOrOk();
+    }
+
+    /// <summary>
     /// List a data set’s versions
     /// </summary>
     /// <remarks>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -42,7 +42,7 @@ public class DataSetsController : ControllerBase
     /// Get a data set version
     /// </summary>
     /// <remarks>
-    /// Get a data set version, including a full list of its changes.
+    /// Get a data set version's summary details.
     /// </remarks>
     [HttpGet("{dataSetId:guid}/versions/{dataSetVersion}")]
     [Produces("application/json")]
@@ -50,7 +50,7 @@ public class DataSetsController : ControllerBase
     [SwaggerResponse(404)]
     public async Task<ActionResult<DataSetVersionViewModel>> GetVersion(
         [SwaggerParameter("The ID of the data set.")] Guid dataSetId,
-        [SwaggerParameter("The data set version.")] string dataSetVersion)
+        [SwaggerParameter("The data set version e.g. 1.0, 1.1, 2.0, etc.")] string dataSetVersion)
     {
         return await _dataSetService
             .GetVersion(dataSetId, dataSetVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
@@ -112,15 +113,15 @@ internal class DataSetService : IDataSetService
         Guid dataSetId,
         string dataSetVersion)
     {
-        if (!VersionUtils.TryParse(dataSetVersion, out int major, out int minor, out int _))
+        if (!VersionUtils.TryParse(dataSetVersion, out SemVersion version))
         {
             return new NotFoundResult();
         }
 
         return await _publicDataDbContext.DataSetVersions
             .Where(dsv => dsv.DataSetId == dataSetId)
-            .Where(dsv => dsv.VersionMajor == major)
-            .Where(dsv => dsv.VersionMinor == minor)
+            .Where(dsv => dsv.VersionMajor == version.Major)
+            .Where(dsv => dsv.VersionMinor == version.Minor)
             .Where(ds => ds.Status == DataSetVersionStatus.Published
                 || ds.Status == DataSetVersionStatus.Unpublished
                 || ds.Status == DataSetVersionStatus.Deprecated)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -111,13 +111,17 @@ internal class DataSetService : IDataSetService
         Guid dataSetId,
         string dataSetVersion)
     {
-        return await _publicDataDbContext.DataSetVersions
+        var dataSetVersions = await _publicDataDbContext.DataSetVersions
             .Where(dsv => dsv.DataSetId == dataSetId)
-            .Where(dsv => dsv.Version == dataSetVersion)
             .Where(ds => ds.Status == DataSetVersionStatus.Published
                 || ds.Status == DataSetVersionStatus.Unpublished
                 || ds.Status == DataSetVersionStatus.Deprecated)
-            .SingleOrNotFound();
+            .ToListAsync();
+
+        return await dataSetVersions
+            .Where(dsv => dsv.Version == dataSetVersion)
+            .SingleOrDefault()
+            .OrNotFound();
     }
 
     private static DataSetLatestVersionViewModel MapLatestVersion(DataSetVersion latestVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -113,7 +113,7 @@ internal class DataSetService : IDataSetService
         Guid dataSetId,
         string dataSetVersion)
     {
-        if (!VersionUtils.TryParse(dataSetVersion, out SemVersion version))
+        if (!VersionUtils.TryParse(dataSetVersion, out var version))
         {
             return new NotFoundResult();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
@@ -111,17 +112,19 @@ internal class DataSetService : IDataSetService
         Guid dataSetId,
         string dataSetVersion)
     {
-        var dataSetVersions = await _publicDataDbContext.DataSetVersions
+        if (!VersionUtils.TryParse(dataSetVersion, out int major, out int minor, out int _))
+        {
+            return new NotFoundResult();
+        }
+
+        return await _publicDataDbContext.DataSetVersions
             .Where(dsv => dsv.DataSetId == dataSetId)
+            .Where(dsv => dsv.VersionMajor == major)
+            .Where(dsv => dsv.VersionMinor == minor)
             .Where(ds => ds.Status == DataSetVersionStatus.Published
                 || ds.Status == DataSetVersionStatus.Unpublished
                 || ds.Status == DataSetVersionStatus.Deprecated)
-            .ToListAsync();
-
-        return await dataSetVersions
-            .Where(dsv => dsv.Version == dataSetVersion)
-            .SingleOrDefault()
-            .OrNotFound();
+            .SingleOrNotFound();
     }
 
     private static DataSetLatestVersionViewModel MapLatestVersion(DataSetVersion latestVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetService.cs
@@ -13,6 +13,10 @@ public interface IDataSetService
         int pageSize, 
         Guid publicationId);
 
+    Task<Either<ActionResult, DataSetVersionViewModel>> GetVersion(
+        Guid dataSetId, 
+        string dataSetVersion);
+
     Task<Either<ActionResult, DataSetVersionPaginatedListViewModel>> ListVersions(
         int page,
         int pageSize,


### PR DESCRIPTION
Adding an endpoint for retrieving a single Data Set Version.

The endpoint lives at `api/v1/data-sets/{dataSetId}/versions/{version}`.

The endpoint returns the following status codes:
- 200
- 404

And returns the following JSON response when the response is a 200 OK:

```json
{
  "number": "string",
  "type": "string",
  "status": "string",
  "published": "string(datetime)",
  "unpublished": "string(datetime)",
  "notes": "string",
  "totalResults": 0,
  "timePeriods": {
    "start": "string",
    "end": "string"
  },
  "geographicLevels": [
    "string"
  ],
  "filters": [
    "string"
  ],
  "indicators": [
    "string"
  ]
}
```