### PR TITLE
EES-4814 - fixing Robot test run issues around logout under Entra ID.  Making logout under Keycloak more consistent.

### DIFF
--- a/docker/keycloak/keycloak-ees-realm.json
+++ b/docker/keycloak/keycloak-ees-realm.json
@@ -5,8 +5,8 @@
   "defaultSignatureAlgorithm" : "RS256",
   "revokeRefreshToken" : false,
   "refreshTokenMaxReuse" : 0,
-  "accessTokenLifespan" : 300,
-  "accessTokenLifespanForImplicitFlow" : 900,
+  "accessTokenLifespan" : 1800,
+  "accessTokenLifespanForImplicitFlow" : 1800,
   "ssoSessionIdleTimeout" : 1800,
   "ssoSessionMaxLifespan" : 36000,
   "ssoSessionIdleTimeoutRememberMe" : 0,
@@ -363,16 +363,8 @@
   "webAuthnPolicyPasswordlessCreateTimeout" : 0,
   "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
   "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
-  "clientProfiles" : {
-    "profiles" : [ ]
-  },
-  "clientPolicies" : {
-    "policies" : [ {
-      "name" : "builtin-default-policy",
-      "builtin" : true,
-      "enable" : false
-    } ]
-  },
+  "clientProfiles" : { },
+  "clientPolicies" : { },
   "users" : [ {
     "id" : "ff6f5bd8-9ee4-4ae8-b4c0-04e2e518f807",
     "createdTimestamp" : 1621852447135,
@@ -484,28 +476,6 @@
     "notBefore" : 0,
     "groups" : [ ]
   }, {
-    "id" : "b70d480c-38f0-4c98-9920-ddcfcaa24986",
-    "createdTimestamp" : 1707388396992,
-    "username" : "pendinginvite",
-    "enabled" : true,
-    "totp" : false,
-    "emailVerified" : true,
-    "firstName" : "Pending",
-    "lastName" : "Invite",
-    "email" : "ees-test.pendinginvite@education.gov.uk",
-    "credentials" : [ {
-      "id" : "a33d59a1-543c-421f-b8bd-5c2445e51a54",
-      "type" : "password",
-      "createdDate" : 1707388408898,
-      "secretData" : "{\"value\":\"pQpynymlYx3+J8BbcA/4/SQRNe86TF5E6mqI/zlDx9/hJpKW1WKQx3/TvGpG7c4KKXoPUQ/VV8KvNPys6MJ6zw==\",\"salt\":\"2P1o7V0XUDcoelZfh4Tg8w==\",\"additionalParameters\":{}}",
-      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
-    } ],
-    "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ ],
-    "realmRoles" : [ "default-roles-ees" ],
-    "notBefore" : 0,
-    "groups" : [ ]
-  }, {
     "id" : "dd13c7f2-f6f4-467c-8b87-b73cc795aa1c",
     "createdTimestamp" : 1621850929630,
     "username" : "expiredinvite",
@@ -542,6 +512,28 @@
       "type" : "password",
       "createdDate" : 1707301207444,
       "secretData" : "{\"value\":\"xJV5QojBoi8RUz6zwgMRuAQI7jL5uilVEC0HmPw6+RkP8wGND4o2NFiZ/FmfyCDi+cjv2hs4rqqRo7n0B+SiJQ==\",\"salt\":\"Z5nlX9SLfCaTmWxao/552Q==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-ees" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "b70d480c-38f0-4c98-9920-ddcfcaa24986",
+    "createdTimestamp" : 1707388396992,
+    "username" : "pendinginvite",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "Pending",
+    "lastName" : "Invite",
+    "email" : "ees-test.pendinginvite@education.gov.uk",
+    "credentials" : [ {
+      "id" : "a33d59a1-543c-421f-b8bd-5c2445e51a54",
+      "type" : "password",
+      "createdDate" : 1707388408898,
+      "secretData" : "{\"value\":\"pQpynymlYx3+J8BbcA/4/SQRNe86TF5E6mqI/zlDx9/hJpKW1WKQx3/TvGpG7c4KKXoPUQ/VV8KvNPys6MJ6zw==\",\"salt\":\"2P1o7V0XUDcoelZfh4Tg8w==\",\"additionalParameters\":{}}",
       "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
     } ],
     "disableableCredentialTypes" : [ ],
@@ -732,7 +724,7 @@
     "enabled" : true,
     "alwaysDisplayInConsole" : false,
     "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ "https://localhost:5021/dashboard", "https://ees.local:5021/dashboard" ],
+    "redirectUris" : [ "https://localhost:5021/signed-out", "https://ees.local:5021/signed-out", "https://localhost:5021/dashboard", "https://ees.local:5021/dashboard" ],
     "webOrigins" : [ "https://localhost:5021", "https://ees.local:5021" ],
     "notBefore" : 0,
     "bearerOnly" : false,
@@ -1380,7 +1372,7 @@
       "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "oidc-full-name-mapper", "oidc-sha256-pairwise-sub-mapper" ]
+        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "saml-user-property-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "oidc-address-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper" ]
       }
     }, {
       "id" : "0eec2c28-82d2-4e0d-bb5c-ae54b79e000c",
@@ -1398,7 +1390,7 @@
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-usermodel-property-mapper", "saml-role-list-mapper", "oidc-address-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "oidc-full-name-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "saml-user-attribute-mapper", "oidc-address-mapper", "saml-user-property-mapper" ]
       }
     }, {
       "id" : "137d1b2b-936f-4d73-924e-13b6362ed036",
@@ -1446,7 +1438,7 @@
   "internationalizationEnabled" : false,
   "supportedLocales" : [ ],
   "authenticationFlows" : [ {
-    "id" : "2fcafb86-5cc9-4bdc-b533-693f6c869226",
+    "id" : "c18bd115-7ade-4895-94c3-9776fefcab5d",
     "alias" : "Account verification options",
     "description" : "Method with which to verity the existing account",
     "providerId" : "basic-flow",
@@ -1468,7 +1460,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "0edb0c06-6d42-42e9-ad0c-fc99a1e3966d",
+    "id" : "f2498a39-5f39-40a4-88b0-6de63317a4b2",
     "alias" : "Authentication Options",
     "description" : "Authentication options.",
     "providerId" : "basic-flow",
@@ -1497,7 +1489,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "52eb911b-df39-48d3-9b18-a51ac17e2abd",
+    "id" : "1d74f486-830b-4473-98a2-184518554443",
     "alias" : "Browser - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1519,7 +1511,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "4e96467d-a084-41a5-aa82-c2a4c077e5e2",
+    "id" : "46d3a450-6fb2-4b69-97e6-eb8e9b1b5af9",
     "alias" : "Direct Grant - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1541,7 +1533,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "b31ae24a-cd66-4cde-907c-4a5fbab90b78",
+    "id" : "46daefc1-877c-4bf4-8c56-f8a3a9a289ab",
     "alias" : "First broker login - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1563,7 +1555,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "00b0d7a7-387b-4a24-8109-c36f30bd7313",
+    "id" : "dc737ff0-a223-42a9-b7f2-68c446953ca4",
     "alias" : "Handle Existing Account",
     "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
     "providerId" : "basic-flow",
@@ -1585,7 +1577,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "4c011d16-cfcc-4621-bcfe-15769d3917b4",
+    "id" : "6ba5efbd-85dc-41f6-a44b-0b7e1fe63be6",
     "alias" : "Reset - Conditional OTP",
     "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
     "providerId" : "basic-flow",
@@ -1607,7 +1599,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "22d28bc9-9fab-45d3-81b0-edeb80570f20",
+    "id" : "714919f8-c169-4651-b888-e3043bf668e8",
     "alias" : "User creation or linking",
     "description" : "Flow for the existing/non-existing user alternatives",
     "providerId" : "basic-flow",
@@ -1630,7 +1622,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "1bca99b5-fe1e-4ff0-a299-54a50d6a2e01",
+    "id" : "28d2123d-51c2-45ba-aa6c-14aba0b81e14",
     "alias" : "Verify Existing Account by Re-authentication",
     "description" : "Reauthentication of existing account",
     "providerId" : "basic-flow",
@@ -1652,7 +1644,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "1f7f431a-c56a-4b6c-9bf6-95a10a08c4f9",
+    "id" : "9fc7ffd8-c36f-43d9-bca1-646997f471cf",
     "alias" : "browser",
     "description" : "browser based authentication",
     "providerId" : "basic-flow",
@@ -1688,7 +1680,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "66922dc1-4db2-4e08-8fdd-b0ef5f690b98",
+    "id" : "dc057e8a-3bd5-49e0-99ca-e25cf6c6418d",
     "alias" : "clients",
     "description" : "Base authentication for clients",
     "providerId" : "client-flow",
@@ -1724,7 +1716,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "ada93900-22f9-42b5-b088-e8ebe9139aa3",
+    "id" : "c8e858de-e780-4d85-a3ad-4875a30394d5",
     "alias" : "direct grant",
     "description" : "OpenID Connect Resource Owner Grant",
     "providerId" : "basic-flow",
@@ -1753,7 +1745,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "a22f8326-4cda-47f9-825b-00c6d4e2d383",
+    "id" : "3e19e929-cb8e-4dea-87be-c16379319042",
     "alias" : "docker auth",
     "description" : "Used by Docker clients to authenticate against the IDP",
     "providerId" : "basic-flow",
@@ -1768,7 +1760,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "b7d5a38a-6060-48a3-99cd-df0c929a3cc6",
+    "id" : "6acfbba2-67c7-4084-a0ed-2effb184275b",
     "alias" : "first broker login",
     "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
     "providerId" : "basic-flow",
@@ -1791,7 +1783,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "d4ad385e-0070-42fd-ae5e-d87c16c4eb66",
+    "id" : "201401cd-092b-4130-9fce-1fb5d6197471",
     "alias" : "forms",
     "description" : "Username, password, otp and other auth forms.",
     "providerId" : "basic-flow",
@@ -1813,7 +1805,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "22f62e3b-6538-45c4-935b-2e51b14ffa32",
+    "id" : "58dc95dc-b6e3-4088-9619-487fcaca8a64",
     "alias" : "http challenge",
     "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
     "providerId" : "basic-flow",
@@ -1835,7 +1827,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "f06aab32-3857-4b6f-ac07-dac86754bf7b",
+    "id" : "f297d5c5-84cc-4e1d-86ce-1d962fe12df5",
     "alias" : "registration",
     "description" : "registration flow",
     "providerId" : "basic-flow",
@@ -1851,7 +1843,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "0736d0d6-9e1a-4b26-a033-5c0c455c8234",
+    "id" : "811ec90c-c9f9-4739-b599-fb716a2363f4",
     "alias" : "registration form",
     "description" : "registration form",
     "providerId" : "form-flow",
@@ -1887,7 +1879,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "e4b028de-3113-4e8d-99c3-6f99d391c8e9",
+    "id" : "efc5e8fa-47ee-4d12-918a-da18dfa6cfcf",
     "alias" : "reset credentials",
     "description" : "Reset credentials for a user if they forgot their password or something",
     "providerId" : "basic-flow",
@@ -1923,7 +1915,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "92adbf10-56e0-46e7-98fe-46dc0aafb40c",
+    "id" : "0cf35568-713c-476d-8ba7-4a40c3097216",
     "alias" : "saml ecp",
     "description" : "SAML ECP Profile Authentication Flow",
     "providerId" : "basic-flow",
@@ -1939,13 +1931,13 @@
     } ]
   } ],
   "authenticatorConfig" : [ {
-    "id" : "af7f04b6-dff1-4cc7-a242-c33f00784d2b",
+    "id" : "2d2f20cb-d991-4b90-b25b-a3c9e44574c5",
     "alias" : "create unique user config",
     "config" : {
       "require.password.update.after.registration" : "false"
     }
   }, {
-    "id" : "c587f02e-4e68-4fbb-ab35-a14a6ce2e873",
+    "id" : "cfec98e3-5695-475b-bb23-9d59988b341b",
     "alias" : "review profile config",
     "config" : {
       "update.profile.on.first.login" : "missing"

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ConfigurationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ConfigurationControllerTests.cs
@@ -61,6 +61,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             Assert.Equal($"{realm}/protocol/openid-connect/token", authorityMetadata.TokenEndpoint);
             Assert.Equal(realm, authorityMetadata.Issuer);
             Assert.Equal($"{realm}/protocol/openid-connect/userinfo", authorityMetadata.UserInfoEndpoint);
+            Assert.Equal($"{realm}/protocol/openid-connect/logout", authorityMetadata.EndSessionEndpoint);
         }
 
         private static IConfiguration GetConfiguration()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ClaimsPrincipalTransformationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ClaimsPrincipalTransformationServiceTests.cs
@@ -82,6 +82,7 @@ public class ClaimsPrincipalTransformationServiceTests : IntegrationTest<TestSta
             .WithWebHostBuilder(builder => builder
                 .WithAdditionalControllers(typeof(TestController)))
             .SetUser(claimsPrincipal)
+            .ResetUsersAndRolesDbContext()
             .AddUsersAndRolesDbTestData(context =>
             {
                 var globalRoles = GetGlobalRoles();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ConfigurationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ConfigurationController.cs
@@ -55,6 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         public string TokenEndpoint { get; set; } = null!;
         public string Issuer { get; set; } = null!;
         public string UserInfoEndpoint { get; set; } = null!;
+        public string EndSessionEndpoint { get; set; } = null!;
     }
 
     public class OpenIdConnectSpaClientOptions

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Keycloak.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Keycloak.json
@@ -46,7 +46,8 @@
       "AuthorizationEndpoint": "https://ees.local:5031/auth/realms/ees-realm/protocol/openid-connect/auth",
       "TokenEndpoint": "https://ees.local:5031/auth/realms/ees-realm/protocol/openid-connect/token",
       "Issuer": "https://ees.local:5031/auth/realms/ees-realm",
-      "UserInfoEndpoint": "https://ees.local:5031/auth/realms/ees-realm/protocol/openid-connect/userinfo"
+      "UserInfoEndpoint": "https://ees.local:5031/auth/realms/ees-realm/protocol/openid-connect/userinfo",
+      "EndSessionEndpoint": "https://ees.local:5031/auth/realms/ees-realm/protocol/openid-connect/logout"
     }
   }
 }

--- a/src/explore-education-statistics-admin/src/components/PageHeader.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageHeader.tsx
@@ -123,15 +123,6 @@ interface LoggedInLinksProps {
 
 const LoggedInLinks = ({ user }: LoggedInLinksProps) => (
   <>
-    {/* EES-2464
-      {user.permissions.canAccessAnalystPages && (
-      <li className="govuk-header__navigation-item">
-        <a className="govuk-header__link" href="/documentation">
-          Administrators' guide
-        </a>
-      </li>
-    )} */}
-
     {user.permissions.isBauUser && (
       <li className="govuk-header__navigation-item">
         <a className="govuk-header__link" href="/administration">
@@ -143,6 +134,7 @@ const LoggedInLinks = ({ user }: LoggedInLinksProps) => (
       <ButtonText
         className={`govuk-header__link ${styles.signOutLink}`}
         onClick={() => handleLogout()}
+        testId="header-sign-out-button"
       >
         Sign out
       </ButtonText>

--- a/src/explore-education-statistics-admin/src/config.ts
+++ b/src/explore-education-statistics-admin/src/config.ts
@@ -8,6 +8,7 @@ export interface OidcConfig {
     readonly tokenEndpoint: string;
     readonly issuer: string;
     readonly userInfoEndpoint: string;
+    readonly endSessionEndpoint: string;
   };
 }
 

--- a/src/explore-education-statistics-admin/src/contexts/ConfigContext.tsx
+++ b/src/explore-education-statistics-admin/src/contexts/ConfigContext.tsx
@@ -46,6 +46,7 @@ const defaultTestConfig: Config = {
       tokenEndpoint: '',
       issuer: '',
       userInfoEndpoint: '',
+      endSessionEndpoint: '',
     },
   },
 };

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
@@ -14,7 +14,8 @@ import WarningMessage from '@common/components/WarningMessage';
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import methodologyQueries from '@admin/queries/methodologyQueries';
-import { signOutRoute } from '@admin/routes/routes';
+import { handleLogout } from '@admin/auth/msal';
+import ButtonText from '@common/components/ButtonText';
 
 const AdminDashboardPage = () => {
   const { user } = useAuthContext();
@@ -66,10 +67,15 @@ const AdminDashboardPage = () => {
           <p className="govuk-body-s">
             {user && (
               <>
-                Logged in as <strong>{user?.name}</strong>. Not you?{' '}
+                Logged in as <strong>{user.name}</strong>. Not you?{' '}
               </>
             )}
-            <Link to={signOutRoute.path}>Sign out</Link>
+            <ButtonText
+              onClick={() => handleLogout()}
+              testId="dashboard-sign-out-button"
+            >
+              Sign out
+            </ButtonText>
           </p>
 
           {isApprover && totalApprovals > 0 && (

--- a/src/explore-education-statistics-admin/src/routes/routes.ts
+++ b/src/explore-education-statistics-admin/src/routes/routes.ts
@@ -50,8 +50,8 @@ export const signInRoute: PublicRouteProps = {
   exact: true,
 };
 
-export const signOutRoute: PublicRouteProps = {
-  path: '/sign-out',
+export const signedOutRoute: PublicRouteProps = {
+  path: '/signed-out',
   component: SignedOutPage,
   exact: true,
 };
@@ -177,7 +177,7 @@ export const releaseDataGuidanceRoute: ProtectedRouteProps = {
 
 export const publicRoutes = {
   signInRoute,
-  signOutRoute,
+  signedOutRoute,
   expiredInviteRoute,
   noInvitationRoute,
 };

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -245,7 +245,7 @@ def run():
         if failing_suites:
             logger.info(f"Number of failing suites: {len(failing_suites)}")
             logger.info(f"Failing suites:")
-            [logger.info(r"  * file://" + suite.strip()) for suite in failing_suites]
+            [logger.info(r"  * file://" + suite) for suite in failing_suites]
         else:
             logger.info("\nAll tests passed!")
 

--- a/tests/robot-tests/tests/admin/authentication/login_and_logout.robot
+++ b/tests/robot-tests/tests/admin/authentication/login_and_logout.robot
@@ -1,0 +1,59 @@
+*** Settings ***
+Library             ../../libs/admin_api.py
+Resource            ../../libs/admin-common.robot
+
+Suite Setup         user opens the browser
+Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
+
+Force Tags          Admin    Local    Dev
+
+
+*** Test Cases ***
+Log in as BAU and check the dashboard is looking OK and the sign out buttons are available
+    user navigates to admin frontend    %{ADMIN_URL}/dashboard
+    user waits until h1 is visible    Sign in
+    user clicks element    id:signin-button
+    user logs in via identity provider
+    ...    %{ADMIN_EMAIL}
+    ...    %{ADMIN_PASSWORD}
+    user waits until page contains title    Dashboard
+    user waits until page contains    Welcome Bau1
+    user waits until page contains    Logged in as Bau1
+
+Log out using the button in the page header
+    user clicks element    testid:header-sign-out-button
+    user waits until page contains title    Signed out
+
+Check that logging out via the header link has successfully removed the ability to access the dashboard
+    user navigates to admin frontend    %{ADMIN_URL}/dashboard
+    user waits until page contains title    Sign in
+
+Log in again and log out using the button in the dashboard
+    user clicks element    id:signin-button
+    user logs in via identity provider
+    ...    %{ADMIN_EMAIL}
+    ...    %{ADMIN_PASSWORD}
+    ...    True
+    user waits until page contains title    Dashboard
+    user waits until page contains element    testid:dashboard-sign-out-button
+    user clicks element    testid:dashboard-sign-out-button
+    user waits until page contains title    Signed out
+
+Check that logging out with the dashboard link has successfully removed the ability to access the dashboard
+    user navigates to admin frontend    %{ADMIN_URL}/dashboard
+    user waits until page contains title    Sign in
+
+Switch users in the same browser
+    user clicks element    id:signin-button
+    user logs in via identity provider
+    ...    %{ADMIN_EMAIL}
+    ...    %{ADMIN_PASSWORD}
+    ...    True
+
+    # This is testing our optimised user switching behaviour where we reuse access tokens for each user
+    # to log in rather than carrying out a full login flow via the Identity Provider.
+    user changes to analyst1
+    user changes to bau1
+    user changes to analyst1
+    user changes to bau1

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -11,7 +11,10 @@ ${ANALYST1_BROWSER}=    analyst1
 
 *** Keywords ***
 user logs in via identity provider
-    [Arguments]    ${email}    ${password}
+    [Arguments]
+    ...    ${email}
+    ...    ${password}
+    ...    ${expect_account_selection_page}=False
 
     IF    "%{IDENTITY_PROVIDER}" == "KEYCLOAK"
         user waits until page contains element    xpath://h1[contains(text(), "Sign in to your account")]
@@ -19,9 +22,16 @@ user logs in via identity provider
         user enters text into element    id:password    ${password}
         user clicks element    id:kc-login
     ELSE IF    "%{IDENTITY_PROVIDER}" == "AZURE"
-        user waits until page contains element    xpath://*[.='Sign in']
-        user enters text into element    xpath://*[@name='loginfmt']    ${email}
-        user clicks element    //*[@type='submit']
+        IF    ${expect_account_selection_page}
+            user waits until page contains    Pick an account
+            user clicks element
+            ...    xpath://div[contains(translate(text(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '${email}')]
+        ELSE
+            user waits until page contains element    xpath://*[.='Sign in']
+            user enters text into element    xpath://*[@name='loginfmt']    ${email}
+            user clicks element    //*[@type='submit']
+        END
+
         user waits until page contains element    xpath://*[@name='passwd']
         user enters text into element    xpath://*[@name='passwd']    ${password}
         user clicks element    xpath://*[@type='submit']
@@ -62,12 +72,20 @@ user switches to analyst1 browser
     user switches browser    ${ANALYST1_BROWSER}
 
 user changes to bau1
-    user clicks button    Sign out    css:#navigation
+    user logs out
     user signs in as bau1    False
 
 user changes to analyst1
-    user clicks button    Sign out    css:#navigation
+    user logs out
     user signs in as analyst1    False
+
+user logs out
+    user clicks element    testid:header-sign-out-button
+    IF    "%{IDENTITY_PROVIDER}" == "KEYCLOAK"
+        user waits until page contains title    Signed out
+    ELSE IF    "%{IDENTITY_PROVIDER}" == "AZURE"
+        user waits until page contains    signed out of your account
+    END
 
 user selects dashboard theme and topic if possible
     [Arguments]

--- a/tests/robot-tests/tests/libs/fail_fast.py
+++ b/tests/robot-tests/tests/libs/fail_fast.py
@@ -4,6 +4,7 @@ their Tests fails.  If the "fail tests suites fast" option is enabled, this file
 scripts, firstly to record that a test suite is failing, and then again on subsequent Tests starting to see if they
 should continue to run or if they should fail immediately and therefore fail the test suite immediately.
 """
+
 import os.path
 
 from robot.libraries.BuiltIn import BuiltIn
@@ -22,7 +23,7 @@ def _get_current_test_suite() -> str:
 def current_test_suite_failing_fast() -> bool:
     test_suite = _get_current_test_suite()
     failing_suites = get_failing_test_suites()
-    return f"{test_suite}{os.linesep}" in failing_suites
+    return f"{test_suite}" in failing_suites
 
 
 def record_failing_test_suite():
@@ -51,10 +52,11 @@ def get_failing_test_suites() -> []:
         #
         # We therefore explicitly remove any duplicates from the list here.
 
-        file = open(failing_suites_filename, "r")
-        failing_suites = file.readlines()
-        file.close()
-        return list(dict.fromkeys(failing_suites))
+        with open(failing_suites_filename, "r") as file:
+            failing_suites = file.readlines()
+            stripped_suite_names = [failing_suite.strip() for failing_suite in failing_suites]
+            filtered_suite_names = filter(None, stripped_suite_names)
+            return list(dict.fromkeys(filtered_suite_names))
     return []
 
 


### PR DESCRIPTION
:warning: Keycloak Docker containers and images need to be dropped and recreated when this PR goes in.

:warning: All App Registrations for Admin SPAs across each environment will need to be configured to return the optional "login_hint" Claim to enable silent logout.

# Overview

This PR aims to fix issues that some team members are experiencing around inconsistent logout behaviour when running under Entra ID.

It also brings Keycloak logout behaviour more in line with Entra ID's logout by supplying a logout endpoint in the authority metadata so that a full logout redirect flow can be supported which results in the user being logged out of Keycloak as well as the app, thus ensuring they log in again instead of just hitting "Sign in" and being magically signed in again!

I've added a new login and logout Robot test as well, for testing various logout cases.

# Other changes

## Silent logout

I've configured the App Registration for our local development Admin SPA to support silent logout so that we don't have to select an account when logging out.  By adding the "login_hint" optional Claim to the ID token that Entra ID returns, this will allow Entra ID to know who is logging out.

## Potential fix to ClaimPrincipalTransformationTests

I've added a "ResetUsersAndRolesDbContext()" to ClaimPrincipalTransformationTests in order to ensure it starts with a fresh InMemory db.

## Increased the access token lifetime for Keycloak

As a temporary fix for 401s caused by direct-to-API calls during slower UI test runs (e.g. admin_api.delete_test_user) when using Keycloak, I've increase the lifetime of the tokens it issues.  The real fix is to reauthenticate on getting 401s with these direct API calls during Robot test runs, but that'll take a bit longer to put in place properly.

# UI test results

## Using Entra ID

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/60cb49dd-6009-4be8-8cb0-33c8ad14f17f)

## Using Keycloak

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/6c63db5f-8f63-4469-b81d-22b301fc71d1)
