### PR TITLE
EES-4923 prevent validation errors for emails in content blocks

### DIFF
--- a/src/explore-education-statistics-admin/src/components/form/FormFieldEditor.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/FormFieldEditor.tsx
@@ -162,11 +162,12 @@ function getInvalidLinks(elements: Element[]) {
       const url = attributes.linkHref as string;
 
       try {
-        // exclude anchor links and localhost as they fail Yup url validation.
+        // exclude anchor links, localhost and emails as they fail Yup url validation.
         if (
           url &&
           !url.startsWith('#') &&
-          !url.startsWith('http://localhost')
+          !url.startsWith('http://localhost') &&
+          !url.startsWith('mailto:')
         ) {
           Yup.string().url().validateSync(url.trim());
         }


### PR DESCRIPTION
The URL validation on text blocks in releases was preventing adding `mailto` links, this prevents the validation from catching them.