### PR TITLE
EES-4935 ensure govuk styles are loaded first

### DIFF
--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -1,5 +1,3 @@
-// Load app styles first to ensure correct style ordering
-import './styles/_all.scss';
 import PageErrorBoundary from '@admin/components/PageErrorBoundary';
 import ProtectedRoute from '@admin/components/ProtectedRoute';
 import { AuthContextProvider } from '@admin/contexts/AuthContext';

--- a/src/explore-education-statistics-admin/src/index.tsx
+++ b/src/explore-education-statistics-admin/src/index.tsx
@@ -1,3 +1,5 @@
+// Load app styles first to ensure correct style ordering
+import './styles/_all.scss';
 import '@admin/polyfill';
 import configureAxios from '@admin/services/utils/configureAxios';
 import React from 'react';


### PR DESCRIPTION
Moves the import of the global styles to try to ensure that they get loaded before the module styles.

This fixes styling bugs in the admin caused by gov.uk styles overriding module styles.