### PR TITLE
Add `--dump-sql` option to `seed:data` script

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="CliFx" Version="2.3.5" />
+      <PackageReference Include="CliWrap" Version="3.6.6" />
       <PackageReference Include="Dapper" Version="2.1.24" />
       <PackageReference Include="DuckDB.NET.Data.Full" Version="0.9.2" />
       <PackageReference Include="linq2db.EntityFrameworkCore" Version="8.0.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/README.md
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/README.md
@@ -13,16 +13,12 @@ To run any of these scripts, you can either:
 
 ## Seed data - `seed:data`
 
-Data for the public data API can be seeded using this command. To run, simply:
-
-```bash
-dotnet run -- seed:data
-```
+Data for the public data API can be seeded using this command.
 
 ### Prerequisites
 
-Before using this command, you will first need to place any required seed CSVs in the `SeedFiles` directory. The seed 
-CSVs can be found in Google Drive.
+Before using this command, you will first need to place any required seed CSVs in the `SeedFiles` 
+directory. The seed CSVs can be found in Google Drive.
 
 Once you have done this, ensure the public API Docker database is running:
 
@@ -33,3 +29,21 @@ docker-compose up -d public-api-db
 # Via project start script
 pnpm start publicApiDb
 ```
+
+### Usage
+
+```bash
+dotnet run -- seed:data
+```
+
+Additional options can be provided to the script after `seed:data` argument like:
+
+```bash
+dotnet run -- seed:data --dump-sql
+```
+
+### Options
+
+- `--dump-sql` 
+  - Creates an SQL dump of the seed data at `data/public-api-db/public_data.sql`
+  - Useful for creating seed data dumps for Google Drive.


### PR DESCRIPTION
This PR adds a `--dump-sql` option to the `seed:data` script so that we can conveniently dump out seed data SQL at the end of the script.

This is a minor quality of life improvement to help us create new seed data dumps.