### PR TITLE
EES- 4822/Use 301 for Redirects

### DIFF
--- a/src/explore-education-statistics-frontend/next.config.js
+++ b/src/explore-education-statistics-frontend/next.config.js
@@ -24,25 +24,6 @@ const nextConfig = {
     GA_TRACKING_ID: process.env.GA_TRACKING_ID,
     PUBLIC_URL: process.env.PUBLIC_URL,
   },
-  async redirects() {
-    return [
-      {
-        source: '/download-latest-data',
-        destination: '/data-catalogue',
-        permanent: true,
-      },
-      {
-        source: '/find-statistics/:publication/meta-guidance',
-        destination: '/find-statistics/:publication/data-guidance',
-        permanent: true,
-      },
-      {
-        source: '/find-statistics/:publication/:release/meta-guidance',
-        destination: '/find-statistics/:publication/:release/data-guidance',
-        permanent: true,
-      },
-    ];
-  },
   async headers() {
     return [
       {

--- a/src/explore-education-statistics-frontend/server.js
+++ b/src/explore-education-statistics-frontend/server.js
@@ -69,13 +69,16 @@ async function startServer() {
   const server = express();
 
   function replaceLastOccurance(input, pattern, replacement) {
-    if (input === undefined || input === null || input.length === 0) {
+    if (
+      input === undefined ||
+      input === null ||
+      input.length === 0 ||
+      !input.endsWith(pattern)
+    ) {
       return input;
     }
 
-    return input.endsWith(pattern)
-      ? `${input.slice(0, -pattern.length)}${replacement}`
-      : input;
+    return `${input.slice(0, -pattern.length)}${replacement}`;
   }
 
   // Redirect URLs with trailing slash to equivalent without slash with 301
@@ -89,7 +92,7 @@ async function startServer() {
       '/data-catalogue',
     );
 
-    if (newUri !== req.url) {
+    if (newUri !== req.url && newUri !== '') {
       return res.redirect(301, newUri);
     }
     nextNotShadowed();

--- a/src/explore-education-statistics-frontend/server.js
+++ b/src/explore-education-statistics-frontend/server.js
@@ -68,6 +68,34 @@ async function startServer() {
 
   const server = express();
 
+  function replaceLastOccurance(input, pattern, replacement) {
+    if (input === undefined || input === null || input.length === 0) {
+      return input;
+    }
+
+    return input.endsWith(pattern)
+      ? `${input.slice(0, -pattern.length)}${replacement}`
+      : input;
+  }
+
+  // Redirect URLs with trailing slash to equivalent without slash with 301
+  server.use((req, res, nextNotShadowed) => {
+    let newUri = req.url;
+    newUri = replaceLastOccurance(newUri, '/', '');
+    newUri = replaceLastOccurance(newUri, '/meta-guidance', '/data-guidance');
+    newUri = replaceLastOccurance(
+      newUri,
+      '/download-latest-data',
+      '/data-catalogue',
+    );
+
+    if (newUri !== req.url) {
+      return res.redirect(301, newUri);
+    }
+    nextNotShadowed();
+    return undefined;
+  });
+
   server.use(
     helmet({
       contentSecurityPolicy: {

--- a/src/explore-education-statistics-frontend/server.js
+++ b/src/explore-education-statistics-frontend/server.js
@@ -82,7 +82,7 @@ async function startServer() {
   }
 
   // Redirect URLs with trailing slash to equivalent without slash with 301
-  server.use((req, res, nextNotShadowed) => {
+  server.use((req, res, nextFunc) => {
     let newUri = req.url;
     newUri = replaceLastOccurance(newUri, '/', '');
     newUri = replaceLastOccurance(newUri, '/meta-guidance', '/data-guidance');
@@ -95,7 +95,7 @@ async function startServer() {
     if (newUri !== req.url && newUri !== '') {
       return res.redirect(301, newUri);
     }
-    nextNotShadowed();
+    nextFunc();
     return undefined;
   });
 

--- a/tests/playwright-tests/tests/public/redirects.spec.ts
+++ b/tests/playwright-tests/tests/public/redirects.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import environment from '@util/env';
+
+const { PUBLIC_URL } = environment;
+
+test.describe('Redirect behaviour', () => {
+  test('Absolute paths with trailing slashes are redirected without them', async ({
+    page,
+  }) => {
+    await page.goto(`${PUBLIC_URL}/data-catalogue/`);
+    await expect(page).toHaveURL(`${PUBLIC_URL}/data-catalogue`);
+
+    await page.goto(`${PUBLIC_URL}/data-catalogue`);
+    await expect(page).toHaveURL(`${PUBLIC_URL}/data-catalogue`);
+
+    await page.goto(`${PUBLIC_URL}/glossary/?someRandomUrlParameter=123`);
+    await expect(page).toHaveURL(
+      `${PUBLIC_URL}/glossary?someRandomUrlParameter=123`,
+    );
+
+    // Would be amazing if we could assert that these redirects
+    // were done with a 301 rather than a 308...
+  });
+
+  test('Redirects do not affect browser history', async ({ page }) => {
+    await page.goto(`about:blank`);
+
+    await page.goto(`${PUBLIC_URL}/data-catalogue/`);
+    await expect(page).toHaveURL(`${PUBLIC_URL}/data-catalogue`);
+
+    await page.goBack();
+    await expect(page).toHaveURL(`about:blank`);
+  });
+
+  test('Routes without an absolute path still permit trailing slashes', async ({
+    page,
+  }) => {
+    await page.goto('http://localhost:3000');
+    await expect(page).toHaveURL('http://localhost:3000/');
+
+    await page.goto('http://localhost:3000/');
+    await expect(page).toHaveURL('http://localhost:3000/');
+  });
+
+  test('meta-guidance is redirected to data-guidance', async ({ page }) => {
+    await page.goto(
+      `${PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance`,
+    );
+    await expect(page).toHaveURL(
+      `${PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance`,
+    );
+
+    await page.goto(
+      `${PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance/`,
+    );
+    await expect(page).toHaveURL(
+      `${PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance`,
+    );
+  });
+
+  test('download-latest-data is redirected to data-catalogue', async ({
+    page,
+  }) => {
+    await page.goto(`${PUBLIC_URL}/download-latest-data`);
+    await expect(page).toHaveURL(`${PUBLIC_URL}/data-catalogue`);
+
+    await page.goto(`${PUBLIC_URL}/download-latest-data/`);
+    await expect(page).toHaveURL(`${PUBLIC_URL}/data-catalogue`);
+  });
+});

--- a/tests/robot-tests/tests/general_public/redirects.robot
+++ b/tests/robot-tests/tests/general_public/redirects.robot
@@ -1,0 +1,44 @@
+*** Settings ***
+Resource            ../libs/public-common.robot
+
+Suite Setup         user opens the browser
+Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
+
+Force Tags          GeneralPublic    Local    Dev    Test    Preprod    Prod
+
+
+*** Test Cases ***
+Verify that absolute paths with trailing slashes are redirected without them
+    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/
+    user waits until page contains    Browse our open data
+    browser should be at address    %{PUBLIC_URL}/data-catalogue
+
+    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue
+    user waits until page contains    Browse our open data
+    browser should be at address    %{PUBLIC_URL}/data-catalogue
+
+    user navigates to public frontend    %{PUBLIC_URL}/glossary/?someRandomUrlParameter=123
+    user waits until page contains    Glossary
+    browser should be at address    %{PUBLIC_URL}/glossary?someRandomUrlParameter=123
+
+    # Would be amazing if we could verify these redirects were done with a 301 rather than a 308...
+
+Verify that redirects do not affect browser history
+    user navigates to    about:blank
+
+    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/
+    user waits until page contains    Browse our open data
+    browser should be at address    %{PUBLIC_URL}/data-catalogue
+
+    browser navigates    back
+    browser should be at address    about:blank
+
+Verify that routes without an absolute path still permit trailing slashes
+    user navigates to public frontend    %{PUBLIC_URL}/
+    user waits until page contains    Explore education statistics
+    browser should be at address    %{PUBLIC_URL}/
+
+    user navigates to public frontend    %{PUBLIC_URL}
+    user waits until page contains    Explore education statistics
+    browser should be at address    %{PUBLIC_URL}/

--- a/tests/robot-tests/tests/general_public/redirects.robot
+++ b/tests/robot-tests/tests/general_public/redirects.robot
@@ -42,3 +42,21 @@ Verify that routes without an absolute path still permit trailing slashes
     user navigates to public frontend    %{PUBLIC_URL}
     user waits until page contains    Explore education statistics
     browser should be at address    %{PUBLIC_URL}/
+
+Verify that meta-guidance is redirected to data-guidance
+    user navigates to public frontend    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance
+    user waits until page contains    Seed publication - Release Approver
+    browser should be at address    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance
+
+    user navigates to public frontend    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance/
+    user waits until page contains    Seed publication - Release Approver
+    browser should be at address    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance
+
+Verify that download-latest-data is redirected to data-catalogue
+    user navigates to public frontend    %{PUBLIC_URL}/download-latest-data
+    user waits until page contains    Browse our open data
+    browser should be at address    %{PUBLIC_URL}/data-catalogue
+
+    user navigates to public frontend    %{PUBLIC_URL}/download-latest-data/
+    user waits until page contains    Browse our open data
+    browser should be at address    %{PUBLIC_URL}/data-catalogue

--- a/tests/robot-tests/tests/general_public/redirects.robot
+++ b/tests/robot-tests/tests/general_public/redirects.robot
@@ -12,15 +12,15 @@ Force Tags          GeneralPublic    Local    Dev    Test    Preprod    Prod
 Verify that absolute paths with trailing slashes are redirected without them
     user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/
     user waits until page contains    Browse our open data
-    browser should be at address    %{PUBLIC_URL}/data-catalogue
+    user checks url equals    %{PUBLIC_URL}/data-catalogue
 
     user navigates to public frontend    %{PUBLIC_URL}/data-catalogue
     user waits until page contains    Browse our open data
-    browser should be at address    %{PUBLIC_URL}/data-catalogue
+    user checks url equals    %{PUBLIC_URL}/data-catalogue
 
     user navigates to public frontend    %{PUBLIC_URL}/glossary/?someRandomUrlParameter=123
     user waits until page contains    Glossary
-    browser should be at address    %{PUBLIC_URL}/glossary?someRandomUrlParameter=123
+    user checks url equals    %{PUBLIC_URL}/glossary?someRandomUrlParameter=123
 
     # Would be amazing if we could verify these redirects were done with a 301 rather than a 308...
 
@@ -29,34 +29,34 @@ Verify that redirects do not affect browser history
 
     user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/
     user waits until page contains    Browse our open data
-    browser should be at address    %{PUBLIC_URL}/data-catalogue
+    user checks url equals    %{PUBLIC_URL}/data-catalogue
 
-    browser navigates    back
-    browser should be at address    about:blank
+    user goes back
+    user checks url equals    about:blank
 
 Verify that routes without an absolute path still permit trailing slashes
     user navigates to public frontend    %{PUBLIC_URL}/
     user waits until page contains    Explore education statistics
-    browser should be at address    %{PUBLIC_URL}/
+    user checks url equals    %{PUBLIC_URL}/
 
     user navigates to public frontend    %{PUBLIC_URL}
     user waits until page contains    Explore education statistics
-    browser should be at address    %{PUBLIC_URL}/
+    user checks url equals    %{PUBLIC_URL}/
 
 Verify that meta-guidance is redirected to data-guidance
     user navigates to public frontend    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance
     user waits until page contains    Seed publication - Release Approver
-    browser should be at address    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance
+    user checks url equals    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance
 
     user navigates to public frontend    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance/
     user waits until page contains    Seed publication - Release Approver
-    browser should be at address    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance
+    user checks url equals    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance
 
 Verify that download-latest-data is redirected to data-catalogue
     user navigates to public frontend    %{PUBLIC_URL}/download-latest-data
     user waits until page contains    Browse our open data
-    browser should be at address    %{PUBLIC_URL}/data-catalogue
+    user checks url equals    %{PUBLIC_URL}/data-catalogue
 
     user navigates to public frontend    %{PUBLIC_URL}/download-latest-data/
     user waits until page contains    Browse our open data
-    browser should be at address    %{PUBLIC_URL}/data-catalogue
+    user checks url equals    %{PUBLIC_URL}/data-catalogue

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -915,6 +915,11 @@ user navigates to public frontend
     enable basic auth headers
     go to    ${URL}
 
+user navigates to
+    [Arguments]    ${URL}
+    enable basic auth headers
+    go to    ${URL}
+
 check that variable is not empty
     [Arguments]    ${variable_name}    ${variable_value}
     IF    '${variable_value}'=='${EMPTY}'

--- a/tests/robot-tests/tests/libs/public-utilities.py
+++ b/tests/robot-tests/tests/libs/public-utilities.py
@@ -24,23 +24,6 @@ def cookie_should_have_value(name, value):
     raise_assertion_error(f"Couldn't find cookie {name} with value {value}")
 
 
-def browser_should_be_at_address(expected):
-    actual = sl().driver.current_url
-
-    if actual != expected:
-        raise_assertion_error(f"Browser is at address {actual} but was expected to be at {expected}")
-
-
-def browser_navigates(direction):
-    if direction == "back":
-        sl().driver.back()
-        return
-    if direction == "forward":
-        sl().driver.forward()
-        return
-    raise_assertion_error(f"Browser navigation direction must be 'back' or 'forward'. Received {direction}")
-
-
 def cookie_names_should_be_on_page():
     cookies = sl().driver.get_cookies()
     for cookie in cookies:

--- a/tests/robot-tests/tests/libs/public-utilities.py
+++ b/tests/robot-tests/tests/libs/public-utilities.py
@@ -24,6 +24,23 @@ def cookie_should_have_value(name, value):
     raise_assertion_error(f"Couldn't find cookie {name} with value {value}")
 
 
+def browser_should_be_at_address(expected):
+    actual = sl().driver.current_url
+
+    if actual != expected:
+        raise_assertion_error(f"Browser is at address {actual} but was expected to be at {expected}")
+
+
+def browser_navigates(direction):
+    if direction == "back":
+        sl().driver.back()
+        return
+    if direction == "forward":
+        sl().driver.forward()
+        return
+    raise_assertion_error(f"Browser navigation direction must be 'back' or 'forward'. Received {direction}")
+
+
 def cookie_names_should_be_on_page():
     cookies = sl().driver.get_cookies()
     for cookie in cookies:


### PR DESCRIPTION
This PR reconfigures the public site to redirect using HTTP Status Code 301 rather than 308. 

NextJS uses Http Status 308 for permanent redirects, as oppose to the usual 301. This is a deliberate design choice as 308s preserve the HTTP Verb when redirecting, however 301s turn everything to a GET. Unfortunately, NextJS does not provide a configuration option to use 301s instead. Luckily, we are using a custom server, so we are able to configure redirects in Express JS before reaching Next at all. 

By default, Next sets the [trailingSlash](https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash) config to false, meaning urls ending with slashes get redirected with the slash curtailed. This behaviour is re-created in `server.js` with the 301 status code. 

We also have two manual redirects, `meta-guidance` -> `data-guidance` and `download-latest-data` -> `data-catalogue`. These ideally need to be removed, however Google has trawled them within the past 6 months so I don't believe we can just yet. For now, these have also been re-created using 301s. 

New robot tests have been added to verify that these redirects still perform correctly, although sadly I don't believe robot can assert on which status code was used for the redirect. 

Exactly the same tests like-for-like have been created in Playwright as an experiment (spoiler alert: the playwright tests were SO much easier and took less than a quarter of the time...)