### PR TITLE
EES-4716 Change PaginatedListViewModels to use `required` in public API

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -50,7 +50,11 @@ internal class DataSetService : IDataSetService
             .Select(MapDataSet)
             .ToList();
 
-        return new DataSetPaginatedListViewModel(dataSets, totalResults, page, pageSize);
+        return new DataSetPaginatedListViewModel
+        {
+            Results = dataSets,
+            Paging = new PagingViewModel(page: page, pageSize: pageSize, totalResults: totalResults)
+        };
     }
 
     public async Task<Either<ActionResult, DataSetVersionViewModel>> GetVersion(
@@ -83,7 +87,11 @@ internal class DataSetService : IDataSetService
             .Select(MapDataSetVersion)
             .ToList();
 
-        return new DataSetVersionPaginatedListViewModel(dataSetVersions, totalResults, page, pageSize);
+        return new DataSetVersionPaginatedListViewModel
+        {
+            Results = dataSetVersions,
+            Paging = new PagingViewModel(page: page, pageSize: pageSize, totalResults: totalResults)
+        };
     }
 
     private async Task<Either<ActionResult, DataSet>> CheckDataSetExists(Guid dataSetId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PublicationService.cs
@@ -27,24 +27,27 @@ internal class PublicationService : IPublicationService
         string? search = null)
     {
         return await GetPublishedDataSetPublicationIds()
-            .OnSuccess(async (publicationIds) =>
+            .OnSuccess(async publicationIds =>
                 await _contentApiClient.ListPublications(page, pageSize, search, publicationIds))
-            .OnSuccess((paginatedPublications) =>
+            .OnSuccess(paginatedPublications =>
             {
                 var results = paginatedPublications.Results.Select(MapPublication).ToList();
 
-                return new PublicationPaginatedListViewModel(
-                    results: results,
-                    totalResults: paginatedPublications.Paging.TotalResults,
-                    page: paginatedPublications.Paging.Page,
-                    pageSize: paginatedPublications.Paging.PageSize);
+                return new PublicationPaginatedListViewModel
+                {
+                    Results = results,
+                    Paging = new PagingViewModel(
+                        totalResults: paginatedPublications.Paging.TotalResults,
+                        page: paginatedPublications.Paging.Page,
+                        pageSize: paginatedPublications.Paging.PageSize),
+                };
             });
     }
 
     public async Task<Either<ActionResult, PublicationSummaryViewModel>> GetPublication(Guid publicationId)
     {
         return await CheckPublicationIsPublished(publicationId)
-            .OnSuccess(async (publicationIds) => await _contentApiClient.GetPublication(publicationId))
+            .OnSuccess(async _ => await _contentApiClient.GetPublication(publicationId))
             .OnSuccess(publication => new PublicationSummaryViewModel
             {
                 Id  = publication.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/DataSetViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/DataSetViewModels.cs
@@ -90,27 +90,7 @@ public record DataSetLatestVersionViewModel
 /// <summary>
 /// A paginated list of data sets.
 /// </summary>
-public record DataSetPaginatedListViewModel : PaginatedListViewModel<DataSetViewModel>
-{
-    public DataSetPaginatedListViewModel(
-        List<DataSetViewModel> results,
-        int totalResults,
-        int page,
-        int pageSize)
-        : base(
-            results: results,
-            totalResults: totalResults,
-            page: page,
-            pageSize: pageSize)
-    {
-    }
-
-    [JsonConstructor]
-    public DataSetPaginatedListViewModel(List<DataSetViewModel> results, PagingViewModel paging)
-        : base(results, paging)
-    {
-    }
-}
+public record DataSetPaginatedListViewModel : PaginatedListViewModel<DataSetViewModel>;
 
 public class DataSetVersionViewModel
 {
@@ -187,24 +167,4 @@ public class DataSetVersionViewModel
 /// <summary>
 /// A paginated list of data set versions.
 /// </summary>
-public record DataSetVersionPaginatedListViewModel : PaginatedListViewModel<DataSetVersionViewModel>
-{
-    public DataSetVersionPaginatedListViewModel(
-        List<DataSetVersionViewModel> results,
-        int totalResults,
-        int page,
-        int pageSize)
-        : base(
-            results: results,
-            totalResults: totalResults,
-            page: page,
-            pageSize: pageSize)
-    {
-    }
-
-    [JsonConstructor]
-    public DataSetVersionPaginatedListViewModel(List<DataSetVersionViewModel> results, PagingViewModel paging)
-        : base(results, paging)
-    {
-    }
-}
+public record DataSetVersionPaginatedListViewModel : PaginatedListViewModel<DataSetVersionViewModel>;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/PaginatedListViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/PaginatedListViewModel.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
 
 public abstract record PaginatedListViewModel<T>
@@ -7,26 +5,13 @@ public abstract record PaginatedListViewModel<T>
     /// <summary>
     /// The list of results for this page.
     /// </summary>
-    public List<T> Results { get; }
+    public required List<T> Results { get; init; }
 
     /// <summary>
     /// Provides metadata for use in pagination.
     /// </summary>
-    public PagingViewModel Paging { get; }
-
-    public PaginatedListViewModel(List<T> results, int totalResults, int page, int pageSize)
-    {
-        Results = results;
-        Paging = new PagingViewModel(page: page, pageSize: pageSize, totalResults: totalResults);
-    }
-
-    [JsonConstructor]
-    public PaginatedListViewModel(List<T> results, PagingViewModel paging)
-    {
-        Results = results;
-        Paging = paging;
-    }
-};
+    public required PagingViewModel Paging { get; init; }
+}
 
 public record PagingViewModel
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/PublicationViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/PublicationViewModels.cs
@@ -36,24 +36,4 @@ public record PublicationSummaryViewModel
 /// <summary>
 /// A paginated list of publication summaries.
 /// </summary>
-public record PublicationPaginatedListViewModel : PaginatedListViewModel<PublicationSummaryViewModel>
-{
-    public PublicationPaginatedListViewModel(
-        List<PublicationSummaryViewModel> results,
-        int totalResults,
-        int page,
-        int pageSize)
-        : base(
-            results: results,
-            totalResults: totalResults,
-            page: page,
-            pageSize: pageSize)
-    {
-    }
-
-    [JsonConstructor]
-    public PublicationPaginatedListViewModel(List<PublicationSummaryViewModel> results, PagingViewModel paging)
-        : base(results, paging)
-    {
-    }
-}
+public record PublicationPaginatedListViewModel : PaginatedListViewModel<PublicationSummaryViewModel>;


### PR DESCRIPTION
This simplifies the construction of `PaginatedListViewModel` and its subtypes as we can just use an object initializer for everything in combination with `required`.