### PR TITLE
EES-4407 improve keyboard accessibility for tables in content

### DIFF
--- a/src/explore-education-statistics-common/src/components/ContentHtml.module.scss
+++ b/src/explore-education-statistics-common/src/components/ContentHtml.module.scss
@@ -3,4 +3,8 @@
 .tableContainer {
   margin: govuk-spacing(6) govuk-spacing(4);
   overflow: auto;
+
+  &:focus-visible {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+  }
 }

--- a/src/explore-education-statistics-common/src/components/ContentHtml.tsx
+++ b/src/explore-education-statistics-common/src/components/ContentHtml.tsx
@@ -121,21 +121,22 @@ function renderTable(element: Element): ReactElement | undefined {
     child => child instanceof Element && child.name === 'table',
   ) as Element | undefined;
 
+  if (!table) {
+    return undefined;
+  }
+
   const figcaption = children.find(
     child => child instanceof Element && child.name === 'figcaption',
   ) as Element | undefined;
 
-  if (!table || !figcaption) {
-    return undefined;
-  }
-
   return (
-    <div className={styles.tableContainer}>
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+    <div className={styles.tableContainer} tabIndex={0}>
       <table
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...attributesToProps(table.attribs)}
       >
-        <caption>{domToReact(figcaption.children)}</caption>
+        {figcaption && <caption>{domToReact(figcaption.children)}</caption>}
         {domToReact(table.children, { trim: true })}
       </table>
     </div>

--- a/src/explore-education-statistics-common/src/components/__tests__/ContentHtml.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ContentHtml.test.tsx
@@ -105,36 +105,29 @@ describe('ContentHtml', () => {
     ).toBeInTheDocument();
   });
 
-  test('fixes inaccessible table markup from CKEditor', () => {
-    const html = `
-      <figure class="table">
-        <table>
-          <tbody>
-          <tr>
-            <td>Test 1</td>
-            <td>Test 2</td>
-          </tr>
-          </tbody>
-        </table>
-        <figcaption>
-          Test <strong>bold</strong> caption
-        </figcaption>
-      </figure>
-    `;
-
-    const { container } = render(<ContentHtml html={html} />);
-
-    expect(container.innerHTML).toMatchInlineSnapshot(`
-      <div class="dfe-content">
-        <div class="tableContainer">
+  describe('formatting tables', () => {
+    test('removes figure and adds tabindex to table markup from CKEditor', () => {
+      const html = `
+        <figure class="table">
           <table>
-            <caption>
-              Test
-              <strong>
-                bold
-              </strong>
-              caption
-            </caption>
+            <tbody>
+            <tr>
+              <td>Test 1</td>
+              <td>Test 2</td>
+            </tr>
+            </tbody>
+          </table>
+        </figure>
+      `;
+
+      const { container } = render(<ContentHtml html={html} />);
+
+      expect(container.innerHTML).toMatchInlineSnapshot(`
+      <div class="dfe-content">
+        <div class="tableContainer"
+             tabindex="0"
+        >
+          <table>
             <tbody>
               <tr>
                 <td>
@@ -148,7 +141,56 @@ describe('ContentHtml', () => {
           </table>
         </div>
       </div>
-    `);
+      `);
+    });
+
+    test('fixes inaccessible table caption markup from CKEditor', () => {
+      const html = `
+        <figure class="table">
+          <table>
+            <tbody>
+            <tr>
+              <td>Test 1</td>
+              <td>Test 2</td>
+            </tr>
+            </tbody>
+          </table>
+          <figcaption>
+            Test <strong>bold</strong> caption
+          </figcaption>
+        </figure>
+      `;
+
+      const { container } = render(<ContentHtml html={html} />);
+
+      expect(container.innerHTML).toMatchInlineSnapshot(`
+        <div class="dfe-content">
+          <div class="tableContainer"
+               tabindex="0"
+          >
+            <table>
+              <caption>
+                Test
+                <strong>
+                  bold
+                </strong>
+                caption
+              </caption>
+              <tbody>
+                <tr>
+                  <td>
+                    Test 1
+                  </td>
+                  <td>
+                    Test 2
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      `);
+    });
   });
 
   describe('formatting links', () => {


### PR DESCRIPTION
Fixes an accessibility issue where scrollable tables in content blocks couldn't be accessed by keyboard. This adds a `tabindex` and a focus style to fix that.

Also, the `renderTable` function in `ContentHtml.tsx` was resulting in different markup depending on if the table has a caption or not - without a caption it left in the unnecessary `figure` element that CKEditor adds. I've changed this so the `figure` is always removed.