### PR TITLE
EES-4673 maintain position when switch between modes on release content

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
@@ -79,41 +79,39 @@ const EditableAccordion = (props: EditableAccordionProps) => {
     );
   }, [isReordering, props, sections]);
 
-  if (editingMode !== 'edit') {
-    return <Accordion {...props}>{children}</Accordion>;
-  }
-
   return (
     <div className={styles.container}>
-      <div className="dfe-flex dfe-justify-content--space-between govuk-!-margin-bottom-3">
-        <h2 className="govuk-heading-l govuk-!-margin-bottom-0">
-          {sectionName}
-        </h2>
+      {editingMode === 'edit' && (
+        <div className="dfe-flex dfe-justify-content--space-between govuk-!-margin-bottom-3">
+          <h2 className="govuk-heading-l govuk-!-margin-bottom-0">
+            {sectionName}
+          </h2>
 
-        {sections.length > 1 &&
-          (!isReordering ? (
-            <Button
-              variant="secondary"
-              className="govuk-!-font-size-16 govuk-!-margin-bottom-0"
-              id={`${id}-reorder`}
-              onClick={toggleReordering.on}
-            >
-              Reorder<span className="govuk-visually-hidden"> sections</span>
-            </Button>
-          ) : (
-            <Button
-              className="govuk-!-font-size-16 govuk-!-margin-bottom-0"
-              onClick={saveOrder}
-            >
-              Save order
-            </Button>
-          ))}
-      </div>
+          {sections.length > 1 &&
+            (!isReordering ? (
+              <Button
+                variant="secondary"
+                className="govuk-!-font-size-16 govuk-!-margin-bottom-0"
+                id={`${id}-reorder`}
+                onClick={toggleReordering.on}
+              >
+                Reorder<span className="govuk-visually-hidden"> sections</span>
+              </Button>
+            ) : (
+              <Button
+                className="govuk-!-font-size-16 govuk-!-margin-bottom-0"
+                onClick={saveOrder}
+              >
+                Save order
+              </Button>
+            ))}
+        </div>
+      )}
 
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable
           droppableId={id}
-          isDropDisabled={!isReordering}
+          isDropDisabled={editingMode !== 'edit' || !isReordering}
           type="accordion"
         >
           {(droppableProvided, snapshot) => (
@@ -131,16 +129,17 @@ const EditableAccordion = (props: EditableAccordionProps) => {
           )}
         </Droppable>
       </DragDropContext>
-
-      <div>
-        <Button
-          onClick={onAddSection}
-          className={styles.addSectionButton}
-          disabled={isReordering}
-        >
-          Add new section
-        </Button>
-      </div>
+      {editingMode === 'edit' && (
+        <div>
+          <Button
+            onClick={onAddSection}
+            className={styles.addSectionButton}
+            disabled={isReordering}
+          >
+            Add new section
+          </Button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordionSection.tsx
@@ -100,7 +100,7 @@ const EditableAccordionSection = (props: EditableAccordionSectionProps) => {
       );
     }
 
-    if (isReordering) {
+    if (isReordering && editingMode === 'edit') {
       return createElement(
         headingTag,
         {
@@ -112,6 +112,7 @@ const EditableAccordionSection = (props: EditableAccordionSectionProps) => {
 
     return undefined;
   }, [
+    editingMode,
     heading,
     headingTag,
     id,
@@ -122,74 +123,81 @@ const EditableAccordionSection = (props: EditableAccordionSectionProps) => {
     toggleEditingHeading,
   ]);
 
-  if (editingMode !== 'edit') {
-    return <AccordionSection {...props} />;
-  }
-
   return (
     <DraggableItem
-      className={classNames({ [styles.draggableItem]: isReordering })}
+      className={classNames({
+        [styles.draggableItem]: isReordering && editingMode === 'edit',
+      })}
       id={id}
       index={index}
-      isReordering={isReordering}
+      isDisabled={editingMode !== 'edit'}
+      isReordering={isReordering && editingMode === 'edit'}
       testId="editableAccordionSection"
     >
-      <AccordionSection {...props} id={id} heading={heading} header={header}>
+      <AccordionSection
+        {...props}
+        id={id}
+        heading={heading}
+        header={header}
+        trackScroll
+      >
         {sectionProps => (
           <>
-            <ButtonGroup>
-              {isEditingHeading ? (
-                <Button onClick={saveHeading}>Save section title</Button>
-              ) : (
-                <Tooltip
-                  text={disabledHeadingChangeTooltip}
-                  enabled={!!disabledHeadingChangeTooltip}
-                >
-                  {({ ref }) => (
-                    <Button
-                      ariaDisabled={!!disabledHeadingChangeTooltip}
-                      type="button"
-                      ref={ref}
-                      variant="secondary"
-                      onClick={toggleEditingHeading}
-                    >
-                      Edit section title
-                    </Button>
-                  )}
-                </Tooltip>
-              )}
+            {editingMode === 'edit' && (
+              <ButtonGroup>
+                {isEditingHeading ? (
+                  <Button onClick={saveHeading}>Save section title</Button>
+                ) : (
+                  <Tooltip
+                    text={disabledHeadingChangeTooltip}
+                    enabled={!!disabledHeadingChangeTooltip}
+                  >
+                    {({ ref }) => (
+                      <Button
+                        ariaDisabled={!!disabledHeadingChangeTooltip}
+                        type="button"
+                        ref={ref}
+                        variant="secondary"
+                        onClick={toggleEditingHeading}
+                      >
+                        Edit section title
+                      </Button>
+                    )}
+                  </Tooltip>
+                )}
 
-              {headerButtons}
+                {headerButtons}
 
-              {onRemoveSection && (
-                <Tooltip
-                  text={disabledRemoveSectionTooltip}
-                  enabled={!!disabledRemoveSectionTooltip}
-                >
-                  {({ ref }) => (
-                    <ModalConfirm
-                      title="Removing section"
-                      triggerButton={
-                        <Button
-                          ariaDisabled={!!disabledRemoveSectionTooltip}
-                          ref={ref}
-                          variant="warning"
-                        >
-                          Remove this section
-                        </Button>
-                      }
-                      onConfirm={onRemoveSection}
-                    >
-                      <p>
-                        Are you sure you want to remove the following section?
-                        <br />
-                        <strong>"{heading}"</strong>
-                      </p>
-                    </ModalConfirm>
-                  )}
-                </Tooltip>
-              )}
-            </ButtonGroup>
+                {onRemoveSection && (
+                  <Tooltip
+                    text={disabledRemoveSectionTooltip}
+                    enabled={!!disabledRemoveSectionTooltip}
+                  >
+                    {({ ref }) => (
+                      <ModalConfirm
+                        title="Removing section"
+                        triggerButton={
+                          <Button
+                            ariaDisabled={!!disabledRemoveSectionTooltip}
+                            ref={ref}
+                            variant="warning"
+                          >
+                            Remove this section
+                          </Button>
+                        }
+                        onConfirm={onRemoveSection}
+                      >
+                        <p>
+                          Are you sure you want to remove the following section?
+                          <br />
+                          <strong>"{heading}"</strong>
+                        </p>
+                      </ModalConfirm>
+                    )}
+                  </Tooltip>
+                )}
+              </ButtonGroup>
+            )}
 
             {typeof children === 'function' ? children(sectionProps) : children}
           </>

--- a/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditablePageModeToggle.tsx
@@ -17,7 +17,7 @@ export default function EditablePageModeToggle({
   previewLabel = 'Preview content',
   showTablePreviewOption = false,
 }: Props) {
-  const { editingMode, setEditingMode } = useEditingContext();
+  const { activeSection, editingMode, setEditingMode } = useEditingContext();
   const [isOpen, toggleOpen] = useToggle(true);
   const { isMedia: isMobileMedia } = useMobileMedia();
 
@@ -84,6 +84,26 @@ export default function EditablePageModeToggle({
           options={options}
           onChange={event => {
             setEditingMode(event.target.value as EditingMode);
+
+            // Zero timeout to ensure it's moved on to the next
+            // event in the loop before scrolling. Otherwise it might
+            // scroll while still switching mode.
+            setTimeout(() => {
+              // Add some spacing at the top so it's not covered by the
+              // editable mode bar and there's a bit of space below it.
+              const spacing = 150;
+              const section = activeSection
+                ? document.getElementById(activeSection)
+                : undefined;
+
+              if (section) {
+                const top =
+                  section.getBoundingClientRect().top +
+                  document.documentElement.scrollTop;
+
+                window.scrollTo(0, top - spacing);
+              }
+            }, 0);
           }}
         />
       </div>

--- a/src/explore-education-statistics-admin/src/components/editable/EditableSectionBlocks.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableSectionBlocks.tsx
@@ -5,7 +5,7 @@ import { EditableBlock } from '@admin/services/types/content';
 import InsetText from '@common/components/InsetText';
 import reorder from '@common/utils/reorder';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
-import React, { Fragment, ReactNode, useCallback } from 'react';
+import React, { ReactNode, useCallback } from 'react';
 
 export interface EditableSectionBlockProps<
   T extends EditableBlock = EditableBlock,
@@ -41,7 +41,13 @@ const EditableSectionBlocks = <T extends EditableBlock = EditableBlock>({
     return blocks.length > 0 ? (
       <>
         {blocks.map(block => (
-          <Fragment key={block.id}>{renderBlock(block)}</Fragment>
+          <div
+            data-scroll
+            id={`editableSectionBlocks-${block.id}`}
+            key={block.id}
+          >
+            {renderBlock(block)}
+          </div>
         ))}
       </>
     ) : (
@@ -55,16 +61,20 @@ const EditableSectionBlocks = <T extends EditableBlock = EditableBlock>({
 
   return (
     <DragDropContext onDragEnd={handleDragEnd}>
-      <BlockDroppable droppable={isReordering} droppableId={sectionId}>
+      <BlockDroppable
+        droppable={isReordering && editingMode === 'edit'}
+        droppableId={sectionId}
+      >
         {blocks.map((block, index) => (
           <div
             key={block.id}
             id={`editableSectionBlocks-${block.id}`}
             className="govuk-!-margin-bottom-9"
+            data-scroll
             data-testid="editableSectionBlock"
           >
             <BlockDraggable
-              draggable={isReordering}
+              draggable={isReordering && editingMode === 'edit'}
               draggableId={block.id}
               key={block.id}
               index={index}

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditablePageModeToggle.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditablePageModeToggle.test.tsx
@@ -22,7 +22,7 @@ describe('EditablePageModeToggle', () => {
     expect(options[1]).toEqual(screen.getByLabelText('Preview content'));
   });
 
-  test('deso not render the edit content option when canUpdateRelease is false', () => {
+  test('does not render the edit content option when canUpdateRelease is false', () => {
     render(<EditablePageModeToggle canUpdateRelease={false} />);
 
     const group = screen.getByRole('group', { name: 'Change page view' });

--- a/src/explore-education-statistics-admin/src/contexts/EditingContext.tsx
+++ b/src/explore-education-statistics-admin/src/contexts/EditingContext.tsx
@@ -16,10 +16,12 @@ export type EditingMode = 'preview' | 'table-preview' | 'edit';
 export type BlockCommentIds = Dictionary<string[]>;
 
 export interface EditingContextState {
+  activeSection?: string;
   addUnsavedBlock: (blockId: string) => void;
   clearUnsavedCommentDeletions: (blockId: string) => void;
   editingMode: EditingMode;
   removeUnsavedBlock: (blockId: string) => void;
+  setActiveSection: (sectionId: string) => void;
   setEditingMode: (mode: EditingMode) => void;
   totalUnresolvedComments: number;
   totalUnsavedBlocks: number;
@@ -39,6 +41,7 @@ export const EditingContext = createContext<EditingContextState>({
   clearUnsavedCommentDeletions: noop,
   editingMode: 'preview',
   removeUnsavedBlock: noop,
+  setActiveSection: noop,
   setEditingMode: noop,
   totalUnsavedBlocks: 0,
   totalUnresolvedComments: 0,
@@ -70,6 +73,9 @@ export const EditingContextProvider = ({
 }: EditingContextProviderProps) => {
   const [editingMode, setEditingMode] =
     useState<EditingMode>(initialEditingMode);
+
+  const [activeSection, setActiveSection] = useState<string>();
+
   const [unresolvedComments, setUnresolvedComments] = useState<BlockCommentIds>(
     initialUnresolvedComments,
   );
@@ -166,10 +172,12 @@ export const EditingContextProvider = ({
       };
 
     return {
+      activeSection,
       addUnsavedBlock,
+      clearUnsavedCommentDeletions,
       editingMode,
       removeUnsavedBlock,
-      clearUnsavedCommentDeletions,
+      setActiveSection,
       setEditingMode,
       totalUnresolvedComments,
       totalUnsavedBlocks,
@@ -180,6 +188,7 @@ export const EditingContextProvider = ({
       updateUnsavedCommentDeletions,
     };
   }, [
+    activeSection,
     editingMode,
     totalUnsavedBlocks,
     totalUnresolvedComments,

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/MethodologyContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/MethodologyContentPage.tsx
@@ -1,29 +1,20 @@
-import BrowserWarning from '@admin/components/BrowserWarning';
 import EditablePageModeToggle from '@admin/components/editable/EditablePageModeToggle';
 import PageTitle from '@admin/components/PageTitle';
 import { EditingContextProvider } from '@admin/contexts/EditingContext';
-import PrintThisPage from '@admin/components/PrintThisPage';
 import { MethodologyRouteParams } from '@admin/routes/methodologyRoutes';
-import FormattedDate from '@common/components/FormattedDate';
 import LoadingSpinner from '@common/components/LoadingSpinner';
-import PageSearchForm from '@common/components/PageSearchForm';
 import WarningMessage from '@common/components/WarningMessage';
-import MethodologyAccordion from '@admin/pages/methodology/edit-methodology/content/components/MethodologyAccordion';
-import MethodologyNotesSection from '@admin/pages/methodology/edit-methodology/content/components/MethodologyNotesSection';
 import {
   MethodologyContentProvider,
   useMethodologyContentState,
 } from '@admin/pages/methodology/edit-methodology/content/context/MethodologyContentContext';
-import SummaryList from '@common/components/SummaryList';
-import SummaryListItem from '@common/components/SummaryListItem';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
-import MethodologyHelpAndSupportSection from '@common/modules/methodology/components/MethodologyHelpAndSupportSection';
-import RelatedInformation from '@common/components/RelatedInformation';
 import { useQuery } from '@tanstack/react-query';
 import methodologyQueries from '@admin/queries/methodologyQueries';
 import methodologyContentQueries from '@admin/queries/methodologyContentQueries';
 import permissionQueries from '@admin/queries/permissionQueries';
+import MethodologyContent from './components/MethodologyContent';
 
 export const MethodologyContentPageInternal = () => {
   const {
@@ -37,103 +28,22 @@ export const MethodologyContentPageInternal = () => {
 
   return (
     <EditingContextProvider editingMode={canUpdateContent ? 'edit' : 'preview'}>
-      {({ editingMode }) => (
-        <>
-          {canUpdateContent && <EditablePageModeToggle />}
+      {canUpdateContent && <EditablePageModeToggle />}
 
-          <div className="govuk-width-container">
-            <div className="govuk-grid-row">
-              <div className="govuk-grid-column-two-thirds">
-                <section
-                  className={
-                    editingMode === 'edit'
-                      ? 'dfe-page-editing'
-                      : 'dfe-page-preview'
-                  }
-                >
-                  {editingMode === 'edit' && (
-                    <BrowserWarning>
-                      <ul>
-                        <li>Editing text blocks</li>
-                      </ul>
-                    </BrowserWarning>
-                  )}
+      <div className="govuk-width-container">
+        {isPreRelease ? (
+          <PageTitle caption="Methodology" title={methodology.title} />
+        ) : (
+          <h2 aria-hidden className="govuk-heading-lg" data-testid="page-title">
+            {methodology.title}
+          </h2>
+        )}
 
-                  {isPreRelease ? (
-                    <PageTitle
-                      caption="Methodology"
-                      title={methodology.title}
-                    />
-                  ) : (
-                    <h2
-                      aria-hidden
-                      className="govuk-heading-lg"
-                      data-testid="page-title"
-                    >
-                      {methodology.title}
-                    </h2>
-                  )}
-
-                  <SummaryList>
-                    <SummaryListItem term="Publish date">
-                      {methodology.published ? (
-                        <FormattedDate>{methodology.published}</FormattedDate>
-                      ) : (
-                        'Not yet published'
-                      )}
-                    </SummaryListItem>
-                    <MethodologyNotesSection methodology={methodology} />
-                  </SummaryList>
-                  {editingMode !== 'edit' && (
-                    <>
-                      <PageSearchForm inputLabel="Search in this methodology page." />
-                      <PrintThisPage />
-                    </>
-                  )}
-                </section>
-              </div>
-              <div className="govuk-grid-column-one-third">
-                <RelatedInformation>
-                  <h3 className="govuk-heading-s" id="related-pages">
-                    Help and support
-                  </h3>
-                  <ul className="govuk-list">
-                    <li>
-                      <a href="#contact-us">Contact us</a>
-                    </li>
-                  </ul>
-                </RelatedInformation>
-              </div>
-            </div>
-          </div>
-
-          <div className="govuk-width-container">
-            <section
-              className={
-                editingMode === 'edit' ? 'dfe-page-editing' : 'dfe-page-preview'
-              }
-            >
-              <MethodologyAccordion
-                methodology={methodology}
-                sectionKey="content"
-                title="Content"
-              />
-              {editingMode !== 'edit' && methodology.annexes.length ? (
-                <h2>Annexes</h2>
-              ) : null}
-              <MethodologyAccordion
-                methodology={methodology}
-                sectionKey="annexes"
-                title="Annexes"
-              />
-
-              <MethodologyHelpAndSupportSection
-                owningPublication={methodologyVersion.owningPublication}
-              />
-            </section>
-          </div>
-        </>
-      )}
+        <MethodologyContent
+          methodology={methodology}
+          methodologyVersion={methodologyVersion}
+        />
+      </div>
     </EditingContextProvider>
   );
 };

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
@@ -12,6 +12,7 @@ export interface MethodologyAccordionProps {
   sectionKey: ContentSectionKeys;
   title: string;
   methodology: MethodologyContent;
+  onSectionOpen: ({ id, title }: { id: string; title: string }) => void;
 }
 
 const MethodologyAccordion = ({
@@ -19,6 +20,7 @@ const MethodologyAccordion = ({
   methodology,
   id = `methodologyAccordion-${sectionKey}`,
   title,
+  onSectionOpen,
 }: MethodologyAccordionProps) => {
   const { editingMode } = useEditingContext();
   const { addContentSection, updateContentSectionsOrder } =
@@ -65,6 +67,7 @@ const MethodologyAccordion = ({
       sectionName={title}
       onAddSection={onAddSection}
       onReorder={reorderAccordionSections}
+      onSectionOpen={onSectionOpen}
     >
       {methodology[sectionKey].map(section => (
         <MethodologyAccordionSection

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyContent.tsx
@@ -1,0 +1,123 @@
+import { useEditingContext } from '@admin/contexts/EditingContext';
+import PrintThisPage from '@admin/components/PrintThisPage';
+
+import FormattedDate from '@common/components/FormattedDate';
+
+import PageSearchForm from '@common/components/PageSearchForm';
+
+import MethodologyAccordion from '@admin/pages/methodology/edit-methodology/content/components/MethodologyAccordion';
+import MethodologyNotesSection from '@admin/pages/methodology/edit-methodology/content/components/MethodologyNotesSection';
+
+import SummaryList from '@common/components/SummaryList';
+import SummaryListItem from '@common/components/SummaryListItem';
+import React, { useEffect } from 'react';
+
+import MethodologyHelpAndSupportSection from '@common/modules/methodology/components/MethodologyHelpAndSupportSection';
+import RelatedInformation from '@common/components/RelatedInformation';
+
+import { MethodologyContent as MethodologyContentData } from '@admin/services/methodologyContentService';
+import { MethodologyVersion } from '@admin/services/methodologyService';
+import useDebouncedCallback from '@common/hooks/useDebouncedCallback';
+
+interface Props {
+  methodology: MethodologyContentData;
+  methodologyVersion: MethodologyVersion;
+}
+
+export default function MethodologyContent({
+  methodology,
+  methodologyVersion,
+}: Props) {
+  const { editingMode, setActiveSection } = useEditingContext();
+
+  const [handleScroll] = useDebouncedCallback(() => {
+    const sections = document.querySelectorAll('[data-scroll]');
+
+    // Set a section as active when it's in the top third of the page.
+    const buffer = window.innerHeight / 3;
+    const scrollPosition = window.scrollY + buffer;
+
+    sections.forEach(section => {
+      if (section) {
+        const { height } = section.getBoundingClientRect();
+        const top =
+          section.getBoundingClientRect().top +
+          document.documentElement.scrollTop;
+        const bottom = top + height;
+        if (scrollPosition > top && scrollPosition < bottom) {
+          setActiveSection(section.id);
+        }
+      }
+    });
+  }, 100);
+
+  // has anchor link is the problems in preview - it puts position relative on.
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [handleScroll]);
+
+  return (
+    <>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <div data-scroll id="summary">
+            <SummaryList>
+              <SummaryListItem term="Publish date">
+                {methodology.published ? (
+                  <FormattedDate>{methodology.published}</FormattedDate>
+                ) : (
+                  'Not yet published'
+                )}
+              </SummaryListItem>
+              <MethodologyNotesSection methodology={methodology} />
+            </SummaryList>
+            {editingMode !== 'edit' && (
+              <>
+                <PageSearchForm inputLabel="Search in this methodology page." />
+                <PrintThisPage />
+              </>
+            )}
+          </div>
+        </div>
+        <div className="govuk-grid-column-one-third">
+          <RelatedInformation>
+            <h3 className="govuk-heading-s" id="related-pages">
+              Help and support
+            </h3>
+            <ul className="govuk-list">
+              <li>
+                <a href="#contact-us">Contact us</a>
+              </li>
+            </ul>
+          </RelatedInformation>
+        </div>
+      </div>
+
+      <MethodologyAccordion
+        methodology={methodology}
+        sectionKey="content"
+        title="Content"
+        onSectionOpen={({ id }) => setActiveSection(id)}
+      />
+      {editingMode !== 'edit' && methodology.annexes.length ? (
+        <h2>Annexes</h2>
+      ) : null}
+      <MethodologyAccordion
+        methodology={methodology}
+        sectionKey="annexes"
+        title="Annexes"
+        onSectionOpen={({ id }) => setActiveSection(id)}
+      />
+
+      <MethodologyHelpAndSupportSection
+        owningPublication={methodologyVersion.owningPublication}
+        trackScroll
+      />
+    </>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
@@ -83,8 +83,8 @@ const ReleaseContentPageLoaded = () => {
 
             <div
               className={classNames({
-                [styles.container]: editingMode === 'edit',
-                'govuk-width-container': editingMode !== 'table-preview',
+                [`govuk-width-container ${styles.container}`]:
+                  editingMode !== 'table-preview',
               })}
             >
               <div

--- a/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
@@ -447,6 +447,57 @@ describe('ReleaseContentPage', () => {
     expect(radios[2]).toEqual(screen.getByLabelText('Preview table tool'));
   });
 
+  test('maintains the open state of accordions when switching between edit and preview mode', async () => {
+    releaseContentService.getContent.mockResolvedValue(testReleaseContent);
+    featuredTableService.listFeaturedTables.mockResolvedValue(
+      testFeaturedTables,
+    );
+    permissionService.canUpdateRelease.mockResolvedValue(true);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Academic year 2020/21')).toBeInTheDocument();
+    });
+
+    const contentAccordion = screen.getAllByTestId('accordion')[0];
+    const contentAccordionSections =
+      within(contentAccordion).getAllByTestId('accordionSection');
+
+    const section1Button = within(contentAccordionSections[0]).getByRole(
+      'button',
+      {
+        name: /Section 1/,
+      },
+    );
+
+    expect(section1Button).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(section1Button);
+
+    expect(section1Button).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.click(screen.getByLabelText('Preview release page'));
+
+    await waitFor(() =>
+      expect(screen.queryByText('Add note')).not.toBeInTheDocument(),
+    );
+
+    expect(section1Button).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.click(section1Button);
+
+    expect(section1Button).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(screen.getByLabelText('Edit content'));
+
+    await waitFor(() =>
+      expect(screen.getByText('Add note')).toBeInTheDocument(),
+    );
+
+    expect(section1Button).toHaveAttribute('aria-expanded', 'false');
+  });
+
   describe('edit content mode', () => {
     test('renders the release content in edit mode', async () => {
       releaseContentService.getContent.mockResolvedValue(testReleaseContent);

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -30,7 +30,8 @@ import ScrollableContainer from '@common/components/ScrollableContainer';
 import Tag from '@common/components/Tag';
 import ReleaseSummarySection from '@common/modules/release/components/ReleaseSummarySection';
 import ReleaseDataAndFiles from '@common/modules/release/components/ReleaseDataAndFiles';
-import React, { useCallback, useMemo } from 'react';
+import useDebouncedCallback from '@common/hooks/useDebouncedCallback';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { generatePath, useLocation } from 'react-router';
 
 interface MethodologyLink {
@@ -46,8 +47,12 @@ const ReleaseContent = ({
 }) => {
   const config = useConfig();
   const location = useLocation();
-  const { editingMode, unsavedBlocks, unsavedCommentDeletions } =
-    useEditingContext();
+  const {
+    editingMode,
+    setActiveSection,
+    unsavedBlocks,
+    unsavedCommentDeletions,
+  } = useEditingContext();
   const { release } = useReleaseContentState();
   const { addContentSectionBlock } = useReleaseContentActions();
 
@@ -121,6 +126,34 @@ const ReleaseContent = ({
     release.publication.releases.length +
     release.publication.legacyReleases.length;
 
+  const [handleScroll] = useDebouncedCallback(() => {
+    const sections = document.querySelectorAll('[data-scroll]');
+
+    // Set a section as active when it's in the top third of the page.
+    const buffer = window.innerHeight / 3;
+    const scrollPosition = window.scrollY + buffer;
+
+    sections.forEach(section => {
+      if (section) {
+        const { height } = section.getBoundingClientRect();
+        const { offsetTop } = section as HTMLElement;
+        const offsetBottom = offsetTop + height;
+
+        if (scrollPosition > offsetTop && scrollPosition < offsetBottom) {
+          setActiveSection(section.id);
+        }
+      }
+    });
+  }, 100);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [handleScroll]);
+
   return (
     <>
       <RouteLeavingGuard
@@ -155,6 +188,7 @@ const ReleaseContent = ({
                 Sign up for email alerts
               </a>
             }
+            trackScroll
           />
 
           <div id="releaseSummary" data-testid="release-summary">
@@ -436,6 +470,8 @@ const ReleaseContent = ({
               />
             ) : null
           }
+          trackScroll
+          onSectionOpen={({ id }) => setActiveSection(id)}
         />
       )}
       {editingMode === 'edit' &&
@@ -451,6 +487,7 @@ const ReleaseContent = ({
         release={release}
         sectionName="Contents"
         transformFeaturedTableLinks={transformFeaturedTableLinks}
+        onSectionOpen={({ id }) => setActiveSection(id)}
       />
 
       <ReleaseHelpAndSupportSection
@@ -470,6 +507,7 @@ const ReleaseContent = ({
             )}
           </>
         )}
+        trackScroll
       />
       <PrintThisPage />
     </>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
@@ -11,6 +11,7 @@ interface ReleaseContentAccordionProps {
   release: EditableRelease;
   sectionName: string;
   transformFeaturedTableLinks?: (url: string, text: string) => void;
+  onSectionOpen: ({ id, title }: { id: string; title: string }) => void;
 }
 
 const ReleaseContentAccordion = ({
@@ -18,6 +19,7 @@ const ReleaseContentAccordion = ({
   id = 'releaseMainContent',
   sectionName,
   transformFeaturedTableLinks,
+  onSectionOpen,
 }: ReleaseContentAccordionProps) => {
   const { addContentSection, updateContentSectionsOrder } =
     useReleaseContentActions();
@@ -50,6 +52,7 @@ const ReleaseContentAccordion = ({
       sectionName={sectionName}
       onReorder={reorderAccordionSections}
       onAddSection={addAccordionSection}
+      onSectionOpen={onSectionOpen}
     >
       {orderBy(release.content, 'order').map(section => (
         <ReleaseContentAccordionSection

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -186,7 +186,7 @@ const ReleaseContentAccordionSection = ({
         <>
           <EditableSectionBlocks
             blocks={blocks}
-            isReordering={isReordering}
+            isReordering={isReordering && editingMode === 'edit'}
             sectionId={sectionId}
             onBlocksChange={setBlocks}
             renderBlock={block => (

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
@@ -39,7 +39,7 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
 
   const headlinesTab = (
     <TabsSection title="Summary">
-      <section id="releaseHeadlines-keyStatistics">
+      <section data-scroll id="releaseHeadlines-keyStatistics">
         <KeyStatistics release={release} isEditing={editingMode === 'edit'} />
       </section>
       <section id="releaseHeadlines-headlines">
@@ -79,7 +79,11 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
 
   return (
     <section id="releaseHeadlines">
-      <h2 className="dfe-print-break-before">
+      <h2
+        className="dfe-print-break-before"
+        data-scroll
+        id="release-headlines-header"
+      >
         Headline facts and figures - {release.yearTitle}
       </h2>
 

--- a/src/explore-education-statistics-common/src/components/AccordionSection.tsx
+++ b/src/explore-education-statistics-common/src/components/AccordionSection.tsx
@@ -10,6 +10,8 @@ import GoToTopLink from './GoToTopLink';
 export type ToggleHandler = (open: boolean, id: string) => void;
 
 export interface AccordionSectionProps {
+  anchorLinkIdPrefix?: string;
+  anchorLinkUrl?: (id: string) => string;
   caption?: string;
   children?:
     | ReactNode
@@ -19,7 +21,6 @@ export interface AccordionSectionProps {
         contentId: string;
       }) => ReactNode);
   className?: string;
-  anchorLinkUrl?: (id: string) => string;
   goToTop?: boolean;
   header?: ReactNode;
   heading: string;
@@ -29,8 +30,9 @@ export interface AccordionSectionProps {
    */
   headingTag?: 'h2' | 'h3' | 'h4';
   id?: string;
-  anchorLinkIdPrefix?: string;
+
   open?: boolean;
+  trackScroll?: boolean;
   onToggle?: ToggleHandler;
 }
 
@@ -46,6 +48,7 @@ const classes = {
 export const accordionSectionClasses = classes;
 
 const AccordionSection = ({
+  anchorLinkIdPrefix = 'section',
   anchorLinkUrl,
   caption,
   className,
@@ -55,8 +58,8 @@ const AccordionSection = ({
   heading,
   headingTag = 'h2',
   id = 'accordionSection',
-  anchorLinkIdPrefix = 'section',
   open = false,
+  trackScroll = false,
   onToggle,
 }: AccordionSectionProps) => {
   const { isMounted } = useMounted();
@@ -93,6 +96,7 @@ const AccordionSection = ({
                 aria-controls={contentId}
                 aria-expanded={open}
                 className={classes.sectionButton}
+                data-scroll={trackScroll ? true : undefined}
                 id={headingId}
                 type="button"
                 onClick={() => {

--- a/src/explore-education-statistics-common/src/modules/methodology/components/MethodologyHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-common/src/modules/methodology/components/MethodologyHelpAndSupportSection.tsx
@@ -4,13 +4,15 @@ import { PublicationSummary } from '@common/services/publicationService';
 
 interface Props {
   owningPublication: PublicationSummary;
+  trackScroll?: boolean;
 }
 
 export default function MethodologyHelpAndSupportSection({
   owningPublication,
+  trackScroll = false,
 }: Props) {
   return (
-    <>
+    <div data-scroll={trackScroll ? true : undefined} id="help-section">
       <h2
         className="govuk-!-margin-top-9"
         data-testid="extra-information"
@@ -23,6 +25,6 @@ export default function MethodologyHelpAndSupportSection({
         publicationContact={owningPublication.contact}
         publicationTitle={owningPublication.title}
       />
-    </>
+    </div>
   );
 }

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFiles.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFiles.tsx
@@ -18,6 +18,7 @@ interface Props {
   renderDownloadLink: (file: FileInfo) => ReactNode;
   renderRelatedDashboards?: ReactNode;
   showDownloadFilesList?: boolean;
+  trackScroll?: boolean;
   onSectionOpen?: (accordionSection: { id: string; title: string }) => void;
 }
 
@@ -31,6 +32,7 @@ const ReleaseDataAndFiles = ({
   renderDownloadLink,
   renderRelatedDashboards,
   showDownloadFilesList = false,
+  trackScroll = false,
   onSectionOpen,
 }: Props) => {
   const dataFiles = orderBy(
@@ -50,54 +52,59 @@ const ReleaseDataAndFiles = ({
 
   return (
     <>
-      <h2 className="govuk-heading-m" id="explore-data-and-files">
-        Explore data and files used in this release
-      </h2>
+      <div
+        id="data-and-files-section"
+        data-scroll={trackScroll ? true : undefined}
+      >
+        <h2 className="govuk-heading-m" id="explore-data-and-files">
+          Explore data and files used in this release
+        </h2>
 
-      <ChevronGrid testId="data-and-files">
-        <ChevronCard
-          description="View tables that we have built for you, or create your own tables from open data using our table tool"
-          link={renderCreateTablesLink}
-        />
-        {downloadFiles && (
-          <>
-            <ChevronCard
-              description="Browse and download open data files from this release in our data catalogue"
-              descriptionAfter={
-                showDownloadFilesList &&
-                dataFiles.length > 0 && (
-                  <Details
-                    summary="Download files"
-                    className="govuk-!-margin-bottom-0 govuk-!-margin-top-2 dfe-position--relative"
-                  >
-                    <ul className="govuk-list" data-testid="data-files">
-                      {dataFiles.map(file => (
-                        <li key={file.id}>{renderDownloadLink(file)}</li>
-                      ))}
-                    </ul>
-                  </Details>
-                )
-              }
-              link={renderDataCatalogueLink}
-            />
-
-            {hasDataGuidance && (
+        <ChevronGrid testId="data-and-files">
+          <ChevronCard
+            description="View tables that we have built for you, or create your own tables from open data using our table tool"
+            link={renderCreateTablesLink}
+          />
+          {downloadFiles && (
+            <>
               <ChevronCard
-                description="Learn more about the data files used in this release using our online guidance"
-                link={renderDataGuidanceLink}
+                description="Browse and download open data files from this release in our data catalogue"
+                descriptionAfter={
+                  showDownloadFilesList &&
+                  dataFiles.length > 0 && (
+                    <Details
+                      summary="Download files"
+                      className="govuk-!-margin-bottom-0 govuk-!-margin-top-2 dfe-position--relative"
+                    >
+                      <ul className="govuk-list" data-testid="data-files">
+                        {dataFiles.map(file => (
+                          <li key={file.id}>{renderDownloadLink(file)}</li>
+                        ))}
+                      </ul>
+                    </Details>
+                  )
+                }
+                link={renderDataCatalogueLink}
               />
-            )}
 
-            {hasAllFilesButton && (
-              <ChevronCard
-                description="Download all data available in this release as a compressed ZIP file"
-                link={renderAllFilesLink}
-                noChevron
-              />
-            )}
-          </>
-        )}
-      </ChevronGrid>
+              {hasDataGuidance && (
+                <ChevronCard
+                  description="Learn more about the data files used in this release using our online guidance"
+                  link={renderDataGuidanceLink}
+                />
+              )}
+
+              {hasAllFilesButton && (
+                <ChevronCard
+                  description="Download all data available in this release as a compressed ZIP file"
+                  link={renderAllFilesLink}
+                  noChevron
+                />
+              )}
+            </>
+          )}
+        </ChevronGrid>
+      </div>
 
       {(ancillaryFiles.length > 0 || renderRelatedDashboards) && (
         <Accordion
@@ -109,30 +116,37 @@ const ReleaseDataAndFiles = ({
             <AccordionSection
               id="supporting-files"
               heading="Additional supporting files"
+              trackScroll
             >
-              <p>
-                All supporting files from this release are listed for individual
-                download below:
-              </p>
-              <ul className="govuk-list" data-testid="other-files">
-                {ancillaryFiles.map(file => (
-                  <li
-                    key={file.id}
-                    className={`${styles.listItem} govuk-!-margin-bottom-4`}
-                  >
-                    <h3 className="govuk-heading-s govuk-!-margin-bottom-2">
-                      {renderDownloadLink(file)}
-                    </h3>
-                    {file.summary && <p>{file.summary}</p>}
-                  </li>
-                ))}
-              </ul>
+              <div
+                data-scroll={trackScroll ? true : undefined}
+                id="supporting-files-inner"
+              >
+                <p>
+                  All supporting files from this release are listed for
+                  individual download below:
+                </p>
+                <ul className="govuk-list" data-testid="other-files">
+                  {ancillaryFiles.map(file => (
+                    <li
+                      key={file.id}
+                      className={`${styles.listItem} govuk-!-margin-bottom-4`}
+                    >
+                      <h3 className="govuk-heading-s govuk-!-margin-bottom-2">
+                        {renderDownloadLink(file)}
+                      </h3>
+                      {file.summary && <p>{file.summary}</p>}
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </AccordionSection>
           )}
           {renderRelatedDashboards && (
             <AccordionSection
               id="related-dashboards"
               heading="View related dashboard(s)"
+              trackScroll
             >
               {renderRelatedDashboards}
             </AccordionSection>

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseHelpAndSupportSection.tsx
@@ -15,6 +15,7 @@ interface Props {
     externalMethodology: ExternalMethodology,
   ) => ReactNode;
   renderMethodologyLink: (methodology: MethodologySummary) => ReactNode;
+  trackScroll?: boolean;
 }
 
 export default function ReleaseHelpAndSupportSection({
@@ -22,11 +23,12 @@ export default function ReleaseHelpAndSupportSection({
   releaseType,
   renderMethodologyLink,
   renderExternalMethodologyLink,
+  trackScroll = false,
 }: Props) {
   const { externalMethodology, methodologies, contact, title } = publication;
 
   return (
-    <>
+    <div data-scroll={trackScroll ? true : undefined} id="help-section">
       <h2
         className="govuk-!-margin-top-9"
         data-testid="extra-information"
@@ -57,6 +59,6 @@ export default function ReleaseHelpAndSupportSection({
       <ReleaseTypeSection type={releaseType} />
 
       <ContactUsSection publicationContact={contact} publicationTitle={title} />
-    </>
+    </div>
   );
 }

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseSummarySection.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseSummarySection.tsx
@@ -36,6 +36,7 @@ interface Props {
   renderReleaseNotes: ReactNode;
   renderStatusTags: ReactNode;
   renderSubscribeLink: ReactNode;
+  trackScroll?: boolean;
   onShowReleaseTypeModal?: () => void;
 }
 
@@ -49,10 +50,11 @@ export default function ReleaseSummarySection({
   renderReleaseNotes,
   renderStatusTags,
   renderSubscribeLink,
+  trackScroll = false,
   onShowReleaseTypeModal,
 }: Props) {
   return (
-    <>
+    <div data-scroll={trackScroll ? true : undefined} id="summary-section">
       <div className="dfe-flex dfe-align-items--center dfe-justify-content--space-between govuk-!-margin-bottom-3">
         <div>{renderStatusTags}</div>
         {releaseTypesToIcons[releaseType] && (
@@ -111,6 +113,6 @@ export default function ReleaseSummarySection({
           {renderSubscribeLink}
         </SummaryListItem>
       </SummaryList>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
Attempts to maintain your position on the page when editing release or methodology content and switching between editing and preview modes by:

- keeping accordions open (or closed) when you switch views
- setting the active section as you scroll or when you open an accordion section; then when you switch view it scrolls to the active section. This uses a `data-scroll` attribute which is only added in the admin.

It won't be perfect but should go some way to helping analysts keep their place when they're reviewing release and methodology content. 

Also:
- I've refactored the methodology content tab a bit to make the layout more closely match the public version 
