### PR TITLE
EES-4818 prevent negative numbers with symbols from wrapping

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
@@ -54,7 +54,8 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
                       rowSpan: cell.rowSpan,
                       scope: cell.scope,
                       className: classNames({
-                        'govuk-table__cell--numeric': cell.tag === 'td',
+                        'govuk-table__cell--numeric dfe-white-space--nowrap':
+                          cell.tag === 'td',
                       }),
                     },
                     cell.text,

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FixedMultiHeaderDataTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FixedMultiHeaderDataTable.test.tsx.snap
@@ -42,10 +42,10 @@ exports[`FixedMultiHeaderDataTable renders underlying table 1`] = `
           >
             Row header
           </th>
-          <td class="govuk-table__cell--numeric">
+          <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
             425,590
           </td>
-          <td class="govuk-table__cell--numeric">
+          <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
             425,591
           </td>
         </tr>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/MultiHeaderTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/MultiHeaderTable.test.tsx.snap
@@ -57,16 +57,16 @@ exports[`MultiHeaderTable can render a complicated table with nesting 1`] = `
       >
         Indicator value 1
       </th>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         35
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         no data
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         315
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         no data
       </td>
     </tr>
@@ -78,16 +78,16 @@ exports[`MultiHeaderTable can render a complicated table with nesting 1`] = `
       >
         Indicator value 2
       </th>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         18,015
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         18,350
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         106,720
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         107,995
       </td>
     </tr>
@@ -99,16 +99,16 @@ exports[`MultiHeaderTable can render a complicated table with nesting 1`] = `
       >
         Indicator value 3
       </th>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         6,790
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         6,190
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         68,685
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         58,435
       </td>
     </tr>
@@ -173,16 +173,16 @@ exports[`MultiHeaderTable can render a complicated table with nesting 2`] = `
       >
         Indicator value 1
       </th>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         35
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         no data
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         315
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         no data
       </td>
     </tr>
@@ -194,16 +194,16 @@ exports[`MultiHeaderTable can render a complicated table with nesting 2`] = `
       >
         Indicator value 2
       </th>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         18,015
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         18,350
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         106,720
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         107,995
       </td>
     </tr>
@@ -215,16 +215,16 @@ exports[`MultiHeaderTable can render a complicated table with nesting 2`] = `
       >
         Indicator value 3
       </th>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         6,790
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         6,190
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         68,685
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         58,435
       </td>
     </tr>
@@ -263,10 +263,10 @@ exports[`MultiHeaderTable can render basic table 1`] = `
       >
         Row header
       </th>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         425,590
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         425,591
       </td>
     </tr>
@@ -305,10 +305,10 @@ exports[`MultiHeaderTable can render basic table 2`] = `
       >
         Row header
       </th>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         425,590
       </td>
-      <td class="govuk-table__cell--numeric">
+      <td class="govuk-table__cell--numeric dfe-white-space--nowrap">
         425,591
       </td>
     </tr>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/TimePeriodDataTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/TimePeriodDataTable.test.tsx.snap
@@ -48,17 +48,17 @@ exports[`TimePeriodDataTable renders table correctly when region group is missin
         Authorised absence rate
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         18.3%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         21.5%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         20.2%
       </td>
@@ -124,17 +124,17 @@ exports[`TimePeriodDataTable renders table correctly when region group is missin
         Authorised absence rate
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         18.3%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         21.5%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         20.2%
       </td>
@@ -177,7 +177,7 @@ exports[`TimePeriodDataTable renders table correctly when region group is missin
         England
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         18.3%
       </td>
@@ -192,7 +192,7 @@ exports[`TimePeriodDataTable renders table correctly when region group is missin
         Barnsley
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         21.5%
       </td>
@@ -207,7 +207,7 @@ exports[`TimePeriodDataTable renders table correctly when region group is missin
         Barnet
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         20.2%
       </td>
@@ -250,7 +250,7 @@ exports[`TimePeriodDataTable renders table correctly when region group is missin
         England
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         18.3%
       </td>
@@ -273,7 +273,7 @@ exports[`TimePeriodDataTable renders table correctly when region group is missin
         Barnsley
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         21.5%
       </td>
@@ -288,7 +288,7 @@ exports[`TimePeriodDataTable renders table correctly when region group is missin
         Barnet
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         20.2%
       </td>
@@ -384,22 +384,22 @@ exports[`TimePeriodDataTable renders table with completely empty columns removed
         Number of authorised absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         6,492
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         5,542
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         4,185
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         no data
       </td>
@@ -414,22 +414,22 @@ exports[`TimePeriodDataTable renders table with completely empty columns removed
         Number of overall absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         7,280
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         6,493
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         5,142
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         no data
       </td>
@@ -460,22 +460,22 @@ exports[`TimePeriodDataTable renders table with completely empty columns removed
         Number of authorised absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         4,179
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         4,809
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         5,322
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         x
       </td>
@@ -490,22 +490,22 @@ exports[`TimePeriodDataTable renders table with completely empty columns removed
         Number of overall absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         4,390
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         5,076
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         5,483
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         x
       </td>
@@ -587,17 +587,17 @@ exports[`TimePeriodDataTable renders table with completely empty rows removed 1`
         Number of authorised absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         6,492
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         5,542
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         4,185
       </td>
@@ -612,17 +612,17 @@ exports[`TimePeriodDataTable renders table with completely empty rows removed 1`
         Number of overall absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         7,280
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         6,493
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         5,142
       </td>
@@ -653,17 +653,17 @@ exports[`TimePeriodDataTable renders table with completely empty rows removed 1`
         Number of authorised absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         4,179
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         4,809
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         5,322
       </td>
@@ -678,17 +678,17 @@ exports[`TimePeriodDataTable renders table with completely empty rows removed 1`
         Number of overall absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         4,390
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         5,076
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         5,483
       </td>
@@ -711,17 +711,17 @@ exports[`TimePeriodDataTable renders table with completely empty rows removed 1`
         Number of authorised absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         x
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         no data
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         no data
       </td>
@@ -736,17 +736,17 @@ exports[`TimePeriodDataTable renders table with completely empty rows removed 1`
         Number of overall absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         x
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         no data
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         no data
       </td>
@@ -789,7 +789,7 @@ exports[`TimePeriodDataTable renders table with location hierarchies 1`] = `
         England
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         18.3%
       </td>
@@ -812,7 +812,7 @@ exports[`TimePeriodDataTable renders table with location hierarchies 1`] = `
         Barnsley
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         21.5%
       </td>
@@ -835,7 +835,7 @@ exports[`TimePeriodDataTable renders table with location hierarchies 1`] = `
         Barnet
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         20.2%
       </td>
@@ -900,17 +900,17 @@ exports[`TimePeriodDataTable renders table with no filters 1`] = `
         Authorised absence rate
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         18.3%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         18.6%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         19.2%
       </td>
@@ -925,17 +925,17 @@ exports[`TimePeriodDataTable renders table with no filters 1`] = `
         Number of authorised absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         1,280,964
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         1,397,521
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         1,488,865
       </td>
@@ -950,17 +950,17 @@ exports[`TimePeriodDataTable renders table with no filters 1`] = `
         Number of overall absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2,212,399
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2,453,340
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2,637,752
       </td>
@@ -1003,7 +1003,7 @@ exports[`TimePeriodDataTable renders table with only one of each option 1`] = `
         England
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         18.3%
       </td>
@@ -1046,7 +1046,7 @@ exports[`TimePeriodDataTable renders table with only one of each option and no f
         England
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         18.3%
       </td>
@@ -1089,7 +1089,7 @@ exports[`TimePeriodDataTable renders table with only one of each option and no f
         England
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         18.3%
       </td>
@@ -1185,22 +1185,22 @@ exports[`TimePeriodDataTable renders table with two of every option 1`] = `
         Number of authorised absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         32,125
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         33,725
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         31,241
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         31,322
       </td>
@@ -1215,22 +1215,22 @@ exports[`TimePeriodDataTable renders table with two of every option 1`] = `
         Number of overall absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         39,697
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         41,239
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         41,945
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         41,228
       </td>
@@ -1253,22 +1253,22 @@ exports[`TimePeriodDataTable renders table with two of every option 1`] = `
         Number of authorised absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         1,135
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         1,582
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         904
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         939
       </td>
@@ -1283,22 +1283,22 @@ exports[`TimePeriodDataTable renders table with two of every option 1`] = `
         Number of overall absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         1,512
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2,122
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         1,215
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         1,268
       </td>
@@ -1329,22 +1329,22 @@ exports[`TimePeriodDataTable renders table with two of every option 1`] = `
         Number of authorised absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         30,389
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         31,244
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         25,741
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         26,594
       </td>
@@ -1359,22 +1359,22 @@ exports[`TimePeriodDataTable renders table with two of every option 1`] = `
         Number of overall absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         34,689
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         36,083
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         33,422
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         37,084
       </td>
@@ -1397,22 +1397,22 @@ exports[`TimePeriodDataTable renders table with two of every option 1`] = `
         Number of authorised absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         481
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         274
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         442
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         745
       </td>
@@ -1427,22 +1427,22 @@ exports[`TimePeriodDataTable renders table with two of every option 1`] = `
         Number of overall absence sessions
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         752
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         571
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         788
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         1,105
       </td>
@@ -1530,22 +1530,22 @@ exports[`TimePeriodDataTable renders table without indicators when there is only
         Barnet
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         3.4%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         3.4%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2.9%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2.8%
       </td>
@@ -1560,22 +1560,22 @@ exports[`TimePeriodDataTable renders table without indicators when there is only
         Barnsley
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         3.7%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         4.3%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2.5%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2.4%
       </td>
@@ -1598,22 +1598,22 @@ exports[`TimePeriodDataTable renders table without indicators when there is only
         Barnet
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         3.3%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         3.3%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2.9%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         3.0%
       </td>
@@ -1628,22 +1628,22 @@ exports[`TimePeriodDataTable renders table without indicators when there is only
         Barnsley
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         3.3%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2.1%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         1.8%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2.6%
       </td>
@@ -1701,12 +1701,12 @@ exports[`TimePeriodDataTable renders table without time period when there is onl
         Barnet
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         3.4%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2.8%
       </td>
@@ -1721,12 +1721,12 @@ exports[`TimePeriodDataTable renders table without time period when there is onl
         Barnsley
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         4.3%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2.4%
       </td>
@@ -1749,12 +1749,12 @@ exports[`TimePeriodDataTable renders table without time period when there is onl
         Barnet
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         3.3%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         3.0%
       </td>
@@ -1769,12 +1769,12 @@ exports[`TimePeriodDataTable renders table without time period when there is onl
         Barnsley
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2.1%
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2.6%
       </td>

--- a/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/__snapshots__/PermalinkPage.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/__snapshots__/PermalinkPage.test.tsx.snap
@@ -55,22 +55,22 @@ exports[`PermalinkPage renders correctly with permalink 1`] = `
         State-funded primary
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         420,194
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         385,676
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         403,409
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         402,755
       </td>
@@ -85,22 +85,22 @@ exports[`PermalinkPage renders correctly with permalink 1`] = `
         State-funded primary and secondary
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         567,279
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         516,897
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         543,325
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         540,135
       </td>
@@ -115,22 +115,22 @@ exports[`PermalinkPage renders correctly with permalink 1`] = `
         State-funded secondary
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         147,085
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         131,221
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         139,916
       </td>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         137,380
       </td>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`TableToolPage renders the page correctly with pre-built table when a fa
         Gender gap
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         20.00%
       </td>
@@ -57,7 +57,7 @@ exports[`TableToolPage renders the page correctly with pre-built table when a fa
         Graduates included in earnings figures
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2
       </td>
@@ -80,7 +80,7 @@ exports[`TableToolPage renders the page correctly with pre-built table when a fa
         Gender gap
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         60.00%
       </td>
@@ -95,7 +95,7 @@ exports[`TableToolPage renders the page correctly with pre-built table when a fa
         Graduates included in earnings figures
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         2
       </td>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__snapshots__/TableToolFinalStep.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__snapshots__/TableToolFinalStep.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`TableToolFinalStep renders the final step successfully 1`] = `
         2020 Week 23
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         22,500
       </td>
@@ -65,7 +65,7 @@ exports[`TableToolFinalStep renders the final step successfully 1`] = `
         2020 Week 23
       </th>
       <td
-        class="govuk-table__cell--numeric"
+        class="govuk-table__cell--numeric dfe-white-space--nowrap"
       >
         1%
       </td>


### PR DESCRIPTION
Before:
<img width="349" alt="Screenshot 2024-03-05 164909" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/48a14607-d5fe-476c-badf-9176ca22279c">

After:
<img width="347" alt="Screenshot 2024-03-05 164857" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/5a53d8cf-79ba-4bd3-84a8-4f0636a1e7c6">


