### PR TITLE
Disable `csharp_style_unused_value_expression_statement_preference` (IDE0058)

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -165,7 +165,7 @@ csharp_style_deconstructed_variable_declaration = true:suggestion
 ## IDE0059 (https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0059?pivots=lang-csharp-vb)
 csharp_style_unused_value_assignment_preference = discard_variable:suggestion
 ## IDE0058 (https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0058)
-csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 
 # Field preferences
 ## IDE0044 (https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0044)


### PR DESCRIPTION
This disables the [csharp_style_unused_value_expression_statement_preference](https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/ide0058) (IDE0058) rule as this creates lots of unnecessary suggestions where a method may return something, but nothing has been assigned to it. 

For example, given a builder like the following:

```cs
public class MyBuilder
{
    public MyBuilder DoSomething()
    {
        return this;     
    }
}
```

We'll get a suggestion for the rule:

```cs
var builder = new MyBuilder();

builder.DoSomething();  // IDE0058

// With the rule set to `discard_variable` (currently) it suggests:
_ = builder.DoSomething();

// With the rule set to `unused_local_variable` it suggests:
var unused = builder.DoSomething();
```

Either suggestions seems completely unnecessary and creates unnecessary noise, particularly when using builder-like classes. I proposed that we disable it.