### PR TITLE
EES-4668 Rename `Publication.Releases` to `Publication.ReleaseVersions`.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfReleaseAuthorizationHandlersTests.cs
@@ -37,7 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 0, draftVersion: true)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv is { Published: null, Version: 0 });
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: null, Version: 0 });
 
                 // Assert that no users can amend an unpublished Release that is the only version
                 await AssertHandlerSucceedsWithCorrectClaims<ReleaseVersion, MakeAmendmentOfSpecificReleaseRequirement>(
@@ -60,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 1)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv is { Published: not null, Version: 0 });
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: not null, Version: 0 });
 
                 // Assert that users with the "MakeAmendmentOfAllReleases" claim can amend a published Release that is the only version
                 await AssertHandlerSucceedsWithCorrectClaims<ReleaseVersion, MakeAmendmentOfSpecificReleaseRequirement>(
@@ -84,7 +84,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 1, draftVersion: true)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv is { Published: null, Version: 1 });
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: null, Version: 1 });
 
                 // Assert that no users can amend a version that is not published
                 await AssertHandlerSucceedsWithCorrectClaims<ReleaseVersion, MakeAmendmentOfSpecificReleaseRequirement>(
@@ -107,7 +107,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 2)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv.Version == 0);
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv.Version == 0);
 
                 // Assert that no users can amend an amendment Release if it is not the latest version
                 await AssertHandlerSucceedsWithCorrectClaims<ReleaseVersion, MakeAmendmentOfSpecificReleaseRequirement>(
@@ -130,7 +130,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 2)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv.Version == 1);
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv.Version == 1);
 
                 // Assert that users with the "MakeAmendmentOfAllReleases" claim can amend a published Release that is the latest version
                 await AssertHandlerSucceedsWithCorrectClaims<ReleaseVersion, MakeAmendmentOfSpecificReleaseRequirement>(
@@ -157,7 +157,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 0, draftVersion: true)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv is { Published: null, Version: 0 });
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: null, Version: 0 });
 
                 // Assert that no User Publication roles will allow an unpublished Release that is the only version to be amended
                 await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
@@ -181,7 +181,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 1)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv is { Published: not null, Version: 0 });
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: not null, Version: 0 });
 
                 // Assert that a User who has the Publication Owner role on a Release can amend it if it is the only version published
                 await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
@@ -206,7 +206,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 1, draftVersion: true)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv is { Published: null, Version: 1 });
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: null, Version: 1 });
 
                 // Assert that no User Publication roles will allow an amendment Release that is not yet approved to be amended
                 await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
@@ -230,7 +230,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 2)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv.Version == 0);
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv.Version == 0);
 
                 // Assert that no User Publication roles will allow an amendment Release that is not the latest version to be amended
                 await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
@@ -254,7 +254,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 2)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv.Version == 1);
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv.Version == 1);
 
                 // Assert that a User who has the Publication Owner role on a Release can amend it if it is the latest published version
                 await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
@@ -282,7 +282,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 0, draftVersion: true)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv is { Published: null, Version: 0 });
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: null, Version: 0 });
 
                 // Assert that no User Release roles will allow an unpublished Release that is the only version to be amended
                 await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MakeAmendmentOfSpecificReleaseRequirement>(
@@ -305,7 +305,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 1)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv is { Published: not null, Version: 0 });
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: not null, Version: 0 });
 
                 // Assert that no User Release roles will allow a published Release that is the only version to be amended
                 await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MakeAmendmentOfSpecificReleaseRequirement>(
@@ -328,7 +328,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 1, draftVersion: true)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv is { Published: null, Version: 1 });
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: null, Version: 1 });
 
                 // Assert that no User Release roles will allow an amendment Release that is not yet approved to be amended
                 await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MakeAmendmentOfSpecificReleaseRequirement>(
@@ -351,7 +351,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 2)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv.Version == 0);
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv.Version == 0);
 
                 // Assert that no User Release roles will allow an amendment Release that is not the latest version to be amended
                 await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MakeAmendmentOfSpecificReleaseRequirement>(
@@ -374,7 +374,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .DefaultReleaseParent(publishedVersions: 2)
                         .Generate(1));
 
-                var releaseVersion = publication.Releases.Single(rv => rv.Version == 1);
+                var releaseVersion = publication.ReleaseVersions.Single(rv => rv.Version == 1);
 
                 // Assert that no User Release roles will allow an amendment Release that is the latest version to be amended
                 await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MakeAmendmentOfSpecificReleaseRequirement>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -984,7 +984,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         Owner = true
                     }
                 ),
-                Releases = ListOf(
+                ReleaseVersions = ListOf(
                     new ReleaseVersion
                     {
                         Published = DateTime.UtcNow,
@@ -1022,7 +1022,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         Owner = false
                     }
                 ),
-                Releases = ListOf(
+                ReleaseVersions = ListOf(
                     new ReleaseVersion
                     {
                         Published = DateTime.UtcNow,
@@ -1069,19 +1069,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 // Check that only unpublished Releases are included and that they are in the correct order
 
-                var expectedReleaseAtIndex0 = adoptingPublication.Releases.Single(rv =>
+                var expectedReleaseAtIndex0 = adoptingPublication.ReleaseVersions.Single(rv =>
                     rv.Year == 2021 && rv.TimePeriodCoverage == FinancialYearQ2);
 
-                var expectedReleaseAtIndex1 = adoptingPublication.Releases.Single(rv =>
+                var expectedReleaseAtIndex1 = adoptingPublication.ReleaseVersions.Single(rv =>
                     rv.Year == 2021 && rv.TimePeriodCoverage == FinancialYearQ1);
 
-                var expectedReleaseAtIndex2 = adoptingPublication.Releases.Single(rv =>
+                var expectedReleaseAtIndex2 = adoptingPublication.ReleaseVersions.Single(rv =>
                     rv.Year == 2020 && rv.TimePeriodCoverage == FinancialYearQ4);
 
-                var expectedReleaseAtIndex3 = owningPublication.Releases.Single(rv =>
+                var expectedReleaseAtIndex3 = owningPublication.ReleaseVersions.Single(rv =>
                     rv.Year == 2021 && rv.TimePeriodCoverage == CalendarYear);
 
-                var expectedReleaseAtIndex4 = owningPublication.Releases.Single(rv =>
+                var expectedReleaseAtIndex4 = owningPublication.ReleaseVersions.Single(rv =>
                     rv.Year == 2020 && rv.TimePeriodCoverage == CalendarYear);
 
                 Assert.Equal(5, result.Count);
@@ -1183,7 +1183,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         Owner = true
                     }
                 ),
-                Releases = ListOf(
+                ReleaseVersions = ListOf(
                     new ReleaseVersion
                     {
                         Published = DateTime.UtcNow,
@@ -1203,7 +1203,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         Owner = false
                     }
                 ),
-                Releases = ListOf(
+                ReleaseVersions = ListOf(
                     new ReleaseVersion
                     {
                         Published = DateTime.UtcNow,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationRepositoryTests.cs
@@ -96,15 +96,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(3, result.Count);
 
                 Assert.Equal("Related publication 2", result[0].Title);
-                Assert.Empty(result[0].Releases); // ListPublicationsForUser doesn't hydrate releases
+                Assert.Empty(result[0].ReleaseVersions); // ListPublicationsForUser doesn't hydrate releases
                 Assert.Empty(result[0].Methodologies); // ListPublicationsForUser doesn't hydrate methodologies
 
                 Assert.Equal("Related publication 3", result[1].Title);
-                Assert.Empty(result[1].Releases);
+                Assert.Empty(result[1].ReleaseVersions);
                 Assert.Empty(result[1].Methodologies);
 
                 Assert.Equal("Related publication 1", result[2].Title);
-                Assert.Empty(result[2].Releases);
+                Assert.Empty(result[2].ReleaseVersions);
                 Assert.Empty(result[2].Methodologies);
             }
         }
@@ -239,22 +239,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.False(result.Exists(pub => pub.Title == "Release PrereleaseViewer publication"));
 
                 Assert.Equal("Publication Owner publication", result[0].Title);
-                Assert.Empty(result[0].Releases); // ListPublicationsForUser doesn't hydrate releases
+                Assert.Empty(result[0].ReleaseVersions); // ListPublicationsForUser doesn't hydrate releases
 
                 Assert.Equal("Publication Approver publication", result[1].Title);
-                Assert.Empty(result[1].Releases);
+                Assert.Empty(result[1].ReleaseVersions);
 
                 Assert.Equal("Publication Owner publication 2", result[2].Title);
-                Assert.Empty(result[2].Releases);
+                Assert.Empty(result[2].ReleaseVersions);
 
                 Assert.Equal("Release Contributor publication", result[3].Title);
-                Assert.Empty(result[3].Releases);
+                Assert.Empty(result[3].ReleaseVersions);
 
                 Assert.Equal("Release Viewer publication", result[4].Title);
-                Assert.Empty(result[4].Releases);
+                Assert.Empty(result[4].ReleaseVersions);
 
                 Assert.Equal("Release Contributor publication 2", result[5].Title);
-                Assert.Empty(result[5].Releases);
+                Assert.Empty(result[5].ReleaseVersions);
             }
         }
 
@@ -289,7 +289,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Publication = new Publication
                 {
                     Title = "Unrelated publication 2",
-                    Releases = new List<ReleaseVersion>
+                    ReleaseVersions = new List<ReleaseVersion>
                     {
                         new()
                         {
@@ -354,7 +354,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Publication = new Publication
                 {
                     Title = "Related publication 2",
-                    Releases = new List<ReleaseVersion>
+                    ReleaseVersions = new List<ReleaseVersion>
                     {
                         new()
                         {
@@ -461,8 +461,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var resultPublication = Assert.Single(publications);
                 Assert.Equal("Publication", resultPublication.Title);
 
-                var resultRelease = Assert.Single(resultPublication.Releases);
-                Assert.Equal("Academic year 2011/12", resultRelease.Title);
+                var resultReleaseVersion = Assert.Single(resultPublication.ReleaseVersions);
+                Assert.Equal("Academic year 2011/12", resultReleaseVersion.Title);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -2579,9 +2579,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(new[]
                 {
-                    publication.Releases.Single(rv => rv is { Year: 2022, Version: 1 }).Id,
-                    publication.Releases.Single(rv => rv is { Year: 2021, Version: 0 }).Id,
-                    publication.Releases.Single(rv => rv is { Year: 2020, Version: 1 }).Id
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 }).Id,
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2021, Version: 0 }).Id,
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 1 }).Id
                 }, releases.Select(r => r.Id).ToArray());
             }
         }
@@ -2595,7 +2595,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -2664,7 +2664,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(new[]
                 {
-                    publication.Releases.Single(rv => rv is { Year: 2022, Version: 1 }).Id
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 }).Id
                 }, releases.Select(r => r.Id).ToArray());
             }
         }
@@ -2700,8 +2700,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(new[]
                 {
-                    publication.Releases.Single(rv => rv is { Year: 2021, Version: 0 }).Id,
-                    publication.Releases.Single(rv => rv is { Year: 2020, Version: 1 }).Id
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2021, Version: 0 }).Id,
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 1 }).Id
                 }, releases.Select(r => r.Id).ToArray());
             }
         }
@@ -2817,7 +2817,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Assert.Equal(expectedTotalResults, pagedResult.Paging.TotalResults);
 
                     var expectedLatestReleaseVersionIds = years.Select(year =>
-                        publication.Releases.Single(rv => rv.Year == year && rv.Version == 1).Id).ToArray();
+                        publication.ReleaseVersions.Single(rv => rv.Year == year && rv.Version == 1).Id).ToArray();
 
                     Assert.Equal(expectedLatestReleaseVersionIds, pagedResult.Results.Select(r => r.Id).ToArray());
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseInviteServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseInviteServicePermissionTests.cs
@@ -32,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication = new Publication
             {
                 Id = Guid.NewGuid(),
-                Releases = ListOf(releaseVersion),
+                ReleaseVersions = ListOf(releaseVersion),
             };
 
             await PolicyCheckBuilder<SecurityPolicies>()
@@ -67,7 +67,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication = new Publication
             {
                 Id = Guid.NewGuid(),
-                Releases = ListOf(releaseVersion),
+                ReleaseVersions = ListOf(releaseVersion),
             };
 
             await PolicyCheckBuilder<SecurityPolicies>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseInviteServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseInviteServiceTests.cs
@@ -78,8 +78,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.InviteContributor(
                     email: "test@test.com",
                     publicationId: publication.Id,
-                    releaseVersionIds: ListOf(publication.Releases[0].Id,
-                        publication.Releases[1].Id));
+                    releaseVersionIds: ListOf(publication.ReleaseVersions[0].Id,
+                        publication.ReleaseVersions[1].Id));
 
                 emailService.Verify(
                     s => s.SendEmail(
@@ -123,14 +123,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(2, userReleaseInvites.Count);
 
                 Assert.Equal("test@test.com", userReleaseInvites[0].Email);
-                Assert.Equal(publication.Releases[0].Id, userReleaseInvites[0].ReleaseVersionId);
+                Assert.Equal(publication.ReleaseVersions[0].Id, userReleaseInvites[0].ReleaseVersionId);
                 Assert.Equal(Contributor, userReleaseInvites[0].Role);
                 Assert.Equal(CreatedById, userReleaseInvites[0].CreatedById);
                 Assert.True(userReleaseInvites[0].EmailSent);
                 Assert.InRange(DateTime.UtcNow.Subtract(userReleaseInvites[0].Created).Milliseconds, 0, 1500);
 
                 Assert.Equal("test@test.com", userReleaseInvites[1].Email);
-                Assert.Equal(publication.Releases[1].Id, userReleaseInvites[1].ReleaseVersionId);
+                Assert.Equal(publication.ReleaseVersions[1].Id, userReleaseInvites[1].ReleaseVersionId);
                 Assert.Equal(Contributor, userReleaseInvites[1].Role);
                 Assert.Equal(CreatedById, userReleaseInvites[1].CreatedById);
                 Assert.True(userReleaseInvites[1].EmailSent);
@@ -155,7 +155,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var existingUserReleaseRole = new UserReleaseRole
             {
                 User = user,
-                ReleaseVersion = publication.Releases[0],
+                ReleaseVersion = publication.ReleaseVersions[0],
                 Role = Contributor,
                 Created = new DateTime(2000, 1, 1),
                 CreatedById = Guid.NewGuid(),
@@ -203,8 +203,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.InviteContributor(
                     email: "test@test.com",
                     publicationId: publication.Id,
-                    releaseVersionIds: ListOf(publication.Releases[0].Id,
-                        publication.Releases[1].Id));
+                    releaseVersionIds: ListOf(publication.ReleaseVersions[0].Id,
+                        publication.ReleaseVersions[1].Id));
 
                 emailService.Verify(
                     s => s.SendEmail(
@@ -242,7 +242,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(existingUserReleaseRole.CreatedById, userReleaseRoles[0].CreatedById);
 
                 Assert.Equal(user.Id, userReleaseRoles[1].UserId);
-                Assert.Equal(publication.Releases[1].Id, userReleaseRoles[1].ReleaseVersionId);
+                Assert.Equal(publication.ReleaseVersions[1].Id, userReleaseRoles[1].ReleaseVersionId);
                 Assert.Equal(Contributor, userReleaseRoles[1].Role);
                 Assert.Equal(CreatedById, userReleaseRoles[1].CreatedById);
                 userReleaseRoles[1].Created.AssertUtcNow();
@@ -267,7 +267,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var userRelease1Invite = new UserReleaseInvite
             {
                 Email = "test@test.com",
-                ReleaseVersion = publication.Releases[0],
+                ReleaseVersion = publication.ReleaseVersions[0],
                 Role = Contributor,
                 Created = new DateTime(2000, 1, 1),
                 CreatedById = Guid.NewGuid(),
@@ -276,7 +276,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var userRelease2Invite = new UserReleaseInvite
             {
                 Email = "test@test.com",
-                ReleaseVersion = publication.Releases[1],
+                ReleaseVersion = publication.ReleaseVersions[1],
                 Role = Contributor,
                 Created = new DateTime(2001, 1, 1),
                 CreatedById = Guid.NewGuid(),
@@ -301,8 +301,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.InviteContributor(
                     email: "test@test.com",
                     publicationId: publication.Id,
-                    releaseVersionIds: ListOf(publication.Releases[0].Id,
-                        publication.Releases[1].Id));
+                    releaseVersionIds: ListOf(publication.ReleaseVersions[0].Id,
+                        publication.ReleaseVersions[1].Id));
 
                 result.AssertBadRequest(UserAlreadyHasReleaseRoleInvites);
             }
@@ -349,7 +349,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var userRelease1Role = new UserReleaseRole
             {
                 User = user,
-                ReleaseVersion = publication.Releases[0],
+                ReleaseVersion = publication.ReleaseVersions[0],
                 Role = Contributor,
                 Created = new DateTime(2000, 1, 1),
                 CreatedById = Guid.NewGuid(),
@@ -358,7 +358,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var userRelease2Role = new UserReleaseRole
             {
                 User = user,
-                ReleaseVersion = publication.Releases[1],
+                ReleaseVersion = publication.ReleaseVersions[1],
                 Role = Contributor,
                 Created = new DateTime(2001, 1, 1),
                 CreatedById = Guid.NewGuid(),
@@ -384,8 +384,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.InviteContributor(
                     email: "test@test.com",
                     publicationId: publication.Id,
-                    releaseVersionIds: ListOf(publication.Releases[0].Id,
-                        publication.Releases[1].Id));
+                    releaseVersionIds: ListOf(publication.ReleaseVersions[0].Id,
+                        publication.ReleaseVersions[1].Id));
 
                 result.AssertBadRequest(UserAlreadyHasReleaseRoles);
             }
@@ -454,7 +454,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.InviteContributor(
                     email: "test@test.com",
                     publicationId: publication.Id,
-                    releaseVersionIds: ListOf(publication.Releases[0].Id));
+                    releaseVersionIds: ListOf(publication.ReleaseVersions[0].Id));
 
                 emailService.Verify(
                     s => s.SendEmail(
@@ -536,7 +536,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.InviteContributor(
                     email: "test@test.com",
                     publicationId: publication.Id,
-                    releaseVersionIds: ListOf(publication.Releases[0].Id));
+                    releaseVersionIds: ListOf(publication.ReleaseVersions[0].Id));
 
                 emailService.Verify(
                     s => s.SendEmail(
@@ -604,8 +604,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.InviteContributor(
                     email: "test@test.com",
                     publicationId: publication1.Id,
-                    releaseVersionIds: ListOf(publication1.Releases[0].Id,
-                        publication2.Releases[0].Id));
+                    releaseVersionIds: ListOf(publication1.ReleaseVersions[0].Id,
+                        publication2.ReleaseVersions[0].Id));
 
                 result.AssertBadRequest(NotAllReleasesBelongToPublication);
             }
@@ -649,7 +649,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication1 = new Publication
             {
                 Title = "Publication title",
-                Releases = ListOf(release1Version1, release2Version1)
+                ReleaseVersions = ListOf(release1Version1, release2Version1)
             };
 
             var release3Version1 = new ReleaseVersion()
@@ -660,7 +660,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication2 = new Publication
             {
                 Title = "Ignored publication title",
-                Releases = ListOf(release3Version1),
+                ReleaseVersions = ListOf(release3Version1),
             };
 
             var invite1 = new UserReleaseInvite

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleasePermissionServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleasePermissionServicePermissionTests.cs
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         private static readonly Publication Publication = new()
         {
             Id = Guid.NewGuid(),
-            Releases = new List<ReleaseVersion>
+            ReleaseVersions = new List<ReleaseVersion>
             {
                 ReleaseVersion
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -227,7 +227,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         Id = new Guid("403d3c5d-a8cd-4d54-a029-0c74c86c55b2"),
                         Title = "Publication",
-                        Releases = ListOf(templateRelease)
+                        ReleaseVersions = ListOf(templateRelease)
                     }
                 );
                 await context.ContentBlocks.AddRangeAsync(dataBlock1, dataBlock2);
@@ -790,7 +790,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Title = "Test publication",
                 Slug = "test-publication",
                 LatestPublishedReleaseVersion = releaseVersion,
-                Releases =
+                ReleaseVersions =
                 {
                     releaseVersion
                 }
@@ -863,7 +863,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var publication = new Publication
             {
-                Releases =
+                ReleaseVersions =
                 {
                     releaseVersion
                 }
@@ -906,7 +906,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var publication = new Publication
             {
-                Releases =
+                ReleaseVersions =
                 {
                     releaseVersion
                 }
@@ -991,7 +991,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var publication = new Publication
             {
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     releaseVersion
                 },
@@ -1292,12 +1292,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 // assert that soft-deleted entities do not appear via references from other entities by default
                 var publicationWithoutDeletedRelease = context
                     .Publications
-                    .Include(p => p.Releases)
+                    .Include(p => p.ReleaseVersions)
                     .AsNoTracking()
                     .First(p => p.Id == publication.Id);
 
-                Assert.Single(publicationWithoutDeletedRelease.Releases);
-                Assert.Equal(anotherRelease.Id, publicationWithoutDeletedRelease.Releases[0].Id);
+                Assert.Single(publicationWithoutDeletedRelease.ReleaseVersions);
+                Assert.Equal(anotherRelease.Id, publicationWithoutDeletedRelease.ReleaseVersions[0].Id);
 
                 // assert that soft-deleted entities have had their soft-deleted flag set to true
                 var updatedRelease = context
@@ -1324,16 +1324,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 // assert that soft-deleted entities appear via references from other entities when explicitly searched for
                 var publicationWithDeletedRelease = context
                     .Publications
-                    .Include(p => p.Releases)
+                    .Include(p => p.ReleaseVersions)
                     .IgnoreQueryFilters()
                     .AsNoTracking()
                     .First(p => p.Id == publication.Id);
 
-                Assert.Equal(2, publicationWithDeletedRelease.Releases.Count);
-                Assert.Equal(updatedRelease.Id, publicationWithDeletedRelease.Releases[0].Id);
-                Assert.Equal(anotherRelease.Id, publicationWithDeletedRelease.Releases[1].Id);
-                Assert.True(publicationWithDeletedRelease.Releases[0].SoftDeleted);
-                Assert.False(publicationWithDeletedRelease.Releases[1].SoftDeleted);
+                Assert.Equal(2, publicationWithDeletedRelease.ReleaseVersions.Count);
+                Assert.Equal(updatedRelease.Id, publicationWithDeletedRelease.ReleaseVersions[0].Id);
+                Assert.Equal(anotherRelease.Id, publicationWithDeletedRelease.ReleaseVersions[1].Id);
+                Assert.True(publicationWithDeletedRelease.ReleaseVersions[0].SoftDeleted);
+                Assert.False(publicationWithDeletedRelease.ReleaseVersions[1].SoftDeleted);
 
                 // assert that other entities were not accidentally soft-deleted
                 var retrievedAnotherReleaseRole = context
@@ -1373,7 +1373,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication = new Publication
             {
                 LatestPublishedReleaseVersionId = Guid.NewGuid(),
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     new()
                     {
@@ -1402,7 +1402,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             releaseCacheService.Setup(s => s.UpdateRelease(releaseVersionId,
                 publication.Slug,
-                publication.Releases[0].Slug
+                publication.ReleaseVersions[0].Slug
             )).ReturnsAsync(new ReleaseCacheViewModel(releaseVersionId));
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -1438,7 +1438,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication = new Publication
             {
                 LatestPublishedReleaseVersionId = releaseVersionId,
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     new()
                     {
@@ -1467,7 +1467,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             releaseCacheService.Setup(s => s.UpdateRelease(releaseVersionId,
                 publication.Slug,
-                publication.Releases[0].Slug
+                publication.ReleaseVersions[0].Slug
             )).ReturnsAsync(new ReleaseCacheViewModel(releaseVersionId));
 
             // As the release is the latest for the publication the separate cache entry for the publication's latest
@@ -1510,7 +1510,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication = new Publication
             {
                 LatestPublishedReleaseVersionId = Guid.NewGuid(),
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     new()
                     {
@@ -1557,7 +1557,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication = new Publication
             {
                 LatestPublishedReleaseVersionId = Guid.NewGuid(),
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     new()
                     {
@@ -1604,7 +1604,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication = new Publication
             {
                 LatestPublishedReleaseVersionId = Guid.NewGuid(),
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     new()
                     {
@@ -1633,7 +1633,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             releaseCacheService.Setup(s => s.UpdateRelease(releaseVersionId,
                 publication.Slug,
-                publication.Releases[0].Slug
+                publication.ReleaseVersions[0].Slug
             )).ReturnsAsync(new ReleaseCacheViewModel(releaseVersionId));
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -1692,31 +1692,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .DefaultUserReleaseRole()
                     .WithUser(User)
                     .WithRole(ReleaseRole.Contributor)
-                    .WithReleaseVersions(publications[0].Releases)
+                    .WithReleaseVersions(publications[0].ReleaseVersions)
                     .GenerateList();
 
                 var approverReleaseRolesForUser = _fixture
                     .DefaultUserReleaseRole()
                     .WithUser(User)
                     .WithRole(ReleaseRole.Approver)
-                    .WithReleaseVersions(publications[1].Releases)
+                    .WithReleaseVersions(publications[1].ReleaseVersions)
                     .GenerateList();
 
                 var prereleaseReleaseRolesForUser = _fixture
                     .DefaultUserReleaseRole()
                     .WithUser(User)
                     .WithRole(ReleaseRole.PrereleaseViewer)
-                    .WithReleaseVersions(publications[2].Releases)
+                    .WithReleaseVersions(publications[2].ReleaseVersions)
                     .GenerateList();
 
                 var approverReleaseRolesForOtherUser = _fixture
                     .DefaultUserReleaseRole()
                     .WithUser(otherUser)
                     .WithRole(ReleaseRole.Approver)
-                    .WithReleaseVersions(publications.SelectMany(publication => publication.Releases))
+                    .WithReleaseVersions(publications.SelectMany(publication => publication.ReleaseVersions))
                     .GenerateList();
 
-                var higherReviewReleaseWithApproverRoleForUser = publications[1].Releases[1];
+                var higherReviewReleaseWithApproverRoleForUser = publications[1].ReleaseVersions[1];
 
                 await using (var context = InMemoryApplicationDbContext(contextId))
                 {
@@ -1796,8 +1796,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .WithPublications(publications)
                     .GenerateList();
 
-                var release1WithApproverRoleForUser = publications[1].Releases[1];
-                var release2WithApproverRoleForUser = publications[1].Releases[3];
+                var release1WithApproverRoleForUser = publications[1].ReleaseVersions[1];
+                var release2WithApproverRoleForUser = publications[1].ReleaseVersions[3];
 
                 await using (var context = InMemoryApplicationDbContext(contextId))
                 {
@@ -1843,7 +1843,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .DefaultUserReleaseRole()
                     .WithUser(User)
                     .WithRole(ReleaseRole.Approver)
-                    .WithReleaseVersions(publication.Releases)
+                    .WithReleaseVersions(publication.ReleaseVersions)
                     .GenerateList();
 
                 var approverPublicationRoleForUser = _fixture
@@ -1872,7 +1872,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     // Assert that the Release only appears once despite the user having approval directly via the
                     // Release itself AND via the overarching Publication.
                     Assert.Single(viewModels);
-                    Assert.Equal(publication.Releases[0].Id, viewModels[0].Id);
+                    Assert.Equal(publication.ReleaseVersions[0].Id, viewModels[0].Id);
                 }
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionRepositoryTests.cs
@@ -142,7 +142,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     Title = "Test publication 1",
                     Slug = "test-publication-1",
-                    Releases = new List<ReleaseVersion>
+                    ReleaseVersions = new List<ReleaseVersion>
                     {
                         new()
                         {
@@ -159,7 +159,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "Test publication 2",
                 Slug = "test-publication-2",
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     new()
                     {
@@ -183,7 +183,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await repository.ListReleasesForUser(userId,
                         ReleaseApprovalStatus.Approved);
                 Assert.Single(result);
-                Assert.Equal(userPublicationRole1.Publication.Releases[0].Id, result[0].Id);
+                Assert.Equal(userPublicationRole1.Publication.ReleaseVersions[0].Id, result[0].Id);
             }
         }
 
@@ -198,7 +198,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     Title = "Test publication 1",
                     Slug = "test-publication-1",
-                    Releases = new List<ReleaseVersion>
+                    ReleaseVersions = new List<ReleaseVersion>
                     {
                         new()
                         {
@@ -238,7 +238,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     Title = "Test publication 1",
                     Slug = "test-publication-1",
-                    Releases = new List<ReleaseVersion>
+                    ReleaseVersions = new List<ReleaseVersion>
                     {
                         new()
                         {
@@ -255,7 +255,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "Test publication 2",
                 Slug = "test-publication-2",
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     new()
                     {
@@ -280,7 +280,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         ReleaseApprovalStatus.Approved);
 
                 var resultRelease = Assert.Single(result);
-                Assert.Equal(userPublicationRole1.Publication.Releases[0].Id, resultRelease.Id);
+                Assert.Equal(userPublicationRole1.Publication.ReleaseVersions[0].Id, resultRelease.Id);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
@@ -500,7 +500,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Id = publicationId,
                 Topic = topic,
-                Releases = AsList(new ReleaseVersion
+                ReleaseVersions = AsList(new ReleaseVersion
                     {
                         Id = releaseVersion2Id,
                         PreviousVersionId = releaseVersion1Id
@@ -654,7 +654,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Id = publicationId,
                 Topic = topic,
-                Releases = AsList(new ReleaseVersion
+                ReleaseVersions = AsList(new ReleaseVersion
                 {
                     Id = releaseVersionId
                 })
@@ -716,7 +716,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Id = publicationId,
                 Topic = topic,
-                Releases = AsList(new ReleaseVersion
+                ReleaseVersions = AsList(new ReleaseVersion
                 {
                     Id = releaseVersionId
                 })

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseInviteRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseInviteRepositoryTests.cs
@@ -223,7 +223,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var releaseVersion3 = new ReleaseVersion();
             var publication = new Publication
             {
-                Releases = ListOf(releaseVersion1, releaseVersion3),
+                ReleaseVersions = ListOf(releaseVersion1, releaseVersion3),
             };
             var invite1 = new UserReleaseInvite
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseRoleRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseRoleRepositoryTests.cs
@@ -565,7 +565,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var publication = new Publication
             {
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     new() { Id = Guid.NewGuid(), },
                     new() { Id = Guid.NewGuid(), },
@@ -574,7 +574,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             };
             var publication2 = new Publication
             {
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     new() { Id = Guid.NewGuid(), }
                 }
@@ -583,31 +583,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var userReleaseRole1 = new UserReleaseRole
             {
                 User = user,
-                ReleaseVersion = publication.Releases[0],
+                ReleaseVersion = publication.ReleaseVersions[0],
                 Role = Contributor,
             };
             var userReleaseRole2 = new UserReleaseRole
             {
                 User = user,
-                ReleaseVersion = publication.Releases[2],
+                ReleaseVersion = publication.ReleaseVersions[2],
                 Role = Contributor,
             };
             var notDeletedUserReleaseRole1 = new UserReleaseRole
             {
                 User = user,
-                ReleaseVersion = publication.Releases[0],
+                ReleaseVersion = publication.ReleaseVersions[0],
                 Role = PrereleaseViewer,
             };
             var notDeletedUserReleaseRole2 = new UserReleaseRole
             {
                 User = user,
-                ReleaseVersion = publication2.Releases[0],
+                ReleaseVersion = publication2.ReleaseVersions[0],
                 Role = Contributor,
             };
             var notDeletedUserReleaseRole3 = new UserReleaseRole
             {
                 UserId = Guid.NewGuid(),
-                ReleaseVersion = publication.Releases[0],
+                ReleaseVersion = publication.ReleaseVersions[0],
                 Role = Contributor,
             };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseRoleServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseRoleServiceTests.cs
@@ -32,38 +32,38 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var userReleaseRole1 = new UserReleaseRole
             {
                 User = new User { Id = Guid.NewGuid() },
-                ReleaseVersion = publication.Releases[0],
+                ReleaseVersion = publication.ReleaseVersions[0],
                 Role = Contributor,
             };
             var userReleaseRole2 = new UserReleaseRole
             {
                 User = new User { Id = Guid.NewGuid() },
-                ReleaseVersion = publication.Releases[0],
+                ReleaseVersion = publication.ReleaseVersions[0],
                 Role = Contributor,
             };
             var userReleaseRole3 = new UserReleaseRole
             {
                 User = new User { Id = Guid.NewGuid() },
-                ReleaseVersion = publication.Releases[1],
+                ReleaseVersion = publication.ReleaseVersions[1],
                 Role = Contributor,
             };
             var userReleaseRoleIgnored1 = new UserReleaseRole // Ignored because not Contributor role
             {
                 User = new User { Id = Guid.NewGuid() },
-                ReleaseVersion = publication.Releases[0],
+                ReleaseVersion = publication.ReleaseVersions[0],
                 Role = Lead,
             };
             var userReleaseRoleIgnored2 = new UserReleaseRole // Ignored because Deleted set
             {
                 User = new User { Id = Guid.NewGuid() },
-                ReleaseVersion = publication.Releases[0],
+                ReleaseVersion = publication.ReleaseVersions[0],
                 Role = Contributor,
                 Deleted = DateTime.UtcNow,
             };
             var userReleaseRoleIgnored3 = new UserReleaseRole // Ignored due to release under different publication
             {
                 User = new User { Id = Guid.NewGuid() },
-                ReleaseVersion = publicationIgnored.Releases[0],
+                ReleaseVersion = publicationIgnored.ReleaseVersions[0],
                 Role = Contributor,
             };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserRoleServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserRoleServicePermissionTests.cs
@@ -63,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication = new Publication
             {
                 Id = Guid.NewGuid(),
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     releaseVersion,
                 }
@@ -191,7 +191,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publication = new Publication
             {
                 Id = Guid.NewGuid(),
-                Releases = new List<ReleaseVersion>
+                ReleaseVersions = new List<ReleaseVersion>
                 {
                     releaseVersion,
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -131,9 +131,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                                 Title = rv.Publication.Topic.Theme.Title
                             }
                         },
-                        Releases = rv.Publication.Releases
+                        Releases = rv.Publication.ReleaseVersions
                             .FindAll(otherReleaseVersion => rv.Id != otherReleaseVersion.Id &&
-                                                     IsLatestVersionOfRelease(rv.Publication.Releases, otherReleaseVersion.Id))
+                                                     IsLatestVersionOfRelease(rv.Publication.ReleaseVersions, otherReleaseVersion.Id))
                             .OrderByDescending(otherReleaseVersion => otherReleaseVersion.Year)
                             .ThenByDescending(otherReleaseVersion => otherReleaseVersion.TimePeriodCoverage)
                             .Select(otherReleaseVersion => new PreviousReleaseViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
@@ -1929,7 +1929,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .OnDelete(DeleteBehavior.NoAction);
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", "Publication")
-                        .WithMany("Releases")
+                        .WithMany("ReleaseVersions")
                         .HasForeignKey("PublicationId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -2159,7 +2159,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.Navigation("Methodologies");
 
-                    b.Navigation("Releases");
+                    b.Navigation("ReleaseVersions");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseParent", b =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
@@ -138,7 +138,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                 .Include(rv => rv.Publication)
                 .ThenInclude(publication => publication.Contact)
                 .Include(rv => rv.Publication)
-                .ThenInclude(publication => publication.Releases)
+                .ThenInclude(publication => publication.ReleaseVersions)
                 .Include(rv => rv.Publication)
                 .ThenInclude(publication => publication.LegacyReleases)
                 .Include(rv => rv.Publication)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseInviteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseInviteService.cs
@@ -90,7 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             return await _contentPersistenceHelper
                 .CheckEntityExists<Publication>(publicationId, query => query
-                    .Include(p => p.Releases))
+                    .Include(p => p.ReleaseVersions))
                 .OnSuccessDo(
                     publication => _userService.CheckCanUpdateReleaseRole(publication, releaseRole))
                 .OnSuccess(async publication =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleasePermissionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleasePermissionService.cs
@@ -180,7 +180,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return await _persistenceHelper
                 .CheckEntityExists<Publication>(publicationId,
                     query =>
-                        query.Include(p => p.Releases))
+                        query.Include(p => p.ReleaseVersions))
                 .OnSuccessDo(publication => _userService
                     .CheckCanUpdateReleaseRole(publication, Contributor))
                 .OnSuccessVoid(async publication =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -376,7 +376,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var indirectReleasesWithApprovalRole = await _context
                 .UserPublicationRoles
                 .Where(role => role.UserId == userId && role.Role == PublicationRole.Approver)
-                .SelectMany(role => role.Publication.Releases.Select(releaseVersion => releaseVersion.Id))
+                .SelectMany(role => role.Publication.ReleaseVersions.Select(releaseVersion => releaseVersion.Id))
                 .ToListAsync();
 
             var releaseVersionIdsForApproval = directReleasesWithApprovalRole

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseInviteRepository.cs
@@ -117,10 +117,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             _contentDbContext.Update(publication);
             await _contentDbContext.Entry(publication)
-                .Collection(p => p.Releases)
+                .Collection(p => p.ReleaseVersions)
                 .LoadAsync();
 
-            var releaseVersionIds = publication.Releases
+            var releaseVersionIds = publication.ReleaseVersions
                 .Select(rv => rv.Id)
                 .ToList();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseRoleRepository.cs
@@ -37,10 +37,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             ContentDbContext.Update(publication);
             await ContentDbContext
                 .Entry(publication)
-                .Collection(p => p.Releases)
+                .Collection(p => p.ReleaseVersions)
                 .LoadAsync();
             var allReleaseVersionIds = publication
-                .Releases // Remove on previous release versions as well
+                .ReleaseVersions // Remove on previous release versions as well
                 .Select(rv => rv.Id)
                 .ToList();
             var userReleaseRoles = await ContentDbContext.UserReleaseRoles

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -66,8 +66,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Generate(2)
                     .ToTuple2();
 
-                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[0]);
-                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[0]);
+                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[0]);
+                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[0]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -80,7 +80,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     })
                     .CreateClient();
 
-                var query = new DataSetsListRequest(ReleaseId: publication1.Releases[0].Id);
+                var query = new DataSetsListRequest(ReleaseId: publication1.ReleaseVersions[0].Id);
                 var response = await ListDataSets(client, query);
 
                 MockUtils.VerifyAllMocks(MemoryCacheService);
@@ -105,8 +105,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Generate(2)
                     .ToTuple2();
 
-                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[0]);
-                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[0]);
+                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[0]);
+                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[0]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -147,8 +147,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Generate(2)
                     .ToTuple2();
 
-                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[0]);
-                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[0]);
+                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[0]);
+                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[0]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -190,8 +190,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0]);
-                var release2Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[1]);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0]);
+                var release2Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[1]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -206,7 +206,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
 
                 var query = new DataSetsListRequest
                 {
-                    ReleaseId = publication.Releases[1].Id,
+                    ReleaseId = publication.ReleaseVersions[1].Id,
                     LatestOnly = latestOnly
                 };
                 var response = await ListDataSets(client, query);
@@ -237,8 +237,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0]);
-                var release2Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[1]);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0]);
+                var release2Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[1]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -253,7 +253,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
 
                 var query = new DataSetsListRequest
                 {
-                    ReleaseId = publication.Releases[1].Id,
+                    ReleaseId = publication.ReleaseVersions[1].Id,
                     LatestOnly = true
                 };
                 var response = await ListDataSets(client, query);
@@ -287,9 +287,9 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Generate(2)
                     .ToTuple2();
 
-                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[0]);
-                var publication1Release1Version2Files = GenerateDataSetsForReleaseVersion(publication1.Releases[1]);
-                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[0]);
+                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[0]);
+                var publication1Release1Version2Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[1]);
+                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[0]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -305,7 +305,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
 
                 var query = new DataSetsListRequest
                 {
-                    ReleaseId = publication1.Releases[1].Id,
+                    ReleaseId = publication1.ReleaseVersions[1].Id,
                     LatestOnly = latestOnly
                 };
                 var response = await ListDataSets(client, query);
@@ -333,8 +333,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0]);
-                var release1Version2Files = GenerateDataSetsForReleaseVersion(publication.Releases[1]);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0]);
+                var release1Version2Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[1]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -349,7 +349,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
 
                 var query = new DataSetsListRequest
                 {
-                    ReleaseId = publication.Releases[0].Id,
+                    ReleaseId = publication.ReleaseVersions[0].Id,
                     LatestOnly = latestOnly
                 };
                 var response = await ListDataSets(client, query);
@@ -381,8 +381,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Generate(2)
                     .ToTuple2();
 
-                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[0]);
-                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[0]);
+                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[0]);
+                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[0]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -426,8 +426,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Generate(2)
                     .ToTuple2();
 
-                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[0]);
-                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[0]);
+                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[0]);
+                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[0]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -460,7 +460,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0]);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0]);
 
                 var freeTextRanks = new List<FreeTextRank>
                 {
@@ -472,7 +472,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
 
                 var contentDbContext = ContentDbContextMock(
-                    publication.Releases,
+                    publication.ReleaseVersions,
                     release1Version1Files,
                     freeTextRanks);
 
@@ -506,13 +506,13 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0]);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
 
                 var contentDbContext = ContentDbContextMock(
-                    publication.Releases,
+                    publication.ReleaseVersions,
                     release1Version1Files);
 
                 var client = BuildApp(contentDbContext.Object)
@@ -551,11 +551,11 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Generate(2)
                     .ToTuple2();
 
-                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[0]);
-                var publication1Release2Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[1]);
-                var publication1Release2Version2Files = GenerateDataSetsForReleaseVersion(publication1.Releases[2]);
-                var publication1Release2Version3Files = GenerateDataSetsForReleaseVersion(publication1.Releases[3]);
-                var publication1Release3Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[4]);
+                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[0]);
+                var publication1Release2Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[1]);
+                var publication1Release2Version2Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[2]);
+                var publication1Release2Version3Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[3]);
+                var publication1Release3Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[4]);
 
                 var publication1ReleaseFiles = publication1Release1Version1Files
                     .Concat(publication1Release2Version1Files)
@@ -564,11 +564,11 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Concat(publication1Release3Version1Files)
                     .ToList();
 
-                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[0]);
-                var publication2Release2Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[1]);
-                var publication2Release2Version2Files = GenerateDataSetsForReleaseVersion(publication2.Releases[2]);
-                var publication2Release2Version3Files = GenerateDataSetsForReleaseVersion(publication2.Releases[3]);
-                var publication2Release3Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[4]);
+                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[0]);
+                var publication2Release2Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[1]);
+                var publication2Release2Version2Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[2]);
+                var publication2Release2Version3Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[3]);
+                var publication2Release3Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[4]);
 
                 var publication2ReleaseFiles = publication2Release1Version1Files
                     .Concat(publication2Release2Version1Files)
@@ -625,11 +625,11 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Generate(2)
                     .ToTuple2();
 
-                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[0]);
-                var publication1Release2Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[1]);
-                var publication1Release2Version2Files = GenerateDataSetsForReleaseVersion(publication1.Releases[2]);
-                var publication1Release2Version3Files = GenerateDataSetsForReleaseVersion(publication1.Releases[3]);
-                var publication1Release3Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[4]);
+                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[0]);
+                var publication1Release2Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[1]);
+                var publication1Release2Version2Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[2]);
+                var publication1Release2Version3Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[3]);
+                var publication1Release3Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[4]);
 
                 var publication1ReleaseFiles = publication1Release1Version1Files
                     .Concat(publication1Release2Version1Files)
@@ -638,11 +638,11 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Concat(publication1Release3Version1Files)
                     .ToList();
 
-                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[0]);
-                var publication2Release2Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[1]);
-                var publication2Release2Version2Files = GenerateDataSetsForReleaseVersion(publication2.Releases[2]);
-                var publication2Release2Version3Files = GenerateDataSetsForReleaseVersion(publication2.Releases[3]);
-                var publication2Release3Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[4]);
+                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[0]);
+                var publication2Release2Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[1]);
+                var publication2Release2Version2Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[2]);
+                var publication2Release2Version3Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[3]);
+                var publication2Release3Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[4]);
 
                 var publication2ReleaseFiles = publication2Release1Version1Files
                     .Concat(publication2Release2Version1Files)
@@ -695,8 +695,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Generate(2)
                     .ToTuple2();
 
-                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.Releases[0]);
-                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.Releases[0]);
+                var publication1Release1Version1Files = GenerateDataSetsForReleaseVersion(publication1.ReleaseVersions[0]);
+                var publication2Release1Version1Files = GenerateDataSetsForReleaseVersion(publication2.ReleaseVersions[0]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -745,7 +745,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0]);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0]);
 
                 // Apply a descending sequence of titles to the data set files
                 release1Version1Files[0].Name = "b";
@@ -789,7 +789,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0]);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0]);
 
                 // Apply an ascending sequence of titles to the data set files
                 release1Version1Files[0].Name = "a";
@@ -836,7 +836,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0]);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0]);
 
                 // Apply a descending natural order to the data set files
                 release1Version1Files[0].Order = 1;
@@ -851,7 +851,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
 
                 var query = new DataSetsListRequest
                 {
-                    ReleaseId = publication.Releases[0].Id,
+                    ReleaseId = publication.ReleaseVersions[0].Id,
                     OrderBy = DataSetsListRequestOrderBy.Natural,
                     Sort = sortOrder
                 };
@@ -882,7 +882,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0]);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0]);
 
                 // Apply an ascending natural order to the data set files
                 release1Version1Files[0].Order = 0;
@@ -897,7 +897,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
 
                 var query = new DataSetsListRequest
                 {
-                    ReleaseId = publication.Releases[0].Id,
+                    ReleaseId = publication.ReleaseVersions[0].Id,
                     OrderBy = DataSetsListRequestOrderBy.Natural,
                     Sort = SortOrder.Desc
                 };
@@ -931,8 +931,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Generate(2)
                     .ToTuple2();
 
-                var publication1Release1Version1 = publication1.Releases[0];
-                var publication2Release1Version1 = publication2.Releases[0];
+                var publication1Release1Version1 = publication1.ReleaseVersions[0];
+                var publication2Release1Version1 = publication2.ReleaseVersions[0];
 
                 // Apply a descending sequence of published dates to the releases
                 publication1Release1Version1.Published = DateTime.UtcNow.AddDays(-1);
@@ -992,8 +992,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .Generate(2)
                     .ToTuple2();
 
-                var publication1Release1Version1 = publication1.Releases[0];
-                var publication2Release1Version1 = publication2.Releases[0];
+                var publication1Release1Version1 = publication1.ReleaseVersions[0];
+                var publication2Release1Version1 = publication2.ReleaseVersions[0];
 
                 // Apply an ascending sequence of published dates to the releases
                 publication1Release1Version1.Published = DateTime.UtcNow.AddDays(-2);
@@ -1047,7 +1047,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0], numberOfDataSets: 3);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0], numberOfDataSets: 3);
 
                 var freeTextRanks = new List<FreeTextRank>
                 {
@@ -1060,7 +1060,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
 
                 var contentDbContext = ContentDbContextMock(
-                    publication.Releases,
+                    publication.ReleaseVersions,
                     release1Version1Files,
                     freeTextRanks);
 
@@ -1103,7 +1103,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0], numberOfDataSets: 3);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0], numberOfDataSets: 3);
 
                 var freeTextRanks = new List<FreeTextRank>
                 {
@@ -1116,7 +1116,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
 
                 var contentDbContext = ContentDbContextMock(
-                    publication.Releases,
+                    publication.ReleaseVersions,
                     release1Version1Files,
                     freeTextRanks);
 
@@ -1171,8 +1171,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var supersedingPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersedingPublication.Releases[0]);
-                var supersededPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersededPublication.Releases[0]);
+                var supersedingPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersedingPublication.ReleaseVersions[0]);
+                var supersededPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersededPublication.ReleaseVersions[0]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -1218,8 +1218,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var supersedingPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersedingPublication.Releases[0]);
-                var supersededPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersededPublication.Releases[0]);
+                var supersedingPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersedingPublication.ReleaseVersions[0]);
+                var supersededPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersededPublication.ReleaseVersions[0]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -1265,8 +1265,8 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var supersedingPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersedingPublication.Releases[0]);
-                var supersededPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersededPublication.Releases[0]);
+                var supersedingPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersedingPublication.ReleaseVersions[0]);
+                var supersededPublicationReleaseFiles = GenerateDataSetsForReleaseVersion(supersededPublication.ReleaseVersions[0]);
 
                 MemoryCacheService
                     .SetupNotFoundForAnyKey<ListDataSetsCacheKey, PaginatedListViewModel<DataSetListViewModel>>();
@@ -1532,7 +1532,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTopic(_fixture.DefaultTopic()
                         .WithTheme(_fixture.DefaultTheme()));
 
-                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.Releases[0]);
+                var release1Version1Files = GenerateDataSetsForReleaseVersion(publication.ReleaseVersions[0]);
 
                 release1Version1Files.ForEach(releaseFile =>
                 {
@@ -1626,13 +1626,13 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
         }
 
         private static Mock<ContentDbContext> ContentDbContextMock(
-            IEnumerable<ReleaseVersion>? releases = null,
+            IEnumerable<ReleaseVersion>? releaseVersions = null,
             IEnumerable<ReleaseFile>? releaseFiles = null,
             IEnumerable<FreeTextRank>? freeTextRanks = null)
         {
             var contentDbContext = new Mock<ContentDbContext>();
             contentDbContext.Setup(context => context.ReleaseVersions)
-                .Returns((releases ?? Array.Empty<ReleaseVersion>()).AsQueryable().BuildMockDbSet().Object);
+                .Returns((releaseVersions ?? Array.Empty<ReleaseVersion>()).AsQueryable().BuildMockDbSet().Object);
             contentDbContext.Setup(context => context.ReleaseFiles)
                 .Returns((releaseFiles ?? Array.Empty<ReleaseFile>()).AsQueryable().BuildMockDbSet().Object);
             contentDbContext.Setup(context => context.ReleaseFilesFreeTextTable(It.IsAny<string>()))
@@ -1658,7 +1658,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTheme(_fixture.DefaultTheme()));
 
             ReleaseFile releaseFile = _fixture.DefaultReleaseFile()
-                .WithReleaseVersion(publication.Releases[0])
+                .WithReleaseVersion(publication.ReleaseVersions[0])
                 .WithFile(_fixture.DefaultFile());
 
             var client = BuildApp()
@@ -1706,7 +1706,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTheme(_fixture.DefaultTheme()));
 
             ReleaseFile releaseFile = _fixture.DefaultReleaseFile()
-                .WithReleaseVersion(publication.Releases[0])
+                .WithReleaseVersion(publication.ReleaseVersions[0])
                 .WithFile(_fixture.DefaultFile());
 
             var client = BuildApp()
@@ -1734,7 +1734,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTheme(_fixture.DefaultTheme()));
 
             ReleaseFile releaseFile = _fixture.DefaultReleaseFile()
-                .WithReleaseVersion(publication.Releases[0])
+                .WithReleaseVersion(publication.ReleaseVersions[0])
                 .WithFile(_fixture.DefaultFile());
 
             var client = BuildApp()
@@ -1744,7 +1744,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                 })
                 .CreateClient();
 
-            var uri = $"/api/releases/{publication.Releases[0].Id}/data-sets/{Guid.NewGuid()}";
+            var uri = $"/api/releases/{publication.ReleaseVersions[0].Id}/data-sets/{Guid.NewGuid()}";
 
             var response = await client.GetAsync(uri);
 
@@ -1762,7 +1762,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                     .WithTheme(_fixture.DefaultTheme()));
 
             ReleaseFile releaseFile = _fixture.DefaultReleaseFile()
-                .WithReleaseVersion(publication.Releases[0])
+                .WithReleaseVersion(publication.ReleaseVersions[0])
                 .WithFile(_fixture.DefaultFile());
 
             var client = BuildApp()
@@ -1792,15 +1792,15 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
             File file = _fixture.DefaultFile();
 
             ReleaseFile releaseFile0 = _fixture.DefaultReleaseFile()
-                .WithReleaseVersion(publication.Releases[0]) // the previous published version
+                .WithReleaseVersion(publication.ReleaseVersions[0]) // the previous published version
                 .WithFile(file);
 
             ReleaseFile releaseFile1 = _fixture.DefaultReleaseFile()
-                .WithReleaseVersion(publication.Releases[1]) // the latest published version
+                .WithReleaseVersion(publication.ReleaseVersions[1]) // the latest published version
                 .WithFile(file);
 
             ReleaseFile releaseFile2 = _fixture.DefaultReleaseFile()
-                .WithReleaseVersion(publication.Releases[2]) // the draft version
+                .WithReleaseVersion(publication.ReleaseVersions[2]) // the draft version
                 .WithFile(file);
 
             var client = BuildApp()
@@ -1810,7 +1810,7 @@ public class DataSetsControllerTests : IntegrationTest<TestStartup>
                 })
                 .CreateClient();
 
-            var uri = $"/api/releases/{publication.Releases[2].Id}/data-sets/{releaseFile2.FileId}";
+            var uri = $"/api/releases/{publication.ReleaseVersions[2].Id}/data-sets/{releaseFile2.FileId}";
 
             var response = await client.GetAsync(uri);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
@@ -106,7 +106,7 @@ public static class PublicationGeneratorExtensions
         this InstanceSetters<Publication> setters,
         Func<SetterContext, IEnumerable<ReleaseParent>> releaseParents)
         => setters.Set(
-                p => p.Releases,
+                p => p.ReleaseVersions,
                 (_, publication, context) =>
                 {
                     var list = releaseParents.Invoke(context).ToList();
@@ -125,7 +125,7 @@ public static class PublicationGeneratorExtensions
             )
             .Set(p => p.LatestPublishedReleaseVersion, (_, publication, _) =>
             {
-                var publishedVersions = publication.Releases
+                var publishedVersions = publication.ReleaseVersions
                     .Where(releaseVersion => releaseVersion.Published.HasValue)
                     .ToList();
 
@@ -167,7 +167,7 @@ public static class PublicationGeneratorExtensions
         this InstanceSetters<Publication> setters,
         Func<SetterContext, IEnumerable<ReleaseVersion>> releaseVersions)
         => setters.Set(
-            p => p.Releases,
+            p => p.ReleaseVersions,
             (_, publication, context) =>
             {
                 var list = releaseVersions.Invoke(context).ToList();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/ReleaseVersionRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/ReleaseVersionRepositoryTests.cs
@@ -41,7 +41,7 @@ public class ReleaseVersionRepositoryTests
 
             // Expect the result to be the latest published version taken from releases of the specified publication in
             // reverse chronological order
-            var expectedReleaseVersion = publications[0].Releases
+            var expectedReleaseVersion = publications[0].ReleaseVersions
                 .Single(rv => rv is { Published: not null, Year: 2021, Version: 1 });
 
             Assert.NotNull(result);
@@ -124,7 +124,7 @@ public class ReleaseVersionRepositoryTests
             var result = await repository.GetLatestPublishedReleaseVersion(publications[0].Id, "2021-22");
 
             // Expect the result to be the latest published version for the 2021-22 release of the specified publication
-            var expectedReleaseVersion = publications[0].Releases
+            var expectedReleaseVersion = publications[0].ReleaseVersions
                 .Single(rv => rv is { Published: not null, Year: 2021, Version: 1 });
 
             Assert.NotNull(result);
@@ -229,7 +229,7 @@ public class ReleaseVersionRepositoryTests
 
             // Expect the result to be the latest version taken from releases of the specified publication in
             // reverse chronological order
-            var expectedReleaseVersion = publications[0].Releases
+            var expectedReleaseVersion = publications[0].ReleaseVersions
                 .Single(rv => rv is { Year: 2022, Version: 0 });
 
             Assert.NotNull(result);
@@ -287,7 +287,7 @@ public class ReleaseVersionRepositoryTests
             await using var contentDbContext = InMemoryContentDbContext(contextId);
             var repository = BuildRepository(contentDbContext);
 
-            var releaseVersions = publication.Releases;
+            var releaseVersions = publication.ReleaseVersions;
 
             // Expect only the highest published version of the release to be the latest
             Assert.False(await repository.IsLatestPublishedReleaseVersion(releaseVersions[0].Id));
@@ -308,7 +308,7 @@ public class ReleaseVersionRepositoryTests
             await using var contentDbContext = InMemoryContentDbContext(contextId);
             var repository = BuildRepository(contentDbContext);
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             Assert.False(await repository.IsLatestPublishedReleaseVersion(releaseVersion.Id));
         }
@@ -345,7 +345,7 @@ public class ReleaseVersionRepositoryTests
             await using var contentDbContext = InMemoryContentDbContext(contextId);
             var repository = BuildRepository(contentDbContext);
 
-            var releaseVersions = publication.Releases;
+            var releaseVersions = publication.ReleaseVersions;
 
             // Expect only the highest version of the release to be the latest
             Assert.False(await repository.IsLatestReleaseVersion(releaseVersions[0].Id));
@@ -395,8 +395,8 @@ public class ReleaseVersionRepositoryTests
             // Expect the result to contain the highest published version of each release for the specified publication
             AssertIdsAreEqualIgnoringOrder(new[]
             {
-                publications[0].Releases[2].Id,
-                publications[0].Releases[5].Id
+                publications[0].ReleaseVersions[2].Id,
+                publications[0].ReleaseVersions[5].Id
             }, result);
         }
 
@@ -481,8 +481,8 @@ public class ReleaseVersionRepositoryTests
             // Expect the result to contain the highest published version of each release for the specified publication
             AssertIdsAreEqualIgnoringOrder(new[]
             {
-                publications[0].Releases[2].Id,
-                publications[0].Releases[5].Id
+                publications[0].ReleaseVersions[2].Id,
+                publications[0].ReleaseVersions[5].Id
             }, result);
         }
 
@@ -569,9 +569,9 @@ public class ReleaseVersionRepositoryTests
             // Expect the result to contain the highest version of each release for the specified publication
             AssertIdsAreEqualIgnoringOrder(new[]
             {
-                publications[0].Releases[0].Id,
-                publications[0].Releases[3].Id,
-                publications[0].Releases[5].Id
+                publications[0].ReleaseVersions[0].Id,
+                publications[0].ReleaseVersions[3].Id,
+                publications[0].ReleaseVersions[5].Id
             }, result);
         }
 
@@ -636,12 +636,12 @@ public class ReleaseVersionRepositoryTests
             // Expect the result to contain the highest version of each release for each publication
             AssertIdsAreEqualIgnoringOrder(new[]
             {
-                publications[0].Releases[0].Id,
-                publications[0].Releases[3].Id,
-                publications[0].Releases[5].Id,
-                publications[1].Releases[0].Id,
-                publications[1].Releases[3].Id,
-                publications[1].Releases[5].Id
+                publications[0].ReleaseVersions[0].Id,
+                publications[0].ReleaseVersions[3].Id,
+                publications[0].ReleaseVersions[5].Id,
+                publications[1].ReleaseVersions[0].Id,
+                publications[1].ReleaseVersions[3].Id,
+                publications[1].ReleaseVersions[5].Id
             }, result);
         }
 
@@ -691,9 +691,9 @@ public class ReleaseVersionRepositoryTests
             // Expect the result to contain the highest version of each release for the specified publication
             AssertIdsAreEqualIgnoringOrder(new[]
             {
-                publications[0].Releases[0].Id,
-                publications[0].Releases[3].Id,
-                publications[0].Releases[5].Id
+                publications[0].ReleaseVersions[0].Id,
+                publications[0].ReleaseVersions[3].Id,
+                publications[0].ReleaseVersions[5].Id
             }, result);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -17,7 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         [MaxLength(160)]
         public string Summary { get; set; } = string.Empty;
 
-        public List<ReleaseVersion> Releases { get; set; } = new();
+        public List<ReleaseVersion> ReleaseVersions { get; set; } = new();
 
         public List<PublicationMethodology> Methodologies { get; set; } = new();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewReleaseAuthorizationHandlerTests.cs
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single(rv => rv is { Published: not null, Version: 0 });
+            var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: not null, Version: 0 });
 
             var contextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -57,7 +57,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
                     .DefaultReleaseParent(publishedVersions: 2, draftVersion: true)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single(rv => rv is { Published: not null, Version: 1 });
+            var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: not null, Version: 1 });
 
             var contextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -87,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
                     .DefaultReleaseParent(publishedVersions: 1, draftVersion: true)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single(rv => rv is { Published: null, Version: 1 });
+            var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: null, Version: 1 });
 
             var contextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -117,7 +117,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.Auth
                     .DefaultReleaseParent(publishedVersions: 2)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single(rv => rv is { Published: not null, Version: 0 });
+            var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: not null, Version: 0 });
 
             var contextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryContentDbContext(contextId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -150,8 +150,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                             .DefaultTheme()));
 
                 // Expect the latest published release versions in reverse chronological order
-                var expectedReleaseVersion1 = publication.Releases.Single(rv => rv is { Year: 2022, Version: 1 });
-                var expectedReleaseVersion2 = publication.Releases.Single(rv => rv is { Year: 2020, Version: 0 });
+                var expectedReleaseVersion1 = publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 });
+                var expectedReleaseVersion2 = publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
 
                 var contentDbContextId = Guid.NewGuid().ToString();
                 await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
@@ -669,7 +669,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     // Latest release has no data
                     new()
                     {
-                        ReleaseVersion = publication.Releases[1],
+                        ReleaseVersion = publication.ReleaseVersions[1],
                         File = new File
                         {
                             Type = FileType.Data
@@ -678,7 +678,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     // Older release has no data
                     new()
                     {
-                        ReleaseVersion = publication.Releases[0],
+                        ReleaseVersion = publication.ReleaseVersions[0],
                         File = new File
                         {
                             Type = FileType.Ancillary
@@ -738,7 +738,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     // Latest release has no data
                     new()
                     {
-                        ReleaseVersion = publication.Releases[1],
+                        ReleaseVersion = publication.ReleaseVersions[1],
                         File = new File
                         {
                             Type = FileType.Ancillary
@@ -747,7 +747,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     // Older release has data, so the publication is visible
                     new()
                     {
-                        ReleaseVersion = publication.Releases[0],
+                        ReleaseVersion = publication.ReleaseVersions[0],
                         File = new File
                         {
                             Type = FileType.Data
@@ -807,7 +807,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     // Latest release has no data
                     new()
                     {
-                        ReleaseVersion = publication.Releases[1],
+                        ReleaseVersion = publication.ReleaseVersions[1],
                         File = new File
                         {
                             Type = FileType.Ancillary
@@ -816,7 +816,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     // Unpublished release has data but this shouldn't alter anything
                     new()
                     {
-                        ReleaseVersion = publication.Releases[0],
+                        ReleaseVersion = publication.ReleaseVersions[0],
                         File = new File
                         {
                             Type = FileType.Data

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseServiceTests.cs
@@ -437,7 +437,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 .WithReleaseParents(_dataFixture.DefaultReleaseParent(publishedVersions: 0, draftVersion: true)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases[0];
+            var releaseVersion = publication.ReleaseVersions[0];
 
             var originalContent = @"
                 <p>
@@ -553,7 +553,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 .WithReleaseParents(_dataFixture.DefaultReleaseParent(publishedVersions: 0, draftVersion: true)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single(rv => rv is { Published: null });
+            var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: null });
 
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
@@ -586,7 +586,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 .WithReleaseParents(_dataFixture.DefaultReleaseParent(publishedVersions: 0, draftVersion: true)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single(rv => rv is { Published: null });
+            var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: null });
 
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
@@ -619,7 +619,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 .WithReleaseParents(_dataFixture.DefaultReleaseParent(publishedVersions: 1, draftVersion: true)
                     .Generate(1));
 
-            var (previousReleaseVersion, releaseVersion) = publication.Releases.ToTuple2();
+            var (previousReleaseVersion, releaseVersion) = publication.ReleaseVersions.ToTuple2();
             releaseVersion.UpdatePublishedDate = false;
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -655,7 +655,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 .WithReleaseParents(_dataFixture.DefaultReleaseParent(publishedVersions: 1, draftVersion: true)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases[1];
+            var releaseVersion = publication.ReleaseVersions[1];
             releaseVersion.UpdatePublishedDate = true;
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -722,7 +722,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(2));
 
-            var (release1Version1, release2Version1) = publication.Releases.ToTuple2();
+            var (release1Version1, release2Version1) = publication.ReleaseVersions.ToTuple2();
 
             var contextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -793,7 +793,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
                 Assert.Equal(new[]
                 {
-                    publication.Releases.Single(rv => rv is { Version: 2 }).Id
+                    publication.ReleaseVersions.Single(rv => rv is { Version: 2 }).Id
                 }, releases.Select(r => r.Id).ToArray());
             }
         }
@@ -824,8 +824,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
                 Assert.Equal(new[]
                 {
-                    publication.Releases.Single(rv => rv is { Year: 2001, Published: not null }).Id,
-                    publication.Releases.Single(rv => rv is { Year: 2000, Published: not null }).Id
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2001, Published: not null }).Id,
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2000, Published: not null }).Id
                 }, releases.Select(r => r.Id).ToArray());
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -67,7 +67,7 @@ public class PublicationService : IPublicationService
     {
         return await _contentPersistenceHelper
             .CheckEntityExists<Publication>(query => query
-                .Include(p => p.Releases)
+                .Include(p => p.ReleaseVersions)
                 .Include(p => p.Contact)
                 .Include(p => p.LegacyReleases)
                 .Include(p => p.Topic)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Security/AuthorizationHandlers/ViewSubjectDataForPublishedReleasesAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Security/AuthorizationHandlers/ViewSubjectDataForPublishedReleasesAuthorizationHandlerTests.cs
@@ -30,7 +30,7 @@ public class ViewSubjectDataForPublishedReleasesAuthorizationHandlerTests
                 .DefaultReleaseParent(publishedVersions: 1, draftVersion: true)
                 .Generate(1));
 
-        var releaseVersion = publication.Releases.Single(rv => rv is { Published: null, Version: 1 });
+        var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: null, Version: 1 });
 
         ReleaseSubject releaseSubject = _dataFixture
             .DefaultReleaseSubject()
@@ -69,7 +69,7 @@ public class ViewSubjectDataForPublishedReleasesAuthorizationHandlerTests
                 .DefaultReleaseParent(publishedVersions: 2, draftVersion: true)
                 .Generate(1));
 
-        var releaseVersion = publication.Releases.Single(rv => rv is { Published: not null, Version: 1 });
+        var releaseVersion = publication.ReleaseVersions.Single(rv => rv is { Published: not null, Version: 1 });
 
         ReleaseSubject releaseSubject = _dataFixture
             .DefaultReleaseSubject()

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectResultMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectResultMetaServiceTests.cs
@@ -89,7 +89,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases[0];
+            var releaseVersion = publication.ReleaseVersions[0];
 
             Subject subject = _dataFixture
                 .DefaultSubject();
@@ -210,7 +210,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases[0];
+            var releaseVersion = publication.ReleaseVersions[0];
 
             Subject subject = _dataFixture
                 .DefaultSubject();
@@ -387,7 +387,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases[0];
+            var releaseVersion = publication.ReleaseVersions[0];
 
             Subject subject = _dataFixture
                 .DefaultSubject();
@@ -679,7 +679,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases[0];
+            var releaseVersion = publication.ReleaseVersions[0];
 
             Subject subject = _dataFixture
                 .DefaultSubject();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
@@ -51,7 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -246,7 +246,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -292,7 +292,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             // Set up a ReleaseSubject that references a non-existent publication
             ReleaseSubject releaseSubject = _fixture
@@ -372,7 +372,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -455,7 +455,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -645,7 +645,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -690,7 +690,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -735,7 +735,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -895,7 +895,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .DefaultReleaseSubject()
                 .WithReleaseVersion(_fixture
                     .DefaultStatsReleaseVersion()
-                    .WithId(publication.Releases[0].Id)
+                    .WithId(publication.ReleaseVersions[0].Id)
                     .WithPublicationId(publication.Id))
                 .WithSubject(_fixture.DefaultSubject()
                     .WithFilters(filters)
@@ -1054,7 +1054,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -1102,7 +1102,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -1187,7 +1187,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             var filters = _fixture.DefaultFilter()
                 .ForIndex(0, s =>
@@ -1373,7 +1373,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -1509,7 +1509,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -1557,7 +1557,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()
@@ -1605,7 +1605,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .DefaultReleaseParent(publishedVersions: 1)
                     .Generate(1));
 
-            var releaseVersion = publication.Releases.Single();
+            var releaseVersion = publication.ReleaseVersions.Single();
 
             ReleaseSubject releaseSubject = _fixture
                 .DefaultReleaseSubject()

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Extensions/PublisherExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Extensions/PublisherExtensionTests.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Extensions
                 Published = DateTime.UtcNow.AddSeconds(-1)
             };
 
-            publication.Releases = new List<ReleaseVersion>
+            publication.ReleaseVersions = new List<ReleaseVersion>
             {
                 releaseVersion
             };
@@ -41,7 +41,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Extensions
                 Published = null
             };
 
-            publication.Releases = new List<ReleaseVersion>
+            publication.ReleaseVersions = new List<ReleaseVersion>
             {
                 releaseVersion
             };
@@ -61,7 +61,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Extensions
                 Published = null
             };
 
-            publication.Releases = new List<ReleaseVersion>
+            publication.ReleaseVersions = new List<ReleaseVersion>
             {
                 releaseVersion
             };
@@ -93,7 +93,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Extensions
                 Version = 1
             };
 
-            publication.Releases = new List<ReleaseVersion>
+            publication.ReleaseVersions = new List<ReleaseVersion>
             {
                 originalReleaseVersion,
                 amendmentReleaseVersion
@@ -125,7 +125,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Extensions
                 Published = DateTime.UtcNow.AddSeconds(-1)
             };
 
-            publication.Releases = new List<ReleaseVersion>
+            publication.ReleaseVersions = new List<ReleaseVersion>
             {
                 originalReleaseVersion,
                 amendmentReleaseVersion
@@ -156,7 +156,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Extensions
                 Version = 1
             };
 
-            publication.Releases = new List<ReleaseVersion>
+            publication.ReleaseVersions = new List<ReleaseVersion>
             {
                 originalReleaseVersion,
                 amendmentReleaseVersion

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Extensions/PublisherExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Extensions/PublisherExtensions.cs
@@ -24,7 +24,7 @@ public static class PublisherExtensions
     private static bool IsLatestPublishedVersionOfRelease(this ReleaseVersion releaseVersion,
         IEnumerable<Guid> includedReleaseIds)
     {
-        if (releaseVersion.Publication?.Releases == null || !releaseVersion.Publication.Releases.Any())
+        if (releaseVersion.Publication?.ReleaseVersions == null || !releaseVersion.Publication.ReleaseVersions.Any())
         {
             throw new ArgumentException(
                 "All release versions of the publication must be hydrated to test the latest published version");
@@ -34,7 +34,7 @@ public static class PublisherExtensions
             // Release version itself must be live
             releaseVersion.Live
             // It must also be the latest version unless the later version is a draft not included for publishing
-            && !releaseVersion.Publication.Releases.Any(rv =>
+            && !releaseVersion.Publication.ReleaseVersions.Any(rv =>
                 (rv.Live || includedReleaseIds != null && includedReleaseIds.Contains(rv.Id))
                 && rv.PreviousVersionId == releaseVersion.Id
                 && rv.Id != releaseVersion.Id);


### PR DESCRIPTION
This is a change which was missed from https://github.com/dfe-analytical-services/explore-education-statistics/pull/4611.

It's a straightforward IDE renaming of `Publication.Releases` to `Publication.ReleaseVersions` without any other changes.

There are no database migrations required although there's a tiny change in `ContentDbContextModelSnapshot.cs`.