### PR TITLE
Tell ESLint to ignore the Playwright Report folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,4 +10,6 @@ wwwroot/
 # Ignore backend projects
 src/GovUk.Education.ExploreEducationStatistics.*/
 src/explore-education-statistics-ckeditor/sample
+
+# Ignore playwright test reports
 tests/playwright-tests/playwright-report/*

--- a/.eslintignore
+++ b/.eslintignore
@@ -10,3 +10,4 @@ wwwroot/
 # Ignore backend projects
 src/GovUk.Education.ExploreEducationStatistics.*/
 src/explore-education-statistics-ckeditor/sample
+tests/playwright-tests/playwright-report/*


### PR DESCRIPTION
By default, Playwright will write a report to the `tests/playwright-tests/playwright-report` folder. This report contains generated javascript files which do not conform to our ES-Lint config, and cause failures when running `pnpm lint`. 

This PR simply tells ES-Lint to ignore the reports auto-generated by playwright, as we don't care about them being linted. 