### PR TITLE
EES-4959 data set details page

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetPage.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetPage.module.scss
@@ -1,0 +1,30 @@
+@import '~govuk-frontend/govuk/base';
+
+.info {
+  background-color: govuk-colour('light-grey');
+
+  margin-bottom: govuk-spacing(4);
+  padding: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    align-items: center;
+    display: flex;
+  }
+}
+
+.infoSectionHeading {
+  color: govuk-colour('dark-grey');
+  display: block;
+
+  @include govuk-media-query($until: tablet) {
+    margin-top: govuk-spacing(2);
+  }
+}
+
+.infoDownloadButton {
+  margin-left: auto;
+
+  @include govuk-media-query($until: tablet) {
+    margin-top: govuk-spacing(2);
+  }
+}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetPage.tsx
@@ -1,0 +1,332 @@
+import ButtonText from '@common/components/ButtonText';
+import Tag from '@common/components/Tag';
+import Button from '@common/components/Button';
+import { releaseTypes } from '@common/services/types/releaseType';
+import downloadService from '@common/services/downloadService';
+import { Dictionary } from '@common/types';
+import ContentHtml from '@common/components/ContentHtml';
+import CollapsibleList from '@common/components/CollapsibleList';
+import FormattedDate from '@common/components/FormattedDate';
+import SummaryList from '@common/components/SummaryList';
+import SummaryListItem from '@common/components/SummaryListItem';
+import InfoIcon from '@common/components/InfoIcon';
+import Modal from '@common/components/Modal';
+import useToggle from '@common/hooks/useToggle';
+import ReleaseTypeSection from '@common/modules/release/components/ReleaseTypeSection';
+import getTimePeriodString from '@common/modules/table-tool/utils/getTimePeriodString';
+import ChevronGrid from '@common/components/ChevronGrid';
+import ChevronCard from '@common/components/ChevronCard';
+import useDebouncedCallback from '@common/hooks/useDebouncedCallback';
+import Link from '@frontend/components/Link';
+import Page from '@frontend/components/Page';
+import DataSetPageSection from '@frontend/modules/data-catalogue/components/DataSetPageSection';
+import DataSetPageNav from '@frontend/modules/data-catalogue/components/DataSetPageNav';
+import DataSetPreview from '@frontend/modules/data-catalogue/components/DataSetPreview';
+import styles from '@frontend/modules/data-catalogue/DataSetPage.module.scss';
+import NotFoundPage from '@frontend/modules/NotFoundPage';
+import dataSetQueries from '@frontend/queries/dataSetQueries';
+import { logEvent } from '@frontend/services/googleAnalyticsService';
+import withAxiosHandler from '@frontend/middleware/ssr/withAxiosHandler';
+import React, { useEffect, useState } from 'react';
+import { QueryClient, dehydrate, useQuery } from '@tanstack/react-query';
+import { GetServerSideProps } from 'next';
+import { orderBy } from 'lodash';
+import classNames from 'classnames';
+
+export const pageSections: Dictionary<string> = {
+  details: 'Data set details',
+  using: 'Using this data',
+  // TODO EES-4856
+  // preview: 'Data set preview',
+  // variables: 'Variables in this data set',
+  // footnotes: 'Footnotes',
+};
+
+export type PageSection = keyof typeof pageSections & string;
+
+interface Props {
+  dataSetId: string;
+  releaseId: string;
+}
+
+export default function DataSetPage({ dataSetId, releaseId }: Props) {
+  const { data: dataSet } = useQuery({
+    ...dataSetQueries.get(dataSetId, releaseId),
+    keepPreviousData: true,
+    staleTime: 60000,
+    retry: false,
+  });
+
+  const [activeSection, setActiveSection] = useState<PageSection>('details');
+  const [fullScreenPreview, toggleFullScreenPreview] = useToggle(false);
+  const [showAllPreview, toggleShowAllPreview] = useToggle(false);
+
+  const handleDownload = async () => {
+    await downloadService.downloadFiles(release.id, [file.id]);
+
+    logEvent({
+      category: 'Data catalogue - data set page',
+      action: 'Data set file download',
+      label: `Publication: ${release.publication.title}, Release: ${release.title}, Data set: ${title}`,
+    });
+  };
+
+  const [handleScroll] = useDebouncedCallback(() => {
+    const sections = document.querySelectorAll('[data-scroll]');
+
+    // Set a section as active when it's in the top third of the page.
+    const buffer = window.innerHeight / 3;
+    const scrollPosition = window.scrollY + buffer;
+
+    sections.forEach(section => {
+      if (section) {
+        const { height } = section.getBoundingClientRect();
+        const { offsetTop } = section as HTMLElement;
+        const offsetBottom = offsetTop + height;
+
+        if (scrollPosition > offsetTop && scrollPosition < offsetBottom) {
+          setActiveSection(section.id);
+          window.history.pushState({}, '', `#${section.id}`);
+        }
+      }
+    });
+  }, 10);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [handleScroll]);
+
+  if (!dataSet) {
+    return <NotFoundPage />;
+  }
+
+  const {
+    file,
+    filters,
+    geographicLevels,
+    indicators,
+    release,
+    summary,
+    timePeriods,
+    title,
+  } = dataSet;
+
+  return (
+    <Page
+      title={title}
+      caption={`Data set from ${release.publication.themeTitle}`}
+      breadcrumbs={[{ name: 'Data catalogue', link: '/data-catalogue' }]}
+      wide={fullScreenPreview}
+    >
+      {fullScreenPreview ? (
+        <DataSetPreview
+          fullScreen={fullScreenPreview}
+          showAll={showAllPreview}
+          onToggleFullScreen={toggleFullScreenPreview}
+          onToggleShowAll={toggleShowAllPreview}
+        />
+      ) : (
+        <>
+          <div className={styles.info}>
+            {release.isLatestPublishedRelease ? (
+              <Tag className="govuk-!-margin-right-5">Latest data</Tag>
+            ) : (
+              <Tag className="govuk-!-margin-right-5" colour="orange">
+                Not the latest data
+              </Tag>
+            )}
+
+            <div className="govuk-!-font-size-16 govuk-!-margin-right-5">
+              <span className={styles.infoSectionHeading}>Published</span>{' '}
+              <FormattedDate format="d MMMM yyyy">
+                {release.published}
+              </FormattedDate>
+            </div>
+
+            <Button
+              className={classNames(
+                'govuk-!-margin-bottom-0',
+                styles.infoDownloadButton,
+              )}
+              onClick={handleDownload}
+            >
+              Download data set (ZIP)
+            </Button>
+          </div>
+
+          <ContentHtml html={summary} />
+
+          <hr className="govuk-!-margin-bottom-8 govuk-!-margin-top-6" />
+
+          <div className="govuk-grid-row">
+            <DataSetPageNav
+              activeSection={activeSection}
+              onClickItem={setActiveSection}
+            />
+
+            <div className="govuk-grid-column-two-thirds">
+              <DataSetPageSection heading={pageSections.details} id="details">
+                <SummaryList
+                  ariaLabel={`Details list for ${title}`}
+                  className="govuk-!-margin-bottom-4 govuk-!-margin-top-4"
+                  noBorder
+                >
+                  <SummaryListItem term="Theme">
+                    {release.publication.themeTitle}
+                  </SummaryListItem>
+                  <SummaryListItem term="Publication">
+                    {release.publication.title}
+                  </SummaryListItem>
+                  <SummaryListItem term="Release">
+                    <Link
+                      to={`/find-statistics/${release.publication.slug}/${release.slug}`}
+                    >
+                      {release.title}
+                    </Link>
+                  </SummaryListItem>
+                  <SummaryListItem term="Release type">
+                    <Modal
+                      showClose
+                      title={releaseTypes[release.type]}
+                      triggerButton={
+                        <ButtonText>
+                          {releaseTypes[release.type]}{' '}
+                          <InfoIcon
+                            description={`Information on ${
+                              releaseTypes[release.type]
+                            }`}
+                          />
+                        </ButtonText>
+                      }
+                    >
+                      <ReleaseTypeSection
+                        showHeading={false}
+                        type={release.type}
+                      />
+                    </Modal>
+                  </SummaryListItem>
+
+                  {geographicLevels && geographicLevels.length > 0 && (
+                    <SummaryListItem term="Geographic levels">
+                      {orderBy(geographicLevels).join(', ')}
+                    </SummaryListItem>
+                  )}
+                  {indicators && indicators.length > 0 && (
+                    <SummaryListItem term="Indicators">
+                      <CollapsibleList
+                        buttonClassName="govuk-!-margin-bottom-1"
+                        buttonHiddenText={`for ${title}`}
+                        collapseAfter={3}
+                        id="indicators"
+                        itemName="indicator"
+                        itemNamePlural="indicators"
+                        listClassName="govuk-!-margin-top-0 govuk-!-margin-bottom-1"
+                        testId="indicators"
+                      >
+                        {indicators.map((indicator, index) => (
+                          <li key={`indicator-${index.toString()}`}>
+                            {indicator}
+                          </li>
+                        ))}
+                      </CollapsibleList>
+                    </SummaryListItem>
+                  )}
+                  {filters && filters.length > 0 && (
+                    <SummaryListItem term="Filters">
+                      <CollapsibleList
+                        buttonClassName="govuk-!-margin-bottom-1"
+                        buttonHiddenText={`for ${title}`}
+                        collapseAfter={3}
+                        id="filters"
+                        itemName="filter"
+                        itemNamePlural="filters"
+                        listClassName="govuk-!-margin-top-0 govuk-!-margin-bottom-1"
+                        testId="filters"
+                      >
+                        {filters.map((filter, index) => (
+                          <li key={`filter-${index.toString()}`}>{filter}</li>
+                        ))}
+                      </CollapsibleList>
+                    </SummaryListItem>
+                  )}
+                  {timePeriods && (timePeriods.from || timePeriods.to) && (
+                    <SummaryListItem term="Time period">
+                      {getTimePeriodString(timePeriods)}
+                    </SummaryListItem>
+                  )}
+                </SummaryList>
+              </DataSetPageSection>
+
+              {/* TODO EES-4856 */}
+              {/* <DataSetPreview
+                fullScreen={fullScreenPreview}
+                showAll={showAllPreview}
+                onToggleFullScreen={() => {
+                  toggleFullScreenPreview();
+                  window.scrollTo(0, 0);
+                }}
+                onToggleShowAll={toggleShowAllPreview}
+              /> */}
+
+              {/* TODO EES-4856 */}
+              {/* <DataSetVariables /> */}
+
+              {/* TODO EES-4856 */}
+              {/* <DataSetFootnotes /> */}
+
+              <DataSetPageSection heading={pageSections.using} id="using">
+                <ChevronGrid>
+                  <ChevronCard
+                    cardSize="l"
+                    description="Download the underlying data as a compressed ZIP file"
+                    link={
+                      <ButtonText onClick={handleDownload}>
+                        Download this data set (ZIP)
+                      </ButtonText>
+                    }
+                    noBorder
+                    noChevron
+                  />
+                  <ChevronCard
+                    cardSize="l"
+                    description="View tables that we have built for you, or create your own tables from open data using our table tool"
+                    link={
+                      <Link
+                        to={`/data-tables/${release.publication.slug}/${release.slug}`}
+                      >
+                        View or create your own tables
+                      </Link>
+                    }
+                  />
+                </ChevronGrid>
+              </DataSetPageSection>
+            </div>
+          </div>
+        </>
+      )}
+    </Page>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = withAxiosHandler(
+  async context => {
+    const { dataSetId = '', releaseId = '' } =
+      context.query as Dictionary<string>;
+
+    const queryClient = new QueryClient();
+    await queryClient.prefetchQuery(dataSetQueries.get(dataSetId, releaseId));
+
+    const props: Props = {
+      dataSetId,
+      releaseId,
+    };
+
+    return {
+      props: { ...props, dehydratedState: dehydrate(queryClient) },
+    };
+  },
+);

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
@@ -1,6 +1,5 @@
-import { DataSetSummary } from '@frontend/services/dataSetService';
+import { DataSet, DataSetSummary } from '@frontend/services/dataSetService';
 
-// eslint-disable-next-line import/prefer-default-export
 export const testDataSetSummaries: DataSetSummary[] = [
   {
     fileExtension: 'csv',
@@ -90,3 +89,31 @@ export const testDataSetSummaries: DataSetSummary[] = [
     title: 'Data set 3',
   },
 ];
+
+export const testDataSet: DataSet = {
+  file: { id: 'file-id', name: 'file name', size: 'file size' },
+  release: {
+    id: 'release-id',
+    isLatestPublishedRelease: true,
+    publication: {
+      id: 'publication-id',
+      slug: 'publication-slug',
+      themeTitle: 'Theme 1',
+      title: 'Publication 1',
+    },
+    published: new Date('2024-01-01'),
+    slug: 'release-slug',
+    title: 'Release 1',
+    type: 'NationalStatistics',
+  },
+  summary: 'Data set 1 summary',
+  title: 'Data set 1',
+  // These aren't in the backend yet, so may change.
+  filters: ['Filter 1', 'Filter 2'],
+  geographicLevels: ['Local authority', 'National'],
+  indicators: ['Indicator 1', 'Indicator 2'],
+  timePeriods: {
+    from: '2023',
+    to: '2024',
+  },
+};

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetPage.test.tsx
@@ -1,0 +1,140 @@
+import _downloadService from '@common/services/downloadService';
+import render from '@common-test/render';
+import DataSetPage from '@frontend/modules/data-catalogue/DataSetPage';
+import _dataSetService from '@frontend/services/dataSetService';
+import { testDataSet } from '@frontend/modules/data-catalogue/__data__/testDataSets';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+jest.mock('@frontend/services/dataSetService');
+jest.mock('@common/services/downloadService');
+
+const dataSetService = _dataSetService as jest.Mocked<typeof _dataSetService>;
+const downloadService = _downloadService as jest.Mocked<
+  typeof _downloadService
+>;
+
+describe('DataSetPage', () => {
+  test('renders the page correctly', async () => {
+    dataSetService.getDataSet.mockResolvedValue(testDataSet);
+    render(<DataSetPage dataSetId="data-set-id" releaseId="release-id" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('On this page')).toBeInTheDocument(),
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Data set 1' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Latest data')).toBeInTheDocument();
+    expect(screen.getByText('1 January 2024')).toBeInTheDocument();
+    expect(screen.getByText('Data set 1 summary')).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId('Theme')).getByText('Theme 1'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('Publication')).getByText('Publication 1'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('Release')).getByRole('link', {
+        name: 'Release 1',
+      }),
+    ).toHaveAttribute('href', '/find-statistics/publication-slug/release-slug');
+    expect(
+      within(screen.getByTestId('Release type')).getByRole('button', {
+        name: /National statistics/,
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Download data set (ZIP)' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Download this data set (ZIP)' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {
+        name: 'View or create your own tables',
+      }),
+    ).toHaveAttribute('href', '/data-tables/publication-slug/release-slug');
+
+    const nav = within(
+      screen.getByRole('navigation', { name: 'On this page' }),
+    );
+    const navLinks = nav.getAllByRole('link');
+    expect(navLinks).toHaveLength(2);
+    expect(navLinks[0]).toHaveAttribute('href', '#details');
+    expect(navLinks[1]).toHaveAttribute('href', '#using');
+  });
+
+  test('renders the `latest data` tag when it is the latest data', async () => {
+    dataSetService.getDataSet.mockResolvedValue(testDataSet);
+    render(<DataSetPage dataSetId="data-set-id" releaseId="release-id" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('On this page')).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText('Latest data')).toBeInTheDocument();
+    expect(screen.queryByText('Not the latest data')).not.toBeInTheDocument();
+  });
+
+  test('renders the `not the latest data` tag when it is not the latest data', async () => {
+    dataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      release: { ...testDataSet.release, isLatestPublishedRelease: false },
+    });
+    render(<DataSetPage dataSetId="data-set-id" releaseId="release-id" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('On this page')).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText('Not the latest data')).toBeInTheDocument();
+
+    expect(screen.queryByText('Latest data')).not.toBeInTheDocument();
+  });
+
+  test('calls the download service with the correct id when the download button is clicked', async () => {
+    dataSetService.getDataSet.mockResolvedValue(testDataSet);
+    render(<DataSetPage dataSetId="data-set-id" releaseId="release-id" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('On this page')).toBeInTheDocument(),
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Download data set (ZIP)' }),
+    );
+
+    await waitFor(() => {
+      expect(downloadService.downloadFiles).toHaveBeenCalledWith<
+        Parameters<typeof downloadService.downloadFiles>
+      >('release-id', ['file-id']);
+    });
+  });
+
+  test('clicking the release type shows the modal', async () => {
+    dataSetService.getDataSet.mockResolvedValue(testDataSet);
+    render(<DataSetPage dataSetId="data-set-id" releaseId="release-id" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('On this page')).toBeInTheDocument(),
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /National statistics/ }),
+    );
+
+    const modal = within(screen.getByRole('dialog'));
+    expect(
+      modal.getByRole('heading', { name: 'National statistics' }),
+    ).toBeInTheDocument();
+    expect(modal.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFootnotes.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFootnotes.tsx
@@ -1,0 +1,28 @@
+import DataSetPageSection from '@frontend/modules/data-catalogue/components/DataSetPageSection';
+import { pageSections } from '@frontend/modules/data-catalogue/DataSetPage';
+import React from 'react';
+
+// TODO EES-4856 replace with real data
+const footnotes = [
+  {
+    id: 'footnote-1',
+    label:
+      'Local authority response rates to the data collection vary by census date. To account for non-response, national and regional figures have been uprated based on local authority pupil populations.',
+  },
+  {
+    id: 'footnote-2',
+    label:
+      'Local authority response rates to the data collection vary by census date. To account for non-response, national and regional figures have been uprated based on local authority pupil populations.',
+  },
+];
+export default function DataSetFootnotes() {
+  return (
+    <DataSetPageSection heading={pageSections.footnotes} id="footnotes">
+      <ol className="govuk-!-margin-bottom-6">
+        {footnotes.map(footnote => (
+          <li key={footnote.id}>{footnote.label}</li>
+        ))}
+      </ol>
+    </DataSetPageSection>
+  );
+}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetPageNav.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetPageNav.module.scss
@@ -1,0 +1,10 @@
+@import '~govuk-frontend/govuk/base';
+
+.navContainer {
+  @include govuk-media-query($from: tablet) {
+    border-bottom: 0;
+    max-height: 100vh;
+    position: sticky;
+    top: govuk-spacing(4);
+  }
+}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetPageNav.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetPageNav.tsx
@@ -1,0 +1,83 @@
+import { useMobileMedia } from '@common/hooks/useMedia';
+import styles from '@frontend/modules/data-catalogue/components/DataSetPageNav.module.scss';
+import {
+  PageSection,
+  pageSections,
+} from '@frontend/modules/data-catalogue/DataSetPage';
+import classNames from 'classnames';
+import React from 'react';
+
+interface Props {
+  activeSection: PageSection;
+  onClickItem: (id: PageSection) => void;
+}
+export default function DataSetPageNav({ activeSection, onClickItem }: Props) {
+  const { isMedia: isMobileMedia } = useMobileMedia();
+
+  return (
+    <div
+      className={classNames('govuk-grid-column-one-third', styles.navContainer)}
+    >
+      <h2 className="govuk-heading-s" id="nav-heading">
+        On this page
+      </h2>
+      <nav aria-labelledby="nav-heading" role="navigation">
+        <ul className={classNames('govuk-list', styles.navList)}>
+          {Object.keys(pageSections).map(id => (
+            <NavItem
+              hashId={id}
+              key={id}
+              text={pageSections[id]}
+              isActive={!isMobileMedia && activeSection === id}
+              onClick={() => onClickItem(id)}
+            />
+          ))}
+
+          {isMobileMedia ? (
+            <hr />
+          ) : (
+            <NavItem
+              className="govuk-!-padding-top-4"
+              hashId="main-content"
+              text="Back to top"
+              onClick={() => onClickItem('details')}
+            />
+          )}
+        </ul>
+      </nav>
+    </div>
+  );
+}
+
+interface NavItemProps {
+  className?: string;
+  hashId: PageSection | 'main-content';
+  isActive?: boolean;
+  text: string;
+  onClick: () => void;
+}
+
+function NavItem({
+  className,
+  hashId,
+  isActive = false,
+  text,
+  onClick,
+}: NavItemProps) {
+  return (
+    <li className={className}>
+      <a
+        className={classNames(
+          'govuk-link--no-visited-state govuk-link--no-underline',
+          {
+            'govuk-!-font-weight-bold': isActive,
+          },
+        )}
+        href={`#${hashId}`}
+        onClick={onClick}
+      >
+        {text}
+      </a>
+    </li>
+  );
+}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetPageSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetPageSection.tsx
@@ -1,0 +1,31 @@
+import { useMobileMedia } from '@common/hooks/useMedia';
+import { PageSection } from '@frontend/modules/data-catalogue/DataSetPage';
+import React, { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  heading: string;
+  id: PageSection;
+}
+export default function DataSetPageSection({ children, heading, id }: Props) {
+  const { isMedia: isMobileMedia } = useMobileMedia();
+
+  return (
+    <div
+      className="dfe-border-bottom govuk-!-margin-bottom-6"
+      id={id}
+      data-scroll
+    >
+      <h2>{heading}</h2>
+      {children}
+
+      {isMobileMedia && (
+        <p>
+          <a className="govuk-link--no-visited-state" href="#main-content">
+            Back to top
+          </a>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetPreview.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetPreview.module.scss
@@ -1,0 +1,10 @@
+@import '~govuk-frontend/govuk/base';
+
+.container {
+  margin-bottom: govuk-spacing(6);
+  overflow: auto;
+
+  &:focus-visible {
+    outline: $govuk-focus-colour solid $govuk-focus-width;
+  }
+}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetPreview.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetPreview.tsx
@@ -1,0 +1,178 @@
+import ButtonText from '@common/components/ButtonText';
+import DataSetPageSection from '@frontend/modules/data-catalogue/components/DataSetPageSection';
+import styles from '@frontend/modules/data-catalogue/components/DataSetPreview.module.scss';
+import { pageSections } from '@frontend/modules/data-catalogue/DataSetPage';
+import React from 'react';
+
+// TODO EES-4856 replace with real data
+const tableHeaders = [
+  'time_period',
+  'time_identifier',
+  'geographic_level',
+  'country_code',
+  'country_name',
+  'group',
+  'standard',
+  'age',
+  'apprenticeship_level',
+];
+
+const tableRows = [
+  [
+    '201819',
+    'Academic year',
+    'National',
+    'E9200001',
+    'England',
+    'Ethnicity group',
+    'Framework',
+    '16-18',
+    'advanced',
+  ],
+  [
+    '201819',
+    'Academic year',
+    'National',
+    'E9200001',
+    'England',
+    'Ethnicity group',
+    'Framework',
+    '16-18',
+    'advanced',
+  ],
+  [
+    '201819',
+    'Academic year',
+    'National',
+    'E9200001',
+    'England',
+    'Ethnicity group',
+    'Framework',
+    '16-18',
+    'advanced',
+  ],
+  [
+    '201819',
+    'Academic year',
+    'National',
+    'E9200001',
+    'England',
+    'Ethnicity group',
+    'Framework',
+    '16-18',
+    'advanced',
+  ],
+  [
+    '201819',
+    'Academic year',
+    'National',
+    'E9200001',
+    'England',
+    'Ethnicity group',
+    'Framework',
+    '16-18',
+    'advanced',
+  ],
+  [
+    '201819',
+    'Academic year',
+    'National',
+    'E9200001',
+    'England',
+    'Ethnicity group',
+    'Framework',
+    '16-18',
+    'advanced',
+  ],
+  [
+    '201819',
+    'Academic year',
+    'National',
+    'E9200001',
+    'England',
+    'Ethnicity group',
+    'Framework',
+    '16-18',
+    'advanced',
+  ],
+  [
+    '201819',
+    'Academic year',
+    'National',
+    'E9200001',
+    'England',
+    'Ethnicity group',
+    'Framework',
+    '16-18',
+    'advanced',
+  ],
+  [
+    '201819',
+    'Academic year',
+    'National',
+    'E9200001',
+    'England',
+    'Ethnicity group',
+    'Framework',
+    '16-18',
+    'advanced',
+  ],
+];
+
+const tableId = 'preview-table';
+
+interface Props {
+  fullScreen: boolean;
+  showAll: boolean;
+  onToggleFullScreen: () => void;
+  onToggleShowAll: () => void;
+}
+
+export default function DataSetPreview({
+  fullScreen,
+  showAll,
+  onToggleFullScreen,
+  onToggleShowAll,
+}: Props) {
+  const displayRows = showAll ? tableRows : tableRows.slice(0, 4);
+
+  return (
+    <DataSetPageSection heading={pageSections.preview} id="preview">
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+      <div className={styles.container} tabIndex={0}>
+        <table id={tableId}>
+          <caption className="govuk-!-font-weight-regular govuk-!-margin-bottom-3">
+            Table showing first 5 rows from underlying data
+          </caption>
+          <thead>
+            {tableHeaders.map(header => (
+              <th key={header}>{header}</th>
+            ))}
+          </thead>
+          <tbody>
+            {displayRows.map((row, rowIndex) => (
+              <tr key={`row-${rowIndex.toString()}`}>
+                {row.map((cell, cellIndex) => (
+                  <td key={`cell-${cellIndex.toString()}`}>{cell}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="govuk-!-margin-bottom-6">
+        <ButtonText
+          ariaControls={tableId}
+          ariaExpanded={!showAll}
+          className="govuk-!-margin-right-3"
+          onClick={onToggleShowAll}
+        >
+          {showAll ? 'Show only 5 rows' : 'Show 5 more rows'}
+        </ButtonText>
+        <ButtonText onClick={onToggleFullScreen}>
+          {fullScreen ? 'Close full screen table' : 'Show full screen table'}
+        </ButtonText>
+      </div>
+    </DataSetPageSection>
+  );
+}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetSummary.tsx
@@ -77,7 +77,9 @@ export default function DataSetSummary({
           className: `govuk-heading-m govuk-!-margin-bottom-2`,
           id: `${id}-heading`,
         },
-        <Link to="#">{title}</Link>,
+        <Link to={`/data-catalogue/release/${release.id}/data-set/${fileId}`}>
+          {title}
+        </Link>,
       )}
 
       <ContentHtml

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetVariables.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetVariables.tsx
@@ -1,0 +1,88 @@
+import ButtonText from '@common/components/ButtonText';
+import useToggle from '@common/hooks/useToggle';
+import DataSetPageSection from '@frontend/modules/data-catalogue/components/DataSetPageSection';
+import { pageSections } from '@frontend/modules/data-catalogue/DataSetPage';
+import React from 'react';
+
+// TODO EES-4856 replace with real data
+const variables = [
+  {
+    value: 'enrolments_pa_10_exact_percent',
+    label: '	Percentage of persistent absentees',
+  },
+  { value: 'num_schools', label: 'Number of schools' },
+  {
+    value: 'enrolments_pa_10_exact_percent',
+    label: '	Percentage of persistent absentees',
+  },
+  { value: 'num_schools', label: 'Number of schools' },
+  {
+    value: 'enrolments_pa_10_exact_percent',
+    label: '	Percentage of persistent absentees',
+  },
+  { value: 'num_schools', label: 'Number of schools' },
+  {
+    value: 'enrolments_pa_10_exact_percent',
+    label: '	Percentage of persistent absentees',
+  },
+  { value: 'num_schools', label: 'Number of schools' },
+  {
+    value: 'enrolments_pa_10_exact_percent',
+    label: '	Percentage of persistent absentees',
+  },
+  { value: 'num_schools', label: 'Number of schools' },
+  {
+    value: 'enrolments_pa_10_exact_percent',
+    label: '	Percentage of persistent absentees',
+  },
+  { value: 'num_schools', label: 'Number of schools' },
+];
+
+const tableId = 'variables-table';
+const defaultVisible = 5;
+
+export default function DataSetVariables() {
+  const [showAll, toggleShowAll] = useToggle(false);
+  const displayVariables = showAll
+    ? variables
+    : variables.slice(0, defaultVisible - 1);
+  const totalVariables = variables.length;
+
+  return (
+    <DataSetPageSection heading={pageSections.variables} id="variables">
+      <table id={tableId}>
+        <caption className="govuk-!-margin-bottom-3">
+          {showAll
+            ? `Table showing all ${totalVariables} variables`
+            : `Table showing first 
+          ${defaultVisible} of ${totalVariables} variables`}
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">Variable name</th>
+            <th scope="col">Variable description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {displayVariables.map(({ value, label }) => (
+            <tr key={value}>
+              <td className="dfe-word-break--break-word">{value}</td>
+              <td>{label}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <ButtonText
+        ariaControls={tableId}
+        className="govuk-!-margin-bottom-6"
+        ariaExpanded={!showAll}
+        onClick={toggleShowAll}
+      >
+        {showAll
+          ? `Show only ${defaultVisible} variables`
+          : `Show all ${totalVariables} variables`}
+      </ButtonText>
+    </DataSetPageSection>
+  );
+}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetPageNav.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetPageNav.test.tsx
@@ -1,0 +1,48 @@
+import DataSetPageNav from '@frontend/modules/data-catalogue/components/DataSetPageNav';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import noop from 'lodash/noop';
+
+let mockIsMedia = false;
+jest.mock('@common/hooks/useMedia', () => ({
+  useMobileMedia: () => {
+    return {
+      isMedia: mockIsMedia,
+    };
+  },
+}));
+
+describe('DataSetPageNav', () => {
+  test('renders the navigation', () => {
+    render(<DataSetPageNav activeSection="details" onClickItem={noop} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'On this page' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', { name: 'Data set details' }),
+    ).toHaveAttribute('href', '#details');
+    expect(
+      screen.getByRole('link', { name: 'Using this data' }),
+    ).toHaveAttribute('href', '#using');
+  });
+
+  test('renders the back to top link on desktop', () => {
+    render(<DataSetPageNav activeSection="details" onClickItem={noop} />);
+
+    expect(screen.getByRole('link', { name: 'Back to top' })).toHaveAttribute(
+      'href',
+      '#main-content',
+    );
+  });
+
+  test('does not render the back to top link on mobile', () => {
+    mockIsMedia = true;
+    render(<DataSetPageNav activeSection="details" onClickItem={noop} />);
+
+    expect(
+      screen.queryByRole('link', { name: 'Back to top' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-frontend/src/pages/data-catalogue/release/[releaseId]/data-set/[dataSetId].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/data-catalogue/release/[releaseId]/data-set/[dataSetId].tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  getServerSideProps,
+} from '@frontend/modules/data-catalogue/DataSetPage';

--- a/src/explore-education-statistics-frontend/src/queries/dataSetQueries.ts
+++ b/src/explore-education-statistics-frontend/src/queries/dataSetQueries.ts
@@ -1,5 +1,6 @@
 import { PaginatedList } from '@common/services/types/pagination';
 import dataSetService, {
+  DataSet,
   DataSetSummary,
 } from '@frontend/services/dataSetService';
 import createDataSetListRequest from '@frontend/modules/data-catalogue/utils/createDataSetListRequest';
@@ -7,6 +8,12 @@ import { ParsedUrlQuery } from 'querystring';
 import { UseQueryOptions } from '@tanstack/react-query';
 
 const dataSetQueries = {
+  get(dataSetId: string, releaseId: string): UseQueryOptions<DataSet> {
+    return {
+      queryKey: [dataSetId],
+      queryFn: () => dataSetService.getDataSet(dataSetId, releaseId),
+    };
+  },
   list(query: ParsedUrlQuery): UseQueryOptions<PaginatedList<DataSetSummary>> {
     return {
       queryKey: ['listDataSets', query],

--- a/src/explore-education-statistics-frontend/src/services/dataSetService.ts
+++ b/src/explore-education-statistics-frontend/src/services/dataSetService.ts
@@ -1,5 +1,34 @@
 import { PaginatedList } from '@common/services/types/pagination';
+import { ReleaseType } from '@common/services/types/releaseType';
 import { contentApi } from '@common/services/api';
+
+export interface DataSet {
+  file: { id: string; name: string; size: string };
+  release: {
+    id: string;
+    isLatestPublishedRelease: boolean;
+    publication: {
+      id: string;
+      slug: string;
+      themeTitle: string;
+      title: string;
+    };
+    published: Date;
+    slug: string;
+    title: string;
+    type: ReleaseType;
+  };
+  summary: string;
+  title: string;
+  // These aren't in the backend yet, so may change.
+  filters: string[];
+  geographicLevels: string[];
+  indicators: string[];
+  timePeriods: {
+    from?: string;
+    to?: string;
+  };
+}
 
 export interface DataSetSummary {
   content: string;
@@ -22,6 +51,7 @@ export interface DataSetSummary {
   };
   latestData: boolean;
   published: Date;
+  // These aren't in the backend yet, so may change.
   timePeriods: {
     from?: string;
     to?: string;
@@ -67,6 +97,9 @@ export interface DataSetListRequest {
 }
 
 const dataSetService = {
+  getDataSet(dataSetId: string, releaseId: string): Promise<DataSet> {
+    return contentApi.get(`/releases/${releaseId}/data-sets/${dataSetId}`);
+  },
   listDataSets(
     params: DataSetListRequest,
   ): Promise<PaginatedList<DataSetSummary>> {

--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -183,8 +183,6 @@ Validate Related information section and links exist
     ...    ${relatedInformation}
 
 Validate data sets list
-    [Tags]    Local    Dev
-
     user checks list has x items    testid:data-sets-list    10
 
     ${dataSet}=    user gets testid element    data-set-summary-${SUBJECT_NAME_3}
@@ -206,33 +204,27 @@ Validate zip contains correct files
     zip should contain directories and files    ui-tests-data-catalogue-%{RUN_IDENTIFIER}_2021-22-q1.zip    ${list}
 
 Validate sort controls exist
-    [Tags]    Local    Dev
     user checks radio is checked    Newest
     user checks page contains radio    Oldest
     user checks page contains radio    A to Z
 
 Validate theme filter exists
-    [Tags]    Local    Dev
     user checks select contains option    id:theme    All themes
     user checks select contains option    id:theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
     user checks select contains option    id:theme    ${ROLE_PERMISSIONS_THEME_TITLE}
 
 Validate publication filter exists
-    [Tags]    Local    Dev
     user checks select contains option    id:publication    All publications
 
 Validate release filter exists
-    [Tags]    Local    Dev
     user checks select contains option    id:release    Latest releases
     user checks select contains option    id:release    All releases
 
 Filter by theme
-    [Tags]    Local    Dev
     user chooses select option    id:theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
     user checks page contains button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
 
 Filter by publication
-    [Tags]    Local    Dev
     user chooses select option    id:publication    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user waits until page contains button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user waits until page contains button    ${PUPIL_ABSENCE_RELEASE_NAME}
@@ -240,19 +232,16 @@ Filter by publication
     user checks page contains button    ${PUPIL_ABSENCE_RELEASE_NAME}
 
 Filter by all releases
-    [Tags]    Local    Dev
     user chooses select option    id:release    All releases
     user checks page contains button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user checks page does not contain button    ${PUPIL_ABSENCE_RELEASE_NAME}
 
 Remove theme filter
-    [Tags]    Local    Dev
     user clicks button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
     user checks page does not contain button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
     user checks page does not contain button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
 
 Remove publication filter
-    [Tags]    Local    Dev
     user chooses select option    id:theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
     user chooses select option    id:publication    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user clicks button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
@@ -261,7 +250,6 @@ Remove publication filter
     user checks page does not contain button    ${PUPIL_ABSENCE_RELEASE_NAME}
 
 Remove release filter
-    [Tags]    Local    Dev
     user chooses select option    id:theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
     user chooses select option    id:publication    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user clicks button    ${PUPIL_ABSENCE_RELEASE_NAME}
@@ -270,7 +258,6 @@ Remove release filter
     user checks page does not contain button    ${PUPIL_ABSENCE_RELEASE_NAME}
 
 Clear all filters
-    [Tags]    Local    Dev
     user clicks element    id:searchForm-search
     user presses keys    pupil
     user clicks button    Search
@@ -286,7 +273,6 @@ Clear all filters
     user checks page does not contain button    Clear filters
 
 Searching
-    [Tags]    Local    Dev
     user clicks element    id:searchForm-search
     user presses keys    Exclusions by geographic level
     user clicks button    Search
@@ -294,6 +280,21 @@ Searching
     user checks list item contains    testid:data-sets-list    1    Exclusions by geographic level
 
 Removing search
-    [Tags]    Local    Dev
     user clicks button    Exclusions by geographic level
     user checks page does not contain button    Exclusions by geographic level
+
+Navigate to data set page
+    user clicks link    ${SUBJECT_NAME_3}
+    user waits until h1 is visible    ${SUBJECT_NAME_3}    %{WAIT_MEDIUM}
+    user waits until page contains title caption    Data set from Test theme    %{WAIT_MEDIUM}
+    user checks page contains    Latest data
+    user checks page contains    ${PUBLICATION_NAME}
+    user checks page contains    ${RELEASE_NAME}
+
+Validate zip contains correct files
+    [Documentation]    EES-4147
+    user clicks button containing text    Download data set (ZIP)
+
+    sleep    8    # wait for file to download
+    ${list}=    create list    data/dates.csv    data-guidance/data-guidance.txt
+    zip should contain directories and files    ui-tests-data-catalogue-%{RUN_IDENTIFIER}_2021-22-q1.zip    ${list}


### PR DESCRIPTION
Adds the new data set details page. The backend work is still in progress so:
- it only shows the details and 'using this data' sections
- I've created the preview, variables and footnotes sections using example data but commented them out for now.

![Screenshot 2024-03-07 164422](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/5a1b39bd-cf72-452a-9d2c-a9ee43f13402)
