### PR TITLE
EES-4716 Part 1 - Add `TimeIdentifier` and `GeographicLevel` schema filters and enum utils

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumUtilsTests.cs
@@ -41,6 +41,22 @@ public static class EnumUtilsTests
         }
     }
 
+    public class TryGetFromEnumValueTests
+    {
+        [Fact]
+        public void WithLabelValue_Success()
+        {
+            Assert.True(EnumUtil.TryGetFromEnumValue<TestEnum>("with-label-value", out var @enum));
+            Assert.Equal(TestEnum.WithLabelValue, @enum);
+        }
+
+        [Fact]
+        public void NoMatch_Invalid()
+        {
+            Assert.False(EnumUtil.TryGetFromEnumValue<TestEnum>("Invalid", out _));
+        }
+    }
+
     public class GetFromEnumLabelTests
     {
         [Fact]
@@ -75,6 +91,29 @@ public static class EnumUtilsTests
             Assert.Equal(
                 $"The label 'Invalid label' is not a valid {nameof(TestEnum)}",
                 exception.Message);
+        }
+    }
+
+    public class TryGetFromEnumLabelTests
+    {
+        [Fact]
+        public void WithLabel_Success()
+        {
+            Assert.True(EnumUtil.TryGetFromEnumLabel<TestEnum>("With label", out var @enum));
+            Assert.Equal(TestEnum.WithLabel, @enum);
+        }
+
+        [Fact]
+        public void WithLabelValue_Success()
+        {
+            Assert.True(EnumUtil.TryGetFromEnumLabel<TestEnum>("With label value", out var @enum));
+            Assert.Equal(TestEnum.WithLabelValue, @enum);
+        }
+
+        [Fact]
+        public void NoMatch_Invalid()
+        {
+            Assert.False(EnumUtil.TryGetFromEnumLabel<TestEnum>("Invalid", out _));
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumUtilsTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Xunit;
 
@@ -104,6 +105,66 @@ public static class EnumUtilsTests
             };
 
             Assert.Equal(expected, EnumUtil.GetEnumsArray<TestEnum>());
+        }
+    }
+
+    public class GetEnumLabelsTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var expected = new List<string>
+            {
+                TestEnum.WithLabel.GetEnumLabel(),
+                TestEnum.WithLabelValue.GetEnumLabel(),
+            };
+
+            Assert.Equal(expected, EnumUtil.GetEnumLabels<TestEnum>());
+        }
+    }
+
+    public class GetEnumLabelsSetTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var expected = new HashSet<string>
+            {
+                TestEnum.WithLabel.GetEnumLabel(),
+                TestEnum.WithLabelValue.GetEnumLabel(),
+            };
+
+            Assert.Equal(expected, EnumUtil.GetEnumLabelsSet<TestEnum>());
+        }
+    }
+
+    public class GetEnumValuesTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var expected = new List<string>
+            {
+                TestEnum.WithLabel.ToString(),
+                TestEnum.WithLabelValue.GetEnumValue(),
+            };
+
+            Assert.Equal(expected, EnumUtil.GetEnumValues<TestEnum>());
+        }
+    }
+
+    public class GetEnumValuesSetTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var expected = new HashSet<string>
+            {
+                TestEnum.WithLabel.ToString(),
+                TestEnum.WithLabelValue.GetEnumValue(),
+            };
+
+            Assert.Equal(expected, EnumUtil.GetEnumValuesSet<TestEnum>());
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/TimeIdentifierUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/TimeIdentifierUtilsTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+
+public class TimeIdentifierUtilsTests
+{
+    private static readonly HashSet<TimeIdentifier> ReleaseOnlyEnums = new()
+    {
+        TimeIdentifier.AcademicYearNationalTutoringProgramme
+    };
+
+    public class DataEnumsTests : TimeIdentifierUtilsTests
+    {
+        [Fact]
+        public void DoesNotContainReleaseOnlyEnums()
+        {
+            var diff = EnumUtil.GetEnums<TimeIdentifier>()
+                .Except(TimeIdentifierUtils.DataEnums)
+                .ToHashSet();
+
+            Assert.Equal(diff, ReleaseOnlyEnums);
+        }
+    }
+
+    public class DataCodesTests : TimeIdentifierUtilsTests
+    {
+        [Fact]
+        public void DoesNotContainReleaseOnlyCodes()
+        {
+            var diff = EnumUtil.GetEnumValues<TimeIdentifier>()
+                .Except(TimeIdentifierUtils.DataCodes)
+                .ToHashSet();
+
+            Assert.Equal(diff, ReleaseOnlyEnums.Select(e => e.GetEnumValue()).ToHashSet());
+        }
+    }
+
+    public class DataLabelsTests : TimeIdentifierUtilsTests
+    {
+        [Fact]
+        public void DoesNotContainReleaseOnlyLabels()
+        {
+            var diff = EnumUtil.GetEnumLabels<TimeIdentifier>()
+                .Except(TimeIdentifierUtils.DataLabels)
+                .ToHashSet();
+
+            Assert.Equal(diff, ReleaseOnlyEnums.Select(e => e.GetEnumLabel()).ToHashSet());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/TimeIdentifierUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/TimeIdentifierUtilsTests.cs
@@ -32,7 +32,7 @@ public class TimeIdentifierUtilsTests
         [Fact]
         public void DoesNotContainReleaseOnlyCodes()
         {
-            var diff = EnumUtil.GetEnumValues<TimeIdentifier>()
+            var diff = EnumUtil.GetEnumValuesSet<TimeIdentifier>()
                 .Except(TimeIdentifierUtils.DataCodes)
                 .ToHashSet();
 
@@ -45,7 +45,7 @@ public class TimeIdentifierUtilsTests
         [Fact]
         public void DoesNotContainReleaseOnlyLabels()
         {
-            var diff = EnumUtil.GetEnumLabels<TimeIdentifier>()
+            var diff = EnumUtil.GetEnumLabelsSet<TimeIdentifier>()
                 .Except(TimeIdentifierUtils.DataLabels)
                 .ToHashSet();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/EnumUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/EnumUtil.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
@@ -13,18 +14,45 @@ public static class EnumUtil
         public static readonly Lazy<Dictionary<string, TEnum>> Values = new(() =>
             GetEnums<TEnum>().ToDictionary(e => e.GetEnumValue()));
 
+        public static readonly Lazy<IReadOnlyList<string>> ValuesList = new(() =>
+            GetEnumValuesUncached<TEnum>().ToList());
+
+        public static readonly Lazy<IReadOnlySet<string>> ValuesSet = new(() =>
+            GetEnumValuesUncached<TEnum>().ToHashSet());
+
         public static readonly Lazy<Dictionary<string, TEnum>> Labels = new(() =>
             GetEnums<TEnum>().ToDictionary(e => e.GetEnumLabel()));
+
+        public static readonly Lazy<IReadOnlyList<string>> LabelsList = new(() =>
+            GetEnumLabelsUncached<TEnum>().ToList());
+
+        public static readonly Lazy<IReadOnlySet<string>> LabelsSet = new(() =>
+            GetEnumLabelsUncached<TEnum>().ToHashSet());
     }
 
     public static TEnum GetFromEnumValue<TEnum>(string value) where TEnum : Enum
     {
-        if (EnumCache<TEnum>.Values.Value.TryGetValue(value, out var enumValue))
+        if (TryGetFromEnumValue<TEnum>(value, out var enumValue))
         {
             return enumValue;
         }
 
         throw new ArgumentException($"The value '{value}' is not a valid {typeof(TEnum).Name}");
+    }
+
+    public static bool TryGetFromEnumValue<TEnum>(
+        string value,
+        [MaybeNullWhen(false)] out TEnum @enum)
+        where TEnum : Enum
+    {
+        if (EnumCache<TEnum>.Values.Value.TryGetValue(value, out var enumValue))
+        {
+            @enum = enumValue;
+            return true;
+        }
+
+        @enum = default;
+        return false;
     }
 
     public static TEnum GetFromEnumLabel<TEnum>(string label) where TEnum : Enum
@@ -37,6 +65,21 @@ public static class EnumUtil
         throw new ArgumentException($"The label '{label}' is not a valid {typeof(TEnum).Name}");
     }
 
+    public static bool TryGetFromEnumLabel<TEnum>(
+        string value,
+        [MaybeNullWhen(false)] out TEnum @enum)
+        where TEnum : Enum
+    {
+        if (EnumCache<TEnum>.Labels.Value.TryGetValue(value, out var enumValue))
+        {
+            @enum = enumValue;
+            return true;
+        }
+
+        @enum = default;
+        return false;
+    }
+
     public static List<TEnum> GetEnums<TEnum>() where TEnum : Enum
     {
         return Enum.GetValues(typeof(TEnum)).Cast<TEnum>().ToList();
@@ -46,4 +89,22 @@ public static class EnumUtil
     {
         return GetEnums<TEnum>().ToArray();
     }
+
+    public static IReadOnlyList<string> GetEnumValues<TEnum>() where TEnum : Enum
+        => EnumCache<TEnum>.ValuesList.Value;
+
+    public static IReadOnlySet<string> GetEnumValuesSet<TEnum>() where TEnum : Enum
+        => EnumCache<TEnum>.ValuesSet.Value;
+
+    public static IReadOnlyList<string> GetEnumLabels<TEnum>() where TEnum : Enum
+        => EnumCache<TEnum>.LabelsList.Value;
+
+    public static IReadOnlySet<string> GetEnumLabelsSet<TEnum>() where TEnum : Enum
+        => EnumCache<TEnum>.LabelsSet.Value;
+
+    private static IEnumerable<string> GetEnumValuesUncached<TEnum>() where TEnum : Enum
+        => GetEnums<TEnum>().Select(e => e.GetEnumValue());
+
+    private static IEnumerable<string> GetEnumLabelsUncached<TEnum>() where TEnum : Enum
+        => GetEnums<TEnum>().Select(e => e.GetEnumLabel());
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/GeographicLevelUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/GeographicLevelUtils.cs
@@ -8,9 +8,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
 
 public static class GeographicLevelUtils
 {
-    private static readonly Lazy<GeographicLevel[]> LevelsLazy =
-        new(EnumUtil.GetEnumsArray<GeographicLevel>);
-
     private static readonly Lazy<IReadOnlyDictionary<GeographicLevel, GeographicCsvColumns>> GeographicLevelCsvColumns =
         new(() => new Dictionary<GeographicLevel, GeographicCsvColumns>
         {
@@ -151,7 +148,11 @@ public static class GeographicLevelUtils
         )
     );
 
-    public static GeographicLevel[] Levels => LevelsLazy.Value;
+    public static IReadOnlyList<GeographicLevel> Levels => EnumUtil.GetEnums<GeographicLevel>();
+
+    public static IReadOnlyList<string> LevelCodes => EnumUtil.GetEnumValues<GeographicLevel>();
+
+    public static IReadOnlyList<string> LevelLabels => EnumUtil.GetEnumLabels<GeographicLevel>();
 
     public static GeographicCsvColumns CsvColumns(this GeographicLevel level) => GeographicLevelCsvColumns.Value[level];
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/TimeIdentifierUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/TimeIdentifierUtils.cs
@@ -9,6 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
 
 public static class TimeIdentifierUtils
 {
+    // TODO: EES-3959 - Remove when we've decoupled time identifiers from releases
     private static readonly HashSet<TimeIdentifier> ReleaseOnlyEnums = new()
     {
         TimeIdentifier.AcademicYearNationalTutoringProgramme

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/TimeIdentifierUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/TimeIdentifierUtils.cs
@@ -1,0 +1,37 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public static class TimeIdentifierUtils
+{
+    private static readonly HashSet<TimeIdentifier> ReleaseOnlyEnums = new()
+    {
+        TimeIdentifier.AcademicYearNationalTutoringProgramme
+    };
+
+    private static readonly Lazy<IReadOnlyList<TimeIdentifier>> DataEnumsLazy = new(() =>
+        EnumUtil.GetEnums<TimeIdentifier>()
+            .Where(ti => !ReleaseOnlyEnums.Contains(ti))
+            .ToList());
+
+    private static readonly Lazy<IReadOnlyList<string>> DataCodesLazy = new(() =>
+        DataEnumsLazy.Value
+            .Select(ti => ti.GetEnumValue())
+            .ToList());
+
+    private static readonly Lazy<IReadOnlyList<string>> DataLabelsLazy = new(() =>
+        DataEnumsLazy.Value
+            .Select(ti => ti.GetEnumLabel())
+            .ToList());
+
+    public static IReadOnlyList<TimeIdentifier> DataEnums => DataEnumsLazy.Value;
+
+    public static IReadOnlyList<string> DataCodes => DataCodesLazy.Value;
+
+    public static IReadOnlyList<string> DataLabels => DataLabelsLazy.Value;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/GeographicLevelSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/GeographicLevelSchemaFilterTests.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
+
+public class GeographicLevelSchemaFilterTests
+{
+    private readonly ISchemaGenerator _schemaGenerator = new SchemaGenerator(
+        new SchemaGeneratorOptions
+        {
+            UseAllOfToExtendReferenceSchemas = true,
+            SchemaFilters = [new GeographicLevelSchemaFilter()],
+        },
+        new JsonSerializerDataContractResolver(new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        })
+    );
+
+    private readonly SchemaRepository _schemaRepository = new("Default");
+
+    [Fact]
+    public void CorrectSchema()
+    {
+        var schema = GenerateSchema();
+        var geographicLevels = EnumUtil.GetEnumValues<GeographicLevel>().ToHashSet();
+
+        Assert.Equal("string", schema.Type);
+        Assert.Equal(geographicLevels.Count, schema.Enum.Count);
+
+        Assert.All(schema.Enum, e =>
+        {
+            var enumString = Assert.IsType<OpenApiString>(e);
+            Assert.Contains(enumString.Value, geographicLevels);
+        });
+    }
+
+    private OpenApiSchema GenerateSchema()
+    {
+        _schemaGenerator.GenerateSchema(typeof(GeographicLevel), _schemaRepository);
+
+        return _schemaRepository.Schemas[nameof(GeographicLevel)];
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/TimeIdentifierSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/TimeIdentifierSchemaFilterTests.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
+
+public class TimeIdentifierSchemaFilterTests
+{
+    private readonly ISchemaGenerator _schemaGenerator = new SchemaGenerator(
+        new SchemaGeneratorOptions
+        {
+            UseAllOfToExtendReferenceSchemas = true,
+            SchemaFilters = [new TimeIdentifierSchemaFilter()],
+        },
+        new JsonSerializerDataContractResolver(new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        })
+    );
+
+    private readonly SchemaRepository _schemaRepository = new("Default");
+
+    [Fact]
+    public void CorrectSchema()
+    {
+        var schema = GenerateSchema();
+
+        var codes = TimeIdentifierUtils.DataCodes.ToHashSet();
+
+        Assert.Equal("string", schema.Type);
+        Assert.Equal(codes.Count, schema.Enum.Count);
+
+        Assert.All(schema.Enum, e =>
+        {
+            var enumString = Assert.IsType<OpenApiString>(e);
+            Assert.Contains(enumString.Value, codes);
+        });
+    }
+
+    private OpenApiSchema GenerateSchema()
+    {
+        _schemaGenerator.GenerateSchema(typeof(TimeIdentifier), _schemaRepository);
+
+        return _schemaRepository.Schemas[nameof(TimeIdentifier)];
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/GeographicLevelSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/GeographicLevelSchemaFilter.cs
@@ -1,0 +1,51 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
+
+public class GeographicLevelSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (context.MemberInfo == null && context.Type == typeof(GeographicLevel))
+        {
+            schema.Type = "string";
+            schema.Format = null;
+
+            schema.Description =
+                """
+                The code for a geographic level that locations are grouped by.
+
+                The allowed values are:
+
+                - `EDA` - English devolved area
+                - `INST` - Institution
+                - `LA` - Local authority
+                - `LAD` - Local authority district
+                - `LEP` - Local enterprise partnership
+                - `LSIP` - Local skills improvement plan area
+                - `MCA` - Mayoral combined authority
+                - `MAT` - MAT
+                - `NAT` - National
+                - `OA` - Opportunity area
+                - `PA` - Planning area
+                - `PCON` - Parliamentary constituency
+                - `PROV` - Provider
+                - `REG` - Regional
+                - `RSC` - RSC region
+                - `SCH` - School
+                - `SPON` - Sponsor
+                - `WARD` - Ward
+                """.TrimIndent();
+
+            schema.Enum = GeographicLevelUtils.LevelCodes
+                .Order()
+                .Select(code => new OpenApiString(code))
+                .ToList<IOpenApiAny>();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
@@ -13,6 +13,8 @@ public class SwaggerConfig(IApiVersionDescriptionProvider provider) : IConfigure
         options.SchemaFilter<JsonConverterSchemaFilter>();
         options.SchemaFilter<DataSetStatusSchemaFilter>();
         options.SchemaFilter<DataSetVersionStatusSchemaFilter>();
+        options.SchemaFilter<GeographicLevelSchemaFilter>();
+        options.SchemaFilter<TimeIdentifierSchemaFilter>();
 
         var fileName = typeof(Program).Assembly.GetName().Name + ".xml";
         var filePath = Path.Combine(AppContext.BaseDirectory, fileName);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/TimeIdentifierSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/TimeIdentifierSchemaFilter.cs
@@ -1,0 +1,50 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
+
+public class TimeIdentifierSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (context.MemberInfo == null && context.Type == typeof(TimeIdentifier))
+        {
+            schema.Type = "string";
+            schema.Format = null;
+
+            schema.Description =
+                """
+                The code identifying the time period's type.
+
+                The allowed values are:
+
+                - `AY` - academic year
+                - `AYQ1 - AYQ4` - academic year quarter 1 to 4
+                - `T1` - academic year's autumn term
+                - `T2` - academic year's spring term
+                - `T3` - academic year's summer term
+                - `T1T2` - academic year's autumn and spring term
+                - `CY` - calendar year
+                - `CYQ1 - CYQ4` - calendar year quart 1 to 4
+                - `RY` - reporting year
+                - `P1` - financial year part 1 (April to September)
+                - `P2` - financial year part 2 (October to March)
+                - `FY` - financial year
+                - `FYQ1 - FYQ4` - financial year quarter 1 to 4
+                - `TY` - tax year
+                - `TYQ1 - FYQ4` - tax year quarter 1 to 4
+                - `W1 - W52` - week 1 to 52
+                - `M1 - M12` - month 1 to 12
+                """.TrimIndent();
+
+            schema.Enum = TimeIdentifierUtils.DataCodes
+                .Order()
+                .Select(code => new OpenApiString(code))
+                .ToList<IOpenApiAny>();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationMetaGeneratorExtensions.cs
@@ -54,7 +54,7 @@ public static class LocationMetaGeneratorExtensions
         => setters
             .Set(
                 m => m.Level,
-                (_, _, context) => GeographicLevelUtils.Levels[context.Index % GeographicLevelUtils.Levels.Length]
+                (_, _, context) => GeographicLevelUtils.Levels[context.Index % GeographicLevelUtils.Levels.Count]
             );
 
     public static InstanceSetters<LocationMeta> SetDataSetVersion(


### PR DESCRIPTION
This PR provides various bits of prep work for EES-4716 by providing `TimeIdentifier` and `GeographicLevel` schema filters. These are commonly used throughout the public API and it consequently makes sense to modify their schemas so that they output their codes (instead of their default representations).

## Related changes

- Added various `EnumUtil` methods for extra convenience when getting enum values or labels. These are cached and should be used in preference to calling `EnumUtil.GetEnums` and iterating over it.
- Added `TimeIdentifierUtils` to separate out the `AYNTP` release-only time identifier from the rest. All other time identifiers can participate in data queries.