### PR TITLE
EES-4716 Part 2 - Allow `SeparatedQueryModelBinder` to bind on string lists via attribute

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ModelBinding/SeparateQueryModelBinderTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ModelBinding/SeparateQueryModelBinderTests.cs
@@ -1,0 +1,225 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.ModelBinding;
+
+public class SeparateQueryModelBinderTests : IntegrationTest<TestStartup>
+{
+    public SeparateQueryModelBinderTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
+    {
+    }
+
+    [Fact]
+    public async Task BindsToIntList()
+    {
+        var client = BuildApp().CreateClient();
+
+        var response = await client.GetAsync(
+            $"{nameof(TestController.IntList)}?items=1,2,3");
+
+        response.AssertOk(new List<int> { 1, 2, 3 });
+    }
+
+    [Fact]
+    public async Task BindsToIntListUsingPost()
+    {
+        var client = BuildApp().CreateClient();
+
+        var response = await client.PostAsync(
+            $"{nameof(TestController.IntListPost)}?items=1,2,3", null);
+
+        response.AssertOk(new List<int> { 1, 2, 3 });
+    }
+
+    [Fact]
+    public async Task BindsToIntListClass()
+    {
+        var client = BuildApp().CreateClient();
+
+        var response = await client.GetAsync(
+            $"{nameof(TestController.IntListClass)}?items=1,2,3");
+
+        response.AssertOk(new IntListRequest
+        {
+            Items = new List<int> { 1, 2, 3 }
+        });
+    }
+    
+    [Fact]
+    public async Task BindsToIntArray()
+    {
+        var client = BuildApp().CreateClient();
+
+        var response = await client.GetAsync(
+            $"{nameof(TestController.IntArray)}?items=1,2,3");
+
+        response.AssertOk(new List<int> { 1, 2, 3 });
+    }
+
+    [Fact]
+    public async Task BindsToGuidList()
+    {
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+        var guid3 = Guid.NewGuid();
+
+        var client = BuildApp().CreateClient();
+
+        var response = await client.GetAsync(
+            $"{nameof(TestController.GuidList)}?items={guid1},{guid2},{guid3}");
+
+        response.AssertOk(new List<Guid> { guid1, guid2, guid3 });
+    }
+
+    [Fact]
+    public async Task DoesNotBindToStringListByDefault()
+    {
+        const string string1 = "one";
+        const string string2 = "two";
+        const string string3 = "three";
+
+        var client = BuildApp().CreateClient();
+
+        var response = await client.GetAsync(
+            $"{nameof(TestController.StringList)}?items={string1},{string2},{string3}");
+
+        // Only a single item list is returned, meaning the model was not bound as expected.
+        response.AssertOk(new List<string> { $"{string1},{string2},{string3}" });
+    }
+
+    [Fact]
+    public async Task DoesNotBindToStringListClassByDefault()
+    {
+        const string string1 = "one";
+        const string string2 = "two";
+        const string string3 = "three";
+
+        var client = BuildApp().CreateClient();
+
+        var response = await client.GetAsync(
+            $"{nameof(TestController.StringListClass)}?items={string1},{string2},{string3}");
+
+        // Only a single item list is returned, meaning the model was not bound as expected.
+        response.AssertOk(new StringListRequest
+        {
+            Items = new List<string> { $"{string1},{string2},{string3}" }
+        });
+    }
+
+    [Fact]
+    public async Task BindsToStringListWithQuerySeparatorAttribute()
+    {
+        const string string1 = "one";
+        const string string2 = "two";
+        const string string3 = "three";
+
+        var client = BuildApp().CreateClient();
+
+        var response = await client.GetAsync(
+            $"{nameof(TestController.StringListQuerySeparator)}?items={string1},{string2},{string3}");
+
+        response.AssertOk(new List<string> { string1, string2, string3 });
+    }
+
+    [Fact]
+    public async Task BindsToStringListClassWithQuerySeparatorAttribute()
+    {
+        const string string1 = "one";
+        const string string2 = "two";
+        const string string3 = "three";
+
+        var client = BuildApp().CreateClient();
+
+        var response = await client.GetAsync(
+            $"{nameof(TestController.StringListClassQuerySeparator)}?items={string1},{string2},{string3}");
+
+        response.AssertOk(new StringListWithQuerySeparatorRequest
+        {
+            Items = new List<string> { string1, string2, string3 }
+        });
+    }
+
+    [Fact]
+    public async Task BindsToStringListWithCustomisedQuerySeparatorAttribute()
+    {
+        const string string1 = "one";
+        const string string2 = "two";
+        const string string3 = "three";
+
+        var client = BuildApp().CreateClient();
+
+        var response = await client.GetAsync(
+            $"{nameof(TestController.StringListQuerySeparatorCustom)}?items={string1}:{string2}:{string3}");
+
+        response.AssertOk(new List<string> { string1, string2, string3 });
+    }
+
+    private record IntListRequest
+    {
+        [FromQuery]
+        public IList<int> Items { get; set; } = default!;
+    }
+
+    private record StringListRequest
+    {
+        [FromQuery]
+        public IList<string> Items { get; set; } = default!;
+    }
+
+    private record StringListWithQuerySeparatorRequest
+    {
+        [FromQuery, QuerySeparator]
+        public IList<string> Items { get; set; } = default!;
+    }
+
+    [ApiController]
+    private class TestController : ControllerBase
+    {
+        [HttpGet(nameof(IntList))]
+        public IList<int> IntList([FromQuery] IList<int> items) => items;
+
+        [HttpPost(nameof(IntListPost))]
+        public IList<int> IntListPost([FromQuery] IList<int> items) => items;
+
+        [HttpGet(nameof(IntListClass))]
+        public IntListRequest IntListClass([FromQuery] IntListRequest request) => request;
+
+        [HttpGet(nameof(IntArray))]
+        public IList<int> IntArray([FromQuery] int[] items) => items;
+
+        [HttpGet(nameof(GuidList))]
+        public IList<Guid> GuidList([FromQuery] IList<Guid> items) => items;
+
+        [HttpGet(nameof(StringList))]
+        public IList<string> StringList([FromQuery] IList<string> items) => items;
+
+        [HttpGet(nameof(StringListClass))]
+        public StringListRequest StringListClass([FromQuery] StringListRequest request) => request;
+
+        [HttpGet(nameof(StringListQuerySeparator))]
+        public IList<string> StringListQuerySeparator(
+            [FromQuery, QuerySeparator] IList<string> items) => items;
+
+        [HttpGet(nameof(StringListClassQuerySeparator))]
+        public StringListWithQuerySeparatorRequest StringListClassQuerySeparator(
+            [FromQuery] StringListWithQuerySeparatorRequest request) => request;
+
+        [HttpGet(nameof(StringListQuerySeparatorCustom))]
+        public IList<string> StringListQuerySeparatorCustom(
+            [FromQuery, QuerySeparator(":")] IList<string> items) => items;
+    }
+
+    private WebApplicationFactory<TestStartup> BuildApp()
+    {
+        return TestApp.WithWebHostBuilder(builder =>
+            builder.WithAdditionalControllers(typeof(TestController)));
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ModelBinding/TrimStringModelBinderTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ModelBinding/TrimStringModelBinderTests.cs
@@ -10,9 +10,9 @@ using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.ModelBinding;
 
-public class TrimStringModelBinderIntegrationTests : IntegrationTest<TestStartup>
+public class TrimStringModelBinderTests : IntegrationTest<TestStartup>
 {
-    public TrimStringModelBinderIntegrationTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
+    public TrimStringModelBinderTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
     {
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/QuerySeparatorAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/QuerySeparatorAttribute.cs
@@ -1,0 +1,23 @@
+#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+
+/// <summary>
+/// Configure <see cref="SeparatedQueryModelBinder"/> to bind from a query parameter
+/// that contains some values separated by delimiters (e.g. a comma). This allows
+/// binding to models that are not supported by default (e.g. enumerable strings).
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
+public class QuerySeparatorAttribute : Attribute
+{
+    /// <summary>
+    /// The separator used in the query parameter. Defaults to a comma.
+    /// </summary>
+    public string Separator { get; set; }
+
+    public QuerySeparatorAttribute(string separator = ",")
+    {
+        Separator = separator;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/SeparatedQueryModelBinder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/SeparatedQueryModelBinder.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ModelBinding;


### PR DESCRIPTION
:warning: Depends on #4640 

This changes `SeparatedQueryModelBinder` so that it can bind enumerable string types from a query parameter containing comma separated strings e.g. `?items=option-1,option-2`.

Previously, this was not possible as the model binder would ignore these model types on the basis that strings often contain commas without being intended to be used as comma-separated list.

We can now enable binding to enumerable string types by adding the `QuerySeparator` attribute to the property or parameter. Note that `FromQuery` is also required.

For example:

```cs
[HttpGet("api/test")]
public ActionResult MyEndpoint([FromQuery, QuerySeparator] IList<string> items)
{
}
```

We can make a request like `GET /api/test?items=item1,item2`, and the `items` list will now be bound with `item1` and `item2` as individual elements. Previously, this would only have bound as a single element like `item1,item2`.