### PR TITLE
EES-4716 Part 1b - Add security policies to public API

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -82,8 +82,8 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
         }
 
         [Theory]
-        [InlineData(DataSetStatus.Staged)]
-        [InlineData(DataSetStatus.Unpublished)]
+        [InlineData(DataSetStatus.Draft)]
+        [InlineData(DataSetStatus.Withdrawn)]
         public async Task DataSetNotAvailable_Returns404(DataSetStatus dataSetStatus)
         {
             DataSet dataSet = DataFixture
@@ -229,7 +229,7 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
 
         [Theory]
         [InlineData(DataSetVersionStatus.Published)]
-        [InlineData(DataSetVersionStatus.Unpublished)]
+        [InlineData(DataSetVersionStatus.Withdrawn)]
         [InlineData(DataSetVersionStatus.Deprecated)]
         public async Task DataSetVersionIsAvailable_Returns200_CorrectViewModel(DataSetVersionStatus dataSetVersionStatus)
         {
@@ -249,8 +249,8 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
                 .WithPublished(DateTimeOffset.UtcNow)
                 .WithDataSetId(dataSet.Id);
 
-            DataSetVersion dataSetVersion = dataSetVersionStatus == DataSetVersionStatus.Unpublished
-                ? dataSetVersionGenerator.WithUnpublished(DateTimeOffset.UtcNow)
+            DataSetVersion dataSetVersion = dataSetVersionStatus == DataSetVersionStatus.Withdrawn
+                ? dataSetVersionGenerator.WithWithdrawn(DateTimeOffset.UtcNow)
                 : dataSetVersionGenerator;
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
@@ -277,7 +277,7 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
                 result.Published.ToUnixTimeSeconds()
             );
             Assert.Equal(
-                dataSetVersion.Unpublished?.ToUnixTimeSeconds(),
+                dataSetVersion.Withdrawn?.ToUnixTimeSeconds(),
                 result.Unpublished?.ToUnixTimeSeconds()
             );
             Assert.Equal(dataSetVersion.Notes, result.Notes);
@@ -350,7 +350,7 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
         }
 
         [Theory]
-        [InlineData(DataSetVersionStatus.Staged)]
+        [InlineData(DataSetVersionStatus.Draft)]
         public async Task DataSetVersionUnavailable_Returns200_EmptyList(DataSetVersionStatus dataSetVersionStatus)
         {
             DataSet dataSet = DataFixture
@@ -526,7 +526,7 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
 
         [Theory]
         [InlineData(DataSetVersionStatus.Published)]
-        [InlineData(DataSetVersionStatus.Unpublished)]
+        [InlineData(DataSetVersionStatus.Withdrawn)]
         [InlineData(DataSetVersionStatus.Deprecated)]
         public async Task VersionIsAvailable_Returns200(DataSetVersionStatus dataSetVersionStatus)
         {
@@ -561,7 +561,7 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
                 content.Published.ToUnixTimeSeconds()
             );
             Assert.Equal(
-                dataSetVersion.Unpublished?.ToUnixTimeSeconds(),
+                dataSetVersion.Withdrawn?.ToUnixTimeSeconds(),
                 content.Unpublished?.ToUnixTimeSeconds()
             );
             Assert.Equal(dataSetVersion.Notes, content.Notes);
@@ -582,7 +582,7 @@ public abstract class DataSetsControllerTests : IntegrationTestFixture
         }
 
         [Theory]
-        [InlineData(DataSetVersionStatus.Staged)]
+        [InlineData(DataSetVersionStatus.Draft)]
         public async Task VersionNotAvailable_Returns404(DataSetVersionStatus dataSetVersionStatus)
         {
             DataSet dataSet = DataFixture

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
@@ -46,7 +46,7 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
 
             var unpublishedDataSets = DataFixture
                 .DefaultDataSet()
-                .WithStatus(DataSetStatus.Unpublished)
+                .WithStatus(DataSetStatus.Withdrawn)
                 .GenerateList(numberOfUnpublishedDataSets);
 
             var allDataSets = publishedDataSets.Concat(unpublishedDataSets).ToArray();
@@ -355,7 +355,7 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
 
             var unpublishedDataSets = DataFixture
                 .DefaultDataSet()
-                .WithStatus(DataSetStatus.Unpublished)
+                .WithStatus(DataSetStatus.Withdrawn)
                 .WithPublicationId(publicationId)
                 .GenerateList(3);
 
@@ -616,8 +616,8 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
         }
 
         [Theory]
-        [InlineData(DataSetStatus.Staged)]
-        [InlineData(DataSetStatus.Unpublished)]
+        [InlineData(DataSetStatus.Draft)]
+        [InlineData(DataSetStatus.Withdrawn)]
         public async Task DataSetUnavailable_Returns200_EmptyList(DataSetStatus dataSetStatus)
         {
             var publicationId = Guid.NewGuid();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandlerTests.cs
@@ -1,0 +1,54 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using static GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlerContextFactory;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Security.AuthorizationHandlers;
+
+public class QueryDataSetVersionAuthorizationHandlerTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    [Theory]
+    [InlineData(DataSetVersionStatus.Deprecated)]
+    [InlineData(DataSetVersionStatus.Published)]
+    public void Success(DataSetVersionStatus status)
+    {
+        DataSetVersion dataSetVersion = _dataFixture
+            .DefaultDataSetVersion()
+            .WithStatus(status);
+
+        var handler = BuildHandler();
+        var context = CreateAnonymousAuthContext<QueryDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
+
+        handler.HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Theory]
+    [InlineData(DataSetVersionStatus.Processing)]
+    [InlineData(DataSetVersionStatus.Failed)]
+    [InlineData(DataSetVersionStatus.Mapping)]
+    [InlineData(DataSetVersionStatus.Draft)]
+    [InlineData(DataSetVersionStatus.Withdrawn)]
+    public void Failure(DataSetVersionStatus status)
+    {
+        DataSetVersion dataSetVersion = _dataFixture
+            .DefaultDataSetVersion()
+            .WithStatus(status);
+
+        var handler = BuildHandler();
+        var context = CreateAnonymousAuthContext<QueryDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
+
+        handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    private static QueryDataSetVersionAuthorizationHandler BuildHandler()
+    {
+        return new QueryDataSetVersionAuthorizationHandler();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandlerTests.cs
@@ -1,0 +1,51 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using static GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlerContextFactory;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Security.AuthorizationHandlers;
+
+public class ViewDataSetAuthorizationHandlerTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    [Theory]
+    [InlineData(DataSetStatus.Deprecated)]
+    [InlineData(DataSetStatus.Published)]
+    public void Success(DataSetStatus status)
+    {
+        DataSet dataSet = _dataFixture
+            .DefaultDataSet()
+            .WithStatus(status);
+
+        var handler = BuildHandler();
+        var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
+
+        handler.HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Theory]
+    [InlineData(DataSetStatus.Draft)]
+    [InlineData(DataSetStatus.Withdrawn)]
+    public void Failure(DataSetStatus status)
+    {
+        DataSet dataSet = _dataFixture
+            .DefaultDataSet()
+            .WithStatus(status);
+
+        var handler = BuildHandler();
+        var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
+
+        handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    private static ViewDataSetAuthorizationHandler BuildHandler()
+    {
+        return new ViewDataSetAuthorizationHandler();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
@@ -1,0 +1,54 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using static GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlerContextFactory;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Security.AuthorizationHandlers;
+
+public class ViewDataSetVersionAuthorizationHandlerTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    [Theory]
+    [InlineData(DataSetVersionStatus.Deprecated)]
+    [InlineData(DataSetVersionStatus.Published)]
+    [InlineData(DataSetVersionStatus.Withdrawn)]
+    public void Success(DataSetVersionStatus status)
+    {
+        DataSetVersion dataSetVersion = _dataFixture
+            .DefaultDataSetVersion()
+            .WithStatus(status);
+
+        var handler = BuildHandler();
+        var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
+
+        handler.HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Theory]
+    [InlineData(DataSetVersionStatus.Processing)]
+    [InlineData(DataSetVersionStatus.Failed)]
+    [InlineData(DataSetVersionStatus.Mapping)]
+    [InlineData(DataSetVersionStatus.Draft)]
+    public void Failure(DataSetVersionStatus status)
+    {
+        DataSetVersion dataSetVersion = _dataFixture
+            .DefaultDataSetVersion()
+            .WithStatus(status);
+
+        var handler = BuildHandler();
+        var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
+
+        handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    private static ViewDataSetVersionAuthorizationHandler BuildHandler()
+    {
+        return new ViewDataSetVersionAuthorizationHandler();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/DataSetStatusSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/DataSetStatusSchemaFilterTests.cs
@@ -38,7 +38,7 @@ public class DataSetStatusSchemaFilterTests
         Assert.Equal(DataSetStatus.Deprecated.ToString(), enumString2.Value);
 
         var enumString3 = Assert.IsType<OpenApiString>(schema.Enum[2]);
-        Assert.Equal(DataSetStatus.Unpublished.ToString(), enumString3.Value);
+        Assert.Equal(DataSetStatus.Withdrawn.ToString(), enumString3.Value);
     }
 
     private OpenApiSchema GenerateSchema()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/DataSetVersionStatusSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/DataSetVersionStatusSchemaFilterTests.cs
@@ -38,7 +38,7 @@ public class DataSetVersionStatusSchemaFilterTests
         Assert.Equal(DataSetVersionStatus.Deprecated.ToString(), enumString2.Value);
 
         var enumString3 = Assert.IsType<OpenApiString>(schema.Enum[2]);
-        Assert.Equal(DataSetVersionStatus.Unpublished.ToString(), enumString3.Value);
+        Assert.Equal(DataSetVersionStatus.Withdrawn.ToString(), enumString3.Value);
     }
 
     private OpenApiSchema GenerateSchema()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -73,9 +73,9 @@ public class DataSetsController : ControllerBase
     {
         return await _dataSetService
             .ListVersions(
+                dataSetId: dataSetId,
                 page: request.Page,
-                pageSize: request.PageSize,
-                dataSetId: dataSetId)
+                pageSize: request.PageSize)
             .HandleFailuresOrOk();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AnonymousAuthenticationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AnonymousAuthenticationHandler.cs
@@ -1,0 +1,20 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security;
+
+public class AnonymousAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public AnonymousAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder) : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        return Task.FromResult(AuthenticateResult.NoResult());
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandler.cs
@@ -1,0 +1,23 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using Microsoft.AspNetCore.Authorization;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
+
+public class QueryDataSetVersionRequirement : IAuthorizationRequirement;
+
+public class QueryDataSetVersionAuthorizationHandler
+    : AuthorizationHandler<QueryDataSetVersionRequirement, DataSetVersion>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        QueryDataSetVersionRequirement requirement,
+        DataSetVersion dataSetVersion)
+    {
+        if (dataSetVersion.Status is DataSetVersionStatus.Published or DataSetVersionStatus.Deprecated)
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandler.cs
@@ -1,0 +1,22 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using Microsoft.AspNetCore.Authorization;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
+
+public class ViewDataSetRequirement : IAuthorizationRequirement;
+
+public class ViewDataSetAuthorizationHandler : AuthorizationHandler<ViewDataSetRequirement, DataSet>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        ViewDataSetRequirement requirement,
+        DataSet dataSet)
+    {
+        if (dataSet.Status is DataSetStatus.Published or DataSetStatus.Deprecated)
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandler.cs
@@ -1,0 +1,25 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using Microsoft.AspNetCore.Authorization;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
+
+public class ViewDataSetVersionRequirement : IAuthorizationRequirement;
+
+public class ViewDataSetVersionAuthorizationHandler 
+    : AuthorizationHandler<ViewDataSetVersionRequirement, DataSetVersion>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        ViewDataSetVersionRequirement requirement,
+        DataSetVersion dataSetVersion)
+    {
+        if (dataSetVersion.Status is DataSetVersionStatus.Published
+            or DataSetVersionStatus.Deprecated
+            or DataSetVersionStatus.Withdrawn)
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/Extensions/DataSetAuthExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/Extensions/DataSetAuthExtensions.cs
@@ -1,0 +1,10 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Extensions;
+
+public static class DataSetAuthExtensions
+{
+    public static IQueryable<DataSet> WherePublicStatus(this IQueryable<DataSet> queryable)
+        => queryable.Where(ds => ds.Status == DataSetStatus.Published
+                                 || ds.Status == DataSetStatus.Deprecated);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/Extensions/DataSetVersionAuthExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/Extensions/DataSetVersionAuthExtensions.cs
@@ -1,0 +1,11 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Extensions;
+
+public static class DataSetVersionAuthExtensions
+{
+    public static IQueryable<DataSetVersion> WherePublicStatus(this IQueryable<DataSetVersion> queryable)
+        => queryable.Where(ds => ds.Status == DataSetVersionStatus.Published
+                                 || ds.Status == DataSetVersionStatus.Withdrawn
+                                 || ds.Status == DataSetVersionStatus.Deprecated);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/Extensions/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/Extensions/UserServiceExtensions.cs
@@ -1,0 +1,30 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Extensions;
+
+public static class UserServiceExtensions
+{
+    public static Task<Either<ActionResult, DataSet>> CheckCanViewDataSet(
+        this IUserService userService,
+        DataSet dataSet)
+    {
+        return userService.CheckPolicy(dataSet, PublicDataSecurityPolicies.CanViewDataSet);
+    }
+    
+    public static Task<Either<ActionResult, DataSetVersion>> CheckCanQueryDataSetVersion(
+        this IUserService userService,
+        DataSetVersion dataSetVersion)
+    {
+        return userService.CheckPolicy(dataSetVersion, PublicDataSecurityPolicies.CanQueryDataSetVersion);
+    }
+
+    public static Task<Either<ActionResult, DataSetVersion>> CheckCanViewDataSetVersion(
+        this IUserService userService,
+        DataSetVersion dataSetVersion)
+    {
+        return userService.CheckPolicy(dataSetVersion, PublicDataSecurityPolicies.CanViewDataSetVersion);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/PublicDataSecurityPolicies.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/PublicDataSecurityPolicies.cs
@@ -1,0 +1,8 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security;
+
+public enum PublicDataSecurityPolicies
+{
+    CanViewDataSet,
+    CanQueryDataSetVersion,
+    CanViewDataSetVersion
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -72,7 +72,7 @@ internal class DataSetService : IDataSetService
         var queryable = _publicDataDbContext.DataSetVersions
             .Where(ds => ds.DataSetId == dataSetId)
             .Where(ds => ds.Status == DataSetVersionStatus.Published
-                || ds.Status == DataSetVersionStatus.Unpublished
+                || ds.Status == DataSetVersionStatus.Withdrawn
                 || ds.Status == DataSetVersionStatus.Deprecated);
 
         var totalResults = await queryable.CountAsync();
@@ -130,7 +130,7 @@ internal class DataSetService : IDataSetService
             .Where(dsv => dsv.VersionMajor == version.Major)
             .Where(dsv => dsv.VersionMinor == version.Minor)
             .Where(ds => ds.Status == DataSetVersionStatus.Published
-                || ds.Status == DataSetVersionStatus.Unpublished
+                || ds.Status == DataSetVersionStatus.Withdrawn
                 || ds.Status == DataSetVersionStatus.Deprecated)
             .SingleOrNotFound();
     }
@@ -166,7 +166,7 @@ internal class DataSetService : IDataSetService
             Type = dataSetVersion.VersionType,
             Status = dataSetVersion.Status,
             Published = dataSetVersion.Published!.Value,
-            Unpublished = dataSetVersion.Unpublished,
+            Unpublished = dataSetVersion.Withdrawn,
             Notes = dataSetVersion.Notes,
             TotalResults = dataSetVersion.TotalResults,
             TimePeriods = MapTimePeriods(dataSetVersion.MetaSummary.TimePeriodRange),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetService.cs
@@ -18,7 +18,7 @@ public interface IDataSetService
         string dataSetVersion);
 
     Task<Either<ActionResult, DataSetVersionPaginatedListViewModel>> ListVersions(
+        Guid dataSetId,
         int page,
-        int pageSize,
-        Guid dataSetId);
+        int pageSize);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -7,6 +7,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Rules;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
@@ -117,6 +119,8 @@ public class Startup
             httpClient.BaseAddress = new Uri(contentApiOptions.Url);
             httpClient.DefaultRequestHeaders.Add(HeaderNames.UserAgent, "EES Public Data API");
         });
+
+        services.AddSecurity();
 
         services.AddScoped<IPublicationService, PublicationService>();
         services.AddScoped<IDataSetService, DataSetService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/StartupSecurityConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/StartupSecurityConfiguration.cs
@@ -1,0 +1,33 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api;
+
+public static class StartupSecurityConfiguration
+{
+    public static void AddSecurity(this IServiceCollection services)
+    {
+        services
+            .AddAuthentication()
+            .AddScheme<AuthenticationSchemeOptions, AnonymousAuthenticationHandler>("Anonymous", null);
+
+        services
+            .AddAuthorizationBuilder()
+            .AddPolicy(PublicDataSecurityPolicies.CanViewDataSet.ToString(), policy =>
+                policy.Requirements.Add(new ViewDataSetRequirement()))
+            .AddPolicy(PublicDataSecurityPolicies.CanQueryDataSetVersion.ToString(), policy =>
+                policy.Requirements.Add(new QueryDataSetVersionRequirement()))
+            .AddPolicy(PublicDataSecurityPolicies.CanViewDataSetVersion.ToString(), policy =>
+                policy.Requirements.Add(new ViewDataSetVersionRequirement()));
+
+        services.AddScoped<IUserService, UserService>();
+        services.AddScoped<IAuthorizationHandler, ViewDataSetAuthorizationHandler>();
+        services.AddScoped<IAuthorizationHandler, QueryDataSetVersionAuthorizationHandler>();
+        services.AddScoped<IAuthorizationHandler, ViewDataSetVersionAuthorizationHandler>();
+
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/DataSetStatusSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/DataSetStatusSchemaFilter.cs
@@ -8,6 +8,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
 public class DataSetStatusSchemaFilter : ISchemaFilter
 {
+    private readonly HashSet<DataSetStatus> _publicStatuses =
+    [
+        DataSetStatus.Published,
+        DataSetStatus.Deprecated,
+        DataSetStatus.Withdrawn,
+    ];
+
     public void Apply(OpenApiSchema schema, SchemaFilterContext context)
     {
         if (context.MemberInfo == null && context.Type == typeof(DataSetStatus))
@@ -15,7 +22,7 @@ public class DataSetStatusSchemaFilter : ISchemaFilter
             schema.Type = "string";
 
             schema.Enum = EnumUtil.GetEnums<DataSetStatus>()
-                .Where(e => e != DataSetStatus.Staged)
+                .Where(_publicStatuses.Contains)
                 .Select(e => new OpenApiString(e.ToString()))
                 .ToList<IOpenApiAny>();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/DataSetVersionStatusSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/DataSetVersionStatusSchemaFilter.cs
@@ -8,6 +8,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
 public class DataSetVersionStatusSchemaFilter : ISchemaFilter
 {
+    private readonly HashSet<DataSetVersionStatus> _publicStatuses =
+    [
+        DataSetVersionStatus.Published,
+        DataSetVersionStatus.Deprecated,
+        DataSetVersionStatus.Withdrawn,
+    ];
+
     public void Apply(OpenApiSchema schema, SchemaFilterContext context)
     {
         if (context.MemberInfo == null && context.Type == typeof(DataSetVersionStatus))
@@ -15,7 +22,7 @@ public class DataSetVersionStatusSchemaFilter : ISchemaFilter
             schema.Type = "string";
 
             schema.Enum = EnumUtil.GetEnums<DataSetVersionStatus>()
-                .Where(e => e != DataSetVersionStatus.Staged)
+                .Where(_publicStatuses.Contains)
                 .Select(e => new OpenApiString(e.ToString()))
                 .ToList<IOpenApiAny>();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetGeneratorExtensions.cs
@@ -25,11 +25,17 @@ public static class DataSetGeneratorExtensions
     public static Generator<DataSet> WithStatusPublished(this Generator<DataSet> generator)
         => generator.ForInstance(s => s.SetStatusPublished());
 
-    public static Generator<DataSet> WithStatusStaged(this Generator<DataSet> generator)
-        => generator.ForInstance(s => s.SetStatusStaged());
+    public static Generator<DataSet> WithStatusDraft(this Generator<DataSet> generator)
+        => generator.ForInstance(s => s.SetStatusDraft());
 
     public static Generator<DataSet> WithStatusUnpublished(this Generator<DataSet> generator)
-        => generator.ForInstance(s => s.SetStatusUnpublished());
+        => generator.ForInstance(s => s.SetStatusWithdrawn());
+
+    public static Generator<DataSet> WithPublished(this Generator<DataSet> generator, DateTimeOffset? published)
+        => generator.ForInstance(s => s.SetPublished(published));
+
+    public static Generator<DataSet> WithWithdrawn(this Generator<DataSet> generator, DateTimeOffset? withdrawn)
+        => generator.ForInstance(s => s.SetWithdrawn(withdrawn));
 
     public static Generator<DataSet> WithSupersedingDataSet(this Generator<DataSet> generator, DataSet? dataSet)
         => generator.ForInstance(s => s.SetSupersedingDataSet(dataSet));
@@ -60,7 +66,7 @@ public static class DataSetGeneratorExtensions
             .SetDefault(ds => ds.Title)
             .SetDefault(ds => ds.Summary)
             .SetDefault(ds => ds.PublicationId)
-            .Set(ds => ds.Status, DataSetStatus.Staged);
+            .Set(ds => ds.Status, DataSetStatus.Draft);
 
     public static InstanceSetters<DataSet> SetTitle(
         this InstanceSetters<DataSet> instanceSetter,
@@ -86,29 +92,29 @@ public static class DataSetGeneratorExtensions
         => instanceSetter
             .SetStatus(DataSetStatus.Published)
             .SetPublished(DateTimeOffset.UtcNow)
-            .SetUnpublished(null);
+            .SetWithdrawn(null);
 
-    public static InstanceSetters<DataSet> SetStatusStaged(this InstanceSetters<DataSet> instanceSetter)
+    public static InstanceSetters<DataSet> SetStatusDraft(this InstanceSetters<DataSet> instanceSetter)
         => instanceSetter
-            .SetStatus(DataSetStatus.Staged)
-            .SetUnpublished(null)
+            .SetStatus(DataSetStatus.Draft)
+            .SetWithdrawn(null)
             .SetPublished(null);
 
-    public static InstanceSetters<DataSet> SetStatusUnpublished(this InstanceSetters<DataSet> instanceSetter)
+    public static InstanceSetters<DataSet> SetStatusWithdrawn(this InstanceSetters<DataSet> instanceSetter)
         => instanceSetter
-            .SetStatus(DataSetStatus.Unpublished)
-            .SetUnpublished(DateTimeOffset.UtcNow)
-            .SetPublished(null);
+            .SetStatus(DataSetStatus.Withdrawn)
+            .SetWithdrawn(DateTimeOffset.UtcNow)
+            .Set((_, dsv) => dsv.Published ??= DateTimeOffset.UtcNow.AddDays(-1));
 
     public static InstanceSetters<DataSet> SetPublished(
         this InstanceSetters<DataSet> instanceSetter,
         DateTimeOffset? published)
         => instanceSetter.Set(ds => ds.Published, published);
 
-    public static InstanceSetters<DataSet> SetUnpublished(
+    public static InstanceSetters<DataSet> SetWithdrawn(
         this InstanceSetters<DataSet> instanceSetter,
-        DateTimeOffset? unpublished)
-        => instanceSetter.Set(ds => ds.Unpublished, unpublished);
+        DateTimeOffset? withdrawn)
+        => instanceSetter.Set(ds => ds.Withdrawn, withdrawn);
 
     public static InstanceSetters<DataSet> SetSupersedingDataSet(
         this InstanceSetters<DataSet> instanceSetter,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
@@ -45,11 +45,6 @@ public static class DataSetVersionGeneratorExtensions
         Guid csvFileId)
         => generator.ForInstance(s => s.SetCsvFileId(csvFileId));
 
-    public static Generator<DataSetVersion> WithParquetFilename(
-        this Generator<DataSetVersion> generator,
-        string parquetFilename)
-        => generator.ForInstance(s => s.SetParquetFilename(parquetFilename));
-
     public static Generator<DataSetVersion> WithVersionNumber(
         this Generator<DataSetVersion> generator,
         int major,
@@ -153,7 +148,6 @@ public static class DataSetVersionGeneratorExtensions
             .SetDefault(dsv => dsv.Id)
             .SetDefault(dsv => dsv.DataSetId)
             .SetDefault(dsv => dsv.CsvFileId)
-            .SetDefault(dsv => dsv.ParquetFilename)
             .SetDefault(dsv => dsv.Notes)
             .Set(dsv => dsv.VersionMajor, 1)
             .Set(dsv => dsv.VersionMinor, (_, _, context) => context.Index)
@@ -176,11 +170,6 @@ public static class DataSetVersionGeneratorExtensions
         this InstanceSetters<DataSetVersion> instanceSetter,
         Guid csvFileId)
         => instanceSetter.Set(dsv => dsv.CsvFileId, csvFileId);
-
-    public static InstanceSetters<DataSetVersion> SetParquetFilename(
-        this InstanceSetters<DataSetVersion> instanceSetter,
-        string parquetFilename)
-        => instanceSetter.Set(dsv => dsv.ParquetFilename, parquetFilename);
 
     public static InstanceSetters<DataSetVersion> SetVersionNumber(
         this InstanceSetters<DataSetVersion> instanceSetter,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
@@ -58,13 +58,13 @@ public static class DataSetVersionGeneratorExtensions
 
     public static Generator<DataSetVersion> WithPublished(
         this Generator<DataSetVersion> generator,
-        DateTimeOffset publishedDate)
-        => generator.ForInstance(s => s.SetPublished(publishedDate));
+        DateTimeOffset published)
+        => generator.ForInstance(s => s.SetPublished(published));
 
-    public static Generator<DataSetVersion> WithUnpublished(
+    public static Generator<DataSetVersion> WithWithdrawn(
         this Generator<DataSetVersion> generator,
-        DateTimeOffset unpublishedDate)
-        => generator.ForInstance(s => s.SetUnpublished(unpublishedDate));
+        DateTimeOffset withdrawn)
+        => generator.ForInstance(s => s.SetWithdrawn(withdrawn));
 
     public static Generator<DataSetVersion> WithStatus(
         this Generator<DataSetVersion> generator,
@@ -74,11 +74,20 @@ public static class DataSetVersionGeneratorExtensions
     public static Generator<DataSetVersion> WithStatusPublished(this Generator<DataSetVersion> generator)
         => generator.ForInstance(s => s.SetStatusPublished());
 
-    public static Generator<DataSetVersion> WithStatusStaged(this Generator<DataSetVersion> generator)
-        => generator.ForInstance(s => s.SetStatusStaged());
+    public static Generator<DataSetVersion> WithStatusDraft(this Generator<DataSetVersion> generator)
+        => generator.ForInstance(s => s.SetStatusDraft());
 
-    public static Generator<DataSetVersion> WithStatusUnpublished(this Generator<DataSetVersion> generator)
-        => generator.ForInstance(s => s.SetStatusUnpublished());
+    public static Generator<DataSetVersion> WithStatusProcessing(this Generator<DataSetVersion> generator)
+        => generator.ForInstance(s => s.SetStatusProcessing());
+
+    public static Generator<DataSetVersion> WithStatusFailed(this Generator<DataSetVersion> generator)
+        => generator.ForInstance(s => s.SetStatusFailed());
+
+    public static Generator<DataSetVersion> WithStatusMapping(this Generator<DataSetVersion> generator)
+        => generator.ForInstance(s => s.SetStatusMapping());
+
+    public static Generator<DataSetVersion> WithStatusWithdrawn(this Generator<DataSetVersion> generator)
+        => generator.ForInstance(s => s.SetStatusWithdrawn());
 
     public static Generator<DataSetVersion> WithTotalResults(
         this Generator<DataSetVersion> generator,
@@ -149,7 +158,7 @@ public static class DataSetVersionGeneratorExtensions
             .Set(dsv => dsv.VersionMajor, 1)
             .Set(dsv => dsv.VersionMinor, (_, _, context) => context.Index)
             .Set(dsv => dsv.TotalResults, f => f.Random.Long(min: 10000, max: 10_000_000))
-            .Set(dsv => dsv.Status, DataSetVersionStatus.Staged);
+            .Set(dsv => dsv.Status, DataSetVersionStatus.Draft);
 
     public static InstanceSetters<DataSetVersion> SetDataSet(
         this InstanceSetters<DataSetVersion> instanceSetter,
@@ -191,19 +200,41 @@ public static class DataSetVersionGeneratorExtensions
         => instanceSetter
             .SetStatus(DataSetVersionStatus.Published)
             .SetPublished(DateTimeOffset.UtcNow)
-            .SetUnpublished(null);
+            .SetWithdrawn(null);
 
-    public static InstanceSetters<DataSetVersion> SetStatusStaged(this InstanceSetters<DataSetVersion> instanceSetter)
-        => instanceSetter
-            .SetStatus(DataSetVersionStatus.Staged)
-            .SetUnpublished(null)
-            .SetPublished(null);
 
-    public static InstanceSetters<DataSetVersion> SetStatusUnpublished(
+    public static InstanceSetters<DataSetVersion> SetStatusProcessing(
         this InstanceSetters<DataSetVersion> instanceSetter)
         => instanceSetter
-            .SetStatus(DataSetVersionStatus.Unpublished)
-            .SetUnpublished(DateTimeOffset.UtcNow)
+            .SetStatus(DataSetVersionStatus.Processing)
+            .SetWithdrawn(null)
+            .SetPublished(null);
+
+    public static InstanceSetters<DataSetVersion> SetStatusFailed(
+        this InstanceSetters<DataSetVersion> instanceSetter)
+        => instanceSetter
+            .SetStatus(DataSetVersionStatus.Failed)
+            .SetWithdrawn(null)
+            .SetPublished(null);
+
+    public static InstanceSetters<DataSetVersion> SetStatusMapping(
+        this InstanceSetters<DataSetVersion> instanceSetter)
+        => instanceSetter
+            .SetStatus(DataSetVersionStatus.Mapping)
+            .SetWithdrawn(null)
+            .SetPublished(null);
+
+    public static InstanceSetters<DataSetVersion> SetStatusDraft(this InstanceSetters<DataSetVersion> instanceSetter)
+        => instanceSetter
+            .SetStatus(DataSetVersionStatus.Draft)
+            .SetWithdrawn(null)
+            .SetPublished(null);
+
+    public static InstanceSetters<DataSetVersion> SetStatusWithdrawn(
+        this InstanceSetters<DataSetVersion> instanceSetter)
+        => instanceSetter
+            .SetStatus(DataSetVersionStatus.Withdrawn)
+            .SetWithdrawn(DateTimeOffset.UtcNow)
             .Set((_, dsv) => dsv.Published ??= DateTimeOffset.UtcNow.AddDays(-1));
 
     public static InstanceSetters<DataSetVersion> SetPublished(
@@ -211,10 +242,10 @@ public static class DataSetVersionGeneratorExtensions
         DateTimeOffset? published)
         => instanceSetter.Set(dsv => dsv.Published, published);
 
-    public static InstanceSetters<DataSetVersion> SetUnpublished(
+    public static InstanceSetters<DataSetVersion> SetWithdrawn(
         this InstanceSetters<DataSetVersion> instanceSetter,
-        DateTimeOffset? unpublished)
-        => instanceSetter.Set(dsv => dsv.Unpublished, unpublished);
+        DateTimeOffset? withdrawn)
+        => instanceSetter.Set(dsv => dsv.Withdrawn, withdrawn);
 
     public static InstanceSetters<DataSetVersion> SetTotalResults(
         this InstanceSetters<DataSetVersion> instanceSetter,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSet.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSet.cs
@@ -28,7 +28,7 @@ public class DataSet : ICreatedUpdatedTimestamps<DateTimeOffset, DateTimeOffset?
 
     public DateTimeOffset? Published { get; set; }
 
-    public DateTimeOffset? Unpublished { get; set; }
+    public DateTimeOffset? Withdrawn { get; set; }
 
     public DateTimeOffset Created { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetStatus.cs
@@ -5,8 +5,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum DataSetStatus
 {
-    Staged,
+    Draft,
     Published,
     Deprecated,
-    Unpublished
+    Withdrawn
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -53,7 +53,7 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public DateTimeOffset? Published { get; set; }
 
-    public DateTimeOffset? Unpublished { get; set; }
+    public DateTimeOffset? Withdrawn { get; set; }
 
     public DateTimeOffset Created { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -19,8 +19,6 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public required Guid CsvFileId { get; set; }
 
-    public required string ParquetFilename { get; set; }
-
     public required int VersionMajor { get; set; }
 
     public required int VersionMinor { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionStatus.cs
@@ -5,8 +5,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum DataSetVersionStatus
 {
-    Staged,
+    Processing,
+    Failed,
+    Mapping,
+    Draft,
     Published,
     Deprecated,
-    Unpublished
+    Withdrawn
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240310195852_InitialMigration.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240310195852_InitialMigration.Designer.cs
@@ -13,7 +13,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
 {
     [DbContext(typeof(PublicDataDbContext))]
-    [Migration("20240303222145_InitialMigration")]
+    [Migration("20240310195852_InitialMigration")]
     partial class InitialMigration
     {
         /// <inheritdoc />
@@ -169,10 +169,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<DateTimeOffset?>("Unpublished")
+                    b.Property<DateTimeOffset?>("Updated")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<DateTimeOffset?>("Updated")
+                    b.Property<DateTimeOffset?>("Withdrawn")
                         .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
@@ -218,9 +218,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Property<long>("TotalResults")
                         .HasColumnType("bigint");
 
-                    b.Property<DateTimeOffset?>("Unpublished")
-                        .HasColumnType("timestamp with time zone");
-
                     b.Property<DateTimeOffset?>("Updated")
                         .HasColumnType("timestamp with time zone");
 
@@ -229,6 +226,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
                     b.Property<int>("VersionMinor")
                         .HasColumnType("integer");
+
+                    b.Property<DateTimeOffset?>("Withdrawn")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240310195852_InitialMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240310195852_InitialMigration.cs
@@ -133,7 +133,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     SupersedingDataSetId = table.Column<Guid>(type: "uuid", nullable: true),
                     LatestVersionId = table.Column<Guid>(type: "uuid", nullable: true),
                     Published = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
-                    Unpublished = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Withdrawn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
                     Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
                     Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
                 },
@@ -162,7 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     TotalResults = table.Column<long>(type: "bigint", nullable: false),
                     MetaSummary = table.Column<string>(type: "jsonb", nullable: false),
                     Published = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
-                    Unpublished = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Withdrawn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
                     Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
                     Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
                 },

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240311024812_InitialMigration.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240311024812_InitialMigration.Designer.cs
@@ -13,7 +13,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
 {
     [DbContext(typeof(PublicDataDbContext))]
-    [Migration("20240310195852_InitialMigration")]
+    [Migration("20240311024812_InitialMigration")]
     partial class InitialMigration
     {
         /// <inheritdoc />
@@ -201,10 +201,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         .HasColumnType("uuid");
 
                     b.Property<string>("Notes")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("ParquetFilename")
                         .IsRequired()
                         .HasColumnType("text");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240311024812_InitialMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240311024812_InitialMigration.cs
@@ -155,7 +155,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     DataSetId = table.Column<Guid>(type: "uuid", nullable: false),
                     Status = table.Column<string>(type: "text", nullable: false),
                     CsvFileId = table.Column<Guid>(type: "uuid", nullable: false),
-                    ParquetFilename = table.Column<string>(type: "text", nullable: false),
                     VersionMajor = table.Column<int>(type: "integer", nullable: false),
                     VersionMinor = table.Column<int>(type: "integer", nullable: false),
                     Notes = table.Column<string>(type: "text", nullable: false),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
@@ -201,10 +201,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<string>("ParquetFilename")
-                        .IsRequired()
-                        .HasColumnType("text");
-
                     b.Property<DateTimeOffset?>("Published")
                         .HasColumnType("timestamp with time zone");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
@@ -166,10 +166,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<DateTimeOffset?>("Unpublished")
+                    b.Property<DateTimeOffset?>("Updated")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<DateTimeOffset?>("Updated")
+                    b.Property<DateTimeOffset?>("Withdrawn")
                         .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
@@ -215,9 +215,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Property<long>("TotalResults")
                         .HasColumnType("bigint");
 
-                    b.Property<DateTimeOffset?>("Unpublished")
-                        .HasColumnType("timestamp with time zone");
-
                     b.Property<DateTimeOffset?>("Updated")
                         .HasColumnType("timestamp with time zone");
 
@@ -226,6 +223,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
                     b.Property<int>("VersionMinor")
                         .HasColumnType("integer");
+
+                    b.Property<DateTimeOffset?>("Withdrawn")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
@@ -309,7 +309,6 @@ public class SeedDataCommand : ICommand
                 VersionMinor = 0,
                 Status = DataSetVersionStatus.Published,
                 Notes = string.Empty,
-                ParquetFilename = string.Empty,
                 CsvFileId = Guid.NewGuid(),
                 DataSetId = _seed.DataSet.Id,
                 TotalResults = totalResults,


### PR DESCRIPTION
This PR adds the initial security policies required for the public API.

As part of this, we've updated `DataSetStatus` and `DataSetVersionStatus` to reflect recently agreed terminology for statuses in [EES-4898](https://dfedigital.atlassian.net/browse/EES-4898). This has required an update to `PublicDataDbContext` to rename the `Published` datetime column (on both `DataSet` and `DataSetVersion`) to `Withdrawn`.

The security policies have now been applied to the relevant `DataSetService` methods.

## Other changes

- Removed unneeded `ParquetFilename` from `DataSetVersion`. This isn't needed as we can compute Parquet file paths from the data set ID and version number.