### PR TITLE
EES-4683 - applying Renovate updates to pipeline to bring Azure resource versions up-to-date

### DIFF
--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -15,7 +15,7 @@ var postgreSqlSubnetPrefix = '10.0.7.0/24'
 var apiContainerAppSubnetPrefix = '10.0.8.0/24'
 
 // Reference the existing VNet.
-resource vNet 'Microsoft.Network/virtualNetworks@2023-04-01' existing = {
+resource vNet 'Microsoft.Network/virtualNetworks@2023-09-01' existing = {
   name: vNetName
 }
 
@@ -72,7 +72,7 @@ var subnets = [
 // Create the subnets sequentially rather than in parallel to avoid "AnotherOperationInProgress" errors when multiple
 // subnets attempt to update the parent VNet at the same time.
 @batchSize(1)
-resource subnetResources 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' = [for subnet in subnets: {
+resource subnetResources 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' = [for subnet in subnets: {
   parent: vNet
   name: subnet.name
   properties: subnet.properties

--- a/infrastructure/templates/public-api/components/blobStore.bicep
+++ b/infrastructure/templates/public-api/components/blobStore.bicep
@@ -10,11 +10,11 @@ param deleteRetentionPolicy int = 7
 param storageAccountName string
 
 // Reference an existing Storage Account.
-resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
   name: storageAccountName
 }
 
-resource blobServices 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = {
+resource blobServices 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
   name: blobStoreName
   parent: storageAccount
   properties: {

--- a/infrastructure/templates/public-api/components/containerRegistry.bicep
+++ b/infrastructure/templates/public-api/components/containerRegistry.bicep
@@ -25,7 +25,7 @@ param tagValues object
 
 var registryName = replace('${resourcePrefix}cr${containerRegistryName}', '-', '')
 
-resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' = if (deployRegistry) {
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' = if (deployRegistry) {
   name: registryName
   location: location
   sku: {
@@ -43,7 +43,7 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-pr
   tags: tagValues
 }
 
-resource currentContainerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' existing = {
+resource currentContainerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
   name: registryName
 }
 

--- a/infrastructure/templates/public-api/components/fileShares.bicep
+++ b/infrastructure/templates/public-api/components/fileShares.bicep
@@ -17,7 +17,7 @@ param storageAccountName string
 var shareName = '${resourcePrefix}-fs-${fileShareName}'
 
 // Reference an existing Storage Account.
-resource apiStorageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
+resource apiStorageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
   name: storageAccountName
 }
 

--- a/infrastructure/templates/public-api/components/keyVault.bicep
+++ b/infrastructure/templates/public-api/components/keyVault.bicep
@@ -29,7 +29,7 @@ param tagValues object
 @description('The name of the Key Vault resource')
 param keyVaultName string
 
-resource keyvault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource keyvault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: '${resourcePrefix}-kv-${keyVaultName}'
   location: location
   properties: {

--- a/infrastructure/templates/public-api/components/keyVaultAccessPolicy.bicep
+++ b/infrastructure/templates/public-api/components/keyVaultAccessPolicy.bicep
@@ -7,7 +7,7 @@ param principalId string
 @description('Specifies the tenant ID of the resource that should have access to the Key Vault')
 param tenantId string
 
-resource keyVaultAccessPolicy 'Microsoft.KeyVault/vaults/accessPolicies@2022-07-01' = {
+resource keyVaultAccessPolicy 'Microsoft.KeyVault/vaults/accessPolicies@2023-07-01' = {
   name: '${keyVaultName}/add'
   properties: {
     accessPolicies: [

--- a/infrastructure/templates/public-api/components/keyVaultSecret.bicep
+++ b/infrastructure/templates/public-api/components/keyVaultSecret.bicep
@@ -15,11 +15,11 @@ param contentType string = 'text/plain'
 param isEnabled bool = true
 
 // Reference an existing Key Vault.
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 
-resource keyVaultSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+resource keyVaultSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: replace(replace(secretName, '.', '-'), ' ', '-')
   parent: keyVault
   properties: {

--- a/infrastructure/templates/public-api/components/network.bicep
+++ b/infrastructure/templates/public-api/components/network.bicep
@@ -15,7 +15,7 @@ param tagValues object
 
 var vNetName = '${subscription}-vnet-${environment}'
 
-resource vNet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource vNet 'Microsoft.Network/virtualNetworks@2023-09-01' = {
   name: vNetName
   location: location
   properties: {

--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -39,7 +39,7 @@ var connectionStringSecretName = '${resourcePrefix}-sa-${storageAccountName}-con
 var endpointSuffix = environment().suffixes.storage
 
 //Resources 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   name: storageName
   location: location
   kind: 'StorageV2'

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -66,18 +66,18 @@ var tagValues = union(resourceTags ?? {}, {
 })
 
 // Reference the existing Key Vault resource as currently managed by the EES ARM template.
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
   scope: resourceGroup(resourceGroup().name)
 }
 
 // Reference the existing Azure Container Registry resource as currently managed by the EES ARM template.
-resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' existing = {
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
   name: 'eesacr'
 }
 
 // Reference the existing core Storage Account as currently managed by the EES ARM template.
-resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
   name: storageAccountName
   scope: resourceGroup(resourceGroup().name)
 }


### PR DESCRIPTION
This PR:
- applies multiple Renovate-raised PRs to bring the API versions of various resource definitions up to date in Bicep templates

This has been tested in a test Resource Group as seen here:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/939293de-9a50-4437-8c1d-303fabc04263)

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/f8cd47f3-ee89-4ba2-821a-abb5c3d3dede)
 