### PR TITLE
EES-4987 Create Prod-Only Redirects.robot test

### DIFF
--- a/tests/robot-tests/tests/general_public/prod_only/redirects.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/redirects.robot
@@ -5,7 +5,7 @@ Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
-Force Tags          GeneralPublic    Local    Dev    Test    Preprod
+Force Tags          GeneralPublic    Prod
 
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/general_public/prod_only/redirects.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/redirects.robot
@@ -22,8 +22,6 @@ Verify that absolute paths with trailing slashes are redirected without them
     user waits until page contains    Glossary
     user checks url equals    %{PUBLIC_URL}/glossary?someRandomUrlParameter=123
 
-    # Would be amazing if we could verify these redirects were done with a 301 rather than a 308...
-
 Verify that redirects do not affect browser history
     user navigates to    about:blank
 
@@ -42,21 +40,3 @@ Verify that routes without an absolute path still permit trailing slashes
     user navigates to public frontend    %{PUBLIC_URL}
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
-
-Verify that meta-guidance is redirected to data-guidance
-    user navigates to public frontend    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance
-    user waits until page contains    Seed publication - Release Approver
-    user checks url equals    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance
-
-    user navigates to public frontend    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance/
-    user waits until page contains    Seed publication - Release Approver
-    user checks url equals    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance
-
-Verify that download-latest-data is redirected to data-catalogue
-    user navigates to public frontend    %{PUBLIC_URL}/download-latest-data
-    user waits until page contains    Browse our open data
-    user checks url equals    %{PUBLIC_URL}/data-catalogue
-
-    user navigates to public frontend    %{PUBLIC_URL}/download-latest-data/
-    user waits until page contains    Browse our open data
-    user checks url equals    %{PUBLIC_URL}/data-catalogue


### PR DESCRIPTION
There are two specific redirects that are remaining for now, but want to be removed once Google agrees that there is no longer any traffic going to the old route. 

For now these are tested in redirects.robot but these tests require the use of seed data. This is currently being ran in prod where there isn't any seed data. This PR effectively removes those tests for Prod (but leaves the other redirects tests).