### PR TITLE
Apply file_scoped_namespaces to the Common project

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainers.cs
@@ -1,71 +1,70 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Common
+﻿namespace GovUk.Education.ExploreEducationStatistics.Common;
+
+public interface IBlobContainer
 {
-    public interface IBlobContainer
+    public string Name { get; }
+    public string EmulatedName { get; }
+}
+
+public static class BlobContainers
+{
+    public static readonly IBlobContainer PrivateReleaseFiles = new BlobContainer("releases");
+    public static readonly IBlobContainer PublicReleaseFiles = new BlobContainer("downloads");
+    public static readonly IBlobContainer PrivateContent = new PrivateBlobContainer("cache");
+    public static readonly IBlobContainer PublicContent = new PublicBlobContainer("cache");
+    public static readonly IBlobContainer PermalinkSnapshots = new BlobContainer("permalink-snapshots");
+    public static readonly IBlobContainer PublisherLeases = new BlobContainer("leases");
+    public static readonly IBlobContainer PrivateMethodologyFiles = new PrivateBlobContainer("methodologies");
+    public static readonly IBlobContainer PublicMethodologyFiles = new PublicBlobContainer("methodologies");
+}
+
+/// <summary>
+/// Blob container with an immutable name that doesn't change when used with emulator storage
+/// </summary>
+public record BlobContainer : IBlobContainer
+{
+    public string Name { get; }
+
+    public BlobContainer(string name)
     {
-        public string Name { get; }
-        public string EmulatedName { get; }
+        Name = name;
     }
 
-    public static class BlobContainers
+    public string EmulatedName => Name;
+
+    public override string ToString() => Name;
+}
+
+/// <summary>
+/// Blob container with a name prefixed by 'public-' when used with emulator storage
+/// </summary>
+public record PublicBlobContainer : IBlobContainer
+{
+    public string Name { get; }
+
+    public PublicBlobContainer(string name)
     {
-        public static readonly IBlobContainer PrivateReleaseFiles = new BlobContainer("releases");
-        public static readonly IBlobContainer PublicReleaseFiles = new BlobContainer("downloads");
-        public static readonly IBlobContainer PrivateContent = new PrivateBlobContainer("cache");
-        public static readonly IBlobContainer PublicContent = new PublicBlobContainer("cache");
-        public static readonly IBlobContainer PermalinkSnapshots = new BlobContainer("permalink-snapshots");
-        public static readonly IBlobContainer PublisherLeases = new BlobContainer("leases");
-        public static readonly IBlobContainer PrivateMethodologyFiles = new PrivateBlobContainer("methodologies");
-        public static readonly IBlobContainer PublicMethodologyFiles = new PublicBlobContainer("methodologies");
+        Name = name;
     }
 
-    /// <summary>
-    /// Blob container with an immutable name that doesn't change when used with emulator storage
-    /// </summary>
-    public record BlobContainer : IBlobContainer
+    public string EmulatedName => $"public-{Name}";
+
+    public override string ToString() => Name;
+}
+
+/// <summary>
+/// Blob container with a name prefixed by 'private-' when used with emulator storage
+/// </summary>
+public record PrivateBlobContainer : IBlobContainer
+{
+    public string Name { get; }
+
+    public PrivateBlobContainer(string name)
     {
-        public string Name { get; }
-
-        public BlobContainer(string name)
-        {
-            Name = name;
-        }
-
-        public string EmulatedName => Name;
-
-        public override string ToString() => Name;
+        Name = name;
     }
 
-    /// <summary>
-    /// Blob container with a name prefixed by 'public-' when used with emulator storage
-    /// </summary>
-    public record PublicBlobContainer : IBlobContainer
-    {
-        public string Name { get; }
+    public string EmulatedName => $"private-{Name}";
 
-        public PublicBlobContainer(string name)
-        {
-            Name = name;
-        }
-
-        public string EmulatedName => $"public-{Name}";
-
-        public override string ToString() => Name;
-    }
-
-    /// <summary>
-    /// Blob container with a name prefixed by 'private-' when used with emulator storage
-    /// </summary>
-    public record PrivateBlobContainer : IBlobContainer
-    {
-        public string Name { get; }
-
-        public PrivateBlobContainer(string name)
-        {
-            Name = name;
-        }
-
-        public string EmulatedName => $"private-{Name}";
-
-        public override string ToString() => Name;
-    }
+    public override string ToString() => Name;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/BlobCacheAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/BlobCacheAttribute.cs
@@ -7,118 +7,117 @@ using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cache;
+
+public class BlobCacheAttribute : CacheAttribute
 {
-    public class BlobCacheAttribute : CacheAttribute
+    private static Dictionary<string, IBlobCacheService> Services { get; set; } = new();
+
+    protected override Type BaseKey => typeof(IBlobCacheKey);
+
+    /// <summary>
+    /// Specify a service to use <see cref="Services"/>.
+    /// Otherwise, we use the first registered service.
+    /// </summary>
+    public string? ServiceName { get; set; }
+
+    public BlobCacheAttribute(Type key, bool forceUpdate = false) : base(key, forceUpdate)
     {
-        private static Dictionary<string, IBlobCacheService> Services { get; set; } = new();
+    }
 
-        protected override Type BaseKey => typeof(IBlobCacheKey);
+    public static void AddService(string name, IBlobCacheService service)
+    {
+        Services[name] = service;
+    }
+    public static void RemoveService(string name)
+    {
+        Services.Remove(name);
+    }
 
-        /// <summary>
-        /// Specify a service to use <see cref="Services"/>.
-        /// Otherwise, we use the first registered service.
-        /// </summary>
-        public string? ServiceName { get; set; }
+    public static void ClearServices()
+    {
+        Services.Clear();
+    }
 
-        public BlobCacheAttribute(Type key, bool forceUpdate = false) : base(key, forceUpdate)
+    public override object? Get(ICacheKey cacheKey, Type returnType)
+    {
+        if (cacheKey is IBlobCacheKey key)
         {
-        }
+            var service = GetService();
 
-        public static void AddService(string name, IBlobCacheService service)
-        {
-            Services[name] = service;
-        }
-        public static void RemoveService(string name)
-        {
-            Services.Remove(name);
-        }
-
-        public static void ClearServices()
-        {
-            Services.Clear();
-        }
-
-        public override object? Get(ICacheKey cacheKey, Type returnType)
-        {
-            if (cacheKey is IBlobCacheKey key)
+            if (service is null)
             {
-                var service = GetService();
-
-                if (service is null)
-                {
-                    return null;
-                }
-
-                return service.GetItem(key, returnType);
+                return null;
             }
 
-            throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
+            return service.GetItem(key, returnType);
         }
 
-        public override async Task<object?> GetAsync(ICacheKey cacheKey, Type returnType)
+        throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
+    }
+
+    public override async Task<object?> GetAsync(ICacheKey cacheKey, Type returnType)
+    {
+        if (cacheKey is IBlobCacheKey key)
         {
-            if (cacheKey is IBlobCacheKey key)
+            var service = GetService();
+
+            if (service is null)
             {
-                var service = GetService();
-
-                if (service is null)
-                {
-                    return null;
-                }
-
-                return await service.GetItemAsync(key, returnType);
+                return null;
             }
 
-            throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
+            return await service.GetItemAsync(key, returnType);
         }
 
-        public override void Set(ICacheKey cacheKey, object value)
+        throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
+    }
+
+    public override void Set(ICacheKey cacheKey, object value)
+    {
+        if (cacheKey is IBlobCacheKey key)
         {
-            if (cacheKey is IBlobCacheKey key)
+            var service = GetService();
+
+            if (service is null)
             {
-                var service = GetService();
-
-                if (service is null)
-                {
-                    return;
-                }
-
-                service.SetItem(key, value);
-
                 return;
             }
 
-            throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
+            service.SetItem(key, value);
+
+            return;
         }
 
-        public override async Task SetAsync(ICacheKey cacheKey, object value)
+        throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
+    }
+
+    public override async Task SetAsync(ICacheKey cacheKey, object value)
+    {
+        if (cacheKey is IBlobCacheKey key)
         {
-            if (cacheKey is IBlobCacheKey key)
+            var service = GetService();
+
+            if (service is null)
             {
-                var service = GetService();
-
-                if (service is null)
-                {
-                    return;
-                }
-
-                await service.SetItemAsync(key, value);
-
                 return;
             }
 
-            throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
+            await service.SetItemAsync(key, value);
+
+            return;
         }
 
-        private IBlobCacheService? GetService()
+        throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
+    }
+
+    private IBlobCacheService? GetService()
+    {
+        if (ServiceName is not null)
         {
-            if (ServiceName is not null)
-            {
-                return Services[ServiceName];
-            }
-
-            return Services.Count > 0 ? Services.First().Value : null;
+            return Services[ServiceName];
         }
+
+        return Services.Count > 0 ? Services.First().Value : null;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheAspect.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheAspect.cs
@@ -5,53 +5,52 @@ using System.Threading.Tasks;
 using AspectInjector.Broker;
 using Aspects.Universal.Aspects;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cache;
+
+[Aspect(Scope.PerInstance)]
+public class CacheAspect : BaseUniversalWrapperAspect
 {
-    [Aspect(Scope.PerInstance)]
-    public class CacheAspect : BaseUniversalWrapperAspect
+    private const BindingFlags ConstructorBindingFlags =
+        BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance |
+        BindingFlags.OptionalParamBinding;
+
+    /// <summary>
+    /// Enables cache attribute processing.
+    /// <para>
+    /// This is set to false by default so that test code
+    /// isn't affected by this aspect. It should be set to
+    /// true in your application startup, or if your tests
+    /// are concerned with testing caching details.
+    /// </para>
+    /// </summary>
+    public static bool Enabled { get; set; }
+
+    [Advice(Kind.Around)]
+    public object Handle(
+        [Argument(Source.Instance)] object instance,
+        [Argument(Source.Type)] Type type,
+        [Argument(Source.Metadata)] MethodBase method,
+        [Argument(Source.Target)] Func<object[], object> target,
+        [Argument(Source.Name)] string name,
+        [Argument(Source.Arguments)] object[] args,
+        [Argument(Source.ReturnType)] Type returnType,
+        [Argument(Source.Triggers)] Attribute[] triggers)
     {
-        private const BindingFlags ConstructorBindingFlags =
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance |
-            BindingFlags.OptionalParamBinding;
-
-        /// <summary>
-        /// Enables cache attribute processing.
-        /// <para>
-        /// This is set to false by default so that test code
-        /// isn't affected by this aspect. It should be set to
-        /// true in your application startup, or if your tests
-        /// are concerned with testing caching details.
-        /// </para>
-        /// </summary>
-        public static bool Enabled { get; set; }
-
-        [Advice(Kind.Around)]
-        public object Handle(
-            [Argument(Source.Instance)] object instance,
-            [Argument(Source.Type)] Type type,
-            [Argument(Source.Metadata)] MethodBase method,
-            [Argument(Source.Target)] Func<object[], object> target,
-            [Argument(Source.Name)] string name,
-            [Argument(Source.Arguments)] object[] args,
-            [Argument(Source.ReturnType)] Type returnType,
-            [Argument(Source.Triggers)] Attribute[] triggers)
+        if (!Enabled)
         {
-            if (!Enabled)
-            {
-                return target(args);
-            }
-
-            if (typeof(void) == returnType)
-            {
-                throw new ArgumentException("Method return type cannot be void");
-            }
-
-            if (typeof(Task).IsAssignableFrom(returnType) && !returnType.IsConstructedGenericType)
-            {
-                throw new ArgumentException("Method return type cannot be Task. Consider using Task<TResult>");
-            }
-
-            return BaseHandle(instance, type, method, target, name, args, returnType, triggers);
+            return target(args);
         }
+
+        if (typeof(void) == returnType)
+        {
+            throw new ArgumentException("Method return type cannot be void");
+        }
+
+        if (typeof(Task).IsAssignableFrom(returnType) && !returnType.IsConstructedGenericType)
+        {
+            throw new ArgumentException("Method return type cannot be Task. Consider using Task<TResult>");
+        }
+
+        return BaseHandle(instance, type, method, target, name, args, returnType, triggers);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheAttribute.cs
@@ -10,415 +10,414 @@ using Aspects.Universal.Events;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cache;
+
+/// <summary>
+/// Base caching attribute that should be extended with specific
+/// caching implementations e.g. blob storage, memory, Redis, etc.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+[Injection(typeof(CacheAspect), Inherited = true)]
+public abstract class CacheAttribute : BaseUniversalWrapperAttribute
 {
+    private const BindingFlags ConstructorBindingFlags =
+        BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance |
+        BindingFlags.OptionalParamBinding;
+
     /// <summary>
-    /// Base caching attribute that should be extended with specific
-    /// caching implementations e.g. blob storage, memory, Redis, etc.
+    /// The base type of the cache key to use.
+    /// The <see cref="Key"/> must be assignable to this.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
-    [Injection(typeof(CacheAspect), Inherited = true)]
-    public abstract class CacheAttribute : BaseUniversalWrapperAttribute
+    protected virtual Type BaseKey => typeof(ICacheKey);
+
+    /// <summary>
+    /// The explicit type of the caching key to use. It must be assignable
+    /// to the <see cref="BaseKey"/>.
+    /// <para>
+    /// We construct the caching key by passing in the method parameters into
+    /// one of its constructors. We will try our best to match each of
+    /// these based on the their types and names.
+    /// </para>
+    ///<para>
+    /// In situations where it is ambiguous which parameters to use, we will
+    /// throw an appropriate exception. For more control (and to avoid ambiguity),
+    /// use <see cref="CacheKeyParamAttribute"/> to configure which parameters
+    /// should be passed through. We recommend that you keep your constructor
+    /// as simple as possible as the matching algorithm is not perfect and
+    /// will probably need updates for additional use-cases in the future.
+    /// </para>
+    /// </summary>
+    public Type Key { get; }
+    
+    /// <summary>
+    /// Flag signifying that this caching attribute forces a cache update.
+    /// When an attribute with this flag set is invoked, it will retrieve a fresh
+    /// value rather than a cached item and then set or update it in the cache,
+    /// therefore always caching and then supplying a freshly retrieved value.
+    /// </summary>
+    public bool ForceUpdate { get; }
+
+    protected CacheAttribute(Type key, bool forceUpdate)
     {
-        private const BindingFlags ConstructorBindingFlags =
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance |
-            BindingFlags.OptionalParamBinding;
+        Key = key;
+        ForceUpdate = forceUpdate;
+        ValidateOptions();
+    }
 
-        /// <summary>
-        /// The base type of the cache key to use.
-        /// The <see cref="Key"/> must be assignable to this.
-        /// </summary>
-        protected virtual Type BaseKey => typeof(ICacheKey);
-
-        /// <summary>
-        /// The explicit type of the caching key to use. It must be assignable
-        /// to the <see cref="BaseKey"/>.
-        /// <para>
-        /// We construct the caching key by passing in the method parameters into
-        /// one of its constructors. We will try our best to match each of
-        /// these based on the their types and names.
-        /// </para>
-        ///<para>
-        /// In situations where it is ambiguous which parameters to use, we will
-        /// throw an appropriate exception. For more control (and to avoid ambiguity),
-        /// use <see cref="CacheKeyParamAttribute"/> to configure which parameters
-        /// should be passed through. We recommend that you keep your constructor
-        /// as simple as possible as the matching algorithm is not perfect and
-        /// will probably need updates for additional use-cases in the future.
-        /// </para>
-        /// </summary>
-        public Type Key { get; }
-        
-        /// <summary>
-        /// Flag signifying that this caching attribute forces a cache update.
-        /// When an attribute with this flag set is invoked, it will retrieve a fresh
-        /// value rather than a cached item and then set or update it in the cache,
-        /// therefore always caching and then supplying a freshly retrieved value.
-        /// </summary>
-        public bool ForceUpdate { get; }
-
-        protected CacheAttribute(Type key, bool forceUpdate)
+    private void ValidateOptions()
+    {
+        if (Key is null)
         {
-            Key = key;
-            ForceUpdate = forceUpdate;
-            ValidateOptions();
+            throw new ArgumentException("Cache key type cannot be null");
         }
 
-        private void ValidateOptions()
+        if (!BaseKey.IsAssignableFrom(Key))
         {
-            if (Key is null)
-            {
-                throw new ArgumentException("Cache key type cannot be null");
-            }
+            throw new ArgumentException($"Cache key type {Key.GetPrettyFullName()} must be assignable to {BaseKey.GetPrettyFullName()}");
+        }
+    }
 
-            if (!BaseKey.IsAssignableFrom(Key))
-            {
-                throw new ArgumentException($"Cache key type {Key.GetPrettyFullName()} must be assignable to {BaseKey.GetPrettyFullName()}");
-            }
+    protected override T WrapSync<T>(Func<object[], T> target, object[] args, AspectEventArgs eventArgs)
+    {
+        var unboxedResultType = typeof(T).GetUnboxedResultTypePath().Last();
+
+        var cacheKey = GetCacheKey(Key, args, eventArgs.Method);
+
+        object? cachedResult = null;
+        if (!ForceUpdate)
+        {
+            cachedResult = Get(cacheKey, unboxedResultType);
         }
 
-        protected override T WrapSync<T>(Func<object[], T> target, object[] args, AspectEventArgs eventArgs)
+        if (cachedResult?.TryBoxToResult(typeof(T), out cachedResult) == true)
         {
-            var unboxedResultType = typeof(T).GetUnboxedResultTypePath().Last();
+            return (T)cachedResult;
+        }
 
-            var cacheKey = GetCacheKey(Key, args, eventArgs.Method);
+        try
+        {
+            var result = target(args);
 
-            object? cachedResult = null;
-            if (!ForceUpdate)
+            if (!result.TryUnboxResult(out cachedResult) || cachedResult is null)
             {
-                cachedResult = Get(cacheKey, unboxedResultType);
-            }
-
-            if (cachedResult?.TryBoxToResult(typeof(T), out cachedResult) == true)
-            {
-                return (T)cachedResult;
-            }
-
-            try
-            {
-                var result = target(args);
-
-                if (!result.TryUnboxResult(out cachedResult) || cachedResult is null)
-                {
-                    return result;
-                }
-
-                Set(cacheKey, cachedResult);
-
                 return result;
             }
-            catch (Exception exception)
-            {
-                return OnException<T>(eventArgs, exception);
-            }
+
+            Set(cacheKey, cachedResult);
+
+            return result;
+        }
+        catch (Exception exception)
+        {
+            return OnException<T>(eventArgs, exception);
+        }
+    }
+
+    protected override async Task<T> WrapAsync<T>(Func<object[], Task<T>> target, object[] args, AspectEventArgs eventArgs)
+    {
+        var unboxedResultType = typeof(T).GetUnboxedResultTypePath().Last();
+
+        var cacheKey = GetCacheKey(Key, args, eventArgs.Method);
+
+        object? cachedResult = null;
+        if (!ForceUpdate)
+        {
+            cachedResult = await GetAsync(cacheKey, unboxedResultType);
         }
 
-        protected override async Task<T> WrapAsync<T>(Func<object[], Task<T>> target, object[] args, AspectEventArgs eventArgs)
+        if (cachedResult?.TryBoxToResult(typeof(T), out cachedResult) == true)
         {
-            var unboxedResultType = typeof(T).GetUnboxedResultTypePath().Last();
+            return (T)cachedResult;
+        }
 
-            var cacheKey = GetCacheKey(Key, args, eventArgs.Method);
+        try
+        {
+            var result = await target(args);
 
-            object? cachedResult = null;
-            if (!ForceUpdate)
+            if (!result.TryUnboxResult(out cachedResult) || cachedResult is null)
             {
-                cachedResult = await GetAsync(cacheKey, unboxedResultType);
-            }
-
-            if (cachedResult?.TryBoxToResult(typeof(T), out cachedResult) == true)
-            {
-                return (T)cachedResult;
-            }
-
-            try
-            {
-                var result = await target(args);
-
-                if (!result.TryUnboxResult(out cachedResult) || cachedResult is null)
-                {
-                    return result;
-                }
-
-                await SetAsync(cacheKey, cachedResult);
-
                 return result;
             }
-            catch (Exception exception)
-            {
-                return OnException<T>(eventArgs, exception);
-            }
+
+            await SetAsync(cacheKey, cachedResult);
+
+            return result;
         }
-
-        public abstract object? Get(ICacheKey cacheKey, Type returnType);
-
-        public abstract void Set(ICacheKey cacheKey, object value);
-
-        public abstract Task<object?> GetAsync(ICacheKey cacheKey, Type returnType);
-
-        public abstract Task SetAsync(ICacheKey cacheKey, object value);
-
-        protected virtual T OnException<T>(AspectEventArgs eventArgs, Exception exception) => throw exception;
-
-        public ICacheKey GetCacheKey(Type cacheKeyType, object[] methodArgs, MethodBase method)
+        catch (Exception exception)
         {
-            // Order constructors from most parameters to least so that we can
-            // try and find the constructor with the most matching arguments first.
-            var constructors = cacheKeyType.GetConstructors()
-                .OrderByDescending(constructor => constructor.GetParameters().Length)
-                .ToList();
+            return OnException<T>(eventArgs, exception);
+        }
+    }
 
-            if (constructors.Count == 0)
-            {
-                throw new MissingMethodException(
-                    $"Cache key {cacheKeyType.GetPrettyFullName()} must have at least one constructor"
-                );
-            }
+    public abstract object? Get(ICacheKey cacheKey, Type returnType);
 
-            var parameters = GetMatchingParams(constructors, method, cacheKeyType);
+    public abstract void Set(ICacheKey cacheKey, object value);
 
-            var invokeArgs = parameters
-                .Select(param =>
-                    {
-                        if (param.Param is not null)
-                        {
-                            return methodArgs[param.Param.Position];
-                        }
+    public abstract Task<object?> GetAsync(ICacheKey cacheKey, Type returnType);
 
-                        return param.HasDefaultValue ? Type.Missing : null;
-                    }
-                )
-                .ToList();
+    public abstract Task SetAsync(ICacheKey cacheKey, object value);
 
-            // For some reason, invoking with only missing values
-            // will lead to an exception being thrown.
-            if (invokeArgs.All(arg => arg == Type.Missing))
-            {
-                invokeArgs.Clear();
-            }
+    protected virtual T OnException<T>(AspectEventArgs eventArgs, Exception exception) => throw exception;
 
-            var keyInstance = Activator.CreateInstance(
-                cacheKeyType,
-                bindingAttr: ConstructorBindingFlags,
-                args: invokeArgs.ToArray(),
-                binder: null,
-                culture: null
-            );
+    public ICacheKey GetCacheKey(Type cacheKeyType, object[] methodArgs, MethodBase method)
+    {
+        // Order constructors from most parameters to least so that we can
+        // try and find the constructor with the most matching arguments first.
+        var constructors = cacheKeyType.GetConstructors()
+            .OrderByDescending(constructor => constructor.GetParameters().Length)
+            .ToList();
 
-            if (keyInstance is ICacheKey key)
-            {
-                return key;
-            }
-
-            throw new InvalidOperationException(
-                $"Constructor returned null when it should instantiate {cacheKeyType.GetPrettyFullName()}"
+        if (constructors.Count == 0)
+        {
+            throw new MissingMethodException(
+                $"Cache key {cacheKeyType.GetPrettyFullName()} must have at least one constructor"
             );
         }
-        private static List<ParameterInfoScore> GetMatchingParams(
-            List<ConstructorInfo> constructors,
-            MethodBase method,
-            Type cacheKeyType)
-        {
-            var methodParams = method.GetParameters();
 
-            var cacheKeyParams = methodParams
-                .Select(
-                    param =>
+        var parameters = GetMatchingParams(constructors, method, cacheKeyType);
+
+        var invokeArgs = parameters
+            .Select(param =>
+                {
+                    if (param.Param is not null)
                     {
-                        var attribute = param.GetCustomAttribute<CacheKeyParamAttribute>();
-
-                        return attribute is not null ? new CacheKeyParamInfo(param, attribute) : null;
+                        return methodArgs[param.Param.Position];
                     }
-                )
+
+                    return param.HasDefaultValue ? Type.Missing : null;
+                }
+            )
+            .ToList();
+
+        // For some reason, invoking with only missing values
+        // will lead to an exception being thrown.
+        if (invokeArgs.All(arg => arg == Type.Missing))
+        {
+            invokeArgs.Clear();
+        }
+
+        var keyInstance = Activator.CreateInstance(
+            cacheKeyType,
+            bindingAttr: ConstructorBindingFlags,
+            args: invokeArgs.ToArray(),
+            binder: null,
+            culture: null
+        );
+
+        if (keyInstance is ICacheKey key)
+        {
+            return key;
+        }
+
+        throw new InvalidOperationException(
+            $"Constructor returned null when it should instantiate {cacheKeyType.GetPrettyFullName()}"
+        );
+    }
+    private static List<ParameterInfoScore> GetMatchingParams(
+        List<ConstructorInfo> constructors,
+        MethodBase method,
+        Type cacheKeyType)
+    {
+        var methodParams = method.GetParameters();
+
+        var cacheKeyParams = methodParams
+            .Select(
+                param =>
+                {
+                    var attribute = param.GetCustomAttribute<CacheKeyParamAttribute>();
+
+                    return attribute is not null ? new CacheKeyParamInfo(param, attribute) : null;
+                }
+            )
+            .WhereNotNull()
+            .ToList();
+
+        List<string> matchErrors = new();
+
+        foreach (var constructor in constructors)
+        {
+            var constructorParams = constructor.GetParameters();
+
+            var constructorParamMatches = cacheKeyParams.Count > 0
+                ? MatchConstructorToCacheKeyParams(constructorParams, cacheKeyParams)
+                : MatchConstructorToMethodParams(constructorParams, methodParams);
+
+            // Not enough arguments match the constructor's
+            // parameters, so we should move onto the next one.
+            if (constructorParamMatches.Count != constructorParams.Length)
+            {
+                continue;
+            }
+
+            if (!constructorParamMatches.All(HasUnambiguousMatch))
+            {
+                matchErrors.Add(GetMultipleMatchesError(constructorParams, constructorParamMatches));
+
+                continue;
+            }
+
+            // The final param candidates that we select
+            // to invoke the cache key constructor with.
+            var selectedParams = constructorParamMatches
+                .Select(matches => matches[0])
+                .ToList();
+
+            var nonNullParams = selectedParams
+                .Select(param => param.Param)
                 .WhereNotNull()
                 .ToList();
 
-            List<string> matchErrors = new();
+            var distinctNonNullParams = nonNullParams.Distinct().ToList();
 
-            foreach (var constructor in constructors)
+            if (nonNullParams.Count != distinctNonNullParams.Count)
             {
-                var constructorParams = constructor.GetParameters();
+                matchErrors.Add(GetCandidateParametersError(constructorParams, distinctNonNullParams));
 
-                var constructorParamMatches = cacheKeyParams.Count > 0
-                    ? MatchConstructorToCacheKeyParams(constructorParams, cacheKeyParams)
-                    : MatchConstructorToMethodParams(constructorParams, methodParams);
-
-                // Not enough arguments match the constructor's
-                // parameters, so we should move onto the next one.
-                if (constructorParamMatches.Count != constructorParams.Length)
-                {
-                    continue;
-                }
-
-                if (!constructorParamMatches.All(HasUnambiguousMatch))
-                {
-                    matchErrors.Add(GetMultipleMatchesError(constructorParams, constructorParamMatches));
-
-                    continue;
-                }
-
-                // The final param candidates that we select
-                // to invoke the cache key constructor with.
-                var selectedParams = constructorParamMatches
-                    .Select(matches => matches[0])
-                    .ToList();
-
-                var nonNullParams = selectedParams
-                    .Select(param => param.Param)
-                    .WhereNotNull()
-                    .ToList();
-
-                var distinctNonNullParams = nonNullParams.Distinct().ToList();
-
-                if (nonNullParams.Count != distinctNonNullParams.Count)
-                {
-                    matchErrors.Add(GetCandidateParametersError(constructorParams, distinctNonNullParams));
-
-                    continue;
-                }
-
-                return selectedParams;
+                continue;
             }
 
-            if (matchErrors.Any())
-            {
-                throw new AmbiguousMatchException(
-                    $"No constructor for cache key {cacheKeyType.GetPrettyFullName()} could be unambiguously matched. Found the following problems: \n- " +
-                    matchErrors.JoinToString("\n- ")
-                );
-            }
+            return selectedParams;
+        }
 
-            throw new MissingMemberException(
-                $"No matching constructor for cache key {cacheKeyType.GetPrettyFullName()} using parameters from method: {method}"
+        if (matchErrors.Any())
+        {
+            throw new AmbiguousMatchException(
+                $"No constructor for cache key {cacheKeyType.GetPrettyFullName()} could be unambiguously matched. Found the following problems: \n- " +
+                matchErrors.JoinToString("\n- ")
             );
         }
 
-        private static string GetMultipleMatchesError(
-            ParameterInfo[] constructorParams,
-            List<List<ParameterInfoScore>> constructorParamMatches)
-        {
-            var positions = constructorParamMatches
-                .Select((matches, index) => !HasUnambiguousMatch(matches) ? index.ToString() : "")
-                .Where(position => !position.IsNullOrEmpty())
-                .JoinToString(", ");
-
-            var constructorString = constructorParams
-                .Select(param => param.ToShortString())
-                .JoinToString(", ");
-
-            return $"Constructor ({constructorString}) has multiple matches at position(s): {positions}";
-        }
-
-        private static string GetCandidateParametersError(
-            IEnumerable<ParameterInfo> constructorParams,
-            IEnumerable<ParameterInfo> selectedParams)
-        {
-            var constructorString = constructorParams
-                .Select(param => param.ToShortString())
-                .JoinToString(", ");
-
-            var paramsString = selectedParams
-                .Select(param => param.ToShortString())
-                .JoinToString(", ");
-
-            return
-                $"Constructor ({constructorString}) has candidate parameters ({paramsString}) that could not be unambiguously matched";
-        }
-
-        private static bool HasUnambiguousMatch(List<ParameterInfoScore> matches)
-        {
-            return matches.Count > 1
-                ? matches[0].Score > matches[1].Score
-                : matches.Count == 1;
-        }
-
-        private static List<List<ParameterInfoScore>> MatchConstructorToCacheKeyParams(
-            ParameterInfo[] constructorParams,
-            List<CacheKeyParamInfo> cacheKeyParams)
-        {
-            return MatchConstructorToParams(
-                constructorParams,
-                constructorParam =>  cacheKeyParams
-                    .Where(param => constructorParam.ParameterType.IsAssignableFrom(param.Info.ParameterType))
-                    .Select(param => ScoreCacheKeyParam(param, constructorParam))
-                    .OrderByDescending(param => param.Score)
-                    .ToList()
-            );
-        }
-
-        private static List<List<ParameterInfoScore>> MatchConstructorToMethodParams(
-            ParameterInfo[] constructorParams,
-            ParameterInfo[] methodParams)
-        {
-            return MatchConstructorToParams(
-                constructorParams,
-                constructorParam => methodParams
-                    .Where(param => constructorParam.ParameterType.IsAssignableFrom(param.ParameterType))
-                    .Select(param => ScoreParam(param, constructorParam))
-                    .OrderByDescending(param => param.Score)
-                    .ToList()
-            );
-        }
-
-        private static List<List<ParameterInfoScore>> MatchConstructorToParams(
-            ParameterInfo[] constructorParams,
-            Func<ParameterInfo, List<ParameterInfoScore>> matcher)
-        {
-            return constructorParams.Select(
-                    constructorParam =>
-                    {
-                        var matches = matcher(constructorParam);
-
-                        if (!matches.Any() && (constructorParam.IsNullable() || constructorParam.HasDefaultValue))
-                        {
-                            matches.Add(new ParameterInfoScore(null, 0, constructorParam.HasDefaultValue));
-                        }
-
-                        return matches;
-                    }
-                )
-                .Where(paramMatches => paramMatches.Any())
-                .ToList();
-        }
-
-        private static ParameterInfoScore ScoreCacheKeyParam(
-            CacheKeyParamInfo cacheKeyParam,
-            ParameterInfo constructorParam)
-        {
-            var (cacheKeyParamInfo, cacheKeyParamAttribute) = cacheKeyParam;
-
-            var score = 0;
-
-            if (cacheKeyParamAttribute.Name is not null
-                && cacheKeyParamAttribute.Name == constructorParam.Name)
-            {
-                score += 1;
-            }
-            else if (constructorParam.Name is not null
-                     && constructorParam.Name.Equals(cacheKeyParamInfo.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                score += 1;
-            }
-
-            return new ParameterInfoScore(cacheKeyParam.Info, score, constructorParam.HasDefaultValue);
-        }
-
-        private static ParameterInfoScore ScoreParam(
-            ParameterInfo methodParam,
-            ParameterInfo constructorParam)
-        {
-            var score = 0;
-
-            if (constructorParam.Name is not null
-                && constructorParam.Name.Equals(methodParam.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                score += 1;
-            }
-
-            return new ParameterInfoScore(methodParam, score, constructorParam.HasDefaultValue);
-        }
-
-        private record CacheKeyParamInfo(ParameterInfo Info, CacheKeyParamAttribute Attribute);
-
-        private record ParameterInfoScore(ParameterInfo? Param, int Score, bool HasDefaultValue = false);
+        throw new MissingMemberException(
+            $"No matching constructor for cache key {cacheKeyType.GetPrettyFullName()} using parameters from method: {method}"
+        );
     }
+
+    private static string GetMultipleMatchesError(
+        ParameterInfo[] constructorParams,
+        List<List<ParameterInfoScore>> constructorParamMatches)
+    {
+        var positions = constructorParamMatches
+            .Select((matches, index) => !HasUnambiguousMatch(matches) ? index.ToString() : "")
+            .Where(position => !position.IsNullOrEmpty())
+            .JoinToString(", ");
+
+        var constructorString = constructorParams
+            .Select(param => param.ToShortString())
+            .JoinToString(", ");
+
+        return $"Constructor ({constructorString}) has multiple matches at position(s): {positions}";
+    }
+
+    private static string GetCandidateParametersError(
+        IEnumerable<ParameterInfo> constructorParams,
+        IEnumerable<ParameterInfo> selectedParams)
+    {
+        var constructorString = constructorParams
+            .Select(param => param.ToShortString())
+            .JoinToString(", ");
+
+        var paramsString = selectedParams
+            .Select(param => param.ToShortString())
+            .JoinToString(", ");
+
+        return
+            $"Constructor ({constructorString}) has candidate parameters ({paramsString}) that could not be unambiguously matched";
+    }
+
+    private static bool HasUnambiguousMatch(List<ParameterInfoScore> matches)
+    {
+        return matches.Count > 1
+            ? matches[0].Score > matches[1].Score
+            : matches.Count == 1;
+    }
+
+    private static List<List<ParameterInfoScore>> MatchConstructorToCacheKeyParams(
+        ParameterInfo[] constructorParams,
+        List<CacheKeyParamInfo> cacheKeyParams)
+    {
+        return MatchConstructorToParams(
+            constructorParams,
+            constructorParam =>  cacheKeyParams
+                .Where(param => constructorParam.ParameterType.IsAssignableFrom(param.Info.ParameterType))
+                .Select(param => ScoreCacheKeyParam(param, constructorParam))
+                .OrderByDescending(param => param.Score)
+                .ToList()
+        );
+    }
+
+    private static List<List<ParameterInfoScore>> MatchConstructorToMethodParams(
+        ParameterInfo[] constructorParams,
+        ParameterInfo[] methodParams)
+    {
+        return MatchConstructorToParams(
+            constructorParams,
+            constructorParam => methodParams
+                .Where(param => constructorParam.ParameterType.IsAssignableFrom(param.ParameterType))
+                .Select(param => ScoreParam(param, constructorParam))
+                .OrderByDescending(param => param.Score)
+                .ToList()
+        );
+    }
+
+    private static List<List<ParameterInfoScore>> MatchConstructorToParams(
+        ParameterInfo[] constructorParams,
+        Func<ParameterInfo, List<ParameterInfoScore>> matcher)
+    {
+        return constructorParams.Select(
+                constructorParam =>
+                {
+                    var matches = matcher(constructorParam);
+
+                    if (!matches.Any() && (constructorParam.IsNullable() || constructorParam.HasDefaultValue))
+                    {
+                        matches.Add(new ParameterInfoScore(null, 0, constructorParam.HasDefaultValue));
+                    }
+
+                    return matches;
+                }
+            )
+            .Where(paramMatches => paramMatches.Any())
+            .ToList();
+    }
+
+    private static ParameterInfoScore ScoreCacheKeyParam(
+        CacheKeyParamInfo cacheKeyParam,
+        ParameterInfo constructorParam)
+    {
+        var (cacheKeyParamInfo, cacheKeyParamAttribute) = cacheKeyParam;
+
+        var score = 0;
+
+        if (cacheKeyParamAttribute.Name is not null
+            && cacheKeyParamAttribute.Name == constructorParam.Name)
+        {
+            score += 1;
+        }
+        else if (constructorParam.Name is not null
+                 && constructorParam.Name.Equals(cacheKeyParamInfo.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            score += 1;
+        }
+
+        return new ParameterInfoScore(cacheKeyParam.Info, score, constructorParam.HasDefaultValue);
+    }
+
+    private static ParameterInfoScore ScoreParam(
+        ParameterInfo methodParam,
+        ParameterInfo constructorParam)
+    {
+        var score = 0;
+
+        if (constructorParam.Name is not null
+            && constructorParam.Name.Equals(methodParam.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            score += 1;
+        }
+
+        return new ParameterInfoScore(methodParam, score, constructorParam.HasDefaultValue);
+    }
+
+    private record CacheKeyParamInfo(ParameterInfo Info, CacheKeyParamAttribute Attribute);
+
+    private record ParameterInfoScore(ParameterInfo? Param, int Score, bool HasDefaultValue = false);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheKeyParamAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/CacheKeyParamAttribute.cs
@@ -1,20 +1,19 @@
 #nullable enable
 using System;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
-{
-    [AttributeUsage(AttributeTargets.Parameter)]
-    public class CacheKeyParamAttribute : Attribute
-    {
-        /// <summary>
-        /// The specific name of the parameter in the
-        /// caching key constructor to use.
-        /// </summary>
-        public string? Name { get; set; }
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cache;
 
-        public CacheKeyParamAttribute(string? name = null)
-        {
-            Name = name;
-        }
+[AttributeUsage(AttributeTargets.Parameter)]
+public class CacheKeyParamAttribute : Attribute
+{
+    /// <summary>
+    /// The specific name of the parameter in the
+    /// caching key constructor to use.
+    /// </summary>
+    public string? Name { get; set; }
+
+    public CacheKeyParamAttribute(string? name = null)
+    {
+        Name = name;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/Interfaces/IBlobCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/Interfaces/IBlobCacheKey.cs
@@ -1,8 +1,7 @@
 #nullable enable
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
+
+public interface IBlobCacheKey : ICacheKey
 {
-    public interface IBlobCacheKey : ICacheKey
-    {
-        IBlobContainer Container { get; }
-    }
+    IBlobContainer Container { get; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/Interfaces/ICacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/Interfaces/ICacheKey.cs
@@ -1,8 +1,7 @@
 ﻿#nullable enable
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
+
+public interface ICacheKey
 {
-    public interface ICacheKey
-    {
-        public string Key { get; }
-    }
+    public string Key { get; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/MemoryCacheAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/MemoryCacheAttribute.cs
@@ -9,142 +9,141 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using Microsoft.Extensions.Configuration;
 using NCrontab;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cache;
+
+public class MemoryCacheAttribute : CacheAttribute
 {
-    public class MemoryCacheAttribute : CacheAttribute
+    /// <summary>
+    /// A Dictionary of available IMemoryCacheService implementations. It is possible here to register
+    /// MemoryCacheServices that can each handle a different cache and with a different configuration. Therefore
+    /// we could register services that handle short-lived caches, caches that never expire etc, and the individual
+    /// [MemoryCache] attributes on methods could identify which cache service they need via the "ServiceName"
+    /// parameter.
+    /// </summary>
+    private static Dictionary<string, IMemoryCacheService> Services { get; set; } = new();
+
+    private static int? _overrideDurationInSeconds;
+
+    private static CrontabSchedule? _overrideExpirySchedule;
+
+    protected override Type BaseKey => typeof(IMemoryCacheKey);
+    
+    private int DurationInSeconds { get; }
+    
+    private CrontabSchedule? ExpirySchedule { get; }
+
+    /// <summary>
+    /// Specify a service to use <see cref="Services"/>.
+    /// Otherwise, we use the first registered service.
+    /// </summary>
+    public string? ServiceName { get; set; }
+
+    public MemoryCacheAttribute(
+        Type key, 
+        int durationInSeconds, 
+        string? expiryScheduleCron = null,
+        bool forceUpdate = false
+    ) : base(key, forceUpdate)
     {
-        /// <summary>
-        /// A Dictionary of available IMemoryCacheService implementations. It is possible here to register
-        /// MemoryCacheServices that can each handle a different cache and with a different configuration. Therefore
-        /// we could register services that handle short-lived caches, caches that never expire etc, and the individual
-        /// [MemoryCache] attributes on methods could identify which cache service they need via the "ServiceName"
-        /// parameter.
-        /// </summary>
-        private static Dictionary<string, IMemoryCacheService> Services { get; set; } = new();
+        DurationInSeconds = durationInSeconds;
+        ExpirySchedule = expiryScheduleCron != null ? CrontabSchedule.Parse(expiryScheduleCron) : null;
+    }
 
-        private static int? _overrideDurationInSeconds;
+    public static void AddService(string name, IMemoryCacheService service)
+    {
+        Services[name] = service;
+    }
+    public static void ClearServices()
+    {
+        Services.Clear();
+    }
 
-        private static CrontabSchedule? _overrideExpirySchedule;
+    public static void SetOverrideConfiguration(IConfigurationSection? configurationSection)
+    {
+        var overrideDurationInSeconds = configurationSection?.GetValue<int?>("DurationInSeconds");
 
-        protected override Type BaseKey => typeof(IMemoryCacheKey);
-        
-        private int DurationInSeconds { get; }
-        
-        private CrontabSchedule? ExpirySchedule { get; }
+        _overrideDurationInSeconds = overrideDurationInSeconds != null && overrideDurationInSeconds != -1
+            ? overrideDurationInSeconds.Value : null;
 
-        /// <summary>
-        /// Specify a service to use <see cref="Services"/>.
-        /// Otherwise, we use the first registered service.
-        /// </summary>
-        public string? ServiceName { get; set; }
+        var overrideExpirySchedule = configurationSection?.GetValue<string?>("ExpirySchedule");
 
-        public MemoryCacheAttribute(
-            Type key, 
-            int durationInSeconds, 
-            string? expiryScheduleCron = null,
-            bool forceUpdate = false
-        ) : base(key, forceUpdate)
+        _overrideExpirySchedule = !overrideExpirySchedule.IsNullOrEmpty()
+            ? CrontabSchedule.Parse(overrideExpirySchedule) : null;
+    }
+
+    public override object? Get(ICacheKey cacheKey, Type returnType)
+    {
+        if (cacheKey is not IMemoryCacheKey key)
         {
-            DurationInSeconds = durationInSeconds;
-            ExpirySchedule = expiryScheduleCron != null ? CrontabSchedule.Parse(expiryScheduleCron) : null;
+            throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
         }
 
-        public static void AddService(string name, IMemoryCacheService service)
+        var service = GetService();
+
+        return service?.GetItem(key, returnType);
+    }
+
+    public override Task<object?> GetAsync(ICacheKey cacheKey, Type returnType)
+    {
+        if (cacheKey is not IMemoryCacheKey key)
         {
-            Services[name] = service;
-        }
-        public static void ClearServices()
-        {
-            Services.Clear();
-        }
-
-        public static void SetOverrideConfiguration(IConfigurationSection? configurationSection)
-        {
-            var overrideDurationInSeconds = configurationSection?.GetValue<int?>("DurationInSeconds");
-
-            _overrideDurationInSeconds = overrideDurationInSeconds != null && overrideDurationInSeconds != -1
-                ? overrideDurationInSeconds.Value : null;
-
-            var overrideExpirySchedule = configurationSection?.GetValue<string?>("ExpirySchedule");
-
-            _overrideExpirySchedule = !overrideExpirySchedule.IsNullOrEmpty()
-                ? CrontabSchedule.Parse(overrideExpirySchedule) : null;
+            throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
         }
 
-        public override object? Get(ICacheKey cacheKey, Type returnType)
+        var service = GetService();
+
+        if (service is null)
         {
-            if (cacheKey is not IMemoryCacheKey key)
-            {
-                throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
-            }
-
-            var service = GetService();
-
-            return service?.GetItem(key, returnType);
+            return Task.FromResult<object?>(null);
         }
 
-        public override Task<object?> GetAsync(ICacheKey cacheKey, Type returnType)
+        var cachedItem = service.GetItem(key, returnType);
+        return Task.FromResult(cachedItem);
+    }
+
+    public override void Set(ICacheKey cacheKey, object value)
+    {
+        if (cacheKey is not IMemoryCacheKey key)
         {
-            if (cacheKey is not IMemoryCacheKey key)
-            {
-                throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
-            }
-
-            var service = GetService();
-
-            if (service is null)
-            {
-                return Task.FromResult<object?>(null);
-            }
-
-            var cachedItem = service.GetItem(key, returnType);
-            return Task.FromResult(cachedItem);
+            throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
         }
 
-        public override void Set(ICacheKey cacheKey, object value)
-        {
-            if (cacheKey is not IMemoryCacheKey key)
-            {
-                throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
-            }
+        var service = GetService();
 
-            var service = GetService();
-
-            service?.SetItem(key, value,
-                new MemoryCacheConfiguration(
-                    _overrideDurationInSeconds ?? DurationInSeconds,
-                    _overrideExpirySchedule ?? ExpirySchedule));
-        }
-
-        public override Task SetAsync(ICacheKey cacheKey, object value)
-        {
-            if (cacheKey is not IMemoryCacheKey key)
-            {
-                throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
-            }
-
-            var service = GetService();
-
-            if (service is null)
-            {
-                return Task.CompletedTask;
-            }
-
-            var itemCachingConfiguration = new MemoryCacheConfiguration(
+        service?.SetItem(key, value,
+            new MemoryCacheConfiguration(
                 _overrideDurationInSeconds ?? DurationInSeconds,
-                _overrideExpirySchedule ?? ExpirySchedule);
-            service.SetItem(key, value, itemCachingConfiguration);
+                _overrideExpirySchedule ?? ExpirySchedule));
+    }
+
+    public override Task SetAsync(ICacheKey cacheKey, object value)
+    {
+        if (cacheKey is not IMemoryCacheKey key)
+        {
+            throw new ArgumentException($"Cache key must by assignable to {BaseKey.GetPrettyFullName()}");
+        }
+
+        var service = GetService();
+
+        if (service is null)
+        {
             return Task.CompletedTask;
         }
 
-        private IMemoryCacheService? GetService()
-        {
-            if (ServiceName is not null)
-            {
-                return Services[ServiceName];
-            }
+        var itemCachingConfiguration = new MemoryCacheConfiguration(
+            _overrideDurationInSeconds ?? DurationInSeconds,
+            _overrideExpirySchedule ?? ExpirySchedule);
+        service.SetItem(key, value, itemCachingConfiguration);
+        return Task.CompletedTask;
+    }
 
-            return Services.Count > 0 ? Services.First().Value : null;
+    private IMemoryCacheService? GetService()
+    {
+        if (ServiceName is not null)
+        {
+            return Services[ServiceName];
         }
+
+        return Services.Count > 0 ? Services.First().Value : null;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cancellation/CancellationTokenTimeoutAspect.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cancellation/CancellationTokenTimeoutAspect.cs
@@ -6,84 +6,83 @@ using System.Threading;
 using AspectInjector.Broker;
 using Microsoft.EntityFrameworkCore.Internal;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cancellation
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
+
+[Aspect(Scope.Global)]
+public class CancellationTokenTimeoutAspect
 {
-    [Aspect(Scope.Global)]
-    public class CancellationTokenTimeoutAspect
+    /// <summary>
+    /// Enables the <see cref="CancellationTokenTimeoutAspect" /> Aspect that supports use of the
+    /// <see cref="CancellationTokenTimeoutAttribute" /> to annotate methods.
+    /// <para>
+    /// This is set to false by default so that test code
+    /// isn't affected by this aspect. It should be set to
+    /// true in your application startup, or if your tests
+    /// are concerned with testing cancellations.
+    /// </para>
+    /// </summary>
+    public static bool Enabled { get; set; }
+    
+    [Advice(Kind.Around)]
+    public object Handle(
+        [Argument(Source.Target)] Func<object[], object> target,
+        [Argument(Source.Arguments)] object[] args,
+        [Argument(Source.Metadata)] MethodBase method,
+        [Argument(Source.Triggers)] Attribute[] triggers)
     {
-        /// <summary>
-        /// Enables the <see cref="CancellationTokenTimeoutAspect" /> Aspect that supports use of the
-        /// <see cref="CancellationTokenTimeoutAttribute" /> to annotate methods.
-        /// <para>
-        /// This is set to false by default so that test code
-        /// isn't affected by this aspect. It should be set to
-        /// true in your application startup, or if your tests
-        /// are concerned with testing cancellations.
-        /// </para>
-        /// </summary>
-        public static bool Enabled { get; set; }
+        var cancellationTokenParameters = method
+            .GetParameters()
+            .Where(parameter => parameter.ParameterType == typeof(CancellationToken)
+                                || parameter.ParameterType == typeof(CancellationToken?))
+            .ToArray();
         
-        [Advice(Kind.Around)]
-        public object Handle(
-            [Argument(Source.Target)] Func<object[], object> target,
-            [Argument(Source.Arguments)] object[] args,
-            [Argument(Source.Metadata)] MethodBase method,
-            [Argument(Source.Triggers)] Attribute[] triggers)
+        if (cancellationTokenParameters.Count() != 1)
         {
-            var cancellationTokenParameters = method
-                .GetParameters()
-                .Where(parameter => parameter.ParameterType == typeof(CancellationToken)
-                                    || parameter.ParameterType == typeof(CancellationToken?))
-                .ToArray();
-            
-            if (cancellationTokenParameters.Count() != 1)
-            {
-                throw new ArgumentException($"Method {method.Name} annotated with the " +
-                                            $"{nameof(CancellationTokenTimeoutAspect)} attribute must " +
-                                            $"accept a single {nameof(CancellationToken)} parameter");
-            }
-
-            var cancellationTokenParamPosition = method
-                .GetParameters()
-                .ToList()
-                .IndexOf(cancellationTokenParameters.Single());
-            
-            if (!Enabled)
-            {
-                return target(args);
-            }
-            
-            var trigger = triggers
-                .OfType<CancellationTokenTimeoutAttribute>()
-                .Single();
-
-            var timeoutToken = new CancellationTokenSource(trigger.TimeoutMillis).Token;
-            var passedInToken = args[cancellationTokenParamPosition] as CancellationToken?;
-            var newArgs = args.ToArray();
-            newArgs[cancellationTokenParamPosition] = CombineTokens(passedInToken, timeoutToken);
-            return target(newArgs);
+            throw new ArgumentException($"Method {method.Name} annotated with the " +
+                                        $"{nameof(CancellationTokenTimeoutAspect)} attribute must " +
+                                        $"accept a single {nameof(CancellationToken)} parameter");
         }
 
-        private static CancellationToken CombineTokens(params CancellationToken?[] tokens)
+        var cancellationTokenParamPosition = method
+            .GetParameters()
+            .ToList()
+            .IndexOf(cancellationTokenParameters.Single());
+        
+        if (!Enabled)
         {
-            var nonNullTokens = tokens
-                .Where(token => token != null)
-                .Cast<CancellationToken>()
-                .ToArray();
-
-            if (nonNullTokens.Length == 0)
-            {
-                return new CancellationToken();
-            }
-
-            if (nonNullTokens.Length == 1)
-            {
-                return nonNullTokens[0];
-            }
-
-            return CancellationTokenSource
-                .CreateLinkedTokenSource(nonNullTokens)
-                .Token;
+            return target(args);
         }
+        
+        var trigger = triggers
+            .OfType<CancellationTokenTimeoutAttribute>()
+            .Single();
+
+        var timeoutToken = new CancellationTokenSource(trigger.TimeoutMillis).Token;
+        var passedInToken = args[cancellationTokenParamPosition] as CancellationToken?;
+        var newArgs = args.ToArray();
+        newArgs[cancellationTokenParamPosition] = CombineTokens(passedInToken, timeoutToken);
+        return target(newArgs);
+    }
+
+    private static CancellationToken CombineTokens(params CancellationToken?[] tokens)
+    {
+        var nonNullTokens = tokens
+            .Where(token => token != null)
+            .Cast<CancellationToken>()
+            .ToArray();
+
+        if (nonNullTokens.Length == 0)
+        {
+            return new CancellationToken();
+        }
+
+        if (nonNullTokens.Length == 1)
+        {
+            return nonNullTokens[0];
+        }
+
+        return CancellationTokenSource
+            .CreateLinkedTokenSource(nonNullTokens)
+            .Token;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cancellation/CancellationTokenTimeoutAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cancellation/CancellationTokenTimeoutAttribute.cs
@@ -3,67 +3,66 @@ using System;
 using AspectInjector.Broker;
 using Microsoft.Extensions.Configuration;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cancellation
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
+
+/// <summary>
+/// An attribute that, when used upon a method that accepts a
+/// <see cref="CancellationToken" /> as a parameter, provides a 
+/// CancellationToken with the given timeout in milliseconds
+/// to the method as its CancellationToken argument.
+///
+/// If a CancellationToken has been passed to the annotated method as
+/// an argument already by the calling code, this advice will
+/// create a new linked CancellationToken with the one originally
+/// passed in, thus allowing cancellation to be initiated by either
+/// the calling code or the timeout itself. 
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+[Injection(typeof(CancellationTokenTimeoutAspect))]
+public class CancellationTokenTimeoutAttribute : Attribute
 {
-    /// <summary>
-    /// An attribute that, when used upon a method that accepts a
-    /// <see cref="CancellationToken" /> as a parameter, provides a 
-    /// CancellationToken with the given timeout in milliseconds
-    /// to the method as its CancellationToken argument.
-    ///
-    /// If a CancellationToken has been passed to the annotated method as
-    /// an argument already by the calling code, this advice will
-    /// create a new linked CancellationToken with the one originally
-    /// passed in, thus allowing cancellation to be initiated by either
-    /// the calling code or the timeout itself. 
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
-    [Injection(typeof(CancellationTokenTimeoutAspect))]
-    public class CancellationTokenTimeoutAttribute : Attribute
+    private static IConfiguration? _timeoutConfiguration;
+
+    public int TimeoutMillis { get; }
+    
+    public CancellationTokenTimeoutAttribute(int timeoutMillis)
     {
-        private static IConfiguration? _timeoutConfiguration;
-
-        public int TimeoutMillis { get; }
-        
-        public CancellationTokenTimeoutAttribute(int timeoutMillis)
+        TimeoutMillis = timeoutMillis;
+    }
+    
+    public CancellationTokenTimeoutAttribute(string configurationKey)
+    {
+        if (!CancellationTokenTimeoutAspect.Enabled)
         {
-            TimeoutMillis = timeoutMillis;
+            return;
         }
         
-        public CancellationTokenTimeoutAttribute(string configurationKey)
+        if (_timeoutConfiguration == null)
         {
-            if (!CancellationTokenTimeoutAspect.Enabled)
-            {
-                return;
-            }
-            
-            if (_timeoutConfiguration == null)
-            {
-                throw new ArgumentException("Timeout configuration section cannot be null when using the " +
-                                            $"{nameof(CancellationTokenTimeoutAttribute)} alongside a timeout " +
-                                            $"configuration key");
-            }
-            
-            var timeoutConfig = _timeoutConfiguration.GetSection(configurationKey).Value;
-
-            if (timeoutConfig == null)
-            {
-                throw new ArgumentException($"Could not find timeout configuration setting for " +
-                                            $"key {configurationKey}");
-            }
-            
-            if (!int.TryParse(timeoutConfig, out var timeoutValue))
-            {
-                throw new ArgumentException($"Timeout configuration setting for " +
-                                            $"key {configurationKey} must be an integer");
-            }
-            
-            TimeoutMillis = timeoutValue;
+            throw new ArgumentException("Timeout configuration section cannot be null when using the " +
+                                        $"{nameof(CancellationTokenTimeoutAttribute)} alongside a timeout " +
+                                        $"configuration key");
         }
+        
+        var timeoutConfig = _timeoutConfiguration.GetSection(configurationKey).Value;
 
-        public static void SetTimeoutConfiguration(IConfiguration? timeoutConfiguration)
+        if (timeoutConfig == null)
         {
-            _timeoutConfiguration = timeoutConfiguration;
+            throw new ArgumentException($"Could not find timeout configuration setting for " +
+                                        $"key {configurationKey}");
         }
+        
+        if (!int.TryParse(timeoutConfig, out var timeoutValue))
+        {
+            throw new ArgumentException($"Timeout configuration setting for " +
+                                        $"key {configurationKey} must be an integer");
+        }
+        
+        TimeoutMillis = timeoutValue;
+    }
+
+    public static void SetTimeoutConfiguration(IConfiguration? timeoutConfiguration)
+    {
+        _timeoutConfiguration = timeoutConfiguration;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cancellation/OperationCancelledExceptionFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cancellation/OperationCancelledExceptionFilter.cs
@@ -3,23 +3,22 @@ using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using Microsoft.AspNetCore.Mvc.Filters;
 using static GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cancellation
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
+
+/// <summary>
+/// A filter that converts CancellationToken-initiated cancellations into a 400 API error response. 
+/// </summary>
+public class OperationCancelledExceptionFilter : ExceptionFilterAttribute
 {
-    /// <summary>
-    /// A filter that converts CancellationToken-initiated cancellations into a 400 API error response. 
-    /// </summary>
-    public class OperationCancelledExceptionFilter : ExceptionFilterAttribute
+    public override void OnException(ExceptionContext context)
     {
-        public override void OnException(ExceptionContext context)
+        if (context.Exception is OperationCanceledException)
         {
-            if (context.Exception is OperationCanceledException)
+            context.ExceptionHandled = true;
+            context.Result = ValidationResult(new ErrorViewModel
             {
-                context.ExceptionHandled = true;
-                context.Result = ValidationResult(new ErrorViewModel
-                {
-                    Code = "RequestCancelled"
-                });
-            }
+                Code = "RequestCancelled"
+            });
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cancellation/RequestTimeoutConfigurationKeys.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cancellation/RequestTimeoutConfigurationKeys.cs
@@ -1,7 +1,6 @@
-namespace GovUk.Education.ExploreEducationStatistics.Common.Cancellation
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
+
+public static class RequestTimeoutConfigurationKeys
 {
-    public static class RequestTimeoutConfigurationKeys
-    {
-        public const string TableBuilderQuery = "TableBuilderQuery";
-    }
+    public const string TableBuilderQuery = "TableBuilderQuery";
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Config/SensitiveDataTelemetryProcessor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Config/SensitiveDataTelemetryProcessor.cs
@@ -9,159 +9,158 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Config
+namespace GovUk.Education.ExploreEducationStatistics.Common.Config;
+
+/// <summary>
+/// Tries to filter out any potentially sensitive data from telemetry
+/// before it is sent to Application Insights e.g. query string parameters
+/// containing things like access tokens or codes.
+/// </summary>
+public class SensitiveDataTelemetryProcessor : ITelemetryProcessor
 {
-    /// <summary>
-    /// Tries to filter out any potentially sensitive data from telemetry
-    /// before it is sent to Application Insights e.g. query string parameters
-    /// containing things like access tokens or codes.
-    /// </summary>
-    public class SensitiveDataTelemetryProcessor : ITelemetryProcessor
+    private const string RedactedValue = "__redacted__";
+
+    private readonly HashSet<string> _redactedTokens = new()
     {
-        private const string RedactedValue = "__redacted__";
+        "code",
+        "email",
+        "phone",
+        "token",
+        "passphrase",
+        "password",
+        "pass",
+        "user",
+        "name",
+        "username",
+        "firstname",
+        "lastname",
+        "fullname"
+    };
 
-        private readonly HashSet<string> _redactedTokens = new()
+    private readonly char[] _tokenDelimiters =
+    {
+        '_', '-', ':', '.', '|', ' ', '[', ']', '+'
+    };
+
+    private readonly Regex _casingRegex = new("([A-Z][a-z]*|[0-9])", RegexOptions.Compiled);
+
+    private ITelemetryProcessor Next { get; }
+
+    public SensitiveDataTelemetryProcessor(ITelemetryProcessor next)
+    {
+        Next = next;
+    }
+
+    public void Process(ITelemetry item)
+    {
+        switch (item)
         {
-            "code",
-            "email",
-            "phone",
-            "token",
-            "passphrase",
-            "password",
-            "pass",
-            "user",
-            "name",
-            "username",
-            "firstname",
-            "lastname",
-            "fullname"
-        };
+            case RequestTelemetry telemetry:
+            {
+                telemetry.Url = FilterUrl(telemetry.Url);
+                break;
+            }
+            case PageViewTelemetry telemetry:
+            {
+                telemetry.Url = FilterUrl(telemetry.Url);
 
-        private readonly char[] _tokenDelimiters =
-        {
-            '_', '-', ':', '.', '|', ' ', '[', ']', '+'
-        };
+                if (telemetry.Properties.ContainsKey("refUri"))
+                {
+                    telemetry.Properties["refUri"] = FilterUriQuery(telemetry.Properties["refUri"]);
+                }
 
-        private readonly Regex _casingRegex = new("([A-Z][a-z]*|[0-9])", RegexOptions.Compiled);
-
-        private ITelemetryProcessor Next { get; }
-
-        public SensitiveDataTelemetryProcessor(ITelemetryProcessor next)
-        {
-            Next = next;
+                break;
+            }
+            case DependencyTelemetry telemetry:
+            {
+                HandleDependencyTelemetry(telemetry);
+                break;
+            }
         }
 
-        public void Process(ITelemetry item)
-        {
-            switch (item)
-            {
-                case RequestTelemetry telemetry:
-                {
-                    telemetry.Url = FilterUrl(telemetry.Url);
-                    break;
-                }
-                case PageViewTelemetry telemetry:
-                {
-                    telemetry.Url = FilterUrl(telemetry.Url);
+        Next.Process(item);
+    }
 
-                    if (telemetry.Properties.ContainsKey("refUri"))
+    private void HandleDependencyTelemetry(DependencyTelemetry telemetry)
+    {
+        if (telemetry.Type != "Http")
+        {
+            return;
+        }
+
+        telemetry.Name = FilterUriQuery(telemetry.Name);
+        telemetry.Data = FilterUriQuery(telemetry.Data);
+    }
+
+    private Uri? FilterUrl(Uri? uri)
+    {
+        if (uri is null)
+        {
+            return uri;
+        }
+
+        var filteredUri = FilterUriQuery(uri.AbsoluteUri);
+
+        return filteredUri is null ? uri : new Uri(filteredUri);
+    }
+
+    private string? FilterUriQuery(string? uri)
+    {
+        if (uri.IsNullOrEmpty())
+        {
+            return uri;
+        }
+
+        var pathAndQuery = uri.Split('?', 2);
+
+        if (pathAndQuery.Length < 2)
+        {
+            return uri;
+        }
+
+        var queryParts = pathAndQuery[1].Split('&');
+
+        var filteredQuery = queryParts.Select(
+                keyValue =>
+                {
+                    var parts = keyValue.Split('=', 2);
+
+                    if (parts.Length < 2)
                     {
-                        telemetry.Properties["refUri"] = FilterUriQuery(telemetry.Properties["refUri"]);
+                        return keyValue;
                     }
 
-                    break;
+                    var key = parts[0];
+
+                    return IsRedactedKey(key) ? $"{key}={RedactedValue}" : keyValue;
                 }
-                case DependencyTelemetry telemetry:
+            )
+            .JoinToString('&');
+
+        return $"{pathAndQuery[0]}?{filteredQuery}";
+    }
+
+    private bool IsRedactedKey(string key)
+    {
+        return HttpUtility.UrlDecode(key)
+            .Split(_tokenDelimiters, StringSplitOptions.RemoveEmptyEntries)
+            .Any(
+                token =>
                 {
-                    HandleDependencyTelemetry(telemetry);
-                    break;
+                    if (_redactedTokens.Contains(token.ToLower()))
+                    {
+                        return true;
+                    }
+
+                    // The token may be camel/pascal cased, meaning we should split
+                    // it up to check if any of the words is a matching token.
+                    // Note - we can't just check if any of the redacted tokens are inside of
+                    // the current token as redacted tokens may constitute actual words
+                    // e.g. `code` is in `encode` (which shouldn't be redacted).
+                    var words = _casingRegex.Split(token);
+
+                    return words.Any(word => _redactedTokens.Contains(word.ToLower()));
                 }
-            }
-
-            Next.Process(item);
-        }
-
-        private void HandleDependencyTelemetry(DependencyTelemetry telemetry)
-        {
-            if (telemetry.Type != "Http")
-            {
-                return;
-            }
-
-            telemetry.Name = FilterUriQuery(telemetry.Name);
-            telemetry.Data = FilterUriQuery(telemetry.Data);
-        }
-
-        private Uri? FilterUrl(Uri? uri)
-        {
-            if (uri is null)
-            {
-                return uri;
-            }
-
-            var filteredUri = FilterUriQuery(uri.AbsoluteUri);
-
-            return filteredUri is null ? uri : new Uri(filteredUri);
-        }
-
-        private string? FilterUriQuery(string? uri)
-        {
-            if (uri.IsNullOrEmpty())
-            {
-                return uri;
-            }
-
-            var pathAndQuery = uri.Split('?', 2);
-
-            if (pathAndQuery.Length < 2)
-            {
-                return uri;
-            }
-
-            var queryParts = pathAndQuery[1].Split('&');
-
-            var filteredQuery = queryParts.Select(
-                    keyValue =>
-                    {
-                        var parts = keyValue.Split('=', 2);
-
-                        if (parts.Length < 2)
-                        {
-                            return keyValue;
-                        }
-
-                        var key = parts[0];
-
-                        return IsRedactedKey(key) ? $"{key}={RedactedValue}" : keyValue;
-                    }
-                )
-                .JoinToString('&');
-
-            return $"{pathAndQuery[0]}?{filteredQuery}";
-        }
-
-        private bool IsRedactedKey(string key)
-        {
-            return HttpUtility.UrlDecode(key)
-                .Split(_tokenDelimiters, StringSplitOptions.RemoveEmptyEntries)
-                .Any(
-                    token =>
-                    {
-                        if (_redactedTokens.Contains(token.ToLower()))
-                        {
-                            return true;
-                        }
-
-                        // The token may be camel/pascal cased, meaning we should split
-                        // it up to check if any of the words is a matching token.
-                        // Note - we can't just check if any of the redacted tokens are inside of
-                        // the current token as redacted tokens may constitute actual words
-                        // e.g. `code` is in `encode` (which shouldn't be redacted).
-                        var words = _casingRegex.Split(token);
-
-                        return words.Any(word => _redactedTokens.Contains(word.ToLower()));
-                    }
-                );
-        }
+            );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/ContentBlockChartConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/ContentBlockChartConverter.cs
@@ -4,36 +4,35 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Converters
+namespace GovUk.Education.ExploreEducationStatistics.Common.Converters;
+
+public class ContentBlockChartConverter : JsonConverter<IChart>
 {
-    public class ContentBlockChartConverter : JsonConverter<IChart>
+    public override bool CanWrite => false;
+
+    public override IChart ReadJson(JsonReader reader, Type objectType,
+        IChart existingValue, bool hasExistingValue, JsonSerializer serializer)
     {
-        public override bool CanWrite => false;
+        var jsonObject = JObject.Load(reader);
+        var type = jsonObject["Type"] ?? jsonObject["type"];
+        var chartType = EnumUtil.GetFromEnumValue<ChartType>(type.Value<string>());
 
-        public override IChart ReadJson(JsonReader reader, Type objectType,
-            IChart existingValue, bool hasExistingValue, JsonSerializer serializer)
+        IChart contentBlock = chartType switch
         {
-            var jsonObject = JObject.Load(reader);
-            var type = jsonObject["Type"] ?? jsonObject["type"];
-            var chartType = EnumUtil.GetFromEnumValue<ChartType>(type.Value<string>());
+            ChartType.Line => new LineChart(),
+            ChartType.HorizontalBar => new HorizontalBarChart(),
+            ChartType.VerticalBar => new VerticalBarChart(),
+            ChartType.Map => new MapChart(),
+            ChartType.Infographic => new InfographicChart(),
+            _ => throw new ArgumentOutOfRangeException()
+        };
 
-            IChart contentBlock = chartType switch
-            {
-                ChartType.Line => new LineChart(),
-                ChartType.HorizontalBar => new HorizontalBarChart(),
-                ChartType.VerticalBar => new VerticalBarChart(),
-                ChartType.Map => new MapChart(),
-                ChartType.Infographic => new InfographicChart(),
-                _ => throw new ArgumentOutOfRangeException()
-            };
+        serializer.Populate(jsonObject.CreateReader(), contentBlock);
+        return contentBlock;
+    }
 
-            serializer.Populate(jsonObject.CreateReader(), contentBlock);
-            return contentBlock;
-        }
-
-        public override void WriteJson(JsonWriter writer, IChart value, JsonSerializer serializer)
-        {
-            throw new InvalidOperationException("Use default serialization.");
-        }
+    public override void WriteJson(JsonWriter writer, IChart value, JsonSerializer serializer)
+    {
+        throw new InvalidOperationException("Use default serialization.");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/DateTimeToDateJsonConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/DateTimeToDateJsonConverter.cs
@@ -1,15 +1,14 @@
 ﻿using Newtonsoft.Json.Converters;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Converters
+namespace GovUk.Education.ExploreEducationStatistics.Common.Converters;
+
+/**
+ * Converts a <see cref="DateTime"/> to and from the format yyyy-MM-dd (e.g. <c>"2008-04-12"</c>).
+ */
+public class DateTimeToDateJsonConverter : IsoDateTimeConverter
 {
-    /**
-     * Converts a <see cref="DateTime"/> to and from the format yyyy-MM-dd (e.g. <c>"2008-04-12"</c>).
-     */
-    public class DateTimeToDateJsonConverter : IsoDateTimeConverter
+    public DateTimeToDateJsonConverter()
     {
-        public DateTimeToDateJsonConverter()
-        {
-            DateTimeFormat = "yyyy-MM-dd";
-        }
+        DateTimeFormat = "yyyy-MM-dd";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/EnumToEnumValueJsonConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/EnumToEnumValueJsonConverter.cs
@@ -3,22 +3,21 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Newtonsoft.Json;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Converters
-{
-    public class EnumToEnumValueJsonConverter<TEnum> : JsonConverter<TEnum> where TEnum : Enum
-    {
-        public override void WriteJson(JsonWriter writer, TEnum value, JsonSerializer serializer)
-        {
-            if (value != null)
-            {
-                writer.WriteValue(value.GetEnumValue());
-            }
-        }
+namespace GovUk.Education.ExploreEducationStatistics.Common.Converters;
 
-        public override TEnum ReadJson(JsonReader reader, Type objectType, TEnum existingValue, bool hasExistingValue,
-            JsonSerializer serializer)
+public class EnumToEnumValueJsonConverter<TEnum> : JsonConverter<TEnum> where TEnum : Enum
+{
+    public override void WriteJson(JsonWriter writer, TEnum value, JsonSerializer serializer)
+    {
+        if (value != null)
         {
-            return EnumUtil.GetFromEnumValue<TEnum>(reader.Value.ToString());
+            writer.WriteValue(value.GetEnumValue());
         }
+    }
+
+    public override TEnum ReadJson(JsonReader reader, Type objectType, TEnum existingValue, bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        return EnumUtil.GetFromEnumValue<TEnum>(reader.Value.ToString());
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/TimeIdentifierCategoryJsonConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/TimeIdentifierCategoryJsonConverter.cs
@@ -5,30 +5,29 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Converters
-{
-    public class TimeIdentifierCategoryJsonConverter : JsonConverter<TimeIdentifierCategory?>
-    {
-        public override void WriteJson(JsonWriter writer, TimeIdentifierCategory? value, JsonSerializer serializer)
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("value");
-            writer.WriteValue(value.GetEnumValue());
-            writer.WritePropertyName("label");
-            writer.WriteValue(value.GetEnumLabel());
-            writer.WriteEndObject();
-        }
+namespace GovUk.Education.ExploreEducationStatistics.Common.Converters;
 
-        public override TimeIdentifierCategory? ReadJson(JsonReader reader, Type objectType,
-            TimeIdentifierCategory? existingValue,
-            bool hasExistingValue,
-            JsonSerializer serializer)
-        {
-            if (reader.TokenType == JsonToken.Null) return null;
-            
-            var jsonValue = JObject.Load(reader).GetValue("value").Value<string>();
-            var categories = ((TimeIdentifierCategory[]) Enum.GetValues(typeof(TimeIdentifierCategory)));
-            return categories.First(category => category.GetEnumValue() == jsonValue);
-        }
+public class TimeIdentifierCategoryJsonConverter : JsonConverter<TimeIdentifierCategory?>
+{
+    public override void WriteJson(JsonWriter writer, TimeIdentifierCategory? value, JsonSerializer serializer)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("value");
+        writer.WriteValue(value.GetEnumValue());
+        writer.WritePropertyName("label");
+        writer.WriteValue(value.GetEnumLabel());
+        writer.WriteEndObject();
+    }
+
+    public override TimeIdentifierCategory? ReadJson(JsonReader reader, Type objectType,
+        TimeIdentifierCategory? existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        if (reader.TokenType == JsonToken.Null) return null;
+        
+        var jsonValue = JObject.Load(reader).GetValue("value").Value<string>();
+        var categories = ((TimeIdentifierCategory[]) Enum.GetValues(typeof(TimeIdentifierCategory)));
+        return categories.First(category => category.GetEnumValue() == jsonValue);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/TimeIdentifierJsonConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/TimeIdentifierJsonConverter.cs
@@ -5,29 +5,28 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Converters
+namespace GovUk.Education.ExploreEducationStatistics.Common.Converters;
+
+public class TimeIdentifierJsonConverter : JsonConverter<TimeIdentifier?>
 {
-    public class TimeIdentifierJsonConverter : JsonConverter<TimeIdentifier?>
+    public override void WriteJson(JsonWriter writer, TimeIdentifier? value, JsonSerializer serializer)
     {
-        public override void WriteJson(JsonWriter writer, TimeIdentifier? value, JsonSerializer serializer)
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("value");
-            writer.WriteValue(value.GetEnumValue());
-            writer.WritePropertyName("label");
-            writer.WriteValue(value.GetEnumLabel());
-            writer.WriteEndObject();
-        }
+        writer.WriteStartObject();
+        writer.WritePropertyName("value");
+        writer.WriteValue(value.GetEnumValue());
+        writer.WritePropertyName("label");
+        writer.WriteValue(value.GetEnumLabel());
+        writer.WriteEndObject();
+    }
 
-        public override TimeIdentifier? ReadJson(JsonReader reader, Type objectType, TimeIdentifier? existingValue,
-            bool hasExistingValue,
-            JsonSerializer serializer)
-        {
-            if (reader.TokenType == JsonToken.Null) return null;
+    public override TimeIdentifier? ReadJson(JsonReader reader, Type objectType, TimeIdentifier? existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        if (reader.TokenType == JsonToken.Null) return null;
 
-            var jsonValue = JObject.Load(reader).GetValue("value").Value<string>();
-            var timeIdentifiers = ((TimeIdentifier[]) Enum.GetValues(typeof(TimeIdentifier)));
-            return timeIdentifiers.First(identifier => identifier.GetEnumValue() == jsonValue);
-        }
+        var jsonValue = JObject.Load(reader).GetValue("value").Value<string>();
+        var timeIdentifiers = ((TimeIdentifier[]) Enum.GetValues(typeof(TimeIdentifier)));
+        return timeIdentifiers.First(identifier => identifier.GetEnumValue() == jsonValue);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Database/EnumLabelValueAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Database/EnumLabelValueAttribute.cs
@@ -1,22 +1,21 @@
 using System;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Database
-{   
-    [AttributeUsage(AttributeTargets.Field)]
-    public class EnumLabelValueAttribute : Attribute
-    {
-        public string Label { get; }
-        public string Value { get; }
+namespace GovUk.Education.ExploreEducationStatistics.Common.Database;
 
-        public EnumLabelValueAttribute(string label, string value)
-        {
-            Label = label;
-            Value = value;
-        }
-        
-        public EnumLabelValueAttribute(string label)
-        {
-            Label = label;
-        }
+[AttributeUsage(AttributeTargets.Field)]
+public class EnumLabelValueAttribute : Attribute
+{
+    public string Label { get; }
+    public string Value { get; }
+
+    public EnumLabelValueAttribute(string label, string value)
+    {
+        Label = label;
+        Value = value;
+    }
+    
+    public EnumLabelValueAttribute(string label)
+    {
+        Label = label;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Database/TimeIdentifierMetaAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Database/TimeIdentifierMetaAttribute.cs
@@ -1,28 +1,27 @@
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Database
+namespace GovUk.Education.ExploreEducationStatistics.Common.Database;
+
+[AttributeUsage(AttributeTargets.Field)]
+public class TimeIdentifierMetaAttribute : EnumLabelValueAttribute
 {
-    [AttributeUsage(AttributeTargets.Field)]
-    public class TimeIdentifierMetaAttribute : EnumLabelValueAttribute
+    public TimePeriodYearFormat YearFormat { get; }
+    public TimePeriodLabelFormat LabelFormat { get; }
+    public string ShortLabel { get; }
+
+    public TimeIdentifierCategory Category { get; }
+
+    public TimeIdentifierMetaAttribute(string label,
+        string value,
+        TimeIdentifierCategory category,
+        TimePeriodYearFormat yearFormat = TimePeriodYearFormat.Default,
+        TimePeriodLabelFormat labelFormat = TimePeriodLabelFormat.FullLabel,
+        string shortLabel = null) : base(label, value)
     {
-        public TimePeriodYearFormat YearFormat { get; }
-        public TimePeriodLabelFormat LabelFormat { get; }
-        public string ShortLabel { get; }
-
-        public TimeIdentifierCategory Category { get; }
-
-        public TimeIdentifierMetaAttribute(string label,
-            string value,
-            TimeIdentifierCategory category,
-            TimePeriodYearFormat yearFormat = TimePeriodYearFormat.Default,
-            TimePeriodLabelFormat labelFormat = TimePeriodLabelFormat.FullLabel,
-            string shortLabel = null) : base(label, value)
-        {
-            YearFormat = yearFormat;
-            LabelFormat = labelFormat;
-            ShortLabel = shortLabel;
-            Category = category;
-        }
+        YearFormat = yearFormat;
+        LabelFormat = labelFormat;
+        ShortLabel = shortLabel;
+        Category = category;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Database/TimePeriodLabelFormat.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Database/TimePeriodLabelFormat.cs
@@ -1,13 +1,12 @@
-namespace GovUk.Education.ExploreEducationStatistics.Common.Database
+namespace GovUk.Education.ExploreEducationStatistics.Common.Database;
+
+/// <summary>
+/// Formats that can be used to label a <c>TimeIdentifier</c>
+/// </summary>
+public enum TimePeriodLabelFormat
 {
-    /// <summary>
-    /// Formats that can be used to label a <c>TimeIdentifier</c>
-    /// </summary>
-    public enum TimePeriodLabelFormat
-    {
-        FullLabel,
-        FullLabelBeforeYear,
-        NoLabel,
-        ShortLabel
-    }
+    FullLabel,
+    FullLabelBeforeYear,
+    NoLabel,
+    ShortLabel
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Database/TimePeriodYearFormat.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Database/TimePeriodYearFormat.cs
@@ -1,20 +1,19 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Common.Database
-{
-    public enum TimePeriodYearFormat
-    {
-        /**
-         * Formats the year without alteration e.g. 2018
-         */
-        Default,
+﻿namespace GovUk.Education.ExploreEducationStatistics.Common.Database;
 
-        /**
-         * Formats the year as an academic year e.g. 2018 becomes 2018/19
-         */
-        Academic,
-        
-        /**
-         * Formats the year as a fiscal year e.g. 2018 becomes 2018-19
-         */
-        Fiscal
-    }
+public enum TimePeriodYearFormat
+{
+    /**
+     * Formats the year without alteration e.g. 2018
+     */
+    Default,
+
+    /**
+     * Formats the year as an academic year e.g. 2018 becomes 2018/19
+     */
+    Academic,
+    
+    /**
+     * Formats the year as a fiscal year e.g. 2018 becomes 2018-19
+     */
+    Fiscal
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ControllerExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ControllerExtensions.cs
@@ -6,68 +6,67 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class ControllerExtensions
 {
-    public static class ControllerExtensions
+    public static async Task<Either<ActionResult, Unit>> CacheWithLastModified(
+        this ControllerBase controller,
+        DateTimeOffset? lastModified)
     {
-        public static async Task<Either<ActionResult, Unit>> CacheWithLastModified(
-            this ControllerBase controller,
-            DateTimeOffset? lastModified)
+        controller.Response.GetTypedHeaders().LastModified = lastModified;
+
+        var requestHeaders = controller.Request.GetTypedHeaders();
+
+        if (lastModified.HasValue
+            && requestHeaders.IfModifiedSince.HasValue
+            && requestHeaders.IfModifiedSince.Value >= lastModified)
         {
-            controller.Response.GetTypedHeaders().LastModified = lastModified;
-
-            var requestHeaders = controller.Request.GetTypedHeaders();
-
-            if (lastModified.HasValue
-                && requestHeaders.IfModifiedSince.HasValue
-                && requestHeaders.IfModifiedSince.Value >= lastModified)
-            {
-                return controller.StatusCode(StatusCodes.Status304NotModified);
-            }
-
-            return await Task.FromResult(Unit.Instance);
+            return controller.StatusCode(StatusCodes.Status304NotModified);
         }
 
-        public static async Task<Either<ActionResult, Unit>> CacheWithETag(
-            this ControllerBase controller,
-            string content,
-            bool isWeak = true)
+        return await Task.FromResult(Unit.Instance);
+    }
+
+    public static async Task<Either<ActionResult, Unit>> CacheWithETag(
+        this ControllerBase controller,
+        string content,
+        bool isWeak = true)
+    {
+        var eTag = new EntityTagHeaderValue($"\"{content}\"", isWeak);
+
+        controller.Response.GetTypedHeaders().ETag = eTag;
+
+        var requestHeaders = controller.Request.GetTypedHeaders();
+
+        if (requestHeaders.IfNoneMatch.Contains(eTag))
         {
-            var eTag = new EntityTagHeaderValue($"\"{content}\"", isWeak);
-
-            controller.Response.GetTypedHeaders().ETag = eTag;
-
-            var requestHeaders = controller.Request.GetTypedHeaders();
-
-            if (requestHeaders.IfNoneMatch.Contains(eTag))
-            {
-                return controller.StatusCode(StatusCodes.Status304NotModified);
-            }
-
-            return await Task.FromResult(Unit.Instance);
+            return controller.StatusCode(StatusCodes.Status304NotModified);
         }
 
-        public static async Task<Either<ActionResult, Unit>> CacheWithLastModifiedAndETag(
-            this ControllerBase controller,
-            DateTimeOffset? lastModified,
-            string eTagContent,
-            bool isWeak = true)
+        return await Task.FromResult(Unit.Instance);
+    }
+
+    public static async Task<Either<ActionResult, Unit>> CacheWithLastModifiedAndETag(
+        this ControllerBase controller,
+        DateTimeOffset? lastModified,
+        string eTagContent,
+        bool isWeak = true)
+    {
+        var eTag = new EntityTagHeaderValue($"\"{eTagContent}\"", isWeak);
+
+        controller.Response.GetTypedHeaders().ETag = eTag;
+
+        var requestHeaders = controller.Request.GetTypedHeaders();
+
+        if (lastModified.HasValue
+            && requestHeaders.IfModifiedSince.HasValue
+            && requestHeaders.IfModifiedSince.Value >= lastModified
+            && requestHeaders.IfNoneMatch.Contains(eTag))
         {
-            var eTag = new EntityTagHeaderValue($"\"{eTagContent}\"", isWeak);
-
-            controller.Response.GetTypedHeaders().ETag = eTag;
-
-            var requestHeaders = controller.Request.GetTypedHeaders();
-
-            if (lastModified.HasValue
-                && requestHeaders.IfModifiedSince.HasValue
-                && requestHeaders.IfModifiedSince.Value >= lastModified
-                && requestHeaders.IfNoneMatch.Contains(eTag))
-            {
-                return controller.StatusCode(StatusCodes.Status304NotModified);
-            }
-
-            return await Task.FromResult(Unit.Instance);
+            return controller.StatusCode(StatusCodes.Status304NotModified);
         }
+
+        return await Task.FromResult(Unit.Instance);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeExtensions.cs
@@ -2,43 +2,42 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class DateTimeExtensions
 {
-    public static class DateTimeExtensions
+    /**
+     * The resulting UTC DateTime will correspond to the start of the day
+     * in the specified time zone (defaults to UK).
+     *
+     * For example, 2020-06-06T16:00:00 converts to:
+     * - 2020-06-05T23:00:00 (when BST)
+     * - 2020-06-06T00:00:00 (when GMT)
+     */
+    public static DateTime AsStartOfDayUtcForTimeZone(this DateTime dateTime, TimeZoneInfo? timezone = null)
     {
-        /**
-         * The resulting UTC DateTime will correspond to the start of the day
-         * in the specified time zone (defaults to UK).
-         *
-         * For example, 2020-06-06T16:00:00 converts to:
-         * - 2020-06-05T23:00:00 (when BST)
-         * - 2020-06-06T00:00:00 (when GMT)
-         */
-        public static DateTime AsStartOfDayUtcForTimeZone(this DateTime dateTime, TimeZoneInfo? timezone = null)
-        {
-            var dateTimeStartOfDay = new DateTime(dateTime.Year, dateTime.Month, dateTime.Day, 0, 0, 0, DateTimeKind.Unspecified);
-            return TimeZoneInfo.ConvertTimeToUtc(dateTimeStartOfDay, timezone ?? GetUkTimeZone());
-        }
+        var dateTimeStartOfDay = new DateTime(dateTime.Year, dateTime.Month, dateTime.Day, 0, 0, 0, DateTimeKind.Unspecified);
+        return TimeZoneInfo.ConvertTimeToUtc(dateTimeStartOfDay, timezone ?? GetUkTimeZone());
+    }
 
-        public static DateTime ConvertUtcToUkTimeZone(this DateTime dateTime)
-        {
-            return TimeZoneInfo.ConvertTimeFromUtc(dateTime, GetUkTimeZone());
-        }
+    public static DateTime ConvertUtcToUkTimeZone(this DateTime dateTime)
+    {
+        return TimeZoneInfo.ConvertTimeFromUtc(dateTime, GetUkTimeZone());
+    }
 
-        public static TimeZoneInfo GetUkTimeZone()
-        {
-            return TimeZoneInfo.FindSystemTimeZoneById(
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "GMT Standard Time" : "Europe/London");
-        }
+    public static TimeZoneInfo GetUkTimeZone()
+    {
+        return TimeZoneInfo.FindSystemTimeZoneById(
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "GMT Standard Time" : "Europe/London");
+    }
 
-        public static bool IsBefore(this DateTime subject, DateTime target)
-        {
-            return subject.CompareTo(target) < 0;
-        }
+    public static bool IsBefore(this DateTime subject, DateTime target)
+    {
+        return subject.CompareTo(target) < 0;
+    }
 
-        public static bool IsAfterInclusive(this DateTime subject, DateTime target)
-        {
-            return subject.CompareTo(target) >= 0;
-        }
+    public static bool IsAfterInclusive(this DateTime subject, DateTime target)
+    {
+        return subject.CompareTo(target) >= 0;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DbContextExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DbContextExtensions.cs
@@ -5,102 +5,101 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Thinktecture.Internal;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class DbContextExtensions
 {
-    public static class DbContextExtensions
+    /// <summary>
+    /// Ensure that an entity is not detached from the database context, reloading it if necessary before returning.
+    /// Throws an exception if the entity cannot be reloaded.
+    /// </summary>
+    public static T AssertEntityLoaded<T>(this DbContext context, T entity) where T : class
     {
-        /// <summary>
-        /// Ensure that an entity is not detached from the database context, reloading it if necessary before returning.
-        /// Throws an exception if the entity cannot be reloaded.
-        /// </summary>
-        public static T AssertEntityLoaded<T>(this DbContext context, T entity) where T : class
+        var reloaded = context.ReloadEntity(entity);
+
+        if (reloaded is null)
         {
-            var reloaded = context.ReloadEntity(entity);
-
-            if (reloaded is null)
-            {
-                var displayString = context.GetDisplayString(entity);
-                throw new InvalidOperationException($"Unable to reload {displayString}");
-            }
-
-            return reloaded;
+            var displayString = context.GetDisplayString(entity);
+            throw new InvalidOperationException($"Unable to reload {displayString}");
         }
 
-        /// <summary>
-        /// Reload an entity into the context if it has been detached.
-        /// </summary>
-        /// <remarks>
-        /// If it has been deleted, or cannot be reloaded, we return null as the
-        /// entity would be unsafe to work with.
-        /// <para>
-        /// This is most useful in code where we receive an entity from some other
-        /// service (e.g. in authorization handlers). As we cannot be sure about the
-        /// tracking state of the entity, it is recommended to call this method to
-        /// ensure that it is not stale and has not been deleted.
-        /// </para>
-        /// </remarks>
-        public static T? ReloadEntity<T>(this DbContext context, T entity) where T : class
+        return reloaded;
+    }
+
+    /// <summary>
+    /// Reload an entity into the context if it has been detached.
+    /// </summary>
+    /// <remarks>
+    /// If it has been deleted, or cannot be reloaded, we return null as the
+    /// entity would be unsafe to work with.
+    /// <para>
+    /// This is most useful in code where we receive an entity from some other
+    /// service (e.g. in authorization handlers). As we cannot be sure about the
+    /// tracking state of the entity, it is recommended to call this method to
+    /// ensure that it is not stale and has not been deleted.
+    /// </para>
+    /// </remarks>
+    public static T? ReloadEntity<T>(this DbContext context, T entity) where T : class
+    {
+        var entry = context.Entry(entity);
+
+        // The entity has been detached from the context
+        // and may be stale, so we need to reload it for
+        // the most up-to-date version.
+        if (entry.State == EntityState.Detached)
         {
-            var entry = context.Entry(entity);
-
-            // The entity has been detached from the context
-            // and may be stale, so we need to reload it for
-            // the most up-to-date version.
-            if (entry.State == EntityState.Detached)
-            {
-                entry.Reload();
-            }
-
-            if (entry.State == EntityState.Deleted)
-            {
-                return null;
-            }
-
-            // If entry is still detached, we can only assume
-            // it does not exist in the database anymore and
-            // is now unsafe to work with (it should be null).
-            if (entry.State == EntityState.Detached)
-            {
-                return null;
-            }
-
-            return entity;
+            entry.Reload();
         }
 
-        /// <summary>
-        /// Try to reload an entity, returning false if it cannot be reloaded.
-        /// </summary>
-        public static bool TryReloadEntity<T>(this DbContext context, T entity, out T reloadedEntity)
-            where T : class
+        if (entry.State == EntityState.Deleted)
         {
-            reloadedEntity = entity;
-
-            var reloaded = context.ReloadEntity(entity);
-
-            if (reloaded is null)
-            {
-                return false;
-            }
-
-            reloadedEntity = reloaded;
-            return true;
+            return null;
         }
 
-        public static DbSet<TEntity> TempTableSet<TEntity>(this DbContext dbContext) where TEntity : class
+        // If entry is still detached, we can only assume
+        // it does not exist in the database anymore and
+        // is now unsafe to work with (it should be null).
+        if (entry.State == EntityState.Detached)
         {
-            return dbContext.Set<TEntity>(EntityNameProvider.GetTempTableName(typeof(TEntity)));
-        } 
-
-        private static string GetDisplayString(this DbContext context, object entity)
-        {
-            var entry = context.Entry(entity);
-            var primaryKey = entry.Metadata.FindPrimaryKey();
-            var typeName = entity.GetType().ShortDisplayName();
-            var primaryKeyValues = primaryKey.Properties
-                .Select(property => $"{property.Name}: '{property.PropertyInfo.GetValue(entity)}'")
-                .JoinToString(", ");
-
-            return $"{typeName} {{{primaryKeyValues}}}";
+            return null;
         }
+
+        return entity;
+    }
+
+    /// <summary>
+    /// Try to reload an entity, returning false if it cannot be reloaded.
+    /// </summary>
+    public static bool TryReloadEntity<T>(this DbContext context, T entity, out T reloadedEntity)
+        where T : class
+    {
+        reloadedEntity = entity;
+
+        var reloaded = context.ReloadEntity(entity);
+
+        if (reloaded is null)
+        {
+            return false;
+        }
+
+        reloadedEntity = reloaded;
+        return true;
+    }
+
+    public static DbSet<TEntity> TempTableSet<TEntity>(this DbContext dbContext) where TEntity : class
+    {
+        return dbContext.Set<TEntity>(EntityNameProvider.GetTempTableName(typeof(TEntity)));
+    } 
+
+    private static string GetDisplayString(this DbContext context, object entity)
+    {
+        var entry = context.Entry(entity);
+        var primaryKey = entry.Metadata.FindPrimaryKey();
+        var typeName = entity.GetType().ShortDisplayName();
+        var primaryKeyValues = primaryKey.Properties
+            .Select(property => $"{property.Name}: '{property.PropertyInfo.GetValue(entity)}'")
+            .JoinToString(", ");
+
+        return $"{typeName} {{{primaryKeyValues}}}";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DictionaryExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DictionaryExtensions.cs
@@ -2,39 +2,38 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class DictionaryExtensions
 {
-    public static class DictionaryExtensions
+    public static Dictionary<TKey, TValue> Filter<TKey, TValue>(
+        this Dictionary<TKey, TValue> dictionary,
+        Predicate<KeyValuePair<TKey, TValue>> predicate)
     {
-        public static Dictionary<TKey, TValue> Filter<TKey, TValue>(
-            this Dictionary<TKey, TValue> dictionary,
-            Predicate<KeyValuePair<TKey, TValue>> predicate)
-        {
-            return dictionary
-                .Where(pair => predicate(pair))
-                .ToDictionary(pair => pair.Key, pair => pair.Value);
-        }
+        return dictionary
+            .Where(pair => predicate(pair))
+            .ToDictionary(pair => pair.Key, pair => pair.Value);
+    }
 
-        public static TValue GetOrSet<TKey, TValue>(
-            this Dictionary<TKey, TValue> dictionary,
-            TKey key,
-            TValue value)
-        {
-            return dictionary.GetOrSet(key, () => value);
-        }
+    public static TValue GetOrSet<TKey, TValue>(
+        this Dictionary<TKey, TValue> dictionary,
+        TKey key,
+        TValue value)
+    {
+        return dictionary.GetOrSet(key, () => value);
+    }
 
-        public static TValue GetOrSet<TKey, TValue>(
-            this Dictionary<TKey, TValue> dictionary,
-            TKey key,
-            Func<TValue> supplier)
+    public static TValue GetOrSet<TKey, TValue>(
+        this Dictionary<TKey, TValue> dictionary,
+        TKey key,
+        Func<TValue> supplier)
+    {
+        if (dictionary.ContainsKey(key))
         {
-            if (dictionary.ContainsKey(key))
-            {
-                return dictionary[key];
-            }
-
-            dictionary[key] = supplier();
             return dictionary[key];
         }
+
+        dictionary[key] = supplier();
+        return dictionary[key];
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EitherTaskExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EitherTaskExtensions.cs
@@ -4,97 +4,96 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class EitherTaskExtensions
 {
-    public static class EitherTaskExtensions
+    public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this TRight? result)
+        where TRight : struct
     {
-        public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this TRight? result)
-            where TRight : struct
+        return await OrNotFound(Task.FromResult(result));
+    }
+
+    public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this Task<TRight?> task)
+        where TRight : struct
+    {
+        var result = await task;
+
+        return result is not null ? result : new NotFoundResult();
+    }
+
+    public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this TRight? result)
+        where TRight : class?
+    {
+        return await OrNotFound(Task.FromResult(result));
+    }
+
+    public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this Task<TRight?> task)
+        where TRight : class?
+    {
+        var result = await task;
+
+        return result is not null ? result : new NotFoundResult();
+    }
+
+    public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this Task<Either<ActionResult, TRight?>> task)
+        where TRight : class?
+    {
+        var prev = await task;
+
+        return prev.OnSuccess(result => 
+            result ?? new Either<ActionResult, TRight>(new NotFoundResult()));
+    }
+
+    public static async Task<ActionResult> HandleFailures<TRight>(
+        this Task<Either<ActionResult, TRight>> task) where TRight : ActionResult
+    {
+        var result = await task;
+
+        return result.IsRight ? result.Right : result.Left;
+    }
+
+    public static async Task<ActionResult> HandleFailuresOr<T>(
+        this Task<Either<ActionResult, T>> task,
+        Func<T, ActionResult> successFn)
+    {
+        var result = await task;
+
+        return result.IsRight ? successFn.Invoke(result.Right) : result.Left;
+    }
+
+    public static async Task<ActionResult<T>> HandleFailuresOrOk<T>(
+        this Task<Either<ActionResult, T>> task)
+    {
+        var result = await task;
+
+        return result.IsRight ? new ActionResult<T>(result.Right) : result.Left;
+    }
+
+    public static async Task<ActionResult> HandleFailuresOrNoContent<T>(
+        this Task<Either<ActionResult, T>> validationErrorsRaisingAction,
+        bool convertNotFoundToNoContent = true)
+    {
+        var result = await validationErrorsRaisingAction;
+
+        if (result.IsRight)
         {
-            return await OrNotFound(Task.FromResult(result));
+            return new NoContentResult();
         }
 
-        public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this Task<TRight?> task)
-            where TRight : struct
+        if (convertNotFoundToNoContent && result.Left is NotFoundResult)
         {
-            var result = await task;
-
-            return result is not null ? result : new NotFoundResult();
+            return new NoContentResult();
         }
 
-        public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this TRight? result)
-            where TRight : class?
-        {
-            return await OrNotFound(Task.FromResult(result));
-        }
+        return result.Left;
+    }
 
-        public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this Task<TRight?> task)
-            where TRight : class?
-        {
-            var result = await task;
+    public static async Task<HubResult<T>> HandleFailuresOrHubResult<T>(
+        this Task<Either<ActionResult, T>> task) where T : class
+    {
+        var result = await task;
 
-            return result is not null ? result : new NotFoundResult();
-        }
-
-        public static async Task<Either<ActionResult, TRight>> OrNotFound<TRight>(this Task<Either<ActionResult, TRight?>> task)
-            where TRight : class?
-        {
-            var prev = await task;
-
-            return prev.OnSuccess(result => 
-                result ?? new Either<ActionResult, TRight>(new NotFoundResult()));
-        }
-
-        public static async Task<ActionResult> HandleFailures<TRight>(
-            this Task<Either<ActionResult, TRight>> task) where TRight : ActionResult
-        {
-            var result = await task;
-
-            return result.IsRight ? result.Right : result.Left;
-        }
-
-        public static async Task<ActionResult> HandleFailuresOr<T>(
-            this Task<Either<ActionResult, T>> task,
-            Func<T, ActionResult> successFn)
-        {
-            var result = await task;
-
-            return result.IsRight ? successFn.Invoke(result.Right) : result.Left;
-        }
-
-        public static async Task<ActionResult<T>> HandleFailuresOrOk<T>(
-            this Task<Either<ActionResult, T>> task)
-        {
-            var result = await task;
-
-            return result.IsRight ? new ActionResult<T>(result.Right) : result.Left;
-        }
-
-        public static async Task<ActionResult> HandleFailuresOrNoContent<T>(
-            this Task<Either<ActionResult, T>> validationErrorsRaisingAction,
-            bool convertNotFoundToNoContent = true)
-        {
-            var result = await validationErrorsRaisingAction;
-
-            if (result.IsRight)
-            {
-                return new NoContentResult();
-            }
-
-            if (convertNotFoundToNoContent && result.Left is NotFoundResult)
-            {
-                return new NoContentResult();
-            }
-
-            return result.Left;
-        }
-
-        public static async Task<HubResult<T>> HandleFailuresOrHubResult<T>(
-            this Task<Either<ActionResult, T>> task) where T : class
-        {
-            var result = await task;
-
-            return result.IsRight ? new HubResult<T>(result.Right) : new HubResult<T>(result.Left);
-        }
+        return result.IsRight ? new HubResult<T>(result.Right) : new HubResult<T>(result.Left);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumExtensions.cs
@@ -3,44 +3,43 @@ using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class EnumExtensions
 {
-    public static class EnumExtensions
+    public static string GetEnumLabel(this Enum enumValue)
     {
-        public static string GetEnumLabel(this Enum enumValue)
-        {
-            return GetEnumLabelValueAttribute(enumValue)?.Label ?? enumValue.ToString();
-        }
+        return GetEnumLabelValueAttribute(enumValue)?.Label ?? enumValue.ToString();
+    }
 
-        public static string GetEnumValue(this Enum enumValue)
-        {
-            return GetEnumLabelValueAttribute(enumValue)?.Value ?? enumValue.ToString();
-        }
+    public static string GetEnumValue(this Enum enumValue)
+    {
+        return GetEnumLabelValueAttribute(enumValue)?.Value ?? enumValue.ToString();
+    }
 
-        public static TAttribute GetEnumAttribute<TAttribute>(this Enum enumValue) where TAttribute : Attribute
-        {
-            var memberInfo = enumValue.GetType().GetMember(enumValue.ToString());
+    public static TAttribute GetEnumAttribute<TAttribute>(this Enum enumValue) where TAttribute : Attribute
+    {
+        var memberInfo = enumValue.GetType().GetMember(enumValue.ToString());
 
-            return memberInfo[0].GetCustomAttributes(typeof(TAttribute), false)
-                .OfType<TAttribute>()
-                .FirstOrDefault();
-        }
+        return memberInfo[0].GetCustomAttributes(typeof(TAttribute), false)
+            .OfType<TAttribute>()
+            .FirstOrDefault();
+    }
 
-        private static EnumLabelValueAttribute GetEnumLabelValueAttribute(this Enum enumValue)
-        {
-            return enumValue.GetEnumAttribute<EnumLabelValueAttribute>();
-        }
-        
-        
-        public static List<EnumValue> GetValues<T>() where T: Enum
-        {
-            return (from object itemType in Enum.GetValues(typeof(T)) select new EnumValue() {Name = Enum.GetName(typeof(T), itemType), Value = (int) itemType}).ToList();
-        }
-        
-        public class EnumValue
-        {
-            public string Name { get; set; }
-            public int Value { get; set; }
-        }
+    private static EnumLabelValueAttribute GetEnumLabelValueAttribute(this Enum enumValue)
+    {
+        return enumValue.GetEnumAttribute<EnumLabelValueAttribute>();
+    }
+    
+    
+    public static List<EnumValue> GetValues<T>() where T: Enum
+    {
+        return (from object itemType in Enum.GetValues(typeof(T)) select new EnumValue() {Name = Enum.GetName(typeof(T), itemType), Value = (int) itemType}).ToList();
+    }
+    
+    public class EnumValue
+    {
+        public string Name { get; set; }
+        public int Value { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -6,295 +6,294 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class EnumerableExtensions
 {
-    public static class EnumerableExtensions
+    /// <summary>
+    /// Batches the source sequence into sized buckets.
+    /// </summary>
+    /// <typeparam name="TSource">Type of elements in <paramref name="source"/> sequence.</typeparam>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="size">Size of buckets.</param>
+    /// <returns>A sequence of equally sized buckets containing elements of the source collection.</returns>
+    /// <remarks>
+    /// This operator uses deferred execution and streams its results (buckets and bucket content).
+    /// </remarks>
+    public static IEnumerable<IEnumerable<TSource>> Batch<TSource>(this IEnumerable<TSource> source, int size)
     {
-        /// <summary>
-        /// Batches the source sequence into sized buckets.
-        /// </summary>
-        /// <typeparam name="TSource">Type of elements in <paramref name="source"/> sequence.</typeparam>
-        /// <param name="source">The source sequence.</param>
-        /// <param name="size">Size of buckets.</param>
-        /// <returns>A sequence of equally sized buckets containing elements of the source collection.</returns>
-        /// <remarks>
-        /// This operator uses deferred execution and streams its results (buckets and bucket content).
-        /// </remarks>
-        public static IEnumerable<IEnumerable<TSource>> Batch<TSource>(this IEnumerable<TSource> source, int size)
+        return Batch(source, size, x => x);
+    }
+
+    /// <summary>
+    /// Batches the source sequence into sized buckets and applies a projection to each bucket.
+    /// </summary>
+    /// <typeparam name="TSource">Type of elements in <paramref name="source"/> sequence.</typeparam>
+    /// <typeparam name="TResult">Type of result returned by <paramref name="resultSelector"/>.</typeparam>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="size">Size of buckets.</param>
+    /// <param name="resultSelector">The projection to apply to each bucket.</param>
+    /// <returns>A sequence of projections on equally sized buckets containing elements of the source collection.</returns>
+    /// <remarks>
+    /// This operator uses deferred execution and streams its results (buckets and bucket content).
+    /// </remarks>
+    public static IEnumerable<TResult> Batch<TSource, TResult>(this IEnumerable<TSource> source, int size,
+        Func<IEnumerable<TSource>, TResult> resultSelector)
+    {
+        if (source == null) throw new ArgumentNullException(nameof(source));
+        if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
+        if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+
+        return _();
+
+        IEnumerable<TResult> _()
         {
-            return Batch(source, size, x => x);
-        }
+            TSource[]? bucket = null;
+            var count = 0;
 
-        /// <summary>
-        /// Batches the source sequence into sized buckets and applies a projection to each bucket.
-        /// </summary>
-        /// <typeparam name="TSource">Type of elements in <paramref name="source"/> sequence.</typeparam>
-        /// <typeparam name="TResult">Type of result returned by <paramref name="resultSelector"/>.</typeparam>
-        /// <param name="source">The source sequence.</param>
-        /// <param name="size">Size of buckets.</param>
-        /// <param name="resultSelector">The projection to apply to each bucket.</param>
-        /// <returns>A sequence of projections on equally sized buckets containing elements of the source collection.</returns>
-        /// <remarks>
-        /// This operator uses deferred execution and streams its results (buckets and bucket content).
-        /// </remarks>
-        public static IEnumerable<TResult> Batch<TSource, TResult>(this IEnumerable<TSource> source, int size,
-            Func<IEnumerable<TSource>, TResult> resultSelector)
-        {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
-
-            return _();
-
-            IEnumerable<TResult> _()
+            foreach (var item in source)
             {
-                TSource[]? bucket = null;
-                var count = 0;
-
-                foreach (var item in source)
+                if (bucket == null)
                 {
-                    if (bucket == null)
-                    {
-                        bucket = new TSource[size];
-                    }
-
-                    bucket[count++] = item;
-
-                    // The bucket is fully buffered before it's yielded
-                    if (count != size)
-                    {
-                        continue;
-                    }
-
-                    yield return resultSelector(bucket);
-
-                    bucket = null;
-                    count = 0;
+                    bucket = new TSource[size];
                 }
 
-                // Return the last bucket with all remaining elements
-                if (bucket != null && count > 0)
+                bucket[count++] = item;
+
+                // The bucket is fully buffered before it's yielded
+                if (count != size)
                 {
-                    Array.Resize(ref bucket, count);
-                    yield return resultSelector(bucket);
-                }
-            }
-        }
-
-        public static void ForEach<T>(this IEnumerable<T> source, Action<T> func)
-        {
-            foreach (var item in source)
-            {
-                func(item);
-            }
-        }
-
-        public static void ForEach<T>(this IEnumerable<T> source, Action<T, int> func)
-        {
-            var index = 0;
-
-            foreach (var item in source)
-            {
-                func(item, index);
-                index += 1;
-            }
-        }
-
-        public static int IndexOfFirst<T>(this IEnumerable<T> source, Func<T, bool> predicate)
-        {
-            var index = 0;
-
-            foreach (var item in source)
-            {
-                if (predicate(item))
-                {
-                    return index;
+                    continue;
                 }
 
-                index += 1;
+                yield return resultSelector(bucket);
+
+                bucket = null;
+                count = 0;
             }
 
-            return -1;
-        }
-
-        public static async Task<Either<TLeft, List<TRight>>> ForEachAsync<T, TLeft, TRight>(this IEnumerable<T> source,
-            Func<T, Task<Either<TLeft, TRight>>> func)
-        {
-            var rightResults = new List<TRight>();
-
-            foreach (var item in source)
+            // Return the last bucket with all remaining elements
+            if (bucket != null && count > 0)
             {
-                var result = await func(item);
-
-                if (result.IsLeft)
-                {
-                    return new Either<TLeft, List<TRight>>(result.Left);
-                }
-
-                rightResults.Add(result.Right);
+                Array.Resize(ref bucket, count);
+                yield return resultSelector(bucket);
             }
-
-            return rightResults;
         }
+    }
 
-        public static Dictionary<TKey, TElement> ToDictionaryIndexed<TSource, TKey, TElement>(
-            this IEnumerable<TSource> source,
-            Func<TSource, TKey> keySelector,
-            Func<TSource, int, TElement> elementSelector) where TKey : notnull
+    public static void ForEach<T>(this IEnumerable<T> source, Action<T> func)
+    {
+        foreach (var item in source)
         {
-            var sourceList = source.ToList();
-
-            var result = new Dictionary<TKey, TElement>(sourceList.Count);
-            sourceList.ForEach((value, index) => { result.Add(keySelector(value), elementSelector(value, index)); });
-            return result;
+            func(item);
         }
+    }
 
-        public static bool IsNullOrEmpty<T>(this IEnumerable<T>? list)
+    public static void ForEach<T>(this IEnumerable<T> source, Action<T, int> func)
+    {
+        var index = 0;
+
+        foreach (var item in source)
         {
-            if (list == null)
+            func(item, index);
+            index += 1;
+        }
+    }
+
+    public static int IndexOfFirst<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+    {
+        var index = 0;
+
+        foreach (var item in source)
+        {
+            if (predicate(item))
             {
-                return true;
+                return index;
             }
 
-            return !list.Any();
+            index += 1;
         }
 
-        public static string JoinToString<T>(this IEnumerable<T> source)
-        {
-            return string.Join(string.Empty, source);
-        }
+        return -1;
+    }
 
-        public static string JoinToString<T>(this IEnumerable<T> source, char delimiter)
-        {
-            return string.Join(delimiter, source);
-        }
+    public static async Task<Either<TLeft, List<TRight>>> ForEachAsync<T, TLeft, TRight>(this IEnumerable<T> source,
+        Func<T, Task<Either<TLeft, TRight>>> func)
+    {
+        var rightResults = new List<TRight>();
 
-        public static string JoinToString<T>(this IEnumerable<T> source, string delimiter)
+        foreach (var item in source)
         {
-            return string.Join(delimiter, source);
-        }
+            var result = await func(item);
 
-        public static IEnumerable<TResult> SelectNullSafe<TSource, TResult>(
-            this IEnumerable<TSource>? source, Func<TSource, TResult> selector)
-        {
-            if (source == null)
+            if (result.IsLeft)
             {
-                return new List<TResult>();
+                return new Either<TLeft, List<TRight>>(result.Left);
             }
 
-            return source.Select(selector);
+            rightResults.Add(result.Right);
         }
 
-        public static async Task<IEnumerable<TResult>> SelectAsync<TSource, TResult>(
-            this IEnumerable<TSource> source, Func<TSource, Task<TResult>> asyncSelector)
-        {
-            var result = new List<TResult>();
+        return rightResults;
+    }
 
-            foreach (var item in source)
+    public static Dictionary<TKey, TElement> ToDictionaryIndexed<TSource, TKey, TElement>(
+        this IEnumerable<TSource> source,
+        Func<TSource, TKey> keySelector,
+        Func<TSource, int, TElement> elementSelector) where TKey : notnull
+    {
+        var sourceList = source.ToList();
+
+        var result = new Dictionary<TKey, TElement>(sourceList.Count);
+        sourceList.ForEach((value, index) => { result.Add(keySelector(value), elementSelector(value, index)); });
+        return result;
+    }
+
+    public static bool IsNullOrEmpty<T>(this IEnumerable<T>? list)
+    {
+        if (list == null)
+        {
+            return true;
+        }
+
+        return !list.Any();
+    }
+
+    public static string JoinToString<T>(this IEnumerable<T> source)
+    {
+        return string.Join(string.Empty, source);
+    }
+
+    public static string JoinToString<T>(this IEnumerable<T> source, char delimiter)
+    {
+        return string.Join(delimiter, source);
+    }
+
+    public static string JoinToString<T>(this IEnumerable<T> source, string delimiter)
+    {
+        return string.Join(delimiter, source);
+    }
+
+    public static IEnumerable<TResult> SelectNullSafe<TSource, TResult>(
+        this IEnumerable<TSource>? source, Func<TSource, TResult> selector)
+    {
+        if (source == null)
+        {
+            return new List<TResult>();
+        }
+
+        return source.Select(selector);
+    }
+
+    public static async Task<IEnumerable<TResult>> SelectAsync<TSource, TResult>(
+        this IEnumerable<TSource> source, Func<TSource, Task<TResult>> asyncSelector)
+    {
+        var result = new List<TResult>();
+
+        foreach (var item in source)
+        {
+            result.Add(await asyncSelector(item));
+        }
+
+        return result;
+    }
+
+    public static async Task<TSource?> FirstOrDefaultAsync<TSource>(
+        this IEnumerable<TSource> source, Func<TSource, Task<bool>> predicate)
+        where TSource : class
+    {
+        foreach (var item in source)
+        {
+            if (await predicate(item))
             {
-                result.Add(await asyncSelector(item));
+                return item;
             }
-
-            return result;
         }
 
-        public static async Task<TSource?> FirstOrDefaultAsync<TSource>(
-            this IEnumerable<TSource> source, Func<TSource, Task<bool>> predicate)
-            where TSource : class
+        return default;
+    }
+
+    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source)
+        where T : class
+    {
+        return source.Where(item => item is not null)!;
+    }
+
+    public static IAsyncEnumerable<T> WhereNotNull<T>(this IAsyncEnumerable<T?> source)
+        where T: class
+    {
+        return source.Where(item => item is not null)!;
+    }
+
+    public static IEnumerable<(T item, int index)> WithIndex<T>(this IEnumerable<T> self) =>
+        self.Select((item, index) => (item, index));
+
+    /// <summary>
+    /// Filter a list down to distinct elements based on a property of the type.
+    /// </summary>
+    ///
+    /// <remarks>
+    /// As IEqualityComparers (as used in Linq's Distinct() method) compare with GetHashCode() rather than with
+    /// Equals(), the property being used to compare distinctions against needs to produce a reliable hash code
+    /// that we can use for equality.  A good property type then could be a Guid Id field, as two identical Guid Ids
+    /// can then represent that 2 or more entities in the list are duplicates as they will have the same hash code.
+    /// </remarks>
+    ///
+    /// <param name="source">Sequence of elements to filter on a distinct property</param>
+    /// <param name="propertyGetter">A supplier of a property from each entity to check for equality. The property
+    /// chosen must produce the same hash code for any two elements in the source list that are considered
+    /// duplicates.  A good example would be a Guid Id.</param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static IEnumerable<T> DistinctByProperty<T>(
+        this IEnumerable<T> source,
+        Func<T, object> propertyGetter)
+        where T : class
+    {
+        return source.Distinct(ComparerUtils.CreateComparerByProperty(propertyGetter));
+    }
+
+    public static bool IsSameAsIgnoringOrder<T>(this IEnumerable<T> first, IEnumerable<T> second)
+    {
+        var firstList = first.ToList();
+        var secondList = second.ToList();
+
+        var firstNotInSecond = firstList.Except(secondList);
+        var secondNotInFirst = secondList.Except(firstList);
+
+        return !(firstNotInSecond.Any() || secondNotInFirst.Any());
+    }
+    
+    public static Tuple<T, T> ToTuple2<T>(this IEnumerable<T> collection)
+        where T : class
+    {
+        var list = collection.ToList();
+
+        if (list.Count != 2)
         {
-            foreach (var item in source)
-            {
-                if (await predicate(item))
-                {
-                    return item;
-                }
-            }
-
-            return default;
-        }
-
-        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source)
-            where T : class
-        {
-            return source.Where(item => item is not null)!;
-        }
-
-        public static IAsyncEnumerable<T> WhereNotNull<T>(this IAsyncEnumerable<T?> source)
-            where T: class
-        {
-            return source.Where(item => item is not null)!;
-        }
-
-        public static IEnumerable<(T item, int index)> WithIndex<T>(this IEnumerable<T> self) =>
-            self.Select((item, index) => (item, index));
-
-        /// <summary>
-        /// Filter a list down to distinct elements based on a property of the type.
-        /// </summary>
-        ///
-        /// <remarks>
-        /// As IEqualityComparers (as used in Linq's Distinct() method) compare with GetHashCode() rather than with
-        /// Equals(), the property being used to compare distinctions against needs to produce a reliable hash code
-        /// that we can use for equality.  A good property type then could be a Guid Id field, as two identical Guid Ids
-        /// can then represent that 2 or more entities in the list are duplicates as they will have the same hash code.
-        /// </remarks>
-        ///
-        /// <param name="source">Sequence of elements to filter on a distinct property</param>
-        /// <param name="propertyGetter">A supplier of a property from each entity to check for equality. The property
-        /// chosen must produce the same hash code for any two elements in the source list that are considered
-        /// duplicates.  A good example would be a Guid Id.</param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public static IEnumerable<T> DistinctByProperty<T>(
-            this IEnumerable<T> source,
-            Func<T, object> propertyGetter)
-            where T : class
-        {
-            return source.Distinct(ComparerUtils.CreateComparerByProperty(propertyGetter));
-        }
-
-        public static bool IsSameAsIgnoringOrder<T>(this IEnumerable<T> first, IEnumerable<T> second)
-        {
-            var firstList = first.ToList();
-            var secondList = second.ToList();
-
-            var firstNotInSecond = firstList.Except(secondList);
-            var secondNotInFirst = secondList.Except(firstList);
-
-            return !(firstNotInSecond.Any() || secondNotInFirst.Any());
+            throw new ArgumentException(
+                $"Expected 2 list items when constructing a 2-tuple, but found {list.Count}");
         }
         
-        public static Tuple<T, T> ToTuple2<T>(this IEnumerable<T> collection)
-            where T : class
-        {
-            var list = collection.ToList();
+        return new Tuple<T, T>(list[0], list[1]);
+    }
+    
+    public static Tuple<T, T, T> ToTuple3<T>(this IEnumerable<T> collection)
+        where T : class
+    {
+        var list = collection.ToList();
 
-            if (list.Count != 2)
-            {
-                throw new ArgumentException(
-                    $"Expected 2 list items when constructing a 2-tuple, but found {list.Count}");
-            }
-            
-            return new Tuple<T, T>(list[0], list[1]);
+        if (list.Count != 3)
+        {
+            throw new ArgumentException(
+                $"Expected 3 list items when constructing a 3-tuple, but found {list.Count}");
         }
         
-        public static Tuple<T, T, T> ToTuple3<T>(this IEnumerable<T> collection)
-            where T : class
-        {
-            var list = collection.ToList();
+        return new Tuple<T, T, T>(list[0], list[1], list[2]);
+    }
 
-            if (list.Count != 3)
-            {
-                throw new ArgumentException(
-                    $"Expected 3 list items when constructing a 3-tuple, but found {list.Count}");
-            }
-            
-            return new Tuple<T, T, T>(list[0], list[1], list[2]);
-        }
-
-        public static bool ContainsAll<T>(this IEnumerable<T> source, IEnumerable<T> values)
-        {
-            return values.All(id => source.Contains(id));
-        }
+    public static bool ContainsAll<T>(this IEnumerable<T> source, IEnumerable<T> values)
+    {
+        return values.All(id => source.Contains(id));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/FindExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/FindExtensions.cs
@@ -6,79 +6,78 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+/**
+ * Provide extension to filter by primary key generically.
+ * https://stackoverflow.com/a/55272426
+ */
+public static class FindExtensions
 {
-    /**
-     * Provide extension to filter by primary key generically.
-     * https://stackoverflow.com/a/55272426
-     */
-    public static class FindExtensions
+    public static IQueryable<TEntity> FindByPrimaryKey<TEntity>(this IQueryable<TEntity> queryable,
+        DbContext context, object key) where TEntity : class
     {
-        public static IQueryable<TEntity> FindByPrimaryKey<TEntity>(this IQueryable<TEntity> queryable,
-            DbContext context, object key) where TEntity : class
+        return FindByPrimaryKey(queryable, context, new[] {key});
+    }
+
+    public static IQueryable<TEntity> FindByPrimaryKey<TEntity>(this IQueryable<TEntity> queryable,
+        DbContext context, object[] key) where TEntity : class
+    {
+        return queryable.Where(context.FindByPrimaryKeyPredicate<TEntity>(key));
+    }
+
+    public static IQueryable<TEntity> FindAll<TEntity>(this IQueryable<TEntity> queryable,
+        DbContext dbContext,
+        params object[] keyValues) where TEntity : class
+    {
+        var entityType = dbContext.Model.FindEntityType(typeof(TEntity));
+        var primaryKey = entityType.FindPrimaryKey();
+        if (primaryKey.Properties.Count != 1)
+            throw new NotSupportedException("Only a single primary key is supported");
+
+        var pkProperty = primaryKey.Properties[0];
+        var pkPropertyType = pkProperty.ClrType;
+
+        foreach (var keyValue in keyValues)
         {
-            return FindByPrimaryKey(queryable, context, new[] {key});
+            if (!pkPropertyType.IsAssignableFrom(keyValue.GetType()))
+                throw new ArgumentException($"Key value '{keyValue}' is not of the right type");
         }
 
-        public static IQueryable<TEntity> FindByPrimaryKey<TEntity>(this IQueryable<TEntity> queryable,
-            DbContext context, object[] key) where TEntity : class
-        {
-            return queryable.Where(context.FindByPrimaryKeyPredicate<TEntity>(key));
-        }
+        var pkMemberInfo = typeof(TEntity).GetProperty(pkProperty.Name);
+        if (pkMemberInfo == null)
+            throw new ArgumentException("Type does not contain the primary key as an accessible property");
 
-        public static IQueryable<TEntity> FindAll<TEntity>(this IQueryable<TEntity> queryable,
-            DbContext dbContext,
-            params object[] keyValues) where TEntity : class
-        {
-            var entityType = dbContext.Model.FindEntityType(typeof(TEntity));
-            var primaryKey = entityType.FindPrimaryKey();
-            if (primaryKey.Properties.Count != 1)
-                throw new NotSupportedException("Only a single primary key is supported");
+        var parameter = Expression.Parameter(typeof(TEntity), "e");
+        var body = Expression.Call(null, ContainsMethod,
+            Expression.Constant(keyValues),
+            Expression.Convert(Expression.MakeMemberAccess(parameter, pkMemberInfo), typeof(object)));
+        var predicateExpression = Expression.Lambda<Func<TEntity, bool>>(body, parameter);
 
-            var pkProperty = primaryKey.Properties[0];
-            var pkPropertyType = pkProperty.ClrType;
+        return queryable.Where(predicateExpression);
+    }
 
-            foreach (var keyValue in keyValues)
-            {
-                if (!pkPropertyType.IsAssignableFrom(keyValue.GetType()))
-                    throw new ArgumentException($"Key value '{keyValue}' is not of the right type");
-            }
+    // TODO Precompile expression so this doesn't happen every time
+    private static Expression<Func<T, bool>> FindByPrimaryKeyPredicate<T>(this DbContext dbContext, object[] id)
+    {
+        var keyProperties = dbContext.GetPrimaryKeyProperties<T>();
+        var parameter = Expression.Parameter(typeof(T), "e");
+        var body = keyProperties
+            .Select((p, i) => Expression.Equal(
+                Expression.Property(parameter, p.Name),
+                Expression.Convert(
+                    Expression.PropertyOrField(Expression.Constant(new {id = id[i]}), "id"),
+                    p.ClrType)))
+            .Aggregate(Expression.AndAlso);
+        return Expression.Lambda<Func<T, bool>>(body, parameter);
+    }
 
-            var pkMemberInfo = typeof(TEntity).GetProperty(pkProperty.Name);
-            if (pkMemberInfo == null)
-                throw new ArgumentException("Type does not contain the primary key as an accessible property");
+    private static readonly MethodInfo ContainsMethod = typeof(Enumerable).GetMethods()
+        .FirstOrDefault(m => m.Name == "Contains" && m.GetParameters().Length == 2)
+        .MakeGenericMethod(typeof(object));
 
-            var parameter = Expression.Parameter(typeof(TEntity), "e");
-            var body = Expression.Call(null, ContainsMethod,
-                Expression.Constant(keyValues),
-                Expression.Convert(Expression.MakeMemberAccess(parameter, pkMemberInfo), typeof(object)));
-            var predicateExpression = Expression.Lambda<Func<TEntity, bool>>(body, parameter);
-
-            return queryable.Where(predicateExpression);
-        }
-
-        // TODO Precompile expression so this doesn't happen every time
-        private static Expression<Func<T, bool>> FindByPrimaryKeyPredicate<T>(this DbContext dbContext, object[] id)
-        {
-            var keyProperties = dbContext.GetPrimaryKeyProperties<T>();
-            var parameter = Expression.Parameter(typeof(T), "e");
-            var body = keyProperties
-                .Select((p, i) => Expression.Equal(
-                    Expression.Property(parameter, p.Name),
-                    Expression.Convert(
-                        Expression.PropertyOrField(Expression.Constant(new {id = id[i]}), "id"),
-                        p.ClrType)))
-                .Aggregate(Expression.AndAlso);
-            return Expression.Lambda<Func<T, bool>>(body, parameter);
-        }
-
-        private static readonly MethodInfo ContainsMethod = typeof(Enumerable).GetMethods()
-            .FirstOrDefault(m => m.Name == "Contains" && m.GetParameters().Length == 2)
-            .MakeGenericMethod(typeof(object));
-
-        private static IReadOnlyList<IProperty> GetPrimaryKeyProperties<T>(this DbContext dbContext)
-        {
-            return dbContext.Model.FindEntityType(typeof(T)).FindPrimaryKey().Properties;
-        }
+    private static IReadOnlyList<IProperty> GetPrimaryKeyProperties<T>(this DbContext dbContext)
+    {
+        return dbContext.Model.FindEntityType(typeof(T)).FindPrimaryKey().Properties;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/IntExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/IntExtensions.cs
@@ -1,36 +1,35 @@
 using System.Collections.Generic;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
-{
-    public static class IntExtensions
-    {
-        /// <summary>
-        /// Enumerate a series of integers up to the specified value
-        /// </summary>
-        /// <remarks>
-        /// If the input integer is negative, a negative series
-        /// of integers will be produced instead.
-        /// </remarks>
-        public static IEnumerable<int> ToEnumerable(this int value)
-        {
-            if (value == 0)
-            {
-                yield break;
-            }
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
-            if (value > 0)
+public static class IntExtensions
+{
+    /// <summary>
+    /// Enumerate a series of integers up to the specified value
+    /// </summary>
+    /// <remarks>
+    /// If the input integer is negative, a negative series
+    /// of integers will be produced instead.
+    /// </remarks>
+    public static IEnumerable<int> ToEnumerable(this int value)
+    {
+        if (value == 0)
+        {
+            yield break;
+        }
+
+        if (value > 0)
+        {
+            for (var i = 1; i <= value; i++)
             {
-                for (var i = 1; i <= value; i++)
-                {
-                    yield return i;
-                }
+                yield return i;
             }
-            else
+        }
+        else
+        {
+            for (var i = -1; i >= value; i--)
             {
-                for (var i = -1; i >= value; i--)
-                {
-                    yield return i;
-                }
+                yield return i;
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/MigrationBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/MigrationBuilderExtensions.cs
@@ -3,35 +3,34 @@ using System.IO;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class MigrationBuilderExtensions
 {
-    public static class MigrationBuilderExtensions
+    public static void SqlFromFile(this MigrationBuilder migrationBuilder,
+        string migrationsPath,
+        string filename,
+        bool suppressTransaction = false)
     {
-        public static void SqlFromFile(this MigrationBuilder migrationBuilder,
-            string migrationsPath,
-            string filename,
-            bool suppressTransaction = false)
+        var file = Path.Combine(
+            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+            $"{migrationsPath}{Path.DirectorySeparatorChar}{filename}");
+
+        migrationBuilder.Sql(File.ReadAllText(file), suppressTransaction);
+    }
+
+    public static void SqlFromFileByLine(this MigrationBuilder migrationBuilder,
+        string migrationsPath,
+        string filename)
+    {
+        var file = Path.Combine(
+            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+            $"{migrationsPath}{Path.DirectorySeparatorChar}{filename}");
+
+        var lines = File.ReadAllLines(file);
+        foreach (var line in lines)
         {
-            var file = Path.Combine(
-                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
-                $"{migrationsPath}{Path.DirectorySeparatorChar}{filename}");
-
-            migrationBuilder.Sql(File.ReadAllText(file), suppressTransaction);
-        }
-
-        public static void SqlFromFileByLine(this MigrationBuilder migrationBuilder,
-            string migrationsPath,
-            string filename)
-        {
-            var file = Path.Combine(
-                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
-                $"{migrationsPath}{Path.DirectorySeparatorChar}{filename}");
-
-            var lines = File.ReadAllLines(file);
-            foreach (var line in lines)
-            {
-                migrationBuilder.Sql(line);
-            }
+            migrationBuilder.Sql(line);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ParameterInfoExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ParameterInfoExtensions.cs
@@ -2,21 +2,20 @@
 using System.Reflection;
 using Namotion.Reflection;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
-{
-    public static class ParameterInfoExtensions
-    {
-        public static bool IsNullable(this ParameterInfo parameter)
-        {
-            // Need to use a custom library for this as out of the box reflection
-            // currently isn't good enough to detect this. Think this potentially gets
-            // solved by .NET 6. See: https://github.com/dotnet/runtime/issues/29723
-            return parameter.ToContextualParameter().Nullability == Nullability.Nullable;
-        }
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
-        public static string ToShortString(this ParameterInfo parameter)
-        {
-            return $"{parameter.ParameterType.Name} {parameter.Name}";
-        }
+public static class ParameterInfoExtensions
+{
+    public static bool IsNullable(this ParameterInfo parameter)
+    {
+        // Need to use a custom library for this as out of the box reflection
+        // currently isn't good enough to detect this. Think this potentially gets
+        // solved by .NET 6. See: https://github.com/dotnet/runtime/issues/29723
+        return parameter.ToContextualParameter().Nullability == Nullability.Nullable;
+    }
+
+    public static string ToShortString(this ParameterInfo parameter)
+    {
+        return $"{parameter.ParameterType.Name} {parameter.Name}";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ReflectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ReflectionExtensions.cs
@@ -5,142 +5,141 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+/// <summary>
+/// Aka the magic box of tricks. Use with caution.
+/// </summary>
+public static class ReflectionExtensions
 {
     /// <summary>
-    /// Aka the magic box of tricks. Use with caution.
+    /// Recursively box up an unknown value until a target
+    /// box type is reached e.g. an Either, Task or ActionResult.
+    /// <para>
+    /// This is particularly useful in situations where we cannot know
+    /// the type of the value at compile-time and only have access to
+    /// runtime types instead i.e. in AOP code.
+    /// </para>
     /// </summary>
-    public static class ReflectionExtensions
+    public static bool TryBoxToResult(this object value, Type targetType, out object? boxedValue)
     {
-        /// <summary>
-        /// Recursively box up an unknown value until a target
-        /// box type is reached e.g. an Either, Task or ActionResult.
-        /// <para>
-        /// This is particularly useful in situations where we cannot know
-        /// the type of the value at compile-time and only have access to
-        /// runtime types instead i.e. in AOP code.
-        /// </para>
-        /// </summary>
-        public static bool TryBoxToResult(this object value, Type targetType, out object? boxedValue)
+        boxedValue = value;
+
+        var path = targetType.GetUnboxedResultTypePath();
+        path.Reverse();
+
+        // Would not be able to reach the target type.
+        if (!path.First().IsInstanceOfType(value))
         {
-            boxedValue = value;
+            return false;
+        }
 
-            var path = targetType.GetUnboxedResultTypePath();
-            path.Reverse();
+        path = path.Skip(1).ToList();
 
-            // Would not be able to reach the target type.
-            if (!path.First().IsInstanceOfType(value))
+        foreach (var boxType in path)
+        {
+            // Stop at the first non-generic type along
+            // the path. This is a non-boxable type.
+            if (!boxType.IsConstructedGenericType)
             {
                 return false;
             }
 
-            path = path.Skip(1).ToList();
-
-            foreach (var boxType in path)
+            // Potentially unsafe to use just the name for this,
+            // but realistically, we're never going to create
+            // other types with these names.
+            switch (boxType.GetNameWithoutGenericArity())
             {
-                // Stop at the first non-generic type along
-                // the path. This is a non-boxable type.
-                if (!boxType.IsConstructedGenericType)
-                {
+                case "ActionResult":
+                    var actionResultType = typeof(ActionResult<>).MakeGenericType(boxType.GenericTypeArguments);
+                    var actionResult = Activator.CreateInstance(actionResultType, boxedValue);
+
+                    boxedValue = actionResult;
+                    break;
+
+                case "Task":
+                    var task = typeof(Task).GetMethod("FromResult")
+                        ?.MakeGenericMethod(boxType.GenericTypeArguments)
+                        .Invoke(null, new[] { boxedValue });
+
+                    boxedValue = task;
+                    break;
+
+                case "Either":
+                    var eitherType = typeof(Either<,>).MakeGenericType(boxType.GenericTypeArguments);
+                    var either = Activator.CreateInstance(eitherType, boxedValue);
+
+                    boxedValue = either;
+                    break;
+
+                default:
+                    // Not a type that we handle so we
+                    // can't box this any further.
                     return false;
-                }
-
-                // Potentially unsafe to use just the name for this,
-                // but realistically, we're never going to create
-                // other types with these names.
-                switch (boxType.GetNameWithoutGenericArity())
-                {
-                    case "ActionResult":
-                        var actionResultType = typeof(ActionResult<>).MakeGenericType(boxType.GenericTypeArguments);
-                        var actionResult = Activator.CreateInstance(actionResultType, boxedValue);
-
-                        boxedValue = actionResult;
-                        break;
-
-                    case "Task":
-                        var task = typeof(Task).GetMethod("FromResult")
-                            ?.MakeGenericMethod(boxType.GenericTypeArguments)
-                            .Invoke(null, new[] { boxedValue });
-
-                        boxedValue = task;
-                        break;
-
-                    case "Either":
-                        var eitherType = typeof(Either<,>).MakeGenericType(boxType.GenericTypeArguments);
-                        var either = Activator.CreateInstance(eitherType, boxedValue);
-
-                        boxedValue = either;
-                        break;
-
-                    default:
-                        // Not a type that we handle so we
-                        // can't box this any further.
-                        return false;
-                }
             }
-
-            return true;
         }
 
-        /// <summary>
-        /// Try to unbox an unknown boxed value into its final
-        /// result value by recursively unboxing each result.
-        /// </summary>
-        public static bool TryUnboxResult(this object? value, out object? result)
+        return true;
+    }
+
+    /// <summary>
+    /// Try to unbox an unknown boxed value into its final
+    /// result value by recursively unboxing each result.
+    /// </summary>
+    public static bool TryUnboxResult(this object? value, out object? result)
+    {
+        result = value;
+
+        while (true)
         {
-            result = value;
-
-            while (true)
+            if (result is null)
             {
-                if (result is null)
-                {
-                    result = null;
+                result = null;
+                return true;
+            }
+
+            if (result is Task)
+            {
+                // TODO: EES-4268 Create async variant of this method
+                throw new ArgumentException("Cannot unbox Tasks as this may cause thread exhaustion. Consider awaiting the result first.");
+            }
+
+            var resultType = result.GetType();
+
+            // Stop at the first non-generic result type type.
+            // We cannot un-box it further, so we should finish.
+            if (!resultType.IsConstructedGenericType)
+            {
+                return true;
+            }
+
+            if (result == Task.CompletedTask)
+            {
+                result = null;
+                return false;
+            }
+
+            // Potentially unsafe to use just the name for this,
+            // but realistically, we're never going to create
+            // other types with these names.
+            switch (resultType.GetNameWithoutGenericArity())
+            {
+                case "ActionResult":
+                    result = resultType.GetProperty("Value")?.GetValue(result);
+                    continue;
+
+                case "Either":
+                    if (resultType.GetProperty("IsLeft")?.GetValue(result) is true)
+                    {
+                        result = null;
+                        return false;
+                    }
+
+                    result = resultType.GetProperty("Right")?.GetValue(result);
+                    continue;
+
+                default:
                     return true;
-                }
-
-                if (result is Task)
-                {
-                    // TODO: EES-4268 Create async variant of this method
-                    throw new ArgumentException("Cannot unbox Tasks as this may cause thread exhaustion. Consider awaiting the result first.");
-                }
-
-                var resultType = result.GetType();
-
-                // Stop at the first non-generic result type type.
-                // We cannot un-box it further, so we should finish.
-                if (!resultType.IsConstructedGenericType)
-                {
-                    return true;
-                }
-
-                if (result == Task.CompletedTask)
-                {
-                    result = null;
-                    return false;
-                }
-
-                // Potentially unsafe to use just the name for this,
-                // but realistically, we're never going to create
-                // other types with these names.
-                switch (resultType.GetNameWithoutGenericArity())
-                {
-                    case "ActionResult":
-                        result = resultType.GetProperty("Value")?.GetValue(result);
-                        continue;
-
-                    case "Either":
-                        if (resultType.GetProperty("IsLeft")?.GetValue(result) is true)
-                        {
-                            result = null;
-                            return false;
-                        }
-
-                        result = resultType.GetProperty("Right")?.GetValue(result);
-                        continue;
-
-                    default:
-                        return true;
-                }
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StreamExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StreamExtensions.cs
@@ -3,51 +3,50 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class StreamExtensions
 {
-    public static class StreamExtensions
+    public static void WriteText(this Stream stream, string text)
     {
-        public static void WriteText(this Stream stream, string text)
+        using var writer = new StreamWriter(stream, leaveOpen: true);
+        writer.Write(text);
+        writer.Flush();
+    }
+
+    public static byte[] ReadFully(this Stream stream)
+    {
+        using var memoryStream = new MemoryStream();
+        stream.CopyTo(memoryStream);
+        return memoryStream.ToArray();
+    }
+
+    public static string ReadToEnd(this Stream stream, bool leaveOpen = false)
+    {
+        using var reader = new StreamReader(stream, leaveOpen);
+        return reader.ReadToEnd();
+    }
+
+    public static string ComputeMd5Hash(this Stream stream)
+    {
+        using var md5 = MD5.Create();
+        var hash = md5.ComputeHash(stream);
+
+        if (stream.CanSeek)
         {
-            using var writer = new StreamWriter(stream, leaveOpen: true);
-            writer.Write(text);
-            writer.Flush();
+            stream.Position = 0;
         }
 
-        public static byte[] ReadFully(this Stream stream)
+        return BitConverter.ToString(hash)
+            .Replace("-", string.Empty)
+            .ToLowerInvariant();
+    }
+
+    public static void SeekToBeginning(this Stream stream)
+    {
+        if (stream.CanSeek)
         {
-            using var memoryStream = new MemoryStream();
-            stream.CopyTo(memoryStream);
-            return memoryStream.ToArray();
-        }
-
-        public static string ReadToEnd(this Stream stream, bool leaveOpen = false)
-        {
-            using var reader = new StreamReader(stream, leaveOpen);
-            return reader.ReadToEnd();
-        }
-
-        public static string ComputeMd5Hash(this Stream stream)
-        {
-            using var md5 = MD5.Create();
-            var hash = md5.ComputeHash(stream);
-
-            if (stream.CanSeek)
-            {
-                stream.Position = 0;
-            }
-
-            return BitConverter.ToString(hash)
-                .Replace("-", string.Empty)
-                .ToLowerInvariant();
-        }
-
-        public static void SeekToBeginning(this Stream stream)
-        {
-            if (stream.CanSeek)
-            {
-                stream.Seek(offset: 0, origin: SeekOrigin.Begin);
-            }
+            stream.Seek(offset: 0, origin: SeekOrigin.Begin);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -9,147 +9,146 @@ using System.Text;
 using System.Text.RegularExpressions;
 using AngleSharp.Text;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class StringExtensions
 {
-    public static class StringExtensions
+    /// <summary>
+    /// Convert a string into an enumerable of its constituent lines.
+    /// </summary>
+    public static IEnumerable<string> ToLines(this string value)
     {
-        /// <summary>
-        /// Convert a string into an enumerable of its constituent lines.
-        /// </summary>
-        public static IEnumerable<string> ToLines(this string value)
+        var reader = new StringReader(value);
+
+        var currentLine = reader.ReadLine();
+
+        while (currentLine != null)
         {
-            var reader = new StringReader(value);
-
-            var currentLine = reader.ReadLine();
-
-            while (currentLine != null)
-            {
-                yield return currentLine;
-                currentLine = reader.ReadLine();
-            }
-
-            reader.Close();
+            yield return currentLine;
+            currentLine = reader.ReadLine();
         }
 
-        /// <summary>
-        /// Convert a string into a list of its constituent lines.
-        /// </summary>
-        public static IList<string> ToLinesList(this string value)
+        reader.Close();
+    }
+
+    /// <summary>
+    /// Convert a string into a list of its constituent lines.
+    /// </summary>
+    public static IList<string> ToLinesList(this string value)
+    {
+        return value.ToLines().ToList();
+    }
+
+    public static Stream ToStream(this string value)
+    {
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
+
+        writer.Write(value);
+        writer.Flush();
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    public static string StripLines(this string value)
+    {
+        return value.StripLineBreaks();
+    }
+
+    public static int IndentWidth(this string value)
+    {
+        var firstChar = value.IndexOfFirst(c => !c.IsWhiteSpaceCharacter());
+        return firstChar > -1 ? firstChar : value.Length;
+    }
+
+    public static string TrimToLower(this string value)
+    {
+        return value.Trim().ToLower(); 
+    }
+
+    public static string TrimIndent(this string value)
+    {
+        var lines = value.ToLines()
+            .ToList();
+
+        var minIndent = lines.Where(line => !string.IsNullOrEmpty(line))
+            .Select(line => line.IndentWidth())
+            .Min();
+
+        return lines
+            .Select(line => line.Skip(minIndent).JoinToString())
+            .JoinToString("\n");
+    }
+
+    public static string AppendTrailingSlash(this string input)
+    {
+        return input.EndsWith("/") ? input : input + "/";
+    }
+
+    public static string CamelCase(this string input)
+    {
+        if (input.IsNullOrEmpty())
         {
-            return value.ToLines().ToList();
-        }
-
-        public static Stream ToStream(this string value)
-        {
-            var stream = new MemoryStream();
-            var writer = new StreamWriter(stream);
-
-            writer.Write(value);
-            writer.Flush();
-
-            stream.Position = 0;
-            return stream;
-        }
-
-        public static string StripLines(this string value)
-        {
-            return value.StripLineBreaks();
-        }
-
-        public static int IndentWidth(this string value)
-        {
-            var firstChar = value.IndexOfFirst(c => !c.IsWhiteSpaceCharacter());
-            return firstChar > -1 ? firstChar : value.Length;
-        }
-
-        public static string TrimToLower(this string value)
-        {
-            return value.Trim().ToLower(); 
-        }
-
-        public static string TrimIndent(this string value)
-        {
-            var lines = value.ToLines()
-                .ToList();
-
-            var minIndent = lines.Where(line => !string.IsNullOrEmpty(line))
-                .Select(line => line.IndentWidth())
-                .Min();
-
-            return lines
-                .Select(line => line.Skip(minIndent).JoinToString())
-                .JoinToString("\n");
-        }
-
-        public static string AppendTrailingSlash(this string input)
-        {
-            return input.EndsWith("/") ? input : input + "/";
-        }
-
-        public static string CamelCase(this string input)
-        {
-            if (input.IsNullOrEmpty())
-            {
-                return input;
-            }
-
-            var s = PascalCase(input);
-            return char.ToLowerInvariant(s[0]) + s.Substring(1);
-        }
-
-        public static bool IsNullOrEmpty(this string? value)
-        {
-            return string.IsNullOrEmpty(value);
-        }
-
-        public static bool IsNullOrWhitespace(this string? value)
-        {
-            return string.IsNullOrWhiteSpace(value);
-        }
-
-        public static string? NullIfWhiteSpace(this string value)
-        {
-            return string.IsNullOrWhiteSpace(value) ? null : value;
-        }
-
-        public static string PascalCase(this string input)
-        {
-            if (input.IsNullOrEmpty())
-            {
-                return input;
-            }
-
-            var cultInfo = CultureInfo.CurrentCulture.TextInfo;
-            input = Regex.Replace(input, "[^A-Za-z0-9]", " ");
-            input = Regex.Replace(input, "([A-Z]+)", " $1");
-            input = cultInfo.ToTitleCase(input);
-            input = input.Replace(" ", "");
             return input;
         }
 
-        public static string SnakeCase(this string input)
+        var s = PascalCase(input);
+        return char.ToLowerInvariant(s[0]) + s.Substring(1);
+    }
+
+    public static bool IsNullOrEmpty(this string? value)
+    {
+        return string.IsNullOrEmpty(value);
+    }
+
+    public static bool IsNullOrWhitespace(this string? value)
+    {
+        return string.IsNullOrWhiteSpace(value);
+    }
+
+    public static string? NullIfWhiteSpace(this string value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    public static string PascalCase(this string input)
+    {
+        if (input.IsNullOrEmpty())
         {
-            if (input.IsNullOrEmpty())
-            {
-                return input;
-            }
-
-            input = Regex.Replace(input, "[^A-Za-z0-9]", " ");
-            input = Regex.Replace(input, "([A-Z]+)", " $1").Trim();
-            input = Regex.Replace(input, "(\\s+)", "_");
-
-            return input.ToLower();
+            return input;
         }
 
-        public static string ToMd5Hash(this string input, Encoding? encoding = null)
+        var cultInfo = CultureInfo.CurrentCulture.TextInfo;
+        input = Regex.Replace(input, "[^A-Za-z0-9]", " ");
+        input = Regex.Replace(input, "([A-Z]+)", " $1");
+        input = cultInfo.ToTitleCase(input);
+        input = input.Replace(" ", "");
+        return input;
+    }
+
+    public static string SnakeCase(this string input)
+    {
+        if (input.IsNullOrEmpty())
         {
-            using var md5 = MD5.Create();
-
-            var inputBytes = (encoding ?? Encoding.UTF8).GetBytes(input);
-
-            return BitConverter.ToString(md5.ComputeHash(inputBytes))
-                .Replace("-", string.Empty)
-                .ToLowerInvariant();
+            return input;
         }
+
+        input = Regex.Replace(input, "[^A-Za-z0-9]", " ");
+        input = Regex.Replace(input, "([A-Z]+)", " $1").Trim();
+        input = Regex.Replace(input, "(\\s+)", "_");
+
+        return input.ToLower();
+    }
+
+    public static string ToMd5Hash(this string input, Encoding? encoding = null)
+    {
+        using var md5 = MD5.Create();
+
+        var inputBytes = (encoding ?? Encoding.UTF8).GetBytes(input);
+
+        return BitConverter.ToString(md5.ComputeHash(inputBytes))
+            .Replace("-", string.Empty)
+            .ToLowerInvariant();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/TableHeadersExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/TableHeadersExtensions.cs
@@ -3,13 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class TableHeadersExtensions
 {
-    public static class TableHeadersExtensions
+    public static List<TableHeader> FilterByType(this IEnumerable<TableHeader> tableHeaders, TableHeaderType type)
     {
-        public static List<TableHeader> FilterByType(this IEnumerable<TableHeader> tableHeaders, TableHeaderType type)
-        {
-            return tableHeaders.Where(header => header.Type == type).ToList();
-        }
+        return tableHeaders.Where(header => header.Type == type).ToList();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/TimeIdentifierCategoryExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/TimeIdentifierCategoryExtensions.cs
@@ -3,14 +3,13 @@ using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class TimeIdentifierCategoryExtensions
 {
-    public static class TimeIdentifierCategoryExtensions
+    public static TimeIdentifier[] GetTimeIdentifiers(this TimeIdentifierCategory category)
     {
-        public static TimeIdentifier[] GetTimeIdentifiers(this TimeIdentifierCategory category)
-        {
-            var all = (TimeIdentifier[]) Enum.GetValues(typeof(TimeIdentifier));
-            return all.Where(i => i.GetEnumAttribute<TimeIdentifierMetaAttribute>().Category == category).ToArray();
-        }
+        var all = (TimeIdentifier[]) Enum.GetValues(typeof(TimeIdentifier));
+        return all.Where(i => i.GetEnumAttribute<TimeIdentifierMetaAttribute>().Category == category).ToArray();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/TypeExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/TypeExtensions.cs
@@ -4,86 +4,85 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class TypeExtensions
 {
-    public static class TypeExtensions
+    public static string GetPrettyFullName(this Type type)
     {
-        public static string GetPrettyFullName(this Type type)
+        // Remove our namespace as it really clutters up the logs
+        return type.FullName?.Replace("GovUk.Education.ExploreEducationStatistics.", string.Empty)
+               ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Returns the <see cref="Type.Name"/> property
+    /// without including generic type information.
+    /// </summary>
+    public static string GetNameWithoutGenericArity(this Type t)
+    {
+        var name = t.Name;
+        var index = name.IndexOf('`');
+
+        return index == -1 ? name : name[..index];
+    }
+
+    /// <summary>
+    /// Get a list of types that describes the path needed to
+    /// reach an unboxed 'result' type in the type's generic
+    /// arguments e.g. the right of an Either, or the result of a Task.
+    /// </summary>
+    /// <remarks>
+    /// We currently only support 'result' types (e.g. Either, Task
+    /// or ActionResult), although it may be useful to handle other
+    /// types such as Lists, Dictionary, etc, in the future.
+    /// </remarks>
+    public static List<Type> GetUnboxedResultTypePath(this Type type)
+    {
+        var path = new List<Type>{ type };
+
+        while (true)
         {
-            // Remove our namespace as it really clutters up the logs
-            return type.FullName?.Replace("GovUk.Education.ExploreEducationStatistics.", string.Empty)
-                   ?? string.Empty;
-        }
+            var currentType = path.Last();
 
-        /// <summary>
-        /// Returns the <see cref="Type.Name"/> property
-        /// without including generic type information.
-        /// </summary>
-        public static string GetNameWithoutGenericArity(this Type t)
-        {
-            var name = t.Name;
-            var index = name.IndexOf('`');
-
-            return index == -1 ? name : name[..index];
-        }
-
-        /// <summary>
-        /// Get a list of types that describes the path needed to
-        /// reach an unboxed 'result' type in the type's generic
-        /// arguments e.g. the right of an Either, or the result of a Task.
-        /// </summary>
-        /// <remarks>
-        /// We currently only support 'result' types (e.g. Either, Task
-        /// or ActionResult), although it may be useful to handle other
-        /// types such as Lists, Dictionary, etc, in the future.
-        /// </remarks>
-        public static List<Type> GetUnboxedResultTypePath(this Type type)
-        {
-            var path = new List<Type>{ type };
-
-            while (true)
+            if (!currentType.IsConstructedGenericType)
             {
-                var currentType = path.Last();
-
-                if (!currentType.IsConstructedGenericType)
-                {
-                    return path;
-                }
-
-                // Potentially unsafe to use just the name for this,
-                // but realistically, we're never going to create
-                // other types with these names.
-                switch (currentType.GetNameWithoutGenericArity())
-                {
-                    case "Task":
-                    case "ActionResult":
-                        path.Add(currentType.GenericTypeArguments[0]);
-                        continue;
-
-                    case "Either":
-                        path.Add(currentType.GenericTypeArguments[1]);
-                        continue;
-                }
-
                 return path;
             }
-        }
 
-        /// <summary>
-        /// Get the loadable types for an assembly, ignoring types that may
-        /// transitively consume types from an inaccessible assembly.
-        /// </summary>
-        /// <param name="assembly">The assembly to load types from.</param>
-        public static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
+            // Potentially unsafe to use just the name for this,
+            // but realistically, we're never going to create
+            // other types with these names.
+            switch (currentType.GetNameWithoutGenericArity())
+            {
+                case "Task":
+                case "ActionResult":
+                    path.Add(currentType.GenericTypeArguments[0]);
+                    continue;
+
+                case "Either":
+                    path.Add(currentType.GenericTypeArguments[1]);
+                    continue;
+            }
+
+            return path;
+        }
+    }
+
+    /// <summary>
+    /// Get the loadable types for an assembly, ignoring types that may
+    /// transitively consume types from an inaccessible assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly to load types from.</param>
+    public static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
+    {
+        try
         {
-            try
-            {
-                return assembly.GetTypes();
-            }
-            catch (ReflectionTypeLoadException e)
-            {
-                return e.Types.WhereNotNull();
-            }
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException e)
+        {
+            return e.Types.WhereNotNull();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ZipArchiveExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ZipArchiveExtensions.cs
@@ -2,23 +2,22 @@
 using System;
 using System.IO.Compression;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class ZipArchiveExtensions
 {
-    public static class ZipArchiveExtensions
+    /// <summary>
+    /// Adds Unix file permissions to the zip entry.
+    /// </summary>
+    /// <remarks>
+    /// We need this due to .NET not adding these permissions for us.
+    /// See: https://github.com/dotnet/runtime/issues/1548
+    /// This should be fixed in .NET 6 as part of the following PR:
+    /// https://github.com/dotnet/runtime/pull/55531
+    /// </remarks>
+    public static ZipArchiveEntry SetUnixPermissions(this ZipArchiveEntry entry, string permissions)
     {
-        /// <summary>
-        /// Adds Unix file permissions to the zip entry.
-        /// </summary>
-        /// <remarks>
-        /// We need this due to .NET not adding these permissions for us.
-        /// See: https://github.com/dotnet/runtime/issues/1548
-        /// This should be fixed in .NET 6 as part of the following PR:
-        /// https://github.com/dotnet/runtime/pull/55531
-        /// </remarks>
-        public static ZipArchiveEntry SetUnixPermissions(this ZipArchiveEntry entry, string permissions)
-        {
-            entry.ExternalAttributes |= Convert.ToInt32(permissions, 8) << 16;
-            return entry;
-        }
+        entry.ExternalAttributes |= Convert.ToInt32(permissions, 8) << 16;
+        return entry;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Functions/ConnectionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Functions/ConnectionUtils.cs
@@ -2,55 +2,54 @@ using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Functions
+namespace GovUk.Education.ExploreEducationStatistics.Common.Functions;
+
+public enum ConnectionTypes
 {
-    public enum ConnectionTypes
+    AZURE_STORAGE,
+    AZURE_SQL
+}
+
+public static class ConnectionUtils
+{
+
+    public static string GetAzureStorageConnectionString(string name)
     {
-        AZURE_STORAGE,
-        AZURE_SQL
+        return GetConnectionString(name,
+            $"{ConnectionTypeValues[ConnectionTypes.AZURE_STORAGE]}");
+    }
+    
+    public static string GetAzureSqlConnectionString(string name)
+    {
+        return GetConnectionString(name,
+            $"{ConnectionTypeValues[ConnectionTypes.AZURE_SQL]}");
+    }
+    
+    private static string GetConnectionString(string name, string connectionTypeValue)
+    {
+        // Attempt to get a connection string defined for running locally.
+        // Settings in the local.settings.json file are only used by Functions tools when running locally.
+        var connectionString =
+            Environment.GetEnvironmentVariable($"ConnectionStrings:{name}", EnvironmentVariableTarget.Process);
+
+        if (connectionString.IsNullOrEmpty())
+        {
+            // Get the connection string from the Azure Functions App using the naming convention for type SQLAzure.
+            connectionString = Environment.GetEnvironmentVariable($"{connectionTypeValue}_{name}", EnvironmentVariableTarget.Process);
+        }
+
+        return connectionString;
     }
 
-    public static class ConnectionUtils
-    {
-
-        public static string GetAzureStorageConnectionString(string name)
+    
+    private static readonly Dictionary<ConnectionTypes, string> ConnectionTypeValues =
+        new Dictionary<ConnectionTypes, string>
         {
-            return GetConnectionString(name,
-                $"{ConnectionTypeValues[ConnectionTypes.AZURE_STORAGE]}");
-        }
-        
-        public static string GetAzureSqlConnectionString(string name)
-        {
-            return GetConnectionString(name,
-                $"{ConnectionTypeValues[ConnectionTypes.AZURE_SQL]}");
-        }
-        
-        private static string GetConnectionString(string name, string connectionTypeValue)
-        {
-            // Attempt to get a connection string defined for running locally.
-            // Settings in the local.settings.json file are only used by Functions tools when running locally.
-            var connectionString =
-                Environment.GetEnvironmentVariable($"ConnectionStrings:{name}", EnvironmentVariableTarget.Process);
-
-            if (connectionString.IsNullOrEmpty())
             {
-                // Get the connection string from the Azure Functions App using the naming convention for type SQLAzure.
-                connectionString = Environment.GetEnvironmentVariable($"{connectionTypeValue}_{name}", EnvironmentVariableTarget.Process);
+                ConnectionTypes.AZURE_STORAGE, "CUSTOMCONNSTR"
+            },
+            {
+                ConnectionTypes.AZURE_SQL, "SQLAZURECONNSTR"
             }
-
-            return connectionString;
-        }
-
-        
-        private static readonly Dictionary<ConnectionTypes, string> ConnectionTypeValues =
-            new Dictionary<ConnectionTypes, string>
-            {
-                {
-                    ConnectionTypes.AZURE_STORAGE, "CUSTOMCONNSTR"
-                },
-                {
-                    ConnectionTypes.AZURE_SQL, "SQLAZURECONNSTR"
-                }
-            }; 
-    }
+        }; 
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/BlobInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/BlobInfo.cs
@@ -2,38 +2,37 @@
 using System;
 using System.Collections.Generic;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public class BlobInfo
 {
-    public class BlobInfo
+    public readonly string Path;
+
+    public readonly string ContentType;
+
+    public readonly long ContentLength;
+
+    public readonly IDictionary<string, string> Meta;
+
+    public readonly DateTimeOffset? Created;
+
+    public readonly DateTimeOffset? Updated;
+
+    public BlobInfo(
+        string path,
+        string contentType,
+        long contentLength,
+        IDictionary<string, string>? meta = null,
+        DateTimeOffset? created = null,
+        DateTimeOffset? updated = null)
     {
-        public readonly string Path;
-
-        public readonly string ContentType;
-
-        public readonly long ContentLength;
-
-        public readonly IDictionary<string, string> Meta;
-
-        public readonly DateTimeOffset? Created;
-
-        public readonly DateTimeOffset? Updated;
-
-        public BlobInfo(
-            string path,
-            string contentType,
-            long contentLength,
-            IDictionary<string, string>? meta = null,
-            DateTimeOffset? created = null,
-            DateTimeOffset? updated = null)
-        {
-            Path = path;
-            ContentType = contentType;
-            ContentLength = contentLength;
-            Meta = meta ?? new Dictionary<string, string>();
-            Created = created;
-            Updated = updated;
-        }
-
-        public string FileName => Path.Substring(Path.LastIndexOf('/') + 1);
+        Path = path;
+        ContentType = contentType;
+        ContentLength = contentLength;
+        Meta = meta ?? new Dictionary<string, string>();
+        Created = created;
+        Updated = updated;
     }
+
+    public string FileName => Path.Substring(Path.LastIndexOf('/') + 1);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/BlobLease.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/BlobLease.cs
@@ -1,20 +1,19 @@
 using System.Threading.Tasks;
 using Azure.Storage.Blobs.Specialized;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public class BlobLease
 {
-    public class BlobLease
+    private readonly BlobLeaseClient _leaseClient;
+
+    public BlobLease(BlobLeaseClient leaseClient)
     {
-        private readonly BlobLeaseClient _leaseClient;
+        _leaseClient = leaseClient;
+    }
 
-        public BlobLease(BlobLeaseClient leaseClient)
-        {
-            _leaseClient = leaseClient;
-        }
-
-        public async Task Release()
-        {
-            await _leaseClient.ReleaseAsync();
-        }
+    public async Task Release()
+    {
+        await _leaseClient.ReleaseAsync();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
@@ -5,96 +5,95 @@ using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
+
+public class ChartAxisConfiguration
 {
-    public class ChartAxisConfiguration
-    {
-        public string Name = null!;
+    public string Name = null!;
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public AxisType Type;
+    [JsonConverter(typeof(StringEnumConverter))]
+    public AxisType Type;
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public AxisGroupBy? GroupBy;
+    [JsonConverter(typeof(StringEnumConverter))]
+    public AxisGroupBy? GroupBy;
 
-        public string? GroupByFilter;
-        public bool GroupByFilterGroups;
+    public string? GroupByFilter;
+    public bool GroupByFilterGroups;
 
-        public string SortBy = null!;
-        public bool SortAsc = true;
+    public string SortBy = null!;
+    public bool SortAsc = true;
 
-        public List<ChartDataSet> DataSets = new();
-        public List<AxisReferenceLine> ReferenceLines = new();
-        public bool Visible = true;
-        public string Title = null!;
-        public string Unit = null!;
-        public bool ShowGrid = true;
+    public List<ChartDataSet> DataSets = new();
+    public List<AxisReferenceLine> ReferenceLines = new();
+    public bool Visible = true;
+    public string Title = null!;
+    public string Unit = null!;
+    public bool ShowGrid = true;
 
-        public AxisLabel Label = null!;
+    public AxisLabel Label = null!;
 
-        public int? Min;
-        public int? Max;
-        public int? Size;
+    public int? Min;
+    public int? Max;
+    public int? Size;
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public AxisTickConfig TickConfig;
+    [JsonConverter(typeof(StringEnumConverter))]
+    public AxisTickConfig TickConfig;
 
-        public int? TickSpacing;
-    }
+    public int? TickSpacing;
+}
 
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public enum AxisGroupBy
-    {
-        timePeriod,
-        locations,
-        filters,
-        indicators
-    }
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public enum AxisGroupBy
+{
+    timePeriod,
+    locations,
+    filters,
+    indicators
+}
 
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public enum AxisType
-    {
-        major,
-        minor
-    }
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public enum AxisType
+{
+    major,
+    minor
+}
 
-    public class AxisLabel
-    {
-        public string Text = null!;
-        public int? Width;
-        public bool? Rotated;
-    }
+public class AxisLabel
+{
+    public string Text = null!;
+    public int? Width;
+    public bool? Rotated;
+}
 
-    public class AxisReferenceLine
-    {
-        public string Label = null!;
-        public string Position = null!;
-        
-        [JsonConverter(typeof(StringEnumConverter))]
-        public AxisReferenceLineStyle? Style;
+public class AxisReferenceLine
+{
+    public string Label = null!;
+    public string Position = null!;
+    
+    [JsonConverter(typeof(StringEnumConverter))]
+    public AxisReferenceLineStyle? Style;
 
-        public int? LabelWidth;
+    public int? LabelWidth;
 
-        public int? OtherAxisPosition;
+    public int? OtherAxisPosition;
 
-        public string? OtherAxisStart;
+    public string? OtherAxisStart;
 
-        public string? OtherAxisEnd;
-    }
+    public string? OtherAxisEnd;
+}
 
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public enum AxisTickConfig
-    {
-        [EnumMember(Value = "default")] Default,
-        startEnd,
-        custom
-    }
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public enum AxisTickConfig
+{
+    [EnumMember(Value = "default")] Default,
+    startEnd,
+    custom
+}
 
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public enum AxisReferenceLineStyle
-    {
-        dashed,
-        solid,
-        none
-    }
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public enum AxisReferenceLineStyle
+{
+    dashed,
+    solid,
+    none
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataSet.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataSet.cs
@@ -4,40 +4,39 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
+
+public class ChartBaseDataSet
 {
-    public class ChartBaseDataSet
-    {
-        public Guid? Indicator;
-        public List<Guid> Filters = new();
-        public ChartDataSetLocation? Location;
-        public string? TimePeriod;
-    }
+    public Guid? Indicator;
+    public List<Guid> Filters = new();
+    public ChartDataSetLocation? Location;
+    public string? TimePeriod;
+}
 
-    public class ChartDataSet : ChartBaseDataSet
-    {
-        public int? Order;
+public class ChartDataSet : ChartBaseDataSet
+{
+    public int? Order;
 
-        // TODO EES-1649 Migrate data set configs to legend item configs
-        public ChartDataSetConfiguration? Config;
-    }
+    // TODO EES-1649 Migrate data set configs to legend item configs
+    public ChartDataSetConfiguration? Config;
+}
 
-    public class ChartDataSetLocation
-    {
-        public string Level;
-        public Guid Value;
-    }
+public class ChartDataSetLocation
+{
+    public string Level;
+    public Guid Value;
+}
 
-    [Obsolete("Use legend item configurations")]
-    public class ChartDataSetConfiguration
-    {
-        public string Label;
-        public string Colour;
+[Obsolete("Use legend item configurations")]
+public class ChartDataSetConfiguration
+{
+    public string Label;
+    public string Colour;
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public ChartLineSymbol? Symbol;
+    [JsonConverter(typeof(StringEnumConverter))]
+    public ChartLineSymbol? Symbol;
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public ChartLineStyle? LineStyle;
-    }
+    [JsonConverter(typeof(StringEnumConverter))]
+    public ChartLineStyle? LineStyle;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataSetConfig.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataSetConfig.cs
@@ -4,27 +4,26 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
+
+public class ChartDataSetConfig
 {
-    public class ChartDataSetConfig
-    {
-        public ChartBaseDataSet DataSet;
-        public ChartDataGrouping DataGrouping;
-        public BoundaryLevel BoundaryLevels;
-    }
+    public ChartBaseDataSet DataSet;
+    public ChartDataGrouping DataGrouping;
+    public BoundaryLevel BoundaryLevels;
+}
 
-    [JsonConverter(typeof(StringEnumConverter))]
-    public enum ChartDataGroupingType
-    {
-        EqualIntervals,
-        Quantiles,
-        Custom,
-    }
+[JsonConverter(typeof(StringEnumConverter))]
+public enum ChartDataGroupingType
+{
+    EqualIntervals,
+    Quantiles,
+    Custom,
+}
 
-    public class ChartDataGrouping
-    {
-        public ChartDataGroupingType Type;
-        public int NumberOfGroups;
-        public List<ChartCustomDataGroup> CustomGroups = new();
-    }
+public class ChartDataGrouping
+{
+    public ChartDataGroupingType Type;
+    public int NumberOfGroups;
+    public List<ChartCustomDataGroup> CustomGroups = new();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLegend.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLegend.cs
@@ -5,37 +5,36 @@ using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
+
+public class ChartLegend
 {
-    public class ChartLegend
-    {
-        public ChartLegendPosition? Position;
-        public List<ChartLegendItem> Items = new List<ChartLegendItem>();
-    }
+    public ChartLegendPosition? Position;
+    public List<ChartLegendItem> Items = new List<ChartLegendItem>();
+}
 
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[JsonConverter(typeof(StringEnumConverter))]
+public enum ChartLegendPosition
+{
+    none,
+    bottom,
+    top,
+    inline
+}
+
+public class ChartLegendItem
+{
+    public ChartBaseDataSet DataSet;
+    public string Label;
+    public string Colour;
+
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum ChartLegendPosition
-    {
-        none,
-        bottom,
-        top,
-        inline
-    }
+    public ChartLineSymbol? Symbol;
 
-    public class ChartLegendItem
-    {
-        public ChartBaseDataSet DataSet;
-        public string Label;
-        public string Colour;
+    [JsonConverter(typeof(StringEnumConverter))]
+    public ChartLineStyle? LineStyle;
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public ChartLineSymbol? Symbol;
-
-        [JsonConverter(typeof(StringEnumConverter))]
-        public ChartLineStyle? LineStyle;
-
-        [JsonConverter(typeof(StringEnumConverter))]
-        public ChartInlinePosition? InlinePosition;
-    }
+    [JsonConverter(typeof(StringEnumConverter))]
+    public ChartInlinePosition? InlinePosition;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLineEnums.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLineEnums.cs
@@ -1,31 +1,30 @@
 using System.Diagnostics.CodeAnalysis;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
+
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public enum ChartLineStyle
 {
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public enum ChartLineStyle
-    {
-        solid,
-        dashed,
-        dotted
-    }
+    solid,
+    dashed,
+    dotted
+}
 
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public enum ChartLineSymbol
-    {
-        circle,
-        cross,
-        diamond,
-        square,
-        star,
-        triangle,
-        wye,
-        none
-    }
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public enum ChartLineSymbol
+{
+    circle,
+    cross,
+    diamond,
+    square,
+    star,
+    triangle,
+    wye,
+    none
+}
 
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public enum ChartInlinePosition
-    {
-        above, below
-    }
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public enum ChartInlinePosition
+{
+    above, below
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartType.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartType.cs
@@ -3,24 +3,23 @@ using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using Newtonsoft.Json;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
+
+[SuppressMessage("ReSharper", "IdentifierTypo")]
+[SuppressMessage("ReSharper", "StringLiteralTypo")]
+[JsonConverter(typeof(EnumToEnumValueJsonConverter<ChartType>))]
+public enum ChartType
 {
-    [SuppressMessage("ReSharper", "IdentifierTypo")]
-    [SuppressMessage("ReSharper", "StringLiteralTypo")]
-    [JsonConverter(typeof(EnumToEnumValueJsonConverter<ChartType>))]
-    public enum ChartType
-    {
-        [EnumLabelValue("Line", "line")] Line,
+    [EnumLabelValue("Line", "line")] Line,
 
-        [EnumLabelValue("Horizontal Bar", "horizontalbar")]
-        HorizontalBar,
+    [EnumLabelValue("Horizontal Bar", "horizontalbar")]
+    HorizontalBar,
 
-        [EnumLabelValue("Vertical Bar", "verticalbar")]
-        VerticalBar,
+    [EnumLabelValue("Vertical Bar", "verticalbar")]
+    VerticalBar,
 
-        [EnumLabelValue("Map", "map")] Map,
+    [EnumLabelValue("Map", "map")] Map,
 
-        [EnumLabelValue("Infographic", "infographic")]
-        Infographic
-    }
+    [EnumLabelValue("Infographic", "infographic")]
+    Infographic
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
@@ -7,106 +7,105 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.Chart.ChartType;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
+
+
+[JsonConverter(typeof(StringEnumConverter), typeof(CamelCaseNamingStrategy))]
+public enum BarChartDataLabelPosition
 {
+    Inside, Outside
+}
 
-    [JsonConverter(typeof(StringEnumConverter), typeof(CamelCaseNamingStrategy))]
-    public enum BarChartDataLabelPosition
-    {
-        Inside, Outside
-    }
+[JsonConverter(typeof(StringEnumConverter), typeof(CamelCaseNamingStrategy))]
+public enum LineChartDataLabelPosition
+{
+    Above, Below
+}
 
-    [JsonConverter(typeof(StringEnumConverter), typeof(CamelCaseNamingStrategy))]
-    public enum LineChartDataLabelPosition
-    {
-        Above, Below
-    }
+[JsonConverter(typeof(ContentBlockChartConverter))]
+public interface IChart
+{
+    ChartType Type { get; }
+    string? Title { get; set; }
+    string Alt { get; set; }
+    int Height { get; set; }
+    int? Width { get; set; }
+    bool IncludeNonNumericData { get; set; }
 
-    [JsonConverter(typeof(ContentBlockChartConverter))]
-    public interface IChart
-    {
-        ChartType Type { get; }
-        string? Title { get; set; }
-        string Alt { get; set; }
-        int Height { get; set; }
-        int? Width { get; set; }
-        bool IncludeNonNumericData { get; set; }
+    Dictionary<string, ChartAxisConfiguration>? Axes { get; set; }
+    public ChartLegend? Legend { get; set; }
 
-        Dictionary<string, ChartAxisConfiguration>? Axes { get; set; }
-        public ChartLegend? Legend { get; set; }
+}
 
-    }
+public abstract class Chart : IChart
+{
+    public string? Title { get; set; }
+    public string? Subtitle { get; set; }
+    public string Alt { get; set; }
+    public int Height { get; set; }
+    public int? Width { get; set; }
+    public bool IncludeNonNumericData { get; set; } = false;
 
-    public abstract class Chart : IChart
-    {
-        public string? Title { get; set; }
-        public string? Subtitle { get; set; }
-        public string Alt { get; set; }
-        public int Height { get; set; }
-        public int? Width { get; set; }
-        public bool IncludeNonNumericData { get; set; } = false;
+    public abstract ChartType Type { get; }
 
-        public abstract ChartType Type { get; }
+    public Dictionary<string, ChartAxisConfiguration>? Axes { get; set; }
 
-        public Dictionary<string, ChartAxisConfiguration>? Axes { get; set; }
+    public ChartLegend? Legend { get; set; }
+}
 
-        public ChartLegend? Legend { get; set; }
-    }
+public class LineChart : Chart
+{
+    public override ChartType Type => Line;
+    public bool ShowDataLabels { get; set; }
+    public LineChartDataLabelPosition? DataLabelPosition { get; set; }
+}
 
-    public class LineChart : Chart
-    {
-        public override ChartType Type => Line;
-        public bool ShowDataLabels { get; set; }
-        public LineChartDataLabelPosition? DataLabelPosition { get; set; }
-    }
+public class HorizontalBarChart : Chart
+{
+    public override ChartType Type => HorizontalBar;
 
-    public class HorizontalBarChart : Chart
-    {
-        public override ChartType Type => HorizontalBar;
+    public int? BarThickness { get; set; }
+    public bool Stacked;
+    public bool ShowDataLabels { get; set; }
+    public BarChartDataLabelPosition? DataLabelPosition { get; set; }
+}
 
-        public int? BarThickness { get; set; }
-        public bool Stacked;
-        public bool ShowDataLabels { get; set; }
-        public BarChartDataLabelPosition? DataLabelPosition { get; set; }
-    }
+public class VerticalBarChart : Chart
+{
+    public override ChartType Type => VerticalBar;
 
-    public class VerticalBarChart : Chart
-    {
-        public override ChartType Type => VerticalBar;
+    public int? BarThickness { get; set; }
+    public bool Stacked;
+    public bool ShowDataLabels { get; set; }
+    public BarChartDataLabelPosition? DataLabelPosition { get; set; }
+}
 
-        public int? BarThickness { get; set; }
-        public bool Stacked;
-        public bool ShowDataLabels { get; set; }
-        public BarChartDataLabelPosition? DataLabelPosition { get; set; }
-    }
+public class MapChart : Chart
+{
+    public override ChartType Type => ChartType.Map;
 
-    public class MapChart : Chart
-    {
-        public override ChartType Type => ChartType.Map;
+    // TODO EES-3319 - make mandatory when all Map Charts are migrated to have a Boundary Level set
+    public long? BoundaryLevel { get; set; }
 
-        // TODO EES-3319 - make mandatory when all Map Charts are migrated to have a Boundary Level set
-        public long? BoundaryLevel { get; set; }
+    // TODO EES-4271
+    [Obsolete("Migrate to `DataSetConfigs` in EES-4271")]
+    [JsonConverter(typeof(StringEnumConverter))]
+    public ChartDataClassification? DataClassification { get; set; }
 
-        // TODO EES-4271
-        [Obsolete("Migrate to `DataSetConfigs` in EES-4271")]
-        [JsonConverter(typeof(StringEnumConverter))]
-        public ChartDataClassification? DataClassification { get; set; }
+    // TODO EES-4271
+    [Obsolete("Migrate to `DataSetConfigs` in EES-4271")]
+    public int? DataGroups { get; set; }
 
-        // TODO EES-4271
-        [Obsolete("Migrate to `DataSetConfigs` in EES-4271")]
-        public int? DataGroups { get; set; }
+    public MapChartConfig Map { get; set; } = new();
+}
 
-        public MapChartConfig Map { get; set; } = new();
-    }
+public class MapChartConfig
+{
+    public List<ChartDataSetConfig> DataSetConfigs { get; set; } = new();
+}
 
-    public class MapChartConfig
-    {
-        public List<ChartDataSetConfig> DataSetConfigs { get; set; } = new();
-    }
-
-    public class InfographicChart : Chart
-    {
-        public override ChartType Type => Infographic;
-        public string FileId { get; set; }
-    }
+public class InfographicChart : Chart
+{
+    public override ChartType Type => Infographic;
+    public string FileId { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/BoundaryLevel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/BoundaryLevel.cs
@@ -1,18 +1,17 @@
 using System;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+
+public class BoundaryLevel
 {
-    public class BoundaryLevel
-    {
-        public long Id { get; set; }
-        public GeographicLevel Level { get; set; }
-        
-        public string Label { get; set; }
-        
-        // The date that this Boundary Level was introduced to the service.
-        public DateTime Created { get; set; }
-        
-        // The date that this Boundary Level was published by the data issuer.
-        public DateTime Published { get; set; }
-    }
+    public long Id { get; set; }
+    public GeographicLevel Level { get; set; }
+    
+    public string Label { get; set; }
+    
+    // The date that this Boundary Level was introduced to the service.
+    public DateTime Created { get; set; }
+    
+    // The date that this Boundary Level was published by the data issuer.
+    public DateTime Published { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/GeographicLevel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/GeographicLevel.cs
@@ -1,53 +1,52 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+
+public enum GeographicLevel
 {
-    public enum GeographicLevel
-    {
-        [EnumLabelValue("English devolved area", "EDA")]
-        EnglishDevolvedArea,
+    [EnumLabelValue("English devolved area", "EDA")]
+    EnglishDevolvedArea,
 
-        [EnumLabelValue("Local authority", "LA")]
-        LocalAuthority,
+    [EnumLabelValue("Local authority", "LA")]
+    LocalAuthority,
 
-        [EnumLabelValue("Local authority district", "LAD")]
-        LocalAuthorityDistrict,
+    [EnumLabelValue("Local authority district", "LAD")]
+    LocalAuthorityDistrict,
 
-        [EnumLabelValue("Local enterprise partnership", "LEP")]
-        LocalEnterprisePartnership,
+    [EnumLabelValue("Local enterprise partnership", "LEP")]
+    LocalEnterprisePartnership,
 
-        [EnumLabelValue("Local skills improvement plan area", "LSIP")]
-        LocalSkillsImprovementPlanArea,
+    [EnumLabelValue("Local skills improvement plan area", "LSIP")]
+    LocalSkillsImprovementPlanArea,
 
-        [EnumLabelValue("Institution", "INST")] Institution,
+    [EnumLabelValue("Institution", "INST")] Institution,
 
-        [EnumLabelValue("Mayoral combined authority", "MCA")]
-        MayoralCombinedAuthority,
+    [EnumLabelValue("Mayoral combined authority", "MCA")]
+    MayoralCombinedAuthority,
 
-        [EnumLabelValue("MAT", "MAT")] MultiAcademyTrust,
+    [EnumLabelValue("MAT", "MAT")] MultiAcademyTrust,
 
-        [EnumLabelValue("National", "NAT")] Country,
+    [EnumLabelValue("National", "NAT")] Country,
 
-        [EnumLabelValue("Opportunity area", "OA")]
-        OpportunityArea,
+    [EnumLabelValue("Opportunity area", "OA")]
+    OpportunityArea,
 
-        [EnumLabelValue("Parliamentary constituency", "PCON")]
-        ParliamentaryConstituency,
+    [EnumLabelValue("Parliamentary constituency", "PCON")]
+    ParliamentaryConstituency,
 
-        [EnumLabelValue("Provider", "PROV")] Provider,
+    [EnumLabelValue("Provider", "PROV")] Provider,
 
-        [EnumLabelValue("Regional", "REG")] Region,
+    [EnumLabelValue("Regional", "REG")] Region,
 
-        // Regional School Commissioner Region
-        [EnumLabelValue("RSC region", "RSC")] RscRegion,
+    // Regional School Commissioner Region
+    [EnumLabelValue("RSC region", "RSC")] RscRegion,
 
-        [EnumLabelValue("School", "SCH")] School,
+    [EnumLabelValue("School", "SCH")] School,
 
-        [EnumLabelValue("Sponsor", "SPON")] Sponsor,
+    [EnumLabelValue("Sponsor", "SPON")] Sponsor,
 
-        [EnumLabelValue("Ward", "WARD")] Ward,
+    [EnumLabelValue("Ward", "WARD")] Ward,
 
-        [EnumLabelValue("Planning area", "PA")] PlanningArea
-    }
+    [EnumLabelValue("Planning area", "PA")] PlanningArea
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/ObservationQueryContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/ObservationQueryContext.cs
@@ -2,28 +2,27 @@ using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query
-{
-    public class ObservationQueryContext
-    {
-        public Guid SubjectId { get; set; }
-        public TimePeriodQuery TimePeriod { get; set; }
-        public IEnumerable<Guid> Filters { get; set; } = new List<Guid>();
-        // TODO EES-3328 - remove BoundaryLevel from ObservationQueryContext as we now store it on
-        // MapChart configuration instead
-        public long? BoundaryLevel { get; set; }
-        public IEnumerable<Guid> Indicators { get; set; } = new List<Guid>();
-        public List<Guid> LocationIds { get; set; } = new();
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 
-        public override string ToString()
-        {
-            return
-                $"{nameof(SubjectId)}: {SubjectId}, " +
-                $"{nameof(TimePeriod)}: {TimePeriod}, " +
-                $"{nameof(Filters)}: [{(Filters == null ? string.Empty : Filters.JoinToString(", "))}], " +
-                $"{nameof(BoundaryLevel)}: {BoundaryLevel}, " +
-                $"{nameof(Indicators)}: [{(Indicators == null ? string.Empty : Indicators.JoinToString(", "))}], " +
-                $"{nameof(LocationIds)}: [{LocationIds.JoinToString(", ")}]";
-        }
+public class ObservationQueryContext
+{
+    public Guid SubjectId { get; set; }
+    public TimePeriodQuery TimePeriod { get; set; }
+    public IEnumerable<Guid> Filters { get; set; } = new List<Guid>();
+    // TODO EES-3328 - remove BoundaryLevel from ObservationQueryContext as we now store it on
+    // MapChart configuration instead
+    public long? BoundaryLevel { get; set; }
+    public IEnumerable<Guid> Indicators { get; set; } = new List<Guid>();
+    public List<Guid> LocationIds { get; set; } = new();
+
+    public override string ToString()
+    {
+        return
+            $"{nameof(SubjectId)}: {SubjectId}, " +
+            $"{nameof(TimePeriod)}: {TimePeriod}, " +
+            $"{nameof(Filters)}: [{(Filters == null ? string.Empty : Filters.JoinToString(", "))}], " +
+            $"{nameof(BoundaryLevel)}: {BoundaryLevel}, " +
+            $"{nameof(Indicators)}: [{(Indicators == null ? string.Empty : Indicators.JoinToString(", "))}], " +
+            $"{nameof(LocationIds)}: [{LocationIds.JoinToString(", ")}]";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/TimePeriodQuery.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/TimePeriodQuery.cs
@@ -2,30 +2,29 @@ using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Newtonsoft.Json;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+
+public record TimePeriodQuery
 {
-    public record TimePeriodQuery
+    public int StartYear { get; set; }
+
+    [JsonConverter(typeof(EnumToEnumValueJsonConverter<TimeIdentifier>))]
+    public TimeIdentifier StartCode { get; set; }
+
+    public int EndYear { get; set; }
+
+    [JsonConverter(typeof(EnumToEnumValueJsonConverter<TimeIdentifier>))]
+    public TimeIdentifier EndCode { get; set; }
+
+    public TimePeriodQuery()
     {
-        public int StartYear { get; set; }
+    }
 
-        [JsonConverter(typeof(EnumToEnumValueJsonConverter<TimeIdentifier>))]
-        public TimeIdentifier StartCode { get; set; }
-
-        public int EndYear { get; set; }
-
-        [JsonConverter(typeof(EnumToEnumValueJsonConverter<TimeIdentifier>))]
-        public TimeIdentifier EndCode { get; set; }
-
-        public TimePeriodQuery()
-        {
-        }
-
-        public TimePeriodQuery(int startYear, TimeIdentifier startCode, int endYear, TimeIdentifier endCode)
-        {
-            StartYear = startYear;
-            StartCode = startCode;
-            EndYear = endYear;
-            EndCode = endCode;
-        }
+    public TimePeriodQuery(int startYear, TimeIdentifier startCode, int endYear, TimeIdentifier endCode)
+    {
+        StartYear = startYear;
+        StartCode = startCode;
+        EndYear = endYear;
+        EndCode = endCode;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/TableBuilderConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/TableBuilderConfiguration.cs
@@ -1,8 +1,7 @@
 #nullable enable
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+
+public class TableBuilderConfiguration
 {
-    public class TableBuilderConfiguration
-    {
-        public TableHeaders TableHeaders { get; set; } = new();
-    }
+    public TableHeaders TableHeaders { get; set; } = new();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/TableHeader.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/TableHeader.cs
@@ -3,42 +3,41 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+
+public class TableHeader
 {
-    public class TableHeader
+    public string? Level { get; set; }
+    public string Value { get; set; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public TableHeaderType Type { get; set; }
+
+    private TableHeader()
     {
-        public string? Level { get; set; }
-        public string Value { get; set; }
-
-        [JsonConverter(typeof(StringEnumConverter))]
-        public TableHeaderType Type { get; set; }
-
-        private TableHeader()
-        {
-        }
-
-        public TableHeader(string value, TableHeaderType type)
-        {
-            Value = value;
-            Type = type;
-        }
-
-        public static TableHeader NewLocationHeader(GeographicLevel level, string value)
-        {
-            return new()
-            {
-                Level = level.ToString().CamelCase(),
-                Value = value,
-                Type = TableHeaderType.Location
-            };
-        }
     }
 
-    public enum TableHeaderType
+    public TableHeader(string value, TableHeaderType type)
     {
-        Filter,
-        Indicator,
-        Location,
-        TimePeriod
+        Value = value;
+        Type = type;
     }
+
+    public static TableHeader NewLocationHeader(GeographicLevel level, string value)
+    {
+        return new()
+        {
+            Level = level.ToString().CamelCase(),
+            Value = value,
+            Type = TableHeaderType.Location
+        };
+    }
+}
+
+public enum TableHeaderType
+{
+    Filter,
+    Indicator,
+    Location,
+    TimePeriod
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/DataArchiveFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/DataArchiveFile.cs
@@ -1,35 +1,34 @@
 using System.IO.Compression;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public interface IDataArchiveFile
 {
-    public interface IDataArchiveFile
-    {
-        public string DataFileName { get; }
-        public string MetaFileName { get; }
+    public string DataFileName { get; }
+    public string MetaFileName { get; }
 
-        public long DataFileSize { get; }
-        public long MetaFileSize { get; }
+    public long DataFileSize { get; }
+    public long MetaFileSize { get; }
+}
+
+public class DataArchiveFile : IDataArchiveFile
+{
+    private readonly ZipArchiveEntry _dataFile;
+    private readonly ZipArchiveEntry _metaFile;
+
+    public DataArchiveFile()
+    {
     }
 
-    public class DataArchiveFile : IDataArchiveFile
+    public DataArchiveFile(ZipArchiveEntry dataFile, ZipArchiveEntry metaFile)
     {
-        private readonly ZipArchiveEntry _dataFile;
-        private readonly ZipArchiveEntry _metaFile;
-
-        public DataArchiveFile()
-        {
-        }
-
-        public DataArchiveFile(ZipArchiveEntry dataFile, ZipArchiveEntry metaFile)
-        {
-            _dataFile = dataFile;
-            _metaFile = metaFile;
-        }
-
-        public string DataFileName => _dataFile.Name.ToLower();
-        public string MetaFileName => _metaFile.Name.ToLower();
-
-        public long DataFileSize => _dataFile.Length;
-        public long MetaFileSize => _metaFile.Length;
+        _dataFile = dataFile;
+        _metaFile = metaFile;
     }
+
+    public string DataFileName => _dataFile.Name.ToLower();
+    public string MetaFileName => _metaFile.Name.ToLower();
+
+    public long DataFileSize => _dataFile.Length;
+    public long MetaFileSize => _metaFile.Length;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/DataFilePermissions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/DataFilePermissions.cs
@@ -1,7 +1,6 @@
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public class DataFilePermissions
 {
-    public class DataFilePermissions
-    {
-        public bool CanCancelImport { get; set; }
-    }
+    public bool CanCancelImport { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -3,576 +3,575 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public class Either<TL, TR>
 {
-    public class Either<TL, TR>
+    private readonly TL _left;
+    private readonly TR _right;
+
+    public Either(TL left)
     {
-        private readonly TL _left;
-        private readonly TR _right;
-
-        public Either(TL left)
-        {
-            _left = left;
-            IsLeft = true;
-        }
-
-        public Either(TR right)
-        {
-            _right = right;
-            IsLeft = false;
-        }
-
-        public bool IsLeft { get; }
-
-        public bool IsRight => !IsLeft;
-
-        public TL Left => IsLeft ? _left : throw new ArgumentException("Calling Left on a Right");
-
-        public TR Right => !IsLeft ? _right : throw new ArgumentException("Calling Right on a Left");
-
-        private Either<TL, T> Map<T>(Func<TR, T> func) =>
-            IsLeft ? new Either<TL, T>(Left) : new Either<TL, T>(func.Invoke(Right));
-
-        public Either<TL, T> OnSuccess<T>(Func<TR, T> func) => Map(func);
-
-        public async Task<Either<TL, T>> OnSuccess<T>(Func<Task<Either<TL, T>>> func)
-        {
-            if (IsLeft)
-            {
-                return _left;
-            }
-
-            return await func();
-        }
-
-        public async Task<Either<TL, T>> OnSuccess<T>(Func<TR, Task<Either<TL, T>>> func)
-        {
-            if (IsLeft)
-            {
-                return _left;
-            }
-
-            return await func.Invoke(_right);
-        }
-
-        public Either<TL, T> OnSuccess<T>(Func<T> func) => Map(_ => func.Invoke());
-
-        public Either<TL, T> OnSuccess<T>(Func<TR, Either<TL, T>> func) => IsLeft ? Left : func.Invoke(Right);
-
-        public Either<TL, TR> OrElse(Func<TR> func) => IsLeft ? func() : Right;
-
-        public Either<TL, TR> OrElse(Func<TL, TR> func) => IsLeft ? func(Left) : Right;
-
-        public T Fold<T>(Func<TL, T> leftFunc, Func<TR, T> rightFunc) => IsRight ? rightFunc(Right) : leftFunc(Left);
-
-        public T FoldLeft<T>(Func<TL, T> leftFunc, T defaultValue) => IsLeft ? leftFunc(Left) : defaultValue;
-
-        public T FoldRight<T>(Func<TR, T> rightFunc, T defaultValue) => IsRight ? rightFunc(Right) : defaultValue;
-
-        public static implicit operator Either<TL, TR>(TL left) => new(left);
-
-        public static implicit operator Either<TL, TR>(TR right) => new(right);
+        _left = left;
+        IsLeft = true;
     }
 
-    public static class EitherExtensions
+    public Either(TR right)
     {
-        /// <summary>
-        /// If all Eithers in the provided list are successful, return a list of the successful results. Otherwise,
-        /// return the first failure.
-        /// </summary>
-        public static Either<TFailure, List<TSuccess>> OnSuccessAll<TFailure, TSuccess>(
-            this IEnumerable<Either<TFailure, TSuccess>> items)
-        {
-            var result = new List<TSuccess>();
-            foreach (var either in items)
-            {
-                if (either.IsLeft)
-                {
-                    return either.Left;
-                }
+        _right = right;
+        IsLeft = false;
+    }
 
-                result.Add(either.Right);
-            }
-            return result;
+    public bool IsLeft { get; }
+
+    public bool IsRight => !IsLeft;
+
+    public TL Left => IsLeft ? _left : throw new ArgumentException("Calling Left on a Right");
+
+    public TR Right => !IsLeft ? _right : throw new ArgumentException("Calling Right on a Left");
+
+    private Either<TL, T> Map<T>(Func<TR, T> func) =>
+        IsLeft ? new Either<TL, T>(Left) : new Either<TL, T>(func.Invoke(Right));
+
+    public Either<TL, T> OnSuccess<T>(Func<TR, T> func) => Map(func);
+
+    public async Task<Either<TL, T>> OnSuccess<T>(Func<Task<Either<TL, T>>> func)
+    {
+        if (IsLeft)
+        {
+            return _left;
         }
 
-        /// <summary>
-        /// If all Eithers in the provided list are successful, return Unit.Instance. Otherwise, return the first
-        /// failure.
-        /// </summary>
-        public static Either<TFailure, Unit> OnSuccessAllReturnVoid<TFailure, TSuccess>(
-            this IEnumerable<Either<TFailure, TSuccess>> items)
+        return await func();
+    }
+
+    public async Task<Either<TL, T>> OnSuccess<T>(Func<TR, Task<Either<TL, T>>> func)
+    {
+        if (IsLeft)
         {
-            return items
-                .OnSuccessAll()
-                .OnSuccessVoid();
+            return _left;
         }
 
-        public static Either<TFailure, Unit> OnSuccessVoid<TFailure, TSuccess>(
-            this Either<TFailure, TSuccess> either)
+        return await func.Invoke(_right);
+    }
+
+    public Either<TL, T> OnSuccess<T>(Func<T> func) => Map(_ => func.Invoke());
+
+    public Either<TL, T> OnSuccess<T>(Func<TR, Either<TL, T>> func) => IsLeft ? Left : func.Invoke(Right);
+
+    public Either<TL, TR> OrElse(Func<TR> func) => IsLeft ? func() : Right;
+
+    public Either<TL, TR> OrElse(Func<TL, TR> func) => IsLeft ? func(Left) : Right;
+
+    public T Fold<T>(Func<TL, T> leftFunc, Func<TR, T> rightFunc) => IsRight ? rightFunc(Right) : leftFunc(Left);
+
+    public T FoldLeft<T>(Func<TL, T> leftFunc, T defaultValue) => IsLeft ? leftFunc(Left) : defaultValue;
+
+    public T FoldRight<T>(Func<TR, T> rightFunc, T defaultValue) => IsRight ? rightFunc(Right) : defaultValue;
+
+    public static implicit operator Either<TL, TR>(TL left) => new(left);
+
+    public static implicit operator Either<TL, TR>(TR right) => new(right);
+}
+
+public static class EitherExtensions
+{
+    /// <summary>
+    /// If all Eithers in the provided list are successful, return a list of the successful results. Otherwise,
+    /// return the first failure.
+    /// </summary>
+    public static Either<TFailure, List<TSuccess>> OnSuccessAll<TFailure, TSuccess>(
+        this IEnumerable<Either<TFailure, TSuccess>> items)
+    {
+        var result = new List<TSuccess>();
+        foreach (var either in items)
         {
             if (either.IsLeft)
             {
                 return either.Left;
             }
 
-            return Unit.Instance;
+            result.Add(either.Right);
         }
+        return result;
     }
 
-    public static class EitherTaskExtensions
+    /// <summary>
+    /// If all Eithers in the provided list are successful, return Unit.Instance. Otherwise, return the first
+    /// failure.
+    /// </summary>
+    public static Either<TFailure, Unit> OnSuccessAllReturnVoid<TFailure, TSuccess>(
+        this IEnumerable<Either<TFailure, TSuccess>> items)
     {
-        public static async Task<bool> IsLeft<TFailure, TSuccess>(this Task<Either<TFailure, TSuccess>> task)
+        return items
+            .OnSuccessAll()
+            .OnSuccessVoid();
+    }
+
+    public static Either<TFailure, Unit> OnSuccessVoid<TFailure, TSuccess>(
+        this Either<TFailure, TSuccess> either)
+    {
+        if (either.IsLeft)
         {
-            return (await task).IsLeft;
+            return either.Left;
         }
 
-        public static async Task<bool> IsRight<TFailure, TSuccess>(this Task<Either<TFailure, TSuccess>> task)
+        return Unit.Instance;
+    }
+}
+
+public static class EitherTaskExtensions
+{
+    public static async Task<bool> IsLeft<TFailure, TSuccess>(this Task<Either<TFailure, TSuccess>> task)
+    {
+        return (await task).IsLeft;
+    }
+
+    public static async Task<bool> IsRight<TFailure, TSuccess>(this Task<Either<TFailure, TSuccess>> task)
+    {
+        return (await task).IsRight;
+    }
+
+    public static async Task<Either<TFailure, TSuccess>> OnSuccessDo<TFailure, TSuccess>(
+        this Task<Either<TFailure, TSuccess>> task,
+        Func<Task> successTask)
+    {
+        return await task.OnSuccessDo(async _ => await successTask());
+    }
+
+    public static async Task<Either<TFailure, TSuccess>> OnSuccessDo<TFailure, TSuccess>(
+        this Task<Either<TFailure, TSuccess>> task,
+        Func<TSuccess, Task> successTask)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsLeft)
         {
-            return (await task).IsRight;
+            return firstResult.Left;
         }
 
-        public static async Task<Either<TFailure, TSuccess>> OnSuccessDo<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task,
-            Func<Task> successTask)
+        await successTask(firstResult.Right);
+        return firstResult.Right;
+    }
+
+    public static async Task<Either<TFailure, TSuccess1>> OnSuccessDo<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<Task<Either<TFailure, TSuccess2>>> successTask)
+    {
+        return await task.OnSuccessDo(async _ => await successTask());
+    }
+
+    public static async Task<Either<TFailure, TSuccess1>> OnSuccessDo<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<Either<TFailure, TSuccess2>> successTask)
+    {
+        return await task.OnSuccessDo(async _ => await Task.FromResult(successTask()));
+    }
+
+    public static async Task<Either<TFailure, TSuccess1>> OnSuccessDo<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<TSuccess1, Either<TFailure, TSuccess2>> successTask)
+    {
+        return await task.OnSuccessDo(async result => await Task.FromResult(successTask(result)));
+    }
+
+    public static async Task<Either<TFailure, TSuccess1>> OnSuccessDo<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<TSuccess1, Task<Either<TFailure, TSuccess2>>> successTask)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsLeft)
         {
-            return await task.OnSuccessDo(async _ => await successTask());
+            return firstResult.Left;
         }
 
-        public static async Task<Either<TFailure, TSuccess>> OnSuccessDo<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task,
-            Func<TSuccess, Task> successTask)
+        var result = await successTask(firstResult.Right);
+
+        if (result.IsRight)
         {
-            var firstResult = await task;
-
-            if (firstResult.IsLeft)
-            {
-                return firstResult.Left;
-            }
-
-            await successTask(firstResult.Right);
             return firstResult.Right;
         }
 
-        public static async Task<Either<TFailure, TSuccess1>> OnSuccessDo<TFailure, TSuccess1, TSuccess2>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<Task<Either<TFailure, TSuccess2>>> successTask)
+        return result.Left;
+    }
+
+    /**
+     * Convenience method so that the chained function can be
+     * void and doesn't have to explicitly return a Unit.
+     */
+    public static async Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess>(
+        this Task<Either<TFailure, TSuccess>> task,
+        Func<Task> func)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsLeft)
         {
-            return await task.OnSuccessDo(async _ => await successTask());
+            return firstResult.Left;
         }
 
-        public static async Task<Either<TFailure, TSuccess1>> OnSuccessDo<TFailure, TSuccess1, TSuccess2>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<Either<TFailure, TSuccess2>> successTask)
+        await func();
+
+        return Unit.Instance;
+    }
+
+    /**
+     * Convenience method so that the chained function can be
+     * void and doesn't have to explicitly return a Unit.
+     */
+    public static async Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess>(
+        this Task<Either<TFailure, TSuccess>> task,
+        Action action)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsLeft)
         {
-            return await task.OnSuccessDo(async _ => await Task.FromResult(successTask()));
+            return firstResult.Left;
         }
 
-        public static async Task<Either<TFailure, TSuccess1>> OnSuccessDo<TFailure, TSuccess1, TSuccess2>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<TSuccess1, Either<TFailure, TSuccess2>> successTask)
+        action();
+
+        return Unit.Instance;
+    }
+
+    /**
+     * Convenience method so that the success chain can be converted to a Unit without having to explicitly supply
+     * it.
+     */
+    public static Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess>(
+        this Task<Either<TFailure, TSuccess>> task)
+    {
+        return OnSuccessVoid(task, () => { });
+    }
+
+    public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<Task<TSuccess2>> func)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsLeft)
         {
-            return await task.OnSuccessDo(async result => await Task.FromResult(successTask(result)));
+            return firstResult.Left;
         }
 
-        public static async Task<Either<TFailure, TSuccess1>> OnSuccessDo<TFailure, TSuccess1, TSuccess2>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<TSuccess1, Task<Either<TFailure, TSuccess2>>> successTask)
+        return await func();
+    }
+
+    [Obsolete("Use OnSuccessDo or OnSuccessVoid for chaining a non-generic Task")]
+    public static async Task<Either<TFailure, Unit>> OnSuccess<TFailure, TSuccess1>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<TSuccess1, Task> func)
+    {
+        return await task.OnSuccessVoid(func);
+    }
+
+    public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<Task<Either<TFailure, TSuccess2>>> func)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsLeft)
         {
-            var firstResult = await task;
-
-            if (firstResult.IsLeft)
-            {
-                return firstResult.Left;
-            }
-
-            var result = await successTask(firstResult.Right);
-
-            if (result.IsRight)
-            {
-                return firstResult.Right;
-            }
-
-            return result.Left;
+            return firstResult.Left;
         }
 
-        /**
-         * Convenience method so that the chained function can be
-         * void and doesn't have to explicitly return a Unit.
-         */
-        public static async Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task,
-            Func<Task> func)
+        return await func();
+    }
+
+    /**
+     * Convenience method so that the chained function can be
+     * void and doesn't have to explicitly return a Unit.
+     */
+    public static async Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess>(
+        this Task<Either<TFailure, TSuccess>> task,
+        Func<TSuccess, Task> func)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsLeft)
         {
-            var firstResult = await task;
-
-            if (firstResult.IsLeft)
-            {
-                return firstResult.Left;
-            }
-
-            await func();
-
-            return Unit.Instance;
+            return firstResult.Left;
         }
 
-        /**
-         * Convenience method so that the chained function can be
-         * void and doesn't have to explicitly return a Unit.
-         */
-        public static async Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task,
-            Action action)
-        {
-            var firstResult = await task;
+        await func(firstResult.Right);
 
-            if (firstResult.IsLeft)
-            {
-                return firstResult.Left;
-            }
+        return Unit.Instance;
+    }
 
-            action();
+    /**
+     * Convenience method so that the chained function can be
+     * void and doesn't have to explicitly return a Unit.
+     */
+    public static Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<TSuccess1, Task<Either<TFailure, TSuccess2>>> task2)
+    {
+        return task
+            .OnSuccess(task2.Invoke)
+            .OnSuccessVoid();
+    }
 
-            return Unit.Instance;
-        }
-
-        /**
-         * Convenience method so that the success chain can be converted to a Unit without having to explicitly supply
-         * it.
-         */
-        public static Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task)
-        {
-            return OnSuccessVoid(task, () => { });
-        }
-
-        public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<Task<TSuccess2>> func)
-        {
-            var firstResult = await task;
-
-            if (firstResult.IsLeft)
-            {
-                return firstResult.Left;
-            }
-
-            return await func();
-        }
-
-        [Obsolete("Use OnSuccessDo or OnSuccessVoid for chaining a non-generic Task")]
-        public static async Task<Either<TFailure, Unit>> OnSuccess<TFailure, TSuccess1>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<TSuccess1, Task> func)
-        {
-            return await task.OnSuccessVoid(func);
-        }
-
-        public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<Task<Either<TFailure, TSuccess2>>> func)
-        {
-            var firstResult = await task;
-
-            if (firstResult.IsLeft)
-            {
-                return firstResult.Left;
-            }
-
-            return await func();
-        }
-
-        /**
-         * Convenience method so that the chained function can be
-         * void and doesn't have to explicitly return a Unit.
-         */
-        public static async Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task,
-            Func<TSuccess, Task> func)
-        {
-            var firstResult = await task;
-
-            if (firstResult.IsLeft)
-            {
-                return firstResult.Left;
-            }
-
-            await func(firstResult.Right);
-
-            return Unit.Instance;
-        }
-
-        /**
-         * Convenience method so that the chained function can be
-         * void and doesn't have to explicitly return a Unit.
-         */
-        public static Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess1, TSuccess2>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<TSuccess1, Task<Either<TFailure, TSuccess2>>> task2)
-        {
-            return task
-                .OnSuccess(task2.Invoke)
-                .OnSuccessVoid();
-        }
-
-        /**
-         * Convenience method so that the chained function can be
-         * void and doesn't have to explicitly return a Unit.
-         */
-        public static Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess1, TSuccess2>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<Task<Either<TFailure, TSuccess2>>> func)
-        {
-            return task
-                .OnSuccess(func.Invoke)
-                .OnSuccessVoid();
-        }
+    /**
+     * Convenience method so that the chained function can be
+     * void and doesn't have to explicitly return a Unit.
+     */
+    public static Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<Task<Either<TFailure, TSuccess2>>> func)
+    {
+        return task
+            .OnSuccess(func.Invoke)
+            .OnSuccessVoid();
+    }
 
 
-        public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<TSuccess1, TSuccess2> func)
-        {
-            return await task.OnSuccess(async success => await Task.FromResult(func(success)));
-        }
+    public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<TSuccess1, TSuccess2> func)
+    {
+        return await task.OnSuccess(async success => await Task.FromResult(func(success)));
+    }
 
-        /**
-         * Allows 2 OnSuccess(...) calls to be chained and the next OnSuccess() to receive a Tuple containing both of
-         * the results.  If either OnSuccess(...) fails, the entire result fails and additionally, if the first result
-         * fails, the second OnSuccess(...) will not be called.
-         *
-         * When C# allows better destructuring, we will be able to destructure the resulting Tuple much better.
-         */
-        public static async Task<Either<TFailure, Tuple<TSuccess1, TSuccess2>>>
-            OnSuccessCombineWith<TFailure, TSuccess1, TSuccess2>(
-                this Task<Either<TFailure, TSuccess1>> task,
-                Func<TSuccess1, Task<Either<TFailure, TSuccess2>>> func)
-        {
-            return await task.OnSuccess(success =>
-            {
-                return func(success).OnSuccess(combinator => TupleOf(success, combinator));
-            });
-        }
-
-        /**
-         * Allows 3 OnSuccess(...) calls to be chained and the next OnSuccess() to receive a Tuple containing all 3 of
-         * the results.  If any OnSuccess(...) fails, the entire result fails and additionally, if the first result
-         * fails, the subsequent OnSuccess(...) will not be called.
-         *
-         * When C# allows better destructuring, we will be able to destructure the resulting Tuple much better.
-         */
-        public static async Task<Either<TFailure, Tuple<TSuccess1, TSuccess2, TSuccess3>>>
-            OnSuccessCombineWith<TFailure, TSuccess1, TSuccess2, TSuccess3>(
-                this Task<Either<TFailure, Tuple<TSuccess1, TSuccess2>>> task,
-                Func<Tuple<TSuccess1, TSuccess2>, Task<Either<TFailure, TSuccess3>>> func)
-        {
-            return await task.OnSuccess(success =>
-            {
-                return func(success).OnSuccess(combinator =>
-                    new Tuple<TSuccess1, TSuccess2, TSuccess3>(success.Item1, success.Item2, combinator));
-            });
-        }
-
-        /**
-         * Allows 2 OnSuccess(...) calls to be chained and the next OnSuccess() to receive a Tuple containing both of
-         * the results.  If either OnSuccess(...) fails, the entire result fails and additionally, if the first result
-         * fails, the second OnSuccess(...) will not be called.
-         *
-         * When C# allows better destructuring, we will be able to destructure the resulting Tuple much better.
-         */
-        public static async Task<Either<TFailure, Tuple<TSuccess1, TSuccess2>>>
-            OnSuccessCombineWith<TFailure, TSuccess1, TSuccess2>(
-                this Task<Either<TFailure, TSuccess1>> task,
-                Func<TSuccess1, Either<TFailure, TSuccess2>> func)
-        {
-            return await task.OnSuccess(success =>
-            {
-                return func(success).OnSuccess(combinator => TupleOf(success, combinator));
-            });
-        }
-
-        public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<TSuccess1, Task<TSuccess2>> func)
-        {
-            var firstResult = await task;
-
-            if (firstResult.IsLeft)
-            {
-                return firstResult.Left;
-            }
-
-            return await func(firstResult.Right);
-        }
-
-        public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
-            this Task<Either<TFailure, TSuccess1>> task,
-            Func<TSuccess1, Either<TFailure, TSuccess2>> func)
-        {
-            return await task.OnSuccess(async success => await Task.FromResult(func(success)));
-        }
-
-        public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
+    /**
+     * Allows 2 OnSuccess(...) calls to be chained and the next OnSuccess() to receive a Tuple containing both of
+     * the results.  If either OnSuccess(...) fails, the entire result fails and additionally, if the first result
+     * fails, the second OnSuccess(...) will not be called.
+     *
+     * When C# allows better destructuring, we will be able to destructure the resulting Tuple much better.
+     */
+    public static async Task<Either<TFailure, Tuple<TSuccess1, TSuccess2>>>
+        OnSuccessCombineWith<TFailure, TSuccess1, TSuccess2>(
             this Task<Either<TFailure, TSuccess1>> task,
             Func<TSuccess1, Task<Either<TFailure, TSuccess2>>> func)
+    {
+        return await task.OnSuccess(success =>
         {
-            var firstResult = await task;
+            return func(success).OnSuccess(combinator => TupleOf(success, combinator));
+        });
+    }
 
-            if (firstResult.IsLeft)
-            {
-                return firstResult.Left;
-            }
-
-            return await func(firstResult.Right);
-        }
-
-        public static async Task<Either<Unit, TSuccess>> OnFailureVoid<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task,
-            Action<TFailure> failureTask)
+    /**
+     * Allows 3 OnSuccess(...) calls to be chained and the next OnSuccess() to receive a Tuple containing all 3 of
+     * the results.  If any OnSuccess(...) fails, the entire result fails and additionally, if the first result
+     * fails, the subsequent OnSuccess(...) will not be called.
+     *
+     * When C# allows better destructuring, we will be able to destructure the resulting Tuple much better.
+     */
+    public static async Task<Either<TFailure, Tuple<TSuccess1, TSuccess2, TSuccess3>>>
+        OnSuccessCombineWith<TFailure, TSuccess1, TSuccess2, TSuccess3>(
+            this Task<Either<TFailure, Tuple<TSuccess1, TSuccess2>>> task,
+            Func<Tuple<TSuccess1, TSuccess2>, Task<Either<TFailure, TSuccess3>>> func)
+    {
+        return await task.OnSuccess(success =>
         {
-            var firstResult = await task;
+            return func(success).OnSuccess(combinator =>
+                new Tuple<TSuccess1, TSuccess2, TSuccess3>(success.Item1, success.Item2, combinator));
+        });
+    }
 
-            if (firstResult.IsRight)
-            {
-                return firstResult.Right;
-            }
-
-            failureTask(firstResult.Left);
-            return Unit.Instance;
-        }
-
-        public static async Task<Either<TFailure1, TFailure2>> OnFailureDo<TFailure1, TFailure2>(
-            this Task<Either<TFailure1, TFailure2>> task,
-            Func<TFailure1, Task> failureTask)
+    /**
+     * Allows 2 OnSuccess(...) calls to be chained and the next OnSuccess() to receive a Tuple containing both of
+     * the results.  If either OnSuccess(...) fails, the entire result fails and additionally, if the first result
+     * fails, the second OnSuccess(...) will not be called.
+     *
+     * When C# allows better destructuring, we will be able to destructure the resulting Tuple much better.
+     */
+    public static async Task<Either<TFailure, Tuple<TSuccess1, TSuccess2>>>
+        OnSuccessCombineWith<TFailure, TSuccess1, TSuccess2>(
+            this Task<Either<TFailure, TSuccess1>> task,
+            Func<TSuccess1, Either<TFailure, TSuccess2>> func)
+    {
+        return await task.OnSuccess(success =>
         {
-            var firstResult = await task;
+            return func(success).OnSuccess(combinator => TupleOf(success, combinator));
+        });
+    }
 
-            if (firstResult.IsRight)
-            {
-                return firstResult.Right;
-            }
+    public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<TSuccess1, Task<TSuccess2>> func)
+    {
+        var firstResult = await task;
 
-            await failureTask(firstResult.Left);
+        if (firstResult.IsLeft)
+        {
             return firstResult.Left;
         }
 
-        public static async Task<Either<TFailure1, TFailure2>> OnFailureDo<TFailure1, TFailure2>(
-            this Task<Either<TFailure1, TFailure2>> task,
-            Action<TFailure1> failureAction)
+        return await func(firstResult.Right);
+    }
+
+    public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<TSuccess1, Either<TFailure, TSuccess2>> func)
+    {
+        return await task.OnSuccess(async success => await Task.FromResult(func(success)));
+    }
+
+    public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(
+        this Task<Either<TFailure, TSuccess1>> task,
+        Func<TSuccess1, Task<Either<TFailure, TSuccess2>>> func)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsLeft)
         {
-            var firstResult = await task;
-
-            if (firstResult.IsRight)
-            {
-                return firstResult.Right;
-            }
-
-            failureAction(firstResult.Left);
             return firstResult.Left;
         }
 
-        public static async Task<Either<TFailure1, TFailure2>> OnFailureFailWith<TFailure1, TFailure2>(
-            this Task<Either<TFailure1, TFailure2>> task,
-            Func<TFailure1> failure)
+        return await func(firstResult.Right);
+    }
+
+    public static async Task<Either<Unit, TSuccess>> OnFailureVoid<TFailure, TSuccess>(
+        this Task<Either<TFailure, TSuccess>> task,
+        Action<TFailure> failureTask)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsRight)
         {
-            return await task.OnFailureFailWith(async _ => await Task.FromResult(failure()));
+            return firstResult.Right;
         }
 
-        /**
-         * If the previous Either failed, provide the errors to the given action and then return a new set of errors
-         * provided by the action.
-         */
-        public static async Task<Either<TFailure1, TFailure2>> OnFailureFailWith<TFailure1, TFailure2>(
-            this Task<Either<TFailure1, TFailure2>> task,
-            Func<TFailure1, Task<TFailure1>> func)
-        {
-            var firstResult = await task;
+        failureTask(firstResult.Left);
+        return Unit.Instance;
+    }
 
-            if (firstResult.IsRight)
+    public static async Task<Either<TFailure1, TFailure2>> OnFailureDo<TFailure1, TFailure2>(
+        this Task<Either<TFailure1, TFailure2>> task,
+        Func<TFailure1, Task> failureTask)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsRight)
+        {
+            return firstResult.Right;
+        }
+
+        await failureTask(firstResult.Left);
+        return firstResult.Left;
+    }
+
+    public static async Task<Either<TFailure1, TFailure2>> OnFailureDo<TFailure1, TFailure2>(
+        this Task<Either<TFailure1, TFailure2>> task,
+        Action<TFailure1> failureAction)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsRight)
+        {
+            return firstResult.Right;
+        }
+
+        failureAction(firstResult.Left);
+        return firstResult.Left;
+    }
+
+    public static async Task<Either<TFailure1, TFailure2>> OnFailureFailWith<TFailure1, TFailure2>(
+        this Task<Either<TFailure1, TFailure2>> task,
+        Func<TFailure1> failure)
+    {
+        return await task.OnFailureFailWith(async _ => await Task.FromResult(failure()));
+    }
+
+    /**
+     * If the previous Either failed, provide the errors to the given action and then return a new set of errors
+     * provided by the action.
+     */
+    public static async Task<Either<TFailure1, TFailure2>> OnFailureFailWith<TFailure1, TFailure2>(
+        this Task<Either<TFailure1, TFailure2>> task,
+        Func<TFailure1, Task<TFailure1>> func)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsRight)
+        {
+            return firstResult.Right;
+        }
+
+        return await func(firstResult.Left);
+    }
+
+    /**
+     * If the previous Either failed, perform the given action and then handle it as a success case anyway.
+     * This allows a prior step to fail but overall be treated as a success (unless a subsequent step happens to
+     * fail after this one).
+    */
+    public static async Task<Either<TFailure, TSuccess>> OnFailureSucceedWith<TFailure, TSuccess>(
+        this Task<Either<TFailure, TSuccess>> task,
+        Func<TFailure, Task<TSuccess>> func)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsRight)
+        {
+            return firstResult.Right;
+        }
+
+        return await func(firstResult.Left);
+    }
+
+    public static async Task<TSuccess> OrElse<TFailure, TSuccess>(
+        this Task<Either<TFailure, TSuccess>> task,
+        Func<Task<TSuccess>> func)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsRight)
+        {
+            return firstResult.Right;
+        }
+
+        return await func();
+    }
+
+    public static async Task<Either<TFailure, TSuccess>> OrElse<TFailure, TSuccess>(
+        this Task<Either<TFailure, TSuccess>> task,
+        Func<Task<Either<TFailure, TSuccess>>> func)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsRight)
+        {
+            return firstResult.Right;
+        }
+
+        return await func();
+    }
+
+    public static async Task<TSuccess> OrElse<TFailure, TSuccess>(
+        this Task<Either<TFailure, TSuccess>> task,
+        Func<TSuccess> func)
+    {
+        var firstResult = await task;
+
+        if (firstResult.IsRight)
+        {
+            return firstResult.Right;
+        }
+
+        return func();
+    }
+
+    public static async Task<Either<TFailure, List<TSuccess>>> OnSuccessAll<TFailure, TSuccess>(
+        this IEnumerable<Task<Either<TFailure, TSuccess>>> tasks)
+    {
+        var result = new List<TSuccess>();
+        foreach (var task in tasks)
+        {
+            var r = await task;
+            if (r.IsLeft)
             {
-                return firstResult.Right;
+                return r.Left;
             }
 
-            return await func(firstResult.Left);
+            result.Add(r.Right);
         }
 
-        /**
-         * If the previous Either failed, perform the given action and then handle it as a success case anyway.
-         * This allows a prior step to fail but overall be treated as a success (unless a subsequent step happens to
-         * fail after this one).
-        */
-        public static async Task<Either<TFailure, TSuccess>> OnFailureSucceedWith<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task,
-            Func<TFailure, Task<TSuccess>> func)
-        {
-            var firstResult = await task;
-
-            if (firstResult.IsRight)
-            {
-                return firstResult.Right;
-            }
-
-            return await func(firstResult.Left);
-        }
-
-        public static async Task<TSuccess> OrElse<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task,
-            Func<Task<TSuccess>> func)
-        {
-            var firstResult = await task;
-
-            if (firstResult.IsRight)
-            {
-                return firstResult.Right;
-            }
-
-            return await func();
-        }
-
-        public static async Task<Either<TFailure, TSuccess>> OrElse<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task,
-            Func<Task<Either<TFailure, TSuccess>>> func)
-        {
-            var firstResult = await task;
-
-            if (firstResult.IsRight)
-            {
-                return firstResult.Right;
-            }
-
-            return await func();
-        }
-
-        public static async Task<TSuccess> OrElse<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task,
-            Func<TSuccess> func)
-        {
-            var firstResult = await task;
-
-            if (firstResult.IsRight)
-            {
-                return firstResult.Right;
-            }
-
-            return func();
-        }
-
-        public static async Task<Either<TFailure, List<TSuccess>>> OnSuccessAll<TFailure, TSuccess>(
-            this IEnumerable<Task<Either<TFailure, TSuccess>>> tasks)
-        {
-            var result = new List<TSuccess>();
-            foreach (var task in tasks)
-            {
-                var r = await task;
-                if (r.IsLeft)
-                {
-                    return r.Left;
-                }
-
-                result.Add(r.Right);
-            }
-
-            return result;
-        }
+        return result;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/FileInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/FileInfo.cs
@@ -4,27 +4,26 @@ using System.IO;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using Newtonsoft.Json;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public class FileInfo
 {
-    public class FileInfo
-    {
-        public Guid? Id { get; set; }
+    public Guid? Id { get; set; }
 
-        public string Extension => Path.GetExtension(FileName).TrimStart('.');
+    public string Extension => Path.GetExtension(FileName).TrimStart('.');
 
-        public string FileName { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
 
-        public string Name { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
 
-        public string? Summary { get; set; }
+    public string? Summary { get; set; }
 
-        public string Size { get; set; } = string.Empty;
+    public string Size { get; set; } = string.Empty;
 
-        [JsonConverter(typeof(EnumToEnumValueJsonConverter<FileType>))]
-        public FileType Type { get; set; }
+    [JsonConverter(typeof(EnumToEnumValueJsonConverter<FileType>))]
+    public FileType Type { get; set; }
 
-        public DateTime? Created { get; set; }
+    public DateTime? Created { get; set; }
 
-        public string? UserName { get; set; }
-    }
+    public string? UserName { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/FileType.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/FileType.cs
@@ -1,24 +1,23 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public enum FileType
 {
-    public enum FileType
-    {
-        [EnumLabelValue("ancillary")]
-        Ancillary,
-        [EnumLabelValue("zip")]
-        AllFilesZip,
-        [EnumLabelValue("chart")]
-        Chart,
-        [EnumLabelValue("data")]
-        Data,
-        [EnumLabelValue("data-zip")]
-        DataZip,
-        [EnumLabelValue("image")]
-        Image,
-        [EnumLabelValue("metadata")]
-        Metadata,
-        [EnumLabelValue("data-guidance")]
-        DataGuidance
-    }
+    [EnumLabelValue("ancillary")]
+    Ancillary,
+    [EnumLabelValue("zip")]
+    AllFilesZip,
+    [EnumLabelValue("chart")]
+    Chart,
+    [EnumLabelValue("data")]
+    Data,
+    [EnumLabelValue("data-zip")]
+    DataZip,
+    [EnumLabelValue("image")]
+    Image,
+    [EnumLabelValue("metadata")]
+    Metadata,
+    [EnumLabelValue("data-guidance")]
+    DataGuidance
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/IndicatorUnit.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/IndicatorUnit.cs
@@ -1,22 +1,21 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public enum IndicatorUnit
 {
-    public enum IndicatorUnit
-    {
-        [EnumLabelValue("", "")]
-        Number,
+    [EnumLabelValue("", "")]
+    Number,
 
-        [EnumLabelValue("%", "%")]
-        Percent,
+    [EnumLabelValue("%", "%")]
+    Percent,
 
-        [EnumLabelValue("£", "£")]
-        Pound,
+    [EnumLabelValue("£", "£")]
+    Pound,
 
-        [EnumLabelValue("£m", "£m")]
-        MillionPounds,
+    [EnumLabelValue("£m", "£m")]
+    MillionPounds,
 
-        [EnumLabelValue("pp", "pp")]
-        PercentagePoint,
-    }
+    [EnumLabelValue("pp", "pp")]
+    PercentagePoint,
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/LabelValue.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/LabelValue.cs
@@ -1,19 +1,18 @@
 #nullable enable
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public record LabelValue
 {
-    public record LabelValue
+    public string Label { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+
+    protected LabelValue()
     {
-        public string Label { get; set; } = string.Empty;
-        public string Value { get; set; } = string.Empty;
+    }
 
-        protected LabelValue()
-        {
-        }
-
-        public LabelValue(string label, string value)
-        {
-            Label = label;
-            Value = value;
-        }
+    public LabelValue(string label, string value)
+    {
+        Label = label;
+        Value = value;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/PartialDate.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/PartialDate.cs
@@ -5,88 +5,87 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using static System.Int32;
 using static System.String;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public record PartialDate
 {
-    public record PartialDate
+    public static readonly Regex YearRegex = new(@"^([0-9]{4})?$");
+    public static readonly Regex MonthRegex = new(@"^([0-9]{1,2})?$");
+    public static readonly Regex DayRegex = new(@"^([0-9]{1,2})?$");
+
+    private readonly string? _month;
+    private readonly string? _day;
+
+    public string Year { get; init; } = Empty;
+
+    public string Month
     {
-        public static readonly Regex YearRegex = new(@"^([0-9]{4})?$");
-        public static readonly Regex MonthRegex = new(@"^([0-9]{1,2})?$");
-        public static readonly Regex DayRegex = new(@"^([0-9]{1,2})?$");
+        get => _month ?? Empty;
+        init => _month = value;
+    }
 
-        private readonly string? _month;
-        private readonly string? _day;
+    public string Day
+    {
+        get => _day ?? Empty;
+        init => _day = value;
+    }
 
-        public string Year { get; init; } = Empty;
+    public bool IsValid()
+    {
+        var hasYear = !Year.IsNullOrWhitespace();
+        var hasMonth = !Month.IsNullOrWhitespace();
+        var hasDay = !Day.IsNullOrWhitespace();
 
-        public string Month
+        if (!hasYear)
         {
-            get => _month ?? Empty;
-            init => _month = value;
+            return false;
         }
 
-        public string Day
+        if (hasDay && !hasMonth)
         {
-            get => _day ?? Empty;
-            init => _day = value;
+            return false;
         }
 
-        public bool IsValid()
+        if (!YearRegex.Match(Year).Success || !MonthRegex.Match(Month).Success || !DayRegex.Match(Day).Success)
         {
-            var hasYear = !Year.IsNullOrWhitespace();
-            var hasMonth = !Month.IsNullOrWhitespace();
-            var hasDay = !Day.IsNullOrWhitespace();
-
-            if (!hasYear)
-            {
-                return false;
-            }
-
-            if (hasDay && !hasMonth)
-            {
-                return false;
-            }
-
-            if (!YearRegex.Match(Year).Success || !MonthRegex.Match(Month).Success || !DayRegex.Match(Day).Success)
-            {
-                return false; // Failed rudimentary number validation
-            }
-
-            if (!EmptyOrBetween(Month, 1, 12) || !EmptyOrBetween(Day, 1, 31))
-            {
-                return false; // Failed more precise number validation
-            }
-
-            if (hasMonth && hasDay)
-            {
-                // We at least have a month and a day so at the very least we can check that they are acceptable
-                // together. If we have a year we can do even more if we do not then we use a leap year as this gives a
-                // wider range of acceptable values.
-                const int leapYear = 2016;
-                var yearToCheckAgainst = !IsNullOrEmpty(Year) ? Parse(Year) : leapYear;
-                var intDay = Parse(Day);
-                var intMonth = Parse(Month);
-                var daysInMonth = DateTime.DaysInMonth(yearToCheckAgainst, intMonth);
-                if (intDay > daysInMonth || intDay < 1)
-                {
-                    return false; // Failed more specific day / month validation
-                }
-            }
-
-            return true;
+            return false; // Failed rudimentary number validation
         }
 
-        public bool IsEmpty()
+        if (!EmptyOrBetween(Month, 1, 12) || !EmptyOrBetween(Day, 1, 31))
         {
-            var hasYear = !Year.IsNullOrWhitespace();
-            var hasMonth = !Month.IsNullOrWhitespace();
-            var hasDay = !Day.IsNullOrWhitespace();
-
-            return !hasYear && !hasMonth && !hasDay;
+            return false; // Failed more precise number validation
         }
 
-        private static bool EmptyOrBetween(string value, int lower, int upper)
+        if (hasMonth && hasDay)
         {
-            return IsNullOrEmpty(value) || (Parse(value) >= lower && Parse(value) <= upper);
+            // We at least have a month and a day so at the very least we can check that they are acceptable
+            // together. If we have a year we can do even more if we do not then we use a leap year as this gives a
+            // wider range of acceptable values.
+            const int leapYear = 2016;
+            var yearToCheckAgainst = !IsNullOrEmpty(Year) ? Parse(Year) : leapYear;
+            var intDay = Parse(Day);
+            var intMonth = Parse(Month);
+            var daysInMonth = DateTime.DaysInMonth(yearToCheckAgainst, intMonth);
+            if (intDay > daysInMonth || intDay < 1)
+            {
+                return false; // Failed more specific day / month validation
+            }
         }
+
+        return true;
+    }
+
+    public bool IsEmpty()
+    {
+        var hasYear = !Year.IsNullOrWhitespace();
+        var hasMonth = !Month.IsNullOrWhitespace();
+        var hasDay = !Day.IsNullOrWhitespace();
+
+        return !hasYear && !hasMonth && !hasDay;
+    }
+
+    private static bool EmptyOrBetween(string value, int lower, int upper)
+    {
+        return IsNullOrEmpty(value) || (Parse(value) >= lower && Parse(value) <= upper);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifier.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifier.cs
@@ -6,293 +6,292 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Database.TimePeri
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifierCategory;
 using Category = GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifierCategory;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+public enum TimeIdentifier
 {
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public enum TimeIdentifier
-    {
-        [TimeIdentifierMeta("Academic year", "AY", Category.AcademicYear, Academic, NoLabel)]
-        AcademicYear,
+    [TimeIdentifierMeta("Academic year", "AY", Category.AcademicYear, Academic, NoLabel)]
+    AcademicYear,
 
-        [TimeIdentifierMeta("Academic year Q1", "AYQ1", Category.AcademicYear, Academic, ShortLabel, "Q1")]
-        AcademicYearQ1,
+    [TimeIdentifierMeta("Academic year Q1", "AYQ1", Category.AcademicYear, Academic, ShortLabel, "Q1")]
+    AcademicYearQ1,
 
-        [TimeIdentifierMeta("Academic year Q2", "AYQ2", Category.AcademicYear, Academic, ShortLabel, "Q2")]
-        AcademicYearQ2,
+    [TimeIdentifierMeta("Academic year Q2", "AYQ2", Category.AcademicYear, Academic, ShortLabel, "Q2")]
+    AcademicYearQ2,
 
-        [TimeIdentifierMeta("Academic year Q3", "AYQ3", Category.AcademicYear, Academic, ShortLabel, "Q3")]
-        AcademicYearQ3,
+    [TimeIdentifierMeta("Academic year Q3", "AYQ3", Category.AcademicYear, Academic, ShortLabel, "Q3")]
+    AcademicYearQ3,
 
-        [TimeIdentifierMeta("Academic year Q4", "AYQ4", Category.AcademicYear, Academic, ShortLabel, "Q4")]
-        AcademicYearQ4,
+    [TimeIdentifierMeta("Academic year Q4", "AYQ4", Category.AcademicYear, Academic, ShortLabel, "Q4")]
+    AcademicYearQ4,
 
-        [TimeIdentifierMeta("Calendar year", "CY", Category.CalendarYear, Default, NoLabel)]
-        CalendarYear,
+    [TimeIdentifierMeta("Calendar year", "CY", Category.CalendarYear, Default, NoLabel)]
+    CalendarYear,
 
-        [TimeIdentifierMeta("Calendar year Q1", "CYQ1", Category.CalendarYear, Default, ShortLabel, "Q1")]
-        CalendarYearQ1,
+    [TimeIdentifierMeta("Calendar year Q1", "CYQ1", Category.CalendarYear, Default, ShortLabel, "Q1")]
+    CalendarYearQ1,
 
-        [TimeIdentifierMeta("Calendar year Q2", "CYQ2", Category.CalendarYear, Default, ShortLabel, "Q2")]
-        CalendarYearQ2,
+    [TimeIdentifierMeta("Calendar year Q2", "CYQ2", Category.CalendarYear, Default, ShortLabel, "Q2")]
+    CalendarYearQ2,
 
-        [TimeIdentifierMeta("Calendar year Q3", "CYQ3", Category.CalendarYear, Default, ShortLabel, "Q3")]
-        CalendarYearQ3,
+    [TimeIdentifierMeta("Calendar year Q3", "CYQ3", Category.CalendarYear, Default, ShortLabel, "Q3")]
+    CalendarYearQ3,
 
-        [TimeIdentifierMeta("Calendar year Q4", "CYQ4", Category.CalendarYear, Default, ShortLabel, "Q4")]
-        CalendarYearQ4,
+    [TimeIdentifierMeta("Calendar year Q4", "CYQ4", Category.CalendarYear, Default, ShortLabel, "Q4")]
+    CalendarYearQ4,
 
-        [TimeIdentifierMeta("Part 1 (April to September)", "P1", FinancialYearPart, Fiscal, ShortLabel,
-            "Part 1 (Apr to Sep)")]
-        FinancialYearPart1,
+    [TimeIdentifierMeta("Part 1 (April to September)", "P1", FinancialYearPart, Fiscal, ShortLabel,
+        "Part 1 (Apr to Sep)")]
+    FinancialYearPart1,
 
-        [TimeIdentifierMeta("Part 2 (October to March)", "P2", FinancialYearPart, Fiscal, ShortLabel,
-            "Part 2 (Oct to Mar)")]
-        FinancialYearPart2,
+    [TimeIdentifierMeta("Part 2 (October to March)", "P2", FinancialYearPart, Fiscal, ShortLabel,
+        "Part 2 (Oct to Mar)")]
+    FinancialYearPart2,
 
-        [TimeIdentifierMeta("Financial year", "FY", Category.FinancialYear, Fiscal, NoLabel)]
-        FinancialYear,
+    [TimeIdentifierMeta("Financial year", "FY", Category.FinancialYear, Fiscal, NoLabel)]
+    FinancialYear,
 
-        [TimeIdentifierMeta("Financial year Q1", "FYQ1", Category.FinancialYear, Fiscal, ShortLabel, "Q1")]
-        FinancialYearQ1,
+    [TimeIdentifierMeta("Financial year Q1", "FYQ1", Category.FinancialYear, Fiscal, ShortLabel, "Q1")]
+    FinancialYearQ1,
 
-        [TimeIdentifierMeta("Financial year Q2", "FYQ2", Category.FinancialYear, Fiscal, ShortLabel, "Q2")]
-        FinancialYearQ2,
+    [TimeIdentifierMeta("Financial year Q2", "FYQ2", Category.FinancialYear, Fiscal, ShortLabel, "Q2")]
+    FinancialYearQ2,
 
-        [TimeIdentifierMeta("Financial year Q3", "FYQ3", Category.FinancialYear, Fiscal, ShortLabel, "Q3")]
-        FinancialYearQ3,
+    [TimeIdentifierMeta("Financial year Q3", "FYQ3", Category.FinancialYear, Fiscal, ShortLabel, "Q3")]
+    FinancialYearQ3,
 
-        [TimeIdentifierMeta("Financial year Q4", "FYQ4", Category.FinancialYear, Fiscal, ShortLabel, "Q4")]
-        FinancialYearQ4,
+    [TimeIdentifierMeta("Financial year Q4", "FYQ4", Category.FinancialYear, Fiscal, ShortLabel, "Q4")]
+    FinancialYearQ4,
 
-        [TimeIdentifierMeta("Tax year", "TY", Category.TaxYear, Fiscal, NoLabel)]
-        TaxYear,
+    [TimeIdentifierMeta("Tax year", "TY", Category.TaxYear, Fiscal, NoLabel)]
+    TaxYear,
 
-        [TimeIdentifierMeta("Tax year Q1", "TYQ1", Category.TaxYear, Fiscal, ShortLabel, "Q1")]
-        TaxYearQ1,
+    [TimeIdentifierMeta("Tax year Q1", "TYQ1", Category.TaxYear, Fiscal, ShortLabel, "Q1")]
+    TaxYearQ1,
 
-        [TimeIdentifierMeta("Tax year Q2", "TYQ2", Category.TaxYear, Fiscal, ShortLabel, "Q2")]
-        TaxYearQ2,
+    [TimeIdentifierMeta("Tax year Q2", "TYQ2", Category.TaxYear, Fiscal, ShortLabel, "Q2")]
+    TaxYearQ2,
 
-        [TimeIdentifierMeta("Tax year Q3", "TYQ3", Category.TaxYear, Fiscal, ShortLabel, "Q3")]
-        TaxYearQ3,
+    [TimeIdentifierMeta("Tax year Q3", "TYQ3", Category.TaxYear, Fiscal, ShortLabel, "Q3")]
+    TaxYearQ3,
 
-        [TimeIdentifierMeta("Tax year Q4", "TYQ4", Category.TaxYear, Fiscal, ShortLabel, "Q4")]
-        TaxYearQ4,
+    [TimeIdentifierMeta("Tax year Q4", "TYQ4", Category.TaxYear, Fiscal, ShortLabel, "Q4")]
+    TaxYearQ4,
 
-        [TimeIdentifierMeta("Reporting year", "RY", Category.ReportingYear, Default, NoLabel)]
-        ReportingYear,
+    [TimeIdentifierMeta("Reporting year", "RY", Category.ReportingYear, Default, NoLabel)]
+    ReportingYear,
 
-        [TimeIdentifierMeta("Autumn term", "T1", Term, Academic)]
-        AutumnTerm,
+    [TimeIdentifierMeta("Autumn term", "T1", Term, Academic)]
+    AutumnTerm,
 
-        [TimeIdentifierMeta("Autumn and spring term", "T1T2", Term, Academic)]
-        AutumnSpringTerm,
+    [TimeIdentifierMeta("Autumn and spring term", "T1T2", Term, Academic)]
+    AutumnSpringTerm,
 
-        [TimeIdentifierMeta("Spring term", "T2", Term, Academic)]
-        SpringTerm,
+    [TimeIdentifierMeta("Spring term", "T2", Term, Academic)]
+    SpringTerm,
 
-        [TimeIdentifierMeta("Summer term", "T3", Term, Academic)]
-        SummerTerm,
+    [TimeIdentifierMeta("Summer term", "T3", Term, Academic)]
+    SummerTerm,
 
-        [TimeIdentifierMeta("Week 1", "W1", Week)]
-        Week1,
+    [TimeIdentifierMeta("Week 1", "W1", Week)]
+    Week1,
 
-        [TimeIdentifierMeta("Week 2", "W2", Week)]
-        Week2,
+    [TimeIdentifierMeta("Week 2", "W2", Week)]
+    Week2,
 
-        [TimeIdentifierMeta("Week 3", "W3", Week)]
-        Week3,
+    [TimeIdentifierMeta("Week 3", "W3", Week)]
+    Week3,
 
-        [TimeIdentifierMeta("Week 4", "W4", Week)]
-        Week4,
+    [TimeIdentifierMeta("Week 4", "W4", Week)]
+    Week4,
 
-        [TimeIdentifierMeta("Week 5", "W5", Week)]
-        Week5,
+    [TimeIdentifierMeta("Week 5", "W5", Week)]
+    Week5,
 
-        [TimeIdentifierMeta("Week 6", "W6", Week)]
-        Week6,
+    [TimeIdentifierMeta("Week 6", "W6", Week)]
+    Week6,
 
-        [TimeIdentifierMeta("Week 7", "W7", Week)]
-        Week7,
+    [TimeIdentifierMeta("Week 7", "W7", Week)]
+    Week7,
 
-        [TimeIdentifierMeta("Week 8", "W8", Week)]
-        Week8,
+    [TimeIdentifierMeta("Week 8", "W8", Week)]
+    Week8,
 
-        [TimeIdentifierMeta("Week 9", "W9", Week)]
-        Week9,
+    [TimeIdentifierMeta("Week 9", "W9", Week)]
+    Week9,
 
-        [TimeIdentifierMeta("Week 10", "W10", Week)]
-        Week10,
+    [TimeIdentifierMeta("Week 10", "W10", Week)]
+    Week10,
 
-        [TimeIdentifierMeta("Week 11", "W11", Week)]
-        Week11,
+    [TimeIdentifierMeta("Week 11", "W11", Week)]
+    Week11,
 
-        [TimeIdentifierMeta("Week 12", "W12", Week)]
-        Week12,
+    [TimeIdentifierMeta("Week 12", "W12", Week)]
+    Week12,
 
-        [TimeIdentifierMeta("Week 13", "W13", Week)]
-        Week13,
+    [TimeIdentifierMeta("Week 13", "W13", Week)]
+    Week13,
 
-        [TimeIdentifierMeta("Week 14", "W14", Week)]
-        Week14,
+    [TimeIdentifierMeta("Week 14", "W14", Week)]
+    Week14,
 
-        [TimeIdentifierMeta("Week 15", "W15", Week)]
-        Week15,
+    [TimeIdentifierMeta("Week 15", "W15", Week)]
+    Week15,
 
-        [TimeIdentifierMeta("Week 16", "W16", Week)]
-        Week16,
+    [TimeIdentifierMeta("Week 16", "W16", Week)]
+    Week16,
 
-        [TimeIdentifierMeta("Week 17", "W17", Week)]
-        Week17,
+    [TimeIdentifierMeta("Week 17", "W17", Week)]
+    Week17,
 
-        [TimeIdentifierMeta("Week 18", "W18", Week)]
-        Week18,
+    [TimeIdentifierMeta("Week 18", "W18", Week)]
+    Week18,
 
-        [TimeIdentifierMeta("Week 19", "W19", Week)]
-        Week19,
+    [TimeIdentifierMeta("Week 19", "W19", Week)]
+    Week19,
 
-        [TimeIdentifierMeta("Week 20", "W20", Week)]
-        Week20,
+    [TimeIdentifierMeta("Week 20", "W20", Week)]
+    Week20,
 
-        [TimeIdentifierMeta("Week 21", "W21", Week)]
-        Week21,
+    [TimeIdentifierMeta("Week 21", "W21", Week)]
+    Week21,
 
-        [TimeIdentifierMeta("Week 22", "W22", Week)]
-        Week22,
+    [TimeIdentifierMeta("Week 22", "W22", Week)]
+    Week22,
 
-        [TimeIdentifierMeta("Week 23", "W23", Week)]
-        Week23,
+    [TimeIdentifierMeta("Week 23", "W23", Week)]
+    Week23,
 
-        [TimeIdentifierMeta("Week 24", "W24", Week)]
-        Week24,
+    [TimeIdentifierMeta("Week 24", "W24", Week)]
+    Week24,
 
-        [TimeIdentifierMeta("Week 25", "W25", Week)]
-        Week25,
+    [TimeIdentifierMeta("Week 25", "W25", Week)]
+    Week25,
 
-        [TimeIdentifierMeta("Week 26", "W26", Week)]
-        Week26,
+    [TimeIdentifierMeta("Week 26", "W26", Week)]
+    Week26,
 
-        [TimeIdentifierMeta("Week 27", "W27", Week)]
-        Week27,
+    [TimeIdentifierMeta("Week 27", "W27", Week)]
+    Week27,
 
-        [TimeIdentifierMeta("Week 28", "W28", Week)]
-        Week28,
+    [TimeIdentifierMeta("Week 28", "W28", Week)]
+    Week28,
 
-        [TimeIdentifierMeta("Week 29", "W29", Week)]
-        Week29,
+    [TimeIdentifierMeta("Week 29", "W29", Week)]
+    Week29,
 
-        [TimeIdentifierMeta("Week 30", "W30", Week)]
-        Week30,
+    [TimeIdentifierMeta("Week 30", "W30", Week)]
+    Week30,
 
-        [TimeIdentifierMeta("Week 31", "W31", Week)]
-        Week31,
+    [TimeIdentifierMeta("Week 31", "W31", Week)]
+    Week31,
 
-        [TimeIdentifierMeta("Week 32", "W32", Week)]
-        Week32,
+    [TimeIdentifierMeta("Week 32", "W32", Week)]
+    Week32,
 
-        [TimeIdentifierMeta("Week 33", "W33", Week)]
-        Week33,
+    [TimeIdentifierMeta("Week 33", "W33", Week)]
+    Week33,
 
-        [TimeIdentifierMeta("Week 34", "W34", Week)]
-        Week34,
+    [TimeIdentifierMeta("Week 34", "W34", Week)]
+    Week34,
 
-        [TimeIdentifierMeta("Week 35", "W35", Week)]
-        Week35,
+    [TimeIdentifierMeta("Week 35", "W35", Week)]
+    Week35,
 
-        [TimeIdentifierMeta("Week 36", "W36", Week)]
-        Week36,
+    [TimeIdentifierMeta("Week 36", "W36", Week)]
+    Week36,
 
-        [TimeIdentifierMeta("Week 37", "W37", Week)]
-        Week37,
+    [TimeIdentifierMeta("Week 37", "W37", Week)]
+    Week37,
 
-        [TimeIdentifierMeta("Week 38", "W38", Week)]
-        Week38,
+    [TimeIdentifierMeta("Week 38", "W38", Week)]
+    Week38,
 
-        [TimeIdentifierMeta("Week 39", "W39", Week)]
-        Week39,
+    [TimeIdentifierMeta("Week 39", "W39", Week)]
+    Week39,
 
-        [TimeIdentifierMeta("Week 40", "W40", Week)]
-        Week40,
+    [TimeIdentifierMeta("Week 40", "W40", Week)]
+    Week40,
 
-        [TimeIdentifierMeta("Week 41", "W41", Week)]
-        Week41,
+    [TimeIdentifierMeta("Week 41", "W41", Week)]
+    Week41,
 
-        [TimeIdentifierMeta("Week 42", "W42", Week)]
-        Week42,
+    [TimeIdentifierMeta("Week 42", "W42", Week)]
+    Week42,
 
-        [TimeIdentifierMeta("Week 43", "W43", Week)]
-        Week43,
+    [TimeIdentifierMeta("Week 43", "W43", Week)]
+    Week43,
 
-        [TimeIdentifierMeta("Week 44", "W44", Week)]
-        Week44,
+    [TimeIdentifierMeta("Week 44", "W44", Week)]
+    Week44,
 
-        [TimeIdentifierMeta("Week 45", "W45", Week)]
-        Week45,
+    [TimeIdentifierMeta("Week 45", "W45", Week)]
+    Week45,
 
-        [TimeIdentifierMeta("Week 46", "W46", Week)]
-        Week46,
+    [TimeIdentifierMeta("Week 46", "W46", Week)]
+    Week46,
 
-        [TimeIdentifierMeta("Week 47", "W47", Week)]
-        Week47,
+    [TimeIdentifierMeta("Week 47", "W47", Week)]
+    Week47,
 
-        [TimeIdentifierMeta("Week 48", "W48", Week)]
-        Week48,
+    [TimeIdentifierMeta("Week 48", "W48", Week)]
+    Week48,
 
-        [TimeIdentifierMeta("Week 49", "W49", Week)]
-        Week49,
+    [TimeIdentifierMeta("Week 49", "W49", Week)]
+    Week49,
 
-        [TimeIdentifierMeta("Week 50", "W50", Week)]
-        Week50,
+    [TimeIdentifierMeta("Week 50", "W50", Week)]
+    Week50,
 
-        [TimeIdentifierMeta("Week 51", "W51", Week)]
-        Week51,
+    [TimeIdentifierMeta("Week 51", "W51", Week)]
+    Week51,
 
-        [TimeIdentifierMeta("Week 52", "W52", Week)]
-        Week52,
+    [TimeIdentifierMeta("Week 52", "W52", Week)]
+    Week52,
 
-        [TimeIdentifierMeta("January", "M1", Month)]
-        January,
+    [TimeIdentifierMeta("January", "M1", Month)]
+    January,
 
-        [TimeIdentifierMeta("February", "M2", Month)]
-        February,
+    [TimeIdentifierMeta("February", "M2", Month)]
+    February,
 
-        [TimeIdentifierMeta("March", "M3", Month)]
-        March,
+    [TimeIdentifierMeta("March", "M3", Month)]
+    March,
 
-        [TimeIdentifierMeta("April", "M4", Month)]
-        April,
+    [TimeIdentifierMeta("April", "M4", Month)]
+    April,
 
-        [TimeIdentifierMeta("May", "M5", Month)]
-        May,
+    [TimeIdentifierMeta("May", "M5", Month)]
+    May,
 
-        [TimeIdentifierMeta("June", "M6", Month)]
-        June,
+    [TimeIdentifierMeta("June", "M6", Month)]
+    June,
 
-        [TimeIdentifierMeta("July", "M7", Month)]
-        July,
+    [TimeIdentifierMeta("July", "M7", Month)]
+    July,
 
-        [TimeIdentifierMeta("August", "M8", Month)]
-        August,
+    [TimeIdentifierMeta("August", "M8", Month)]
+    August,
 
-        [TimeIdentifierMeta("September", "M9", Month)]
-        September,
+    [TimeIdentifierMeta("September", "M9", Month)]
+    September,
 
-        [TimeIdentifierMeta("October", "M10", Month)]
-        October,
+    [TimeIdentifierMeta("October", "M10", Month)]
+    October,
 
-        [TimeIdentifierMeta("November", "M11", Month)]
-        November,
+    [TimeIdentifierMeta("November", "M11", Month)]
+    November,
 
-        [TimeIdentifierMeta("December", "M12", Month)]
-        December,
+    [TimeIdentifierMeta("December", "M12", Month)]
+    December,
 
-        // EES-3959 Temporary time identifier added to give the correct order to this release
-        // The publication is made up of months and academic years, so by placing this last, the release
-        // is ordered after all the other monthly releases
-        // https://explore-education-statistics.service.gov.uk/find-statistics/national-tutoring-programme/2022-23,
-        // TODO remove this once we've got a solution for ordering releases which mix categories of time periods
-        [TimeIdentifierMeta("Academic year ", "AYNTP", NationalTutoringProgramme, Academic, NoLabel)]
-        AcademicYearNationalTutoringProgramme,
+    // EES-3959 Temporary time identifier added to give the correct order to this release
+    // The publication is made up of months and academic years, so by placing this last, the release
+    // is ordered after all the other monthly releases
+    // https://explore-education-statistics.service.gov.uk/find-statistics/national-tutoring-programme/2022-23,
+    // TODO remove this once we've got a solution for ordering releases which mix categories of time periods
+    [TimeIdentifierMeta("Academic year ", "AYNTP", NationalTutoringProgramme, Academic, NoLabel)]
+    AcademicYearNationalTutoringProgramme,
 
-    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifierCategory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifierCategory.cs
@@ -1,39 +1,38 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public enum TimeIdentifierCategory
 {
-    public enum TimeIdentifierCategory
-    {
-        [EnumLabelValue("Academic year")]
-        AcademicYear,
+    [EnumLabelValue("Academic year")]
+    AcademicYear,
 
-        [EnumLabelValue("Calendar year")]
-        CalendarYear,
+    [EnumLabelValue("Calendar year")]
+    CalendarYear,
 
-        [EnumLabelValue("Financial year")]
-        FinancialYear,
+    [EnumLabelValue("Financial year")]
+    FinancialYear,
 
-        [EnumLabelValue("Tax year")]
-        TaxYear,
+    [EnumLabelValue("Tax year")]
+    TaxYear,
 
-        [EnumLabelValue("Reporting year")]
-        ReportingYear,
+    [EnumLabelValue("Reporting year")]
+    ReportingYear,
 
-        [EnumLabelValue("Term")]
-        Term,
+    [EnumLabelValue("Term")]
+    Term,
 
-        [EnumLabelValue("Month")]
-        Month,
+    [EnumLabelValue("Month")]
+    Month,
 
-        [EnumLabelValue("Week")]
-        Week,
+    [EnumLabelValue("Week")]
+    Week,
 
-        [EnumLabelValue("Financial year part")]
-        FinancialYearPart,
+    [EnumLabelValue("Financial year part")]
+    FinancialYearPart,
 
-        // EES-3959 Temporary category for the National tutoring programme publication
-        // TODO remove this once we've got a solution for ordering releases which mix categories of time periods
-        [EnumLabelValue("National tutoring programme")]
-        NationalTutoringProgramme,
-    }
+    // EES-3959 Temporary category for the National tutoring programme publication
+    // TODO remove this once we've got a solution for ordering releases which mix categories of time periods
+    [EnumLabelValue("National tutoring programme")]
+    NationalTutoringProgramme,
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Timestamps.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Timestamps.cs
@@ -1,36 +1,35 @@
 #nullable enable
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public interface ICreatedTimestamp<TDate> : ITimestampsInternal.ICreated
 {
-    public interface ICreatedTimestamp<TDate> : ITimestampsInternal.ICreated
-    {
-        TDate Created { get; set; }
-    }
+    TDate Created { get; set; }
+}
 
-    public interface IUpdatedTimestamp<TDate> : ITimestampsInternal.IUpdated
-    {
-        TDate Updated { get; set; }
-    }
+public interface IUpdatedTimestamp<TDate> : ITimestampsInternal.IUpdated
+{
+    TDate Updated { get; set; }
+}
 
-    public interface ISoftDeletedTimestamp<TDate> : ITimestampsInternal.ISoftDeleted
-    {
-        TDate SoftDeleted { get; set; }
-    }
+public interface ISoftDeletedTimestamp<TDate> : ITimestampsInternal.ISoftDeleted
+{
+    TDate SoftDeleted { get; set; }
+}
 
-    public interface ICreatedUpdatedTimestamps<TCreated, TUpdated>
-        : ICreatedTimestamp<TCreated>, IUpdatedTimestamp<TUpdated>
-    {
-    }
+public interface ICreatedUpdatedTimestamps<TCreated, TUpdated>
+    : ICreatedTimestamp<TCreated>, IUpdatedTimestamp<TUpdated>
+{
+}
 
-    /// <summary>
-    /// Marker interfaces for type guards without needing reflection.
-    /// Don't use this application level code (should only be
-    /// used in Entity Framework infrastructure code).
-    /// </summary>
-    public interface ITimestampsInternal
-    {
-        public interface ICreated {}
-        public interface IUpdated {}
-        public interface ISoftDeleted {}
-    }
+/// <summary>
+/// Marker interfaces for type guards without needing reflection.
+/// Don't use this application level code (should only be
+/// used in Entity Framework infrastructure code).
+/// </summary>
+public interface ITimestampsInternal
+{
+    public interface ICreated {}
+    public interface IUpdated {}
+    public interface ISoftDeleted {}
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Unit.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Unit.cs
@@ -1,14 +1,13 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Common.Model
-{
-    /// <summary>
-    /// Class that can be used as a return type representing no meaningful value. 
-    /// </summary>
-    public sealed class Unit
-    {
-        private Unit()
-        {
-        }
+﻿namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
 
-        public static readonly Unit Instance = new Unit();
+/// <summary>
+/// Class that can be used as a return type representing no meaningful value. 
+/// </summary>
+public sealed class Unit
+{
+    private Unit()
+    {
     }
+
+    public static readonly Unit Instance = new Unit();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/SeparatedQueryModelBinder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/SeparatedQueryModelBinder.cs
@@ -3,66 +3,65 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.ModelBinding
+namespace GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+
+/// <summary>
+/// Model binder allowing us to parse values delimited by a separator for
+/// query string keys. This is particularly useful for compressing
+/// the overall size of the URL as the traditional query string
+/// syntax (e.g. `key=a&key=b&key=c`) is really inefficient.
+/// </summary>
+public class SeparatedQueryModelBinder : IModelBinder
 {
-    /// <summary>
-    /// Model binder allowing us to parse values delimited by a separator for
-    /// query string keys. This is particularly useful for compressing
-    /// the overall size of the URL as the traditional query string
-    /// syntax (e.g. `key=a&key=b&key=c`) is really inefficient.
-    /// </summary>
-    public class SeparatedQueryModelBinder : IModelBinder
+    private readonly IModelBinder _modelBinder;
+    private readonly string _separator;
+
+    public SeparatedQueryModelBinder(IModelBinder modelBinder, string separator)
     {
-        private readonly IModelBinder _modelBinder;
-        private readonly string _separator;
+        _modelBinder = modelBinder;
+        _separator = separator;
+    }
 
-        public SeparatedQueryModelBinder(IModelBinder modelBinder, string separator)
+    public async Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        var query = bindingContext.HttpContext.Request.Query;
+
+        // In the below, we swap the current provider with our own, and then swap
+        // it back after the model binder has completed binding to avoid potentially
+        // messing up the value provider for the next value in the current binding.
+        if (bindingContext.ValueProvider is CompositeValueProvider compositeProvider)
         {
-            _modelBinder = modelBinder;
-            _separator = separator;
+            var queryStringProvider = compositeProvider
+                .FirstOrDefault(provider => provider is QueryStringValueProvider);
+
+            if (queryStringProvider is null)
+            {
+                return;
+            }
+
+            var index = compositeProvider.IndexOf(queryStringProvider);
+
+            compositeProvider[index] =
+                new SeparatedQueryStringValueProvider(query, _separator);
+
+            await _modelBinder.BindModelAsync(bindingContext);
+
+            compositeProvider[index] = queryStringProvider;
         }
-
-        public async Task BindModelAsync(ModelBindingContext bindingContext)
+        else if (bindingContext.ValueProvider is QueryStringValueProvider)
         {
-            var query = bindingContext.HttpContext.Request.Query;
+            var originalProvider = bindingContext.ValueProvider;
 
-            // In the below, we swap the current provider with our own, and then swap
-            // it back after the model binder has completed binding to avoid potentially
-            // messing up the value provider for the next value in the current binding.
-            if (bindingContext.ValueProvider is CompositeValueProvider compositeProvider)
-            {
-                var queryStringProvider = compositeProvider
-                    .FirstOrDefault(provider => provider is QueryStringValueProvider);
+            bindingContext.ValueProvider =
+                new SeparatedQueryStringValueProvider(query, _separator);
 
-                if (queryStringProvider is null)
-                {
-                    return;
-                }
+            await _modelBinder.BindModelAsync(bindingContext);
 
-                var index = compositeProvider.IndexOf(queryStringProvider);
-
-                compositeProvider[index] =
-                    new SeparatedQueryStringValueProvider(query, _separator);
-
-                await _modelBinder.BindModelAsync(bindingContext);
-
-                compositeProvider[index] = queryStringProvider;
-            }
-            else if (bindingContext.ValueProvider is QueryStringValueProvider)
-            {
-                var originalProvider = bindingContext.ValueProvider;
-
-                bindingContext.ValueProvider =
-                    new SeparatedQueryStringValueProvider(query, _separator);
-
-                await _modelBinder.BindModelAsync(bindingContext);
-
-                bindingContext.ValueProvider = originalProvider;
-            }
-            else
-            {
-                await _modelBinder.BindModelAsync(bindingContext);
-            }
+            bindingContext.ValueProvider = originalProvider;
+        }
+        else
+        {
+            await _modelBinder.BindModelAsync(bindingContext);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/SeparatedQueryModelBinderProvider.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/SeparatedQueryModelBinderProvider.cs
@@ -6,72 +6,71 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.ModelBinding
+namespace GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+
+/// <summary>
+/// Provides an instance of <see cref="SeparatedQueryModelBinder"/>
+/// when a suitable model parameter is detected e.g. an <see cref="IEnumerable{T}"/>.
+/// </summary>
+public class SeparatedQueryModelBinderProvider : IModelBinderProvider
 {
-    /// <summary>
-    /// Provides an instance of <see cref="SeparatedQueryModelBinder"/>
-    /// when a suitable model parameter is detected e.g. an <see cref="IEnumerable{T}"/>.
-    /// </summary>
-    public class SeparatedQueryModelBinderProvider : IModelBinderProvider
+    private readonly string _separator;
+
+    private static readonly HashSet<Type> SupportedElementTypes = new()
     {
-        private readonly string _separator;
+        typeof(int),
+        typeof(long),
+        typeof(short),
+        typeof(byte),
+        typeof(uint),
+        typeof(ulong),
+        typeof(ushort),
+        typeof(Guid)
+    };
 
-        private static readonly HashSet<Type> SupportedElementTypes = new()
-        {
-            typeof(int),
-            typeof(long),
-            typeof(short),
-            typeof(byte),
-            typeof(uint),
-            typeof(ulong),
-            typeof(ushort),
-            typeof(Guid)
-        };
+    public SeparatedQueryModelBinderProvider(string separator)
+    {
+        _separator = separator;
+    }
 
-        public SeparatedQueryModelBinderProvider(string separator)
+    public IModelBinder? GetBinder(ModelBinderProviderContext context)
+    {
+        var separatorAttribute = context.Metadata is DefaultModelMetadata defaultMetadata
+            ? defaultMetadata.Attributes.Attributes.FirstOrDefault(
+                attribute => attribute is QuerySeparatorAttribute) as QuerySeparatorAttribute
+            : null;
+
+        if (!IsSupported(context, separatorAttribute))
         {
-            _separator = separator;
+            return null;
         }
 
-        public IModelBinder? GetBinder(ModelBinderProviderContext context)
+        IModelBinderProvider provider;
+
+        if (context.Metadata.ModelType.IsArray)
         {
-            var separatorAttribute = context.Metadata is DefaultModelMetadata defaultMetadata
-                ? defaultMetadata.Attributes.Attributes.FirstOrDefault(
-                    attribute => attribute is QuerySeparatorAttribute) as QuerySeparatorAttribute
-                : null;
-
-            if (!IsSupported(context, separatorAttribute))
-            {
-                return null;
-            }
-
-            IModelBinderProvider provider;
-
-            if (context.Metadata.ModelType.IsArray)
-            {
-                provider = new ArrayModelBinderProvider();
-            }
-            else
-            {
-                provider = new CollectionModelBinderProvider();
-            }
-
-            var binder = provider.GetBinder(context)
-                         ?? throw new NullReferenceException($"Could not get binder for {provider.GetType().Name}");
-
-            return new SeparatedQueryModelBinder(binder, separatorAttribute?.Separator ?? _separator);
+            provider = new ArrayModelBinderProvider();
+        }
+        else
+        {
+            provider = new CollectionModelBinderProvider();
         }
 
-        private bool IsSupported(ModelBinderProviderContext context, QuerySeparatorAttribute? attribute)
-        {
-            if (attribute is not null && context.Metadata.IsEnumerableType)
-            {
-                return true;
-            }
+        var binder = provider.GetBinder(context)
+                     ?? throw new NullReferenceException($"Could not get binder for {provider.GetType().Name}");
 
-            return context.BindingInfo.BindingSource == BindingSource.Query
-                   && context.Metadata.IsEnumerableType
-                   && SupportedElementTypes.Contains(context.Metadata.ElementType!);
+        return new SeparatedQueryModelBinder(binder, separatorAttribute?.Separator ?? _separator);
+    }
+
+    private bool IsSupported(ModelBinderProviderContext context, QuerySeparatorAttribute? attribute)
+    {
+        if (attribute is not null && context.Metadata.IsEnumerableType)
+        {
+            return true;
         }
+
+        return context.BindingInfo.BindingSource == BindingSource.Query
+               && context.Metadata.IsEnumerableType
+               && SupportedElementTypes.Contains(context.Metadata.ElementType!);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/SeparatedQueryStringValueProvider.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ModelBinding/SeparatedQueryStringValueProvider.cs
@@ -6,39 +6,38 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Primitives;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.ModelBinding
+namespace GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+
+public class SeparatedQueryStringValueProvider : QueryStringValueProvider
 {
-    public class SeparatedQueryStringValueProvider : QueryStringValueProvider
+    private readonly string _separator;
+
+    public SeparatedQueryStringValueProvider(IQueryCollection values, string separator)
+        : base(BindingSource.Query, values, CultureInfo.InvariantCulture)
     {
-        private readonly string _separator;
+        _separator = separator;
+    }
 
-        public SeparatedQueryStringValueProvider(IQueryCollection values, string separator)
-            : base(BindingSource.Query, values, CultureInfo.InvariantCulture)
+    public override ValueProviderResult GetValue(string key)
+    {
+        var result = base.GetValue(key);
+
+        if (result == ValueProviderResult.None)
         {
-            _separator = separator;
-        }
-
-        public override ValueProviderResult GetValue(string key)
-        {
-            var result = base.GetValue(key);
-
-            if (result == ValueProviderResult.None)
-            {
-                return result;
-            }
-
-            if (result.Values.Any(x => x.IndexOf(_separator, StringComparison.OrdinalIgnoreCase) > 0))
-            {
-                var splitValues = new StringValues(
-                    result.Values
-                        .SelectMany(x => x.Split(_separator, StringSplitOptions.RemoveEmptyEntries))
-                        .ToArray()
-                );
-
-                return new ValueProviderResult(splitValues, result.Culture);
-            }
-
             return result;
         }
+
+        if (result.Values.Any(x => x.IndexOf(_separator, StringComparison.OrdinalIgnoreCase) > 0))
+        {
+            var splitValues = new StringValues(
+                result.Values
+                    .SelectMany(x => x.Split(_separator, StringSplitOptions.RemoveEmptyEntries))
+                    .ToArray()
+            );
+
+            return new ValueProviderResult(splitValues, result.Culture);
+        }
+
+        return result;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Security/AuthorizationHandlers/EntityAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Security/AuthorizationHandlers/EntityAuthorizationHandler.cs
@@ -3,41 +3,40 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlers
+namespace GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlers;
+
+public class EntityAuthorizationContext<TEntity>
 {
-    public class EntityAuthorizationContext<TEntity>
-    {
-        public TEntity Entity { get; set; }
-        
-        public ClaimsPrincipal User { get; set; }
-        
-        public EntityAuthorizationContext(TEntity entity, ClaimsPrincipal user)
-        {
-            Entity = entity;
-            User = user;
-        }
-    }
+    public TEntity Entity { get; set; }
     
-    public abstract class EntityAuthorizationHandler<TRequirement, TEntity> : AuthorizationHandler<TRequirement, TEntity> 
-        where TRequirement : IAuthorizationRequirement
+    public ClaimsPrincipal User { get; set; }
+    
+    public EntityAuthorizationContext(TEntity entity, ClaimsPrincipal user)
     {
-        private readonly Predicate<EntityAuthorizationContext<TEntity>> _entityTest;
+        Entity = entity;
+        User = user;
+    }
+}
 
-        protected EntityAuthorizationHandler(Predicate<EntityAuthorizationContext<TEntity>> entityTest)
+public abstract class EntityAuthorizationHandler<TRequirement, TEntity> : AuthorizationHandler<TRequirement, TEntity> 
+    where TRequirement : IAuthorizationRequirement
+{
+    private readonly Predicate<EntityAuthorizationContext<TEntity>> _entityTest;
+
+    protected EntityAuthorizationHandler(Predicate<EntityAuthorizationContext<TEntity>> entityTest)
+    {
+        _entityTest = entityTest;
+    }
+
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
+        TRequirement requirement,
+        TEntity entity)
+    {
+        if (_entityTest.Invoke(new EntityAuthorizationContext<TEntity>(entity, authContext.User))) 
         {
-            _entityTest = entityTest;
+            authContext.Succeed(requirement);    
         }
 
-        protected override Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
-            TRequirement requirement,
-            TEntity entity)
-        {
-            if (_entityTest.Invoke(new EntityAuthorizationContext<TEntity>(entity, authContext.User))) 
-            {
-                authContext.Succeed(requirement);    
-            }
-
-            return Task.CompletedTask;
-        }
+        return Task.CompletedTask;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobCacheService.cs
@@ -7,86 +7,85 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services;
+
+public class BlobCacheService : IBlobCacheService
 {
-    public class BlobCacheService : IBlobCacheService
+    private readonly IBlobStorageService _blobStorageService;
+    private readonly ILogger<BlobCacheService> _logger;
+
+    public BlobCacheService(IBlobStorageService blobStorageService,
+        ILogger<BlobCacheService> logger)
     {
-        private readonly IBlobStorageService _blobStorageService;
-        private readonly ILogger<BlobCacheService> _logger;
+        _blobStorageService = blobStorageService;
+        _logger = logger;
+    }
 
-        public BlobCacheService(IBlobStorageService blobStorageService,
-            ILogger<BlobCacheService> logger)
+    public object? GetItem(IBlobCacheKey cacheKey, Type targetType)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<object?> GetItemAsync(IBlobCacheKey cacheKey, Type targetType)
+    {
+        var blobContainer = cacheKey.Container;
+        var key = cacheKey.Key;
+
+        // Attempt to read blob from the storage container
+        try
         {
-            _blobStorageService = blobStorageService;
-            _logger = logger;
+            var result = await _blobStorageService.GetDeserializedJson(cacheKey.Container, cacheKey.Key, targetType)
+                .OrElse(() => (object?) null);
+
+            _logger.LogDebug("Blob cache {HitOrMiss} - for key {CacheKey}",
+                result != null ? "hit" : "miss", key);
+
+            return result;
+        }
+        catch (JsonException e)
+        {
+            // If there's an error deserializing the blob, we should
+            // assume it's not salvageable and delete it so that it's re-built.
+            _logger.LogWarning(e, $"Error deserializing JSON for blobContainer {blobContainer} and cache " +
+                                  $"key {key} - deleting cached JSON");
+            await _blobStorageService.DeleteBlob(blobContainer, key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Caught error fetching cache entry from: {BlobContainer}/{Key}", blobContainer, key);
         }
 
-        public object? GetItem(IBlobCacheKey cacheKey, Type targetType)
-        {
-            throw new NotImplementedException();
-        }
+        return default;
+    }
 
-        public async Task<object?> GetItemAsync(IBlobCacheKey cacheKey, Type targetType)
-        {
-            var blobContainer = cacheKey.Container;
-            var key = cacheKey.Key;
+    public void SetItem<TItem>(
+        IBlobCacheKey cacheKey,
+        TItem item)
+    {
+        throw new NotImplementedException();
+    }
 
-            // Attempt to read blob from the storage container
-            try
-            {
-                var result = await _blobStorageService.GetDeserializedJson(cacheKey.Container, cacheKey.Key, targetType)
-                    .OrElse(() => (object?) null);
+    public async Task SetItemAsync<TItem>(
+        IBlobCacheKey cacheKey,
+        TItem item)
+    {
+        // Write result to cache as a json blob before returning
+        await _blobStorageService.UploadAsJson(cacheKey.Container, cacheKey.Key, item);
 
-                _logger.LogDebug("Blob cache {HitOrMiss} - for key {CacheKey}",
-                    result != null ? "hit" : "miss", key);
+        _logger.LogDebug("Blob cache set - for key {CacheKey}", cacheKey.Key);
+    }
 
-                return result;
-            }
-            catch (JsonException e)
-            {
-                // If there's an error deserializing the blob, we should
-                // assume it's not salvageable and delete it so that it's re-built.
-                _logger.LogWarning(e, $"Error deserializing JSON for blobContainer {blobContainer} and cache " +
-                                      $"key {key} - deleting cached JSON");
-                await _blobStorageService.DeleteBlob(blobContainer, key);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Caught error fetching cache entry from: {BlobContainer}/{Key}", blobContainer, key);
-            }
+    public async Task DeleteItemAsync(IBlobCacheKey cacheKey)
+    {
+        await _blobStorageService.DeleteBlob(cacheKey.Container, cacheKey.Key);
 
-            return default;
-        }
+        _logger.LogDebug("Blob cache delete - for key {CacheKey}", cacheKey.Key);
+    }
 
-        public void SetItem<TItem>(
-            IBlobCacheKey cacheKey,
-            TItem item)
-        {
-            throw new NotImplementedException();
-        }
+    public async Task DeleteCacheFolderAsync(IBlobCacheKey cacheFolderKey)
+    {
+        await _blobStorageService.DeleteBlobs(cacheFolderKey.Container, cacheFolderKey.Key);
 
-        public async Task SetItemAsync<TItem>(
-            IBlobCacheKey cacheKey,
-            TItem item)
-        {
-            // Write result to cache as a json blob before returning
-            await _blobStorageService.UploadAsJson(cacheKey.Container, cacheKey.Key, item);
-
-            _logger.LogDebug("Blob cache set - for key {CacheKey}", cacheKey.Key);
-        }
-
-        public async Task DeleteItemAsync(IBlobCacheKey cacheKey)
-        {
-            await _blobStorageService.DeleteBlob(cacheKey.Container, cacheKey.Key);
-
-            _logger.LogDebug("Blob cache delete - for key {CacheKey}", cacheKey.Key);
-        }
-
-        public async Task DeleteCacheFolderAsync(IBlobCacheKey cacheFolderKey)
-        {
-            await _blobStorageService.DeleteBlobs(cacheFolderKey.Container, cacheFolderKey.Key);
-
-            _logger.LogDebug("Blob cache folder delete - for key {CacheKey}", cacheFolderKey.Key);
-        }
+        _logger.LogDebug("Blob cache folder delete - for key {CacheKey}", cacheFolderKey.Key);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -26,674 +26,673 @@ using BlobInfo = GovUk.Education.ExploreEducationStatistics.Common.Model.BlobInf
 using BlobProperties = Azure.Storage.Blobs.Models.BlobProperties;
 using CopyStatus = Azure.Storage.Blobs.Models.CopyStatus;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services;
+
+/// <summary>
+/// Service to perform low-level operations with a blob store
+/// (this will most likely be Azure Blob Storage, but could be any vendor).
+///
+/// Other services should try to consume this if possible as we try to
+/// abstract away as many implementation details as possible to avoid coupling
+/// with the underlying client library. These can and do have major breaking
+/// changes that make it difficult to upgrade when relying on lower-level
+/// details e.g. Azure SDK v12 is an entirely new package compared to v11.
+/// </summary>
+public abstract class BlobStorageService : IBlobStorageService
 {
-    /// <summary>
-    /// Service to perform low-level operations with a blob store
-    /// (this will most likely be Azure Blob Storage, but could be any vendor).
-    ///
-    /// Other services should try to consume this if possible as we try to
-    /// abstract away as many implementation details as possible to avoid coupling
-    /// with the underlying client library. These can and do have major breaking
-    /// changes that make it difficult to upgrade when relying on lower-level
-    /// details e.g. Azure SDK v12 is an entirely new package compared to v11.
-    /// </summary>
-    public abstract class BlobStorageService : IBlobStorageService
+    private readonly string _connectionString;
+    private readonly BlobServiceClient _client;
+    private readonly ILogger<IBlobStorageService> _logger;
+    private readonly IStorageInstanceCreationUtil _storageInstanceCreationUtil;
+
+    protected BlobStorageService(
+        string connectionStringConfigName,
+        ILogger<IBlobStorageService> logger,
+        IConfiguration configuration)
     {
-        private readonly string _connectionString;
-        private readonly BlobServiceClient _client;
-        private readonly ILogger<IBlobStorageService> _logger;
-        private readonly IStorageInstanceCreationUtil _storageInstanceCreationUtil;
+        var privateConnectionString = configuration.GetValue<string>(connectionStringConfigName);
+        _connectionString = privateConnectionString;
+        _client = new BlobServiceClient(privateConnectionString);
+        _logger = logger;
+        _storageInstanceCreationUtil = new StorageInstanceCreationUtil();
+    }
 
-        protected BlobStorageService(
-            string connectionStringConfigName,
-            ILogger<IBlobStorageService> logger,
-            IConfiguration configuration)
+    protected BlobStorageService(string connectionString, BlobServiceClient client, ILogger<IBlobStorageService> logger, IStorageInstanceCreationUtil storageInstanceCreationUtil)
+    {
+        _connectionString = connectionString;
+        _client = client;
+        _logger = logger;
+        _storageInstanceCreationUtil = storageInstanceCreationUtil;
+    }
+
+    public async Task<List<BlobInfo>> ListBlobs(IBlobContainer containerName, string? path)
+    {
+        var blobContainer = await GetBlobContainer(containerName);
+        var blobInfos = new List<BlobInfo>();
+
+        string? continuationToken = null;
+
+        do
         {
-            var privateConnectionString = configuration.GetValue<string>(connectionStringConfigName);
-            _connectionString = privateConnectionString;
-            _client = new BlobServiceClient(privateConnectionString);
-            _logger = logger;
-            _storageInstanceCreationUtil = new StorageInstanceCreationUtil();
-        }
+            var blobPages = blobContainer.GetBlobsAsync(BlobTraits.Metadata, prefix: path)
+                .AsPages(continuationToken);
 
-        protected BlobStorageService(string connectionString, BlobServiceClient client, ILogger<IBlobStorageService> logger, IStorageInstanceCreationUtil storageInstanceCreationUtil)
-        {
-            _connectionString = connectionString;
-            _client = client;
-            _logger = logger;
-            _storageInstanceCreationUtil = storageInstanceCreationUtil;
-        }
-
-        public async Task<List<BlobInfo>> ListBlobs(IBlobContainer containerName, string? path)
-        {
-            var blobContainer = await GetBlobContainer(containerName);
-            var blobInfos = new List<BlobInfo>();
-
-            string? continuationToken = null;
-
-            do
+            await foreach (Page<BlobItem> page in blobPages)
             {
-                var blobPages = blobContainer.GetBlobsAsync(BlobTraits.Metadata, prefix: path)
-                    .AsPages(continuationToken);
-
-                await foreach (Page<BlobItem> page in blobPages)
+                foreach (var blob in page.Values)
                 {
-                    foreach (var blob in page.Values)
+                    if (blob == null)
                     {
-                        if (blob == null)
-                        {
-                            break;
-                        }
-
-                        blobInfos.Add(
-                            new BlobInfo(
-                                path: blob.Name,
-                                contentType: blob.Properties.ContentType,
-                                contentLength: blob.Properties.ContentLength ?? 0,
-                                meta: blob.Metadata,
-                                created: blob.Properties.CreatedOn,
-                                updated: blob.Properties.LastModified
-                            )
-                        );
+                        break;
                     }
 
-                    continuationToken = page.ContinuationToken;
+                    blobInfos.Add(
+                        new BlobInfo(
+                            path: blob.Name,
+                            contentType: blob.Properties.ContentType,
+                            contentLength: blob.Properties.ContentLength ?? 0,
+                            meta: blob.Metadata,
+                            created: blob.Properties.CreatedOn,
+                            updated: blob.Properties.LastModified
+                        )
+                    );
                 }
-            } while (continuationToken != string.Empty);
 
-            return blobInfos;
-        }
-
-        public async Task<bool> CheckBlobExists(IBlobContainer containerName, string path)
-        {
-            var blob = await GetBlobClient(containerName, path);
-            return await blob.ExistsAsync();
-        }
-
-        public async Task<BlobInfo> GetBlob(IBlobContainer containerName, string path)
-        {
-            var blob = await GetBlobClient(containerName, path);
-            BlobProperties properties = await blob.GetPropertiesAsync();
-
-            return new BlobInfo(
-                path: blob.Name,
-                contentType: properties.ContentType,
-                contentLength: properties.ContentLength,
-                meta: properties.Metadata,
-                created: properties.CreatedOn,
-                updated: properties.LastModified
-            );
-        }
-
-        public async Task<BlobInfo?> FindBlob(IBlobContainer containerName, string path)
-        {
-            var exists = await CheckBlobExists(containerName, path);
-
-            if (!exists)
-            {
-                return null;
+                continuationToken = page.ContinuationToken;
             }
+        } while (continuationToken != string.Empty);
 
-            return await GetBlob(containerName, path);
+        return blobInfos;
+    }
+
+    public async Task<bool> CheckBlobExists(IBlobContainer containerName, string path)
+    {
+        var blob = await GetBlobClient(containerName, path);
+        return await blob.ExistsAsync();
+    }
+
+    public async Task<BlobInfo> GetBlob(IBlobContainer containerName, string path)
+    {
+        var blob = await GetBlobClient(containerName, path);
+        BlobProperties properties = await blob.GetPropertiesAsync();
+
+        return new BlobInfo(
+            path: blob.Name,
+            contentType: properties.ContentType,
+            contentLength: properties.ContentLength,
+            meta: properties.Metadata,
+            created: properties.CreatedOn,
+            updated: properties.LastModified
+        );
+    }
+
+    public async Task<BlobInfo?> FindBlob(IBlobContainer containerName, string path)
+    {
+        var exists = await CheckBlobExists(containerName, path);
+
+        if (!exists)
+        {
+            return null;
         }
 
-        public async Task DeleteBlobs(
-            IBlobContainer containerName,
-            string? directoryPath = null,
-            IBlobStorageService.DeleteBlobsOptions? options = null)
+        return await GetBlob(containerName, path);
+    }
+
+    public async Task DeleteBlobs(
+        IBlobContainer containerName,
+        string? directoryPath = null,
+        IBlobStorageService.DeleteBlobsOptions? options = null)
+    {
+        if (!directoryPath.IsNullOrEmpty())
         {
-            if (!directoryPath.IsNullOrEmpty())
+            // Forcefully add a trailing slash to prevent deleting blobs whose names begin with that string
+            directoryPath = directoryPath?.AppendTrailingSlash();
+        }
+
+        var blobContainer = await GetBlobContainer(containerName);
+
+        _logger.LogInformation("Deleting blobs from {containerName}/{path}", blobContainer.Name, directoryPath);
+
+        string? continuationToken = null;
+
+        do
+        {
+            var blobPages = blobContainer.GetBlobsAsync(prefix: directoryPath)
+                .AsPages(continuationToken);
+
+            var deleteTasks = new List<Task>();
+
+            await foreach (Page<BlobItem> page in blobPages)
             {
-                // Forcefully add a trailing slash to prevent deleting blobs whose names begin with that string
-                directoryPath = directoryPath?.AppendTrailingSlash();
-            }
-
-            var blobContainer = await GetBlobContainer(containerName);
-
-            _logger.LogInformation("Deleting blobs from {containerName}/{path}", blobContainer.Name, directoryPath);
-
-            string? continuationToken = null;
-
-            do
-            {
-                var blobPages = blobContainer.GetBlobsAsync(prefix: directoryPath)
-                    .AsPages(continuationToken);
-
-                var deleteTasks = new List<Task>();
-
-                await foreach (Page<BlobItem> page in blobPages)
+                foreach (var blob in page.Values)
                 {
-                    foreach (var blob in page.Values)
+                    if (blob == null)
                     {
-                        if (blob == null)
-                        {
-                            break;
-                        }
-
-                        var excluded = options?.ExcludeRegex?.IsMatch(blob.Name) ?? false;
-                        var included = options?.IncludeRegex?.IsMatch(blob.Name) ?? true;
-
-                        if (excluded || !included)
-                        {
-                            _logger.LogInformation("Ignoring blob {containerName}/{path}", blobContainer.Name, blob.Name);
-                            continue;
-                        }
-
-                        _logger.LogInformation("Deleting blob {containerName}/{path}", blobContainer.Name, blob.Name);
-
-                        deleteTasks.Add(blobContainer.DeleteBlobIfExistsAsync(blob.Name));
+                        break;
                     }
 
-                    continuationToken = page.ContinuationToken;
+                    var excluded = options?.ExcludeRegex?.IsMatch(blob.Name) ?? false;
+                    var included = options?.IncludeRegex?.IsMatch(blob.Name) ?? true;
+
+                    if (excluded || !included)
+                    {
+                        _logger.LogInformation("Ignoring blob {containerName}/{path}", blobContainer.Name, blob.Name);
+                        continue;
+                    }
+
+                    _logger.LogInformation("Deleting blob {containerName}/{path}", blobContainer.Name, blob.Name);
+
+                    deleteTasks.Add(blobContainer.DeleteBlobIfExistsAsync(blob.Name));
                 }
 
-                await Task.WhenAll(deleteTasks);
-            } while (continuationToken != string.Empty);
-        }
+                continuationToken = page.ContinuationToken;
+            }
 
-        public async Task DeleteBlob(IBlobContainer containerName, string path)
-        {
-            var blob = await GetBlobClient(containerName, path);
+            await Task.WhenAll(deleteTasks);
+        } while (continuationToken != string.Empty);
+    }
 
-            _logger.LogInformation("Deleting blob {containerName}/{path}", containerName, path);
+    public async Task DeleteBlob(IBlobContainer containerName, string path)
+    {
+        var blob = await GetBlobClient(containerName, path);
 
-            await blob.DeleteIfExistsAsync();
-        }
+        _logger.LogInformation("Deleting blob {containerName}/{path}", containerName, path);
 
-        public async Task UploadFile(
-            IBlobContainer containerName,
-            string path,
-            IFormFile file)
-        {
-            var blob = await GetBlobClient(containerName, path);
+        await blob.DeleteIfExistsAsync();
+    }
 
-            var tempFilePath = await UploadToTemporaryFile(file);
+    public async Task UploadFile(
+        IBlobContainer containerName,
+        string path,
+        IFormFile file)
+    {
+        var blob = await GetBlobClient(containerName, path);
 
-            _logger.LogInformation("Uploading file to blob {containerName}/{path}", containerName, path);
+        var tempFilePath = await UploadToTemporaryFile(file);
 
-            await blob.UploadAsync(
-                path: tempFilePath,
-                httpHeaders: new BlobHttpHeaders
-                {
-                    ContentType = file.ContentType
-                }
-            );
-        }
+        _logger.LogInformation("Uploading file to blob {containerName}/{path}", containerName, path);
 
-        public async Task<bool> MoveBlob(IBlobContainer containerName,
-            string sourcePath,
-            string destinationPath)
-        {
-            var blobContainer = await GetBlobContainer(containerName);
-
-            var destinationBlob = blobContainer.GetBlobClient(destinationPath);
-            if (await destinationBlob.ExistsAsync())
+        await blob.UploadAsync(
+            path: tempFilePath,
+            httpHeaders: new BlobHttpHeaders
             {
-                _logger.LogWarning(
-                    "Destination already exists while moving blob. Source: '{source}' Destination: '{destination}'",
-                    sourcePath, destinationPath);
+                ContentType = file.ContentType
+            }
+        );
+    }
+
+    public async Task<bool> MoveBlob(IBlobContainer containerName,
+        string sourcePath,
+        string destinationPath)
+    {
+        var blobContainer = await GetBlobContainer(containerName);
+
+        var destinationBlob = blobContainer.GetBlobClient(destinationPath);
+        if (await destinationBlob.ExistsAsync())
+        {
+            _logger.LogWarning(
+                "Destination already exists while moving blob. Source: '{source}' Destination: '{destination}'",
+                sourcePath, destinationPath);
+            return false;
+        }
+
+        var sourceBlob = blobContainer.GetBlobClient(sourcePath);
+        if (!await sourceBlob.ExistsAsync())
+        {
+            _logger.LogWarning(
+                "Source blob not found while moving blob. Source: '{source}' Destination: '{destination}'",
+                sourcePath, destinationPath);
+            return false;
+        }
+
+        // Lease the source blob for the copy operation
+        // to prevent another client from modifying it.
+        var lease = sourceBlob.GetBlobLeaseClient();
+
+        // Specifying -1 for the lease interval creates an infinite lease.
+        await lease.AcquireAsync(TimeSpan.FromSeconds(-1));
+
+        try
+        {
+            await destinationBlob.StartCopyFromUriAsync(sourceBlob.Uri);
+
+            // Get the destination blob's properties and log the progress
+            BlobProperties destinationProperties = await destinationBlob.GetPropertiesAsync();
+            while (destinationProperties.CopyStatus == CopyStatus.Pending)
+            {
+                await Task.Delay(1000);
+                _logger.LogInformation("Copy progress: {progress}", destinationProperties.CopyProgress);
+                destinationProperties = await destinationBlob.GetPropertiesAsync();
+            }
+
+            if (destinationProperties.CopyStatus != CopyStatus.Success)
+            {
                 return false;
             }
-
-            var sourceBlob = blobContainer.GetBlobClient(sourcePath);
-            if (!await sourceBlob.ExistsAsync())
-            {
-                _logger.LogWarning(
-                    "Source blob not found while moving blob. Source: '{source}' Destination: '{destination}'",
-                    sourcePath, destinationPath);
-                return false;
-            }
-
-            // Lease the source blob for the copy operation
-            // to prevent another client from modifying it.
-            var lease = sourceBlob.GetBlobLeaseClient();
-
-            // Specifying -1 for the lease interval creates an infinite lease.
-            await lease.AcquireAsync(TimeSpan.FromSeconds(-1));
-
-            try
-            {
-                await destinationBlob.StartCopyFromUriAsync(sourceBlob.Uri);
-
-                // Get the destination blob's properties and log the progress
-                BlobProperties destinationProperties = await destinationBlob.GetPropertiesAsync();
-                while (destinationProperties.CopyStatus == CopyStatus.Pending)
-                {
-                    await Task.Delay(1000);
-                    _logger.LogInformation("Copy progress: {progress}", destinationProperties.CopyProgress);
-                    destinationProperties = await destinationBlob.GetPropertiesAsync();
-                }
-
-                if (destinationProperties.CopyStatus != CopyStatus.Success)
-                {
-                    return false;
-                }
-            }
-            finally
-            {
-                await lease.ReleaseAsync();
-            }
-
-            await sourceBlob.DeleteAsync();
-            return true;
+        }
+        finally
+        {
+            await lease.ReleaseAsync();
         }
 
-        private static async Task<string> UploadToTemporaryFile(IFormFile file)
+        await sourceBlob.DeleteAsync();
+        return true;
+    }
+
+    private static async Task<string> UploadToTemporaryFile(IFormFile file)
+    {
+        var path = Path.GetTempFileName();
+
+        if (file.Length > 0)
         {
-            var path = Path.GetTempFileName();
-
-            if (file.Length > 0)
-            {
-                await using var stream = new FileStream(path, FileMode.Create);
-                await file.CopyToAsync(stream);
-            }
-
-            return path;
+            await using var stream = new FileStream(path, FileMode.Create);
+            await file.CopyToAsync(stream);
         }
 
-        public async Task UploadStream(
-            IBlobContainer containerName,
-            string path,
-            Stream stream,
-            string contentType,
-            string? contentEncoding = null,
-            CancellationToken cancellationToken = default)
+        return path;
+    }
+
+    public async Task UploadStream(
+        IBlobContainer containerName,
+        string path,
+        Stream stream,
+        string contentType,
+        string? contentEncoding = null,
+        CancellationToken cancellationToken = default)
+    {
+        var blob = await GetBlobClient(containerName, path);
+
+        _logger.LogInformation("Uploading text to blob {containerName}/{path}", containerName, path);
+
+        var httpHeaders = new BlobHttpHeaders
         {
-            var blob = await GetBlobClient(containerName, path);
+            ContentEncoding = contentEncoding,
+            ContentType = contentType
+        };
 
-            _logger.LogInformation("Uploading text to blob {containerName}/{path}", containerName, path);
-
-            var httpHeaders = new BlobHttpHeaders
-            {
-                ContentEncoding = contentEncoding,
-                ContentType = contentType
-            };
-
-            var compress = contentEncoding != null;
-            if (compress)
-            {
-                await using var targetStream = new MemoryStream();
-                await CompressionUtils.CompressToStream(
-                    stream: stream,
-                    targetStream: targetStream,
-                    contentEncoding: contentEncoding!,
-                    cancellationToken: cancellationToken);
-                await blob.UploadAsync(
-                    content: targetStream,
-                    httpHeaders: httpHeaders,
-                    cancellationToken: cancellationToken
-                );
-            }
-            else
-            {
-                stream.SeekToBeginning();
-                await blob.UploadAsync(
-                    content: stream,
-                    httpHeaders: httpHeaders,
-                    cancellationToken: cancellationToken
-                );
-            }
-        }
-
-        public async Task UploadAsJson<T>(
-            IBlobContainer containerName,
-            string path,
-            T content,
-            string? contentEncoding = null,
-            JsonSerializerSettings? settings = null,
-            CancellationToken cancellationToken = default)
+        var compress = contentEncoding != null;
+        if (compress)
         {
-            await using var stream = new MemoryStream();
-            await using var jsonWriter = new JsonTextWriter(new StreamWriter(stream, leaveOpen: true));
-            JsonSerializer.CreateDefault(settings).Serialize(jsonWriter, content, typeof(T));
-            await jsonWriter.FlushAsync(cancellationToken);
-
-            await UploadStream(
-                containerName: containerName,
-                path: path,
+            await using var targetStream = new MemoryStream();
+            await CompressionUtils.CompressToStream(
                 stream: stream,
-                contentEncoding: contentEncoding,
-                contentType: MediaTypeNames.Application.Json,
+                targetStream: targetStream,
+                contentEncoding: contentEncoding!,
                 cancellationToken: cancellationToken);
+            await blob.UploadAsync(
+                content: targetStream,
+                httpHeaders: httpHeaders,
+                cancellationToken: cancellationToken
+            );
         }
-
-        public async Task<Either<ActionResult, Stream>> DownloadToStream(
-            IBlobContainer containerName,
-            string path,
-            Stream targetStream,
-            bool decompress = true,
-            CancellationToken cancellationToken = default)
+        else
         {
-            return await GetBlobClientOrNotFound(containerName, path)
-                .OnSuccess(async blob =>
-                {
-                    if (decompress)
-                    {
-                        BlobProperties blobProperties =
-                            await blob.GetPropertiesAsync(cancellationToken: cancellationToken);
+            stream.SeekToBeginning();
+            await blob.UploadAsync(
+                content: stream,
+                httpHeaders: httpHeaders,
+                cancellationToken: cancellationToken
+            );
+        }
+    }
 
-                        // Check the ContentEncoding property to determine if the blob
-                        // is compressed and only decompress if necessary.
-                        if (blobProperties.ContentEncoding.IsNullOrEmpty())
-                        {
-                            await blob.DownloadToAsync(targetStream, cancellationToken);
-                            targetStream.SeekToBeginning();
-                        }
-                        else
-                        {
-                            var blobStream = await blob.OpenReadAsync(cancellationToken: cancellationToken);
-                            await CompressionUtils.DecompressToStream(
-                                stream: blobStream,
-                                targetStream: targetStream,
-                                contentEncoding: blobProperties.ContentEncoding,
-                                cancellationToken: cancellationToken);
-                        }
-                    }
-                    else
+    public async Task UploadAsJson<T>(
+        IBlobContainer containerName,
+        string path,
+        T content,
+        string? contentEncoding = null,
+        JsonSerializerSettings? settings = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var stream = new MemoryStream();
+        await using var jsonWriter = new JsonTextWriter(new StreamWriter(stream, leaveOpen: true));
+        JsonSerializer.CreateDefault(settings).Serialize(jsonWriter, content, typeof(T));
+        await jsonWriter.FlushAsync(cancellationToken);
+
+        await UploadStream(
+            containerName: containerName,
+            path: path,
+            stream: stream,
+            contentEncoding: contentEncoding,
+            contentType: MediaTypeNames.Application.Json,
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task<Either<ActionResult, Stream>> DownloadToStream(
+        IBlobContainer containerName,
+        string path,
+        Stream targetStream,
+        bool decompress = true,
+        CancellationToken cancellationToken = default)
+    {
+        return await GetBlobClientOrNotFound(containerName, path)
+            .OnSuccess(async blob =>
+            {
+                if (decompress)
+                {
+                    BlobProperties blobProperties =
+                        await blob.GetPropertiesAsync(cancellationToken: cancellationToken);
+
+                    // Check the ContentEncoding property to determine if the blob
+                    // is compressed and only decompress if necessary.
+                    if (blobProperties.ContentEncoding.IsNullOrEmpty())
                     {
                         await blob.DownloadToAsync(targetStream, cancellationToken);
                         targetStream.SeekToBeginning();
                     }
-
-                    return targetStream;
-                });
-        }
-
-        public async Task<Stream> StreamBlob(
-            IBlobContainer containerName,
-            string path,
-            int? bufferSize = null,
-            CancellationToken cancellationToken = default)
-        {
-            var blob = await GetBlobClient(containerName, path);
-
-            try
-            {
-                return await blob.OpenReadAsync(bufferSize: bufferSize, cancellationToken: cancellationToken);
-            }
-            catch (RequestFailedException exception)
-            {
-                if (exception.Status == 404)
-                {
-                    ThrowFileNotFoundException(containerName, path);
-                }
-
-                throw;
-            }
-        }
-
-        public async Task<Either<ActionResult, string>> DownloadBlobText(
-            IBlobContainer containerName,
-            string path,
-            CancellationToken cancellationToken = default)
-        {
-            var blob = await GetBlobClient(containerName, path);
-
-            try
-            {
-                BlobDownloadResult response = await blob.DownloadContentAsync(cancellationToken);
-
-                // Check the ContentEncoding property to determine if the blob
-                // is compressed and only decompress if necessary.
-                var contentEncoding = response.Details.ContentEncoding;
-                if (contentEncoding.IsNullOrEmpty())
-                {
-                    return response.Content.ToString();
-                }
-
-                return await CompressionUtils.DecompressToString(
-                    bytes: response.Content.ToArray(),
-                    contentEncoding: contentEncoding,
-                    cancellationToken: cancellationToken);
-            }
-            catch (RequestFailedException exception)
-                when (exception.Status == 404)
-            {
-                return new NotFoundResult();
-            }
-        }
-
-        public async Task<Either<ActionResult, object?>> GetDeserializedJson(
-            IBlobContainer containerName,
-            string path,
-            Type type,
-            JsonSerializerSettings? settings = null,
-            CancellationToken cancellationToken = default)
-        {
-            return await DownloadBlobText(containerName, path, cancellationToken)
-                .OnSuccess(text =>
-                {
-                    if (string.IsNullOrWhiteSpace(text))
+                    else
                     {
-                        throw new JsonException(
-                            $"Found empty file when trying to deserialize JSON for path: {path}");
+                        var blobStream = await blob.OpenReadAsync(cancellationToken: cancellationToken);
+                        await CompressionUtils.DecompressToStream(
+                            stream: blobStream,
+                            targetStream: targetStream,
+                            contentEncoding: blobProperties.ContentEncoding,
+                            cancellationToken: cancellationToken);
                     }
-
-                    return JsonConvert.DeserializeObject(
-                        value: text,
-                        type,
-                        settings
-                    );
-                });
-        }
-
-        public async Task<Either<ActionResult, T?>> GetDeserializedJson<T>(
-            IBlobContainer containerName,
-            string path,
-            JsonSerializerSettings? settings = null,
-            CancellationToken cancellationToken = default)
-            where T : class
-        {
-            return (await GetDeserializedJson(containerName, path, typeof(T), settings, cancellationToken))
-                .OnSuccess(deserialized => deserialized as T);
-        }
-
-        public async Task<List<BlobInfo>> CopyDirectory(
-            IBlobContainer sourceContainerName,
-            string sourceDirectoryPath,
-            IBlobContainer destinationContainerName,
-            string destinationDirectoryPath,
-            IBlobStorageService.CopyDirectoryOptions? options = null)
-        {
-            _logger.LogInformation(
-                "Copying directory from {sourceContainer}/{sourcePath} to {destinationContainer}/{destinationPath}",
-                sourceContainerName,
-                sourceDirectoryPath,
-                destinationContainerName,
-                destinationDirectoryPath
-            );
-
-            var sourceContainer = await GetCloudBlobContainer(sourceContainerName);
-            var destinationContainer = await GetCloudBlobContainer(
-                destinationContainerName,
-                connectionString: options?.DestinationConnectionString
-            );
-
-            var sourceDirectory = sourceContainer.GetDirectoryReference(sourceDirectoryPath);
-            var destinationDirectory = destinationContainer.GetDirectoryReference(destinationDirectoryPath);
-
-            var copyDirectoryOptions = new CopyDirectoryOptions
-            {
-                Recursive = true
-            };
-
-            var filesTransferred = new List<BlobInfo>();
-
-            var context = new DirectoryTransferContext();
-            context.FileTransferred += (sender, args) => FileTransferredCallback(sender, args, filesTransferred);
-            context.FileFailed += FileFailedCallback;
-            context.FileSkipped += FileSkippedCallback;
-            context.SetAttributesCallbackAsync += options?.SetAttributesCallbackAsync;
-            context.ShouldTransferCallbackAsync += options?.ShouldTransferCallbackAsync;
-            context.ShouldOverwriteCallbackAsync += options?.ShouldOverwriteCallbackAsync;
-
-            // TODO EES-4202 Find alternative to copying directory since TransferManager
-            // depends on deprecated Microsoft.Azure.Storage.Blob SDK v11
-            await TransferManager.CopyDirectoryAsync(
-                sourceDirectory,
-                destinationDirectory,
-                CopyMethod.ServiceSideAsyncCopy,
-                copyDirectoryOptions,
-                context
-            );
-
-            return filesTransferred;
-        }
-
-        public async Task MoveDirectory(
-            IBlobContainer sourceContainerName,
-            string sourceDirectoryPath,
-            IBlobContainer destinationContainerName,
-            string destinationDirectoryPath,
-            IBlobStorageService.MoveDirectoryOptions? options = null)
-        {
-            await CopyDirectory(
-                sourceContainerName: sourceContainerName,
-                sourceDirectoryPath: sourceDirectoryPath,
-                destinationContainerName: destinationContainerName,
-                destinationDirectoryPath: destinationDirectoryPath,
-                options: new IBlobStorageService.CopyDirectoryOptions
-                {
-                    DestinationConnectionString = options?.DestinationConnectionString,
-                    SetAttributesCallbackAsync = options?.SetAttributesCallbackAsync,
-                    ShouldOverwriteCallbackAsync = (source, destination) => Task.FromResult(true),
-                    ShouldTransferCallbackAsync = options?.ShouldTransferCallbackAsync,
                 }
-            );
-            await DeleteBlobs(sourceContainerName, sourceDirectoryPath);
-        }
+                else
+                {
+                    await blob.DownloadToAsync(targetStream, cancellationToken);
+                    targetStream.SeekToBeginning();
+                }
 
-        private void FileTransferredCallback(
-            object sender,
-            TransferEventArgs e,
-            ICollection<BlobInfo> allFilesStream)
+                return targetStream;
+            });
+    }
+
+    public async Task<Stream> StreamBlob(
+        IBlobContainer containerName,
+        string path,
+        int? bufferSize = null,
+        CancellationToken cancellationToken = default)
+    {
+        var blob = await GetBlobClient(containerName, path);
+
+        try
         {
-            var source = (CloudBlockBlob) e.Source;
-            var destination = (CloudBlockBlob) e.Destination;
-
-            allFilesStream.Add(
-                new BlobInfo(
-                    path: destination.Name,
-                    contentType: source.Properties.ContentType,
-                    contentLength: source.Properties.Length,
-                    meta: source.Metadata,
-                    created: source.Properties.Created,
-                    updated: source.Properties.LastModified
-                )
-            );
-
-            _logger.LogInformation(
-                "Transferred {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}",
-                source.Container.Name,
-                source.Name,
-                destination.Container.Name,
-                destination.Name
-            );
+            return await blob.OpenReadAsync(bufferSize: bufferSize, cancellationToken: cancellationToken);
         }
-
-        private void FileFailedCallback(object? sender, TransferEventArgs e)
+        catch (RequestFailedException exception)
         {
-            var source = (CloudBlockBlob) e.Source;
-            var destination = (CloudBlockBlob) e.Destination;
-
-            _logger.LogInformation(
-                "Failed to transfer {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}. Error message: {errorMessage}",
-                source.Container.Name,
-                source.Name,
-                destination.Container.Name,
-                destination.Name,
-                e.Exception.Message
-            );
-        }
-
-        private void FileSkippedCallback(object? sender, TransferEventArgs e)
-        {
-            var source = (CloudBlockBlob) e.Source;
-            var destination = (CloudBlockBlob) e.Destination;
-
-            _logger.LogInformation(
-                "Skipped transfer {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}",
-                source.Container.Name,
-                source.Name,
-                destination.Container.Name,
-                destination.Name
-            );
-        }
-
-        private async Task<BlobClient> GetBlobClient(IBlobContainer containerName, string path)
-        {
-            var blobContainer = await GetBlobContainer(containerName);
-            return blobContainer.GetBlobClient(path);
-        }
-
-        private async Task<Either<ActionResult, BlobClient>> GetBlobClientOrNotFound(IBlobContainer containerName,
-            string path)
-        {
-            var blobClient = await GetBlobClient(containerName, path);
-            if (await blobClient.ExistsAsync())
+            if (exception.Status == 404)
             {
-                return blobClient;
+                ThrowFileNotFoundException(containerName, path);
             }
 
-            _logger.LogWarning("Could not find blob {containerName}/{path}", containerName, path);
+            throw;
+        }
+    }
+
+    public async Task<Either<ActionResult, string>> DownloadBlobText(
+        IBlobContainer containerName,
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        var blob = await GetBlobClient(containerName, path);
+
+        try
+        {
+            BlobDownloadResult response = await blob.DownloadContentAsync(cancellationToken);
+
+            // Check the ContentEncoding property to determine if the blob
+            // is compressed and only decompress if necessary.
+            var contentEncoding = response.Details.ContentEncoding;
+            if (contentEncoding.IsNullOrEmpty())
+            {
+                return response.Content.ToString();
+            }
+
+            return await CompressionUtils.DecompressToString(
+                bytes: response.Content.ToArray(),
+                contentEncoding: contentEncoding,
+                cancellationToken: cancellationToken);
+        }
+        catch (RequestFailedException exception)
+            when (exception.Status == 404)
+        {
             return new NotFoundResult();
         }
+    }
 
-        /**
-         * TODO EES-4202
-         * We still need to use the older CloudBlobContainer implementation as we
-         * need to interop with DataMovement.TransferManager which hasn't been
-         * updated to work with Azure SDK 12 yet.
-         */
-        private async Task<CloudBlobContainer> GetCloudBlobContainer(
-            IBlobContainer container,
-            string? connectionString = null)
+    public async Task<Either<ActionResult, object?>> GetDeserializedJson(
+        IBlobContainer containerName,
+        string path,
+        Type type,
+        JsonSerializerSettings? settings = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await DownloadBlobText(containerName, path, cancellationToken)
+            .OnSuccess(text =>
+            {
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    throw new JsonException(
+                        $"Found empty file when trying to deserialize JSON for path: {path}");
+                }
+
+                return JsonConvert.DeserializeObject(
+                    value: text,
+                    type,
+                    settings
+                );
+            });
+    }
+
+    public async Task<Either<ActionResult, T?>> GetDeserializedJson<T>(
+        IBlobContainer containerName,
+        string path,
+        JsonSerializerSettings? settings = null,
+        CancellationToken cancellationToken = default)
+        where T : class
+    {
+        return (await GetDeserializedJson(containerName, path, typeof(T), settings, cancellationToken))
+            .OnSuccess(deserialized => deserialized as T);
+    }
+
+    public async Task<List<BlobInfo>> CopyDirectory(
+        IBlobContainer sourceContainerName,
+        string sourceDirectoryPath,
+        IBlobContainer destinationContainerName,
+        string destinationDirectoryPath,
+        IBlobStorageService.CopyDirectoryOptions? options = null)
+    {
+        _logger.LogInformation(
+            "Copying directory from {sourceContainer}/{sourcePath} to {destinationContainer}/{destinationPath}",
+            sourceContainerName,
+            sourceDirectoryPath,
+            destinationContainerName,
+            destinationDirectoryPath
+        );
+
+        var sourceContainer = await GetCloudBlobContainer(sourceContainerName);
+        var destinationContainer = await GetCloudBlobContainer(
+            destinationContainerName,
+            connectionString: options?.DestinationConnectionString
+        );
+
+        var sourceDirectory = sourceContainer.GetDirectoryReference(sourceDirectoryPath);
+        var destinationDirectory = destinationContainer.GetDirectoryReference(destinationDirectoryPath);
+
+        var copyDirectoryOptions = new CopyDirectoryOptions
         {
-            var storageAccount = CloudStorageAccount.Parse(connectionString ?? _connectionString);
-            var blobClient = storageAccount.CreateCloudBlobClient();
+            Recursive = true
+        };
 
-            var containerName = IsDevelopmentStorageAccount(blobClient) ? container.EmulatedName : container.Name;
+        var filesTransferred = new List<BlobInfo>();
 
-            var containerClient = blobClient.GetContainerReference(containerName);
+        var context = new DirectoryTransferContext();
+        context.FileTransferred += (sender, args) => FileTransferredCallback(sender, args, filesTransferred);
+        context.FileFailed += FileFailedCallback;
+        context.FileSkipped += FileSkippedCallback;
+        context.SetAttributesCallbackAsync += options?.SetAttributesCallbackAsync;
+        context.ShouldTransferCallbackAsync += options?.ShouldTransferCallbackAsync;
+        context.ShouldOverwriteCallbackAsync += options?.ShouldOverwriteCallbackAsync;
 
-            await _storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
-                _connectionString,
-                AzureStorageType.Blob,
-                containerName,
-                () => containerClient.CreateIfNotExistsAsync());
+        // TODO EES-4202 Find alternative to copying directory since TransferManager
+        // depends on deprecated Microsoft.Azure.Storage.Blob SDK v11
+        await TransferManager.CopyDirectoryAsync(
+            sourceDirectory,
+            destinationDirectory,
+            CopyMethod.ServiceSideAsyncCopy,
+            copyDirectoryOptions,
+            context
+        );
 
-            return containerClient;
+        return filesTransferred;
+    }
+
+    public async Task MoveDirectory(
+        IBlobContainer sourceContainerName,
+        string sourceDirectoryPath,
+        IBlobContainer destinationContainerName,
+        string destinationDirectoryPath,
+        IBlobStorageService.MoveDirectoryOptions? options = null)
+    {
+        await CopyDirectory(
+            sourceContainerName: sourceContainerName,
+            sourceDirectoryPath: sourceDirectoryPath,
+            destinationContainerName: destinationContainerName,
+            destinationDirectoryPath: destinationDirectoryPath,
+            options: new IBlobStorageService.CopyDirectoryOptions
+            {
+                DestinationConnectionString = options?.DestinationConnectionString,
+                SetAttributesCallbackAsync = options?.SetAttributesCallbackAsync,
+                ShouldOverwriteCallbackAsync = (source, destination) => Task.FromResult(true),
+                ShouldTransferCallbackAsync = options?.ShouldTransferCallbackAsync,
+            }
+        );
+        await DeleteBlobs(sourceContainerName, sourceDirectoryPath);
+    }
+
+    private void FileTransferredCallback(
+        object sender,
+        TransferEventArgs e,
+        ICollection<BlobInfo> allFilesStream)
+    {
+        var source = (CloudBlockBlob) e.Source;
+        var destination = (CloudBlockBlob) e.Destination;
+
+        allFilesStream.Add(
+            new BlobInfo(
+                path: destination.Name,
+                contentType: source.Properties.ContentType,
+                contentLength: source.Properties.Length,
+                meta: source.Metadata,
+                created: source.Properties.Created,
+                updated: source.Properties.LastModified
+            )
+        );
+
+        _logger.LogInformation(
+            "Transferred {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}",
+            source.Container.Name,
+            source.Name,
+            destination.Container.Name,
+            destination.Name
+        );
+    }
+
+    private void FileFailedCallback(object? sender, TransferEventArgs e)
+    {
+        var source = (CloudBlockBlob) e.Source;
+        var destination = (CloudBlockBlob) e.Destination;
+
+        _logger.LogInformation(
+            "Failed to transfer {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}. Error message: {errorMessage}",
+            source.Container.Name,
+            source.Name,
+            destination.Container.Name,
+            destination.Name,
+            e.Exception.Message
+        );
+    }
+
+    private void FileSkippedCallback(object? sender, TransferEventArgs e)
+    {
+        var source = (CloudBlockBlob) e.Source;
+        var destination = (CloudBlockBlob) e.Destination;
+
+        _logger.LogInformation(
+            "Skipped transfer {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}",
+            source.Container.Name,
+            source.Name,
+            destination.Container.Name,
+            destination.Name
+        );
+    }
+
+    private async Task<BlobClient> GetBlobClient(IBlobContainer containerName, string path)
+    {
+        var blobContainer = await GetBlobContainer(containerName);
+        return blobContainer.GetBlobClient(path);
+    }
+
+    private async Task<Either<ActionResult, BlobClient>> GetBlobClientOrNotFound(IBlobContainer containerName,
+        string path)
+    {
+        var blobClient = await GetBlobClient(containerName, path);
+        if (await blobClient.ExistsAsync())
+        {
+            return blobClient;
         }
 
-        private async Task<BlobContainerClient> GetBlobContainer(IBlobContainer container)
-        {
-            var containerName = IsDevelopmentStorageAccount(_client) ? container.EmulatedName : container.Name;
+        _logger.LogWarning("Could not find blob {containerName}/{path}", containerName, path);
+        return new NotFoundResult();
+    }
 
-            var containerClient = _client.GetBlobContainerClient(containerName);
+    /**
+     * TODO EES-4202
+     * We still need to use the older CloudBlobContainer implementation as we
+     * need to interop with DataMovement.TransferManager which hasn't been
+     * updated to work with Azure SDK 12 yet.
+     */
+    private async Task<CloudBlobContainer> GetCloudBlobContainer(
+        IBlobContainer container,
+        string? connectionString = null)
+    {
+        var storageAccount = CloudStorageAccount.Parse(connectionString ?? _connectionString);
+        var blobClient = storageAccount.CreateCloudBlobClient();
 
-            await _storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
-                _connectionString,
-                AzureStorageType.Blob,
-                containerName,
-                () => containerClient.CreateIfNotExistsAsync());
+        var containerName = IsDevelopmentStorageAccount(blobClient) ? container.EmulatedName : container.Name;
 
-            return containerClient;
-        }
+        var containerClient = blobClient.GetContainerReference(containerName);
 
-        private static bool IsDevelopmentStorageAccount(BlobServiceClient client)
-        {
-            return client.AccountName.ToLower() == "devstoreaccount1";
-        }
+        await _storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
+            _connectionString,
+            AzureStorageType.Blob,
+            containerName,
+            () => containerClient.CreateIfNotExistsAsync());
 
-        private static bool IsDevelopmentStorageAccount(CloudBlobClient client)
-        {
-            return client.Credentials.AccountName.ToLower() == "devstoreaccount1";
-        }
+        return containerClient;
+    }
 
-        private static void ThrowFileNotFoundException(IBlobContainer containerName, string path)
-        {
-            throw new FileNotFoundException($"Could not find file at {containerName}/{path}");
-        }
+    private async Task<BlobContainerClient> GetBlobContainer(IBlobContainer container)
+    {
+        var containerName = IsDevelopmentStorageAccount(_client) ? container.EmulatedName : container.Name;
+
+        var containerClient = _client.GetBlobContainerClient(containerName);
+
+        await _storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
+            _connectionString,
+            AzureStorageType.Blob,
+            containerName,
+            () => containerClient.CreateIfNotExistsAsync());
+
+        return containerClient;
+    }
+
+    private static bool IsDevelopmentStorageAccount(BlobServiceClient client)
+    {
+        return client.AccountName.ToLower() == "devstoreaccount1";
+    }
+
+    private static bool IsDevelopmentStorageAccount(CloudBlobClient client)
+    {
+        return client.Credentials.AccountName.ToLower() == "devstoreaccount1";
+    }
+
+    private static void ThrowFileNotFoundException(IBlobContainer containerName, string path)
+    {
+        throw new FileNotFoundException($"Could not find file at {containerName}/{path}");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/CollectionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/CollectionUtils.cs
@@ -2,28 +2,27 @@
 using System;
 using System.Collections.Generic;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services;
+
+public static class CollectionUtils
 {
-    public static class CollectionUtils
+    public static List<T> AsList<T>(params T[] objects)
     {
-        public static List<T> AsList<T>(params T[] objects)
-        {
-            return ListOf(objects);
-        }
+        return ListOf(objects);
+    }
 
-        public static List<T> ListOf<T>(params T[] objects)
-        {
-            return new List<T>(objects);
-        }
+    public static List<T> ListOf<T>(params T[] objects)
+    {
+        return new List<T>(objects);
+    }
 
-        public static HashSet<T> SetOf<T>(params T[] objects)
-        {
-            return new HashSet<T>(objects);
-        }
+    public static HashSet<T> SetOf<T>(params T[] objects)
+    {
+        return new HashSet<T>(objects);
+    }
 
-        public static Tuple<T1, T2> TupleOf<T1, T2>(T1 obj1, T2? obj2)
-        {
-            return new Tuple<T1, T2>(obj1, obj2!);
-        }
+    public static Tuple<T1, T2> TupleOf<T1, T2>(T1 obj1, T2? obj2)
+    {
+        return new Tuple<T1, T2>(obj1, obj2!);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -4,93 +4,92 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services;
+
+public static class FileStoragePathUtils
 {
-    public static class FileStoragePathUtils
+    public const string DataBlocksDirectory = "data-blocks";
+    public const string ReleasesDirectory = "releases";
+    public const string SubjectMetaDirectory = "subject-meta";
+    public const string LatestReleaseFileName = "latest-release.json";
+    public const string PublicationFileName = "publication.json";
+
+    public static string PublicContentStagingPath() => "staging";
+
+    private static string PublicContentPublicationParentPath(string publicationSlug, bool staging = false)
     {
-        public const string DataBlocksDirectory = "data-blocks";
-        public const string ReleasesDirectory = "releases";
-        public const string SubjectMetaDirectory = "subject-meta";
-        public const string LatestReleaseFileName = "latest-release.json";
-        public const string PublicationFileName = "publication.json";
+        return
+            $"{AppendPathSeparator(staging ? PublicContentStagingPath() : null)}publications/{publicationSlug.TrimToLower()}";
+    }
 
-        public static string PublicContentStagingPath() => "staging";
+    private static string PublicContentReleaseParentPath(string publicationSlug, string releaseSlug)
+    {
+        return
+            $"{PublicContentPublicationParentPath(publicationSlug)}/{ReleasesDirectory}/{releaseSlug.TrimToLower()}";
+    }
 
-        private static string PublicContentPublicationParentPath(string publicationSlug, bool staging = false)
-        {
-            return
-                $"{AppendPathSeparator(staging ? PublicContentStagingPath() : null)}publications/{publicationSlug.TrimToLower()}";
-        }
+    public static string PublicContentPublicationPath(string publicationSlug)
+    {
+        return $"{PublicContentPublicationParentPath(publicationSlug)}/{PublicationFileName}";
+    }
 
-        private static string PublicContentReleaseParentPath(string publicationSlug, string releaseSlug)
-        {
-            return
-                $"{PublicContentPublicationParentPath(publicationSlug)}/{ReleasesDirectory}/{releaseSlug.TrimToLower()}";
-        }
+    public static string PublicContentLatestReleasePath(string publicationSlug, bool staging = false)
+    {
+        return $"{PublicContentPublicationParentPath(publicationSlug, staging)}/{LatestReleaseFileName}";
+    }
 
-        public static string PublicContentPublicationPath(string publicationSlug)
-        {
-            return $"{PublicContentPublicationParentPath(publicationSlug)}/{PublicationFileName}";
-        }
+    public static string PublicContentReleasePath(string publicationSlug, string releaseSlug, bool staging = false)
+    {
+        return
+            $"{PublicContentPublicationParentPath(publicationSlug, staging)}/{ReleasesDirectory}/{releaseSlug.TrimToLower()}.json";
+    }
 
-        public static string PublicContentLatestReleasePath(string publicationSlug, bool staging = false)
-        {
-            return $"{PublicContentPublicationParentPath(publicationSlug, staging)}/{LatestReleaseFileName}";
-        }
+    public static string PublicContentDataBlockParentPath(string publicationSlug, string releaseSlug)
+    {
+        return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{DataBlocksDirectory}";
+    }
 
-        public static string PublicContentReleasePath(string publicationSlug, string releaseSlug, bool staging = false)
-        {
-            return
-                $"{PublicContentPublicationParentPath(publicationSlug, staging)}/{ReleasesDirectory}/{releaseSlug.TrimToLower()}.json";
-        }
+    public static string PrivateContentDataBlockPath(Guid releaseVersionId, Guid dataBlockId)
+    {
+        return $"{ReleasesDirectory}/{releaseVersionId}/{DataBlocksDirectory}/{dataBlockId}.json";
+    }
 
-        public static string PublicContentDataBlockParentPath(string publicationSlug, string releaseSlug)
-        {
-            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{DataBlocksDirectory}";
-        }
+    public static string PrivateContentSubjectMetaPath(Guid releaseVersionId, Guid subjectId)
+    {
+        return $"{ReleasesDirectory}/{releaseVersionId}/{SubjectMetaDirectory}/{subjectId}.json";
+    }
 
-        public static string PrivateContentDataBlockPath(Guid releaseVersionId, Guid dataBlockId)
-        {
-            return $"{ReleasesDirectory}/{releaseVersionId}/{DataBlocksDirectory}/{dataBlockId}.json";
-        }
+    public static string PublicContentDataBlockPath(
+        string publicationSlug,
+        string releaseSlug,
+        Guid dataBlockId)
+    {
+        return $"{PublicContentDataBlockParentPath(publicationSlug, releaseSlug)}/{dataBlockId}.json";
+    }
 
-        public static string PrivateContentSubjectMetaPath(Guid releaseVersionId, Guid subjectId)
-        {
-            return $"{ReleasesDirectory}/{releaseVersionId}/{SubjectMetaDirectory}/{subjectId}.json";
-        }
+    public static string PublicContentSubjectMetaParentPath(string publicationSlug, string releaseSlug)
+    {
+        return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{SubjectMetaDirectory}";
+    }
 
-        public static string PublicContentDataBlockPath(
-            string publicationSlug,
-            string releaseSlug,
-            Guid dataBlockId)
-        {
-            return $"{PublicContentDataBlockParentPath(publicationSlug, releaseSlug)}/{dataBlockId}.json";
-        }
+    public static string PublicContentSubjectMetaPath(string publicationSlug, string releaseSlug, Guid subjectId)
+    {
+        return $"{PublicContentSubjectMetaParentPath(publicationSlug, releaseSlug)}/{subjectId}.json";
+    }
 
-        public static string PublicContentSubjectMetaParentPath(string publicationSlug, string releaseSlug)
-        {
-            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{SubjectMetaDirectory}";
-        }
+    public static string PublicContentReleaseSubjectsPath(string publicationSlug, string releaseSlug)
+    {
+        return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/subjects.json";
+    }
 
-        public static string PublicContentSubjectMetaPath(string publicationSlug, string releaseSlug, Guid subjectId)
-        {
-            return $"{PublicContentSubjectMetaParentPath(publicationSlug, releaseSlug)}/{subjectId}.json";
-        }
+    public static string FilesPath(Guid rootPath, FileType type)
+    {
+        var typeFolder = (type == Metadata ? Data : type).GetEnumLabel();
+        return $"{rootPath}/{typeFolder}/";
+    }
 
-        public static string PublicContentReleaseSubjectsPath(string publicationSlug, string releaseSlug)
-        {
-            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/subjects.json";
-        }
-
-        public static string FilesPath(Guid rootPath, FileType type)
-        {
-            var typeFolder = (type == Metadata ? Data : type).GetEnumLabel();
-            return $"{rootPath}/{typeFolder}/";
-        }
-
-        private static string AppendPathSeparator(string? segment = null)
-        {
-            return segment == null ? "" : segment + "/";
-        }
+    private static string AppendPathSeparator(string? segment = null)
+    {
+        return segment == null ? "" : segment + "/";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileTypeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileTypeService.cs
@@ -14,207 +14,206 @@ using Microsoft.Extensions.Logging;
 using MimeDetective.Extensions;
 using FileType = MimeDetective.FileType;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services;
+
+public class FileTypeService : IFileTypeService
 {
-    public class FileTypeService : IFileTypeService
+    /// <summary>
+    /// Number of lines to use as a content sample when validating a CSV file's Mime type.
+    /// </summary>
+    /// <remarks>
+    /// Without limiting this, the entire file contents is used in determining whether or not the given file is
+    /// of type application/csv by the Mime library.
+    ///</remarks>
+    private const int CsvMimeTypeSampleLineCount = 1000;
+    
+    public static readonly Regex[] AllowedCsvMimeTypes = {
+        new Regex(@"^(application|text)/csv$"),
+        new Regex(@"^text/plain$")
+    };
+
+    public static readonly string[] AllowedCsvEncodingTypes = {
+        "us-ascii",
+        "utf-8"
+    };
+
+    private readonly ILogger<FileTypeService> _logger;
+    private readonly IConfiguration _configuration;
+
+    public FileTypeService(ILogger<FileTypeService> logger, IConfiguration configuration)
     {
-        /// <summary>
-        /// Number of lines to use as a content sample when validating a CSV file's Mime type.
-        /// </summary>
-        /// <remarks>
-        /// Without limiting this, the entire file contents is used in determining whether or not the given file is
-        /// of type application/csv by the Mime library.
-        ///</remarks>
-        private const int CsvMimeTypeSampleLineCount = 1000;
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    public async Task<string> GetMimeType(IFormFile file)
+    {
+        // The Mime project is generally very good at determining mime types from file contents
+        var mimeType = GetMimeTypeUsingMimeProject(file.OpenReadStream());
+
+        if (IsMimeTypeNullOrZip(mimeType))
+        {
+            var fileType = await GetMimeTypeUsingMimeDetective(file.OpenReadStream());
+            mimeType = fileType?.Mime ?? mimeType;
+        }
+
+        return mimeType;
+    }
+
+    public async Task<bool> HasMatchingMimeType(IFormFile file, IEnumerable<Regex> mimeTypes)
+    {
+        var mimeType = GetMimeTypeUsingMimeProject(file.OpenReadStream());
+
+        if (IsMimeTypeNullOrZip(mimeType))
+        {
+            var fileType = await GetMimeTypeUsingMimeDetective(file.OpenReadStream());
+            mimeType = fileType?.Mime ?? mimeType;
+        }
+
+        return mimeTypes.Any(pattern => pattern.Match(mimeType).Success);
+    }
+
+    public bool HasMatchingEncodingType(IFormFile file, IEnumerable<string> encodingTypes)
+    {
+        var encodingType = GetMimeEncoding(file.OpenReadStream());
+        return encodingTypes.Any(pattern => pattern.Equals(encodingType));
+    }
+
+    public async Task<bool> HasMatchingMimeType(Stream stream, IEnumerable<Regex> mimeTypes)
+    {
+        var mimeType = GetMimeTypeUsingMimeProject(stream);
+
+        if (IsMimeTypeNullOrZip(mimeType))
+        {
+            var fileType = await GetMimeTypeUsingMimeDetective(stream);
+            mimeType = fileType?.Mime ?? mimeType;
+        }
+
+        return mimeTypes.Any(pattern => pattern.Match(mimeType).Success);
+    }
+
+    public bool HasMatchingEncodingType(Stream stream, IEnumerable<string> encodingTypes)
+    {
+        var encodingType = GetMimeEncoding(stream);
+        return encodingTypes.Any(pattern => pattern.Equals(encodingType));
+    }
+
+    public async Task<bool> IsValidCsvFile(Func<Task<Stream>> streamProvider, string filename)
+    {
+        _logger.LogDebug("Validating that {FileName} has a CSV mime type", filename);
+
+        await using var sampleLinesStream = await GetSampleLinesStream(streamProvider, CsvMimeTypeSampleLineCount);
+
+        if (sampleLinesStream == null)
+        {
+            _logger.LogError("Unable to get sample lines for checking the mime type of {FileName}", filename);
+            return false;
+        }
         
-        public static readonly Regex[] AllowedCsvMimeTypes = {
-            new Regex(@"^(application|text)/csv$"),
-            new Regex(@"^text/plain$")
-        };
-
-        public static readonly string[] AllowedCsvEncodingTypes = {
-            "us-ascii",
-            "utf-8"
-        };
-
-        private readonly ILogger<FileTypeService> _logger;
-        private readonly IConfiguration _configuration;
-
-        public FileTypeService(ILogger<FileTypeService> logger, IConfiguration configuration)
+        if (!await HasMatchingMimeType(sampleLinesStream, AllowedCsvMimeTypes))
         {
-            _logger = logger;
-            _configuration = configuration;
+            _logger.LogDebug("{FileName} does not have a valid CSV mime type", filename);
+            return false;
         }
 
-        public async Task<string> GetMimeType(IFormFile file)
-        {
-            // The Mime project is generally very good at determining mime types from file contents
-            var mimeType = GetMimeTypeUsingMimeProject(file.OpenReadStream());
+        _logger.LogDebug("{FileName} has a valid CSV mime type", filename);
 
-            if (IsMimeTypeNullOrZip(mimeType))
+        _logger.LogDebug("Validating that {FileName} has a valid CSV character encoding", filename);
+
+        await using var encodingStream = await streamProvider.Invoke();
+
+        if (!HasMatchingEncodingType(encodingStream, AllowedCsvEncodingTypes))
+        {
+            _logger.LogDebug("{FileName} does not have a valid CSV content encoding", filename);
+            return false;
+        }
+
+        _logger.LogDebug("{FileName} has a valid CSV content encoding", filename);
+        
+        return true;
+    }
+
+    public Task<bool> IsValidCsvFile(IFormFile file)
+    {
+        return IsValidCsvFile(() => Task.FromResult(file.OpenReadStream()), file.FileName);
+    }
+
+    /// <summary>
+    /// Obtain a set of sample lines of the given file, for the purposes of checking the file's mime type and
+    /// content encoding.
+    /// </summary>
+    private async Task<Stream?> GetSampleLinesStream(Func<Task<Stream>> fileStreamProvider, int sampleLineCount)
+    {
+        using var streamReader = new StreamReader(await fileStreamProvider.Invoke());
+
+        var lines = new List<string>();
+        
+        try
+        {
+            var linesRead = 0;
+
+            while (linesRead < sampleLineCount && !streamReader.EndOfStream)
             {
-                var fileType = await GetMimeTypeUsingMimeDetective(file.OpenReadStream());
-                mimeType = fileType?.Mime ?? mimeType;
-            }
+                var nextLine = await streamReader.ReadLineAsync();
 
-            return mimeType;
-        }
-
-        public async Task<bool> HasMatchingMimeType(IFormFile file, IEnumerable<Regex> mimeTypes)
-        {
-            var mimeType = GetMimeTypeUsingMimeProject(file.OpenReadStream());
-
-            if (IsMimeTypeNullOrZip(mimeType))
-            {
-                var fileType = await GetMimeTypeUsingMimeDetective(file.OpenReadStream());
-                mimeType = fileType?.Mime ?? mimeType;
-            }
-
-            return mimeTypes.Any(pattern => pattern.Match(mimeType).Success);
-        }
-
-        public bool HasMatchingEncodingType(IFormFile file, IEnumerable<string> encodingTypes)
-        {
-            var encodingType = GetMimeEncoding(file.OpenReadStream());
-            return encodingTypes.Any(pattern => pattern.Equals(encodingType));
-        }
-
-        public async Task<bool> HasMatchingMimeType(Stream stream, IEnumerable<Regex> mimeTypes)
-        {
-            var mimeType = GetMimeTypeUsingMimeProject(stream);
-
-            if (IsMimeTypeNullOrZip(mimeType))
-            {
-                var fileType = await GetMimeTypeUsingMimeDetective(stream);
-                mimeType = fileType?.Mime ?? mimeType;
-            }
-
-            return mimeTypes.Any(pattern => pattern.Match(mimeType).Success);
-        }
-
-        public bool HasMatchingEncodingType(Stream stream, IEnumerable<string> encodingTypes)
-        {
-            var encodingType = GetMimeEncoding(stream);
-            return encodingTypes.Any(pattern => pattern.Equals(encodingType));
-        }
-
-        public async Task<bool> IsValidCsvFile(Func<Task<Stream>> streamProvider, string filename)
-        {
-            _logger.LogDebug("Validating that {FileName} has a CSV mime type", filename);
-
-            await using var sampleLinesStream = await GetSampleLinesStream(streamProvider, CsvMimeTypeSampleLineCount);
-
-            if (sampleLinesStream == null)
-            {
-                _logger.LogError("Unable to get sample lines for checking the mime type of {FileName}", filename);
-                return false;
-            }
-            
-            if (!await HasMatchingMimeType(sampleLinesStream, AllowedCsvMimeTypes))
-            {
-                _logger.LogDebug("{FileName} does not have a valid CSV mime type", filename);
-                return false;
-            }
-
-            _logger.LogDebug("{FileName} has a valid CSV mime type", filename);
-
-            _logger.LogDebug("Validating that {FileName} has a valid CSV character encoding", filename);
-
-            await using var encodingStream = await streamProvider.Invoke();
-
-            if (!HasMatchingEncodingType(encodingStream, AllowedCsvEncodingTypes))
-            {
-                _logger.LogDebug("{FileName} does not have a valid CSV content encoding", filename);
-                return false;
-            }
-
-            _logger.LogDebug("{FileName} has a valid CSV content encoding", filename);
-            
-            return true;
-        }
-
-        public Task<bool> IsValidCsvFile(IFormFile file)
-        {
-            return IsValidCsvFile(() => Task.FromResult(file.OpenReadStream()), file.FileName);
-        }
-
-        /// <summary>
-        /// Obtain a set of sample lines of the given file, for the purposes of checking the file's mime type and
-        /// content encoding.
-        /// </summary>
-        private async Task<Stream?> GetSampleLinesStream(Func<Task<Stream>> fileStreamProvider, int sampleLineCount)
-        {
-            using var streamReader = new StreamReader(await fileStreamProvider.Invoke());
-
-            var lines = new List<string>();
-            
-            try
-            {
-                var linesRead = 0;
-
-                while (linesRead < sampleLineCount && !streamReader.EndOfStream)
+                if (nextLine == null)
                 {
-                    var nextLine = await streamReader.ReadLineAsync();
-
-                    if (nextLine == null)
-                    {
-                        _logger.LogError("Unable to read next sample line {LineNumber} from CSV", linesRead + 1);
-                        break;
-                    }
-                    
-                    lines.Add(nextLine);
-                    linesRead++;
+                    _logger.LogError("Unable to read next sample line {LineNumber} from CSV", linesRead + 1);
+                    break;
                 }
                 
+                lines.Add(nextLine);
+                linesRead++;
             }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Unable to read sample lines from CSV - {ErrorMessage}", e.Message);
-                return null;
-            }
-
-            var lineStream = new MemoryStream();
-            var writer = new StreamWriter(lineStream);
-            await writer.WriteAsync(lines.JoinToString('\n'));
-            await writer.FlushAsync();
-            lineStream.Position = 0;
-
-            return lineStream;
+            
         }
-
-        private string GetMimeTypeUsingMimeProject(Stream stream)
+        catch (Exception e)
         {
-            // The Mime project is generally very good at determining mime types from file contents
-            return GuessMagicInfo(stream, MagicOpenFlags.MAGIC_MIME_TYPE);
+            _logger.LogError(e, "Unable to read sample lines from CSV - {ErrorMessage}", e.Message);
+            return null;
         }
 
-        private async Task<FileType?> GetMimeTypeUsingMimeDetective(Stream stream)
-        {
-            // Mime Detective is much better at zip files
-            return await stream.GetFileTypeAsync();
-        }
+        var lineStream = new MemoryStream();
+        var writer = new StreamWriter(lineStream);
+        await writer.WriteAsync(lines.JoinToString('\n'));
+        await writer.FlushAsync();
+        lineStream.Position = 0;
 
-        private string GetMimeEncoding(Stream stream)
-        {
-            return GuessMagicInfo(stream, MagicOpenFlags.MAGIC_MIME_ENCODING);
-        }
+        return lineStream;
+    }
 
-        private string GuessMagicInfo(Stream fileStream, MagicOpenFlags flag)
-        {
-            using var reader = new StreamReader(fileStream);
+    private string GetMimeTypeUsingMimeProject(Stream stream)
+    {
+        // The Mime project is generally very good at determining mime types from file contents
+        return GuessMagicInfo(stream, MagicOpenFlags.MAGIC_MIME_TYPE);
+    }
 
-            var dbPath = _configuration.GetValue<string>("MagicFilePath");
-            var magic = new Magic(flag, dbPath);
+    private async Task<FileType?> GetMimeTypeUsingMimeDetective(Stream stream)
+    {
+        // Mime Detective is much better at zip files
+        return await stream.GetFileTypeAsync();
+    }
 
-            var bufferSize = reader.BaseStream.Length >= 1024 ? 1024 : (int) reader.BaseStream.Length;
-            return magic.Read(reader.BaseStream, bufferSize);
-        }
+    private string GetMimeEncoding(Stream stream)
+    {
+        return GuessMagicInfo(stream, MagicOpenFlags.MAGIC_MIME_ENCODING);
+    }
 
-        private bool IsMimeTypeNullOrZip(string mimeType)
-        {
-            return mimeType == null ||
-                   mimeType == "application/octet-stream" ||
-                   mimeType == "application/zip";
-        }
+    private string GuessMagicInfo(Stream fileStream, MagicOpenFlags flag)
+    {
+        using var reader = new StreamReader(fileStream);
+
+        var dbPath = _configuration.GetValue<string>("MagicFilePath");
+        var magic = new Magic(flag, dbPath);
+
+        var bufferSize = reader.BaseStream.Length >= 1024 ? 1024 : (int) reader.BaseStream.Length;
+        return magic.Read(reader.BaseStream, bufferSize);
+    }
+
+    private bool IsMimeTypeNullOrZip(string mimeType)
+    {
+        return mimeType == null ||
+               mimeType == "application/octet-stream" ||
+               mimeType == "application/zip";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobCacheService.cs
@@ -2,12 +2,11 @@
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+
+public interface IBlobCacheService : ICacheService<IBlobCacheKey>
 {
-    public interface IBlobCacheService : ICacheService<IBlobCacheKey>
-    {
-        Task DeleteItemAsync(IBlobCacheKey cacheKey);
-        
-        Task DeleteCacheFolderAsync(IBlobCacheKey cacheFolderKey);
-    }
+    Task DeleteItemAsync(IBlobCacheKey cacheKey);
+    
+    Task DeleteCacheFolderAsync(IBlobCacheKey cacheFolderKey);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
@@ -11,138 +11,137 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Storage.DataMovement;
 using Newtonsoft.Json;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+
+public interface IBlobStorageService
 {
-    public interface IBlobStorageService
+    public Task<List<BlobInfo>> ListBlobs(IBlobContainer containerName, string? path = null);
+
+    public Task<bool> CheckBlobExists(IBlobContainer containerName, string path);
+
+    public Task<BlobInfo> GetBlob(IBlobContainer containerName, string path);
+
+    public Task<BlobInfo?> FindBlob(IBlobContainer containerName, string path);
+
+    public record DeleteBlobsOptions
     {
-        public Task<List<BlobInfo>> ListBlobs(IBlobContainer containerName, string? path = null);
-
-        public Task<bool> CheckBlobExists(IBlobContainer containerName, string path);
-
-        public Task<BlobInfo> GetBlob(IBlobContainer containerName, string path);
-
-        public Task<BlobInfo?> FindBlob(IBlobContainer containerName, string path);
-
-        public record DeleteBlobsOptions
-        {
-            public Regex? ExcludeRegex { get; set; }
-            public Regex? IncludeRegex { get; set; }
-        }
-
-        public Task DeleteBlobs(
-            IBlobContainer containerName,
-            string? directoryPath = null,
-            DeleteBlobsOptions? options = null);
-
-        public Task DeleteBlob(IBlobContainer containerName, string path);
-
-        public Task<bool> MoveBlob(IBlobContainer containerName, string sourcePath, string destinationPath);
-
-        public Task UploadFile(
-            IBlobContainer containerName,
-            string path,
-            IFormFile file);
-
-        public Task UploadStream(
-            IBlobContainer containerName,
-            string path,
-            Stream stream,
-            string contentType,
-            string? contentEncoding = null,
-            CancellationToken cancellationToken = default);
-
-        public Task UploadAsJson<T>(
-            IBlobContainer containerName,
-            string path,
-            T content,
-            string? contentEncoding = null,
-            JsonSerializerSettings? settings = null,
-            CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Download the entirety of a blob to a target stream.
-        /// </summary>
-        /// <param name="containerName">name of the blob container</param>
-        /// <param name="path">path to the blob within the container</param>
-        /// <param name="stream">stream to output blob to</param>
-        /// <param name="decompress">if true, checks the content encoding and decompresses the blob if necessary</param>
-        /// <param name="cancellationToken">used to cancel the download</param>
-        /// <returns>the stream that the blob has been output to</returns>
-        public Task<Either<ActionResult, Stream>> DownloadToStream(
-            IBlobContainer containerName,
-            string path,
-            Stream stream,
-            bool decompress = true,
-            CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Stream a blob in chunks.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This differs from <see cref="DownloadToStream">DownloadToStream</see> in
-        /// that it does not download the entirety of the blob beforehand. This causes
-        /// differences in how the outputted stream behaves that you may or may not want.
-        /// </para>
-        /// </remarks>
-        /// <param name="containerName">Name of the blob container</param>
-        /// <param name="path">Path to the blob within the container</param>
-        /// <param name="bufferSize">Size of the stream buffer</param>
-        /// <param name="cancellationToken">Token to cancel the request</param>
-        /// <returns>The chunked blob stream</returns>
-        public Task<Stream> StreamBlob(
-            IBlobContainer containerName,
-            string path,
-            int? bufferSize = null,
-            CancellationToken cancellationToken = default);
-
-        public Task<Either<ActionResult, string>> DownloadBlobText(
-            IBlobContainer containerName,
-            string path,
-            CancellationToken cancellationToken = default);
-
-        Task<Either<ActionResult, object?>> GetDeserializedJson(
-            IBlobContainer containerName,
-            string path,
-            Type type,
-            JsonSerializerSettings? settings = null,
-            CancellationToken cancellationToken = default);
-
-        Task<Either<ActionResult, T?>> GetDeserializedJson<T>(
-            IBlobContainer containerName,
-            string path,
-            JsonSerializerSettings? settings = null,
-            CancellationToken cancellationToken = default)
-            where T : class;
-
-        public class CopyDirectoryOptions
-        {
-            public string? DestinationConnectionString { get; set; }
-            public SetAttributesCallbackAsync? SetAttributesCallbackAsync { get; set; }
-            public ShouldTransferCallbackAsync? ShouldTransferCallbackAsync { get; set; }
-            public ShouldOverwriteCallbackAsync? ShouldOverwriteCallbackAsync { get; set; }
-        }
-
-        public Task<List<BlobInfo>> CopyDirectory(
-            IBlobContainer sourceContainerName,
-            string sourceDirectoryPath,
-            IBlobContainer destinationContainerName,
-            string destinationDirectoryPath,
-            CopyDirectoryOptions? options = null);
-
-        public class MoveDirectoryOptions
-        {
-            public string? DestinationConnectionString { get; set; }
-            public SetAttributesCallbackAsync? SetAttributesCallbackAsync { get; set; }
-            public ShouldTransferCallbackAsync? ShouldTransferCallbackAsync { get; set; }
-            public ShouldOverwriteCallbackAsync? ShouldOverwriteCallbackAsync { get; set; }
-        }
-
-        public Task MoveDirectory(
-            IBlobContainer sourceContainerName,
-            string sourceDirectoryPath,
-            IBlobContainer destinationContainerName,
-            string destinationDirectoryPath,
-            MoveDirectoryOptions? options = null);
+        public Regex? ExcludeRegex { get; set; }
+        public Regex? IncludeRegex { get; set; }
     }
+
+    public Task DeleteBlobs(
+        IBlobContainer containerName,
+        string? directoryPath = null,
+        DeleteBlobsOptions? options = null);
+
+    public Task DeleteBlob(IBlobContainer containerName, string path);
+
+    public Task<bool> MoveBlob(IBlobContainer containerName, string sourcePath, string destinationPath);
+
+    public Task UploadFile(
+        IBlobContainer containerName,
+        string path,
+        IFormFile file);
+
+    public Task UploadStream(
+        IBlobContainer containerName,
+        string path,
+        Stream stream,
+        string contentType,
+        string? contentEncoding = null,
+        CancellationToken cancellationToken = default);
+
+    public Task UploadAsJson<T>(
+        IBlobContainer containerName,
+        string path,
+        T content,
+        string? contentEncoding = null,
+        JsonSerializerSettings? settings = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Download the entirety of a blob to a target stream.
+    /// </summary>
+    /// <param name="containerName">name of the blob container</param>
+    /// <param name="path">path to the blob within the container</param>
+    /// <param name="stream">stream to output blob to</param>
+    /// <param name="decompress">if true, checks the content encoding and decompresses the blob if necessary</param>
+    /// <param name="cancellationToken">used to cancel the download</param>
+    /// <returns>the stream that the blob has been output to</returns>
+    public Task<Either<ActionResult, Stream>> DownloadToStream(
+        IBlobContainer containerName,
+        string path,
+        Stream stream,
+        bool decompress = true,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stream a blob in chunks.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This differs from <see cref="DownloadToStream">DownloadToStream</see> in
+    /// that it does not download the entirety of the blob beforehand. This causes
+    /// differences in how the outputted stream behaves that you may or may not want.
+    /// </para>
+    /// </remarks>
+    /// <param name="containerName">Name of the blob container</param>
+    /// <param name="path">Path to the blob within the container</param>
+    /// <param name="bufferSize">Size of the stream buffer</param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The chunked blob stream</returns>
+    public Task<Stream> StreamBlob(
+        IBlobContainer containerName,
+        string path,
+        int? bufferSize = null,
+        CancellationToken cancellationToken = default);
+
+    public Task<Either<ActionResult, string>> DownloadBlobText(
+        IBlobContainer containerName,
+        string path,
+        CancellationToken cancellationToken = default);
+
+    Task<Either<ActionResult, object?>> GetDeserializedJson(
+        IBlobContainer containerName,
+        string path,
+        Type type,
+        JsonSerializerSettings? settings = null,
+        CancellationToken cancellationToken = default);
+
+    Task<Either<ActionResult, T?>> GetDeserializedJson<T>(
+        IBlobContainer containerName,
+        string path,
+        JsonSerializerSettings? settings = null,
+        CancellationToken cancellationToken = default)
+        where T : class;
+
+    public class CopyDirectoryOptions
+    {
+        public string? DestinationConnectionString { get; set; }
+        public SetAttributesCallbackAsync? SetAttributesCallbackAsync { get; set; }
+        public ShouldTransferCallbackAsync? ShouldTransferCallbackAsync { get; set; }
+        public ShouldOverwriteCallbackAsync? ShouldOverwriteCallbackAsync { get; set; }
+    }
+
+    public Task<List<BlobInfo>> CopyDirectory(
+        IBlobContainer sourceContainerName,
+        string sourceDirectoryPath,
+        IBlobContainer destinationContainerName,
+        string destinationDirectoryPath,
+        CopyDirectoryOptions? options = null);
+
+    public class MoveDirectoryOptions
+    {
+        public string? DestinationConnectionString { get; set; }
+        public SetAttributesCallbackAsync? SetAttributesCallbackAsync { get; set; }
+        public ShouldTransferCallbackAsync? ShouldTransferCallbackAsync { get; set; }
+        public ShouldOverwriteCallbackAsync? ShouldOverwriteCallbackAsync { get; set; }
+    }
+
+    public Task MoveDirectory(
+        IBlobContainer sourceContainerName,
+        string sourceDirectoryPath,
+        IBlobContainer destinationContainerName,
+        string destinationDirectoryPath,
+        MoveDirectoryOptions? options = null);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
@@ -3,16 +3,15 @@ using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+
+public interface ICacheService<in TKey> where TKey : ICacheKey
 {
-    public interface ICacheService<in TKey> where TKey : ICacheKey
-    {
-        object? GetItem(TKey cacheKey, Type targetType);
+    object? GetItem(TKey cacheKey, Type targetType);
 
-        Task<object?> GetItemAsync(TKey cacheKey, Type targetType);
+    Task<object?> GetItemAsync(TKey cacheKey, Type targetType);
 
-        void SetItem<TItem>(TKey cacheKey, TItem item);
+    void SetItem<TItem>(TKey cacheKey, TItem item);
 
-        Task SetItemAsync<TItem>(TKey cacheKey, TItem item);
-    }
+    Task SetItemAsync<TItem>(TKey cacheKey, TItem item);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IFileTypeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IFileTypeService.cs
@@ -5,16 +5,15 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+
+public interface IFileTypeService
 {
-    public interface IFileTypeService
-    {
-        Task<bool> HasMatchingMimeType(IFormFile file, IEnumerable<Regex> mimeTypes);
+    Task<bool> HasMatchingMimeType(IFormFile file, IEnumerable<Regex> mimeTypes);
 
-        bool HasMatchingEncodingType(IFormFile file, IEnumerable<string> encodingTypes);
+    bool HasMatchingEncodingType(IFormFile file, IEnumerable<string> encodingTypes);
 
-        Task<bool> IsValidCsvFile(Func<Task<Stream>> streamProvider, string filename);
-        
-        Task<bool> IsValidCsvFile(IFormFile file);
-    }
+    Task<bool> IsValidCsvFile(Func<Task<Stream>> streamProvider, string filename);
+    
+    Task<bool> IsValidCsvFile(IFormFile file);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IGuidGenerator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IGuidGenerator.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+
+public interface IGuidGenerator
 {
-    public interface IGuidGenerator
-    {
-        Guid NewGuid();
-    }
+    Guid NewGuid();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IStorageQueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IStorageQueueService.cs
@@ -2,18 +2,17 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+
+public interface IStorageQueueService
 {
-    public interface IStorageQueueService
-    {
-        void AddMessage(string queueName, object value);
+    void AddMessage(string queueName, object value);
 
-        Task AddMessageAsync(string queueName, object value);
+    Task AddMessageAsync(string queueName, object value);
 
-        Task AddMessages<T>(string queueName, List<T> values);
+    Task AddMessages<T>(string queueName, List<T> values);
 
-        Task Clear(string queueName);
+    Task Clear(string queueName);
 
-        Task<int?> GetApproximateMessageCount(string queueName);
-    }
+    Task<int?> GetApproximateMessageCount(string queueName);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ITableStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ITableStorageService.cs
@@ -3,19 +3,18 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos.Table;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+
+public interface ITableStorageService
 {
-    public interface ITableStorageService
-    {
-        Task<IEnumerable<TElement>> ExecuteQueryAsync<TElement>(string tableName, TableQuery<TElement> query)
-            where TElement : ITableEntity, new();
+    Task<IEnumerable<TElement>> ExecuteQueryAsync<TElement>(string tableName, TableQuery<TElement> query)
+        where TElement : ITableEntity, new();
 
-        CloudTable GetTable(string tableName);
+    CloudTable GetTable(string tableName);
 
-        Task<bool> DeleteEntityAsync(string tableName, ITableEntity entity);
+    Task<bool> DeleteEntityAsync(string tableName, ITableEntity entity);
 
-        Task<TableResult> RetrieveEntity(string tableName, ITableEntity entity, List<string> columns);
+    Task<TableResult> RetrieveEntity(string tableName, ITableEntity entity, List<string> columns);
 
-        Task<TableResult> CreateOrUpdateEntity(string tableName, ITableEntity entity);
-    }
+    Task<TableResult> CreateOrUpdateEntity(string tableName, ITableEntity entity);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/Security/IUserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/Security/IUserService.cs
@@ -4,52 +4,51 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+
+public interface IUserService
 {
-    public interface IUserService
+    Guid GetUserId();
+
+    UserProfileFromClaims GetProfileFromClaims();
+
+    Task<bool> MatchesPolicy(Enum policy);
+
+    Task<bool> MatchesPolicy(object resource, Enum policy);
+}
+
+public record UserProfileFromClaims(string Email, string FirstName, string LastName);
+
+public static class UserServiceExtensions
+{
+    public static async Task<Either<ActionResult, TResource>> CheckPolicy<TResource, TPolicy>(
+        this IUserService userService,
+        TResource resource,
+        TPolicy policy)
+        where TPolicy : Enum
     {
-        Guid GetUserId();
+        var result = await userService.MatchesPolicy(resource, policy);
 
-        UserProfileFromClaims GetProfileFromClaims();
+        if (result)
+        {
+            return resource;
+        }
 
-        Task<bool> MatchesPolicy(Enum policy);
-
-        Task<bool> MatchesPolicy(object resource, Enum policy);
+        return new ForbidResult();
     }
 
-    public record UserProfileFromClaims(string Email, string FirstName, string LastName);
-
-    public static class UserServiceExtensions
+    public static async Task<Either<ActionResult, Unit>> CheckPolicy<TPolicy>(
+        this IUserService userService,
+        TPolicy policy)
+        where TPolicy : Enum
     {
-        public static async Task<Either<ActionResult, TResource>> CheckPolicy<TResource, TPolicy>(
-            this IUserService userService,
-            TResource resource,
-            TPolicy policy)
-            where TPolicy : Enum
+        var result = await userService.MatchesPolicy(policy);
+
+        if (result)
         {
-            var result = await userService.MatchesPolicy(resource, policy);
-
-            if (result)
-            {
-                return resource;
-            }
-
-            return new ForbidResult();
+            return Unit.Instance;
         }
 
-        public static async Task<Either<ActionResult, Unit>> CheckPolicy<TPolicy>(
-            this IUserService userService,
-            TPolicy policy)
-            where TPolicy : Enum
-        {
-            var result = await userService.MatchesPolicy(policy);
-
-            if (result)
-            {
-                return Unit.Instance;
-            }
-
-            return new ForbidResult();
-        }
+        return new ForbidResult();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/MapperUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/MapperUtils.cs
@@ -2,23 +2,22 @@
 using System.Collections.Generic;
 using AutoMapper;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services;
+
+public class MapperUtils
 {
-    public class MapperUtils
+    public static IMapper MapperForProfile<T>() where T : Profile, new()
     {
-        public static IMapper MapperForProfile<T>() where T : Profile, new()
-        {
-            return new MapperConfiguration(cfg => cfg.AddProfile<T>()).CreateMapper();
-        }
+        return new MapperConfiguration(cfg => cfg.AddProfile<T>()).CreateMapper();
+    }
 
-        public static IMapper MapperForProfile<T>(Func<Type, object> serviceLocator) where T : Profile, new()
-        {
-            return new MapperConfiguration(cfg => cfg.AddProfile<T>()).CreateMapper(serviceLocator);
-        }
+    public static IMapper MapperForProfile<T>(Func<Type, object> serviceLocator) where T : Profile, new()
+    {
+        return new MapperConfiguration(cfg => cfg.AddProfile<T>()).CreateMapper(serviceLocator);
+    }
 
-        public static IMapper MapperForProfiles(IEnumerable<Profile> profiles)
-        {
-            return new MapperConfiguration(cfg => cfg.AddProfiles(profiles)).CreateMapper();
-        }
+    public static IMapper MapperForProfiles(IEnumerable<Profile> profiles)
+    {
+        return new MapperConfiguration(cfg => cfg.AddProfiles(profiles)).CreateMapper();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Security/AuthorizationServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Security/AuthorizationServiceExtensions.cs
@@ -3,29 +3,28 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Security
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
+
+public static class AuthorizationServiceExtensions
 {
-    public static class AuthorizationServiceExtensions
+    public static async Task<bool> MatchesPolicy(
+        this IAuthorizationService authorizationService,
+        ClaimsPrincipal user, 
+        Enum policy
+    )
     {
-        public static async Task<bool> MatchesPolicy(
-            this IAuthorizationService authorizationService,
-            ClaimsPrincipal user, 
-            Enum policy
-        )
-        {
-            var result = await authorizationService.AuthorizeAsync(user, policy.ToString());
-            return result.Succeeded;
-        }
-        
-        public static async Task<bool> MatchesPolicy(
-            this IAuthorizationService authorizationService,
-            ClaimsPrincipal user, 
-            object resource,
-            Enum policy
-        )
-        {
-            var result = await authorizationService.AuthorizeAsync(user, resource, policy.ToString());
-            return result.Succeeded;
-        }
+        var result = await authorizationService.AuthorizeAsync(user, policy.ToString());
+        return result.Succeeded;
+    }
+    
+    public static async Task<bool> MatchesPolicy(
+        this IAuthorizationService authorizationService,
+        ClaimsPrincipal user, 
+        object resource,
+        Enum policy
+    )
+    {
+        var result = await authorizationService.AuthorizeAsync(user, resource, policy.ToString());
+        return result.Succeeded;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Security/EesClaimTypes.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Security/EesClaimTypes.cs
@@ -1,40 +1,39 @@
 #nullable enable
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Security
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
+
+public static class EesClaimTypes
 {
-    public static class EesClaimTypes
-    {
-        /**
-         * This is the name of the Claim that will hold a user's name.  This is equivalent to JwtClaimType.Name.
-         */
-        public const string Name = "name";
+    /**
+     * This is the name of the Claim that will hold a user's name.  This is equivalent to JwtClaimType.Name.
+     */
+    public const string Name = "name";
 
-        /**
-         * This is the name of the Claim that will hold a user's roles.  This is equivalent to JwtClaimType.Role.
-         */
-        public const string Role = "role";
+    /**
+     * This is the name of the Claim that will hold a user's roles.  This is equivalent to JwtClaimType.Role.
+     */
+    public const string Role = "role";
 
-        /**
-         * This Claim will hold the logged-in user's id from within the content database.
-         */
-        public const string LocalUserId = "LocalId";
+    /**
+     * This Claim will hold the logged-in user's id from within the content database.
+     */
+    public const string LocalUserId = "LocalId";
 
-        /**
-         * This is the name of the "scope" Claim that Keycloak provides, and that is incompatible with
-         * MSAL's scope Claim names that is checks for ("scp" or "http://schemas.microsoft.com/identity/claims/scope").
-         */
-        public const string KeycloakScope = "scope";
+    /**
+     * This is the name of the "scope" Claim that Keycloak provides, and that is incompatible with
+     * MSAL's scope Claim names that is checks for ("scp" or "http://schemas.microsoft.com/identity/claims/scope").
+     */
+    public const string KeycloakScope = "scope";
 
-        /**
-         * This is the name of one of the scope Claims supported by the MSAL framework. We ensure that a user's
-         * scopes are transferred to this supported Claim name. This is equivalent to "ClaimConstants.Scp".
-         */
-        public const string SupportedMsalScope = "scp";
+    /**
+     * This is the name of one of the scope Claims supported by the MSAL framework. We ensure that a user's
+     * scopes are transferred to this supported Claim name. This is equivalent to "ClaimConstants.Scp".
+     */
+    public const string SupportedMsalScope = "scp";
 
-        /**
-         * This is the name of one of the scope Claims supported by the MSAL framework. We ensure that a user's
-         * scopes are transferred to this supported Claim name. This is equivalent to "ClaimConstants.Scope".
-         */
-        public const string SupportedMsalScope2 = "http://schemas.microsoft.com/identity/claims/scope";
-    }
+    /**
+     * This is the name of one of the scope Claims supported by the MSAL framework. We ensure that a user's
+     * scopes are transferred to this supported Claim name. This is equivalent to "ClaimConstants.Scope".
+     */
+    public const string SupportedMsalScope2 = "http://schemas.microsoft.com/identity/claims/scope";
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/SequentialGuidGenerator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/SequentialGuidGenerator.cs
@@ -2,38 +2,37 @@
 using System.Threading;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services;
+
+/**
+ * Generates sequential <see cref="Guid" /> values using the same algorithm as NEWSEQUENTIALID() in Microsoft SQL Server.
+ * Copy of <see cref="Microsoft.EntityFrameworkCore.ValueGeneration.SequentialGuidValueGenerator" /> without the ValueGenerator interface.
+ * Used to reduce fragmentation of clustered indexes on Guid fields.
+ * See https://edgamat.com/2020/01/19/Sequential-Guid-Values-For-SQL-Server.html.
+ */
+public class SequentialGuidGenerator : IGuidGenerator
 {
-    /**
-     * Generates sequential <see cref="Guid" /> values using the same algorithm as NEWSEQUENTIALID() in Microsoft SQL Server.
-     * Copy of <see cref="Microsoft.EntityFrameworkCore.ValueGeneration.SequentialGuidValueGenerator" /> without the ValueGenerator interface.
-     * Used to reduce fragmentation of clustered indexes on Guid fields.
-     * See https://edgamat.com/2020/01/19/Sequential-Guid-Values-For-SQL-Server.html.
-     */
-    public class SequentialGuidGenerator : IGuidGenerator
+    private long _counter = DateTime.UtcNow.Ticks;
+
+    public Guid NewGuid()
     {
-        private long _counter = DateTime.UtcNow.Ticks;
+        var guidBytes = Guid.NewGuid().ToByteArray();
+        var counterBytes = BitConverter.GetBytes(Interlocked.Increment(ref _counter));
 
-        public Guid NewGuid()
+        if (!BitConverter.IsLittleEndian)
         {
-            var guidBytes = Guid.NewGuid().ToByteArray();
-            var counterBytes = BitConverter.GetBytes(Interlocked.Increment(ref _counter));
-
-            if (!BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(counterBytes);
-            }
-
-            guidBytes[08] = counterBytes[1];
-            guidBytes[09] = counterBytes[0];
-            guidBytes[10] = counterBytes[7];
-            guidBytes[11] = counterBytes[6];
-            guidBytes[12] = counterBytes[5];
-            guidBytes[13] = counterBytes[4];
-            guidBytes[14] = counterBytes[3];
-            guidBytes[15] = counterBytes[2];
-
-            return new Guid(guidBytes);
+            Array.Reverse(counterBytes);
         }
+
+        guidBytes[08] = counterBytes[1];
+        guidBytes[09] = counterBytes[0];
+        guidBytes[10] = counterBytes[7];
+        guidBytes[11] = counterBytes[6];
+        guidBytes[12] = counterBytes[5];
+        guidBytes[13] = counterBytes[4];
+        guidBytes[14] = counterBytes[3];
+        guidBytes[15] = counterBytes[2];
+
+        return new Guid(guidBytes);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/StorageQueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/StorageQueueService.cs
@@ -9,87 +9,86 @@ using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Queue;
 using Newtonsoft.Json;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Services
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services;
+
+public class StorageQueueService : IStorageQueueService
 {
-    public class StorageQueueService : IStorageQueueService
+    private readonly string _storageConnectionString;
+    private readonly IStorageInstanceCreationUtil _storageInstanceCreationUtil;
+
+    public StorageQueueService(
+        string storageConnectionString,
+        IStorageInstanceCreationUtil storageInstanceCreationUtil)
     {
-        private readonly string _storageConnectionString;
-        private readonly IStorageInstanceCreationUtil _storageInstanceCreationUtil;
+        _storageConnectionString = storageConnectionString;
+        _storageInstanceCreationUtil = storageInstanceCreationUtil;
+    }
 
-        public StorageQueueService(
-            string storageConnectionString,
-            IStorageInstanceCreationUtil storageInstanceCreationUtil)
-        {
-            _storageConnectionString = storageConnectionString;
-            _storageInstanceCreationUtil = storageInstanceCreationUtil;
-        }
+    public void AddMessage(string queueName, object value)
+    {
+        var queue = GetQueueReference(queueName);
+        queue.AddMessage(ToCloudQueueMessage(value));
+    }
 
-        public void AddMessage(string queueName, object value)
-        {
-            var queue = GetQueueReference(queueName);
-            queue.AddMessage(ToCloudQueueMessage(value));
-        }
+    public async Task AddMessageAsync(string queueName, object value)
+    {
+        var queue = await GetQueueReferenceAsync(queueName);
+        await queue.AddMessageAsync(ToCloudQueueMessage(value));
+    }
 
-        public async Task AddMessageAsync(string queueName, object value)
-        {
-            var queue = await GetQueueReferenceAsync(queueName);
-            await queue.AddMessageAsync(ToCloudQueueMessage(value));
-        }
+    public async Task AddMessages<T>(string queueName, List<T> values)
+    {
+        var queue = await GetQueueReferenceAsync(queueName);
+        await values
+            .ToAsyncEnumerable()
+            .ForEachAwaitAsync(async value => { await queue.AddMessageAsync(ToCloudQueueMessage(value)); });
+    }
 
-        public async Task AddMessages<T>(string queueName, List<T> values)
-        {
-            var queue = await GetQueueReferenceAsync(queueName);
-            await values
-                .ToAsyncEnumerable()
-                .ForEachAwaitAsync(async value => { await queue.AddMessageAsync(ToCloudQueueMessage(value)); });
-        }
+    public async Task<int?> GetApproximateMessageCount(string queueName)
+    {
+        var queue = await GetQueueReferenceAsync(queueName);
+        await queue.FetchAttributesAsync();
+        return queue.ApproximateMessageCount;
+    }
 
-        public async Task<int?> GetApproximateMessageCount(string queueName)
-        {
-            var queue = await GetQueueReferenceAsync(queueName);
-            await queue.FetchAttributesAsync();
-            return queue.ApproximateMessageCount;
-        }
+    public async Task Clear(string queueName)
+    {
+        var queue = await GetQueueReferenceAsync(queueName);
+        await queue.ClearAsync();
+    }
 
-        public async Task Clear(string queueName)
-        {
-            var queue = await GetQueueReferenceAsync(queueName);
-            await queue.ClearAsync();
-        }
+    private CloudQueue GetQueueReference(string queueName)
+    {
+        var storageAccount = CloudStorageAccount.Parse(_storageConnectionString);
+        var client = storageAccount.CreateCloudQueueClient();
+        var queue = client.GetQueueReference(queueName);
 
-        private CloudQueue GetQueueReference(string queueName)
-        {
-            var storageAccount = CloudStorageAccount.Parse(_storageConnectionString);
-            var client = storageAccount.CreateCloudQueueClient();
-            var queue = client.GetQueueReference(queueName);
+        _storageInstanceCreationUtil.CreateInstanceIfNotExists(
+            _storageConnectionString,
+            AzureStorageType.Queue,
+            queueName,
+            () => queue.CreateIfNotExists());
 
-            _storageInstanceCreationUtil.CreateInstanceIfNotExists(
-                _storageConnectionString,
-                AzureStorageType.Queue,
-                queueName,
-                () => queue.CreateIfNotExists());
+        return queue;
+    }
 
-            return queue;
-        }
+    private async Task<CloudQueue> GetQueueReferenceAsync(string queueName)
+    {
+        var storageAccount = CloudStorageAccount.Parse(_storageConnectionString);
+        var client = storageAccount.CreateCloudQueueClient();
+        var queue = client.GetQueueReference(queueName);
 
-        private async Task<CloudQueue> GetQueueReferenceAsync(string queueName)
-        {
-            var storageAccount = CloudStorageAccount.Parse(_storageConnectionString);
-            var client = storageAccount.CreateCloudQueueClient();
-            var queue = client.GetQueueReference(queueName);
+        await _storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
+            _storageConnectionString,
+            AzureStorageType.Queue,
+            queueName,
+            () => queue.CreateIfNotExistsAsync());
 
-            await _storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
-                _storageConnectionString,
-                AzureStorageType.Queue,
-                queueName,
-                () => queue.CreateIfNotExistsAsync());
+        return queue;
+    }
 
-            return queue;
-        }
-
-        private static CloudQueueMessage ToCloudQueueMessage(object value)
-        {
-            return new CloudQueueMessage(JsonConvert.SerializeObject(value));
-        }
+    private static CloudQueueMessage ToCloudQueueMessage(object value)
+    {
+        return new CloudQueueMessage(JsonConvert.SerializeObject(value));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/ComparerUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/ComparerUtils.cs
@@ -2,49 +2,48 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public static class ComparerUtils
 {
-    public static class ComparerUtils
+    public static NullSafePropertyComparer<T> CreateComparerByProperty<T>(Func<T, object> propertyGetter)
     {
-        public static NullSafePropertyComparer<T> CreateComparerByProperty<T>(Func<T, object> propertyGetter)
+        return new NullSafePropertyComparer<T>(propertyGetter);    
+    }
+    
+    public class NullSafePropertyComparer<T> : IEqualityComparer<T> 
+    {
+        private readonly Func<T, object> _propertyGetter;
+
+        public NullSafePropertyComparer(Func<T, object> propertyGetter) 
         {
-            return new NullSafePropertyComparer<T>(propertyGetter);    
-        }
-        
-        public class NullSafePropertyComparer<T> : IEqualityComparer<T> 
-        {
-            private readonly Func<T, object> _propertyGetter;
-
-            public NullSafePropertyComparer(Func<T, object> propertyGetter) 
-            {
-                _propertyGetter = propertyGetter;
-            }
-
-            public bool Equals(T x, T y)
-            {
-                if (ReferenceEquals(x, y))
-                {
-                    return true;
-                }
-
-                if (x == null || y == null)
-                {
-                    return false;
-                }
-                
-                return Equals(_propertyGetter.Invoke(x), _propertyGetter.Invoke(y));
-            }
-
-            public int GetHashCode(T obj)
-            {
-                return _propertyGetter.Invoke(obj).GetHashCode();
-            }
+            _propertyGetter = propertyGetter;
         }
 
-        public static bool SequencesAreEqualIgnoringOrder<T>(IEnumerable<T> left, IEnumerable<T> right)
-            where T : IComparable
+        public bool Equals(T x, T y)
         {
-            return left.OrderBy(id => id).SequenceEqual(right.OrderBy(id => id));
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x == null || y == null)
+            {
+                return false;
+            }
+            
+            return Equals(_propertyGetter.Invoke(x), _propertyGetter.Invoke(y));
         }
+
+        public int GetHashCode(T obj)
+        {
+            return _propertyGetter.Invoke(obj).GetHashCode();
+        }
+    }
+
+    public static bool SequencesAreEqualIgnoringOrder<T>(IEnumerable<T> left, IEnumerable<T> right)
+        where T : IComparable
+    {
+        return left.OrderBy(id => id).SequenceEqual(right.OrderBy(id => id));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/DbContextUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/DbContextUtils.cs
@@ -5,119 +5,118 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public static class DbContextUtils
 {
-    public static class DbContextUtils
+    public static void UpdateTimestamps(object? sender, EntityEntryEventArgs e)
     {
-        public static void UpdateTimestamps(object? sender, EntityEntryEventArgs e)
+        var entity = e.Entry.Entity;
+        var now = DateTime.UtcNow;
+
+        if (e.Entry.State == EntityState.Added && entity is ITimestampsInternal.ICreated)
         {
-            var entity = e.Entry.Entity;
-            var now = DateTime.UtcNow;
-
-            if (e.Entry.State == EntityState.Added && entity is ITimestampsInternal.ICreated)
+            switch (e.Entry.Entity)
             {
-                switch (e.Entry.Entity)
-                {
-                    case ICreatedTimestamp<DateTime> entityWithCreated:
-                        if (entityWithCreated.Created.Equals(default))
-                        {
-                            entityWithCreated.Created = now;
-                        }
-                        break;
+                case ICreatedTimestamp<DateTime> entityWithCreated:
+                    if (entityWithCreated.Created.Equals(default))
+                    {
+                        entityWithCreated.Created = now;
+                    }
+                    break;
 
-                    case ICreatedTimestamp<DateTime?> entityWithCreated:
-                        if (entityWithCreated.Created == null)
-                        {
-                            entityWithCreated.Created = now;
-                        }
-                        break;
+                case ICreatedTimestamp<DateTime?> entityWithCreated:
+                    if (entityWithCreated.Created == null)
+                    {
+                        entityWithCreated.Created = now;
+                    }
+                    break;
 
-                    case ICreatedTimestamp<DateTimeOffset> entityWithCreated:
-                        if (entityWithCreated.Created.Equals(default))
-                        {
-                            entityWithCreated.Created = now;
-                        }
-                        break;
+                case ICreatedTimestamp<DateTimeOffset> entityWithCreated:
+                    if (entityWithCreated.Created.Equals(default))
+                    {
+                        entityWithCreated.Created = now;
+                    }
+                    break;
 
-                    case ICreatedTimestamp<DateTimeOffset?> entityWithCreated:
-                        if (entityWithCreated.Created == null)
-                        {
-                            entityWithCreated.Created = now;
-                        }
-                        break;
+                case ICreatedTimestamp<DateTimeOffset?> entityWithCreated:
+                    if (entityWithCreated.Created == null)
+                    {
+                        entityWithCreated.Created = now;
+                    }
+                    break;
 
-                    default:
-                        throw new NotImplementedException(
-                            "Entity does not implement valid timestamp field for " +
-                            $"{typeof(ICreatedTimestamp<>).GetNameWithoutGenericArity()}"
-                        );
-                }
-
-                return;
+                default:
+                    throw new NotImplementedException(
+                        "Entity does not implement valid timestamp field for " +
+                        $"{typeof(ICreatedTimestamp<>).GetNameWithoutGenericArity()}"
+                    );
             }
 
-            if (e.Entry.State == EntityState.Modified && entity is ITimestampsInternal.IUpdated)
+            return;
+        }
+
+        if (e.Entry.State == EntityState.Modified && entity is ITimestampsInternal.IUpdated)
+        {
+            switch (e.Entry.Entity)
             {
-                switch (e.Entry.Entity)
-                {
-                    case IUpdatedTimestamp<DateTime> entityWithUpdated:
-                        entityWithUpdated.Updated = now;
-                        break;
+                case IUpdatedTimestamp<DateTime> entityWithUpdated:
+                    entityWithUpdated.Updated = now;
+                    break;
 
-                    case IUpdatedTimestamp<DateTime?> entityWithUpdated:
-                        entityWithUpdated.Updated = now;
-                        break;
+                case IUpdatedTimestamp<DateTime?> entityWithUpdated:
+                    entityWithUpdated.Updated = now;
+                    break;
 
-                    case IUpdatedTimestamp<DateTimeOffset> entityWithUpdated:
-                        entityWithUpdated.Updated = now;
-                        break;
+                case IUpdatedTimestamp<DateTimeOffset> entityWithUpdated:
+                    entityWithUpdated.Updated = now;
+                    break;
 
-                    case IUpdatedTimestamp<DateTimeOffset?> entityWithUpdated:
-                        entityWithUpdated.Updated = now;
-                        break;
+                case IUpdatedTimestamp<DateTimeOffset?> entityWithUpdated:
+                    entityWithUpdated.Updated = now;
+                    break;
 
-                    default:
-                        throw new NotImplementedException(
-                            "Entity does not implement valid timestamp field for " +
-                            $"{typeof(IUpdatedTimestamp<>).GetNameWithoutGenericArity()}"
-                        );
-                }
-
-                return;
+                default:
+                    throw new NotImplementedException(
+                        "Entity does not implement valid timestamp field for " +
+                        $"{typeof(IUpdatedTimestamp<>).GetNameWithoutGenericArity()}"
+                    );
             }
 
-            if (e.Entry.State == EntityState.Deleted && entity is ITimestampsInternal.ISoftDeleted)
+            return;
+        }
+
+        if (e.Entry.State == EntityState.Deleted && entity is ITimestampsInternal.ISoftDeleted)
+        {
+            switch (e.Entry.Entity)
             {
-                switch (e.Entry.Entity)
-                {
-                    case ISoftDeletedTimestamp<DateTime> entityWithDeleted:
-                        entityWithDeleted.SoftDeleted = now;
-                        break;
+                case ISoftDeletedTimestamp<DateTime> entityWithDeleted:
+                    entityWithDeleted.SoftDeleted = now;
+                    break;
 
-                    case ISoftDeletedTimestamp<DateTime?> entityWithDeleted:
-                        entityWithDeleted.SoftDeleted = now;
-                        break;
+                case ISoftDeletedTimestamp<DateTime?> entityWithDeleted:
+                    entityWithDeleted.SoftDeleted = now;
+                    break;
 
-                    case ISoftDeletedTimestamp<DateTimeOffset> entityWithDeleted:
-                        entityWithDeleted.SoftDeleted = now;
-                        break;
+                case ISoftDeletedTimestamp<DateTimeOffset> entityWithDeleted:
+                    entityWithDeleted.SoftDeleted = now;
+                    break;
 
-                    case ISoftDeletedTimestamp<DateTimeOffset?> entityWithDeleted:
-                        entityWithDeleted.SoftDeleted = now;
-                        break;
+                case ISoftDeletedTimestamp<DateTimeOffset?> entityWithDeleted:
+                    entityWithDeleted.SoftDeleted = now;
+                    break;
 
-                    default:
-                        throw new NotImplementedException(
-                            "Entity does not implement valid timestamp field for " +
-                            $"{typeof(ISoftDeletedTimestamp<>).GetNameWithoutGenericArity()}"
-                        );
-                }
-
-                // Note that deletion will not actually delete the entity.
-                // We mark the state as `Unchanged` to prevent all of the
-                // entity's fields being updated in the database.
-                e.Entry.State = EntityState.Unchanged;
+                default:
+                    throw new NotImplementedException(
+                        "Entity does not implement valid timestamp field for " +
+                        $"{typeof(ISoftDeletedTimestamp<>).GetNameWithoutGenericArity()}"
+                    );
             }
+
+            // Note that deletion will not actually delete the entity.
+            // We mark the state as `Unchanged` to prevent all of the
+            // entity's fields being updated in the database.
+            e.Entry.State = EntityState.Unchanged;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextConverter.cs
@@ -8,298 +8,297 @@ using AngleSharp.Html.Dom;
 using AngleSharp.Text;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html;
+
+internal class HtmlToTextConverter
 {
-    internal class HtmlToTextConverter
+    private readonly StringBuilder _builder = new();
+
+    public string Convert(INodeList nodes)
     {
-        private readonly StringBuilder _builder = new();
+        _builder.Clear();
 
-        public string Convert(INodeList nodes)
-        {
-            _builder.Clear();
+        ParseNodes(nodes);
 
-            ParseNodes(nodes);
+        return Output();
+    }
 
-            return Output();
-        }
+    public string Convert(IElement rootElement)
+    {
+        _builder.Clear();
 
-        public string Convert(IElement rootElement)
-        {
-            _builder.Clear();
+        ParseChildren(rootElement);
 
-            ParseChildren(rootElement);
+        return Output();
+    }
 
-            return Output();
-        }
+    private string Output()
+    {
+        var rawLines = _builder.ToString().ToLines();
 
-        private string Output()
-        {
-            var rawLines = _builder.ToString().ToLines();
+        // Run post-filtering on lines to:
+        // 1. Remove any extraneous whitespace from the end of lines. This is
+        // mostly for better compatibility with formatters / editors / IDEs, where
+        // trailing whitespace may be automatically removed upon file save.
+        // 2. Ensure we have CRLF (\r\n) line endings for better compatibility with
+        // our Windows users (the majority of users). Otherwise, line endings
+        // would be server OS dependent and this can lead to inconsistent files.
+        var postFilterBuilder = new StringBuilder();
 
-            // Run post-filtering on lines to:
-            // 1. Remove any extraneous whitespace from the end of lines. This is
-            // mostly for better compatibility with formatters / editors / IDEs, where
-            // trailing whitespace may be automatically removed upon file save.
-            // 2. Ensure we have CRLF (\r\n) line endings for better compatibility with
-            // our Windows users (the majority of users). Otherwise, line endings
-            // would be server OS dependent and this can lead to inconsistent files.
-            var postFilterBuilder = new StringBuilder();
+        rawLines.ForEach(line => postFilterBuilder.AppendCrlfLine(line.TrimEnd()));
 
-            rawLines.ForEach(line => postFilterBuilder.AppendCrlfLine(line.TrimEnd()));
+        return postFilterBuilder.ToString().TrimEnd();
+    }
 
-            return postFilterBuilder.ToString().TrimEnd();
-        }
+    private void ParseChildren(INode node)
+    {
+        ParseNodes(node.ChildNodes);
+    }
 
-        private void ParseChildren(INode node)
-        {
-            ParseNodes(node.ChildNodes);
-        }
+    private void ParseNodes(IEnumerable<INode> nodes)
+    {
+        ParseNodes(nodes, (child, _) => ParseElement(child));
+    }
 
-        private void ParseNodes(IEnumerable<INode> nodes)
-        {
-            ParseNodes(nodes, (child, _) => ParseElement(child));
-        }
-
-        private void ParseNodes(IEnumerable<INode> nodes, Action<IElement, int> elementParser)
-        {
-            nodes.ForEach(
-                (node, index) =>
-                {
-                    switch (node)
-                    {
-                        case null:
-                            return;
-
-                        case IElement element:
-                            elementParser(element, index);
-                            break;
-
-                        case IText text:
-                            ParseEdgeNode(text);
-                            break;
-                    }
-                }
-            );
-        }
-
-        private void ParseElement(IElement element)
-        {
-            switch (element.LocalName)
+    private void ParseNodes(IEnumerable<INode> nodes, Action<IElement, int> elementParser)
+    {
+        nodes.ForEach(
+            (node, index) =>
             {
-                case "ul":
-                case "ol":
-                    ParseListElement(element);
-                    break;
-
-                case "dl":
-                    ParseDescriptionListElement(element);
-                    break;
-
-                case "hr":
-                    _builder.AppendLine("---------------");
-                    break;
-
-                case "table":
-                    ParseTableElement(element);
-                    break;
-
-                case "a":
-                    ParseLinkElement(element);
-                    break;
-
-                case "br":
-                    _builder.AppendLine();
-                    break;
-
-                case "cite":
-                    _builder.Append("— ");
-                    ParseChildren(element);
-                    break;
-
-                default:
+                switch (node)
                 {
-                    if (element.HasChildNodes)
-                    {
-                        ParseChildren(element);
-                    }
-                    else
-                    {
-                        ParseEdgeNode(element);
-                    }
+                    case null:
+                        return;
 
-                    break;
+                    case IElement element:
+                        elementParser(element, index);
+                        break;
+
+                    case IText text:
+                        ParseEdgeNode(text);
+                        break;
                 }
             }
+        );
+    }
 
-            AddSpacing(element);
-        }
-
-        private void AddSpacing(IElement element)
+    private void ParseElement(IElement element)
+    {
+        switch (element.LocalName)
         {
-            var next = element.NextNonWhitespaceSibling();
+            case "ul":
+            case "ol":
+                ParseListElement(element);
+                break;
 
-            if (element.IsBlockType() || next is IElement nextElement && nextElement.IsBlockType())
-            {
-                // Get last 4 chars to check their line endings. Windows uses CRLF line endings (\r\n),
-                // so there may be up to 4 chars, instead of 2 for LF (\n) when using Linux / Mac.
-                var currentEnding = _builder.Substring(^4..);
+            case "dl":
+                ParseDescriptionListElement(element);
+                break;
 
-                // If already have two line endings, then don't
-                // append more spacing as this would be excessive.
-                if (currentEnding.EndsWith($"{Environment.NewLine}{Environment.NewLine}"))
-                {
-                    return;
-                }
+            case "hr":
+                _builder.AppendLine("---------------");
+                break;
 
-                // Don't have a trailing line ending currently, so it
-                // should be safe to add an additional line ending to
-                // provide better spacing with the next block.
-                if (!currentEnding.EndsWith(Environment.NewLine))
-                {
-                    _builder.AppendLine();
-                }
+            case "table":
+                ParseTableElement(element);
+                break;
 
+            case "a":
+                ParseLinkElement(element);
+                break;
+
+            case "br":
                 _builder.AppendLine();
+                break;
+
+            case "cite":
+                _builder.Append("— ");
+                ParseChildren(element);
+                break;
+
+            default:
+            {
+                if (element.HasChildNodes)
+                {
+                    ParseChildren(element);
+                }
+                else
+                {
+                    ParseEdgeNode(element);
+                }
+
+                break;
             }
         }
 
-        private void ParseEdgeNode(INode node)
-        {
-            // Text may be split over multiple lines for
-            // formatting purposes in HTML, but this would
-            // lead to unnecessary line breaks in rendered text,
-            // so we should remove these line breaks.
-            var content = node.TextContent.CollapseAndStrip();
+        AddSpacing(element);
+    }
 
-            if (content == string.Empty)
+    private void AddSpacing(IElement element)
+    {
+        var next = element.NextNonWhitespaceSibling();
+
+        if (element.IsBlockType() || next is IElement nextElement && nextElement.IsBlockType())
+        {
+            // Get last 4 chars to check their line endings. Windows uses CRLF line endings (\r\n),
+            // so there may be up to 4 chars, instead of 2 for LF (\n) when using Linux / Mac.
+            var currentEnding = _builder.Substring(^4..);
+
+            // If already have two line endings, then don't
+            // append more spacing as this would be excessive.
+            if (currentEnding.EndsWith($"{Environment.NewLine}{Environment.NewLine}"))
             {
                 return;
             }
 
-            // There are potentially inline elements such as span/strong/em, so we
-            // should try add extra spacing to avoid text bunching up. To do this,
-            // we need to scan the previous sibling elements of the current node to
-            // check that they actually contain something that can be spaced out.
-            var prev = node.PreviousNonWhitespaceSibling();
-
-            if (prev is null)
-            {
-                // If there is no previous non-whitespace sibling, check the siblings of the parent
-                // (if it's an element) instead. For example, when starting from the
-                // `highlight` text node of `some <strong>highlight</strong>`, we want to be able to
-                // locate the `some ` text node that is adjacent to the parent `<strong>` element.
-                if (node.Parent is IElement parentElement && parentElement.IsInlineType())
-                {
-                    prev = parentElement.PreviousNonWhitespaceSibling();
-                }
-            }
-
-            var hasPreviousInlineSibling =
-                prev is IText ||
-                (prev is not IHtmlBreakRowElement and IElement prevElement && prevElement.IsInlineType());
-
-            // We currently only add extra spacing if the text content starts with an
-            // alphanumeric character as we can safely assume this isn't a
-            // punctuation character. Not sure if there may be edge cases to this?
-            if (hasPreviousInlineSibling && content[0].IsAlphanumericAscii())
-            {
-                _builder.Append(' ');
-            }
-
-            _builder.Append(content);
-
-            var next = node.NextNonWhitespaceSibling();
-
-            if (next is IElement nextElement && nextElement.IsBlockType())
+            // Don't have a trailing line ending currently, so it
+            // should be safe to add an additional line ending to
+            // provide better spacing with the next block.
+            if (!currentEnding.EndsWith(Environment.NewLine))
             {
                 _builder.AppendLine();
-                _builder.AppendLine();
             }
+
+            _builder.AppendLine();
+        }
+    }
+
+    private void ParseEdgeNode(INode node)
+    {
+        // Text may be split over multiple lines for
+        // formatting purposes in HTML, but this would
+        // lead to unnecessary line breaks in rendered text,
+        // so we should remove these line breaks.
+        var content = node.TextContent.CollapseAndStrip();
+
+        if (content == string.Empty)
+        {
+            return;
         }
 
-        private void ParseLinkElement(IElement element)
+        // There are potentially inline elements such as span/strong/em, so we
+        // should try add extra spacing to avoid text bunching up. To do this,
+        // we need to scan the previous sibling elements of the current node to
+        // check that they actually contain something that can be spaced out.
+        var prev = node.PreviousNonWhitespaceSibling();
+
+        if (prev is null)
         {
-            ParseChildren(element);
-
-            var href = element.Attributes["href"]?.Value;
-
-            if (!href.IsNullOrWhitespace())
+            // If there is no previous non-whitespace sibling, check the siblings of the parent
+            // (if it's an element) instead. For example, when starting from the
+            // `highlight` text node of `some <strong>highlight</strong>`, we want to be able to
+            // locate the `some ` text node that is adjacent to the parent `<strong>` element.
+            if (node.Parent is IElement parentElement && parentElement.IsInlineType())
             {
-                _builder.Append($" ({href})");
+                prev = parentElement.PreviousNonWhitespaceSibling();
             }
         }
 
-        private void ParseListElement(IElement element)
-        {
-            var isOrdered = element.LocalName == "ol";
-            var listItems = element.ChildNodes
-                .Where(node => node is IElement { LocalName: "li" });
+        var hasPreviousInlineSibling =
+            prev is IText ||
+            (prev is not IHtmlBreakRowElement and IElement prevElement && prevElement.IsInlineType());
 
-            ParseNodes(
-                listItems,
-                (item, index) =>
+        // We currently only add extra spacing if the text content starts with an
+        // alphanumeric character as we can safely assume this isn't a
+        // punctuation character. Not sure if there may be edge cases to this?
+        if (hasPreviousInlineSibling && content[0].IsAlphanumericAscii())
+        {
+            _builder.Append(' ');
+        }
+
+        _builder.Append(content);
+
+        var next = node.NextNonWhitespaceSibling();
+
+        if (next is IElement nextElement && nextElement.IsBlockType())
+        {
+            _builder.AppendLine();
+            _builder.AppendLine();
+        }
+    }
+
+    private void ParseLinkElement(IElement element)
+    {
+        ParseChildren(element);
+
+        var href = element.Attributes["href"]?.Value;
+
+        if (!href.IsNullOrWhitespace())
+        {
+            _builder.Append($" ({href})");
+        }
+    }
+
+    private void ParseListElement(IElement element)
+    {
+        var isOrdered = element.LocalName == "ol";
+        var listItems = element.ChildNodes
+            .Where(node => node is IElement { LocalName: "li" });
+
+        ParseNodes(
+            listItems,
+            (item, index) =>
+            {
+                var lineItemStart = isOrdered ? $"{index + 1}. " : "- ";
+
+                _builder.Append(lineItemStart);
+
+                var indent = string.Empty.PadRight(lineItemStart.Length);
+
+                var converter = new HtmlToTextConverter();
+                var text = converter.Convert(item);
+
+                text.ToLines()
+                    .ForEach(
+                        (line, lineIndex) =>
+                        {
+                            _builder.AppendLine(lineIndex == 0 ? line : indent + line);
+                        }
+                    );
+            }
+        );
+    }
+
+    private void ParseDescriptionListElement(IElement element)
+    {
+        const string indentation = "  ";
+
+        var listItems = element.ChildNodes
+            .Where(node => node is IElement { LocalName: "dt" } or IElement { LocalName: "dd" });
+
+        ParseNodes(
+            listItems,
+            (item, _) =>
+            {
+                switch (item.LocalName)
                 {
-                    var lineItemStart = isOrdered ? $"{index + 1}. " : "- ";
+                    case "dt":
+                        _builder.AppendLine(item.TextContent.CollapseAndStrip());
+                        break;
 
-                    _builder.Append(lineItemStart);
+                    case "dd":
+                        var converter = new HtmlToTextConverter();
+                        var text = converter.Convert(item);
 
-                    var indent = string.Empty.PadRight(lineItemStart.Length);
+                        text.ToLines()
+                            .ForEach(line => _builder.AppendLine(indentation + line));
 
-                    var converter = new HtmlToTextConverter();
-                    var text = converter.Convert(item);
-
-                    text.ToLines()
-                        .ForEach(
-                            (line, lineIndex) =>
-                            {
-                                _builder.AppendLine(lineIndex == 0 ? line : indent + line);
-                            }
-                        );
+                        break;
                 }
-            );
-        }
+            }
+        );
+    }
 
-        private void ParseDescriptionListElement(IElement element)
-        {
-            const string indentation = "  ";
+    private void ParseTableElement(IElement element)
+    {
+        var headerRows = element.QuerySelectorAll<IElement>("thead tr");
+        var bodyRows = element.QuerySelectorAll<IElement>("tbody tr");
 
-            var listItems = element.ChildNodes
-                .Where(node => node is IElement { LocalName: "dt" } or IElement { LocalName: "dd" });
+        var table = new HtmlToTextTableRenderer();
 
-            ParseNodes(
-                listItems,
-                (item, _) =>
-                {
-                    switch (item.LocalName)
-                    {
-                        case "dt":
-                            _builder.AppendLine(item.TextContent.CollapseAndStrip());
-                            break;
+        headerRows.ForEach(row => table.AddHeaderRow(row));
+        bodyRows.ForEach(row => table.AddBodyRow(row));
 
-                        case "dd":
-                            var converter = new HtmlToTextConverter();
-                            var text = converter.Convert(item);
-
-                            text.ToLines()
-                                .ForEach(line => _builder.AppendLine(indentation + line));
-
-                            break;
-                    }
-                }
-            );
-        }
-
-        private void ParseTableElement(IElement element)
-        {
-            var headerRows = element.QuerySelectorAll<IElement>("thead tr");
-            var bodyRows = element.QuerySelectorAll<IElement>("tbody tr");
-
-            var table = new HtmlToTextTableRenderer();
-
-            headerRows.ForEach(row => table.AddHeaderRow(row));
-            bodyRows.ForEach(row => table.AddBodyRow(row));
-
-            _builder.AppendLine(table.Render());
-        }
+        _builder.AppendLine(table.Render());
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextTableRenderer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextTableRenderer.cs
@@ -6,241 +6,240 @@ using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html;
+
+internal class HtmlToTextTableRenderer
 {
-    internal class HtmlToTextTableRenderer
+    private const string Separator = "  |  ";
+    private const string EmptySeparator = "     ";
+
+    private readonly List<List<TableCell>> _headerRows = new();
+    private readonly List<List<TableCell>> _bodyRows = new();
+    private readonly List<int> _columnWidths = new();
+
+    private class TableCell
     {
-        private const string Separator = "  |  ";
-        private const string EmptySeparator = "     ";
+        public readonly IList<string> Lines;
 
-        private readonly List<List<TableCell>> _headerRows = new();
-        private readonly List<List<TableCell>> _bodyRows = new();
-        private readonly List<int> _columnWidths = new();
+        public readonly int RemainingColSpan;
+        public readonly int RemainingRowSpan;
 
-        private class TableCell
+        public TableCell(
+            string text,
+            int remainingColSpan = 0,
+            int remainingRowSpan = 0)
         {
-            public readonly IList<string> Lines;
-
-            public readonly int RemainingColSpan;
-            public readonly int RemainingRowSpan;
-
-            public TableCell(
-                string text,
-                int remainingColSpan = 0,
-                int remainingRowSpan = 0)
-            {
-                Lines = text.ToLinesList();
-                RemainingColSpan = remainingColSpan;
-                RemainingRowSpan = remainingRowSpan;
-            }
+            Lines = text.ToLinesList();
+            RemainingColSpan = remainingColSpan;
+            RemainingRowSpan = remainingRowSpan;
         }
+    }
 
-        public void AddHeaderRow(IElement rowElement)
+    public void AddHeaderRow(IElement rowElement)
+    {
+        _headerRows.Add(
+            GenerateTableCells(
+                rowElement: rowElement,
+                previousRowCells: _headerRows.LastOrDefault()
+            )
+        );
+    }
+
+    public void AddBodyRow(IElement rowElement)
+    {
+        _bodyRows.Add(
+            GenerateTableCells(
+                rowElement: rowElement,
+                previousRowCells: _bodyRows.LastOrDefault()
+            )
+        );
+    }
+
+    private List<TableCell> GenerateTableCells(IElement rowElement, List<TableCell>? previousRowCells)
+    {
+        var cellElements = rowElement.Children
+            .Where(cell => cell is IHtmlTableCellElement)
+            .Cast<IHtmlTableCellElement>()
+            .ToList();
+
+        var cells = new List<TableCell?>();
+
+        if (previousRowCells != null)
         {
-            _headerRows.Add(
-                GenerateTableCells(
-                    rowElement: rowElement,
-                    previousRowCells: _headerRows.LastOrDefault()
-                )
-            );
-        }
-
-        public void AddBodyRow(IElement rowElement)
-        {
-            _bodyRows.Add(
-                GenerateTableCells(
-                    rowElement: rowElement,
-                    previousRowCells: _bodyRows.LastOrDefault()
-                )
-            );
-        }
-
-        private List<TableCell> GenerateTableCells(IElement rowElement, List<TableCell>? previousRowCells)
-        {
-            var cellElements = rowElement.Children
-                .Where(cell => cell is IHtmlTableCellElement)
-                .Cast<IHtmlTableCellElement>()
-                .ToList();
-
-            var cells = new List<TableCell?>();
-
-            if (previousRowCells != null)
-            {
-                previousRowCells.ForEach(
-                    (cell, index) =>
-                    {
-                        // Insert empty cells from the previous row
-                        // that have remaining row span as these need
-                        // to take up space in this current row.
-                        // We insert nulls to represent cells that are to
-                        // be filled by the current list of cell elements.
-                        cells.Insert(
-                            index,
-                            cell.RemainingRowSpan > 0
-                                ? new TableCell(
-                                    text: string.Empty,
-                                    remainingColSpan: cell.RemainingColSpan,
-                                    remainingRowSpan: cell.RemainingRowSpan - 1
-                                )
-                                : null
-                        );
-                    }
-                );
-            }
-            else
-            {
-                cellElements.ForEach(
-                    (cellElement, index) =>
-                    {
-                        // Initialise cells with placeholder
-                        // nulls so that these can be replaced
-                        // by table cells later.
-                        cellElement.ColumnSpan
-                            .ToEnumerable()
-                            .ForEach(
-                                span => { cells.Add(null); }
-                            );
-                    }
-                );
-            }
-
-            cellElements
-                .ForEach(
-                    child =>
-                    {
-                        var converter = new HtmlToTextConverter();
-                        var text = converter.Convert(child);
-
-                        var cellIndex = cells.FindIndex(cell => cell == null);
-
-                        var tableCell = new TableCell(
-                            text: text,
-                            remainingColSpan: child.ColumnSpan - 1,
-                            remainingRowSpan: child.RowSpan - 1
-                        );
-
-                        cells[cellIndex] = tableCell;
-
-                        // Initialise any missing column widths with 0
-                        if (_columnWidths.Count - 1 < cellIndex)
-                        {
-                            var newColumns = (_columnWidths.Count - 1 - cellIndex)
-                                .ToEnumerable()
-                                .Select(_ => 0);
-
-                            _columnWidths.AddRange(newColumns);
-                        }
-
-                        var childWidth = text.ToLines()
-                            .DefaultIfEmpty(string.Empty)
-                            .Max(line => line.Length);
-
-                        if (childWidth > _columnWidths[cellIndex])
-                        {
-                            _columnWidths[cellIndex] = childWidth;
-                        }
-
-                        if (child.ColumnSpan == 1)
-                        {
-                            return;
-                        }
-
-                        // We add empty cells with colspans so that we can
-                        // create a complete matrix of table cells (instead
-                        // of HTML's incomplete representation).
-                        var spans = child.ColumnSpan - 1;
-
-                        spans.ToEnumerable()
-                            .ForEach(
-                                span =>
-                                {
-                                    cells[cellIndex + span] = new TableCell(
-                                        text: string.Empty,
-                                        remainingColSpan: spans - span,
-                                        remainingRowSpan: tableCell.RemainingRowSpan
-                                    );
-                                }
-                            );
-                    }
-                );
-
-            return cells as List<TableCell>;
-        }
-
-        public string Render()
-        {
-            var builder = new StringBuilder();
-
-            // Render table header with an extra row that is
-            // composed of dashes to separate it from the body.
-            if (_headerRows.Count > 0)
-            {
-                RenderRows(builder, _headerRows);
-
-                _columnWidths.ForEach(
-                    (columnWidth, index) =>
-                    {
-                        builder.Append(string.Empty.PadRight(columnWidth, '-'));
-
-                        if (index != _columnWidths.Count - 1)
-                        {
-                            builder.Append(Separator);
-                        }
-                    }
-                );
-
-                builder.AppendLine();
-            }
-
-            RenderRows(builder, _bodyRows);
-
-            return builder.ToString();
-        }
-
-        private void RenderRows(StringBuilder builder, List<List<TableCell>> rows)
-        {
-            rows.ForEach(
-                row =>
+            previousRowCells.ForEach(
+                (cell, index) =>
                 {
-                    var lineIndex = 0;
-                    var hasLines = true;
-
-                    // As table cells can be multi-line, we need to continue
-                    // rendering each row until each cell's lines have been
-                    // completely rendered out to the builder.
-                    while (hasLines)
-                    {
-                        var currentLineIndex = lineIndex;
-
-                        row.ForEach(
-                            (cell, cellIndex) =>
-                            {
-                                var columnWidth = _columnWidths[cellIndex];
-
-                                if (cell.Lines.ElementAtOrDefault(currentLineIndex) != null)
-                                {
-                                    builder.Append(cell.Lines[currentLineIndex].PadRight(columnWidth));
-                                }
-                                else
-                                {
-                                    builder.Append(string.Empty.PadRight(columnWidth));
-                                }
-
-                                if (cellIndex != row.Count - 1)
-                                {
-                                    builder.Append(cell.RemainingColSpan == 0 ? Separator : EmptySeparator);
-                                }
-                            }
-                        );
-
-
-                        hasLines = row.Any(cell => cell.Lines.ElementAtOrDefault(currentLineIndex + 1) != null);
-                        lineIndex += 1;
-
-                        builder.AppendLine();
-                    }
+                    // Insert empty cells from the previous row
+                    // that have remaining row span as these need
+                    // to take up space in this current row.
+                    // We insert nulls to represent cells that are to
+                    // be filled by the current list of cell elements.
+                    cells.Insert(
+                        index,
+                        cell.RemainingRowSpan > 0
+                            ? new TableCell(
+                                text: string.Empty,
+                                remainingColSpan: cell.RemainingColSpan,
+                                remainingRowSpan: cell.RemainingRowSpan - 1
+                            )
+                            : null
+                    );
                 }
             );
         }
+        else
+        {
+            cellElements.ForEach(
+                (cellElement, index) =>
+                {
+                    // Initialise cells with placeholder
+                    // nulls so that these can be replaced
+                    // by table cells later.
+                    cellElement.ColumnSpan
+                        .ToEnumerable()
+                        .ForEach(
+                            span => { cells.Add(null); }
+                        );
+                }
+            );
+        }
+
+        cellElements
+            .ForEach(
+                child =>
+                {
+                    var converter = new HtmlToTextConverter();
+                    var text = converter.Convert(child);
+
+                    var cellIndex = cells.FindIndex(cell => cell == null);
+
+                    var tableCell = new TableCell(
+                        text: text,
+                        remainingColSpan: child.ColumnSpan - 1,
+                        remainingRowSpan: child.RowSpan - 1
+                    );
+
+                    cells[cellIndex] = tableCell;
+
+                    // Initialise any missing column widths with 0
+                    if (_columnWidths.Count - 1 < cellIndex)
+                    {
+                        var newColumns = (_columnWidths.Count - 1 - cellIndex)
+                            .ToEnumerable()
+                            .Select(_ => 0);
+
+                        _columnWidths.AddRange(newColumns);
+                    }
+
+                    var childWidth = text.ToLines()
+                        .DefaultIfEmpty(string.Empty)
+                        .Max(line => line.Length);
+
+                    if (childWidth > _columnWidths[cellIndex])
+                    {
+                        _columnWidths[cellIndex] = childWidth;
+                    }
+
+                    if (child.ColumnSpan == 1)
+                    {
+                        return;
+                    }
+
+                    // We add empty cells with colspans so that we can
+                    // create a complete matrix of table cells (instead
+                    // of HTML's incomplete representation).
+                    var spans = child.ColumnSpan - 1;
+
+                    spans.ToEnumerable()
+                        .ForEach(
+                            span =>
+                            {
+                                cells[cellIndex + span] = new TableCell(
+                                    text: string.Empty,
+                                    remainingColSpan: spans - span,
+                                    remainingRowSpan: tableCell.RemainingRowSpan
+                                );
+                            }
+                        );
+                }
+            );
+
+        return cells as List<TableCell>;
+    }
+
+    public string Render()
+    {
+        var builder = new StringBuilder();
+
+        // Render table header with an extra row that is
+        // composed of dashes to separate it from the body.
+        if (_headerRows.Count > 0)
+        {
+            RenderRows(builder, _headerRows);
+
+            _columnWidths.ForEach(
+                (columnWidth, index) =>
+                {
+                    builder.Append(string.Empty.PadRight(columnWidth, '-'));
+
+                    if (index != _columnWidths.Count - 1)
+                    {
+                        builder.Append(Separator);
+                    }
+                }
+            );
+
+            builder.AppendLine();
+        }
+
+        RenderRows(builder, _bodyRows);
+
+        return builder.ToString();
+    }
+
+    private void RenderRows(StringBuilder builder, List<List<TableCell>> rows)
+    {
+        rows.ForEach(
+            row =>
+            {
+                var lineIndex = 0;
+                var hasLines = true;
+
+                // As table cells can be multi-line, we need to continue
+                // rendering each row until each cell's lines have been
+                // completely rendered out to the builder.
+                while (hasLines)
+                {
+                    var currentLineIndex = lineIndex;
+
+                    row.ForEach(
+                        (cell, cellIndex) =>
+                        {
+                            var columnWidth = _columnWidths[cellIndex];
+
+                            if (cell.Lines.ElementAtOrDefault(currentLineIndex) != null)
+                            {
+                                builder.Append(cell.Lines[currentLineIndex].PadRight(columnWidth));
+                            }
+                            else
+                            {
+                                builder.Append(string.Empty.PadRight(columnWidth));
+                            }
+
+                            if (cellIndex != row.Count - 1)
+                            {
+                                builder.Append(cell.RemainingColSpan == 0 ? Separator : EmptySeparator);
+                            }
+                        }
+                    );
+
+
+                    hasLines = row.Any(cell => cell.Lines.ElementAtOrDefault(currentLineIndex + 1) != null);
+                    lineIndex += 1;
+
+                    builder.AppendLine();
+                }
+            }
+        );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/HtmlToTextUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/HtmlToTextUtils.cs
@@ -3,17 +3,16 @@ using System.Threading.Tasks;
 using AngleSharp.Html.Parser;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils.Html;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
-{
-    public static class HtmlToTextUtils
-    {
-        public static async Task<string> HtmlToText(string html)
-        {
-            var parser = new HtmlParser();
-            var document = await parser.ParseDocumentAsync("");
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
 
-            var converter = new HtmlToTextConverter();
-            return converter.Convert(parser.ParseFragment(html, document.Body!));
-        }
+public static class HtmlToTextUtils
+{
+    public static async Task<string> HtmlToText(string html)
+    {
+        var parser = new HtmlParser();
+        var document = await parser.ParseDocumentAsync("");
+
+        var converter = new HtmlToTextConverter();
+        return converter.Convert(parser.ParseFragment(html, document.Body!));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/IPersistenceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/IPersistenceHelper.cs
@@ -6,27 +6,26 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public interface IPersistenceHelper<TDbContext> where TDbContext : DbContext
 {
-    public interface IPersistenceHelper<TDbContext> where TDbContext : DbContext
-    {
-        Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity, TEntityId>(
-            TEntityId id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
-            where TEntity : class;
+    Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity, TEntityId>(
+        TEntityId id,
+        Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
+        where TEntity : class;
 
-        Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
-            Guid id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
-            where TEntity : class;
+    Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
+        Guid id,
+        Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
+        where TEntity : class;
 
-        Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
-            Func<IQueryable<TEntity>, IQueryable<TEntity>> query)
-            where TEntity : class;
+    Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
+        Func<IQueryable<TEntity>, IQueryable<TEntity>> query)
+        where TEntity : class;
 
-        Task<Either<ActionResult, TEntity?>> CheckOptionalEntityExists<TEntity>(
-            Guid? id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
-            where TEntity : class;
-    }
+    Task<Either<ActionResult, TEntity?>> CheckOptionalEntityExists<TEntity>(
+        Guid? id,
+        Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
+        where TEntity : class;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/LoggerTimingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/LoggerTimingExtensions.cs
@@ -5,163 +5,162 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.Extensions.Logging;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+/// <summary>
+/// This class adds extension methods to ILogger implementations to allow blocks of code to be easily
+/// timed and the durations logged consistently.  In addition, a current indent level is tracked and
+/// used to allow timed elements within other timed elements to be logged at an indented level
+/// relative to its parent's logging indent level, making for easier visualisation of what specific
+/// code might be time-consuming within a parent block of code.
+///
+/// The AsyncLocal is used to track the indentation level throughout an asynchronous execution flow,
+/// meaning that the indent level is retained during the processing of async blocks of code executed by
+/// parent blocks of code.
+/// </summary>
+public static class LoggerTimingExtensions
 {
-    /// <summary>
-    /// This class adds extension methods to ILogger implementations to allow blocks of code to be easily
-    /// timed and the durations logged consistently.  In addition, a current indent level is tracked and
-    /// used to allow timed elements within other timed elements to be logged at an indented level
-    /// relative to its parent's logging indent level, making for easier visualisation of what specific
-    /// code might be time-consuming within a parent block of code.
-    ///
-    /// The AsyncLocal is used to track the indentation level throughout an asynchronous execution flow,
-    /// meaning that the indent level is retained during the processing of async blocks of code executed by
-    /// parent blocks of code.
-    /// </summary>
-    public static class LoggerTimingExtensions
+    private static readonly AsyncLocal<int> CurrentIndentLevel = new AsyncLocal<int>();
+    private const int IndentLength = 4; 
+        
+    public static TResult TraceTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<TResult> action, 
+        string timingDescription, bool includeStartMessage = false)
     {
-        private static readonly AsyncLocal<int> CurrentIndentLevel = new AsyncLocal<int>();
-        private const int IndentLength = 4; 
-            
-        public static TResult TraceTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<TResult> action, 
-            string timingDescription, bool includeStartMessage = false)
+        return LogTime(logger, LogLevel.Trace, action, timingDescription, includeStartMessage);
+    }
+    
+    public static void TraceTime<TLogger>(this ILogger<TLogger> logger, Action action, 
+        string timingDescription, bool includeStartMessage = false)
+    {
+        LogTime(logger, LogLevel.Trace, ActionToFunc(action), timingDescription, includeStartMessage);
+    }
+    
+    public static Task<TResult> TraceTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<Task<TResult>> action, 
+        string timingDescription, bool includeStartMessage = false)
+    {
+        return LogTime(logger, LogLevel.Trace, action, timingDescription, includeStartMessage);
+    }
+    
+    public static Task TraceTime<TLogger>(this ILogger<TLogger> logger, Func<Task> action, 
+        string timingDescription, bool includeStartMessage = false)
+    {
+        return LogTime(logger, LogLevel.Trace, action, timingDescription, includeStartMessage);
+    }
+    
+    public static TResult DebugTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<TResult> action, 
+        string timingDescription, bool includeStartMessage = true) where TResult : class
+    {
+        return LogTime(logger, LogLevel.Debug, action, timingDescription, includeStartMessage);
+    }
+    
+    public static void DebugTime<TLogger>(this ILogger<TLogger> logger, Action action, 
+        string timingDescription, bool includeStartMessage = true)
+    {
+        LogTime(logger, LogLevel.Debug, ActionToFunc(action), timingDescription, includeStartMessage);
+    }
+    
+    public static Task<TResult> DebugTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<Task<TResult>> action, 
+        string timingDescription, bool includeStartMessage = true)
+    {
+        return LogTime(logger, LogLevel.Debug, action, timingDescription, includeStartMessage);
+    }
+    
+    public static Task DebugTime<TLogger>(this ILogger<TLogger> logger, Func<Task> action, 
+        string timingDescription, bool includeStartMessage = true)
+    { 
+        return LogTime(logger, LogLevel.Debug, action, timingDescription, includeStartMessage);
+    }
+    
+    public static TResult InfoTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<TResult> action, 
+        string timingDescription, bool includeStartMessage = false) where TResult : class
+    {
+        return LogTime(logger, LogLevel.Information, action, timingDescription, includeStartMessage);
+    }
+    
+    public static void InfoTime<TLogger>(this ILogger<TLogger> logger, Action action, 
+        string timingDescription, bool includeStartMessage = false)
+    {
+        LogTime(logger, LogLevel.Information, ActionToFunc(action), timingDescription, includeStartMessage);
+    }
+    
+    public static Task<TResult> InfoTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<Task<TResult>> action, 
+        string timingDescription, bool includeStartMessage = false)
+    {
+        return LogTime(logger, LogLevel.Information, action, timingDescription, includeStartMessage);
+    }
+    
+    public static Task InfoTime<TLogger>(this ILogger<TLogger> logger, Func<Task> action, 
+        string timingDescription, bool includeStartMessage = false)
+    {
+        return LogTime(logger, LogLevel.Information, action, timingDescription, includeStartMessage);
+    }
+
+    private static TResult LogTime<
+        TResult, TLogger>(ILogger<TLogger> logger, 
+        LogLevel logLevel, 
+        Func<TResult> action, 
+        string timingDescription,
+        bool includeStartMessage)
+    {
+        return LogTime(logger, logLevel, () => Task.FromResult(action.Invoke()), timingDescription, includeStartMessage).Result;
+    }
+    
+    private static async Task LogTime<TLogger>(ILogger<TLogger> logger, 
+        LogLevel logLevel, 
+        Func<Task> action, 
+        string timingDescription,
+        bool includeStartMessage)
+    {
+        async Task<Unit> TaskFunc()
         {
-            return LogTime(logger, LogLevel.Trace, action, timingDescription, includeStartMessage);
-        }
-        
-        public static void TraceTime<TLogger>(this ILogger<TLogger> logger, Action action, 
-            string timingDescription, bool includeStartMessage = false)
-        {
-            LogTime(logger, LogLevel.Trace, ActionToFunc(action), timingDescription, includeStartMessage);
-        }
-        
-        public static Task<TResult> TraceTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<Task<TResult>> action, 
-            string timingDescription, bool includeStartMessage = false)
-        {
-            return LogTime(logger, LogLevel.Trace, action, timingDescription, includeStartMessage);
-        }
-        
-        public static Task TraceTime<TLogger>(this ILogger<TLogger> logger, Func<Task> action, 
-            string timingDescription, bool includeStartMessage = false)
-        {
-            return LogTime(logger, LogLevel.Trace, action, timingDescription, includeStartMessage);
-        }
-        
-        public static TResult DebugTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<TResult> action, 
-            string timingDescription, bool includeStartMessage = true) where TResult : class
-        {
-            return LogTime(logger, LogLevel.Debug, action, timingDescription, includeStartMessage);
-        }
-        
-        public static void DebugTime<TLogger>(this ILogger<TLogger> logger, Action action, 
-            string timingDescription, bool includeStartMessage = true)
-        {
-            LogTime(logger, LogLevel.Debug, ActionToFunc(action), timingDescription, includeStartMessage);
-        }
-        
-        public static Task<TResult> DebugTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<Task<TResult>> action, 
-            string timingDescription, bool includeStartMessage = true)
-        {
-            return LogTime(logger, LogLevel.Debug, action, timingDescription, includeStartMessage);
-        }
-        
-        public static Task DebugTime<TLogger>(this ILogger<TLogger> logger, Func<Task> action, 
-            string timingDescription, bool includeStartMessage = true)
-        { 
-            return LogTime(logger, LogLevel.Debug, action, timingDescription, includeStartMessage);
-        }
-        
-        public static TResult InfoTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<TResult> action, 
-            string timingDescription, bool includeStartMessage = false) where TResult : class
-        {
-            return LogTime(logger, LogLevel.Information, action, timingDescription, includeStartMessage);
-        }
-        
-        public static void InfoTime<TLogger>(this ILogger<TLogger> logger, Action action, 
-            string timingDescription, bool includeStartMessage = false)
-        {
-            LogTime(logger, LogLevel.Information, ActionToFunc(action), timingDescription, includeStartMessage);
-        }
-        
-        public static Task<TResult> InfoTime<TResult, TLogger>(this ILogger<TLogger> logger, Func<Task<TResult>> action, 
-            string timingDescription, bool includeStartMessage = false)
-        {
-            return LogTime(logger, LogLevel.Information, action, timingDescription, includeStartMessage);
-        }
-        
-        public static Task InfoTime<TLogger>(this ILogger<TLogger> logger, Func<Task> action, 
-            string timingDescription, bool includeStartMessage = false)
-        {
-            return LogTime(logger, LogLevel.Information, action, timingDescription, includeStartMessage);
+            await action.Invoke();
+            return Unit.Instance;
         }
 
-        private static TResult LogTime<
-            TResult, TLogger>(ILogger<TLogger> logger, 
-            LogLevel logLevel, 
-            Func<TResult> action, 
-            string timingDescription,
-            bool includeStartMessage)
+        await LogTime(logger, logLevel, TaskFunc, timingDescription, includeStartMessage);
+    }
+    
+    private static async Task<TResult> LogTime<
+        TResult, TLogger>(ILogger<TLogger> logger,
+        LogLevel logLevel, 
+        Func<Task<TResult>> action, 
+        string timingDescription,
+        bool includeStartMessage)
+    {
+        if (!logger.IsEnabled(logLevel))
         {
-            return LogTime(logger, logLevel, () => Task.FromResult(action.Invoke()), timingDescription, includeStartMessage).Result;
+            return await action.Invoke();
         }
+
+        var stopwatch = Stopwatch.StartNew();
         
-        private static async Task LogTime<TLogger>(ILogger<TLogger> logger, 
-            LogLevel logLevel, 
-            Func<Task> action, 
-            string timingDescription,
-            bool includeStartMessage)
+        var currentIndentLevel = CurrentIndentLevel.Value;
+        var indentPadding = "".PadLeft(currentIndentLevel * IndentLength);
+        CurrentIndentLevel.Value = currentIndentLevel + 1;
+
+        try
         {
-            async Task<Unit> TaskFunc()
+            if (includeStartMessage)
             {
-                await action.Invoke();
-                return Unit.Instance;
+                logger.Log(logLevel, $"{indentPadding}Starting to time {timingDescription}");
             }
 
-            await LogTime(logger, logLevel, TaskFunc, timingDescription, includeStartMessage);
+            var result = await action.Invoke();
+            logger.Log(logLevel, $"{indentPadding}Took {stopwatch.Elapsed.TotalMilliseconds} milliseconds to {timingDescription}");
+            return result;
         }
-        
-        private static async Task<TResult> LogTime<
-            TResult, TLogger>(ILogger<TLogger> logger,
-            LogLevel logLevel, 
-            Func<Task<TResult>> action, 
-            string timingDescription,
-            bool includeStartMessage)
+        finally
         {
-            if (!logger.IsEnabled(logLevel))
-            {
-                return await action.Invoke();
-            }
-
-            var stopwatch = Stopwatch.StartNew();
-            
-            var currentIndentLevel = CurrentIndentLevel.Value;
-            var indentPadding = "".PadLeft(currentIndentLevel * IndentLength);
-            CurrentIndentLevel.Value = currentIndentLevel + 1;
-
-            try
-            {
-                if (includeStartMessage)
-                {
-                    logger.Log(logLevel, $"{indentPadding}Starting to time {timingDescription}");
-                }
-
-                var result = await action.Invoke();
-                logger.Log(logLevel, $"{indentPadding}Took {stopwatch.Elapsed.TotalMilliseconds} milliseconds to {timingDescription}");
-                return result;
-            }
-            finally
-            {
-                CurrentIndentLevel.Value = currentIndentLevel;
-            }
+            CurrentIndentLevel.Value = currentIndentLevel;
         }
+    }
 
-        private static Func<Unit> ActionToFunc(Action action)
+    private static Func<Unit> ActionToFunc(Action action)
+    {
+        return () => 
         {
-            return () => 
-            {
-                action();
-                return Unit.Instance;
-            };
-        }
+            action();
+            return Unit.Instance;
+        };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/PersistenceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/PersistenceHelper.cs
@@ -7,67 +7,66 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public class PersistenceHelper<TDbContext> : IPersistenceHelper<TDbContext>
+    where TDbContext : DbContext
 {
-    public class PersistenceHelper<TDbContext> : IPersistenceHelper<TDbContext>
-        where TDbContext : DbContext
+    private readonly TDbContext _context;
+
+    public PersistenceHelper(
+        TDbContext context)
     {
-        private readonly TDbContext _context;
+        _context = context;
+    }
 
-        public PersistenceHelper(
-            TDbContext context)
-        {
-            _context = context;
-        }
+    public async Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity, TEntityId>(
+        TEntityId id,
+        Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
+        where TEntity : class
+    {
+        var queryableEntities = _context.Set<TEntity>()
+            .FindByPrimaryKey(_context, id);
 
-        public async Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity, TEntityId>(
-            TEntityId id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
-            where TEntity : class
-        {
-            var queryableEntities = _context.Set<TEntity>()
-                .FindByPrimaryKey(_context, id);
+        var hydratedEntities = hydrateEntityFn != null
+            ? hydrateEntityFn.Invoke(queryableEntities)
+            : queryableEntities;
 
-            var hydratedEntities = hydrateEntityFn != null
-                ? hydrateEntityFn.Invoke(queryableEntities)
-                : queryableEntities;
+        var entity = await hydratedEntities
+            .FirstOrDefaultAsync();
 
-            var entity = await hydratedEntities
-                .FirstOrDefaultAsync();
+        return entity == null
+            ? new NotFoundResult()
+            : new Either<ActionResult, TEntity>(entity);
+    }
 
-            return entity == null
-                ? new NotFoundResult()
-                : new Either<ActionResult, TEntity>(entity);
-        }
+    public Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
+        Guid id,
+        Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
+        where TEntity : class
+    {
+        return CheckEntityExists<TEntity, Guid>(id, hydrateEntityFn);
+    }
 
-        public Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
-            Guid id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null)
-            where TEntity : class
-        {
-            return CheckEntityExists<TEntity, Guid>(id, hydrateEntityFn);
-        }
+    public async Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
+        Func<IQueryable<TEntity>, IQueryable<TEntity>> query)
+        where TEntity : class
+    {
+        var queryableEntities = _context.Set<TEntity>();
 
-        public async Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
-            Func<IQueryable<TEntity>, IQueryable<TEntity>> query)
-            where TEntity : class
-        {
-            var queryableEntities = _context.Set<TEntity>();
+        var entity = await query.Invoke(queryableEntities)
+            .FirstOrDefaultAsync();
 
-            var entity = await query.Invoke(queryableEntities)
-                .FirstOrDefaultAsync();
+        return entity == null
+            ? new NotFoundResult()
+            : new Either<ActionResult, TEntity>(entity);
+    }
 
-            return entity == null
-                ? new NotFoundResult()
-                : new Either<ActionResult, TEntity>(entity);
-        }
-
-        public async Task<Either<ActionResult, TEntity?>> CheckOptionalEntityExists<TEntity>(Guid? id,
-            Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null) where TEntity : class
-        {
-            return id.HasValue
-                ? await CheckEntityExists(id.Value, hydrateEntityFn)
-                : (TEntity) null;
-        }
+    public async Task<Either<ActionResult, TEntity?>> CheckOptionalEntityExists<TEntity>(Guid? id,
+        Func<IQueryable<TEntity>, IQueryable<TEntity>>? hydrateEntityFn = null) where TEntity : class
+    {
+        return id.HasValue
+            ? await CheckEntityExists(id.Value, hydrateEntityFn)
+            : (TEntity) null;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/StartupUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/StartupUtils.cs
@@ -1,20 +1,19 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public static class StartupUtils
 {
-    public static class StartupUtils
+    public static void AddPersistenceHelper<TDbContext>(IServiceCollection services)
+        where TDbContext : DbContext
     {
-        public static void AddPersistenceHelper<TDbContext>(IServiceCollection services)
-            where TDbContext : DbContext
-        {
-            services.AddTransient<IPersistenceHelper<TDbContext>, PersistenceHelper<TDbContext>>(
-                s =>
-                {
-                    var dbContext = s.GetService<TDbContext>();
-                    return new PersistenceHelper<TDbContext>(dbContext);
-                }
-            );
-        }
+        services.AddTransient<IPersistenceHelper<TDbContext>, PersistenceHelper<TDbContext>>(
+            s =>
+            {
+                var dbContext = s.GetService<TDbContext>();
+                return new PersistenceHelper<TDbContext>(dbContext);
+            }
+        );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/TimePeriodLabelFormatter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/TimePeriodLabelFormatter.cs
@@ -6,94 +6,93 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using static System.String;
 using static GovUk.Education.ExploreEducationStatistics.Common.Database.TimePeriodYearFormat;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public class TimePeriodLabelFormatter
 {
-    public class TimePeriodLabelFormatter
+    private static readonly Regex YearRegex = new Regex(@"^([0-9]{4})?$");
+    private TimePeriodLabelFormat LabelFormat { get; }
+    private TimePeriodYearFormat YearFormat { get; }
+
+    private TimePeriodLabelFormatter(TimePeriodLabelFormat labelFormat,
+        TimePeriodYearFormat yearFormat)
     {
-        private static readonly Regex YearRegex = new Regex(@"^([0-9]{4})?$");
-        private TimePeriodLabelFormat LabelFormat { get; }
-        private TimePeriodYearFormat YearFormat { get; }
+        LabelFormat = labelFormat;
+        YearFormat = yearFormat;
+    }
 
-        private TimePeriodLabelFormatter(TimePeriodLabelFormat labelFormat,
-            TimePeriodYearFormat yearFormat)
-        {
-            LabelFormat = labelFormat;
-            YearFormat = yearFormat;
-        }
+    public static string Format(
+        int year,
+        TimeIdentifier timeIdentifier,
+        TimePeriodLabelFormat? overridingLabelFormat = null)
+    {
+        return FormatterFor(timeIdentifier, overridingLabelFormat).FormatInternal(year, timeIdentifier);
+    }
 
-        public static string Format(
-            int year,
-            TimeIdentifier timeIdentifier,
-            TimePeriodLabelFormat? overridingLabelFormat = null)
-        {
-            return FormatterFor(timeIdentifier, overridingLabelFormat).FormatInternal(year, timeIdentifier);
-        }
+    public static string FormatYear(int year, TimeIdentifier timeIdentifier)
+    {
+        return FormatterFor(timeIdentifier).FormatYearInternal(year);
+    }
 
-        public static string FormatYear(int year, TimeIdentifier timeIdentifier)
-        {
-            return FormatterFor(timeIdentifier).FormatYearInternal(year);
-        }
+    public static string FormatCsvYear(int year, TimeIdentifier timeIdentifier)
+    {
+        return FormatterFor(timeIdentifier).FormatCsvYearInternal(year);
+    }
 
-        public static string FormatCsvYear(int year, TimeIdentifier timeIdentifier)
+    private string FormatInternal(int year, TimeIdentifier timeIdentifier)
+    {
+        var labelValueAttribute = timeIdentifier.GetEnumAttribute<TimeIdentifierMetaAttribute>();
+        var formattedYear = FormatYearInternal(year);
+        return LabelFormat switch
         {
-            return FormatterFor(timeIdentifier).FormatCsvYearInternal(year);
-        }
+            TimePeriodLabelFormat.FullLabel => $"{formattedYear} {labelValueAttribute.Label}",
+            TimePeriodLabelFormat.FullLabelBeforeYear => $"{labelValueAttribute.Label} {formattedYear}",
+            TimePeriodLabelFormat.NoLabel => formattedYear,
+            TimePeriodLabelFormat.ShortLabel => IsNullOrEmpty(labelValueAttribute.ShortLabel)
+                ? formattedYear
+                : $"{formattedYear} {labelValueAttribute.ShortLabel}",
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
 
-        private string FormatInternal(int year, TimeIdentifier timeIdentifier)
+    private string FormatYearInternal(int year)
+    {
+        if (YearRegex.Match(year.ToString()).Success)
         {
-            var labelValueAttribute = timeIdentifier.GetEnumAttribute<TimeIdentifierMetaAttribute>();
-            var formattedYear = FormatYearInternal(year);
-            return LabelFormat switch
+            return YearFormat switch
             {
-                TimePeriodLabelFormat.FullLabel => $"{formattedYear} {labelValueAttribute.Label}",
-                TimePeriodLabelFormat.FullLabelBeforeYear => $"{labelValueAttribute.Label} {formattedYear}",
-                TimePeriodLabelFormat.NoLabel => formattedYear,
-                TimePeriodLabelFormat.ShortLabel => IsNullOrEmpty(labelValueAttribute.ShortLabel)
-                    ? formattedYear
-                    : $"{formattedYear} {labelValueAttribute.ShortLabel}",
+                Default => year.ToString(),
+                Academic => $"{year}/{(year + 1) % 100:D2}", // Only want the last two digits,
+                Fiscal => $"{year}-{(year + 1) % 100:D2}", // Only want the last two digits,
                 _ => throw new ArgumentOutOfRangeException()
             };
         }
 
-        private string FormatYearInternal(int year)
+        throw new ArgumentOutOfRangeException();
+    }
+
+    private string FormatCsvYearInternal(int year)
+    {
+        if (YearRegex.Match(year.ToString()).Success)
         {
-            if (YearRegex.Match(year.ToString()).Success)
+            return YearFormat switch
             {
-                return YearFormat switch
-                {
-                    Default => year.ToString(),
-                    Academic => $"{year}/{(year + 1) % 100:D2}", // Only want the last two digits,
-                    Fiscal => $"{year}-{(year + 1) % 100:D2}", // Only want the last two digits,
-                    _ => throw new ArgumentOutOfRangeException()
-                };
-            }
-
-            throw new ArgumentOutOfRangeException();
+                Academic or Fiscal => $"{year}{(year + 1) % 100:D2}",
+                _ => year.ToString()
+            };
         }
 
-        private string FormatCsvYearInternal(int year)
-        {
-            if (YearRegex.Match(year.ToString()).Success)
-            {
-                return YearFormat switch
-                {
-                    Academic or Fiscal => $"{year}{(year + 1) % 100:D2}",
-                    _ => year.ToString()
-                };
-            }
+        throw new ArgumentOutOfRangeException();
+    }
 
-            throw new ArgumentOutOfRangeException();
-        }
-
-        private static TimePeriodLabelFormatter FormatterFor(
-            TimeIdentifier timeIdentifier,
-            TimePeriodLabelFormat? overridingLabelFormat = null)
-        {
-            var labelValueAttribute = timeIdentifier.GetEnumAttribute<TimeIdentifierMetaAttribute>();
-            return overridingLabelFormat.HasValue
-                ? new TimePeriodLabelFormatter(overridingLabelFormat.Value, labelValueAttribute.YearFormat)
-                : new TimePeriodLabelFormatter(labelValueAttribute.LabelFormat,
-                    labelValueAttribute.YearFormat);
-        }
+    private static TimePeriodLabelFormatter FormatterFor(
+        TimeIdentifier timeIdentifier,
+        TimePeriodLabelFormat? overridingLabelFormat = null)
+    {
+        var labelValueAttribute = timeIdentifier.GetEnumAttribute<TimeIdentifierMetaAttribute>();
+        return overridingLabelFormat.HasValue
+            ? new TimePeriodLabelFormatter(overridingLabelFormat.Value, labelValueAttribute.YearFormat)
+            : new TimePeriodLabelFormatter(labelValueAttribute.LabelFormat,
+                labelValueAttribute.YearFormat);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ContainsOnlyAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ContainsOnlyAttribute.cs
@@ -7,94 +7,93 @@ using System.Linq;
 using System.Reflection;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Validators
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators;
+
+[AttributeUsage(
+    AttributeTargets.Property | AttributeTargets.Field| AttributeTargets.Parameter,
+    AllowMultiple = true)]
+public class ContainsOnlyAttribute : ValidationAttribute
 {
-    [AttributeUsage(
-        AttributeTargets.Property | AttributeTargets.Field| AttributeTargets.Parameter,
-        AllowMultiple = true)]
-    public class ContainsOnlyAttribute : ValidationAttribute
+    public IEnumerable<object> AllowedValues { get; }
+
+    public string? AllowedValuesProvider { get; set; }
+
+    public ContainsOnlyAttribute(params object[] allowedValues)
     {
-        public IEnumerable<object> AllowedValues { get; }
+        AllowedValues = allowedValues;
+    }
 
-        public string? AllowedValuesProvider { get; set; }
+    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    {
+        var allowedValues = GetAllowedValues(validationContext);
 
-        public ContainsOnlyAttribute(params object[] allowedValues)
+        if (value is not IEnumerable values)
         {
-            AllowedValues = allowedValues;
+            throw new ArgumentException(
+                $"Validated value must implement {nameof(IEnumerable)}",
+                validationContext?.MemberName
+            );
         }
 
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        if (!allowedValues.Any())
         {
-            var allowedValues = GetAllowedValues(validationContext);
-
-            if (value is not IEnumerable values)
-            {
-                throw new ArgumentException(
-                    $"Validated value must implement {nameof(IEnumerable)}",
-                    validationContext?.MemberName
-                );
-            }
-
-            if (!allowedValues.Any())
-            {
-                return ValidationResult.Success;
-            }
-
-            if (!values.Cast<object>().All(allowedValues.Contains))
-            {
-                return new ValidationResult(
-                    ErrorMessage ?? $"Field must contain only values from: {allowedValues.JoinToString(", ")}");
-            }
-
             return ValidationResult.Success;
         }
 
-        private HashSet<object> GetAllowedValues(ValidationContext validationContext)
+        if (!values.Cast<object>().All(allowedValues.Contains))
         {
-            if (AllowedValuesProvider is null)
-            {
-                return AllowedValues.ToHashSet();
-            }
-
-            var instance = validationContext.ObjectInstance;
-            var type = instance.GetType();
-            var member = type.GetMember(
-                    AllowedValuesProvider,
-                    MemberTypes.Field | MemberTypes.Property | MemberTypes.Method,
-                    BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static
-                )
-                .FirstOrDefault();
-
-            if (member is null)
-            {
-                throw new ArgumentException(
-                    $"{nameof(AllowedValuesProvider)} must reference a field or method in {type.FullName}",
-                    AllowedValuesProvider
-                );
-            }
-
-            var providedValues = member.MemberType switch
-            {
-                MemberTypes.Field => ((FieldInfo)member).GetValue(instance),
-                MemberTypes.Property => ((PropertyInfo)member).GetValue(instance),
-                MemberTypes.Method => ((MethodInfo)member).Invoke(instance, new object?[] { }),
-                _ => throw new ArgumentOutOfRangeException(
-                    $"{nameof(AllowedValuesProvider)} is not a valid member on {type.FullName}",
-                    AllowedValuesProvider
-                )
-            };
-
-            if (providedValues is not IEnumerable<object> providedAllowedValues)
-            {
-                throw new ArgumentException(
-                    $"{nameof(AllowedValuesProvider)} on {type.FullName} must implement {nameof(IEnumerable)}",
-                    AllowedValuesProvider
-                );
-            }
-
-            return AllowedValues
-                .Concat(providedAllowedValues)
-                .ToHashSet();
+            return new ValidationResult(
+                ErrorMessage ?? $"Field must contain only values from: {allowedValues.JoinToString(", ")}");
         }
+
+        return ValidationResult.Success;
+    }
+
+    private HashSet<object> GetAllowedValues(ValidationContext validationContext)
+    {
+        if (AllowedValuesProvider is null)
+        {
+            return AllowedValues.ToHashSet();
+        }
+
+        var instance = validationContext.ObjectInstance;
+        var type = instance.GetType();
+        var member = type.GetMember(
+                AllowedValuesProvider,
+                MemberTypes.Field | MemberTypes.Property | MemberTypes.Method,
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static
+            )
+            .FirstOrDefault();
+
+        if (member is null)
+        {
+            throw new ArgumentException(
+                $"{nameof(AllowedValuesProvider)} must reference a field or method in {type.FullName}",
+                AllowedValuesProvider
+            );
+        }
+
+        var providedValues = member.MemberType switch
+        {
+            MemberTypes.Field => ((FieldInfo)member).GetValue(instance),
+            MemberTypes.Property => ((PropertyInfo)member).GetValue(instance),
+            MemberTypes.Method => ((MethodInfo)member).Invoke(instance, new object?[] { }),
+            _ => throw new ArgumentOutOfRangeException(
+                $"{nameof(AllowedValuesProvider)} is not a valid member on {type.FullName}",
+                AllowedValuesProvider
+            )
+        };
+
+        if (providedValues is not IEnumerable<object> providedAllowedValues)
+        {
+            throw new ArgumentException(
+                $"{nameof(AllowedValuesProvider)} on {type.FullName} must implement {nameof(IEnumerable)}",
+                AllowedValuesProvider
+            );
+        }
+
+        return AllowedValues
+            .Concat(providedAllowedValues)
+            .ToHashSet();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/FileTypeValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/FileTypeValidationUtils.cs
@@ -3,48 +3,47 @@ using System.Text.RegularExpressions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 
-namespace GovUk.Education.ExploreEducationStatistics.Common.Validators
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators;
+
+public static class FileTypeValidationUtils
 {
-    public static class FileTypeValidationUtils
-    {
-        public static readonly string[] ZipEncodingTypes = {
-            "binary",
-        };
+    public static readonly string[] ZipEncodingTypes = {
+        "binary",
+    };
 
-        public static readonly Regex[] AllowedAncillaryFileTypes = {
-            new Regex(@"^image/.*"),
-            new Regex(@"^(application|text)/csv$"),
-            new Regex(@"^text/plain$"),
-            new Regex(@"^application/pdf$"),
-            new Regex(@"^application/msword$"),
-            new Regex(@"^application/vnd.ms-excel$"),
-            new Regex(@"^application/vnd.openxmlformats(.*)$"),
-            new Regex(@"^application/vnd.oasis.opendocument(.*)$"),
-            new Regex(@"^application/CDFV2$"),
-            new Regex(@"^(application)/zip$"),
-            new Regex(@"^(application)/x-compressed$")
-        };
+    public static readonly Regex[] AllowedAncillaryFileTypes = {
+        new Regex(@"^image/.*"),
+        new Regex(@"^(application|text)/csv$"),
+        new Regex(@"^text/plain$"),
+        new Regex(@"^application/pdf$"),
+        new Regex(@"^application/msword$"),
+        new Regex(@"^application/vnd.ms-excel$"),
+        new Regex(@"^application/vnd.openxmlformats(.*)$"),
+        new Regex(@"^application/vnd.oasis.opendocument(.*)$"),
+        new Regex(@"^application/CDFV2$"),
+        new Regex(@"^(application)/zip$"),
+        new Regex(@"^(application)/x-compressed$")
+    };
 
-        public static readonly Regex[] AllowedChartFileTypes = {
-            new Regex(@"^image/.*") 
-        };
+    public static readonly Regex[] AllowedChartFileTypes = {
+        new Regex(@"^image/.*") 
+    };
 
-        public static readonly Regex[] AllowedImageMimeTypes = {
-            new Regex(@"^image/.*") 
-        };
+    public static readonly Regex[] AllowedImageMimeTypes = {
+        new Regex(@"^image/.*") 
+    };
 
-        public static readonly Regex[] AllowedArchiveMimeTypes = {
-            new Regex(@"^(application)/zip$"),
-            new Regex(@"^(application)/x-compressed$")
+    public static readonly Regex[] AllowedArchiveMimeTypes = {
+        new Regex(@"^(application)/zip$"),
+        new Regex(@"^(application)/x-compressed$")
+    };
+    
+    public static readonly Dictionary<FileType, IEnumerable<Regex>> AllowedMimeTypesByFileType = 
+        new()
+        {
+            { Ancillary, AllowedAncillaryFileTypes },
+            { Chart, AllowedChartFileTypes },
+            { DataZip, AllowedArchiveMimeTypes },
+            { Image, AllowedImageMimeTypes }
         };
-        
-        public static readonly Dictionary<FileType, IEnumerable<Regex>> AllowedMimeTypesByFileType = 
-            new()
-            {
-                { Ancillary, AllowedAncillaryFileTypes },
-                { Chart, AllowedChartFileTypes },
-                { DataZip, AllowedArchiveMimeTypes },
-                { Image, AllowedImageMimeTypes }
-            };
-    }
 }


### PR DESCRIPTION
This is the sort of PR we can start generating lots of, to slowly apply the .editorconfig rules in reviewable chunks. 

This reformats ONLY the Common project, and applies only the file_scoped_namespaces rule. This was achieved by setting the severity of that rule to error then running 

`dotnet format style GovUk.Education.ExploreEducationStatistics.sln --severity error --include GovUk.Education.ExploreEducationStatistics.Common/`