### PR TITLE
EES-4683 - temp renaming of resources to avoid name clashes with deleted resources. Configuring Function App for connection to secure core storage.

### DIFF
--- a/infrastructure/templates/public-api/components/functionApp.bicep
+++ b/infrastructure/templates/public-api/components/functionApp.bicep
@@ -81,6 +81,7 @@ resource functionAppSettings 'Microsoft.Web/sites/config@2023-01-01' = {
     AzureWebJobsStorage: storageAccountConnectionString
     WEBSITE_CONTENTAZUREFILECONNECTIONSTRING: storageAccountConnectionString
     WEBSITE_CONTENTSHARE: toLower(functionAppName)
+    WEBSITE_CONTENTOVERVNET: 1
     FUNCTIONS_EXTENSION_VERSION: '~4'
     APPINSIGHTS_INSTRUMENTATIONKEY: applicationInsightsKey
     FUNCTIONS_WORKER_RUNTIME: functionAppRuntime

--- a/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
+++ b/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
@@ -72,8 +72,8 @@ param firewallRules {
 param tagValues object
 
 var databaseServerName = empty(serverName)
-  ? '${resourcePrefix}-psql-server2'
-  : '${resourcePrefix}-psql-server2-${serverName}'
+  ? '${resourcePrefix}-psql-flexibleserver'
+  : '${resourcePrefix}-psql-flexibleserver-${serverName}'
 
 var connectionStringSecretName = '${databaseServerName}-connectionString'
 var connectionString = 'Server=${postgreSQLDatabase.name}${az.environment().suffixes.sqlServerHostname};${adminName}Database=<database>;Port=5432;${postgreSQLDatabase.name}User Id=${adminPassword};'

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -168,7 +168,7 @@ module dataProcessorFunctionAppModule 'application/dataProcessorFunctionApp.bice
   params: {
     resourcePrefix: resourcePrefix
     location: location
-    functionAppName: 'data-processor'
+    functionAppName: 'dataset-processor'
     storageAccountConnectionString: storageAccountConnectionString
     dbConnectionString: keyVault.getSecret(postgreSqlServerModule.outputs.connectionStringSecretName)
     tagValues: tagValues


### PR DESCRIPTION
This PR:
- Temporarily renames some Public API resources whilst we wait for deleted resources in our test Resource Group to be purged (after 30 days)
- Adds the "WEBSITE_CONTENTOVERVNET" setting to the Function App to allow it to connect correctly to pre-existing and locked-down Core Storage accounts in the real EES Resource Groups.

# Temporary renaming of resources

The reason we need to amend the names of some resources whilst deploying to the EES Dev Resource Group is that previously we had trialled this deploy process in a Hive Resource Group to prove that it would all work, but in doing so we inadvertently reserved the names of the PSQL server and Function App within that group.

Even after deleting from the test Resource Group, the names remain reserved until a 30 day cooling off period whereby Azure will purge the resources and free up the names again.  At this point, we can go back to using the original desired names!  