### PR TITLE
EES-4988 consistent sanitising of editable content

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.tsx
@@ -18,6 +18,8 @@ import Tooltip from '@common/components/Tooltip';
 import useToggle from '@common/hooks/useToggle';
 import { Dictionary } from '@common/types';
 import sanitizeHtml, {
+  commentTagAttributes,
+  commentTags,
   defaultSanitizeOptions,
   SanitizeHtmlOptions,
   TagFilter,
@@ -95,13 +97,6 @@ const EditableContentBlock = ({
   );
 
   const sanitizeOptions: SanitizeHtmlOptions = useMemo(() => {
-    const commentTagAttributes: SanitizeHtmlOptions['allowedAttributes'] = {
-      'comment-start': ['name'],
-      'comment-end': ['name'],
-      'resolvedcomment-start': ['name'],
-      'resolvedcomment-end': ['name'],
-    };
-
     const commentTagFilter: TagFilter = frame =>
       comments.every(comment => comment.id !== frame.attribs.name);
 
@@ -109,7 +104,7 @@ const EditableContentBlock = ({
       ...defaultSanitizeOptions,
       allowedTags: [
         ...(defaultSanitizeOptions.allowedTags ?? []),
-        ...Object.keys(commentTagAttributes),
+        ...commentTags,
       ],
       allowedAttributes: {
         ...(defaultSanitizeOptions.allowedAttributes ?? {}),

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableContentForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableContentForm.test.tsx
@@ -112,6 +112,28 @@ describe('EditableContentForm', () => {
       });
     });
 
+    test('preserves comment tags when calling the `onSubmit` handler', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <EditableContentForm
+          content={`<p><comment-start name="comment-id-1"></comment-start>fewgwg<comment-end name="comment-id-1"></comment-end></p>`}
+          id="block-id"
+          label="Form label"
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith(
+          `<p><comment-start name="comment-id-1"></comment-start>fewgwg<comment-end name="comment-id-1"></comment-end></p>`,
+        );
+      });
+    });
+
     test('formats links before calling `onSubmit` handler', async () => {
       const handleSubmit = jest.fn();
 

--- a/src/explore-education-statistics-common/src/utils/sanitizeHtml.ts
+++ b/src/explore-education-statistics-common/src/utils/sanitizeHtml.ts
@@ -65,6 +65,15 @@ export const defaultSanitizeOptions: SanitizeHtmlOptions = {
   parseStyleAttributes: false,
 };
 
+export const commentTagAttributes: SanitizeHtmlOptions['allowedAttributes'] = {
+  'comment-start': ['name'],
+  'comment-end': ['name'],
+  'resolvedcomment-start': ['name'],
+  'resolvedcomment-end': ['name'],
+};
+
+export const commentTags = Object.keys(commentTagAttributes);
+
 export default function sanitizeHtml(
   dirtyHtml: string,
   { filterTags, ...options }: SanitizeHtmlOptions = defaultSanitizeOptions,


### PR DESCRIPTION
Fixes a bug where the tags around comments in release content were sometimes being lost on save. This was due to inconsistent sanitisation on the content on manual save and autosaving.