### PR TITLE
Update path of public-common.robot

### DIFF
--- a/tests/robot-tests/tests/general_public/prod_only/redirects.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/redirects.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Resource            ../libs/public-common.robot
+Resource            ../../libs/public-common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser


### PR DESCRIPTION
Corrects the import path for public-common.robot in the prod only redirects tests