### PR TITLE
EES-4716  Part 3 / EES-5018 - Add data set query request models and validations

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
@@ -309,6 +309,56 @@ Test
             }
         }
 
+        public class ToLowerFirstTests
+        {
+            [Fact]
+            public void NullString()
+            {
+                string? input = null;
+                Assert.Null(input!.ToLowerFirst());
+            }
+
+            [Fact]
+            public void EmptyString()
+            {
+                Assert.Equal(string.Empty, string.Empty.ToLowerFirst());
+            }
+
+            [Theory]
+            [InlineData("Foo", "foo")]
+            [InlineData("Bar", "bar")]
+            [InlineData("FooBar", "fooBar")]
+            public void FirstCharacterIsLowerCased(string input, string expected)
+            {
+                Assert.Equal(expected, input.ToLowerFirst());
+            }
+        }
+
+        public class ToUpperFirstTests
+        {
+            [Fact]
+            public void NullString()
+            {
+                string? input = null;
+                Assert.Null(input!.ToUpperFirst());
+            }
+
+            [Fact]
+            public void EmptyString()
+            {
+                Assert.Equal(string.Empty, string.Empty.ToUpperFirst());
+            }
+
+            [Theory]
+            [InlineData("foo", "Foo")]
+            [InlineData("bar", "Bar")]
+            [InlineData("fooBar", "FooBar")]
+            public void FirstCharacterIsLowerCased(string input, string expected)
+            {
+                Assert.Equal(expected, input.ToUpperFirst());
+            }
+        }
+
         public class PascalCaseTests
         {
             [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/AllowedValueValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/AllowedValueValidatorTests.cs
@@ -1,0 +1,75 @@
+#nullable enable
+using System.Collections.Generic;
+using FluentValidation;
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Validators;
+
+public abstract class AllowedValueValidatorTests
+{
+    private static readonly IList<string> AllowedStrings = ListOf("value-1", "value-2", "value-3");
+
+    public class AllowedValueTests
+    {
+        private class TestClass
+        {
+            public string Value { get; init; } = string.Empty;
+        }
+
+        private class Validator : AbstractValidator<TestClass>
+        {
+            public Validator()
+            {
+                RuleFor(t => t.Value).AllowedValue(AllowedStrings);
+            }
+        }
+
+        private readonly Validator _validator = new();
+
+        [Theory]
+        [InlineData("value-1")]
+        [InlineData("value-2")]
+        [InlineData("value-3")]
+        public void Success(string value)
+        {
+            var query = new TestClass
+            {
+                Value = value
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+
+        [Theory]
+        [InlineData("Invalid")]
+        [InlineData("value")]
+        [InlineData("1")]
+        [InlineData("")]
+        public void Failure_Invalid(string value)
+        {
+            var query = new TestClass
+            {
+                Value = value
+            };
+
+            var result = _validator.Validate(query);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.Value), error.PropertyName);
+            Assert.Equal(ValidationMessages.AllowedValue.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.AllowedValue.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<AllowedValueValidator.AllowedErrorDetail<string>>(error.CustomState);
+
+            Assert.Equal(value, state.Value);
+            Assert.Equal(AllowedStrings, state.Allowed);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/FluentValidationExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/FluentValidationExtensions.cs
@@ -1,5 +1,7 @@
 #nullable enable
+using System.Collections.Generic;
 using FluentValidation;
+using FluentValidation.Results;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -13,5 +15,21 @@ public static class FluentValidationRuleExtensions
         return rule
             .WithErrorCode(localizableMessage.Code)
             .WithMessage(localizableMessage.Message);
+    }
+
+    public static void AddFailure<T, TDetail>(
+        this ValidationContext<T> context,
+        LocalizableMessage message,
+        TDetail? detail,
+        Dictionary<string, object>? messagePlaceholders = null) where TDetail : class
+    {
+        context.AddFailure(new ValidationFailure
+        {
+            PropertyName = context.PropertyPath,
+            ErrorCode = message.Code,
+            ErrorMessage = message.Message,
+            CustomState = detail,
+            FormattedMessagePlaceholderValues = messagePlaceholders
+        });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/FluentValidationExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/FluentValidationExtensions.cs
@@ -1,0 +1,17 @@
+#nullable enable
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class FluentValidationRuleExtensions
+{
+    public static IRuleBuilderOptions<T, TProperty> WithMessage<T, TProperty>(
+        this IRuleBuilderOptions<T, TProperty> rule,
+        LocalizableMessage localizableMessage)
+    {
+        return rule
+            .WithErrorCode(localizableMessage.Code)
+            .WithMessage(localizableMessage.Message);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -97,6 +97,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return char.ToLowerInvariant(s[0]) + s.Substring(1);
         }
 
+        public static string ToLowerFirst(this string input)
+        {
+            return input.IsNullOrEmpty() ?
+                input :
+                char.ToLowerInvariant(input[0]) + input[1..];
+        }
+
+        public static string ToUpperFirst(this string input)
+        {
+            return input.IsNullOrEmpty() ?
+                input :
+                char.ToUpperInvariant(input[0]) + input[1..];
+        }
+
         public static bool IsNullOrEmpty(this string? value)
         {
             return string.IsNullOrEmpty(value);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/LocalizableMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/LocalizableMessage.cs
@@ -1,0 +1,5 @@
+#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+public record LocalizableMessage(string Code, string Message);
+

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/AllowedValueValidator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/AllowedValueValidator.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators;
+
+public static class AllowedValueValidator
+{
+    public static IRuleBuilderOptions<T, TProperty> AllowedValue<T, TProperty>(
+        this IRuleBuilder<T, TProperty> rule,
+        IEnumerable<TProperty> allowedValues)
+    {
+        var allowed = allowedValues.ToHashSet();
+
+        return rule
+            .Must((_, value) => allowed.Contains(value))
+            .WithMessage(ValidationMessages.AllowedValue)
+            .WithState((_, value) => GetAllowedDetail(value: value, allowed: allowed));
+    }
+
+    private static AllowedErrorDetail<T> GetAllowedDetail<T>(T value , IEnumerable<T> allowed)
+    {
+        return new AllowedErrorDetail<T>(
+            Value: value,
+            Allowed: allowed.OrderBy(v => v).ToList()
+        );
+    }
+
+    public record AllowedErrorDetail<T>(T Value, IEnumerable<T> Allowed)
+        : InvalidErrorDetail<T>(Value);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ErrorDetails/FormatErrorDetail.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ErrorDetails/FormatErrorDetail.cs
@@ -1,0 +1,10 @@
+#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+
+/// <summary>
+/// Provides details about a value that was incorrectly formatted.
+/// </summary>
+/// <param name="Value">The invalid value</param>
+/// <param name="ExpectedFormat">The format that was expected</param>
+public record FormatErrorDetail(string Value, string ExpectedFormat)
+    : InvalidErrorDetail<string>(Value);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ErrorDetails/InvalidErrorDetail.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ErrorDetails/InvalidErrorDetail.cs
@@ -1,0 +1,8 @@
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+
+/// <summary>
+/// Provides details of an invalid value that caused a validation error.
+/// </summary>
+/// <param name="Value">The invalid value</param>
+/// <typeparam name="T">The invalid value's type</typeparam>
+public record InvalidErrorDetail<T>(T Value);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationMessages.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators;
+
+public static class ValidationMessages
+{
+    public static readonly LocalizableMessage AllowedValue = new(
+        Code: "AllowedValue",
+        Message: "Must be one of the allowed values."
+    );
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryFiltersValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryFiltersValidatorTests.cs
@@ -1,0 +1,285 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public abstract class DataSetGetQueryFiltersValidatorTests
+{
+    private readonly DataSetGetQueryFilters.Validator _validator = new();
+
+    public static IEnumerable<object[]> ValidFiltersSingle()
+    {
+        return
+        [
+            [null],
+            ["abc"],
+            ["12345"],
+            ["123456789"],
+            ["1234567890"],
+        ];
+    }
+
+    public static IEnumerable<object[]> ValidFiltersMultiple()
+    {
+        return
+        [
+            ["abc", "12345", "123456789"],
+            ["1234567890", "123", "abcde"],
+        ];
+    }
+
+    public class EqTests : DataSetGetQueryFiltersValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidFiltersSingle))]
+        public void Success(string? filter)
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                Eq = filter
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                Eq = ""
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Eq)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+
+        [Fact]
+        public void Failure_MaxLength()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                Eq = "12345678901"
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Eq)
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+        }
+    }
+
+    public class NotEqTests : DataSetGetQueryFiltersValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidFiltersSingle))]
+        public void Success(string? filter)
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                NotEq = filter
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                NotEq = ""
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.NotEq)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+
+        [Fact]
+        public void Failure_MaxLength()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                NotEq = "12345678901"
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.NotEq)
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+        }
+    }
+
+    public class InTests : DataSetGetQueryFiltersValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidFiltersMultiple))]
+        public void Success(params string[] filters)
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                In = filters
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Success_Null()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                In = null
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure_EmptyStrings()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                In = ["", ""]
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.In);
+
+            result.ShouldHaveValidationErrorFor("In[0]")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            result.ShouldHaveValidationErrorFor("In[1]")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+
+        [Fact]
+        public void Failure_MaxLengths()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                In = ["12345678901", "999999999999999"]
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.In);
+
+            result.ShouldHaveValidationErrorFor("In[0]")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+            result.ShouldHaveValidationErrorFor("In[1]")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+        }
+    }
+
+    public class NotInTests : DataSetGetQueryFiltersValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidFiltersMultiple))]
+        public void Success(params string[] filters)
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                NotIn = filters
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Success_Null()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                NotIn = null
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure_EmptyStrings()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                NotIn = ["", ""]
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotIn);
+
+            result.ShouldHaveValidationErrorFor("NotIn[0]")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            result.ShouldHaveValidationErrorFor("NotIn[1]")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+
+        [Fact]
+        public void Failure_MaxLengths()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                NotIn = ["12345678901", "999999999999999"]
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotIn);
+
+            result.ShouldHaveValidationErrorFor("NotIn[0]")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+            result.ShouldHaveValidationErrorFor("NotIn[1]")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+        }
+    }
+
+    public class EmptyTests : DataSetGetQueryFiltersValidatorTests
+    {
+        [Fact]
+        public void AllEmpty_Failure()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                Eq = "",
+                NotEq = "",
+                In = [],
+                NotIn = []
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.Eq)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            result.ShouldHaveValidationErrorFor(q => q.NotEq)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            result.ShouldHaveValidationErrorFor(q => q.In)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+
+        [Fact]
+        public void SomeEmpty_Failure()
+        {
+            var query = new DataSetGetQueryFilters
+            {
+                Eq = "123",
+                NotEq = "",
+                In = ["456"],
+                NotIn = []
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldNotHaveValidationErrorFor(q => q.Eq);
+            result.ShouldNotHaveValidationErrorFor(q => q.In);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotEq)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryGeographicLevelsValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryGeographicLevelsValidatorTests.cs
@@ -1,0 +1,261 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public abstract class DataSetGetQueryGeographicLevelsValidatorTests
+{
+    private readonly DataSetGetQueryGeographicLevels.Validator _validator = new();
+
+    public static IEnumerable<object[]> ValidGeographicLevelsSingle()
+    {
+        return
+        [
+            ["NAT"],
+            ["LA"],
+            [null],
+        ];
+    }
+
+    public static IEnumerable<object[]> ValidGeographicLevelsMultiple()
+    {
+        return
+        [
+            ["NAT", "LA", "REG"],
+            ["SCH", "NAT"],
+            ["PROV"],
+        ];
+    }
+
+    public static IEnumerable<object[]> InvalidGeographicLevelsSingle()
+    {
+        return
+        [
+            [""],
+            ["Invalid"],
+            ["National"],
+            ["nat"],
+            ["la"],
+            ["1"],
+        ];
+    }
+
+    public static IEnumerable<object[]> InvalidGeographicLevelsMultiple()
+    {
+        return
+        [
+            ["Invalid1", "Invalid2"],
+            ["National", "LocalAuthority"],
+            ["nat", "la"],
+            ["Local authority"],
+            ["National"],
+        ];
+    }
+
+    public class EqTests : DataSetGetQueryGeographicLevelsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidGeographicLevelsSingle))]
+        public void Success(string? geographicLevel)
+        {
+            var query = new DataSetGetQueryGeographicLevels { Eq = geographicLevel };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidGeographicLevelsSingle))]
+        public void Failure_NotAllowed(string geographicLevel)
+        {
+            var query = new DataSetGetQueryGeographicLevels { Eq = geographicLevel };
+
+            var result = _validator.Validate(query);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(DataSetGetQueryGeographicLevels.Eq), error.PropertyName);
+            Assert.Equal(ValidationMessages.AllowedValue.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.AllowedValue.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<AllowedValueValidator.AllowedErrorDetail<string>>(error.CustomState);
+
+            Assert.Equal(geographicLevel, state.Value);
+            Assert.Equal(EnumUtil.GetEnumValues<GeographicLevel>().Order(), state.Allowed);
+        }
+    }
+
+    public class NotEqTests : DataSetGetQueryGeographicLevelsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidGeographicLevelsSingle))]
+        public void Success(string? geographicLevel)
+        {
+            var query = new DataSetGetQueryGeographicLevels { NotEq = geographicLevel };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidGeographicLevelsSingle))]
+        public void Failure_NotAllowed(string geographicLevel)
+        {
+            var query = new DataSetGetQueryGeographicLevels { NotEq = geographicLevel };
+
+            var result = _validator.Validate(query);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(DataSetGetQueryGeographicLevels.NotEq), error.PropertyName);
+            Assert.Equal(ValidationMessages.AllowedValue.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.AllowedValue.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<AllowedValueValidator.AllowedErrorDetail<string>>(error.CustomState);
+
+            Assert.Equal(geographicLevel, state.Value);
+            Assert.Equal(EnumUtil.GetEnumValues<GeographicLevel>().Order(), state.Allowed);
+        }
+    }
+
+    public class InTests : DataSetGetQueryGeographicLevelsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidGeographicLevelsMultiple))]
+        public void Success(params string[] geographicLevels)
+        {
+            var query = new DataSetGetQueryGeographicLevels { In = geographicLevels };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Success_Null()
+        {
+            var query = new DataSetGetQueryGeographicLevels { In = null };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidGeographicLevelsMultiple))]
+        public void Failure_NotAllowed(params string[] geographicLevels)
+        {
+            var query = new DataSetGetQueryGeographicLevels { In = geographicLevels };
+
+            var result = _validator.Validate(query);
+
+            Assert.False(result.IsValid);
+
+            Assert.All(result.Errors, (error, index) =>
+            {
+                Assert.Equal($"In[{index}]", error.PropertyName);
+                Assert.Equal(ValidationMessages.AllowedValue.Code, error.ErrorCode);
+                Assert.Equal(ValidationMessages.AllowedValue.Message, error.ErrorMessage);
+
+                var state = Assert.IsType<AllowedValueValidator.AllowedErrorDetail<string>>(error.CustomState);
+
+                Assert.Equal(error.AttemptedValue, state.Value);
+                Assert.Equal(EnumUtil.GetEnumValues<GeographicLevel>().Order(), state.Allowed);
+            });
+        }
+    }
+
+    public class NotInTests : DataSetGetQueryGeographicLevelsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidGeographicLevelsMultiple))]
+        public void Success(params string[] geographicLevels)
+        {
+            var query = new DataSetGetQueryGeographicLevels { NotIn = geographicLevels };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Success_Null()
+        {
+            var query = new DataSetGetQueryGeographicLevels { In = null };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+
+        [Theory]
+        [MemberData(nameof(InvalidGeographicLevelsMultiple))]
+        public void Failure_NotAllowed(params string[] geographicLevels)
+        {
+            var query = new DataSetGetQueryGeographicLevels { In = geographicLevels };
+
+            var result = _validator.Validate(query);
+
+            Assert.False(result.IsValid);
+
+            Assert.All(result.Errors, (error, index) =>
+            {
+                Assert.Equal($"In[{index}]", error.PropertyName);
+                Assert.Equal(ValidationMessages.AllowedValue.Code, error.ErrorCode);
+                Assert.Equal(ValidationMessages.AllowedValue.Message, error.ErrorMessage);
+
+                var state = Assert.IsType<AllowedValueValidator.AllowedErrorDetail<string>>(error.CustomState);
+
+                Assert.Equal(error.AttemptedValue, state.Value);
+                Assert.Equal(EnumUtil.GetEnumValues<GeographicLevel>().Order(), state.Allowed);
+            });
+        }
+    }
+
+    public class EmptyTests : DataSetGetQueryGeographicLevelsValidatorTests
+    {
+        [Fact]
+        public void AllEmpty_Failure()
+        {
+            var query = new DataSetGetQueryGeographicLevels
+            {
+                Eq = "",
+                NotEq = "",
+                In = [],
+                NotIn = []
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.Eq)
+                .WithErrorCode(ValidationMessages.AllowedValue.Code);
+            result.ShouldHaveValidationErrorFor(q => q.NotEq)
+                .WithErrorCode(ValidationMessages.AllowedValue.Code);
+            result.ShouldHaveValidationErrorFor(q => q.In)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+
+        [Fact]
+        public void SomeEmpty_Failure()
+        {
+            var query = new DataSetGetQueryGeographicLevels
+            {
+                Eq = "NAT",
+                NotEq = "",
+                In = ["LA"],
+                NotIn = []
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldNotHaveValidationErrorFor(q => q.Eq);
+            result.ShouldNotHaveValidationErrorFor(q => q.In);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotEq)
+                .WithErrorCode(ValidationMessages.AllowedValue.Code);
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryLocationsValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryLocationsValidatorTests.cs
@@ -1,0 +1,212 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ValidationMessages;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public abstract class DataSetGetQueryLocationsValidatorTests
+{
+    private readonly DataSetGetQueryLocations.Validator _validator = new();
+
+    public static IEnumerable<object[]> ValidLocationStringsSingle()
+    {
+        return
+        [
+            ["NAT|id|12345"],
+            ["NAT|code|E92000001"],
+            ["REG|id|12345"],
+            ["REG|code|E12000003"],
+            ["LA|id|12345"],
+            ["LA|code|E08000019"],
+            ["LA|code|E09000021 / E09000027"],
+            ["LA|oldCode|373"],
+            ["LA|oldCode|314 / 318"],
+            ["SCH|id|12345"],
+            ["SCH|urn|107029"],
+            ["SCH|laEstab|3732060"],
+            ["PROV|id|12345"],
+            ["PROV|ukprn|10066874"],
+        ];
+    }
+
+    public static IEnumerable<object[]> ValidLocationStringsMultiple()
+    {
+        return
+        [
+            ["NAT|id|12345", "NAT|code|E92000001"],
+            ["REG|id|12345", "REG|code|E12000003"],
+            ["LA|id|12345", "LA|code|E08000019", "LA|oldCode|373"],
+            ["SCH|id|12345", "SCH|urn|107029", "SCH|laEstab|3732060"],
+            ["PROV|id|12345", "PROV|ukprn|10066874"],
+        ];
+    }
+
+    public static IEnumerable<object[]> InvalidLocationStringsSingle()
+    {
+        return
+        [
+            [""],
+            ["Invalid"],
+            ["NA|id|12345"],
+            ["NAT|urn|12345"],
+            ["NAT|id|99999999999999999999999999"],
+        ];
+    }
+
+    public static IEnumerable<object[]> InvalidLocationStringsMultiple()
+    {
+        return
+        [
+            [],
+            ["", ""],
+            ["Invalid", "NAT|id", "NAT|code|"],
+            ["NA|id|12345", "la|code|12345"],
+            ["NAT|urn|12345", "REG|ukprn|12345", "RSC|code|12345"],
+            ["NAT|id|99999999999999999999999999", "NAT|code|99999999999999999999999999"],
+        ];
+    }
+
+    public class EqTests : DataSetGetQueryLocationsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidLocationStringsSingle))]
+        public void Success(string location)
+        {
+            var query = new DataSetGetQueryLocations { Eq = location };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidLocationStringsSingle))]
+        public void Failure_InvalidString(string location)
+        {
+            var query = new DataSetGetQueryLocations { Eq = location };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Eq);
+        }
+    }
+
+    public class NotEqTests : DataSetGetQueryLocationsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidLocationStringsSingle))]
+        public void Success(string location)
+        {
+            var query = new DataSetGetQueryLocations { NotEq = location };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidLocationStringsSingle))]
+        public void Failure_InvalidString(string location)
+        {
+            var query = new DataSetGetQueryLocations { NotEq = location };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.NotEq);
+        }
+    }
+
+    public class InTests : DataSetGetQueryLocationsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidLocationStringsMultiple))]
+        public void Success(params string[] locations)
+        {
+            var testObj = new DataSetGetQueryLocations { In = locations };
+
+            _validator.TestValidate(testObj).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidLocationStringsMultiple))]
+        public void Failure_InvalidStrings(params string[] locations)
+        {
+            var query = new DataSetGetQueryLocations { In = locations };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.In);
+
+            locations.ForEach((_, index) => result.ShouldHaveValidationErrorFor($"In[{index}]"));
+        }
+    }
+
+    public class NotInTests : DataSetGetQueryLocationsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidLocationStringsMultiple))]
+        public void Success(params string[] locations)
+        {
+            var testObj = new DataSetGetQueryLocations { NotIn = locations };
+
+            _validator.TestValidate(testObj).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidLocationStringsMultiple))]
+        public void Failure_InvalidStrings(params string[] locations)
+        {
+            var query = new DataSetGetQueryLocations { NotIn = locations };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotIn);
+
+            locations.ForEach((_, index) => result.ShouldHaveValidationErrorFor($"NotIn[{index}]"));
+        }
+    }
+
+    public class EmptyTests : DataSetGetQueryLocationsValidatorTests
+    {
+        [Fact]
+        public void AllEmpty_Failure()
+        {
+            var query = new DataSetGetQueryLocations
+            {
+                Eq = "",
+                NotEq = "",
+                In = [],
+                NotIn = []
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.Eq)
+                .WithErrorCode(ValidationMessages.LocationFormat.Code);
+            result.ShouldHaveValidationErrorFor(q => q.NotEq)
+                .WithErrorCode(ValidationMessages.LocationFormat.Code);
+            result.ShouldHaveValidationErrorFor(q => q.In)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+
+        [Fact]
+        public void SomeEmpty_Failure()
+        {
+            var query = new DataSetGetQueryLocations
+            {
+                Eq = "NAT|id|12345",
+                NotEq = "",
+                In = ["LA|code|12345"],
+                NotIn = []
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldNotHaveValidationErrorFor(q => q.Eq);
+            result.ShouldNotHaveValidationErrorFor(q => q.In);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotEq)
+                .WithErrorCode(ValidationMessages.LocationFormat.Code);
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryRequestValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryRequestValidatorTests.cs
@@ -1,0 +1,375 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ValidationMessages;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public abstract class DataSetGetQueryRequestValidatorTests
+{
+    private readonly DataSetGetQueryRequest.Validator _validator = new();
+
+    public class FiltersTests : DataSetGetQueryRequestValidatorTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Filters = new DataSetGetQueryFilters
+                {
+                    Eq = "abc"
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Filters = new DataSetGetQueryFilters
+                {
+                    Eq = ""
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Filters!.Eq)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+
+    public class GeographicLevelsTests : DataSetGetQueryRequestValidatorTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                GeographicLevels = new DataSetGetQueryGeographicLevels
+                {
+                    Eq = "NAT"
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                GeographicLevels = new DataSetGetQueryGeographicLevels
+                {
+                    Eq = "invalid"
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.GeographicLevels!.Eq)
+                .WithErrorCode(Common.Validators.ValidationMessages.AllowedValue.Code);
+        }
+    }
+
+    public class LocationsTests : DataSetGetQueryRequestValidatorTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Locations = new DataSetGetQueryLocations
+                {
+                    Eq = "NAT|id|12345"
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Locations = new DataSetGetQueryLocations
+                {
+                    Eq = "invalid"
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Locations!.Eq)
+                .WithErrorCode(ValidationMessages.LocationFormat.Code);
+        }
+    }
+
+    public class TimePeriodsTests : DataSetGetQueryRequestValidatorTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                TimePeriods = new DataSetGetQueryTimePeriods
+                {
+                    Eq = "2020|AY"
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                TimePeriods = new DataSetGetQueryTimePeriods
+                {
+                    Eq = "invalid"
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.TimePeriods!.Eq)
+                .WithErrorCode(ValidationMessages.TimePeriodFormat.Code);
+        }
+    }
+
+    public class IndicatorsTests : DataSetGetQueryRequestValidatorTests
+    {
+        [Theory]
+        [InlineData("indicator1")]
+        [InlineData("indicator1111111111111111111111111111111")]
+        [InlineData("indicator1", "indicator2")]
+        public void Success(params string[] indicators)
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = indicators,
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = []
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Indicators)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        [InlineData("", " ")]
+        public void Failure_EmptyStrings(params string[] indicators)
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = indicators
+            };
+
+            var result = _validator.TestValidate(query);
+
+            foreach (var (_, index) in indicators.WithIndex())
+            {
+                result.ShouldHaveValidationErrorFor($"Indicators[{index}]")
+                    .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            }
+        }
+
+        [Fact]
+        public void Failure_MaxLength()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = [new string('a', 101), new string('a', 200)]
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result
+                .ShouldHaveValidationErrorFor("Indicators[0]")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+
+            result
+                .ShouldHaveValidationErrorFor("Indicators[1]")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+        }
+
+        [Fact]
+        public void Failure_Mixture()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = [new string('a', 101), ""]
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result
+                .ShouldHaveValidationErrorFor("Indicators[0]")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+
+            result
+                .ShouldHaveValidationErrorFor("Indicators[1]")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+
+    public class SortsTests : DataSetGetQueryRequestValidatorTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                Sorts = ["TimePeriod|Asc", "GeographicLevel|Asc"],
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                Sorts = []
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Sorts)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+
+        [Fact]
+        public void Failure_InvalidStrings()
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                Sorts = ["", "Invalid", "TimePeriod|asc", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|Asc"]
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.Sorts);
+
+            result
+                .ShouldHaveValidationErrorFor("Sorts[0]")
+                .WithErrorCode(ValidationMessages.SortFormat.Code);
+
+            result
+                .ShouldHaveValidationErrorFor("Sorts[1]")
+                .WithErrorCode(ValidationMessages.SortFormat.Code);
+
+            result
+                .ShouldHaveValidationErrorFor("Sorts[2]")
+                .WithErrorCode(ValidationMessages.SortDirection.Code);
+
+            result
+                .ShouldHaveValidationErrorFor("Sorts[3]")
+                .WithErrorCode(ValidationMessages.SortMaxFieldLength.Code);
+        }
+    }
+
+    public class PageTests : DataSetGetQueryRequestValidatorTests
+    {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(10)]
+        [InlineData(100)]
+        public void Success(int page)
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                Page = page,
+            };
+
+            _validator.TestValidate(query)
+                .ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-2)]
+        [InlineData(-10)]
+        public void Failure_LessThanOne(int page)
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                Page = page,
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Page)
+                .WithErrorCode(FluentValidationKeys.GreaterThanOrEqualValidator);
+        }
+    }
+
+    public class PageSizeTests : DataSetGetQueryRequestValidatorTests
+    {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(500)]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        public void Success(int pageSize)
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                PageSize = pageSize,
+            };
+
+            _validator.TestValidate(query)
+                .ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10001)]
+        public void Failure_OutOfBounds(int pageSize)
+        {
+            var query = new DataSetGetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                PageSize = pageSize,
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.PageSize)
+                .WithErrorCode(FluentValidationKeys.InclusiveBetweenValidator);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryTimePeriodsValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryTimePeriodsValidatorTests.cs
@@ -1,0 +1,321 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ValidationMessages;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public abstract class DataSetGetQueryTimePeriodsValidatorTests
+{
+    private readonly DataSetGetQueryTimePeriods.Validator _validator = new();
+
+    public static IEnumerable<object[]> ValidTimePeriodStringsSingle()
+    {
+        return
+        [
+            ["2020|AY"],
+            ["2020/2021|AY"],
+            ["2020|FY"],
+            ["2021|M1"],
+            ["2021|W40"],
+            ["2021|T3"],
+            ["2021/2022|T3"],
+            ["2019|FYQ4"],
+            ["2019/2020|FYQ4"],
+        ];
+    }
+
+    public static IEnumerable<object[]> ValidTimePeriodStringsMultiple()
+    {
+        return
+        [
+            ["2020|AY", "2020/2021|AY", "2020|FY"],
+            ["2021|M1", "2021|W40", "2021|T3"],
+            ["2021/2022|T3", "2019|FYQ4", "2019/2020|FYQ4"],
+        ];
+    }
+
+    public static IEnumerable<object[]> InvalidTimePeriodStringsSingle()
+    {
+        return
+        [
+            [""],
+            ["Invalid"],
+            ["2022"],
+            ["2022/2023"],
+            ["20222"],
+            ["20222|AY"],
+            ["2022|ay"],
+            ["2022/2020|AY"],
+            ["2000/1999|AY"],
+            ["2022|YY"],
+            ["2022|WEEK12"],
+        ];
+    }
+
+    public static IEnumerable<object[]> InvalidTimePeriodStringsMultiple()
+    {
+        return
+        [
+            [],
+            ["", ""],
+            ["Invalid", "2022", "2022/2023"],
+            ["20222", "20222|AY", "2022|ay"],
+            ["2022/2020|AY", "2000/1999|AY"],
+            ["2022|YY", "2022|WEEK12", "2022/2023|ZZ"]
+        ];
+    }
+
+    public class EqTests : DataSetGetQueryTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodStringsSingle))]
+        public void Success(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Eq = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
+        public void Failure_InvalidString(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Eq = timePeriod };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Eq);
+        }
+    }
+
+    public class NotEqTests : DataSetGetQueryTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodStringsSingle))]
+        public void Success(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { NotEq = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
+        public void Failure_InvalidString(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { NotEq = timePeriod };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.NotEq);
+        }
+    }
+
+    public class InTests : DataSetGetQueryTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodStringsMultiple))]
+        public void Success(params string[] timePeriods)
+        {
+            var testObj = new DataSetGetQueryTimePeriods { In = timePeriods };
+
+            _validator.TestValidate(testObj).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodStringsMultiple))]
+        public void Failure_InvalidStrings(params string[] timePeriods)
+        {
+            var query = new DataSetGetQueryTimePeriods { In = timePeriods };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.In);
+
+            timePeriods.ForEach((_, index) => result.ShouldHaveValidationErrorFor($"In[{index}]"));
+        }
+    }
+
+    public class NotInTests : DataSetGetQueryTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodStringsMultiple))]
+        public void Success(params string[] timePeriods)
+        {
+            var testObj = new DataSetGetQueryTimePeriods { NotIn = timePeriods };
+
+            _validator.TestValidate(testObj).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodStringsMultiple))]
+        public void Failure_InvalidStrings(params string[] timePeriods)
+        {
+            var query = new DataSetGetQueryTimePeriods { NotIn = timePeriods };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotIn);
+
+            timePeriods.ForEach((_, index) => result.ShouldHaveValidationErrorFor($"NotIn[{index}]"));
+        }
+    }
+
+    public class GtTests : DataSetGetQueryTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodStringsSingle))]
+        public void Success(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Gt = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
+        public void Failure_InvalidString(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Gt = timePeriod };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Gt);
+        }
+    }
+
+    public class GteTests : DataSetGetQueryTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodStringsSingle))]
+        public void Success(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Gte = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
+        public void Failure_InvalidString(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Gte = timePeriod };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Gte);
+        }
+    }
+
+    public class LtTests : DataSetGetQueryTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodStringsSingle))]
+        public void Success(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Lt = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
+        public void Failure_InvalidString(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Lt = timePeriod };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Lt);
+        }
+    }
+
+    public class LteTests : DataSetGetQueryTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodStringsSingle))]
+        public void Success(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Lte = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
+        public void Failure_InvalidString(string timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Lte = timePeriod };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Lte);
+        }
+    }
+
+    public class EmptyTests : DataSetGetQueryTimePeriodsValidatorTests
+    {
+        [Fact]
+        public void AllEmpty_Failure()
+        {
+            var query = new DataSetGetQueryTimePeriods
+            {
+                Eq = "",
+                NotEq = "",
+                In = [],
+                NotIn = [],
+                Gt = "",
+                Gte = "",
+                Lt = "",
+                Lte = ""
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.Eq)
+                .WithErrorCode(ValidationMessages.TimePeriodFormat.Code);
+            result.ShouldHaveValidationErrorFor(q => q.NotEq)
+                .WithErrorCode(ValidationMessages.TimePeriodFormat.Code);
+            result.ShouldHaveValidationErrorFor(q => q.In)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            result.ShouldHaveValidationErrorFor(q => q.Gt)
+                .WithErrorCode(ValidationMessages.TimePeriodFormat.Code);
+            result.ShouldHaveValidationErrorFor(q => q.Gte)
+                .WithErrorCode(ValidationMessages.TimePeriodFormat.Code);
+            result.ShouldHaveValidationErrorFor(q => q.Lt)
+                .WithErrorCode(ValidationMessages.TimePeriodFormat.Code);
+            result.ShouldHaveValidationErrorFor(q => q.Lte)
+                .WithErrorCode(ValidationMessages.TimePeriodFormat.Code);
+        }
+
+        [Fact]
+        public void SomeEmpty_Failure()
+        {
+            var query = new DataSetGetQueryTimePeriods
+            {
+                Eq = "2020|AY",
+                NotEq = "",
+                In = ["2021/2022|T3"],
+                NotIn = [],
+                Gt = "2019|M4",
+                Gte = "",
+                Lt = "",
+                Lte = "2030|M7"
+            };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldNotHaveValidationErrorFor(q => q.Eq);
+            result.ShouldNotHaveValidationErrorFor(q => q.In);
+            result.ShouldNotHaveValidationErrorFor(q => q.Gt);
+            result.ShouldNotHaveValidationErrorFor(q => q.Lte);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotEq)
+                .WithErrorCode(ValidationMessages.TimePeriodFormat.Code);
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+            result.ShouldHaveValidationErrorFor(q => q.Gte)
+                .WithErrorCode(ValidationMessages.TimePeriodFormat.Code);
+            result.ShouldHaveValidationErrorFor(q => q.Lt)
+                .WithErrorCode(ValidationMessages.TimePeriodFormat.Code);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/SwaggerEnumSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/SwaggerEnumSchemaFilterTests.cs
@@ -1,0 +1,217 @@
+using System.Text.Json;
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
+
+public class SwaggerEnumSchemaFilterTests
+{
+    private readonly SchemaGeneratorOptions _schemaGeneratorOptions = new()
+    {
+        UseAllOfToExtendReferenceSchemas = true,
+        SchemaFilters = [new SwaggerEnumSchemaFilter()],
+    };
+
+    private readonly SchemaRepository _schemaRepository = new("Default");
+
+    [Fact]
+    public void SerializeEnumString()
+    {
+        var schema = GenerateSchema();
+
+        var enums = schema.Properties["string"]
+            .Enum
+            .Cast<OpenApiString>()
+            .ToList();
+
+        Assert.Equal(2, enums.Count);
+        Assert.Equal(TestEnum.Sample1.ToString(), enums[0].Value);
+        Assert.Equal(TestEnum.Sample2.ToString(), enums[1].Value);
+    }
+
+    [Fact]
+    public void SerializeEnumStringsForList()
+    {
+        var schema = GenerateSchema();
+
+        var enums = schema.Properties["stringList"]
+            .Items
+            .Enum
+            .Cast<OpenApiString>()
+            .ToList();
+
+        Assert.Equal(2, enums.Count);
+        Assert.Equal(TestEnum.Sample1.ToString(), enums[0].Value);
+        Assert.Equal(TestEnum.Sample2.ToString(), enums[1].Value);
+    }
+
+    [Fact]
+    public void SerializeEnumInt()
+    {
+        var schema = GenerateSchema();
+
+        var enums = schema.Properties["int"]
+            .Enum
+            .Cast<OpenApiInteger>()
+            .ToList();
+
+        Assert.Equal(2, enums.Count);
+        Assert.Equal((int)TestEnum.Sample1, enums[0].Value);
+        Assert.Equal((int)TestEnum.Sample2, enums[1].Value);
+    }
+
+    [Fact]
+    public void SerializeEnumLabel()
+    {
+        var schema = GenerateSchema();
+
+        var enums = schema.Properties["enumLabel"]
+            .Enum
+            .Cast<OpenApiString>()
+            .ToList();
+
+        Assert.Equal(2, enums.Count);
+        Assert.Equal(TestEnum.Sample1.GetEnumLabel(), enums[0].Value);
+        Assert.Equal(TestEnum.Sample2.GetEnumLabel(), enums[1].Value);
+    }
+
+    [Fact]
+    public void SerializeEnumValue()
+    {
+        var schema = GenerateSchema();
+
+        var enums = schema.Properties["enumValue"]
+            .Enum
+            .Cast<OpenApiString>()
+            .ToList();
+
+        Assert.Equal(2, enums.Count);
+        Assert.Equal(TestEnum.Sample1.GetEnumValue(), enums[0].Value);
+        Assert.Equal(TestEnum.Sample2.GetEnumValue(), enums[1].Value);
+    }
+
+    [Fact]
+    public void SerializeDefault()
+    {
+        var schema = GenerateSchema();
+
+        var enums = schema.Properties["default"]
+            .Enum
+            .Cast<OpenApiInteger>()
+            .ToList();
+
+        Assert.Equal(2, enums.Count);
+        Assert.Equal((int)TestEnum.Sample1, enums[0].Value);
+        Assert.Equal((int)TestEnum.Sample2, enums[1].Value);
+    }
+
+    [Fact]
+    public void SerializeDefault_WithGeographicLevelSchemaFilter()
+    {
+        _schemaGeneratorOptions.SchemaFilters.Add(new GeographicLevelSchemaFilter());
+
+        var schemaGenerator = BuildSchemaGenerator();
+
+        schemaGenerator.GenerateSchema(typeof(GeographicLevel), _schemaRepository);
+        schemaGenerator.GenerateSchema(typeof(TestClassWithGeographicLevel), _schemaRepository);
+
+        var schema = _schemaRepository.Schemas[nameof(TestClassWithGeographicLevel)];
+
+        var enums = schema.Properties["geographicLevel"]
+            .Enum
+            .Cast<OpenApiString>()
+            .Select(e => e.Value)
+            .ToList();
+
+        var geographicLevels = EnumUtil.GetEnumValues<GeographicLevel>();
+
+        Assert.Equal(enums.Order(), geographicLevels.Order());
+    }
+
+    [Fact]
+    public void ThrowsOnInvalidEnumType()
+    {
+        Assert.Throws<InvalidOperationException>(GenerateInvalidSchema);
+    }
+
+
+    private OpenApiSchema GenerateSchema()
+    {
+        var schemaGenerator = BuildSchemaGenerator();
+
+        schemaGenerator.GenerateSchema(typeof(TestEnum), _schemaRepository);
+        schemaGenerator.GenerateSchema(typeof(TestClass), _schemaRepository);
+
+        return _schemaRepository.Schemas[nameof(TestClass)];
+    }
+
+    private OpenApiSchema GenerateInvalidSchema()
+    {
+        var schemaGenerator = BuildSchemaGenerator();
+
+        schemaGenerator.GenerateSchema(typeof(InvalidTestClass), _schemaRepository);
+
+        return _schemaRepository.Schemas[nameof(InvalidTestClass)];
+    }
+
+    private SchemaGenerator BuildSchemaGenerator()
+    {
+        return new SchemaGenerator(
+            _schemaGeneratorOptions,
+            new JsonSerializerDataContractResolver(
+                new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                }
+            )
+        );
+    }
+
+    private enum TestEnum
+    {
+        [EnumLabelValue("Sample 1", "sample-1")]
+        Sample1,
+
+        [EnumLabelValue("Sample 2", "sample-2")]
+        Sample2,
+    }
+
+    private class TestClass
+    {
+        [SwaggerEnum(typeof(TestEnum), SwaggerEnumSerializer.String)]
+        public string String { get; set; }
+
+        [SwaggerEnum(typeof(TestEnum), SwaggerEnumSerializer.String)]
+        public List<string> StringList { get; set; }
+
+        [SwaggerEnum(typeof(TestEnum), SwaggerEnumSerializer.Int)]
+        public int Int { get; set; }
+
+        [SwaggerEnum(typeof(TestEnum), SwaggerEnumSerializer.Label)]
+        public string EnumLabel { get; set; }
+
+        [SwaggerEnum(typeof(TestEnum), SwaggerEnumSerializer.Value)]
+        public string EnumValue { get; set; }
+
+        [SwaggerEnum(typeof(TestEnum))]
+        public string Default { get; set; }
+    }
+
+    private class TestClassWithGeographicLevel
+    {
+        [SwaggerEnum(typeof(GeographicLevel))]
+        public string GeographicLevel { get; set; }
+    }
+
+    private class InvalidTestClass
+    {
+        [SwaggerEnum(typeof(string))]
+        public string Invalid { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/LocationStringValidatorsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/LocationStringValidatorsTests.cs
@@ -1,0 +1,179 @@
+using FluentValidation;
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ValidationMessages;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Validators;
+
+public class LocationStringValidatorsTests
+{
+    public class LocationStringTests : LocationStringValidatorsTests
+    {
+        private class TestClass
+        {
+            public required string Location { get; init; }
+        }
+
+        private class Validator : AbstractValidator<TestClass>
+        {
+            public Validator()
+            {
+                RuleFor(t => t.Location).LocationString();
+            }
+        }
+
+        private readonly Validator _validator = new();
+
+        [Theory]
+        [InlineData("NAT|id|12345")]
+        [InlineData("NAT|code|E92000001")]
+        [InlineData("REG|id|12345")]
+        [InlineData("REG|code|E12000003")]
+        [InlineData("LA|id|12345")]
+        [InlineData("LA|code|E08000019")]
+        [InlineData("LA|code|E09000021 / E09000027")]
+        [InlineData("LA|oldCode|373")]
+        [InlineData("LA|oldCode|314 / 318")]
+        [InlineData("SCH|id|12345")]
+        [InlineData("SCH|urn|107029")]
+        [InlineData("SCH|laEstab|3732060")]
+        [InlineData("PROV|id|12345")]
+        [InlineData("PROV|ukprn|10066874")]
+        public void Success(string location)
+        {
+            var testObj = new TestClass { Location = location };
+
+            _validator.TestValidate(testObj).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("Invalid")]
+        [InlineData("NAT")]
+        [InlineData("id")]
+        [InlineData("code")]
+        [InlineData("NAT|id")]
+        [InlineData("NAT|code")]
+        [InlineData("NAT |code|")]
+        [InlineData("|NAT|code")]
+        [InlineData("NAT | code | 12345")]
+        [InlineData(" NAT | code | 12345 ")]
+        [InlineData("NAT|code | 12345")]
+        [InlineData("NAT | code|12345")]
+        [InlineData(" NAT|code|12345 ")]
+        [InlineData(" NAT|code|12345")]
+        [InlineData("NAT|code|12345 ")]
+        [InlineData("nat|code|12345")]
+        [InlineData("la|code|12345")]
+        [InlineData("LA|code|E09000021  / E09000027")]
+        [InlineData("LA|code|E09000021 /  E09000027")]
+        public void Failure_InvalidFormat(string location)
+        {
+            var testObj = new TestClass { Location = location };
+
+            var result = _validator.Validate(testObj);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.Location), error.PropertyName);
+            Assert.Equal(ValidationMessages.LocationFormat.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.LocationFormat.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<FormatErrorDetail>(error.CustomState);
+
+            Assert.Equal(location, state.Value);
+        }
+
+        [Theory]
+        [InlineData("NA|id|12345")]
+        [InlineData("NA|code|12345")]
+        [InlineData("NT|id|12345")]
+        [InlineData("LAA|code|12345")]
+        [InlineData("LADD|code|12345")]
+        public void Failure_InvalidLevel(string location)
+        {
+            var testObj = new TestClass { Location = location };
+
+            var result = _validator.Validate(testObj);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.Location), error.PropertyName);
+            Assert.Equal(ValidationMessages.LocationAllowedLevel.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.LocationAllowedLevel.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<LocationStringValidators.AllowedLevelErrorDetail>(error.CustomState);
+
+            Assert.Equal(location, state.Value);
+            Assert.Equal(EnumUtil.GetEnumValues<GeographicLevel>().Order(), state.Allowed);
+        }
+
+        [Theory]
+        [InlineData("NAT|urn|12345", "id", "code")]
+        [InlineData("REG|ukprn|12345", "id", "code")]
+        [InlineData("RSC|code|12345", "id")]
+        [InlineData("SCH|code|12345", "id", "urn", "laEstab")]
+        [InlineData("SCH|ukprn|12345", "id", "urn", "laEstab")]
+        [InlineData("PROV|urn|12345", "id", "ukprn")]
+        [InlineData("PROV|code|12345", "id", "ukprn")]
+        public void Failure_InvalidProperty(string location, params string[] allowedProperties)
+        {
+            var testObj = new TestClass { Location = location };
+
+            var result = _validator.Validate(testObj);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.Location), error.PropertyName);
+            Assert.Equal(ValidationMessages.LocationAllowedProperty.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.LocationAllowedProperty.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<LocationStringValidators.AllowedPropertyErrorDetail>(error.CustomState);
+
+            Assert.Equal(location, state.Value);
+            Assert.Equal(allowedProperties, state.Allowed);
+        }
+
+        [Theory]
+        [InlineData("NAT|id", 10)]
+        [InlineData("NAT|code", 25)]
+        [InlineData("LA|id", 10)]
+        [InlineData("LA|code", 25)]
+        [InlineData("LA|oldCode", 10)]
+        [InlineData("RSC|id", 10)]
+        [InlineData("SCH|id", 10)]
+        [InlineData("SCH|urn", 6)]
+        [InlineData("SCH|laEstab", 7)]
+        [InlineData("PROV|id", 10)]
+        [InlineData("PROV|ukprn", 8)]
+        public void Failure_InvalidValueLength(string levelProperty, int expectedMaxLength)
+        {
+            var location = $"{levelProperty}|{new string('X', expectedMaxLength + 1)}";
+            var testObj = new TestClass { Location = location };
+
+            var result = _validator.Validate(testObj);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.Location), error.PropertyName);
+            Assert.Equal(ValidationMessages.LocationMaxValueLength.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.LocationMaxValueLength.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<LocationStringValidators.MaxValueLengthErrorDetail>(error.CustomState);
+
+            Assert.Equal(location, state.Value);
+            Assert.Equal(expectedMaxLength, state.MaxLength);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/SortStringValidatorsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/SortStringValidatorsTests.cs
@@ -1,0 +1,130 @@
+using FluentValidation;
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ValidationMessages;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Validators;
+
+public class SortStringValidatorsTests
+{
+     public class SortStringTests : SortStringValidatorsTests
+    {
+        private class TestClass
+        {
+            public required string Sort { get; init; }
+        }
+
+        private class Validator : AbstractValidator<TestClass>
+        {
+            public Validator()
+            {
+                RuleFor(t => t.Sort).SortString();
+            }
+        }
+
+        private readonly Validator _validator = new();
+
+        [Theory]
+        [InlineData("TimePeriod|Asc")]
+        [InlineData("TimePeriod|Desc")]
+        [InlineData("GeographicLevel|Asc")]
+        [InlineData("GeographicLevel|Desc")]
+        [InlineData("characteristic|Asc")]
+        [InlineData("characteristic|Desc")]
+        [InlineData("school_type|Asc")]
+        [InlineData("school_type|Desc")]
+        [InlineData("ssa_tier_1|Asc")]
+        [InlineData("ssa_tier_2|Desc")]
+        public void Success(string sort)
+        {
+            var testObj = new TestClass { Sort = sort };
+
+            _validator.TestValidate(testObj).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("Invalid")]
+        [InlineData("Asc")]
+        [InlineData("|Asc")]
+        [InlineData(" |Asc")]
+        [InlineData("TimePeriod:Asc")]
+        [InlineData("TimePeriod|")]
+        [InlineData(" TimePeriod|Asc")]
+        [InlineData("TimePeriod| ")]
+        [InlineData("TimePeriod| Asc")]
+        [InlineData(" TimePeriod|Asc ")]
+        [InlineData("TimePeriod |Asc ")]
+        [InlineData("TimePeriod|Asc1")]
+        [InlineData("school-type|Asc")]
+        [InlineData("school_type| Asc")]
+        [InlineData("school_type|Asc ")]
+        public void Failure_InvalidFormat(string sort)
+        {
+            var testObj = new TestClass { Sort = sort };
+
+            var result = _validator.Validate(testObj);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.Sort), error.PropertyName);
+            Assert.Equal(ValidationMessages.SortFormat.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.SortFormat.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<FormatErrorDetail>(error.CustomState);
+
+            Assert.Equal(sort, state.Value);
+        }
+
+        [Theory]
+        [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|Asc")]
+        [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|Desc")]
+        public void Failure_InvalidFieldLength(string sort)
+        {
+            var testObj = new TestClass { Sort = sort };
+
+            var result = _validator.Validate(testObj);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.Sort), error.PropertyName);
+            Assert.Equal(ValidationMessages.SortMaxFieldLength.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.SortMaxFieldLength.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<SortStringValidators.MaxFieldLengthErrorDetail>(error.CustomState);
+
+            Assert.Equal(sort, state.Value);
+            Assert.Equal(40, state.MaxLength);
+        }
+
+        [Theory]
+        [InlineData("TimePeriod|Invalid")]
+        [InlineData("TimePeriod|asc")]
+        [InlineData("TimePeriod|desc")]
+        public void Failure_InvalidDirection(string sort)
+        {
+            var testObj = new TestClass { Sort = sort };
+
+            var result = _validator.Validate(testObj);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.Sort), error.PropertyName);
+            Assert.Equal(ValidationMessages.SortDirection.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.SortDirection.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<SortStringValidators.DirectionErrorDetail>(error.CustomState);
+
+            Assert.Equal(sort, state.Value);
+            Assert.Equal([SortDirection.Asc.ToString(), SortDirection.Desc.ToString()], state.Allowed);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/TimePeriodStringValidatorsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/TimePeriodStringValidatorsTests.cs
@@ -1,0 +1,189 @@
+using FluentValidation;
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ValidationMessages;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Validators;
+
+public class TimePeriodStringValidatorsTests
+{
+   public class TimePeriodStringTests : TimePeriodStringValidatorsTests
+    {
+        private class TestClass
+        {
+            public required string TimePeriod { get; init; }
+        }
+
+        private class Validator : AbstractValidator<TestClass>
+        {
+            public Validator()
+            {
+                RuleFor(t => t.TimePeriod).TimePeriodString();
+            }
+        }
+
+        private readonly Validator _validator = new();
+
+        [Theory]
+        [InlineData("2020|AY")]
+        [InlineData("2020/2021|AY")]
+        [InlineData("2020/2021|AYQ1")]
+        [InlineData("2020/2021|AYQ3")]
+        [InlineData("2020|FY")]
+        [InlineData("2021|CY")]
+        [InlineData("2021|CYQ1")]
+        [InlineData("2021|CYQ2")]
+        [InlineData("2021|RY")]
+        [InlineData("2021|M1")]
+        [InlineData("2021|M12")]
+        [InlineData("2021|W20")]
+        [InlineData("2021|W40")]
+        [InlineData("2021|T1")]
+        [InlineData("2021|T1T2")]
+        [InlineData("2021|T3")]
+        [InlineData("2021/2022|T1")]
+        [InlineData("2021/2022|T1T2")]
+        [InlineData("2021/2022|T3")]
+        [InlineData("2021|P1")]
+        [InlineData("2021|P2")]
+        [InlineData("2021/2022|P1")]
+        [InlineData("2021/2022|P2")]
+        [InlineData("2019|FYQ4")]
+        [InlineData("2019/2020|FYQ4")]
+        public void Success(string timePeriod)
+        {
+            var testObj = new TestClass { TimePeriod = timePeriod };
+
+            _validator.TestValidate(testObj).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [InlineData("Invalid")]
+        [InlineData("2022")]
+        [InlineData("2022/2023")]
+        [InlineData("20222")]
+        [InlineData("20222|AY")]
+        [InlineData("2022 | AY")]
+        [InlineData("2022| AY")]
+        [InlineData("2022 |AY")]
+        [InlineData(" 2022|AY ")]
+        [InlineData(" 2022 | AY ")]
+        [InlineData("2022|ay")]
+        [InlineData("2022/2023|ay")]
+        [InlineData("2022/20233|AY")]
+        [InlineData("2022/202|AY")]
+        [InlineData("202/2023|AY")]
+        public void Failure_InvalidFormat(string timePeriod)
+        {
+            var testObj = new TestClass { TimePeriod = timePeriod };
+
+            var result = _validator.Validate(testObj);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.TimePeriod), error.PropertyName);
+            Assert.Equal(ValidationMessages.TimePeriodFormat.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.TimePeriodFormat.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<FormatErrorDetail>(error.CustomState);
+
+            Assert.Equal(timePeriod, state.Value);
+        }
+
+        [Theory]
+        [InlineData("2022/2020|AY")]
+        [InlineData("2000/1999|AY")]
+        [InlineData("2000/2002|AY")]
+        public void Failure_InvalidYearRange(string timePeriod)
+        {
+            var testObj = new TestClass { TimePeriod = timePeriod };
+
+            var result = _validator.Validate(testObj);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.TimePeriod), error.PropertyName);
+            Assert.Equal(ValidationMessages.TimePeriodYearRange.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.TimePeriodYearRange.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<TimePeriodStringValidators.RangeErrorDetail>(error.CustomState);
+
+            Assert.Equal(timePeriod, state.Value);
+        }
+
+        [Theory]
+        [InlineData("2022|INVALID")]
+        [InlineData("2022|YY")]
+        [InlineData("2022|WEEK12")]
+        [InlineData("2022|JANUARY")]
+        public void Failure_InvalidCode(string timePeriod)
+        {
+            var testObj = new TestClass { TimePeriod = timePeriod };
+
+            var result = _validator.Validate(testObj);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.TimePeriod), error.PropertyName);
+            Assert.Equal(ValidationMessages.TimePeriodAllowedCode.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.TimePeriodAllowedCode.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<TimePeriodStringValidators.AllowedCodeErrorDetail>(error.CustomState);
+
+            Assert.Equal(timePeriod, state.Value);
+            Assert.Equal(TimeIdentifierUtils.DataCodes.Order(), state.Allowed);
+        }
+
+        [Theory]
+        [InlineData("2022/2023|INVALID")]
+        [InlineData("2022/2023|AY1")]
+        [InlineData("2022/2023|ZZ")]
+        [InlineData("2022/2023|CY")]
+        [InlineData("2022/2023|CYQ1")]
+        [InlineData("2022/2023|CYQ3")]
+        [InlineData("2022/2023|RY")]
+        [InlineData("2022/2023|W12")]
+        [InlineData("2022/2023|W40")]
+        [InlineData("2022/2023|M1")]
+        [InlineData("2022/2023|M12")]
+        public void Failure_InvalidCodeForRange(string timePeriod)
+        {
+            var testObj = new TestClass { TimePeriod = timePeriod };
+
+            var result = _validator.Validate(testObj);
+
+            Assert.False(result.IsValid);
+
+            var error = Assert.Single(result.Errors);
+
+            Assert.Equal(nameof(TestClass.TimePeriod), error.PropertyName);
+            Assert.Equal(ValidationMessages.TimePeriodAllowedCode.Code, error.ErrorCode);
+            Assert.Equal(ValidationMessages.TimePeriodAllowedCode.Message, error.ErrorMessage);
+
+            var state = Assert.IsType<TimePeriodStringValidators.AllowedCodeErrorDetail>(error.CustomState);
+
+            Assert.Equal(timePeriod, state.Value);
+
+            Assert.All(state.Allowed, code =>
+            {
+                var yearFormat = EnumUtil
+                    .GetFromEnumValue<TimeIdentifier>(code)
+                    .GetEnumAttribute<TimeIdentifierMetaAttribute>()
+                    .YearFormat;
+
+                Assert.True(yearFormat is TimePeriodYearFormat.Academic or TimePeriodYearFormat.Fiscal);
+            });
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Model/SortDirection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Model/SortDirection.cs
@@ -1,0 +1,10 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+
+/// <summary>
+/// The direction to sort in.
+/// </summary>
+public enum SortDirection
+{
+    Asc,
+    Desc
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryFilters.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryFilters.cs
@@ -1,0 +1,77 @@
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+public record DataSetGetQueryFilters
+{
+    /// <summary>
+    /// Filter the results to have a filter option matching this ID.
+    /// </summary>
+    public string? Eq { get; init; }
+
+    /// <summary>
+    /// Filter the results to not have a filter option matching this ID.
+    /// </summary>
+    public string? NotEq { get; init; }
+
+    /// <summary>
+    /// Filter the results to have a filter option matching at least one of these IDs.
+    /// </summary>
+    [FromQuery, QuerySeparator]
+    public IReadOnlyList<string>? In { get; init; }
+
+    /// <summary>
+    /// Filter the results to not have a filter option matching any of these IDs.
+    /// </summary>
+    [FromQuery, QuerySeparator]
+    public IReadOnlyList<string>? NotIn { get; init; }
+
+    public DataSetQueryCriteriaFilters ToCriteria()
+    {
+        return new DataSetQueryCriteriaFilters
+        {
+            Eq = Eq,
+            NotEq = NotEq,
+            In = In,
+            NotIn = NotIn
+        };
+    }
+
+    public class Validator : AbstractValidator<DataSetGetQueryFilters>
+    {
+        public Validator()
+        {
+            RuleFor(q => q.Eq)
+                .NotEmpty()
+                .MaximumLength(10)
+                .When(q => q.Eq is not null);
+
+            RuleFor(q => q.NotEq)
+                .NotEmpty()
+                .MaximumLength(10)
+                .When(q => q.NotEq is not null);
+
+            When(q => q.In is not null, () =>
+            {
+                RuleFor(q => q.In)
+                    .NotEmpty();
+                
+                RuleForEach(q => q.In)
+                    .NotEmpty()
+                    .MaximumLength(10);
+            });
+
+            When(q => q.NotIn is not null, () =>
+            {
+                RuleFor(q => q.NotIn)
+                    .NotEmpty();
+
+                RuleForEach(q => q.NotIn)
+                    .NotEmpty()
+                    .MaximumLength(10);
+            });
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryGeographicLevels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryGeographicLevels.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
@@ -12,23 +13,29 @@ public record DataSetGetQueryGeographicLevels
     /// <summary>
     /// Filter the results to be in this geographic level.
     /// </summary>
+    [SwaggerEnum(typeof(GeographicLevel))]
     public string? Eq { get; init; }
 
     /// <summary>
     /// Filter the results to not be in this geographic level.
     /// </summary>
+    [SwaggerEnum(typeof(GeographicLevel))]
     public string? NotEq { get; init; }
 
     /// <summary>
     /// Filter the results to be in one of these geographic levels.
     /// </summary>
-    [FromQuery, QuerySeparator]
+    [FromQuery]
+    [QuerySeparator]
+    [SwaggerEnum(typeof(GeographicLevel))]
     public IReadOnlyList<string>? In { get; init; }
 
     /// <summary>
     /// Filter the results to not be in one of these geographic levels.
     /// </summary>
-    [FromQuery, QuerySeparator]
+    [FromQuery]
+    [QuerySeparator]
+    [SwaggerEnum(typeof(GeographicLevel))]
     public IReadOnlyList<string>? NotIn { get; init; }
 
     public DataSetQueryCriteriaGeographicLevels ToCriteria()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryGeographicLevels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryGeographicLevels.cs
@@ -1,0 +1,74 @@
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+public record DataSetGetQueryGeographicLevels
+{
+    /// <summary>
+    /// Filter the results to be in this geographic level.
+    /// </summary>
+    public string? Eq { get; init; }
+
+    /// <summary>
+    /// Filter the results to not be in this geographic level.
+    /// </summary>
+    public string? NotEq { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in one of these geographic levels.
+    /// </summary>
+    [FromQuery, QuerySeparator]
+    public IReadOnlyList<string>? In { get; init; }
+
+    /// <summary>
+    /// Filter the results to not be in one of these geographic levels.
+    /// </summary>
+    [FromQuery, QuerySeparator]
+    public IReadOnlyList<string>? NotIn { get; init; }
+
+    public DataSetQueryCriteriaGeographicLevels ToCriteria()
+    {
+        return new DataSetQueryCriteriaGeographicLevels
+        {
+            Eq = Eq,
+            NotEq = NotEq,
+            In = In,
+            NotIn = NotIn
+        };
+    }
+
+    public class Validator : AbstractValidator<DataSetGetQueryGeographicLevels>
+    {
+        public Validator()
+        {
+            RuleFor(q => q.Eq)
+                .AllowedValue(EnumUtil.GetEnumValues<GeographicLevel>())
+                .When(q => q.Eq is not null);
+
+            RuleFor(q => q.NotEq)
+                .AllowedValue(EnumUtil.GetEnumValues<GeographicLevel>())
+                .When(q => q.NotEq is not null);
+
+            When(q => q.In is not null, () =>
+            {
+                RuleFor(q => q.In)
+                    .NotEmpty();
+                RuleForEach(q => q.In)
+                    .AllowedValue(EnumUtil.GetEnumValues<GeographicLevel>());
+            });
+
+            When(q => q.NotIn is not null, () =>
+            {
+                RuleFor(q => q.NotIn)
+                    .NotEmpty();
+                RuleForEach(q => q.NotIn)
+                    .AllowedValue(EnumUtil.GetEnumValues<GeographicLevel>());
+            });
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryLocations.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryLocations.cs
@@ -1,0 +1,72 @@
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+public record DataSetGetQueryLocations
+{
+    /// <summary>
+    /// Filter the results to be in this location.
+    /// </summary>
+    public string? Eq { get; init; }
+
+    /// <summary>
+    /// Filter the results to not be in this location.
+    /// </summary>
+    public string? NotEq { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in one of these locations.
+    /// </summary>
+    [FromQuery, QuerySeparator]
+    public IReadOnlyList<string>? In { get; init; }
+
+    /// <summary>
+    /// Filter the results not to be in one of these locations.
+    /// </summary>
+    [FromQuery, QuerySeparator]
+    public IReadOnlyList<string>? NotIn { get; init; }
+
+    public DataSetQueryCriteriaLocations ToCriteria()
+    {
+        return new DataSetQueryCriteriaLocations
+        {
+            Eq = Eq is not null ? DataSetQueryLocation.Parse(Eq) : null,
+            NotEq = NotEq is not null ? DataSetQueryLocation.Parse(NotEq) : null,
+            In = In?.Select(DataSetQueryLocation.Parse).ToList(),
+            NotIn = NotIn?.Select(DataSetQueryLocation.Parse).ToList()
+        };
+    }
+
+    public class Validator : AbstractValidator<DataSetGetQueryLocations>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Eq)!
+                .LocationString()
+                .When(request => request.Eq is not null);
+
+            RuleFor(request => request.NotEq)!
+                .LocationString()
+                .When(request => request.NotEq is not null);
+
+            When(q => q.In is not null, () =>
+            {
+                RuleFor(request => request.In)
+                    .NotEmpty();
+                RuleForEach(request => request.In)
+                    .LocationString();
+            });
+
+            When(q => q.NotIn is not null, () =>
+            {
+                RuleFor(request => request.NotIn)
+                    .NotEmpty();
+                RuleForEach(request => request.NotIn)
+                    .LocationString();
+            });
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryRequest.cs
@@ -1,0 +1,102 @@
+using System.ComponentModel;
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+public record DataSetGetQueryRequest
+{
+    /// <summary>
+    /// Query criteria relating to filter options.
+    /// </summary>
+    public DataSetGetQueryFilters? Filters { get; init; }
+
+    /// <summary>
+    /// Query criteria relating to geographic levels.
+    /// </summary>
+    public DataSetGetQueryGeographicLevels? GeographicLevels { get; init; }
+
+    /// <summary>
+    /// Query criteria relating to location options.
+    /// </summary>
+    public DataSetGetQueryLocations? Locations { get; init; }
+
+    /// <summary>
+    /// Query criteria relating to time periods.
+    /// </summary>
+    public DataSetGetQueryTimePeriods? TimePeriods { get; init; }
+
+    /// <summary>
+    /// The IDs of indicators to return values for.
+    /// </summary>
+    public required IReadOnlyList<string> Indicators { get; init; }
+
+    /// <summary>
+    /// The sorts to apply to the results. Sorts at the start of the
+    /// list will be applied first.
+    ///
+    /// By default, results are sorted by time period in descending order.
+    /// </summary>
+    public IReadOnlyList<string>? Sorts { get; init; }
+
+    /// <summary>
+    /// Enable debug mode. Results will be formatted with human-readable
+    /// labels to assist in identification.
+    ///
+    /// This **should not** be enabled in a production environment.
+    /// </summary>
+    public bool Debug { get; init; }
+
+    /// <summary>
+    /// The page of results to fetch.
+    /// </summary>
+    [DefaultValue(1)]
+    public int Page { get; init; } = 1;
+
+    /// <summary>
+    /// The maximum number of results per page.
+    /// </summary>
+    [DefaultValue(1000)]
+    public int PageSize { get; init; } = 1000;
+
+    public class Validator : AbstractValidator<DataSetGetQueryRequest>
+    {
+        public Validator()
+        {
+            RuleFor(q => q.Filters)
+                .SetValidator(new DataSetGetQueryFilters.Validator()!)
+                .When(q => q.Filters is not null);
+
+            RuleFor(q => q.GeographicLevels)
+                .SetValidator(new DataSetGetQueryGeographicLevels.Validator()!)
+                .When(q => q.GeographicLevels is not null);
+
+            RuleFor(q => q.Locations)
+                .SetValidator(new DataSetGetQueryLocations.Validator()!)
+                .When(q => q.Locations is not null);
+
+            RuleFor(q => q.TimePeriods)
+                .SetValidator(new DataSetGetQueryTimePeriods.Validator()!)
+                .When(q => q.TimePeriods is not null);
+
+            RuleFor(q => q.Indicators)
+                .NotEmpty();
+            RuleForEach(q => q.Indicators)
+                .NotEmpty()
+                .MaximumLength(40);
+
+            When(q => q.Sorts is not null, () =>
+            {
+                RuleFor(q => q.Sorts)
+                    .NotEmpty();
+                RuleForEach(q => q.Sorts)
+                    .SortString();
+            });
+
+            RuleFor(request => request.Page)
+                .GreaterThanOrEqualTo(1);
+            RuleFor(request => request.PageSize)
+                .InclusiveBetween(1, 10000);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryTimePeriods.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryTimePeriods.cs
@@ -1,0 +1,116 @@
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+public record DataSetGetQueryTimePeriods
+{
+    /// <summary>
+    /// Filter the results to be in this time period.
+    /// </summary>
+    public string? Eq { get; init; }
+
+    /// <summary>
+    /// Filter the results to not be in this time period.
+    /// </summary>
+    public string? NotEq { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in one of these time periods.
+    /// </summary>
+    [FromQuery, QuerySeparator]
+    public IReadOnlyList<string>? In { get; init; }
+
+    /// <summary>
+    /// Filter the results to not be in one of these time periods.
+    /// </summary>
+    [FromQuery, QuerySeparator]
+    public IReadOnlyList<string>? NotIn { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in a time period that is
+    /// chronologically greater than the one specified.
+    /// </summary>
+    public string? Gt { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in a time period that is
+    /// chronologically greater than or equal to the one specified.
+    /// </summary>
+    public string? Gte { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in a time period that is
+    /// chronologically less than the one specified.
+    /// </summary>
+    public string? Lt { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in a time period that is
+    /// chronologically less than or equal to the one specified.
+    /// </summary>
+    public string? Lte { get; init; }
+
+    public DataSetQueryCriteriaTimePeriods ToCriteria()
+    {
+        return new DataSetQueryCriteriaTimePeriods
+        {
+            Eq = Eq is not null ? DataSetQueryTimePeriod.FromString(Eq) : null,
+            NotEq = NotEq is not null ? DataSetQueryTimePeriod.FromString(NotEq) : null,
+            In = In?.Select(DataSetQueryTimePeriod.FromString).ToList(),
+            NotIn = NotIn?.Select(DataSetQueryTimePeriod.FromString).ToList(),
+            Gt = Gt is not null ? DataSetQueryTimePeriod.FromString(Gt) : null,
+            Gte = Gte is not null ? DataSetQueryTimePeriod.FromString(Gte) : null,
+            Lt = Lt is not null ? DataSetQueryTimePeriod.FromString(Lt) : null,
+            Lte = Lte is not null ? DataSetQueryTimePeriod.FromString(Lte) : null
+        };
+    }
+
+    public class Validator : AbstractValidator<DataSetGetQueryTimePeriods>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Eq)!
+                .TimePeriodString()
+                .When(request => request.Eq is not null);
+
+            RuleFor(request => request.NotEq)!
+                .TimePeriodString()
+                .When(request => request.NotEq is not null);
+
+            When(q => q.In is not null, () =>
+            {
+                RuleFor(request => request.In)
+                    .NotEmpty();
+                RuleForEach(request => request.In)
+                    .TimePeriodString();
+            });
+
+            When(q => q.NotIn is not null, () =>
+            {
+                RuleFor(request => request.NotIn)
+                    .NotEmpty();
+                RuleForEach(request => request.NotIn)
+                    .TimePeriodString();
+            });
+
+            RuleFor(request => request.Gt)!
+                .TimePeriodString()
+                .When(request => request.Gt is not null);
+
+            RuleFor(request => request.Gte)!
+                .TimePeriodString()
+                .When(request => request.Gte is not null);
+
+            RuleFor(request => request.Lt)!
+                .TimePeriodString()
+                .When(request => request.Lt is not null);
+
+            RuleFor(request => request.Lte)!
+                .TimePeriodString()
+                .When(request => request.Lte is not null);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteria.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteria.cs
@@ -1,0 +1,3 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+public abstract record DataSetQueryCriteria;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFacets.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFacets.cs
@@ -1,0 +1,29 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// Criteria outlining the facets of the data to filter results by in the data set query.
+///
+/// All parts of the criteria must resolve to true to match a result.
+/// </summary>
+public record DataSetQueryCriteriaFacets : DataSetQueryCriteria
+{
+    /// <summary>
+    /// Query criteria relating to filter options.
+    /// </summary>
+    public DataSetQueryCriteriaFilters? Filters { get; init; }
+
+    /// <summary>
+    /// Query criteria relating to geographic levels.
+    /// </summary>
+    public DataSetQueryCriteriaGeographicLevels? GeographicLevels { get; init; }
+
+    /// <summary>
+    /// Query criteria relating to location options.
+    /// </summary>
+    public DataSetQueryCriteriaLocations? Locations { get; init; }
+ 
+    /// <summary>
+    /// Query criteria relating to time periods.
+    /// </summary>
+    public DataSetQueryCriteriaTimePeriods? TimePeriods { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFilters.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFilters.cs
@@ -1,0 +1,27 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// The filter option criteria to filter results by in a data set query.
+/// </summary>
+public record DataSetQueryCriteriaFilters
+{
+    /// <summary>
+    /// Filter the results to have a filter option matching this ID.
+    /// </summary>
+    public string? Eq { get; init; }
+
+    /// <summary>
+    /// Filter the results to not have a filter option matching this ID.
+    /// </summary>
+    public string? NotEq { get; init; }
+
+    /// <summary>
+    /// Filter the results to have a filter option matching at least one of these IDs.
+    /// </summary>
+    public IReadOnlyList<string>? In { get; init; }
+
+    /// <summary>
+    /// Filter the results to not have a filter option matching any of these IDs.
+    /// </summary>
+    public IReadOnlyList<string>? NotIn { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaGeographicLevels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaGeographicLevels.cs
@@ -1,0 +1,47 @@
+using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// The geographic levels criteria to filter results by in a data set query.
+/// </summary>
+public record DataSetQueryCriteriaGeographicLevels
+{
+    /// <summary>
+    /// Filter the results to be in this geographic level.
+    /// </summary>
+    public string? Eq { get; init; }
+
+    /// <summary>
+    /// Filter the results to not be in this geographic level.
+    /// </summary>
+    public string? NotEq { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in one of these geographic levels.
+    /// </summary>
+    public IReadOnlyList<string>? In { get; init; }
+
+    /// <summary>
+    /// Filter the results to not be in one of these geographic levels.
+    /// </summary>
+    public IReadOnlyList<string>? NotIn { get; init; }
+
+    [JsonIgnore]
+    public GeographicLevel? ParsedEq
+        => Eq is not null ? EnumUtil.GetFromEnumValue<GeographicLevel>(Eq) : null;
+
+    [JsonIgnore]
+    public GeographicLevel? ParsedNotEq
+        => NotEq is not null ? EnumUtil.GetFromEnumValue<GeographicLevel>(NotEq) : null;
+
+    [JsonIgnore]
+    public IReadOnlyList<GeographicLevel>? ParsedIn
+        => In?.Select(EnumUtil.GetFromEnumValue<GeographicLevel>).ToList();
+
+    [JsonIgnore]
+    public IReadOnlyList<GeographicLevel>? ParsedNotIn
+        => NotIn?.Select(EnumUtil.GetFromEnumValue<GeographicLevel>).ToList();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaLocations.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaLocations.cs
@@ -1,0 +1,37 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// The location option criteria to filter results by in a data set query.
+///
+/// The results can be matched by either the location option's ID or a code.
+/// Note the following differences:
+///
+/// - IDs only match a **single location**
+/// - Codes may match **multiple locations**
+///
+/// Whilst codes are generally unique to a single location, they can be
+/// used for multiple locations. This may match more results than you
+/// expect so it's recommended to use IDs where possible.
+/// </summary>
+public record DataSetQueryCriteriaLocations
+{
+    /// <summary>
+    /// Filter the results to be in this location.
+    /// </summary>
+    public DataSetQueryLocation? Eq { get; init; }
+
+    /// <summary>
+    /// Filter the results to not be in this location.
+    /// </summary>
+    public DataSetQueryLocation? NotEq { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in one of these locations.
+    /// </summary>
+    public IReadOnlyList<DataSetQueryLocation>? In { get; init; }
+
+    /// <summary>
+    /// Filter the results to not be in one of these locations.
+    /// </summary>
+    public IReadOnlyList<DataSetQueryLocation>? NotIn { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaTimePeriods.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaTimePeriods.cs
@@ -1,0 +1,51 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// The time period criteria to filter results by in a data set query.
+/// </summary>
+public record DataSetQueryCriteriaTimePeriods
+{
+    /// <summary>
+    /// Filter the results to be in this time period.
+    /// </summary>
+    public DataSetQueryTimePeriod? Eq { get; init; }
+
+    /// <summary>
+    /// Filter the results to not be in this time period.
+    /// </summary>
+    public DataSetQueryTimePeriod? NotEq { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in one of these time periods.
+    /// </summary>
+    public IReadOnlyList<DataSetQueryTimePeriod>? In { get; init; }
+
+    /// <summary>
+    /// Filter the results to not be in one of these time periods.
+    /// </summary>
+    public IReadOnlyList<DataSetQueryTimePeriod>? NotIn { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in a time period that is
+    /// chronologically greater than the one specified.
+    /// </summary>
+    public DataSetQueryTimePeriod? Gt { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in a time period that is
+    /// chronologically greater than or equal to the one specified.
+    /// </summary>
+    public DataSetQueryTimePeriod? Gte { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in a time period that is
+    /// chronologically less than the one specified.
+    /// </summary>
+    public DataSetQueryTimePeriod? Lt { get; init; }
+
+    /// <summary>
+    /// Filter the results to be in a time period that is
+    /// chronologically less than or equal to the one specified.
+    /// </summary>
+    public DataSetQueryTimePeriod? Lte { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryLocation.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryLocation.cs
@@ -1,0 +1,187 @@
+using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// A location to filter results by.
+///
+/// Locations can be specified by an ID or one of its codes (depending
+/// on the location type). Note that whilst most codes are usually unique
+/// to a single location, they may also be used for multiple locations.
+///
+/// When using codes, you may get more results than expected so it's recommended
+/// to use IDs where possible to ensure only a single location is matched.
+/// </summary>
+public abstract record DataSetQueryLocation
+{
+    /// <summary>
+    /// The geographic level of the location.
+    ///
+    /// This should be a valid geographic level code e.g. `NAT`, `REG`, `LA`.
+    /// </summary>
+    public virtual string Level { get; init; } = string.Empty;
+
+    [JsonIgnore]
+    public GeographicLevel ParsedLevel => EnumUtil.GetFromEnumValue<GeographicLevel>(Level);
+
+    public abstract string Identifier();
+
+    public static DataSetQueryLocation Parse(string location)
+    {
+        var parts = location.Split('|');
+        var level = parts[0];
+        var property = parts[1].ToUpperFirst();
+        var value = parts[2];
+
+        if (property == nameof(DataSetQueryLocationId.Id))
+        {
+            return new DataSetQueryLocationId
+            {
+                Id = value,
+                Level = level
+            };
+        }
+
+        var parsedLevel = EnumUtil.GetFromEnumValue<GeographicLevel>(parts[0]);
+
+        return parsedLevel switch
+        {
+            GeographicLevel.LocalAuthority => property switch
+            {
+                nameof(DataSetQueryLocationLocalAuthority.Code) =>
+                    new DataSetQueryLocationLocalAuthority { Code = value },
+
+                nameof(DataSetQueryLocationLocalAuthority.OldCode) =>
+                    new DataSetQueryLocationLocalAuthority { OldCode = value },
+
+                _ => throw new ArgumentOutOfRangeException(
+                    paramName: nameof(location),
+                    message: $"Invalid {nameof(GeographicLevel.LocalAuthority)} property")
+            },
+            GeographicLevel.Provider => property switch
+            {
+                nameof(DataSetQueryLocationProvider.Ukprn) =>
+                    new DataSetQueryLocationProvider { Ukprn = value },
+
+                _ => throw new ArgumentOutOfRangeException(
+                    paramName: nameof(location),
+                    message: $"Invalid {nameof(GeographicLevel.Provider)} property")
+            },
+            GeographicLevel.School => property switch
+            {
+                nameof(DataSetQueryLocationSchool.Urn) =>
+                    new DataSetQueryLocationSchool { Urn = value },
+
+                nameof(DataSetQueryLocationSchool) =>
+                    new DataSetQueryLocationSchool { LaEstab = value },
+
+                _ => throw new ArgumentOutOfRangeException(
+                    paramName: nameof(location),
+                    message: $"Invalid {nameof(GeographicLevel.School)} property")
+            },
+            _ => property switch
+            {
+                nameof(DataSetQueryLocationCode.Code) =>
+                    new DataSetQueryLocationCode { Code = value, Level = value },
+
+                _ => throw new ArgumentOutOfRangeException(
+                    paramName: nameof(location),
+                    message: "Invalid location property")
+            }
+        };
+    }
+}
+
+public record DataSetQueryLocationId : DataSetQueryLocation
+{
+    /// <summary>
+    /// The ID of the location. If specified, this will be used
+    /// instead of any codes or other types of identifier.
+    ///
+    /// Every ID is unique to a single location, unlike codes
+    /// which may correspond to multiple locations.
+    /// </summary>
+    public required string Id { get; init; }
+
+    public override required string Level { get; init; }
+
+    public override string Identifier() => Id;
+}
+
+public record DataSetQueryLocationCode : DataSetQueryLocation
+{
+    /// <summary>
+    /// The code of the location. This may be an ONS code, or some
+    /// other code that identifies the location.
+    ///
+    /// Note that codes are not necessarily unique to a single location.
+    /// Specify the location ID to ensure only a single location is matched.
+    /// </summary>
+    public required string Code { get; init; }
+
+    public override required string Level { get; init; }
+
+    public override string Identifier() => Code;
+}
+
+public record DataSetQueryLocationLocalAuthority : DataSetQueryLocation
+{
+    /// <summary>
+    /// The ONS code of the local authority. This should be 9 characters
+    /// in the standard ONS format for local authorities (e.g. `E08000019`).
+    /// It can be a combination of two codes (e.g. `E09000021 / E09000027`).
+    /// </summary>
+    public string? Code { get; init; }
+
+    /// <summary>
+    /// The old code (previously the LEA code) of the local authority.
+    /// This should be a 3 digit number (e.g. `318`) or be
+    /// a combination of two codes (e.g. `314 / 318`).
+    /// </summary>
+    public string? OldCode { get; init; }
+
+    public override string Level => GeographicLevel.LocalAuthority.GetEnumValue();
+
+    public override string Identifier()
+        => Code
+           ?? OldCode
+           ?? throw new NullReferenceException($"{nameof(Code)} or {nameof(OldCode)} must not be null");
+}
+
+public record DataSetQueryLocationProvider : DataSetQueryLocation
+{
+    /// <summary>
+    /// The UKPRN (UK provider reference number) of the provider.
+    /// This should be an 8 digit number.
+    /// </summary>
+    public required string Ukprn { get; init; }
+
+    public override string Level => GeographicLevel.Provider.GetEnumValue();
+
+    public override string Identifier() => Ukprn;
+}
+
+public record DataSetQueryLocationSchool : DataSetQueryLocation
+{
+    /// <summary>
+    /// The URN (unique reference number) of the school.
+    /// This should be a 6 digit number.
+    /// </summary>
+    public string? Urn { get; init; }
+
+    /// <summary>
+    /// The LAESTAB (local authority establishment number) of the school.
+    /// This should be a 7 digit number.
+    /// </summary>
+    public string? LaEstab { get; init; }
+
+    public override string Level => GeographicLevel.School.GetEnumValue();
+
+    public override string Identifier()
+        => Urn
+           ?? LaEstab
+           ?? throw new NullReferenceException($"{nameof(Urn)} or {nameof(LaEstab)} must not be null");
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryRequest.cs
@@ -1,0 +1,25 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// A data set query to match results against.
+/// </summary>
+public record DataSetQueryRequest
+{
+    /// <summary>
+    /// The criteria to match.
+    /// </summary>
+    public DataSetQueryCriteria? Criteria { get; init; }
+
+    /// <summary>
+    /// The IDs of indicators in the data set to return values for.
+    /// </summary>
+    public required IReadOnlyList<string> Indicators { get; init; }
+
+    /// <summary>
+    /// The sorts to sort the results by. Sorts at the start of the
+    /// list will be applied first.
+    ///
+    /// By default, results are sorted by time period in descending order.
+    /// </summary>
+    public IReadOnlyList<DataSetQuerySort>? Sorts { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQuerySort.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQuerySort.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// Specifies how the results from a data set query should be sorted.
+///
+/// This consists of a field in the data set and a direction to sort by.
+/// </summary>
+public record DataSetQuerySort
+{
+    /// <summary>
+    /// The name of the field to sort by. This can be one of the following:
+    ///
+    /// - `time_period` to sort by time period
+    /// - `geographic_level` to sort by the geographic level
+    /// - A location level code (e.g. `REG`, `LA`) to sort by the locations in that level
+    /// - A filter ID (e.g. `characteristic`, `school_type`) to sort by the options in that filter
+    /// - An indicator ID (e.g. `sess_authorised`, `enrolments`) to sort by the values in that indicator
+    /// </summary>
+    public required string Field { get; init; }
+
+    /// <summary>
+    /// The direction to sort by. This can be one of the following:
+    ///
+    /// - `Asc` - sort by ascending order
+    /// - `Desc` - sort by descending order
+    /// </summary>
+    public required string Direction { get; init; }
+
+    [JsonIgnore]
+    public SortDirection ParsedDirection => EnumUtil.GetFromEnumValue<SortDirection>(Direction);
+
+    public static DataSetQuerySort FromString(string sort)
+    {
+        var parts = sort.Split('|');
+
+        return new DataSetQuerySort
+        {
+            Field = parts[0],
+            Direction = parts[1]
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryTimePeriod.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryTimePeriod.cs
@@ -1,0 +1,71 @@
+using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// A time period to filter results by.
+///
+/// - `period` is the time period or range (e.g. `2020` or `2020/2021`)
+/// - `code` is the code identifying the time period type (e.g. `AY`, `CY`, `M1`, `W20`)
+///
+/// The `period` should be a single year like `2020`, or a range like `2020/2021`.
+/// Currently, only years (or year ranges) are supported.
+///
+/// Some time period types span two years e.g. financial year part 2 (`P2`), or may fall in a
+/// latter year e.g. academic year summer term (`T3`). For these types, a singular year `period`
+/// like `2020` is considered as `2020/2021`.
+///
+/// For example, a `period` value of `2020` is applicable to the following time periods:
+///
+/// - 2020 calendar year
+/// - 2020/2021 academic year
+/// - 2020/2021 financial year part 2 (October to March)
+/// - 2020/2021 academic year's summer term
+///
+/// If you wish to be more explicit, you may use a range for the `period` e.g. `2020/2021`.
+///
+/// Some examples:
+///
+/// - `2020|AY` is the 2020/21 academic year
+/// - `2021|FY` is the 2021/22 financial year
+/// - `2020|T3` is the 2020/21 academic year's summer term
+/// - `2020|P2` is the 2020/21 financial year part 2 (October to March)
+/// - `2020|CY` is the 2020 calendar year
+/// - `2020|W32` is 2020 week 32
+/// - `2020/2021|AY` is the 2020/21 academic year
+/// - `2021/2022|FY` is the 2021/22 financial year
+/// </summary>
+public record DataSetQueryTimePeriod
+{
+    /// <summary>
+    /// The time period to match results by.
+    ///
+    /// This should be a single year like `2020` or a range like `2020/2021`.
+    /// </summary>
+    public required string Period { get; init; }
+
+    /// <summary>
+    /// The code identifying the time period type to match results by.
+    ///
+    /// This should be a valid time period code e.g. `AY`, `CY`, `M1`, `W20`.
+    /// </summary>
+    public required string Code { get; init; }
+
+    [JsonIgnore]
+    public TimeIdentifier ParsedCode => EnumUtil.GetFromEnumValue<TimeIdentifier>(Code);
+
+    public static DataSetQueryTimePeriod FromString(string timePeriod)
+    {
+        var parts = timePeriod.Split('|');
+        var period = parts[0];
+        var code = parts[1];
+
+        return new DataSetQueryTimePeriod
+        {
+            Period = period,
+            Code = code
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
@@ -11,6 +11,7 @@ public class SwaggerConfig(IApiVersionDescriptionProvider provider) : IConfigure
     {
         options.OperationFilter<DefaultValuesOperationFilter>();
         options.SchemaFilter<JsonConverterSchemaFilter>();
+        options.SchemaFilter<SwaggerEnumSchemaFilter>();
         options.SchemaFilter<DataSetStatusSchemaFilter>();
         options.SchemaFilter<DataSetVersionStatusSchemaFilter>();
         options.SchemaFilter<GeographicLevelSchemaFilter>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerEnumAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerEnumAttribute.cs
@@ -1,0 +1,35 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
+
+/// <summary>
+/// Configures Swashbuckle to provide enum documentation from a specified
+/// enum type, overriding any default behaviour.
+///
+/// Useful for cases where the enum type can't be used directly in the model
+/// (e.g. when deserializing as a string instead of the enum), but we still want
+/// to document it using that enum's characteristics.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
+public class SwaggerEnumAttribute(
+    Type type,
+    SwaggerEnumSerializer serializer = SwaggerEnumSerializer.Default)
+    : Attribute
+{
+    /// <summary>
+    /// The enum type to use.
+    /// </summary>
+    public Type Type { get; init; } = type;
+
+    /// <summary>
+    /// The way in which the enum should be serialized.
+    /// </summary>
+    public SwaggerEnumSerializer Serializer { get; init; } = serializer;
+}
+
+public enum SwaggerEnumSerializer
+{
+    Default,
+    Int,
+    String,
+    Value,
+    Label
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerEnumSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerEnumSchemaFilter.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
+
+public class SwaggerEnumSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        var enumAttribute = context.MemberInfo?.GetCustomAttribute<SwaggerEnumAttribute>();
+
+        if (enumAttribute is null)
+        {
+            return;
+        }
+
+        if (!enumAttribute.Type.IsEnum)
+        {
+            throw new InvalidOperationException(
+                $"Must use an enum type for '{nameof(SwaggerEnumAttribute)}'");
+        }
+
+        var enums = GetOpenApiEnums(context, enumAttribute);
+
+        if (schema.Type == "array")
+        {
+            schema.Items.Enum = enums;
+        }
+        else
+        {
+            schema.Enum = enums;
+        }
+    }
+
+    private IList<IOpenApiAny> GetOpenApiEnums(SchemaFilterContext context, SwaggerEnumAttribute enumAttribute)
+    {
+        if (enumAttribute.Serializer is SwaggerEnumSerializer.Default
+            && context.SchemaRepository.Schemas.TryGetValue(enumAttribute.Type.Name, out var enumSchema))
+        {
+            return enumSchema.Enum;
+        }
+
+        return Enum.GetValues(enumAttribute.Type)
+            .Cast<Enum>()
+            .Select(e => SerializeEnum(e, enumAttribute.Serializer))
+            .ToList<IOpenApiAny>();
+    }
+
+    private IOpenApiPrimitive SerializeEnum(Enum @enum, SwaggerEnumSerializer serializer)
+    {
+        return serializer switch
+        {
+            SwaggerEnumSerializer.Int => new OpenApiInteger(Convert.ToInt32(@enum)),
+            SwaggerEnumSerializer.String => new OpenApiString(@enum.ToString()),
+            SwaggerEnumSerializer.Value => new OpenApiString(@enum.GetEnumValue()),
+            SwaggerEnumSerializer.Label => new OpenApiString(@enum.GetEnumLabel()),
+            _ => new OpenApiInteger(Convert.ToInt32(@enum))
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/LocationStringValidators.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/LocationStringValidators.cs
@@ -1,0 +1,182 @@
+using System.Text.RegularExpressions;
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+
+public static partial class LocationStringValidators
+{
+    private const string ExpectedFormat = "{level}|{property}|{value}";
+
+    public static IRuleBuilderOptionsConditions<T, string> LocationString<T>(this IRuleBuilder<T, string> rule)
+    {
+        return rule.Custom((value, context) =>
+        {
+            if (!HasValidFormat(value))
+            {
+                context.AddFailure(
+                    message: ValidationMessages.LocationFormat,
+                    detail: new FormatErrorDetail(value, ExpectedFormat: ExpectedFormat)
+                );
+                return;
+            }
+
+            var location = new ParsedLocation(value);
+
+            if (!HasAllowedLevel(location))
+            {
+                context.AddFailure(
+                    message: ValidationMessages.LocationAllowedLevel,
+                    detail: new AllowedLevelErrorDetail(location.String)
+                );
+                return;
+            }
+
+            if (!HasAllowedProperty(location))
+            {
+                context.AddFailure(
+                    message: ValidationMessages.LocationAllowedProperty,
+                    detail: new AllowedPropertyErrorDetail(location.String, GetAllowedProperties(location))
+                );
+            }
+
+            if (!HasValidValueLength(location))
+            {
+                var maxLength = GetMaxLength(location);
+
+                context.AddFailure(
+                    message: ValidationMessages.LocationMaxValueLength,
+                    detail: new MaxValueLengthErrorDetail(location.String, maxLength),
+                    messagePlaceholders: new Dictionary<string, object>
+                    {
+                        {
+                            "MaxLength", maxLength
+                        }
+                    }
+                );
+            }
+        });
+    }
+
+    [GeneratedRegex(@"^[A-Z]{2,4}\|[A-Za-z]+\|\w+( \/ )?\w+$", RegexOptions.Compiled, matchTimeoutMilliseconds: 200)]
+    private static partial Regex FormatRegexGenerated();
+
+    private static readonly Regex FormatRegex = FormatRegexGenerated();
+
+    private static bool HasValidFormat(string value) => FormatRegex.IsMatch(value);
+
+    private static bool HasAllowedLevel(ParsedLocation location)
+    {
+        return EnumUtil.TryGetFromEnumValue<GeographicLevel>(location.Level, out _);
+    }
+
+    private static bool HasAllowedProperty(ParsedLocation location)
+    {
+        return GetAllowedProperties(location).Contains(location.Property);
+    }
+
+    private static bool HasValidValueLength(ParsedLocation location)
+    {
+        return location.Value.Length <= GetMaxLength(location);
+    }
+
+    private static string[] GetAllowedProperties(ParsedLocation location)
+    {
+        var geographicLevel = EnumUtil.GetFromEnumValue<GeographicLevel>(location.Level);
+
+        string[] properties = geographicLevel switch
+        {
+            GeographicLevel.LocalAuthority =>
+            [
+                "id",
+                nameof(LocationLocalAuthorityOptionMeta.Code),
+                nameof(LocationLocalAuthorityOptionMeta.OldCode)
+            ],
+            GeographicLevel.School =>
+            [
+                "id",
+                nameof(LocationSchoolOptionMeta.Urn),
+                nameof(LocationSchoolOptionMeta.LaEstab)
+            ],
+            GeographicLevel.Provider =>
+            [
+                "id",
+                nameof(LocationProviderOptionMeta.Ukprn)
+            ],
+            GeographicLevel.RscRegion => ["id"],
+            _ => ["id", "code"]
+        };
+
+        return properties
+            .Select(property => property.ToLowerFirst())
+            .ToArray();
+    }
+
+    private static int GetMaxLength(ParsedLocation location)
+    {
+        var geographicLevel = EnumUtil.GetFromEnumValue<GeographicLevel>(location.Level);
+        var property = location.Property.ToUpperFirst();
+
+        return geographicLevel switch
+        {
+            GeographicLevel.LocalAuthority => property switch
+            {
+                nameof(LocationLocalAuthorityOptionMeta.Code) => 25,
+                nameof(LocationLocalAuthorityOptionMeta.OldCode) => 10,
+                _ => 10
+            },
+            GeographicLevel.School => property switch
+            {
+                nameof(LocationSchoolOptionMeta.Urn) => 6,
+                nameof(LocationSchoolOptionMeta.LaEstab) => 7,
+                _ => 10
+            },
+            GeographicLevel.Provider => property switch
+            {
+                nameof(LocationProviderOptionMeta.Ukprn) => 8,
+                _ => 10
+            },
+            _ => property switch
+            {
+                nameof(LocationCodedOptionMeta.Code) => 25,
+                _ => 10
+            }
+        };
+    }
+
+    public record AllowedLevelErrorDetail(string Value) : InvalidErrorDetail<string>(Value)
+    {
+        public IReadOnlyList<string> Allowed => EnumUtil.GetEnumValues<GeographicLevel>().Order().ToList();
+    }
+
+    public record AllowedPropertyErrorDetail(string Value, IEnumerable<string> Allowed)
+        : InvalidErrorDetail<string>(Value);
+
+    public record MaxValueLengthErrorDetail(string Value, int MaxLength) : InvalidErrorDetail<string>(Value);
+
+    private record ParsedLocation
+    {
+        public string String { get; init; }
+
+        public string Level { get; init; }
+
+        public string Property { get; init; }
+
+        public string Value { get; init; }
+
+
+        public ParsedLocation(string locationString)
+        {
+            var parts = locationString.Split('|');
+
+            String = locationString;
+            Level = parts[0];
+            Property = parts[1];
+            Value = parts[2];
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/SortStringValidators.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/SortStringValidators.cs
@@ -1,0 +1,95 @@
+using System.Text.RegularExpressions;
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+
+public static partial class SortStringValidators
+{
+    private const string ExpectedFormat = "{field}|{order}";
+    private const int MaxFieldLength = 40;
+
+    private static readonly HashSet<string> AllowedSorts = [
+        SortDirection.Asc.ToString(),
+        SortDirection.Desc.ToString()
+    ];
+
+    public static IRuleBuilderOptionsConditions<T, string> SortString<T>(this IRuleBuilder<T, string> rule)
+    {
+        return rule.Custom((value, context) =>
+        {
+            if (!HasValidFormat(value))
+            {
+                context.AddFailure(
+                    message: ValidationMessages.SortFormat,
+                    detail: new FormatErrorDetail(value, ExpectedFormat: ExpectedFormat)
+                );
+
+                return;
+            }
+
+            var sort = new ParsedSort(value);
+
+            if (!HasValidFieldLength(sort))
+            {
+                context.AddFailure(
+                    message: ValidationMessages.SortMaxFieldLength,
+                    detail: new MaxFieldLengthErrorDetail(sort.String),
+                    new Dictionary<string, object>
+                    {
+                        { "MaxLength", MaxFieldLength }
+                    }
+                );
+            }
+
+            if (!HasValidDirection(sort))
+            {
+                context.AddFailure(
+                    message: ValidationMessages.SortDirection,
+                    detail: new DirectionErrorDetail(sort.String)
+                );
+            }
+        });
+    }
+
+    [GeneratedRegex(@"^[\w_]+\|[A-Za-z]+$", RegexOptions.Compiled, matchTimeoutMilliseconds: 200)]
+    private static partial Regex FormatRegexGenerated();
+
+    private static readonly Regex FormatRegex = FormatRegexGenerated();
+
+    private static bool HasValidFormat(string value) => FormatRegex.IsMatch(value);
+
+    private static bool HasValidFieldLength(ParsedSort sort) => sort.Field.Length < MaxFieldLength;
+
+    private static bool HasValidDirection(ParsedSort sort) => AllowedSorts.Contains(sort.Direction);
+
+    public record DirectionErrorDetail(string Value) : InvalidErrorDetail<string>(Value)
+    {
+        public IReadOnlySet<string> Allowed => AllowedSorts;
+    }
+
+    public record MaxFieldLengthErrorDetail(string Value) : InvalidErrorDetail<string>(Value)
+    {
+        public int MaxLength => MaxFieldLength;
+    }
+
+    private record ParsedSort
+    {
+        public string String { get; init; }
+        
+        public string Field { get; init; }
+        
+        public string Direction { get; init; }
+
+        public ParsedSort(string value)
+        {
+            var parts = value.Split('|');
+
+            String = value;
+            Field = parts[0];
+            Direction = parts[1];
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/TimePeriodStringValidators.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/TimePeriodStringValidators.cs
@@ -1,0 +1,135 @@
+using System.Text.RegularExpressions;
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+
+public static partial class TimePeriodStringValidators
+{
+    private const string ExpectedFormat = "{period}|{code}";
+
+    public static IRuleBuilderOptionsConditions<T, string> TimePeriodString<T>(this IRuleBuilder<T, string> rule)
+    {
+        return rule.Custom((value, context) =>
+        {
+            if (!HasValidFormat(value))
+            {
+                context.AddFailure(
+                    message: ValidationMessages.TimePeriodFormat,
+                    detail: new FormatErrorDetail(value, ExpectedFormat: ExpectedFormat)
+                );
+                return;
+            }
+
+            var timePeriod = new ParsedTimePeriod(value);
+
+            if (!HasValidYearRange(timePeriod))
+            {
+                context.AddFailure(
+                    message: ValidationMessages.TimePeriodYearRange,
+                    detail: new RangeErrorDetail(timePeriod.String)
+                );
+            }
+
+            if (!HasAllowedCode(timePeriod))
+            {
+                context.AddFailure(
+                    message: ValidationMessages.TimePeriodAllowedCode,
+                    detail: new AllowedCodeErrorDetail(timePeriod.String)
+                    {
+                        Allowed = timePeriod.HasRangePeriod() ? AllowedRangeCodes : AllowedCodes
+                    }
+                );
+            }
+        });
+    }
+
+    private static readonly IReadOnlySet<TimeIdentifier> AllowedTimeIdentifiers =
+        TimeIdentifierUtils.DataEnums.ToHashSet();
+
+    private static readonly IReadOnlySet<TimeIdentifier> AllowedRangeTimeIdentifiers =
+        AllowedTimeIdentifiers
+            .Where(
+                identifier => identifier.GetEnumAttribute<TimeIdentifierMetaAttribute>().YearFormat
+                    is TimePeriodYearFormat.Academic or TimePeriodYearFormat.Fiscal
+            )
+            .ToHashSet();
+
+    private static readonly IReadOnlyList<string> AllowedCodes =
+        TimeIdentifierUtils.DataCodes
+            .Order()
+            .ToList();
+
+    private static readonly IReadOnlyList<string> AllowedRangeCodes =
+        AllowedRangeTimeIdentifiers
+            .Select(identifier => identifier.GetEnumValue())
+            .Order()
+            .ToList();
+
+    [GeneratedRegex(@"^[0-9]{4}(\/[0-9]{4})?\|[A-Z0-9]+$", RegexOptions.Compiled, matchTimeoutMilliseconds: 200)]
+    private static partial Regex FormatRegexGenerated();
+
+    private static readonly Regex FormatRegex = FormatRegexGenerated();
+
+    private static bool HasValidFormat(string value) => FormatRegex.IsMatch(value);
+
+    private static bool HasValidYearRange(ParsedTimePeriod timePeriod)
+    {
+        // The period is not a range.
+        if (!timePeriod.HasRangePeriod())
+        {
+            return true;
+        }
+
+        var rangeParts = timePeriod.Period.Split('/');
+        var start = rangeParts[0];
+        var end = rangeParts[1];
+
+        return int.TryParse(start, out var startYear)
+               && int.TryParse(end, out var endYear)
+               && endYear == startYear + 1;
+    }
+
+    private static bool HasAllowedCode(ParsedTimePeriod timePeriod)
+    {
+        if (!EnumUtil.TryGetFromEnumValue<TimeIdentifier>(timePeriod.Code, out var code))
+        {
+            return false;
+        }
+
+        return timePeriod.HasRangePeriod()
+            ? AllowedRangeTimeIdentifiers.Contains(code)
+            : AllowedTimeIdentifiers.Contains(code);
+    }
+
+    public record RangeErrorDetail(string Value) : InvalidErrorDetail<string>(Value);
+
+    public record AllowedCodeErrorDetail(string Value) : InvalidErrorDetail<string>(Value)
+    {
+        public required IReadOnlyList<string> Allowed { get; init; }
+    }
+
+    public record ParsedTimePeriod
+    {
+        public string String { get; init; }
+        
+        public string Period { get; init; }
+        
+        public string Code { get; init; }
+
+        public ParsedTimePeriod(string value)
+        {
+            var parts = value.Split('|');
+
+            String = value;
+            Period = parts[0];
+            Code = parts[1];
+        }
+
+        public bool HasRangePeriod() => Period.Contains('/');
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
@@ -1,0 +1,56 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+
+public static class ValidationMessages
+{
+    public static readonly LocalizableMessage LocationFormat = new(
+        Code: "LocationFormat",
+        Message: "Must be a location in the correct format."
+    );
+
+    public static readonly LocalizableMessage LocationAllowedLevel = new(
+        Code: "LocationAllowedLevel",
+        Message: "Must be a location with an allowed level."
+    );
+
+    public static readonly LocalizableMessage LocationAllowedProperty = new(
+        Code: "LocationAllowedProperty",
+        Message: "Must be a location with an allowed identifying property."
+    );
+
+    public static readonly LocalizableMessage LocationMaxValueLength = new(
+        Code: "LocationMaxLengthValue",
+        Message: "Must be a location with an identifying value that is {MaxLength} characters or fewer."
+    );
+
+    public static readonly LocalizableMessage TimePeriodFormat = new(
+        Code: "TimePeriodFormat",
+        Message: "Must be a time period in the correct format."
+    );
+
+    public static readonly LocalizableMessage TimePeriodYearRange = new(
+        Code: "TimePeriodYearRange",
+        Message: "Must be a valid time period range where the start year is one year before the end year."
+    );
+
+    public static readonly LocalizableMessage TimePeriodAllowedCode = new(
+        Code: "TimePeriodAllowedCode",
+        Message: "Must be a time period with an allowed code."
+    );
+
+    public static readonly LocalizableMessage SortFormat = new(
+        Code: "SortFormat",
+        Message: "Must be a sort in the correct format."
+    );
+
+    public static readonly LocalizableMessage SortMaxFieldLength = new(
+        Code: "SortMaxFieldLength",
+        Message: "Must be a sort with a field that is {MaxLength} characters or fewer."
+    );
+
+    public static readonly LocalizableMessage SortDirection = new(
+        Code: "SortDirection",
+        Message: "Must be a sort with an allowed direction."
+    );
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Utils/TimePeriodFormatter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Utils/TimePeriodFormatter.cs
@@ -6,8 +6,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Utils;
 
 public static partial class TimePeriodFormatter
 {
-    [GeneratedRegex(@"^[0-9]{4}(\/[0-9]{4})?$")]
-    private static partial Regex PeriodRegex();
+    [GeneratedRegex(@"^[0-9]{4}(\/[0-9]{4})?$", RegexOptions.Compiled, matchTimeoutMilliseconds: 200)]
+    private static partial Regex PeriodRegexGenerated();
+
+    private static readonly Regex PeriodRegex = PeriodRegexGenerated();
 
     /// <summary>
     /// Format a time period to its human-readable label.
@@ -17,7 +19,7 @@ public static partial class TimePeriodFormatter
     /// <returns>The time period's human-readable label</returns>
     public static string FormatLabel(string period, TimeIdentifier identifier)
     {
-        var match = PeriodRegex().Match(period);
+        var match = PeriodRegex.Match(period);
 
         if (!match.Success)
         {
@@ -41,8 +43,10 @@ public static partial class TimePeriodFormatter
         return TimePeriodLabelFormatter.Format(firstYear, identifier);
     }
 
-    [GeneratedRegex(@"^[0-9]{4}([0-9]{2})?$")]
-    private static partial Regex CsvPeriodRegex();
+    [GeneratedRegex(@"^[0-9]{4}([0-9]{2})?$", RegexOptions.Compiled, matchTimeoutMilliseconds: 200)]
+    private static partial Regex CsvPeriodRegexGenerated();
+
+    private static readonly Regex CsvPeriodRegex = CsvPeriodRegexGenerated();
 
     /// <summary>
     /// Format a time period from a CSV (e.g. 202021) to a standard format (e.g. 2020/2021).
@@ -51,7 +55,7 @@ public static partial class TimePeriodFormatter
     /// <returns>The time period in standard format</returns>
     public static string FormatFromCsv(string period)
     {
-        var match = CsvPeriodRegex().Match(period);
+        var match = CsvPeriodRegex.Match(period);
 
         if (!match.Success)
         {
@@ -87,7 +91,7 @@ public static partial class TimePeriodFormatter
     /// <returns>The time period in CSV format</returns>
     public static string FormatToCsv(string period)
     {
-        var match = PeriodRegex().Match(period);
+        var match = PeriodRegex.Match(period);
 
         if (!match.Success)
         {


### PR DESCRIPTION
This PR adds request models and respective validations for the data set GET query endpoint.

As this a GET endpoint, we've needed to create custom string formats for locations, time periods and sorts to provide all relevant information for the query.

The formats are:

- Locations: `{level}|{property}|{value}` e.g. `?locations.eq=NAT|id|12345`
- Time periods: `{period}|{code}` e.g. `?timePeriods.eq=2022/2023|AY`
- Sorts: `{field}|{direction}` e.g. `?sorts=time_period|Desc`

## Parsed `DataSetQueryCriteria`

As part of this PR, we've also included `DataSetQueryCriteria` and its relevant request models. The idea is that `DataSetGetQueryRequest` will be parsed and map over to `DataSetQueryCriteria`, which is then processed in the service layer.

We intend to use `DataSetQueryCriteria` in the POST endpoint as well.

## Related changes

- Standardised error details (from FluentValidation) to provide the attempted value
- Added `ToLowerFirst` and `ToUpperFirst` extensions that are more efficient than using `CamelCase` or `PascalCase` in situations where we need to change a property's casing.
