### PR TITLE
EES-4668 Update names of Publisher functions and README

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -110,7 +110,7 @@
     "dataFactoryConcurrency": {
       "value": 10
     },
-    "immediatePublicationOfScheduledReleasesEnabled": {
+    "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
     }
   }

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -86,7 +86,7 @@
     "maxStatsDbSizeBytes": {
       "value": 268435456000
     },
-    "immediatePublicationOfScheduledReleasesEnabled": {
+    "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
     }
   }

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -92,7 +92,7 @@
     "maxStatsDbSizeBytes": {
       "value": 268435456000
     },
-    "immediatePublicationOfScheduledReleasesEnabled": {
+    "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
     }
   }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -383,11 +383,11 @@
         "description": "Gov UK Notify service template ID for methodology higher review approver notifications"
       }
     },
-    "immediatePublicationOfScheduledReleasesEnabled": {
+    "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "type": "bool",
       "defaultValue": false,
       "metadata": {
-        "description": "Enables the Functions in the Publisher App which allow scheduled Releases to be published immediately"
+        "description": "Enables the Functions in the Publisher App which allow scheduled release versions to be published immediately"
       }
     },
     "teamEmailAddresses": {
@@ -3192,8 +3192,8 @@
       "properties": {
         "AzureWebJobsDashboard": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher')).secretUriWithVersion, ')')]",
         "AzureWebJobsStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher')).secretUriWithVersion, ')')]",
-        "AzureWebJobs.StageScheduledReleasesImmediately.Disabled": "[not(parameters('immediatePublicationOfScheduledReleasesEnabled'))]",
-        "AzureWebJobs.PublishStagedReleaseContentImmediately.Disabled": "[not(parameters('immediatePublicationOfScheduledReleasesEnabled'))]",
+        "AzureWebJobs.StageScheduledReleaseVersionsImmediately.Disabled": "[not(parameters('immediatePublicationOfScheduledReleaseVersionsEnabled'))]",
+        "AzureWebJobs.PublishStagedReleaseVersionContentImmediately.Disabled": "[not(parameters('immediatePublicationOfScheduledReleaseVersionsEnabled'))]",
         "PublishReleasesCronSchedule": "[parameters('publishReleasesCronSchedule')]",
         "PublishReleaseContentCronSchedule": "[parameters('publishReleaseContentCronSchedule')]",
         "WEBSITE_TIME_ZONE": "[parameters('timeZone')]",

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleasesFunction.cs
@@ -33,11 +33,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         }
 
         /// <summary>
-        /// Azure function which publishes the content for a Release at a scheduled time by moving it from a staging
+        /// Azure function which publishes the content for a release version at a scheduled time by moving it from a staging
         /// directory.
         /// </summary>
         /// <remarks>
-        /// It will then call PublishingCompletionService in order to complete the publishing process for that Release.
+        /// It will then call PublishingCompletionService in order to complete the publishing process for that release version.
         /// </remarks>
         /// <param name="timer"></param>
         /// <param name="executionContext"></param>
@@ -65,12 +65,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         }
 
         /// <summary>
-        /// Azure function which publishes the content for a Release immediately by moving it from a staging
+        /// Azure function which publishes the content for a release version immediately by moving it from a staging
         /// directory. This function is manually triggered by an HTTP POST, and is disabled by default in production
         /// environments. 
         /// </summary>
         /// <remarks>
-        /// It will then call PublishingCompletionService in order to complete the publishing process for that Release.
+        /// It will then call PublishingCompletionService in order to complete the publishing process for that release version.
         /// </remarks>
         /// <param name="request">
         /// An optional JSON request body with a "ReleaseVersionIds" array can be included in the POST request to limit
@@ -79,9 +79,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         /// <param name="executionContext"></param>
         /// <param name="logger"></param>
         /// <returns></returns>
-        [FunctionName("PublishStagedReleaseContentImmediately")]
+        [FunctionName("PublishStagedReleaseVersionContentImmediately")]
         // ReSharper disable once UnusedMember.Global
-        public async Task<ActionResult<ManualTriggerResponse>> PublishScheduledReleasesImmediately(
+        public async Task<ActionResult<ManualTriggerResponse>> PublishStagedReleaseVersionContentImmediately(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post")]
             HttpRequest request,
             ExecutionContext executionContext,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/StageScheduledReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/StageScheduledReleasesFunction.cs
@@ -29,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         }
 
         /// <summary>
-        /// Azure function which triggers publishing files and staging content for all Releases that are scheduled to
+        /// Azure function which triggers publishing files and staging content for all release versions that are scheduled to
         /// be published later during the day. This operates on a schedule which by default occurs at midnight every
         /// night.
         /// </summary>
@@ -56,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         }
 
         /// <summary>
-        /// Azure function which triggers publishing files and staging content for all Releases that are scheduled to
+        /// Azure function which triggers publishing files and staging content for all release versions that are scheduled to
         /// be published later during the day. This is triggered manually by an HTTP post request, and is disabled in
         /// production environments.
         /// </summary>
@@ -66,9 +66,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         /// </param>
         /// <param name="executionContext"></param>
         /// <param name="logger"></param>
-        [FunctionName("StageScheduledReleasesImmediately")]
+        [FunctionName("StageScheduledReleaseVersionsImmediately")]
         // ReSharper disable once UnusedMember.Global
-        public async Task<ActionResult<ManualTriggerResponse>> StageScheduledReleasesImmediately(
+        public async Task<ActionResult<ManualTriggerResponse>> StageScheduledReleaseVersionsImmediately(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post")]
             HttpRequest request,
             ExecutionContext executionContext,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/README.md
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/README.md
@@ -1,84 +1,84 @@
 # Publisher Functions
 
-This project contains Azure Functions responsible for publishing of approved Releases, their content and their files.
+This project contains Azure Functions responsible for publishing of approved release versions, their content and their files.
 
-Releases can be scheduled to be published on a particular date or immediately on approval. There are 2 publisher flows covering these two scenarios.
+Release versions can be scheduled to be published on a particular date or immediately on approval. There are two publisher flows covering these two scenarios.
 
-## Forcing immediate publishing of scheduled Releases in test environments
+## Forcing immediate publishing of scheduled release versions in test environments
 
 All example HTTP requests below show examples of sending requests in a local development environment. Replace `http://localhost:7072` with the relevant environment's
 Publisher Functions URL.
 
-During manual or automated testing, it is handy to have a way to schedule Releases for publishing but to trigger that process to occur on demand, rather than having to wait for a lengthly
-period before the scheduled Publisher Functions run. For this, we provide 2 Functions that can be triggered by HTTP requests; one stages scheduled Releases, whilst the other completes the 
-publishing process for any staged Releases and makes them live.
+During manual or automated testing, it is handy to have a way to schedule release versions for publishing but to trigger that process to occur on demand, rather than having to wait for a lengthy
+period before the scheduled Publisher Functions run. For this, we provide two Functions that can be triggered by HTTP requests; one stages scheduled release versions, whilst the other completes the 
+publishing process for any staged release versions and makes them live.
 
-By default, the two Functions for publishing scheduled Releases immediately will target only Releases scheduled for publication "today". However, passing an array of specific Release Ids
-will affect only those specified Releases (and in addition will ignore their scheduled publishing date).
+By default, the two Functions for publishing scheduled release versions immediately will target only release versions scheduled for publication "today". However, passing an array of specific release version id's
+will affect only those specified release versions (and in addition will ignore their scheduled publishing date).
 
-This first HTTP request will stage scheduled Releases with a scheduled publication date of "today":
+This first HTTP request will stage scheduled release versions with a scheduled publication date of "today":
 
 ```http request
-POST http://localhost:7072/api/StageScheduledReleasesImmediately
+POST http://localhost:7072/api/StageScheduledReleaseVersionsImmediately
 Accept: 'application/json'
 ```
 
-Alternatively to target specific Releases and ignore their scheduled dates:
+Alternatively to target specific release versions and ignore their scheduled dates:
 
 ```http request
-POST http://localhost:7072/api/StageScheduledReleasesImmediately
+POST http://localhost:7072/api/StageScheduledReleaseVersionsImmediately
 Content-Type: 'application/json'
 
 {
-  "releaseIds": ["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]
+  "releaseVersionIds": ["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]
 }
 ```
 
-A JSON response of Release Ids that are now being staged will be returned:
+A JSON response of release version id's that are now being staged will be returned:
 
 ```json
 {
-  "releaseIds": ["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]
+  "releaseVersionIds": ["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]
 }
 ```
 
-After a delay to allow the staging process to complete (the above request queues messages to stage Releases but does not wait for them to complete), this second request will complete the
-publishing process of the staged Releases, returning an array of Release Ids to be published:
+After a delay to allow the staging process to complete (the above request queues messages to stage release versions but does not wait for them to complete), this second request will complete the
+publishing process of the staged release versions, returning an array of release version id's to be published:
 
 ```http request
-POST http://localhost:7072/api/PublishStagedReleaseContentImmediately
+POST http://localhost:7072/api/PublishStagedReleaseVersionContentImmediately
 Accept: 'application/json'
 ```
 
-Alternatively to target specific Releases:
+Alternatively to target specific release versions:
 
 ```http request
-POST http://localhost:7072/api/PublishStagedReleaseContentImmediately
+POST http://localhost:7072/api/PublishStagedReleaseVersionContentImmediately
 Content-Type: 'application/json'
 
 {
-  releaseIds: ["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]
+  releaseVersionIds: ["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]
 }
 ```
 
-A JSON response of Release Ids that have now been published will be returned:
+A JSON response of release version id's that have now been published will be returned:
 
 ```json
 {
-  "releaseIds": ["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]
+  "releaseVersionIds": ["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]
 }
 ```
 
-After the HTTP request completes, the Releases will be published.
+After the HTTP request completes, the release versions will be published.
 
 ### Triggering Functions from CLI
 
 cURL can be used to easily trigger the Functions from the command-line. Some examples below:
 
-`curl http://localhost:7072/api/StageScheduledReleasesImmediately -X POST -H 'Accept: application/json'`
+`curl http://localhost:7072/api/StageScheduledReleaseVersionsImmediately -X POST -H 'Accept: application/json'`
 
-`curl http://localhost:7072/api/StageScheduledReleasesImmediately -X POST -H 'Content-Type: application/json' -d '{"releaseIds":["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]}'`
+`curl http://localhost:7072/api/StageScheduledReleaseVersionsImmediately -X POST -H 'Content-Type: application/json' -d '{"releaseVersionIds":["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]}'`
 
-`curl http://localhost:7072/api/PublishStagedReleaseContentImmediately -X POST -H 'Accept: application/json'`
+`curl http://localhost:7072/api/PublishStagedReleaseVersionContentImmediately -X POST -H 'Accept: application/json'`
 
-`curl http://localhost:7072/api/PublishStagedReleaseContentImmediately -X POST -H 'Content-Type: application/json' -d '{"releaseIds":["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]}'`
+`curl http://localhost:7072/api/PublishStagedReleaseVersionContentImmediately -X POST -H 'Content-Type: application/json' -d '{"releaseVersionIds":["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]}'`

--- a/tests/robot-tests/tests/libs/admin-utilities.py
+++ b/tests/robot-tests/tests/libs/admin-utilities.py
@@ -131,18 +131,18 @@ def user_checks_dashboard_theme_topic_dropdowns_exist():
 
 
 def trigger_immediate_staging_of_scheduled_release(release_version_id):
-    stage_release_response = publisher_functions_client.post(
-        "/api/StageScheduledReleasesImmediately", {"releaseVersionIds": [release_version_id]}
+    stage_release_version_response = publisher_functions_client.post(
+        "/api/StageScheduledReleaseVersionsImmediately", {"releaseVersionIds": [release_version_id]}
     )
     assert (
-        stage_release_response.status_code < 300
-    ), f"Immediate staging of scheduled release API request failed with {stage_release_response.status_code} and {stage_release_response.text}"
+        stage_release_version_response.status_code < 300
+    ), f"Immediate staging of scheduled release version API request failed with {stage_release_version_response.status_code} and {stage_release_version_response.text}"
 
 
 def trigger_immediate_publishing_of_scheduled_release(release_version_id):
-    stage_release_response = publisher_functions_client.post(
-        "/api/PublishStagedReleaseContentImmediately", {"releaseVersionIds": [release_version_id]}
+    stage_release_version_response = publisher_functions_client.post(
+        "/api/PublishStagedReleaseVersionContentImmediately", {"releaseVersionIds": [release_version_id]}
     )
     assert (
-        stage_release_response.status_code < 300
-    ), f"Immediate publishing of staged release API request failed with {stage_release_response.status_code} and {stage_release_response.text}"
+        stage_release_version_response.status_code < 300
+    ), f"Immediate publishing of staged release version API request failed with {stage_release_version_response.status_code} and {stage_release_version_response.text}"


### PR DESCRIPTION
This change is being made after @N-moh raised the issue of the Publisher README instructions about forcing of immediate publishing of scheduled release version's being outdated.

After the renaming of `Release` -> `ReleaseVersion` made by #4611, the key `releaseIds` in the body of the requests was changed to `releaseVersionIds`.

This means all examples in the README such as...

```
"releaseIds": ["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]
```

needed to become...

```
"releaseVersionIds": ["6f6d5510-9f16-40ce-bc39-0dd88aa5e6ea", "c540405b-dc86-42fe-9420-3c3f007a48ef"]
```

At the same time as updating the README for this change I have also renamed the functions themselves to be consistently named for release versions rather than releases. 