### PR TITLE
EES-5005 fix maps in release headlines

### DIFF
--- a/src/explore-education-statistics-common/src/components/Tabs.tsx
+++ b/src/explore-education-statistics-common/src/components/Tabs.tsx
@@ -25,6 +25,9 @@ interface Props {
 
 const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const [hasCheckedHash, setHasCheckedHash] = useState<boolean>(
+    !window.location.hash,
+  );
   const ref = useRef<HTMLDivElement>(null);
 
   const { onMedia } = useDesktopMedia();
@@ -45,7 +48,7 @@ const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
       {
         'aria-labelledby': `${sectionId}-tab`,
         hasSiblings: filteredChildren.length > 1,
-        hidden: selectedTabIndex !== index,
+        hidden: !hasCheckedHash || selectedTabIndex !== index,
         id: sectionId,
         key: sectionId,
       },
@@ -107,6 +110,7 @@ const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
           // the location hash again by using `selectTab`
           setSelectedTabIndex(matchingTabIndex);
         }
+        setHasCheckedHash(true);
       }
     };
 

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapGeoJSON.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapGeoJSON.tsx
@@ -167,6 +167,7 @@ export default function MapGeoJSON({
               color: '#cfdce3',
               fillColor: '#003078',
               fillOpacity: 0.1,
+              stroke: false,
               weight: 1,
             };
           }}

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -64,6 +64,7 @@ const DataBlockTabs = ({
         {!!dataBlock.charts?.length && (
           <TabsSection
             id={`${id}-charts`}
+            lazy
             tabLabel={
               <>
                 Chart


### PR DESCRIPTION
Fixed two issues with maps:

1. Maps in release headlines weren't loading correctly. Making the tab `lazy` fixes this but caused an issue with maps in content accordions, to handle this I've updated `Tabs.tsx` to check for a hash in the url before setting the selected tab.
2. The order of the svg paths isn't stable - sometimes the whole UK path is loaded first, sometimes last, causing the UK outline to sometimes overlap the individual areas resulting in a blurry effect. Trying to set the UK to always be at the back didn't work so instead I've removed the outline on the UK as it was barely visible anyway.