### PR TITLE
EES-4534 update forms to RHF

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableEmbedForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableEmbedForm.test.tsx
@@ -115,13 +115,10 @@ describe('EditableEmbedForm', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(handleSubmit).toHaveBeenCalledWith(
-        {
-          title: 'Dashboard title',
-          url: 'https://department-for-education.shinyapps.io/test-dashboard',
-        },
-        expect.anything(),
-      );
+      expect(handleSubmit).toHaveBeenCalledWith({
+        title: 'Dashboard title',
+        url: 'https://department-for-education.shinyapps.io/test-dashboard',
+      });
     });
   });
 

--- a/src/explore-education-statistics-admin/src/components/form/RHFFormFieldEditor.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/RHFFormFieldEditor.tsx
@@ -1,0 +1,137 @@
+import { Element } from '@admin/types/ckeditor';
+import FormEditor, {
+  EditorElementsHandler,
+  FormEditorProps,
+} from '@admin/components/form/FormEditor';
+import { InvalidUrl } from '@admin/components/editable/EditableContentForm';
+import { useFormIdContext } from '@common/components/form/contexts/FormIdContext';
+import FormGroup from '@common/components/form/FormGroup';
+import { OmitStrict } from '@common/types';
+import WarningMessage from '@common/components/WarningMessage';
+import useRegister from '@common/components/form/rhf/hooks/useRegister';
+import getErrorMessage from '@common/components/form/rhf/util/getErrorMessage';
+import React, { useRef } from 'react';
+import {
+  FieldValues,
+  Path,
+  PathValue,
+  useFormContext,
+  useWatch,
+} from 'react-hook-form';
+
+export const elementsFieldName = (name: string) => `__${name}`;
+
+export interface Props<TFormValues extends FieldValues>
+  extends OmitStrict<FormEditorProps, 'id' | 'value' | 'onChange' | 'onBlur'> {
+  altTextError?: string;
+  name: Path<TFormValues>;
+  formGroupClass?: string;
+  id?: string;
+  invalidLinkErrors?: InvalidUrl[];
+  shouldValidateLinks?: boolean;
+  showError?: boolean;
+  testId?: string;
+  onBlur?: (isDirty: boolean) => void;
+  onChange?: (elements?: Element[]) => void;
+}
+
+export default function RHFFormFieldEditor<TFormValues extends FieldValues>({
+  altTextError,
+  error,
+  formGroupClass,
+  id,
+  invalidLinkErrors = [],
+  name,
+  showError = true,
+  testId,
+  onBlur,
+  onChange,
+  ...props
+}: Props<TFormValues>) {
+  const {
+    formState: { errors },
+    register,
+    getValues,
+    setValue,
+    getFieldState,
+  } = useFormContext<TFormValues>();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { ref, ...field } = useRegister(name, register);
+  const value = useWatch({ name }) || '';
+  const { fieldId } = useFormIdContext();
+  const elements = useRef<Element[]>([]);
+
+  const handleElements: EditorElementsHandler = nextElements => {
+    elements.current = nextElements;
+  };
+  const errorMessage = error || getErrorMessage(errors, name, showError);
+
+  return (
+    <FormGroup hasError={!!errorMessage} className={formGroupClass}>
+      {altTextError && <AltTextWarningMessage />}
+
+      {invalidLinkErrors.length > 0 && (
+        <WarningMessage className="govuk-!-margin-bottom-1">
+          The following links have invalid URLs:
+          <ul className="govuk-!-font-weight-regular govuk-!-margin-bottom-1 govuk-!-margin-top-1">
+            {invalidLinkErrors.map(link => (
+              <li key={link?.text}>
+                {link?.text} ({link?.url})
+              </li>
+            ))}
+          </ul>
+        </WarningMessage>
+      )}
+
+      <FormEditor
+        testId={testId}
+        {...props}
+        {...field}
+        id={fieldId(name as string, id)}
+        value={value}
+        onBlur={() => {
+          const currentValue = getValues(name);
+          setValue(name, currentValue, {
+            shouldDirty: true,
+            shouldTouch: true,
+            shouldValidate: true,
+          });
+
+          if (onBlur) {
+            const fieldState = getFieldState(name);
+            onBlur(fieldState.isDirty);
+          }
+        }}
+        onElementsChange={handleElements}
+        onElementsReady={handleElements}
+        onChange={nextValue => {
+          setValue(
+            name,
+            nextValue as PathValue<TFormValues, Path<TFormValues>>,
+            { shouldDirty: true, shouldTouch: true, shouldValidate: true },
+          );
+
+          onChange?.(elements.current);
+        }}
+        error={errorMessage}
+      />
+    </FormGroup>
+  );
+}
+
+export function AltTextWarningMessage() {
+  return (
+    <WarningMessage>
+      Alternative text must be added for images, for guidance see{' '}
+      <a
+        href="https://www.w3.org/WAI/tutorials/images/tips/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        W3C tips on writing alternative text
+      </a>
+      . <br />
+      Images without alternative text are outlined in red.
+    </WarningMessage>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationAdoptMethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationAdoptMethodologyPage.test.tsx
@@ -104,7 +104,7 @@ describe('PublicationAdoptMethodologyPage', () => {
     );
 
     expect(
-      screen.getByLabelText('Search for a published methodology'),
+      await screen.findByLabelText('Search for a published methodology'),
     ).toBeInTheDocument();
 
     const radios = screen.getAllByRole('radio');
@@ -155,6 +155,7 @@ describe('PublicationAdoptMethodologyPage', () => {
   });
 
   test('handles successful form submission', async () => {
+    const user = userEvent.setup();
     const history = createMemoryHistory();
     publicationService.getAdoptableMethodologies.mockResolvedValue(
       testMethodologies,
@@ -177,9 +178,9 @@ describe('PublicationAdoptMethodologyPage', () => {
       ).toBeInTheDocument(),
     );
 
-    await userEvent.click(screen.getByLabelText('Methodology 2'));
+    await user.click(screen.getByLabelText('Methodology 2'));
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(publicationService.adoptMethodology).toHaveBeenCalledWith(
@@ -194,6 +195,7 @@ describe('PublicationAdoptMethodologyPage', () => {
   });
 
   test('handles clicking the cancel button', async () => {
+    const user = userEvent.setup();
     const history = createMemoryHistory();
     publicationService.getAdoptableMethodologies.mockResolvedValue(
       testMethodologies,
@@ -216,7 +218,7 @@ describe('PublicationAdoptMethodologyPage', () => {
       ).toBeInTheDocument(),
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(publicationService.adoptMethodology).not.toHaveBeenCalled();
 

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -169,7 +169,7 @@ const ReleaseStatusPage = () => {
                     </td>
                     <td>{status.approvalStatus}</td>
                     <td>{status.internalReleaseNote}</td>
-                    <td>{`${status.releaseVersion + 1}`}</td>{' '}
+                    <td>{`${status.releaseVersion + 1}`}</td>
                     {/* +1 because version starts from 0 in DB */}
                     <td>
                       {status.createdByEmail ? (

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -6,17 +6,15 @@ import {
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
-import {
-  Form,
-  FormFieldCheckbox,
-  FormFieldRadioGroup,
-} from '@common/components/form';
-import FormFieldDateInput from '@common/components/form/FormFieldDateInput';
-import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
+import RHFFormFieldCheckbox from '@common/components/form/rhf/RHFFormFieldCheckbox';
+import RHFFormFieldTextArea from '@common/components/form/rhf/RHFFormFieldTextArea';
+import RHFFormFieldDateInput from '@common/components/form/rhf/RHFFormFieldDateInput';
+import RHFFormFieldRadioGroup from '@common/components/form/rhf/RHFFormFieldRadioGroup';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
 import FormattedDate from '@common/components/FormattedDate';
 import ModalConfirm from '@common/components/ModalConfirm';
 import WarningMessage from '@common/components/WarningMessage';
-import useFormSubmit from '@common/hooks/useFormSubmit';
 import useToggle from '@common/hooks/useToggle';
 import { ReleaseApprovalStatus } from '@common/services/publicationService';
 import {
@@ -33,10 +31,10 @@ import {
 } from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
 import { endOfDay, format, isValid, parseISO } from 'date-fns';
-import { Formik } from 'formik';
 import keyBy from 'lodash/keyBy';
 import mapValues from 'lodash/mapValues';
 import React, { useMemo } from 'react';
+import { ObjectSchema } from 'yup';
 
 export interface ReleaseStatusFormValues {
   publishMethod?: 'Scheduled' | 'Immediate';
@@ -101,58 +99,60 @@ const ReleaseStatusForm = ({
     useToggle(false);
   const [showScheduleErrorModal, toggleScheduleErrorModal] = useToggle(false);
 
-  const handleSubmit = useFormSubmit<ReleaseStatusFormValues>(
-    async ({
-      approvalStatus,
-      publishMethod,
-      publishScheduled,
-      notifySubscribers,
-      updatePublishedDate,
-      ...values
-    }) => {
-      const isApproved = approvalStatus === 'Approved';
+  const handleSubmitForm = async ({
+    approvalStatus,
+    publishMethod,
+    publishScheduled,
+    notifySubscribers,
+    updatePublishedDate,
+    ...values
+  }: ReleaseStatusFormValues) => {
+    const isApproved = approvalStatus === 'Approved';
 
-      try {
-        await onSubmit({
-          ...values,
-          approvalStatus,
-          publishMethod: isApproved ? publishMethod : undefined,
-          publishScheduled:
-            isApproved && publishScheduled && publishMethod === 'Scheduled'
-              ? publishScheduled
-              : undefined,
-          notifySubscribers:
-            isApproved && release.amendment ? notifySubscribers : undefined,
-          updatePublishedDate:
-            isApproved && release.amendment ? updatePublishedDate : undefined,
-        });
-      } catch (err) {
-        if (
-          isServerValidationError(err) &&
-          hasErrorMessage(err, ['PublishDateCannotBeScheduled'])
-        ) {
-          toggleScheduleErrorModal.on();
-        }
-
-        throw err;
+    try {
+      await onSubmit({
+        ...values,
+        approvalStatus,
+        publishMethod: isApproved ? publishMethod : undefined,
+        publishScheduled:
+          isApproved && publishScheduled && publishMethod === 'Scheduled'
+            ? publishScheduled
+            : undefined,
+        notifySubscribers:
+          isApproved && release.amendment ? notifySubscribers : undefined,
+        updatePublishedDate:
+          isApproved && release.amendment ? updatePublishedDate : undefined,
+      });
+    } catch (err) {
+      if (
+        isServerValidationError(err) &&
+        hasErrorMessage(err, ['PublishDateCannotBeScheduled'])
+      ) {
+        toggleScheduleErrorModal.on();
       }
-    },
-    errorMappings,
-    { fallbackErrorMapping },
-  );
 
-  const validationSchema = useMemo(() => {
-    const schema = Yup.object<ReleaseStatusFormValues>({
-      approvalStatus: Yup.string().required('Choose a status'),
+      throw err;
+    }
+  };
+
+  const validationSchema = useMemo<
+    ObjectSchema<ReleaseStatusFormValues>
+  >(() => {
+    const schema = Yup.object({
+      approvalStatus: Yup.string()
+        .oneOf(['Draft', 'HigherLevelReview', 'Approved'])
+        .required('Choose a status'),
       internalReleaseNote: Yup.string().when('approvalStatus', {
         is: (value: string) =>
           ['Approved', 'HigherLevelReview'].includes(value),
         then: s => s.required('Enter an internal note'),
       }),
-      publishMethod: Yup.string().when('approvalStatus', {
-        is: 'Approved',
-        then: s => s.required('Choose when to publish'),
-      }),
+      publishMethod: Yup.string()
+        .oneOf(['Scheduled', 'Immediate'])
+        .when('approvalStatus', {
+          is: 'Approved',
+          then: s => s.required('Choose when to publish'),
+        }),
       publishScheduled: Yup.date().when('publishMethod', {
         is: 'Scheduled',
         then: s =>
@@ -167,12 +167,12 @@ const ReleaseStatusForm = ({
             },
           }),
       }),
+
       nextReleaseDate: Yup.object({
-        day: Yup.number(),
         month: Yup.number(),
-        year: Yup.number(),
+        year: Yup.number().required(),
       })
-        .notRequired()
+        .default(undefined)
         .test({
           name: 'validDate',
           message: 'Enter a valid next release date',
@@ -188,6 +188,8 @@ const ReleaseStatusForm = ({
             return isValid(parsePartialDateToLocalDate(value));
           },
         }),
+      notifySubscribers: Yup.boolean(),
+      updatePublishedDate: Yup.boolean(),
     });
 
     if (release.amendment) {
@@ -207,8 +209,9 @@ const ReleaseStatusForm = ({
   }, [release.amendment]);
 
   return (
-    <Formik<ReleaseStatusFormValues>
-      enableReinitialize
+    <FormProvider
+      errorMappings={errorMappings}
+      fallbackErrorMapping={fallbackErrorMapping}
       initialValues={{
         approvalStatus: release.approvalStatus,
         notifySubscribers: release.amendment
@@ -224,214 +227,216 @@ const ReleaseStatusForm = ({
           : undefined,
         nextReleaseDate: release.nextReleaseDate,
       }}
-      onSubmit={handleSubmit}
       validationSchema={validationSchema}
     >
-      {form => (
-        <>
-          <Form id={formId}>
-            <FormFieldRadioGroup<ReleaseStatusFormValues>
-              legend="Status"
-              name="approvalStatus"
-              order={[]}
-              options={[
-                {
-                  label: 'In draft',
-                  value: 'Draft',
-                  disabled: !statusPermissions?.canMarkDraft,
-                },
-                {
-                  label: 'Ready for higher review (this will notify approvers)',
-                  value: 'HigherLevelReview',
-                  disabled: !statusPermissions?.canMarkHigherLevelReview,
-                },
-                {
-                  label: 'Approved for publication',
-                  value: 'Approved',
-                  disabled: !statusPermissions?.canMarkApproved,
-                },
-              ]}
-              onChange={element => {
-                if (release.amendment && element.target.value === 'Approved') {
-                  form.setFieldValue('notifySubscribers', true);
-                  form.setFieldValue('updatePublishedDate', false);
-                }
-              }}
-            />
-
-            <FormFieldTextArea<ReleaseStatusFormValues>
-              name="internalReleaseNote"
-              className="govuk-!-width-one-half"
-              label="Internal note"
-              hint="Please include any relevant information"
-              rows={3}
-            />
-
-            {form.values.approvalStatus === 'Approved' && release.amendment && (
-              <>
-                <FormFieldCheckbox
-                  name="notifySubscribers"
-                  label="Notify subscribers by email"
-                />
-
-                <FormFieldCheckbox<ReleaseStatusFormValues>
-                  name="updatePublishedDate"
-                  label="Update published date"
-                  conditional={
-                    <WarningMessage className="govuk-!-width-two-thirds">
-                      The release's published date in the public view will be
-                      updated once the publication is complete.
-                    </WarningMessage>
-                  }
-                />
-              </>
-            )}
-
-            {form.values.approvalStatus === 'Approved' && (
-              <FormFieldRadioGroup<ReleaseStatusFormValues>
-                name="publishMethod"
-                legend="When to publish"
-                legendSize="m"
-                hint="Do you want to publish this release on a specific date or immediately?"
+      {({ formState, getValues, handleSubmit, reset, setValue, watch }) => {
+        const approvalStatus = watch('approvalStatus');
+        return (
+          <>
+            <RHFForm id={formId} onSubmit={handleSubmitForm}>
+              <RHFFormFieldRadioGroup<ReleaseStatusFormValues>
+                legend="Status"
+                name="approvalStatus"
                 order={[]}
                 options={[
                   {
-                    label: 'On a specific date',
-                    value: 'Scheduled',
-                    conditional: (
-                      <>
-                        {release.preReleaseUsersOrInvitesAdded && (
-                          <WarningMessage className="govuk-!-width-two-thirds">
-                            Pre-release users will have access to a preview of
-                            the release 24 hours before the scheduled publish
-                            date.
-                          </WarningMessage>
-                        )}
-                        <FormFieldDateInput<ReleaseStatusFormValues>
-                          name="publishScheduled"
-                          legend="Publish date"
-                          legendSize="s"
-                        />
-                      </>
-                    ),
+                    label: 'In draft',
+                    value: 'Draft',
+                    disabled: !statusPermissions?.canMarkDraft,
                   },
                   {
-                    label: 'Immediately',
-                    value: 'Immediate',
-                    conditional: (
-                      <>
-                        <p className="govuk-!-width-two-thirds">
-                          The time taken by the release process will vary.
-                          Contact us if the release has not been published
-                          within one hour.
-                        </p>
-                        {release.preReleaseUsersOrInvitesAdded && (
-                          <WarningMessage className="govuk-!-width-two-thirds">
-                            Pre-release users will not have access to a preview
-                            of the release if it is published immediately.
-                          </WarningMessage>
-                        )}
-                      </>
-                    ),
+                    label:
+                      'Ready for higher review (this will notify approvers)',
+                    value: 'HigherLevelReview',
+                    disabled: !statusPermissions?.canMarkHigherLevelReview,
+                  },
+                  {
+                    label: 'Approved for publication',
+                    value: 'Approved',
+                    disabled: !statusPermissions?.canMarkApproved,
                   },
                 ]}
-              />
-            )}
-
-            <FormFieldDateInput<ReleaseStatusFormValues>
-              name="nextReleaseDate"
-              legend="Next release expected (optional)"
-              legendSize="m"
-              type="partialDate"
-              partialDateType="monthYear"
-            />
-
-            <ButtonGroup>
-              <Button
-                type="submit"
-                disabled={form.isSubmitting}
-                onClick={async e => {
-                  e.preventDefault();
-
+                onChange={element => {
                   if (
-                    form.values.approvalStatus === 'Approved' &&
-                    form.values.publishMethod === 'Scheduled' &&
-                    form.values.publishScheduled
+                    release.amendment &&
+                    element.target.value === 'Approved'
                   ) {
-                    // Ensure validation has been run as form state
-                    // may not be up-to-date (seems to only affect tests).
-                    const errors = await form.validateForm();
-
-                    if (Object.keys(errors).length === 0) {
-                      toggleConfirmScheduleModal.on();
-                      return;
-                    }
+                    setValue('notifySubscribers' as const, true);
+                    setValue('updatePublishedDate' as const, false);
                   }
-
-                  await form.submitForm();
                 }}
-              >
-                Update status
-              </Button>
-              <ButtonText
-                onClick={() => {
-                  form.resetForm();
-                  onCancel();
-                }}
-              >
-                Cancel
-              </ButtonText>
-            </ButtonGroup>
-          </Form>
+              />
 
-          <ModalConfirm
-            title="Confirm publish date"
-            open={showConfirmScheduleModal}
-            onConfirm={async () => {
-              await form.submitForm();
-              toggleConfirmScheduleModal.off();
-            }}
-            onExit={toggleConfirmScheduleModal.off}
-          >
-            <p>
-              This release will be published at 09:30 on{' '}
-              <FormattedDate format="EEEE d MMMM yyyy">
-                {form.values.publishScheduled || ''}
-              </FormattedDate>
-              .
-            </p>
-            <p>
-              Once confirmed, if you need to change or cancel the publishing for
-              any reason, you must come back to this page to change it yourself.
-              If you need any support, please contact{' '}
-              <a href="mailto:explore.statistics@education.gov.uk">
-                explore.statistics@education.gov.uk
-              </a>
-              .
-            </p>
-            <p>Are you sure?</p>
-          </ModalConfirm>
+              <RHFFormFieldTextArea<ReleaseStatusFormValues>
+                name="internalReleaseNote"
+                className="govuk-!-width-one-half"
+                label="Internal note"
+                hint="Please include any relevant information"
+                rows={3}
+              />
 
-          <ModalConfirm
-            title="Publish date cannot be scheduled"
-            confirmText="Back to form"
-            showCancel={false}
-            open={showScheduleErrorModal}
-            onConfirm={toggleScheduleErrorModal.off}
-            onExit={toggleScheduleErrorModal.off}
-          >
-            <WarningMessage>
-              Release must be scheduled at least one day in advance of the
-              publishing day. Please speak to{' '}
-              <a href="mailto:explore.statistics@education.gov.uk">
-                explore.statistics@education.gov.uk
-              </a>{' '}
-              if this is an issue.
-            </WarningMessage>
-          </ModalConfirm>
-        </>
-      )}
-    </Formik>
+              {approvalStatus === 'Approved' && release.amendment && (
+                <>
+                  <RHFFormFieldCheckbox
+                    name="notifySubscribers"
+                    label="Notify subscribers by email"
+                  />
+
+                  <RHFFormFieldCheckbox<ReleaseStatusFormValues>
+                    name="updatePublishedDate"
+                    label="Update published date"
+                    conditional={
+                      <WarningMessage className="govuk-!-width-two-thirds">
+                        The release's published date in the public view will be
+                        updated once the publication is complete.
+                      </WarningMessage>
+                    }
+                  />
+                </>
+              )}
+
+              {approvalStatus === 'Approved' && (
+                <RHFFormFieldRadioGroup<ReleaseStatusFormValues>
+                  name="publishMethod"
+                  legend="When to publish"
+                  legendSize="m"
+                  hint="Do you want to publish this release on a specific date or immediately?"
+                  order={[]}
+                  options={[
+                    {
+                      label: 'On a specific date',
+                      value: 'Scheduled',
+                      conditional: (
+                        <>
+                          {release.preReleaseUsersOrInvitesAdded && (
+                            <WarningMessage className="govuk-!-width-two-thirds">
+                              Pre-release users will have access to a preview of
+                              the release 24 hours before the scheduled publish
+                              date.
+                            </WarningMessage>
+                          )}
+                          <RHFFormFieldDateInput<ReleaseStatusFormValues>
+                            name="publishScheduled"
+                            legend="Publish date"
+                            legendSize="s"
+                          />
+                        </>
+                      ),
+                    },
+                    {
+                      label: 'Immediately',
+                      value: 'Immediate',
+                      conditional: (
+                        <>
+                          <p className="govuk-!-width-two-thirds">
+                            The time taken by the release process will vary.
+                            Contact us if the release has not been published
+                            within one hour.
+                          </p>
+                          {release.preReleaseUsersOrInvitesAdded && (
+                            <WarningMessage className="govuk-!-width-two-thirds">
+                              Pre-release users will not have access to a
+                              preview of the release if it is published
+                              immediately.
+                            </WarningMessage>
+                          )}
+                        </>
+                      ),
+                    },
+                  ]}
+                />
+              )}
+
+              <RHFFormFieldDateInput<ReleaseStatusFormValues>
+                name="nextReleaseDate"
+                legend="Next release expected (optional)"
+                legendSize="m"
+                type="partialDate"
+                partialDateType="monthYear"
+              />
+
+              <ButtonGroup>
+                <Button
+                  type="submit"
+                  disabled={formState.isSubmitting}
+                  onClick={async e => {
+                    e.preventDefault();
+
+                    if (
+                      approvalStatus === 'Approved' &&
+                      getValues('publishMethod') === 'Scheduled' &&
+                      getValues('publishScheduled')
+                    ) {
+                      if (formState.isValid) {
+                        toggleConfirmScheduleModal.on();
+                        return;
+                      }
+                    }
+
+                    await handleSubmit(handleSubmitForm)();
+                  }}
+                >
+                  Update status
+                </Button>
+                <ButtonText
+                  onClick={() => {
+                    reset();
+                    onCancel();
+                  }}
+                >
+                  Cancel
+                </ButtonText>
+              </ButtonGroup>
+            </RHFForm>
+            <ModalConfirm
+              title="Confirm publish date"
+              open={showConfirmScheduleModal}
+              onConfirm={async () => {
+                await handleSubmit(handleSubmitForm)();
+                toggleConfirmScheduleModal.off();
+              }}
+              onExit={toggleConfirmScheduleModal.off}
+            >
+              <p>
+                This release will be published at 09:30 on{' '}
+                <FormattedDate format="EEEE d MMMM yyyy">
+                  {getValues('publishScheduled') || ''}
+                </FormattedDate>
+                .
+              </p>
+              <p>
+                Once confirmed, if you need to change or cancel the publishing
+                for any reason, you must come back to this page to change it
+                yourself. If you need any support, please contact{' '}
+                <a href="mailto:explore.statistics@education.gov.uk">
+                  explore.statistics@education.gov.uk
+                </a>
+                .
+              </p>
+              <p>Are you sure?</p>
+            </ModalConfirm>
+
+            <ModalConfirm
+              title="Publish date cannot be scheduled"
+              confirmText="Back to form"
+              showCancel={false}
+              open={showScheduleErrorModal}
+              onConfirm={toggleScheduleErrorModal.off}
+              onExit={toggleScheduleErrorModal.off}
+            >
+              <WarningMessage>
+                Release must be scheduled at least one day in advance of the
+                publishing day. Please speak to{' '}
+                <a href="mailto:explore.statistics@education.gov.uk">
+                  explore.statistics@education.gov.uk
+                </a>{' '}
+                if this is an issue.
+              </WarningMessage>
+            </ModalConfirm>
+          </>
+        );
+      }}
+    </FormProvider>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -189,6 +189,7 @@ describe('ReleaseStatusForm', () => {
 
   describe('in Draft', () => {
     test('submits successfully without changing values', async () => {
+      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
       render(
@@ -202,12 +203,15 @@ describe('ReleaseStatusForm', () => {
 
       expect(handleSubmit).not.toHaveBeenCalled();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
         approvalStatus: 'Draft',
+        internalReleaseNote: '',
+        notifySubscribers: undefined,
+        publishMethod: undefined,
+        publishScheduled: undefined,
+        updatePublishedDate: undefined,
       };
 
       await waitFor(() => {
@@ -216,6 +220,8 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('submits successfully with updated values', async () => {
+      const user = userEvent.setup();
+
       const handleSubmit = jest.fn();
 
       render(
@@ -227,12 +233,12 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.click(
+      await user.click(
         screen.getByLabelText(
           'Ready for higher review (this will notify approvers)',
         ),
       );
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Internal note'),
         'Test release note',
       );
@@ -241,14 +247,12 @@ describe('ReleaseStatusForm', () => {
         screen.getByRole('group', { name: 'Next release expected (optional)' }),
       );
 
-      await userEvent.type(nextReleaseDate.getByLabelText('Month'), '5');
-      await userEvent.type(nextReleaseDate.getByLabelText('Year'), '2021');
+      await user.type(nextReleaseDate.getByLabelText('Month'), '5');
+      await user.type(nextReleaseDate.getByLabelText('Year'), '2021');
 
       expect(handleSubmit).not.toHaveBeenCalled();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
@@ -267,6 +271,8 @@ describe('ReleaseStatusForm', () => {
 
   describe('in Higher Level Review', () => {
     test('shows error message when internal note is empty', async () => {
+      const user = userEvent.setup();
+
       render(
         <ReleaseStatusForm
           release={{
@@ -279,8 +285,8 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.click(screen.getByLabelText('Internal note'));
-      await userEvent.tab();
+      await user.click(screen.getByLabelText('Internal note'));
+      await user.tab();
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -292,6 +298,8 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('fails to submit with invalid values', async () => {
+      const user = userEvent.setup();
+
       const handleSubmit = jest.fn();
 
       render(
@@ -306,9 +314,7 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -322,6 +328,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('submits successfully with updated values', async () => {
+      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
       render(
@@ -336,8 +343,8 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.click(screen.getByLabelText('In draft'));
-      await userEvent.type(
+      await user.click(screen.getByLabelText('In draft'));
+      await user.type(
         screen.getByLabelText('Internal note'),
         'Test release note',
       );
@@ -346,14 +353,12 @@ describe('ReleaseStatusForm', () => {
         screen.getByRole('group', { name: 'Next release expected (optional)' }),
       );
 
-      await userEvent.type(nextReleaseDate.getByLabelText('Month'), '5');
-      await userEvent.type(nextReleaseDate.getByLabelText('Year'), '2021');
+      await user.type(nextReleaseDate.getByLabelText('Month'), '5');
+      await user.type(nextReleaseDate.getByLabelText('Year'), '2021');
 
       expect(handleSubmit).not.toHaveBeenCalled();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
@@ -501,6 +506,8 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('shows error message when internal note is empty', async () => {
+      const user = userEvent.setup();
+
       render(
         <ReleaseStatusForm
           release={{
@@ -513,8 +520,8 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.click(screen.getByLabelText('Internal note'));
-      await userEvent.tab();
+      await user.click(screen.getByLabelText('Internal note'));
+      await user.tab();
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -526,6 +533,8 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('shows error message when no publishing method selected', async () => {
+      const user = userEvent.setup();
+
       render(
         <ReleaseStatusForm
           release={{
@@ -539,9 +548,9 @@ describe('ReleaseStatusForm', () => {
       );
 
       // Focus the field above before tabbing through the options
-      await userEvent.click(screen.getByLabelText('Internal note'));
-      await userEvent.tab();
-      await userEvent.tab();
+      await user.click(screen.getByLabelText('Internal note'));
+      await user.tab();
+      await user.tab();
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -553,6 +562,8 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('shows error message when no publish date', async () => {
+      const user = userEvent.setup();
+
       render(
         <ReleaseStatusForm
           release={{
@@ -565,11 +576,11 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.click(screen.getByLabelText('On a specific date'));
-      await userEvent.tab();
-      await userEvent.tab();
-      await userEvent.tab();
-      await userEvent.tab();
+      await user.click(screen.getByLabelText('On a specific date'));
+      await user.tab();
+      await user.tab();
+      await user.tab();
+      await user.tab();
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -581,6 +592,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('fails to submit with invalid values', async () => {
+      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
       render(
@@ -595,9 +607,7 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -621,6 +631,7 @@ describe('ReleaseStatusForm', () => {
             { code: checklistError, message: '' },
           ]);
         });
+        const user = userEvent.setup();
 
         render(
           <ReleaseStatusForm
@@ -631,9 +642,7 @@ describe('ReleaseStatusForm', () => {
           />,
         );
 
-        await userEvent.click(
-          screen.getByRole('button', { name: 'Update status' }),
-        );
+        await user.click(screen.getByRole('button', { name: 'Update status' }));
 
         await waitFor(() => {
           expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -656,6 +665,7 @@ describe('ReleaseStatusForm', () => {
           { code: 'UnexpectedError', message: '' },
         ]);
       });
+      const user = userEvent.setup();
 
       render(
         <ReleaseStatusForm
@@ -666,9 +676,7 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -685,6 +693,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('submits successfully with updated values and Draft status', async () => {
+      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
       render(
@@ -700,8 +709,8 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.click(screen.getByLabelText('In draft'));
-      await userEvent.type(
+      await user.click(screen.getByLabelText('In draft'));
+      await user.type(
         screen.getByLabelText('Internal note'),
         'Test release note',
       );
@@ -710,14 +719,12 @@ describe('ReleaseStatusForm', () => {
         screen.getByRole('group', { name: 'Next release expected (optional)' }),
       );
 
-      await userEvent.type(nextReleaseDate.getByLabelText('Month'), '5');
-      await userEvent.type(nextReleaseDate.getByLabelText('Year'), '2021');
+      await user.type(nextReleaseDate.getByLabelText('Month'), '5');
+      await user.type(nextReleaseDate.getByLabelText('Year'), '2021');
 
       expect(handleSubmit).not.toHaveBeenCalled();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
@@ -734,6 +741,8 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('shows confirmation modal when submitting with valid values and publish date', async () => {
+      const user = userEvent.setup();
+
       render(
         <ReleaseStatusForm
           release={{
@@ -746,12 +755,12 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Internal note'),
         'Test release note',
       );
 
-      await userEvent.click(screen.getByLabelText('On a specific date'));
+      await user.click(screen.getByLabelText('On a specific date'));
 
       const publishDate = within(
         screen.getByRole('group', { name: 'Publish date' }),
@@ -759,18 +768,13 @@ describe('ReleaseStatusForm', () => {
 
       const nextYear = new Date().getFullYear() + 1;
 
-      await userEvent.type(publishDate.getByLabelText('Day'), '10');
-      await userEvent.type(publishDate.getByLabelText('Month'), '10');
-      await userEvent.type(
-        publishDate.getByLabelText('Year'),
-        nextYear.toString(),
-      );
+      await user.type(publishDate.getByLabelText('Day'), '10');
+      await user.type(publishDate.getByLabelText('Month'), '10');
+      await user.type(publishDate.getByLabelText('Year'), nextYear.toString());
 
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       await waitFor(() => {
         expect(screen.getByText('Confirm publish date')).toBeInTheDocument();
@@ -783,6 +787,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('does not show confirmation modal when submitting invalid values with valid publish date', async () => {
+      const user = userEvent.setup();
       render(
         <ReleaseStatusForm
           release={{
@@ -795,7 +800,7 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.click(screen.getByLabelText('On a specific date'));
+      await user.click(screen.getByLabelText('On a specific date'));
 
       const publishDate = within(
         screen.getByRole('group', { name: 'Publish date' }),
@@ -803,18 +808,13 @@ describe('ReleaseStatusForm', () => {
 
       const nextYear = new Date().getFullYear() + 1;
 
-      await userEvent.type(publishDate.getByLabelText('Day'), '10');
-      await userEvent.type(publishDate.getByLabelText('Month'), '10');
-      await userEvent.type(
-        publishDate.getByLabelText('Year'),
-        nextYear.toString(),
-      );
+      await user.type(publishDate.getByLabelText('Day'), '10');
+      await user.type(publishDate.getByLabelText('Month'), '10');
+      await user.type(publishDate.getByLabelText('Year'), nextYear.toString());
 
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -824,6 +824,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('shows error modal when submitted with publish date that could not be scheduled', async () => {
+      const user = userEvent.setup();
       const handleSubmit = jest.fn().mockImplementation(() => {
         throw createServerValidationErrorMock([
           { code: 'PublishDateCannotBeScheduled', message: '' },
@@ -842,12 +843,12 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Internal note'),
         'Test release note',
       );
 
-      await userEvent.click(screen.getByLabelText('On a specific date'));
+      await user.click(screen.getByLabelText('On a specific date'));
 
       const publishDate = within(
         screen.getByRole('group', { name: 'Publish date' }),
@@ -855,22 +856,17 @@ describe('ReleaseStatusForm', () => {
 
       const nextYear = new Date().getFullYear() + 1;
 
-      await userEvent.type(publishDate.getByLabelText('Day'), '10');
-      await userEvent.type(publishDate.getByLabelText('Month'), '10');
-      await userEvent.type(
-        publishDate.getByLabelText('Year'),
-        nextYear.toString(),
-      );
+      await user.type(publishDate.getByLabelText('Day'), '10');
+      await user.type(publishDate.getByLabelText('Month'), '10');
+      await user.type(publishDate.getByLabelText('Year'), nextYear.toString());
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       await waitFor(() => {
         expect(screen.getByText('Confirm publish date')).toBeInTheDocument();
       });
 
-      await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
       await waitFor(() => {
         expect(
@@ -884,9 +880,7 @@ describe('ReleaseStatusForm', () => {
         'Publish date cannot be scheduled',
       );
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Back to form' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Back to form' }));
 
       expect(
         screen.getByRole('link', {
@@ -896,6 +890,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('submits successfully with updated values and publish date', async () => {
+      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
       render(
@@ -910,12 +905,12 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Internal note'),
         'Test release note',
       );
 
-      await userEvent.click(screen.getByLabelText('On a specific date'));
+      await user.click(screen.getByLabelText('On a specific date'));
 
       const publishDate = within(
         screen.getByRole('group', { name: 'Publish date' }),
@@ -923,25 +918,20 @@ describe('ReleaseStatusForm', () => {
 
       const nextYear = new Date().getFullYear() + 1;
 
-      await userEvent.type(publishDate.getByLabelText('Day'), '10');
-      await userEvent.type(publishDate.getByLabelText('Month'), '10');
-      await userEvent.type(
-        publishDate.getByLabelText('Year'),
-        nextYear.toString(),
-      );
+      await user.type(publishDate.getByLabelText('Day'), '10');
+      await user.type(publishDate.getByLabelText('Month'), '10');
+      await user.type(publishDate.getByLabelText('Year'), nextYear.toString());
 
       const nextReleaseDate = within(
         screen.getByRole('group', { name: 'Next release expected (optional)' }),
       );
 
-      await userEvent.type(nextReleaseDate.getByLabelText('Month'), '5');
-      await userEvent.type(nextReleaseDate.getByLabelText('Year'), '2021');
+      await user.type(nextReleaseDate.getByLabelText('Month'), '5');
+      await user.type(nextReleaseDate.getByLabelText('Year'), '2021');
 
       expect(handleSubmit).not.toHaveBeenCalled();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
@@ -963,7 +953,7 @@ describe('ReleaseStatusForm', () => {
         'Confirm publish date',
       );
 
-      await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
       await waitFor(() => {
         expect(handleSubmit).toHaveBeenCalledWith(expectedValues);
@@ -971,6 +961,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('submits successfully with updated values and immediate publish', async () => {
+      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
       render(
@@ -985,25 +976,23 @@ describe('ReleaseStatusForm', () => {
         />,
       );
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Internal note'),
         'Test release note',
       );
 
-      await userEvent.click(screen.getByLabelText('Immediately'));
+      await user.click(screen.getByLabelText('Immediately'));
 
       const nextReleaseDate = within(
         screen.getByRole('group', { name: 'Next release expected (optional)' }),
       );
 
-      await userEvent.type(nextReleaseDate.getByLabelText('Month'), '5');
-      await userEvent.type(nextReleaseDate.getByLabelText('Year'), '2021');
+      await user.type(nextReleaseDate.getByLabelText('Month'), '5');
+      await user.type(nextReleaseDate.getByLabelText('Year'), '2021');
 
       expect(handleSubmit).not.toHaveBeenCalled();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update status' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
@@ -1049,6 +1038,7 @@ describe('ReleaseStatusForm', () => {
       });
 
       test('renders default values for `notifySubscribers` and `updatePublishedDate` options when status is changed to Approved', async () => {
+        const user = userEvent.setup();
         const handleSubmit = jest.fn();
 
         render(
@@ -1076,7 +1066,7 @@ describe('ReleaseStatusForm', () => {
         expect(screen.getByLabelText('Update published date')).toBeChecked();
 
         // Toggle to Draft status and expect the options to not be rendered
-        await userEvent.click(screen.getByLabelText('In draft'));
+        await user.click(screen.getByLabelText('In draft'));
 
         expect(
           screen.queryByLabelText('Notify subscribers by email'),
@@ -1087,9 +1077,7 @@ describe('ReleaseStatusForm', () => {
         ).not.toBeInTheDocument();
 
         // Toggle back to Approved and expect the options have their default values
-        await userEvent.click(
-          screen.getByLabelText('Approved for publication'),
-        );
+        await user.click(screen.getByLabelText('Approved for publication'));
 
         expect(
           screen.getByLabelText('Notify subscribers by email'),
@@ -1101,6 +1089,7 @@ describe('ReleaseStatusForm', () => {
       });
 
       test('shows warning message when `updatePublishedDate` is selected', async () => {
+        const user = userEvent.setup();
         const handleSubmit = jest.fn();
 
         render(
@@ -1124,7 +1113,7 @@ describe('ReleaseStatusForm', () => {
           ).not.toBeChecked();
         });
 
-        await userEvent.click(screen.getByLabelText('Update published date'));
+        await user.click(screen.getByLabelText('Update published date'));
 
         expect(
           screen.getByText(
@@ -1134,6 +1123,7 @@ describe('ReleaseStatusForm', () => {
       });
 
       test('submits successfully with updated values', async () => {
+        const user = userEvent.setup();
         const handleSubmit = jest.fn();
 
         render(
@@ -1151,24 +1141,20 @@ describe('ReleaseStatusForm', () => {
           />,
         );
 
-        await userEvent.type(
+        await user.type(
           screen.getByLabelText('Internal note'),
           'Test release note',
         );
 
-        await userEvent.click(
-          screen.getByLabelText('Notify subscribers by email'),
-        );
+        await user.click(screen.getByLabelText('Notify subscribers by email'));
 
-        await userEvent.click(screen.getByLabelText('Update published date'));
+        await user.click(screen.getByLabelText('Update published date'));
 
-        await userEvent.click(screen.getByLabelText('Immediately'));
+        await user.click(screen.getByLabelText('Immediately'));
 
         expect(handleSubmit).not.toHaveBeenCalled();
 
-        await userEvent.click(
-          screen.getByRole('button', { name: 'Update status' }),
-        );
+        await user.click(screen.getByRole('button', { name: 'Update status' }));
 
         const expectedValues: ReleaseStatusFormValues = {
           internalReleaseNote: 'Test release note',

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlock.tsx
@@ -17,7 +17,7 @@ export interface EditableKeyStatDataBlockProps {
   keyStat: KeyStatisticDataBlock;
   releaseId: string;
   testId?: string;
-  onRemove?: () => void;
+  onRemove: () => void;
   onSubmit: (values: KeyStatDataBlockFormValues) => void;
 }
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
@@ -1,17 +1,17 @@
-import FormFieldEditor from '@admin/components/form/FormFieldEditor';
 import { toolbarConfigSimple } from '@admin/config/ckEditorConfig';
+import RHFFormFieldEditor from '@admin/components/form/RHFFormFieldEditor';
 import toHtml from '@admin/utils/markdown/toHtml';
 import toMarkdown from '@admin/utils/markdown/toMarkdown';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
-import { Form, FormFieldTextInput } from '@common/components/form';
-import useFormSubmit from '@common/hooks/useFormSubmit';
 import styles from '@common/modules/find-statistics/components/KeyStat.module.scss';
 import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import RHFFormFieldTextInput from '@common/components/form/rhf/RHFFormFieldTextInput';
 import { KeyStatisticDataBlock } from '@common/services/publicationService';
-import { Formik } from 'formik';
-import React from 'react';
 import Yup from '@common/validation/yup';
+import React from 'react';
 
 export interface KeyStatDataBlockFormValues {
   trend: string;
@@ -20,36 +20,34 @@ export interface KeyStatDataBlockFormValues {
 }
 
 export interface EditableKeyStatDataBlockFormProps {
-  keyStat: KeyStatisticDataBlock;
-  title: string;
-  statistic: string;
   isReordering?: boolean;
+  keyStat: KeyStatisticDataBlock;
+  statistic: string;
   testId: string;
+  title: string;
   onSubmit: (values: KeyStatDataBlockFormValues) => void;
   onCancel: () => void;
 }
 
-const EditableKeyStatDataBlockForm = ({
+export default function EditableKeyStatDataBlockForm({
+  isReordering = false,
   keyStat,
-  title,
   statistic,
-  isReordering,
   testId,
+  title,
   onSubmit,
   onCancel,
-}: EditableKeyStatDataBlockFormProps) => {
-  const handleSubmit = useFormSubmit<KeyStatDataBlockFormValues>(
-    async values => {
-      await onSubmit({
-        ...values,
-        guidanceTitle: values.guidanceTitle,
-        guidanceText: toMarkdown(values.guidanceText),
-      });
-    },
-  );
+}: EditableKeyStatDataBlockFormProps) {
+  const handleSubmit = async (values: KeyStatDataBlockFormValues) => {
+    onSubmit({
+      ...values,
+      guidanceTitle: values.guidanceTitle,
+      guidanceText: toMarkdown(values.guidanceText),
+    });
+  };
 
   return (
-    <Formik<KeyStatDataBlockFormValues>
+    <FormProvider
       initialValues={{
         trend: keyStat.trend ?? '',
         guidanceTitle: keyStat.guidanceTitle ?? 'Help',
@@ -60,47 +58,49 @@ const EditableKeyStatDataBlockForm = ({
         guidanceTitle: Yup.string().max(65),
         guidanceText: Yup.string(),
       })}
-      onSubmit={handleSubmit}
     >
-      {form => (
-        <Form id={`editableKeyStatDataBlockForm-${keyStat.id}`}>
-          <KeyStatTile
-            title={title}
-            titleTag="h4"
-            testId={testId}
-            value={statistic}
-            isReordering={isReordering}
+      {({ formState }) => {
+        return (
+          <RHFForm
+            id={`editableKeyStatDataBlockForm-${keyStat.id}`}
+            onSubmit={handleSubmit}
           >
-            <FormFieldTextInput<KeyStatDataBlockFormValues>
-              name="trend"
-              label={<span className={styles.trendText}>Trend</span>}
+            <KeyStatTile
+              title={title}
+              titleTag="h4"
+              testId={testId}
+              value={statistic}
+              isReordering={isReordering}
+            >
+              <RHFFormFieldTextInput<KeyStatDataBlockFormValues>
+                name="trend"
+                label={<span className={styles.trendText}>Trend</span>}
+              />
+            </KeyStatTile>
+
+            <RHFFormFieldTextInput<KeyStatDataBlockFormValues>
+              formGroupClass="govuk-!-margin-top-2"
+              name="guidanceTitle"
+              label="Guidance title"
             />
-          </KeyStatTile>
 
-          <FormFieldTextInput<KeyStatDataBlockFormValues>
-            formGroupClass="govuk-!-margin-top-2"
-            name="guidanceTitle"
-            label="Guidance title"
-          />
+            <RHFFormFieldEditor<KeyStatDataBlockFormValues>
+              name="guidanceText"
+              toolbarConfig={toolbarConfigSimple}
+              label="Guidance text"
+            />
 
-          <FormFieldEditor<KeyStatDataBlockFormValues>
-            name="guidanceText"
-            toolbarConfig={toolbarConfigSimple}
-            label="Guidance text"
-          />
-
-          <ButtonGroup>
-            <Button disabled={form.isSubmitting} type="submit">
-              Save
-            </Button>
-            <Button variant="secondary" onClick={onCancel}>
-              Cancel
-            </Button>
-          </ButtonGroup>
-        </Form>
-      )}
-    </Formik>
+            <ButtonGroup>
+              <Button disabled={formState.isSubmitting} type="submit">
+                Save
+              </Button>
+              <Button variant="secondary" onClick={onCancel}>
+                Cancel
+              </Button>
+            </ButtonGroup>
+          </RHFForm>
+        );
+      }}
+    </FormProvider>
   );
-};
-
-export default EditableKeyStatDataBlockForm;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatPreview.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatPreview.tsx
@@ -11,7 +11,7 @@ export interface EditableKeyStatDisplayProps
   extends OmitStrict<KeyStatProps, 'children' | 'includeWrapper'> {
   isReordering: boolean;
   isEditing: boolean;
-  onRemove?: () => void;
+  onRemove: () => void;
   onEdit: () => void;
 }
 
@@ -32,11 +32,9 @@ export default function EditableKeyStatPreview({
             Edit <VisuallyHidden> key statistic: {title}</VisuallyHidden>
           </Button>
 
-          {onRemove && (
-            <Button variant="secondary" onClick={onRemove}>
-              Remove <VisuallyHidden> key statistic: {title}</VisuallyHidden>
-            </Button>
-          )}
+          <Button variant="secondary" onClick={onRemove}>
+            Remove <VisuallyHidden> key statistic: {title}</VisuallyHidden>
+          </Button>
         </ButtonGroup>
       )}
     </KeyStat>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatText.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatText.tsx
@@ -11,7 +11,7 @@ export interface EditableKeyStatTextProps {
   isReordering?: boolean;
   keyStat: KeyStatisticText;
   testId?: string;
-  onRemove?: () => void;
+  onRemove: () => void;
   onSubmit: (values: KeyStatTextFormValues) => void;
 }
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
@@ -1,4 +1,4 @@
-import FormFieldEditor from '@admin/components/form/FormFieldEditor';
+import RHFFormFieldEditor from '@admin/components/form/RHFFormFieldEditor';
 import {
   pluginsConfigSimple,
   toolbarConfigSimple,
@@ -7,11 +7,11 @@ import toHtml from '@admin/utils/markdown/toHtml';
 import toMarkdown from '@admin/utils/markdown/toMarkdown';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
-import { Form, FormFieldTextInput } from '@common/components/form';
-import useFormSubmit from '@common/hooks/useFormSubmit';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import RHFFormFieldTextInput from '@common/components/form/rhf/RHFFormFieldTextInput';
 import styles from '@common/modules/find-statistics/components/KeyStat.module.scss';
 import { KeyStatisticText } from '@common/services/publicationService';
-import { Formik } from 'formik';
 import React from 'react';
 import classNames from 'classnames';
 import Yup from '@common/validation/yup';
@@ -34,22 +34,22 @@ interface EditableKeyStatTextFormProps {
 
 export default function EditableKeyStatTextForm({
   keyStat,
-  isReordering,
+  isReordering = false,
   onSubmit,
   onCancel,
   testId,
 }: EditableKeyStatTextFormProps) {
-  const handleSubmit = useFormSubmit<KeyStatTextFormValues>(async values => {
+  const handleSubmit = async (values: KeyStatTextFormValues) => {
     await onSubmit({
       ...values,
       guidanceTitle: values.guidanceTitle,
       guidanceText: toMarkdown(values.guidanceText),
     });
-  });
+  };
 
   return (
     <div data-testid={testId}>
-      <Formik<KeyStatTextFormValues>
+      <FormProvider
         initialValues={{
           title: keyStat?.title ?? '',
           statistic: keyStat?.statistic ?? '',
@@ -66,67 +66,69 @@ export default function EditableKeyStatTextForm({
           guidanceTitle: Yup.string().max(65),
           guidanceText: Yup.string(),
         })}
-        onSubmit={handleSubmit}
       >
-        {form => (
-          <Form
-            id={
-              keyStat
-                ? `editableKeyStatTextForm-${keyStat.id}`
-                : 'editableKeyStatTextForm-create'
-            }
-          >
-            <div className={styles.textTile}>
-              <FormFieldTextInput<KeyStatTextFormValues>
-                name="title"
+        {({ formState }) => {
+          return (
+            <RHFForm
+              id={
+                keyStat
+                  ? `editableKeyStatTextForm-${keyStat.id}`
+                  : 'editableKeyStatTextForm-create'
+              }
+              onSubmit={handleSubmit}
+            >
+              <div className={styles.textTile}>
+                <RHFFormFieldTextInput<KeyStatTextFormValues>
+                  name="title"
+                  className={classNames({
+                    'govuk-!-width-one-third': isReordering,
+                  })}
+                  label={<span>Title</span>}
+                />
+                <RHFFormFieldTextInput<KeyStatTextFormValues>
+                  name="statistic"
+                  className={classNames({
+                    'govuk-!-width-one-third': isReordering,
+                  })}
+                  label={<span>Statistic</span>}
+                />
+                <RHFFormFieldTextInput<KeyStatTextFormValues>
+                  name="trend"
+                  className={classNames({
+                    'govuk-!-width-one-third': isReordering,
+                  })}
+                  label={<span>Trend</span>}
+                />
+              </div>
+
+              <RHFFormFieldTextInput<KeyStatTextFormValues>
+                formGroupClass="govuk-!-margin-top-2"
+                name="guidanceTitle"
                 className={classNames({
                   'govuk-!-width-one-third': isReordering,
                 })}
-                label={<span>Title</span>}
+                label="Guidance title"
               />
-              <FormFieldTextInput<KeyStatTextFormValues>
-                name="statistic"
-                className={classNames({
-                  'govuk-!-width-one-third': isReordering,
-                })}
-                label={<span>Statistic</span>}
+
+              <RHFFormFieldEditor<KeyStatTextFormValues>
+                name="guidanceText"
+                includePlugins={pluginsConfigSimple}
+                toolbarConfig={toolbarConfigSimple}
+                label="Guidance text"
               />
-              <FormFieldTextInput<KeyStatTextFormValues>
-                name="trend"
-                className={classNames({
-                  'govuk-!-width-one-third': isReordering,
-                })}
-                label={<span>Trend</span>}
-              />
-            </div>
 
-            <FormFieldTextInput<KeyStatTextFormValues>
-              formGroupClass="govuk-!-margin-top-2"
-              name="guidanceTitle"
-              className={classNames({
-                'govuk-!-width-one-third': isReordering,
-              })}
-              label="Guidance title"
-            />
-
-            <FormFieldEditor<KeyStatTextFormValues>
-              name="guidanceText"
-              includePlugins={pluginsConfigSimple}
-              toolbarConfig={toolbarConfigSimple}
-              label="Guidance text"
-            />
-
-            <ButtonGroup>
-              <Button disabled={form.isSubmitting} type="submit">
-                Save
-              </Button>
-              <Button variant="secondary" onClick={onCancel}>
-                Cancel
-              </Button>
-            </ButtonGroup>
-          </Form>
-        )}
-      </Formik>
+              <ButtonGroup>
+                <Button disabled={formState.isSubmitting} type="submit">
+                  Save
+                </Button>
+                <Button variant="secondary" onClick={onCancel}>
+                  Cancel
+                </Button>
+              </ButtonGroup>
+            </RHFForm>
+          );
+        }}
+      </FormProvider>
     </div>
   );
 }

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNote.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNote.tsx
@@ -1,0 +1,68 @@
+import ReleaseNoteForm, {
+  ReleaseNoteFormValues,
+} from '@admin/pages/release/content/components/ReleaseNoteForm';
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import FormattedDate from '@common/components/FormattedDate';
+import ModalConfirm from '@common/components/ModalConfirm';
+import useToggle from '@common/hooks/useToggle';
+import { ReleaseNote as ReleaseNoteData } from '@common/services/publicationService';
+import React from 'react';
+
+interface Props {
+  isEditable: boolean;
+  releaseNote: ReleaseNoteData;
+  onDelete: (id: string) => void;
+  onSubmit: (id: string, values: ReleaseNoteFormValues) => Promise<void> | void;
+}
+
+export default function ReleaseNote({
+  isEditable,
+  releaseNote,
+  onDelete,
+  onSubmit,
+}: Props) {
+  const [editFormOpen, toggleEditForm] = useToggle(false);
+
+  return (
+    <li>
+      {editFormOpen ? (
+        <ReleaseNoteForm
+          id={`edit-release-note-form-${releaseNote.id}`}
+          initialValues={{
+            on: new Date(releaseNote.on),
+            reason: releaseNote.reason,
+          }}
+          onCancel={toggleEditForm.off}
+          onSubmit={async values => {
+            await onSubmit(releaseNote.id, values);
+            toggleEditForm.off();
+          }}
+        />
+      ) : (
+        <>
+          <FormattedDate className="govuk-body govuk-!-font-weight-bold">
+            {releaseNote.on}
+          </FormattedDate>
+          <p>{releaseNote.reason}</p>
+
+          {isEditable && (
+            <ButtonGroup>
+              <Button variant="secondary" onClick={toggleEditForm.on}>
+                Edit note
+              </Button>
+
+              <ModalConfirm
+                title="Confirm deletion of release note"
+                triggerButton={<Button variant="warning">Remove note</Button>}
+                onConfirm={() => onDelete(releaseNote.id)}
+              >
+                <p>This release note will be removed from this release</p>
+              </ModalConfirm>
+            </ButtonGroup>
+          )}
+        </>
+      )}
+    </li>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNoteForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNoteForm.tsx
@@ -1,0 +1,76 @@
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import RHFFormFieldDateInput from '@common/components/form/rhf/RHFFormFieldDateInput';
+import RHFFormFieldTextArea from '@common/components/form/rhf/RHFFormFieldTextArea';
+import Yup from '@common/validation/yup';
+import React, { useMemo } from 'react';
+import { ObjectSchema } from 'yup';
+
+export interface ReleaseNoteFormValues {
+  on?: Date;
+  reason: string;
+}
+
+interface Props {
+  id: string;
+  initialValues: ReleaseNoteFormValues;
+  onCancel: () => void;
+  onSubmit: (values: ReleaseNoteFormValues) => void;
+}
+
+export default function ReleaseNoteForm({
+  id,
+  initialValues,
+  onCancel,
+  onSubmit,
+}: Props) {
+  const isEditing = !!initialValues.on;
+
+  const validationSchema = useMemo<ObjectSchema<ReleaseNoteFormValues>>(() => {
+    const schema = Yup.object({
+      on: Yup.date(),
+      reason: Yup.string().required('Release note must be provided'),
+    });
+
+    if (isEditing) {
+      return schema.shape({
+        on: Yup.date().required('Enter a valid edit date'),
+      });
+    }
+
+    return schema;
+  }, [isEditing]);
+
+  return (
+    <FormProvider
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+    >
+      <RHFForm id={id} onSubmit={onSubmit}>
+        {isEditing && (
+          <RHFFormFieldDateInput<ReleaseNoteFormValues>
+            name="on"
+            legend="Edit date"
+            legendSize="s"
+          />
+        )}
+        <RHFFormFieldTextArea<ReleaseNoteFormValues>
+          label={isEditing ? 'Edit release note' : 'New release note'}
+          name="reason"
+          rows={3}
+        />
+
+        <ButtonGroup>
+          <Button type="submit">
+            {isEditing ? 'Update note' : 'Save note'}
+          </Button>
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+        </ButtonGroup>
+      </RHFForm>
+    </FormProvider>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNotesSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNotesSection.tsx
@@ -1,239 +1,89 @@
 import { useEditingContext } from '@admin/contexts/EditingContext';
+import ReleaseNoteForm, {
+  ReleaseNoteFormValues,
+} from '@admin/pages/release/content/components/ReleaseNoteForm';
+import ReleaseNote from '@admin/pages/release/content/components/ReleaseNote';
 import { EditableRelease } from '@admin/services/releaseContentService';
 import releaseNoteService from '@admin/services/releaseNoteService';
 import Button from '@common/components/Button';
-import ButtonGroup from '@common/components/ButtonGroup';
 import Details from '@common/components/Details';
-import { Form } from '@common/components/form';
-import FormFieldDateInput from '@common/components/form/FormFieldDateInput';
-import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
-import FormattedDate from '@common/components/FormattedDate';
-import ModalConfirm from '@common/components/ModalConfirm';
-import { ReleaseNote } from '@common/services/publicationService';
-import Yup from '@common/validation/yup';
-import { Formik } from 'formik';
+import useToggle from '@common/hooks/useToggle';
+import { ReleaseNote as ReleaseNoteData } from '@common/services/publicationService';
 import React, { useState } from 'react';
 
 interface Props {
   release: EditableRelease;
 }
 
-interface CreateFormValues {
-  reason: string;
-}
-
-interface EditFormValues {
-  on: Date;
-  reason: string;
-}
-
-const emptyReleaseNote: ReleaseNote = {
-  id: '',
-  on: new Date(),
-  reason: '',
-};
-
-const ReleaseNotesSection = ({ release }: Props) => {
-  const [addFormOpen, setAddFormOpen] = useState<boolean>(false);
-  const [editFormOpen, setEditFormOpen] = useState<boolean>(false);
-  const [selectedReleaseNote, setSelectedReleaseNote] =
-    useState<ReleaseNote>(emptyReleaseNote);
-  const [releaseNotes, setReleaseNotes] = useState<ReleaseNote[]>(
+export default function ReleaseNotesSection({ release }: Props) {
+  const [addFormOpen, toggleAddForm] = useToggle(false);
+  const [releaseNotes, setReleaseNotes] = useState<ReleaseNoteData[]>(
     release.updates,
   );
   const { editingMode } = useEditingContext();
 
-  const addReleaseNote = async (releaseNote: CreateFormValues) => {
-    const newReleaseNotes = await releaseNoteService.create(
+  const handleAddReleaseNote = async (values: ReleaseNoteFormValues) => {
+    const updatedReleaseNotes = await releaseNoteService.create(
       release.id,
-      releaseNote,
+      values,
     );
-
-    setReleaseNotes(newReleaseNotes);
+    setReleaseNotes(updatedReleaseNotes);
+    toggleAddForm.off();
   };
 
-  const editReleaseNote = async (id: string, releaseNote: EditFormValues) => {
-    const newReleaseNotes = await releaseNoteService.edit(id, release.id, {
-      on: releaseNote.on,
-      reason: releaseNote.reason,
+  const handleEditReleaseNote = async (
+    id: string,
+    values: ReleaseNoteFormValues,
+  ) => {
+    if (!values.on) {
+      return;
+    }
+    const updatedReleaseNotes = await releaseNoteService.edit(id, release.id, {
+      on: values.on,
+      reason: values.reason,
     });
 
-    setReleaseNotes(newReleaseNotes);
+    setReleaseNotes(updatedReleaseNotes);
   };
 
-  const openAddForm = () => {
-    setAddFormOpen(true);
-    setEditFormOpen(false);
-  };
-
-  const openEditForm = (selected: ReleaseNote) => {
-    setAddFormOpen(false);
-    setEditFormOpen(true);
-    setSelectedReleaseNote(selected);
-  };
-
-  const renderAddForm = () => {
-    const formId = 'createReleaseNoteForm';
-
-    return !addFormOpen ? (
-      <Button onClick={openAddForm}>Add note</Button>
-    ) : (
-      <Formik<CreateFormValues>
-        initialValues={{ reason: '' }}
-        validationSchema={Yup.object<CreateFormValues>({
-          reason: Yup.string().required('Release note must be provided'),
-        })}
-        onSubmit={releaseNote =>
-          addReleaseNote(releaseNote).then(() => {
-            setAddFormOpen(false);
-          })
-        }
-      >
-        {form => {
-          return (
-            <Form id={formId}>
-              <FormFieldTextArea<CreateFormValues>
-                label="New release note"
-                name="reason"
-                rows={3}
-              />
-
-              <ButtonGroup>
-                <Button type="submit">Save note</Button>
-                <Button
-                  variant="secondary"
-                  onClick={() => {
-                    form.resetForm();
-                    setAddFormOpen(false);
-                  }}
-                >
-                  Cancel
-                </Button>
-              </ButtonGroup>
-            </Form>
-          );
-        }}
-      </Formik>
-    );
-  };
-
-  const renderEditForm = () => {
-    const formId = 'editReleaseNoteForm';
-
-    return (
-      <Formik<EditFormValues>
-        initialValues={
-          selectedReleaseNote
-            ? {
-                on: new Date(selectedReleaseNote.on),
-                reason: selectedReleaseNote.reason,
-              }
-            : ({
-                reason: '',
-              } as EditFormValues)
-        }
-        validationSchema={Yup.object<EditFormValues>({
-          on: Yup.date().required('Enter a valid edit date'),
-          reason: Yup.string().required('Release note must be provided'),
-        })}
-        onSubmit={releaseNote =>
-          editReleaseNote(
-            selectedReleaseNote.id,
-            releaseNote as EditFormValues,
-          ).then(() => {
-            setEditFormOpen(false);
-          })
-        }
-      >
-        {form => {
-          return (
-            <Form id={formId}>
-              <FormFieldDateInput<EditFormValues>
-                name="on"
-                legend="Edit date"
-                legendSize="s"
-              />
-              <FormFieldTextArea<EditFormValues>
-                label="Edit release note"
-                name="reason"
-                rows={3}
-              />
-
-              <ButtonGroup>
-                <Button type="submit">Update note</Button>
-                <Button
-                  variant="secondary"
-                  onClick={() => {
-                    form.resetForm();
-                    setEditFormOpen(false);
-                  }}
-                >
-                  Cancel
-                </Button>
-              </ButtonGroup>
-            </Form>
-          );
-        }}
-      </Formik>
-    );
+  const handleDeleteReleaseNote = async (id: string) => {
+    const updatedReleaseNotes = await releaseNoteService.delete(id, release.id);
+    setReleaseNotes(updatedReleaseNotes);
   };
 
   return (
     releaseNotes && (
       <Details
         summary={`See all updates (${releaseNotes.length})`}
-        id="releaseNotes"
+        id="release-notes"
         open={editingMode === 'edit'}
       >
         <ol className="govuk-list">
-          {releaseNotes.map(elem => (
-            <li key={elem.id}>
-              {editingMode === 'edit' &&
-              editFormOpen &&
-              selectedReleaseNote.id === elem.id ? (
-                renderEditForm()
-              ) : (
-                <>
-                  <FormattedDate className="govuk-body govuk-!-font-weight-bold">
-                    {elem.on}
-                  </FormattedDate>
-                  <p>{elem.reason}</p>
-
-                  {editingMode === 'edit' && (
-                    <ButtonGroup>
-                      <Button
-                        variant="secondary"
-                        onClick={() => openEditForm(elem)}
-                      >
-                        Edit note
-                      </Button>
-
-                      <ModalConfirm
-                        title="Confirm deletion of release note"
-                        triggerButton={
-                          <Button variant="warning">Remove note</Button>
-                        }
-                        onConfirm={async () => {
-                          await releaseNoteService
-                            .delete(elem.id, release.id)
-                            .then(setReleaseNotes);
-                        }}
-                      >
-                        <p>
-                          This release note will be removed from this release
-                        </p>
-                      </ModalConfirm>
-                    </ButtonGroup>
-                  )}
-                </>
-              )}
-            </li>
+          {releaseNotes.map(releaseNote => (
+            <ReleaseNote
+              key={releaseNote.id}
+              isEditable={editingMode === 'edit'}
+              releaseNote={releaseNote}
+              onDelete={handleDeleteReleaseNote}
+              onSubmit={handleEditReleaseNote}
+            />
           ))}
         </ol>
-        {editingMode === 'edit' && renderAddForm()}
+        {editingMode === 'edit' && (
+          <>
+            {addFormOpen ? (
+              <ReleaseNoteForm
+                id="create-release-note-form"
+                initialValues={{ reason: '' }}
+                onCancel={toggleAddForm.off}
+                onSubmit={handleAddReleaseNote}
+              />
+            ) : (
+              <Button onClick={toggleAddForm.on}>Add note</Button>
+            )}
+          </>
+        )}
       </Details>
     )
   );
-};
-
-export default ReleaseNotesSection;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
@@ -80,7 +80,7 @@ describe('EditableKeyStatDataBlock', () => {
     dataBlockParentId: 'block-1',
   };
 
-  test('renders preview correctly', async () => {
+  test('renders correctly when `isEditing` is false', async () => {
     tableBuilderService.getDataBlockTableData.mockResolvedValue(
       testTableDataResponse,
     );
@@ -89,15 +89,12 @@ describe('EditableKeyStatDataBlock', () => {
       <EditableKeyStatDataBlock
         releaseId="release-1"
         keyStat={keyStatDataBlock}
+        onRemove={noop}
         onSubmit={noop}
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-        'DataBlock indicator',
-      );
-    });
+    expect(await screen.findByText('DataBlock indicator')).toBeInTheDocument();
 
     expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
       '608,180',
@@ -105,23 +102,61 @@ describe('EditableKeyStatDataBlock', () => {
     expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
       'DataBlock trend',
     );
-
     expect(
       screen.getByRole('button', {
         name: 'DataBlock guidance title',
       }),
     ).toBeInTheDocument();
-
     expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
       'DataBlock guidance text',
     );
+
+    expect(
+      screen.queryByRole('button', { name: /Edit/ }),
+    ).not.toBeInTheDocument();
 
     expect(
       screen.queryByRole('button', { name: /Remove/ }),
     ).not.toBeInTheDocument();
   });
 
-  test('renders preview correctly without trend', async () => {
+  test('renders correctly when `isEditing` is true', async () => {
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
+
+    render(
+      <EditableKeyStatDataBlock
+        isEditing
+        releaseId="release-1"
+        keyStat={keyStatDataBlock}
+        onRemove={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(await screen.findByText('DataBlock indicator')).toBeInTheDocument();
+
+    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+      '608,180',
+    );
+    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
+      'DataBlock trend',
+    );
+    expect(
+      screen.getByRole('button', {
+        name: 'DataBlock guidance title',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
+      'DataBlock guidance text',
+    );
+
+    expect(screen.getByRole('button', { name: /Edit/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Remove/ })).toBeInTheDocument();
+  });
+
+  test('does not render the trend when `trend` is undefined', async () => {
     tableBuilderService.getDataBlockTableData.mockResolvedValue(
       testTableDataResponse,
     );
@@ -130,39 +165,17 @@ describe('EditableKeyStatDataBlock', () => {
       <EditableKeyStatDataBlock
         releaseId="release-1"
         keyStat={{ ...keyStatDataBlock, trend: undefined }}
+        onRemove={noop}
         onSubmit={noop}
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-        'DataBlock indicator',
-      );
-    });
+    expect(await screen.findByText('DataBlock indicator')).toBeInTheDocument();
 
-    expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(1);
-
-    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-      '608,180',
-    );
     expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
-
-    expect(
-      screen.getByRole('button', {
-        name: 'DataBlock guidance title',
-      }),
-    ).toBeInTheDocument();
-
-    expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
-      'DataBlock guidance text',
-    );
-
-    expect(
-      screen.queryByRole('button', { name: /Remove/ }),
-    ).not.toBeInTheDocument();
   });
 
-  test('renders preview correctly without guidanceTitle', async () => {
+  test('renders the default guidance title when `guidanceTitle` is undefined', async () => {
     tableBuilderService.getDataBlockTableData.mockResolvedValue(
       testTableDataResponse,
     );
@@ -171,39 +184,24 @@ describe('EditableKeyStatDataBlock', () => {
       <EditableKeyStatDataBlock
         releaseId="release-1"
         keyStat={{ ...keyStatDataBlock, guidanceTitle: undefined }}
+        onRemove={noop}
         onSubmit={noop}
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-        'DataBlock indicator',
-      );
-    });
-
-    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-      '608,180',
-    );
-    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-      'DataBlock trend',
-    );
+    expect(await screen.findByText('DataBlock indicator')).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {
         name: 'Help for DataBlock indicator',
       }),
     ).toBeInTheDocument();
-
     expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
       'DataBlock guidance text',
     );
-
-    expect(
-      screen.queryByRole('button', { name: /Remove/ }),
-    ).not.toBeInTheDocument();
   });
 
-  test('renders preview correctly without guidanceText', async () => {
+  test('does not render the guidance when `guidanceText` is undefined', async () => {
     tableBuilderService.getDataBlockTableData.mockResolvedValue(
       testTableDataResponse,
     );
@@ -212,39 +210,25 @@ describe('EditableKeyStatDataBlock', () => {
       <EditableKeyStatDataBlock
         releaseId="release-1"
         keyStat={{ ...keyStatDataBlock, guidanceText: undefined }}
+        onRemove={noop}
         onSubmit={noop}
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-        'DataBlock indicator',
-      );
-    });
-
-    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-      '608,180',
-    );
-    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-      'DataBlock trend',
-    );
+    expect(await screen.findByText('DataBlock indicator')).toBeInTheDocument();
 
     expect(
       screen.queryByRole('button', {
         name: 'DataBlock guidance title',
       }),
     ).not.toBeInTheDocument();
-
     expect(
       screen.queryByTestId('keyStat-guidanceText'),
     ).not.toBeInTheDocument();
-
-    expect(
-      screen.queryByRole('button', { name: /Remove/ }),
-    ).not.toBeInTheDocument();
   });
 
-  test('clicking `Remove` button calls `onRemove` handler', async () => {
+  test('clicking the remove button calls the `onRemove` handler', async () => {
+    const user = userEvent.setup();
     tableBuilderService.getDataBlockTableData.mockResolvedValue(
       testTableDataResponse,
     );
@@ -261,11 +245,9 @@ describe('EditableKeyStatDataBlock', () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByText(/Remove/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText('DataBlock indicator')).toBeInTheDocument();
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: 'Remove key statistic: DataBlock indicator',
       }),
@@ -276,282 +258,119 @@ describe('EditableKeyStatDataBlock', () => {
     });
   });
 
-  describe('when editing', () => {
-    test('renders edit form correctly', async () => {
-      tableBuilderService.getDataBlockTableData.mockResolvedValue(
-        testTableDataResponse,
-      );
+  test('clicking the edit button shows the form', async () => {
+    const user = userEvent.setup();
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
 
-      render(
-        <EditableKeyStatDataBlock
-          releaseId="release-1"
-          keyStat={keyStatDataBlock}
-          isEditing
-          onSubmit={noop}
-        />,
-      );
+    render(
+      <EditableKeyStatDataBlock
+        releaseId="release-1"
+        keyStat={keyStatDataBlock}
+        isEditing
+        onRemove={noop}
+        onSubmit={noop}
+      />,
+    );
 
-      await waitFor(() => {
-        expect(screen.getByText(/Edit/)).toBeInTheDocument();
-      });
+    expect(await screen.findByText('DataBlock indicator')).toBeInTheDocument();
 
-      await userEvent.click(
-        screen.getByRole('button', {
-          name: 'Edit key statistic: DataBlock indicator',
-        }),
-      );
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Edit key statistic: DataBlock indicator',
+      }),
+    );
 
-      await waitFor(() => {
-        expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-          'DataBlock indicator',
-        );
-      });
+    expect(await screen.findByLabelText('Trend')).toBeInTheDocument();
 
-      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-        '608,180',
-      );
+    expect(
+      screen.queryByRole('button', { name: /Edit/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Remove/ }),
+    ).not.toBeInTheDocument();
+  });
 
-      expect(screen.getByLabelText('Trend')).toHaveValue('DataBlock trend');
+  test('clicking the cancel button toggles back to preview', async () => {
+    const user = userEvent.setup();
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
 
-      expect(screen.getByLabelText('Guidance title')).toHaveValue(
-        'DataBlock guidance title',
-      );
+    render(
+      <EditableKeyStatDataBlock
+        releaseId="release-1"
+        keyStat={keyStatDataBlock}
+        isEditing
+        onRemove={noop}
+        onSubmit={noop}
+      />,
+    );
 
-      expect(screen.getByLabelText('Guidance text')).toHaveTextContent(
-        'DataBlock guidance text',
-      );
+    expect(await screen.findByText('DataBlock indicator')).toBeInTheDocument();
 
-      expect(screen.getByRole('button', { name: /Save/ })).toBeInTheDocument();
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Edit key statistic: DataBlock indicator',
+      }),
+    );
 
-      expect(
-        screen.getByRole('button', { name: /Cancel/ }),
-      ).toBeInTheDocument();
+    expect(await screen.findByLabelText('Trend')).toBeInTheDocument();
 
-      expect(
-        screen.queryByRole('button', {
-          name: 'Edit key statistic: Text title',
-        }),
-      ).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
-      expect(
-        screen.queryByRole('button', { name: /Remove/ }),
-      ).not.toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('button', {
+        name: 'Edit key statistic: DataBlock indicator',
+      }),
+    ).toBeInTheDocument();
 
-    test('submitting edit form calls `onSubmit` handler with updated values', async () => {
-      tableBuilderService.getDataBlockTableData.mockResolvedValue(
-        testTableDataResponse,
-      );
+    expect(screen.getByRole('button', { name: /Remove/ })).toBeInTheDocument();
 
-      const onSubmit = jest.fn();
+    expect(screen.queryByLabelText('Trend')).not.toBeInTheDocument();
+  });
 
-      render(
-        <EditableKeyStatDataBlock
-          releaseId="release-1"
-          keyStat={keyStatDataBlock}
-          isEditing
-          onSubmit={onSubmit}
-        />,
-      );
+  test('can click the remove button when data block fails to load', async () => {
+    const user = userEvent.setup();
+    tableBuilderService.getDataBlockTableData.mockRejectedValue(
+      new Error('Something went wrong'),
+    );
 
-      await waitFor(() => {
-        expect(screen.getByText(/Edit/)).toBeInTheDocument();
-      });
+    const onRemove = jest.fn();
 
-      await userEvent.click(
-        screen.getByRole('button', {
-          name: 'Edit key statistic: DataBlock indicator',
-        }),
-      );
+    render(
+      <EditableKeyStatDataBlock
+        releaseId="release-1"
+        keyStat={keyStatDataBlock}
+        onRemove={onRemove}
+        onSubmit={noop}
+      />,
+    );
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Trend')).toBeInTheDocument();
-      });
+    expect(
+      await screen.findByText('Could not load key statistic'),
+    ).toBeInTheDocument();
 
-      await userEvent.clear(screen.getByLabelText('Trend'));
-      await userEvent.type(screen.getByLabelText('Trend'), 'New trend');
+    expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('keyStat-statistic')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('keyStat-guidanceText'),
+    ).not.toBeInTheDocument();
 
-      await userEvent.clear(screen.getByLabelText('Guidance title'));
-      await userEvent.type(
-        screen.getByLabelText('Guidance title'),
-        'New guidance title',
-      );
+    expect(
+      screen.queryByRole('button', { name: 'Edit' }),
+    ).not.toBeInTheDocument();
 
-      await userEvent.clear(screen.getByLabelText('Guidance text'));
-      await userEvent.type(
-        screen.getByLabelText('Guidance text'),
-        'New guidance text',
-      );
+    expect(onRemove).not.toHaveBeenCalled();
 
-      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Remove key statistic',
+      }),
+    );
 
-      await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledWith<KeyStatDataBlockFormValues[]>({
-          trend: 'New trend',
-          guidanceTitle: 'New guidance title',
-          guidanceText: 'New guidance text',
-        });
-      });
-    });
-
-    test('submitting edit form calls `onSubmit` handler with trimmed updated guidance title', async () => {
-      tableBuilderService.getDataBlockTableData.mockResolvedValue(
-        testTableDataResponse,
-      );
-
-      const onSubmit = jest.fn();
-
-      render(
-        <EditableKeyStatDataBlock
-          releaseId="release-1"
-          keyStat={keyStatDataBlock}
-          isEditing
-          onSubmit={onSubmit}
-        />,
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText(/Edit/)).toBeInTheDocument();
-      });
-
-      await userEvent.click(
-        screen.getByRole('button', {
-          name: 'Edit key statistic: DataBlock indicator',
-        }),
-      );
-
-      await waitFor(() => {
-        expect(screen.getByLabelText('Trend')).toBeInTheDocument();
-      });
-
-      await userEvent.clear(screen.getByLabelText('Guidance title'));
-      await userEvent.type(
-        screen.getByLabelText('Guidance title'),
-        '  New guidance title  ',
-      );
-
-      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-      await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledWith<KeyStatDataBlockFormValues[]>({
-          trend: 'DataBlock trend',
-          guidanceTitle: 'New guidance title',
-          guidanceText: 'DataBlock guidance text',
-        });
-      });
-    });
-
-    test('clicking `Cancel` button toggles back to preview', async () => {
-      tableBuilderService.getDataBlockTableData.mockResolvedValue(
-        testTableDataResponse,
-      );
-
-      render(
-        <EditableKeyStatDataBlock
-          releaseId="release-1"
-          keyStat={keyStatDataBlock}
-          isEditing
-          onSubmit={noop}
-        />,
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText(/Edit/)).toBeInTheDocument();
-      });
-
-      await userEvent.click(
-        screen.getByRole('button', {
-          name: 'Edit key statistic: DataBlock indicator',
-        }),
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Cancel')).toBeInTheDocument();
-      });
-
-      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-
-      await waitFor(() => {
-        expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
-      });
-
-      expect(screen.queryByLabelText('Trend')).not.toBeInTheDocument();
-      expect(screen.queryByLabelText('Guidance title')).not.toBeInTheDocument();
-      expect(screen.queryByLabelText('Guidance text')).not.toBeInTheDocument();
-
-      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-        'DataBlock indicator',
-      );
-      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-        '608,180',
-      );
-      expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-        'DataBlock trend',
-      );
-
-      expect(
-        screen.getByRole('button', {
-          name: 'DataBlock guidance title',
-        }),
-      ).toBeInTheDocument();
-      expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
-        'DataBlock guidance text',
-      );
-
-      expect(
-        screen.queryByRole('button', { name: /Edit/ }),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole('button', { name: /Remove/ }),
-      ).not.toBeInTheDocument();
-
-      expect(
-        keyStatisticService.updateKeyStatisticDataBlock,
-      ).not.toHaveBeenCalled();
-    });
-
-    test('can click `Remove` button when data block fails to load', async () => {
-      tableBuilderService.getDataBlockTableData.mockRejectedValue(
-        new Error('Something went wrong'),
-      );
-
-      const onRemove = jest.fn();
-
-      render(
-        <EditableKeyStatDataBlock
-          releaseId="release-1"
-          keyStat={keyStatDataBlock}
-          onRemove={onRemove}
-          onSubmit={noop}
-        />,
-      );
-
-      await waitFor(() => {
-        expect(
-          screen.getByText('Could not load key statistic'),
-        ).toBeInTheDocument();
-      });
-
-      expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('keyStat-statistic')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
-      expect(
-        screen.queryByTestId('keyStat-guidanceText'),
-      ).not.toBeInTheDocument();
-
-      expect(
-        screen.queryByRole('button', { name: 'Edit' }),
-      ).not.toBeInTheDocument();
-
-      expect(onRemove).not.toHaveBeenCalled();
-
-      await userEvent.click(
-        screen.getByRole('button', {
-          name: 'Remove key statistic',
-        }),
-      );
-
-      expect(onRemove).toBeCalledTimes(1);
-    });
+    expect(onRemove).toBeCalledTimes(1);
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
@@ -1,6 +1,4 @@
 import EditableKeyStatDataBlock from '@admin/pages/release/content/components/EditableKeyStatDataBlock';
-import { KeyStatDataBlockFormValues } from '@admin/pages/release/content/components/EditableKeyStatDataBlockForm';
-import _keyStatisticService from '@admin/services/keyStatisticService';
 import { KeyStatisticDataBlock } from '@common/services/publicationService';
 import _tableBuilderService, {
   TableDataResponse,
@@ -11,10 +9,6 @@ import noop from 'lodash/noop';
 import React from 'react';
 
 jest.mock('@admin/services/keyStatisticService');
-const keyStatisticService = _keyStatisticService as jest.Mocked<
-  typeof _keyStatisticService
->;
-
 jest.mock('@common/services/tableBuilderService');
 const tableBuilderService = _tableBuilderService as jest.Mocked<
   typeof _tableBuilderService

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlockForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlockForm.test.tsx
@@ -1,0 +1,126 @@
+import EditableKeyStatDataBlockForm, {
+  KeyStatDataBlockFormValues,
+} from '@admin/pages/release/content/components/EditableKeyStatDataBlockForm';
+import { KeyStatisticDataBlock } from '@common/services/publicationService';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import React from 'react';
+
+describe('EditableKeyStatDataBlockForm', () => {
+  const keyStatDataBlock: KeyStatisticDataBlock = {
+    type: 'KeyStatisticDataBlock',
+    id: 'keyStatDataBlock-1',
+    trend: 'DataBlock trend',
+    guidanceTitle: 'DataBlock guidance title',
+    guidanceText: 'DataBlock guidance text',
+    order: 0,
+    created: '2023-01-01',
+    dataBlockParentId: 'block-1',
+  };
+
+  test('renders correctly', async () => {
+    render(
+      <EditableKeyStatDataBlockForm
+        keyStat={keyStatDataBlock}
+        statistic="Key stat statistic"
+        testId="test-id"
+        title="Key stat title"
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(screen.getByTestId('test-id-title')).toHaveTextContent(
+      'Key stat title',
+    );
+    expect(screen.getByTestId('test-id-statistic')).toHaveTextContent(
+      'Key stat statistic',
+    );
+    expect(screen.getByLabelText('Trend')).toHaveValue('DataBlock trend');
+    expect(screen.getByLabelText('Guidance title')).toHaveValue(
+      'DataBlock guidance title',
+    );
+    expect(screen.getByLabelText('Guidance text')).toHaveTextContent(
+      'DataBlock guidance text',
+    );
+
+    expect(screen.getByRole('button', { name: /Save/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Cancel/ })).toBeInTheDocument();
+  });
+
+  test('submitting the form calls `onSubmit` handler with updated values', async () => {
+    const user = userEvent.setup();
+
+    const handleSubmit = jest.fn();
+
+    render(
+      <EditableKeyStatDataBlockForm
+        keyStat={keyStatDataBlock}
+        statistic="Key stat statistic"
+        testId="test-id"
+        title="Key stat title"
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    await user.clear(screen.getByLabelText('Trend'));
+    await user.type(screen.getByLabelText('Trend'), 'New trend');
+
+    await user.clear(screen.getByLabelText('Guidance title'));
+    await user.type(
+      screen.getByLabelText('Guidance title'),
+      'New guidance title',
+    );
+
+    await user.clear(screen.getByLabelText('Guidance text'));
+    await user.type(
+      screen.getByLabelText('Guidance text'),
+      'New guidance text',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith<KeyStatDataBlockFormValues[]>({
+        trend: 'New trend',
+        guidanceTitle: 'New guidance title',
+        guidanceText: 'New guidance text',
+      });
+    });
+  });
+
+  test('submitting the form calls `onSubmit` handler with trimmed updated guidance title', async () => {
+    const user = userEvent.setup();
+
+    const handleSubmit = jest.fn();
+
+    render(
+      <EditableKeyStatDataBlockForm
+        keyStat={keyStatDataBlock}
+        statistic="Key stat statistic"
+        testId="test-id"
+        title="Key stat title"
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    await user.clear(screen.getByLabelText('Guidance title'));
+    await user.type(
+      screen.getByLabelText('Guidance title'),
+      '  New guidance title  ',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith<KeyStatDataBlockFormValues[]>({
+        trend: 'DataBlock trend',
+        guidanceTitle: 'New guidance title',
+        guidanceText: 'DataBlock guidance text',
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
@@ -1,16 +1,9 @@
 import EditableKeyStatText from '@admin/pages/release/content/components/EditableKeyStatText';
 import { KeyStatisticText } from '@common/services/publicationService';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import noop from 'lodash/noop';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { KeyStatTextFormValues } from '@admin/pages/release/content/components/EditableKeyStatTextForm';
-import _keyStatisticService from '@admin/services/keyStatisticService';
-
-jest.mock('@admin/services/keyStatisticService');
-const keyStatisticService = _keyStatisticService as jest.Mocked<
-  typeof _keyStatisticService
->;
 
 describe('EditableKeyStatText', () => {
   const keyStatText: KeyStatisticText = {
@@ -25,101 +18,10 @@ describe('EditableKeyStatText', () => {
     statistic: 'Over 9000',
   };
 
-  test('renders preview correctly', async () => {
-    render(<EditableKeyStatText keyStat={keyStatText} onSubmit={noop} />);
-
-    expect(screen.getByTestId('keyStat-title')).toHaveTextContent('Text title');
-
-    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-      'Over 9000',
-    );
-
-    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent('Text trend');
-
-    expect(
-      screen.getByRole('button', {
-        name: 'Text guidance title',
-      }),
-    ).toBeInTheDocument();
-
-    expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
-      'Text guidance text',
-    );
-
-    expect(
-      screen.queryByRole('button', { name: /Edit/ }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: /Remove/ }),
-    ).not.toBeInTheDocument();
-  });
-
-  test('renders preview correctly without trend', async () => {
+  test('renders correctly when `isEditing` is false', async () => {
     render(
       <EditableKeyStatText
-        keyStat={{ ...keyStatText, trend: undefined }}
-        onSubmit={noop}
-      />,
-    );
-
-    expect(screen.getByTestId('keyStat-title')).toHaveTextContent('Text title');
-
-    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-      'Over 9000',
-    );
-
-    expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
-
-    expect(
-      screen.getByRole('button', {
-        name: 'Text guidance title',
-      }),
-    ).toBeInTheDocument();
-
-    expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
-      'Text guidance text',
-    );
-
-    expect(
-      screen.queryByRole('button', { name: 'Remove' }),
-    ).not.toBeInTheDocument();
-  });
-
-  test('renders preview correctly without guidanceTitle', async () => {
-    render(
-      <EditableKeyStatText
-        keyStat={{ ...keyStatText, guidanceTitle: undefined }}
-        onSubmit={noop}
-      />,
-    );
-
-    expect(screen.getByTestId('keyStat-title')).toHaveTextContent('Text title');
-
-    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-      'Over 9000',
-    );
-
-    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent('Text trend');
-
-    expect(
-      screen.getByRole('button', {
-        name: 'Help for Text title',
-      }),
-    ).toBeInTheDocument();
-
-    expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
-      'Text guidance text',
-    );
-
-    expect(
-      screen.queryByRole('button', { name: /Remove/ }),
-    ).not.toBeInTheDocument();
-  });
-
-  test('renders preview correctly without guidanceText', async () => {
-    render(
-      <EditableKeyStatText
-        keyStat={{ ...keyStatText, guidanceText: undefined }}
+        keyStat={keyStatText}
         onRemove={noop}
         onSubmit={noop}
       />,
@@ -134,6 +36,97 @@ describe('EditableKeyStatText', () => {
     expect(screen.getByTestId('keyStat-trend')).toHaveTextContent('Text trend');
 
     expect(
+      screen.getByRole('button', {
+        name: 'Text guidance title',
+      }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
+      'Text guidance text',
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /Edit/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Remove/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly when `isEditing` is true', async () => {
+    render(
+      <EditableKeyStatText
+        isEditing
+        keyStat={keyStatText}
+        onRemove={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(screen.getByTestId('keyStat-title')).toHaveTextContent('Text title');
+
+    expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
+      'Over 9000',
+    );
+
+    expect(screen.getByTestId('keyStat-trend')).toHaveTextContent('Text trend');
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Text guidance title',
+      }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
+      'Text guidance text',
+    );
+
+    expect(screen.getByRole('button', { name: /Edit/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Remove/ })).toBeInTheDocument();
+  });
+
+  test('does not render the trend when `trend` is undefined', async () => {
+    render(
+      <EditableKeyStatText
+        keyStat={{ ...keyStatText, trend: undefined }}
+        onRemove={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(screen.queryByTestId('keyStat-trend')).not.toBeInTheDocument();
+  });
+
+  test('renders the default guidance title when `guidanceTitle` is undefined', async () => {
+    render(
+      <EditableKeyStatText
+        keyStat={{ ...keyStatText, guidanceTitle: undefined }}
+        onRemove={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Help for Text title',
+      }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
+      'Text guidance text',
+    );
+  });
+
+  test('does not render the guidance when `guidanceText` is undefined', async () => {
+    render(
+      <EditableKeyStatText
+        keyStat={{ ...keyStatText, guidanceText: undefined }}
+        onRemove={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(
       screen.queryByRole('button', {
         name: 'Text guidance title',
       }),
@@ -142,9 +135,44 @@ describe('EditableKeyStatText', () => {
     expect(
       screen.queryByTestId('keyStat-guidanceText'),
     ).not.toBeInTheDocument();
+  });
+
+  test('clicking the edit button shows the form', async () => {
+    const user = userEvent.setup();
+    render(
+      <EditableKeyStatText
+        keyStat={keyStatText}
+        isEditing
+        onRemove={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Edit key statistic: Text title',
+      }),
+    );
+
+    expect(await screen.findByLabelText('Title')).toBeInTheDocument();
+
+    expect(screen.getByLabelText('Title')).toHaveValue('Text title');
+    expect(screen.getByLabelText('Statistic')).toHaveValue('Over 9000');
+    expect(screen.getByLabelText('Trend')).toHaveValue('Text trend');
+    expect(screen.getByLabelText('Guidance title')).toHaveValue(
+      'Text guidance title',
+    );
+    expect(screen.getByLabelText('Guidance text')).toHaveTextContent(
+      'Text guidance text',
+    );
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
 
     expect(
-      screen.queryByRole('button', { name: /Edit/ }),
+      screen.queryByRole('button', {
+        name: 'Edit key statistic: Text title',
+      }),
     ).not.toBeInTheDocument();
 
     expect(
@@ -152,202 +180,62 @@ describe('EditableKeyStatText', () => {
     ).not.toBeInTheDocument();
   });
 
-  describe('when editing', () => {
-    test('renders edit form correctly', async () => {
-      render(
-        <EditableKeyStatText keyStat={keyStatText} isEditing onSubmit={noop} />,
-      );
+  test('clicking the cancel button toggles back to preview', async () => {
+    const user = userEvent.setup();
+    render(
+      <EditableKeyStatText
+        keyStat={keyStatText}
+        isEditing
+        onRemove={noop}
+        onSubmit={noop}
+      />,
+    );
 
-      expect(screen.getByText(/Edit/)).toBeInTheDocument();
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Edit key statistic: Text title',
+      }),
+    );
 
-      await userEvent.click(
-        screen.getByRole('button', {
-          name: 'Edit key statistic: Text title',
-        }),
-      );
+    expect(await screen.findByLabelText('Title')).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Title')).toHaveValue('Text title');
-      });
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Cancel',
+      }),
+    );
 
-      expect(screen.getByLabelText('Statistic')).toHaveValue('Over 9000');
-      expect(screen.getByLabelText('Trend')).toHaveValue('Text trend');
+    expect(
+      await screen.findByRole('button', {
+        name: 'Edit key statistic: Text title',
+      }),
+    ).toBeInTheDocument();
 
-      expect(screen.getByLabelText('Guidance title')).toHaveValue(
-        'Text guidance title',
-      );
+    expect(screen.getByRole('button', { name: /Remove/ })).toBeInTheDocument();
 
-      expect(screen.getByLabelText('Guidance text')).toHaveTextContent(
-        'Text guidance text',
-      );
+    expect(screen.queryByLabelText('Title')).not.toBeInTheDocument();
+  });
 
-      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', { name: 'Cancel' }),
-      ).toBeInTheDocument();
+  test('clicking the remove button calls the onRemove handler', async () => {
+    const handleOnRemove = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <EditableKeyStatText
+        keyStat={keyStatText}
+        isEditing
+        onRemove={handleOnRemove}
+        onSubmit={noop}
+      />,
+    );
 
-      expect(
-        screen.queryByRole('button', {
-          name: 'Edit key statistic: Text title',
-        }),
-      ).not.toBeInTheDocument();
+    expect(handleOnRemove).not.toHaveBeenCalled();
 
-      expect(
-        screen.queryByRole('button', { name: /Remove/ }),
-      ).not.toBeInTheDocument();
-    });
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Remove key statistic: Text title',
+      }),
+    );
 
-    test('submitting edit form calls `onSubmit` handler with updated values', async () => {
-      const onSubmit = jest.fn();
-
-      render(
-        <EditableKeyStatText
-          keyStat={keyStatText}
-          isEditing
-          onSubmit={onSubmit}
-        />,
-      );
-
-      expect(screen.getByText(/Edit/)).toBeInTheDocument();
-
-      await userEvent.click(
-        screen.getByRole('button', {
-          name: 'Edit key statistic: Text title',
-        }),
-      );
-
-      await waitFor(() => {
-        expect(screen.getByLabelText('Title')).toBeInTheDocument();
-      });
-
-      await userEvent.clear(screen.getByLabelText('Title'));
-      await userEvent.type(screen.getByLabelText('Title'), 'New title');
-
-      await userEvent.clear(screen.getByLabelText('Statistic'));
-      await userEvent.type(screen.getByLabelText('Statistic'), 'New stat');
-
-      await userEvent.clear(screen.getByLabelText('Trend'));
-      await userEvent.type(screen.getByLabelText('Trend'), 'New trend');
-
-      await userEvent.clear(screen.getByLabelText('Guidance title'));
-      await userEvent.type(
-        screen.getByLabelText('Guidance title'),
-        'New guidance title',
-      );
-
-      await userEvent.clear(screen.getByLabelText('Guidance text'));
-      await userEvent.type(
-        screen.getByLabelText('Guidance text'),
-        'New guidance text',
-      );
-
-      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-      await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledWith<KeyStatTextFormValues[]>({
-          title: 'New title',
-          statistic: 'New stat',
-          trend: 'New trend',
-          guidanceTitle: 'New guidance title',
-          guidanceText: 'New guidance text',
-        });
-      });
-    });
-
-    test('submitting edit form calls `onSubmit` handler with trimmed updated guidance title', async () => {
-      const onSubmit = jest.fn();
-
-      render(
-        <EditableKeyStatText
-          keyStat={keyStatText}
-          isEditing
-          onSubmit={onSubmit}
-        />,
-      );
-
-      await userEvent.click(
-        screen.getByRole('button', {
-          name: 'Edit key statistic: Text title',
-        }),
-      );
-
-      await waitFor(() => {
-        expect(screen.getByLabelText('Title')).toBeInTheDocument();
-      });
-
-      await userEvent.clear(screen.getByLabelText('Guidance title'));
-      await userEvent.type(
-        screen.getByLabelText('Guidance title'),
-        '   New guidance title  ',
-      );
-
-      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-      await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledWith<KeyStatTextFormValues[]>({
-          title: 'Text title',
-          statistic: 'Over 9000',
-          trend: 'Text trend',
-          guidanceTitle: 'New guidance title',
-          guidanceText: 'Text guidance text',
-        });
-      });
-    });
-
-    test('clicking `Cancel` button toggles back to preview', async () => {
-      render(
-        <EditableKeyStatText keyStat={keyStatText} isEditing onSubmit={noop} />,
-      );
-
-      expect(screen.getByText(/Edit/)).toBeInTheDocument();
-
-      await userEvent.click(
-        screen.getByRole('button', {
-          name: 'Edit key statistic: Text title',
-        }),
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Cancel')).toBeInTheDocument();
-      });
-
-      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-
-      await waitFor(() => {
-        expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
-      });
-
-      expect(screen.queryByLabelText('Trend')).not.toBeInTheDocument();
-      expect(screen.queryByLabelText('Guidance title')).not.toBeInTheDocument();
-      expect(screen.queryByLabelText('Guidance text')).not.toBeInTheDocument();
-
-      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
-        'Text title',
-      );
-      expect(screen.getByTestId('keyStat-statistic')).toHaveTextContent(
-        'Over 9000',
-      );
-      expect(screen.getByTestId('keyStat-trend')).toHaveTextContent(
-        'Text trend',
-      );
-
-      expect(
-        screen.getByRole('button', {
-          name: 'Text guidance title',
-        }),
-      ).toBeInTheDocument();
-      expect(screen.getByTestId('keyStat-guidanceText')).toHaveTextContent(
-        'Text guidance text',
-      );
-
-      expect(
-        screen.queryByRole('button', { name: /Edit/ }),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole('button', { name: /Remove/ }),
-      ).not.toBeInTheDocument();
-
-      expect(keyStatisticService.updateKeyStatisticText).not.toHaveBeenCalled();
-    });
+    expect(handleOnRemove).toHaveBeenCalled();
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatTextForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatTextForm.test.tsx
@@ -1,0 +1,194 @@
+import EditableKeyStatTextForm, {
+  KeyStatTextFormValues,
+} from '@admin/pages/release/content/components/EditableKeyStatTextForm';
+import { KeyStatisticText } from '@common/services/publicationService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import noop from 'lodash/noop';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+describe('EditableKeyStatTextForm', () => {
+  const keyStatText: KeyStatisticText = {
+    type: 'KeyStatisticText',
+    id: 'keyStatDataBlock-1',
+    trend: 'Text trend',
+    guidanceTitle: 'Text guidance title',
+    guidanceText: 'Text guidance text',
+    order: 0,
+    created: '2023-01-01',
+    title: 'Text title',
+    statistic: 'Over 9000',
+  };
+
+  test('renders correctly without initial values', async () => {
+    render(
+      <EditableKeyStatTextForm
+        testId="test-id"
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(screen.getByLabelText('Title')).not.toHaveValue();
+    expect(screen.getByLabelText('Statistic')).not.toHaveValue();
+    expect(screen.getByLabelText('Trend')).not.toHaveValue();
+    expect(screen.getByLabelText('Guidance title')).toHaveValue('Help');
+    expect(screen.getByLabelText('Guidance text')).not.toHaveValue();
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  test('renders correctly with initial values', async () => {
+    render(
+      <EditableKeyStatTextForm
+        keyStat={keyStatText}
+        testId="test-id"
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(screen.getByLabelText('Title')).toHaveValue('Text title');
+    expect(screen.getByLabelText('Statistic')).toHaveValue('Over 9000');
+    expect(screen.getByLabelText('Trend')).toHaveValue('Text trend');
+    expect(screen.getByLabelText('Guidance title')).toHaveValue(
+      'Text guidance title',
+    );
+    expect(screen.getByLabelText('Guidance text')).toHaveTextContent(
+      'Text guidance text',
+    );
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  test('submitting form calls `onSubmit` handler with updated values', async () => {
+    const user = userEvent.setup();
+    const handleSubmit = jest.fn();
+
+    render(
+      <EditableKeyStatTextForm
+        keyStat={keyStatText}
+        testId="test-id"
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'New title');
+
+    await user.clear(screen.getByLabelText('Statistic'));
+    await user.type(screen.getByLabelText('Statistic'), 'New stat');
+
+    await user.clear(screen.getByLabelText('Trend'));
+    await user.type(screen.getByLabelText('Trend'), 'New trend');
+
+    await user.clear(screen.getByLabelText('Guidance title'));
+    await user.type(
+      screen.getByLabelText('Guidance title'),
+      'New guidance title',
+    );
+
+    await user.clear(screen.getByLabelText('Guidance text'));
+    await user.type(
+      screen.getByLabelText('Guidance text'),
+      'New guidance text',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith<KeyStatTextFormValues[]>({
+        title: 'New title',
+        statistic: 'New stat',
+        trend: 'New trend',
+        guidanceTitle: 'New guidance title',
+        guidanceText: 'New guidance text',
+      });
+    });
+  });
+
+  test('submitting form calls `onSubmit` handler with trimmed updated guidance title', async () => {
+    const user = userEvent.setup();
+    const handleSubmit = jest.fn();
+
+    render(
+      <EditableKeyStatTextForm
+        keyStat={keyStatText}
+        testId="test-id"
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    await user.clear(screen.getByLabelText('Guidance title'));
+    await user.type(
+      screen.getByLabelText('Guidance title'),
+      '   New guidance title  ',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith<KeyStatTextFormValues[]>({
+        title: 'Text title',
+        statistic: 'Over 9000',
+        trend: 'Text trend',
+        guidanceTitle: 'New guidance title',
+        guidanceText: 'Text guidance text',
+      });
+    });
+  });
+
+  test('shows a validation error if submit without a title', async () => {
+    const user = userEvent.setup();
+    const handleSubmit = jest.fn();
+
+    render(
+      <EditableKeyStatTextForm
+        testId="test-id"
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('There is a problem')).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('errorSummary')).getByRole('link', {
+        name: 'Enter a title',
+      }),
+    ).toHaveAttribute('href', '#editableKeyStatTextForm-create-title');
+    expect(
+      screen.getByTestId('editableKeyStatTextForm-create-title-error'),
+    ).toHaveTextContent('Enter a title');
+  });
+
+  test('shows a validation error if submit without a statistic', async () => {
+    const user = userEvent.setup();
+    const handleSubmit = jest.fn();
+
+    render(
+      <EditableKeyStatTextForm
+        testId="test-id"
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('There is a problem')).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('errorSummary')).getByRole('link', {
+        name: 'Enter a statistic',
+      }),
+    ).toHaveAttribute('href', '#editableKeyStatTextForm-create-statistic');
+    expect(
+      screen.getByTestId('editableKeyStatTextForm-create-statistic-error'),
+    ).toHaveTextContent('Enter a statistic');
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/RelatedPagesSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/RelatedPagesSection.test.tsx
@@ -1,0 +1,275 @@
+import RelatedPagesSection from '@admin/pages/release/content/components/RelatedPagesSection';
+import { EditingContextProvider } from '@admin/contexts/EditingContext';
+import _releaseContentRelatedInformationService from '@admin/services/releaseContentRelatedInformationService';
+import { generateEditableRelease } from '@admin-test/generators/releaseContentGenerators';
+import { BasicLink } from '@common/services/publicationService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+jest.mock('@admin/services/releaseContentRelatedInformationService');
+const releaseContentRelatedInformationService =
+  _releaseContentRelatedInformationService as jest.Mocked<
+    typeof _releaseContentRelatedInformationService
+  >;
+
+describe('RelatedPagesSection', () => {
+  const testRelease = generateEditableRelease({});
+  const testReleaseWithNoRelatedPages = generateEditableRelease({
+    relatedInformation: [],
+  });
+
+  describe('editing mode', () => {
+    test('renders correctly with related pages', () => {
+      render(
+        <EditingContextProvider editingMode="edit">
+          <RelatedPagesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+      expect(
+        screen.getByRole('heading', { name: 'Related pages' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Add related page link' }),
+      ).toBeInTheDocument();
+      const pages = screen.getAllByRole('listitem');
+      expect(pages).toHaveLength(1);
+      expect(
+        within(pages[0]).getByRole('link', {
+          name: 'Related information description',
+        }),
+      ).toHaveAttribute('href', 'https://test.com');
+      expect(
+        within(pages[0]).getByRole('button', { name: 'Remove link' }),
+      ).toBeInTheDocument();
+    });
+
+    test('renders correctly without related pages', () => {
+      render(
+        <EditingContextProvider editingMode="edit">
+          <RelatedPagesSection release={testReleaseWithNoRelatedPages} />
+        </EditingContextProvider>,
+      );
+      expect(
+        screen.getByRole('heading', { name: 'Related pages' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Add related page link' }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+    });
+
+    test('shows the form when click the add button', async () => {
+      const user = userEvent.setup();
+      render(
+        <EditingContextProvider editingMode="edit">
+          <RelatedPagesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'Add related page link' }),
+      );
+
+      expect(screen.getByLabelText('Title')).toBeInTheDocument();
+      expect(screen.getByLabelText('Link URL')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Create link' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Cancel' }),
+      ).toBeInTheDocument();
+    });
+
+    test('shows a validation error when no title is set', async () => {
+      const user = userEvent.setup();
+      render(
+        <EditingContextProvider editingMode="edit">
+          <RelatedPagesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'Add related page link' }),
+      );
+
+      await user.click(screen.getByLabelText('Title'));
+      await user.tab();
+
+      await waitFor(() => {
+        expect(screen.getByText('There is a problem')).toBeInTheDocument();
+        expect(
+          screen.getByRole('link', {
+            name: 'Enter a link title',
+          }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('shows a validation error when no url is set', async () => {
+      const user = userEvent.setup();
+      render(
+        <EditingContextProvider editingMode="edit">
+          <RelatedPagesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'Add related page link' }),
+      );
+
+      await user.click(screen.getByLabelText('Link URL'));
+      await user.tab();
+
+      await waitFor(() => {
+        expect(screen.getByText('There is a problem')).toBeInTheDocument();
+        expect(
+          screen.getByRole('link', {
+            name: 'Enter a link URL',
+          }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('shows a validation error when the url is invalid', async () => {
+      const user = userEvent.setup();
+      render(
+        <EditingContextProvider editingMode="edit">
+          <RelatedPagesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'Add related page link' }),
+      );
+
+      await userEvent.type(screen.getByLabelText('Link URL'), 'Not a url');
+      await userEvent.tab();
+
+      await waitFor(() => {
+        expect(screen.getByText('There is a problem')).toBeInTheDocument();
+        expect(
+          screen.getByRole('link', {
+            name: 'Enter a valid link URL',
+          }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('successfully adds a link', async () => {
+      const newLinks: BasicLink[] = [
+        { ...testRelease.relatedInformation[0] },
+        { description: 'Test title', id: 'test-id', url: 'https://gov.uk' },
+      ];
+      releaseContentRelatedInformationService.create.mockResolvedValue(
+        newLinks,
+      );
+      const user = userEvent.setup();
+      render(
+        <EditingContextProvider editingMode="edit">
+          <RelatedPagesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'Add related page link' }),
+      );
+
+      await user.type(screen.getByLabelText('Title'), 'Test title');
+      await user.type(screen.getByLabelText('Link URL'), 'https://gov.uk');
+      await user.click(screen.getByRole('button', { name: 'Create link' }));
+
+      expect(
+        await screen.findByRole('button', { name: 'Add related page link' }),
+      );
+
+      const pages = screen.getAllByRole('listitem');
+      expect(pages).toHaveLength(2);
+      expect(
+        within(pages[0]).getByRole('link', {
+          name: 'Related information description',
+        }),
+      ).toHaveAttribute('href', 'https://test.com');
+      expect(
+        within(pages[0]).getByRole('button', { name: 'Remove link' }),
+      ).toBeInTheDocument();
+
+      expect(
+        within(pages[1]).getByRole('link', {
+          name: 'Test title',
+        }),
+      ).toHaveAttribute('href', 'https://gov.uk');
+      expect(
+        within(pages[1]).getByRole('button', { name: 'Remove link' }),
+      ).toBeInTheDocument();
+    });
+
+    test('successfully removes a link', async () => {
+      releaseContentRelatedInformationService.delete.mockResolvedValue([]);
+      const user = userEvent.setup();
+      render(
+        <EditingContextProvider editingMode="edit">
+          <RelatedPagesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      const pages = screen.getAllByRole('listitem');
+      expect(pages).toHaveLength(1);
+      expect(
+        within(pages[0]).getByRole('link', {
+          name: 'Related information description',
+        }),
+      ).toHaveAttribute('href', 'https://test.com');
+
+      await user.click(
+        within(pages[0]).getByRole('button', { name: 'Remove link' }),
+      );
+
+      waitFor(() =>
+        expect(screen.queryByRole('listitem')).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe('preview mode', () => {
+    test('renders correctly with related pages', () => {
+      render(
+        <EditingContextProvider editingMode="preview">
+          <RelatedPagesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+      expect(
+        screen.getByRole('heading', { name: 'Related pages' }),
+      ).toBeInTheDocument();
+      const pages = screen.getAllByRole('listitem');
+      expect(pages).toHaveLength(1);
+      expect(
+        within(pages[0]).getByRole('link', {
+          name: 'Related information description',
+        }),
+      ).toHaveAttribute('href', 'https://test.com');
+
+      expect(
+        screen.queryByRole('button', { name: 'Remove link' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Add related page link' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('renders correctly without related pages', () => {
+      render(
+        <EditingContextProvider editingMode="preview">
+          <RelatedPagesSection release={testReleaseWithNoRelatedPages} />
+        </EditingContextProvider>,
+      );
+      expect(
+        screen.queryByRole('heading', { name: 'Related pages' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Add related page link' }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseNote.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseNote.test.tsx
@@ -1,0 +1,168 @@
+import ReleaseNote from '@admin/pages/release/content/components/ReleaseNote';
+import { ReleaseNote as ReleaseNoteData } from '@common/services/publicationService';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import React from 'react';
+
+describe('ReleaseNote', () => {
+  const testReleaseNote: ReleaseNoteData = {
+    id: 'test-id',
+    on: new Date('2024-01-01'),
+    reason: 'Test note',
+  };
+
+  describe('is editable', () => {
+    test('renders correctly', () => {
+      render(
+        <ReleaseNote
+          isEditable
+          releaseNote={testReleaseNote}
+          onDelete={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      expect(screen.getByText('1 January 2024')).toBeInTheDocument();
+      expect(screen.getByText('Test note')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Edit note' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Remove note' }),
+      ).toBeInTheDocument();
+    });
+
+    test('clicking the edit button shows the edit form', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReleaseNote
+          isEditable
+          releaseNote={testReleaseNote}
+          onDelete={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Edit note' }));
+
+      expect(
+        screen.getByRole('group', { name: 'Edit date' }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText('Edit release note')).toHaveValue(
+        'Test note',
+      );
+      expect(
+        screen.getByRole('button', { name: 'Update note' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Cancel' }),
+      ).toBeInTheDocument();
+    });
+
+    test('clicking the cancel editing button hides the edit form', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReleaseNote
+          isEditable
+          releaseNote={testReleaseNote}
+          onDelete={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Edit note' }));
+
+      expect(
+        screen.getByRole('group', { name: 'Edit date' }),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(
+        screen.queryByRole('group', { name: 'Edit date' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('submitting the edit form calls onSubmit', async () => {
+      const user = userEvent.setup();
+      const handleSubmit = jest.fn();
+      render(
+        <ReleaseNote
+          isEditable
+          releaseNote={testReleaseNote}
+          onDelete={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Edit note' }));
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole('button', { name: 'Update note' }));
+
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+      expect(handleSubmit).toHaveBeenCalledWith('test-id', {
+        on: new Date('2024-01-01'),
+        reason: 'Test note',
+      });
+    });
+
+    test('clicking the remove button shows a modal and calls onDelete when it is confirmed', async () => {
+      const user = userEvent.setup();
+      const handleDelete = jest.fn();
+      render(
+        <ReleaseNote
+          isEditable
+          releaseNote={testReleaseNote}
+          onDelete={handleDelete}
+          onSubmit={noop}
+        />,
+      );
+
+      expect(handleDelete).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole('button', { name: 'Remove note' }));
+
+      const modal = within(screen.getByRole('dialog'));
+      expect(
+        modal.getByRole('heading', {
+          name: 'Confirm deletion of release note',
+        }),
+      ).toBeInTheDocument();
+
+      await user.click(
+        modal.getByRole('button', {
+          name: 'Confirm',
+        }),
+      );
+
+      expect(handleDelete).toHaveBeenCalledTimes(1);
+      expect(handleDelete).toHaveBeenCalledWith('test-id');
+    });
+  });
+
+  describe('is not editable', () => {
+    test('renders correctly', () => {
+      render(
+        <ReleaseNote
+          isEditable={false}
+          releaseNote={testReleaseNote}
+          onDelete={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      expect(screen.getByText('1 January 2024')).toBeInTheDocument();
+      expect(screen.getByText('Test note')).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', { name: 'Edit note' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Remove note' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseNoteForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseNoteForm.test.tsx
@@ -1,0 +1,203 @@
+import ReleaseNoteForm from '@admin/pages/release/content/components/ReleaseNoteForm';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import React from 'react';
+
+describe('ReleaseNoteForm', () => {
+  describe('creating a release note', () => {
+    test('renders the form correctly', () => {
+      render(
+        <ReleaseNoteForm
+          id="test-id"
+          initialValues={{ reason: '' }}
+          onCancel={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      expect(screen.getByLabelText('New release note')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Save note' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Cancel' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('group', { name: 'Edit date' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('shows a validation error if no reason is given', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReleaseNoteForm
+          id="test-id"
+          initialValues={{ reason: '' }}
+          onCancel={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      await user.click(screen.getByLabelText('New release note'));
+      await user.tab();
+
+      expect(await screen.findByText('There is a problem')).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('link', {
+          name: 'Release note must be provided',
+        }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByTestId('test-id-reason-error')).toHaveTextContent(
+        'Release note must be provided',
+      );
+    });
+
+    test('submits successfully', async () => {
+      const user = userEvent.setup();
+      const handleSubmit = jest.fn();
+      render(
+        <ReleaseNoteForm
+          id="test-id"
+          initialValues={{ reason: '' }}
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      await user.type(screen.getByLabelText('New release note'), 'Test note');
+      await user.click(screen.getByRole('button', { name: 'Save note' }));
+
+      await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
+      expect(handleSubmit).toHaveBeenCalledWith({ reason: 'Test note' });
+    });
+  });
+
+  describe('editing a release note', () => {
+    test('renders the form correctly with initial values', () => {
+      render(
+        <ReleaseNoteForm
+          id="test-id"
+          initialValues={{ on: new Date('2024-01-01'), reason: 'Test note' }}
+          onCancel={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      expect(
+        screen.getByRole('group', { name: 'Edit date' }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText('Day')).toHaveValue(1);
+      expect(screen.getByLabelText('Month')).toHaveValue(1);
+      expect(screen.getByLabelText('Year')).toHaveValue(2024);
+      expect(screen.getByLabelText('Edit release note')).toHaveValue(
+        'Test note',
+      );
+      expect(
+        screen.getByRole('button', { name: 'Update note' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Cancel' }),
+      ).toBeInTheDocument();
+    });
+
+    test('shows a validation error if no reason is given', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReleaseNoteForm
+          id="test-id"
+          initialValues={{ on: new Date('2024-01-01'), reason: 'Test note' }}
+          onCancel={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      await user.clear(screen.getByLabelText('Edit release note'));
+      await user.tab();
+
+      expect(await screen.findByText('There is a problem')).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('link', {
+          name: 'Release note must be provided',
+        }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByTestId('test-id-reason-error')).toHaveTextContent(
+        'Release note must be provided',
+      );
+    });
+
+    test('shows a validation error if no date is given', async () => {
+      const user = userEvent.setup();
+      render(
+        <ReleaseNoteForm
+          id="test-id"
+          initialValues={{ on: new Date('2024-01-01'), reason: 'Test note' }}
+          onCancel={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      await user.clear(screen.getByLabelText('Day'));
+      await user.clear(screen.getByLabelText('Month'));
+      await user.clear(screen.getByLabelText('Year'));
+      await user.tab();
+
+      expect(await screen.findByText('There is a problem')).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('link', {
+          name: 'Enter a valid edit date',
+        }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByTestId('test-id-on-error')).toHaveTextContent(
+        'Enter a valid edit date',
+      );
+    });
+
+    test('submits successfully with updated values', async () => {
+      const user = userEvent.setup();
+      const handleSubmit = jest.fn();
+      render(
+        <ReleaseNoteForm
+          id="test-id"
+          initialValues={{ on: new Date('2024-01-01'), reason: 'Test note' }}
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      await user.clear(screen.getByLabelText('Day'));
+      await user.type(screen.getByLabelText('Day'), '22');
+
+      await user.clear(screen.getByLabelText('Month'));
+      await user.type(screen.getByLabelText('Month'), '02');
+
+      await user.clear(screen.getByLabelText('Year'));
+      await user.type(screen.getByLabelText('Year'), '2025');
+
+      await user.clear(screen.getByLabelText('Edit release note'));
+      await user.type(
+        screen.getByLabelText('Edit release note'),
+        'Updated test note',
+      );
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole('button', { name: 'Update note' }));
+
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+      expect(handleSubmit).toHaveBeenCalledWith({
+        on: new Date('2025-02-22'),
+        reason: 'Updated test note',
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseNotesSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseNotesSection.test.tsx
@@ -1,0 +1,265 @@
+import ReleaseNotesSection from '@admin/pages/release/content/components/ReleaseNotesSection';
+import { EditingContextProvider } from '@admin/contexts/EditingContext';
+import _releaseNoteService from '@admin/services/releaseNoteService';
+import { generateEditableRelease } from '@admin-test/generators/releaseContentGenerators';
+import { ReleaseNote as ReleaseNoteData } from '@common/services/publicationService';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+jest.mock('@admin/services/releaseNoteService');
+const releaseNoteService = _releaseNoteService as jest.Mocked<
+  typeof _releaseNoteService
+>;
+
+describe('ReleaseNote', () => {
+  const testReleaseNotes: ReleaseNoteData[] = [
+    {
+      id: 'test-id-2',
+      on: new Date('2024-02-02'),
+      reason: 'Test note 2',
+    },
+    {
+      id: 'test-id-1',
+      on: new Date('2024-01-01'),
+      reason: 'Test note 1',
+    },
+  ];
+  const testRelease = generateEditableRelease({ updates: testReleaseNotes });
+
+  describe('is editable', () => {
+    test('renders correctly', () => {
+      render(
+        <EditingContextProvider editingMode="edit">
+          <ReleaseNotesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'See all updates (2)' }),
+      ).toBeInTheDocument();
+
+      const updates = screen.getAllByRole('listitem');
+      expect(updates).toHaveLength(2);
+
+      expect(
+        within(updates[0]).getByText('2 February 2024'),
+      ).toBeInTheDocument();
+      expect(within(updates[0]).getByText('Test note 2')).toBeInTheDocument();
+      expect(
+        within(updates[0]).getByRole('button', { name: 'Edit note' }),
+      ).toBeInTheDocument();
+      expect(
+        within(updates[0]).getByRole('button', { name: 'Remove note' }),
+      ).toBeInTheDocument();
+
+      expect(
+        within(updates[1]).getByText('1 January 2024'),
+      ).toBeInTheDocument();
+      expect(within(updates[1]).getByText('Test note 1')).toBeInTheDocument();
+      expect(
+        within(updates[1]).getByRole('button', { name: 'Edit note' }),
+      ).toBeInTheDocument();
+      expect(
+        within(updates[1]).getByRole('button', { name: 'Remove note' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', { name: 'Add note' }),
+      ).toBeInTheDocument();
+    });
+
+    test('clicking the add note button shows the form', async () => {
+      const user = userEvent.setup();
+      render(
+        <EditingContextProvider editingMode="edit">
+          <ReleaseNotesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Add note' }));
+
+      expect(screen.getByLabelText('New release note')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Save note' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Cancel' }),
+      ).toBeInTheDocument();
+    });
+
+    test('adding a note calls the releaseNoteService and updates the notes list', async () => {
+      const user = userEvent.setup();
+      releaseNoteService.create.mockResolvedValue([
+        { id: 'test-id-3', on: new Date('2024-03-04'), reason: 'Test note 3' },
+        ...testReleaseNotes,
+      ]);
+      render(
+        <EditingContextProvider editingMode="edit">
+          <ReleaseNotesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Add note' }));
+
+      expect(releaseNoteService.create).not.toHaveBeenCalled();
+
+      await user.type(screen.getByLabelText('New release note'), 'Test note 3');
+      await user.click(screen.getByRole('button', { name: 'Save note' }));
+
+      expect(releaseNoteService.create).toHaveBeenCalledTimes(1);
+      expect(releaseNoteService.create).toHaveBeenCalledWith(
+        'Release-title-id',
+        {
+          reason: 'Test note 3',
+        },
+      );
+
+      const updates = screen.getAllByRole('listitem');
+      expect(updates).toHaveLength(3);
+
+      expect(within(updates[0]).getByText('4 March 2024')).toBeInTheDocument();
+      expect(within(updates[0]).getByText('Test note 3')).toBeInTheDocument();
+      expect(
+        within(updates[0]).getByRole('button', { name: 'Edit note' }),
+      ).toBeInTheDocument();
+      expect(
+        within(updates[0]).getByRole('button', { name: 'Remove note' }),
+      ).toBeInTheDocument();
+    });
+
+    test('editing a note calls the releaseNoteService and updates the notes list', async () => {
+      const user = userEvent.setup();
+      const updatedReleaseNote: ReleaseNoteData = {
+        id: 'test-id-1',
+        on: new Date('2024-01-02'),
+        reason: 'Test note 1 edited',
+      };
+      releaseNoteService.edit.mockResolvedValue([
+        testReleaseNotes[0],
+        updatedReleaseNote,
+      ]);
+      render(
+        <EditingContextProvider editingMode="edit">
+          <ReleaseNotesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      await user.click(
+        within(screen.getAllByRole('listitem')[1]).getByRole('button', {
+          name: 'Edit note',
+        }),
+      );
+
+      expect(releaseNoteService.edit).not.toHaveBeenCalled();
+
+      await user.clear(screen.getByLabelText('Day'));
+      await user.type(screen.getByLabelText('Day'), '2');
+
+      await user.clear(screen.getByLabelText('Edit release note'));
+      await user.type(
+        screen.getByLabelText('Edit release note'),
+        'Test note 1 edited',
+      );
+      await user.click(screen.getByRole('button', { name: 'Update note' }));
+
+      expect(releaseNoteService.edit).toHaveBeenCalledTimes(1);
+      expect(releaseNoteService.edit).toHaveBeenCalledWith(
+        'test-id-1',
+        'Release-title-id',
+        { on: updatedReleaseNote.on, reason: updatedReleaseNote.reason },
+      );
+
+      const updates = screen.getAllByRole('listitem');
+      expect(updates).toHaveLength(2);
+
+      expect(
+        within(updates[1]).getByText('2 January 2024'),
+      ).toBeInTheDocument();
+      expect(
+        within(updates[1]).getByText('Test note 1 edited'),
+      ).toBeInTheDocument();
+      expect(
+        within(updates[1]).getByRole('button', { name: 'Edit note' }),
+      ).toBeInTheDocument();
+      expect(
+        within(updates[1]).getByRole('button', { name: 'Remove note' }),
+      ).toBeInTheDocument();
+    });
+
+    test('removing a note calls the releaseNoteService and updates the notes list', async () => {
+      const user = userEvent.setup();
+
+      releaseNoteService.delete.mockResolvedValue([testReleaseNotes[0]]);
+      render(
+        <EditingContextProvider editingMode="edit">
+          <ReleaseNotesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      expect(releaseNoteService.delete).not.toHaveBeenCalled();
+
+      await user.click(
+        within(screen.getAllByRole('listitem')[1]).getByRole('button', {
+          name: 'Remove note',
+        }),
+      );
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      expect(releaseNoteService.delete).toHaveBeenCalledTimes(1);
+      expect(releaseNoteService.delete).toHaveBeenCalledWith(
+        'test-id-1',
+        'Release-title-id',
+      );
+
+      const updates = screen.getAllByRole('listitem');
+      expect(updates).toHaveLength(1);
+
+      expect(screen.queryByText('1 January 2024')).not.toBeInTheDocument();
+      expect(screen.queryByText('Test note 1')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('is not editable', () => {
+    test('renders correctly', () => {
+      render(
+        <EditingContextProvider editingMode="preview">
+          <ReleaseNotesSection release={testRelease} />
+        </EditingContextProvider>,
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'See all updates (2)' }),
+      ).toBeInTheDocument();
+
+      const updates = screen.getAllByRole('listitem');
+      expect(updates).toHaveLength(2);
+
+      expect(
+        within(updates[0]).getByText('2 February 2024'),
+      ).toBeInTheDocument();
+      expect(within(updates[0]).getByText('Test note 2')).toBeInTheDocument();
+      expect(
+        within(updates[0]).queryByRole('button', { name: 'Edit note' }),
+      ).not.toBeInTheDocument();
+      expect(
+        within(updates[0]).queryByRole('button', { name: 'Remove note' }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        within(updates[1]).getByText('1 January 2024'),
+      ).toBeInTheDocument();
+      expect(within(updates[1]).getByText('Test note 1')).toBeInTheDocument();
+      expect(
+        within(updates[1]).queryByRole('button', { name: 'Edit note' }),
+      ).not.toBeInTheDocument();
+      expect(
+        within(updates[1]).queryByRole('button', { name: 'Remove note' }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', { name: 'Add note' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseAncillaryFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseAncillaryFilePage.tsx
@@ -73,12 +73,12 @@ export default function ReleaseAncillaryFilePage({
           {file ? (
             <AncillaryFileForm
               files={allFiles.filter(f => f.id !== file.id)}
-              fileFieldLabel="Upload new file"
               initialValues={{
                 title: file.title,
                 summary: file.summary,
                 file: null,
               }}
+              isEditing
               onCancel={navigateBack}
               onSubmit={handleSubmit}
             />

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
@@ -3,35 +3,35 @@ import {
   ReleaseRouteParams,
   releaseDataRoute,
 } from '@admin/routes/releaseRoutes';
+import RHFFormFieldTextInput from '@common/components/form/rhf/RHFFormFieldTextInput';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import useFormSubmit from '@common/hooks/useFormSubmit';
 import React from 'react';
 import releaseDataFileService from '@admin/services/releaseDataFileService';
 import Link from '@admin/components/Link';
 import { generatePath, RouteComponentProps } from 'react-router';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Yup from '@common/validation/yup';
-import { Formik } from 'formik';
-import { Form, FormFieldTextInput } from '@common/components/form';
 import Button from '@common/components/Button';
 
 interface FormValues {
   title: string;
 }
 
-const ReleaseDataFilePage = ({
+export default function ReleaseDataFilePage({
   history,
   match: {
     params: { publicationId, releaseId, fileId },
   },
-}: RouteComponentProps<ReleaseDataFileRouteParams>) => {
+}: RouteComponentProps<ReleaseDataFileRouteParams>) {
   const { value: dataFile, isLoading: dataFileLoading } = useAsyncRetry(
     () => releaseDataFileService.getDataFile(releaseId, fileId),
     [releaseId, fileId],
   );
 
-  const handleSubmit = useFormSubmit<FormValues>(async values => {
+  const handleSubmit = async (values: FormValues) => {
     await releaseDataFileService.updateFile(releaseId, fileId, {
       title: values.title,
     });
@@ -42,7 +42,7 @@ const ReleaseDataFilePage = ({
         releaseId,
       }),
     );
-  });
+  };
 
   return (
     <>
@@ -62,23 +62,22 @@ const ReleaseDataFilePage = ({
           <h2>Edit data file details</h2>
 
           {dataFile ? (
-            <Formik<FormValues>
+            <FormProvider
               initialValues={{ title: dataFile.title }}
               validationSchema={Yup.object<FormValues>({
                 title: Yup.string().required('Enter a title'),
               })}
-              onSubmit={handleSubmit}
             >
-              <Form id="dataFileForm">
-                <FormFieldTextInput<FormValues>
+              <RHFForm id="dataFileForm" onSubmit={handleSubmit}>
+                <RHFFormFieldTextInput<FormValues>
                   className="govuk-!-width-two-thirds"
                   label="Title"
                   name="title"
                 />
 
                 <Button type="submit">Save changes</Button>
-              </Form>
-            </Formik>
+              </RHFForm>
+            </FormProvider>
           ) : (
             <WarningMessage>Could not load data file details</WarningMessage>
           )}
@@ -86,6 +85,4 @@ const ReleaseDataFilePage = ({
       </LoadingSpinner>
     </>
   );
-};
-
-export default ReleaseDataFilePage;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
@@ -223,6 +223,7 @@ const ReleaseDataFileReplacePage = ({
                 <h2>Upload replacement data</h2>
 
                 <DataFileUploadForm
+                  isDataReplacement
                   onSubmit={values => handleSubmit(dataFile, values)}
                 />
               </section>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -13,7 +13,6 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import ModalConfirm from '@common/components/ModalConfirm';
 import WarningMessage from '@common/components/WarningMessage';
 import logger from '@common/services/logger';
-import Yup from '@common/validation/yup';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import React, { useCallback, useMemo, useState } from 'react';
 
@@ -67,8 +66,6 @@ export default function ReleaseFileUploadsSection({
     [files, listFilesQuery.queryKey, queryClient, releaseId],
   );
 
-  const MAX_FILE_SIZE = 2147483647; // 2GB
-
   return (
     <>
       <h2>Add file to release</h2>
@@ -110,18 +107,7 @@ export default function ReleaseFileUploadsSection({
       </InsetText>
 
       {canUpdateRelease ? (
-        <AncillaryFileForm
-          files={files}
-          submitText="Add file"
-          resetAfterSubmit
-          validationSchema={Yup.object<Partial<AncillaryFileFormValues>>({
-            file: Yup.file()
-              .required('Choose a file')
-              .minSize(0, 'Choose a file that is not empty')
-              .maxSize(MAX_FILE_SIZE, 'Choose a file that is under 2GB'),
-          })}
-          onSubmit={handleSubmit}
-        />
+        <AncillaryFileForm files={files} onSubmit={handleSubmit} />
       ) : (
         <WarningMessage>
           This release has been approved, and can no longer be updated.

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/AncillaryFileForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/AncillaryFileForm.test.tsx
@@ -77,7 +77,7 @@ describe('AncillaryFileForm', () => {
     render(<AncillaryFileForm onSubmit={noop} />);
 
     await userEvent.upload(screen.getByLabelText('Upload file'), testFile);
-    await userEvent.click(screen.getByRole('button', { name: 'Save file' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Add file' }));
 
     await waitFor(() => {
       expect(
@@ -91,7 +91,7 @@ describe('AncillaryFileForm', () => {
   test('shows validation messages if submitted form is invalid', async () => {
     render(<AncillaryFileForm onSubmit={noop} />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save file' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Add file' }));
 
     await waitFor(() => {
       expect(
@@ -122,7 +122,7 @@ describe('AncillaryFileForm', () => {
 
     expect(handleSubmit).not.toHaveBeenCalled();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save file' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Add file' }));
 
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledWith<

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
@@ -35,6 +35,8 @@ describe('ReleasePreReleaseAccessPage', () => {
       ).toBeInTheDocument();
     });
 
+    expect(await screen.findByText('Pre-release users')).toBeInTheDocument();
+
     expect(
       screen.getByRole('tab', { name: 'Pre-release users' }),
     ).toBeInTheDocument();

--- a/src/explore-education-statistics-common/src/components/ErrorMessage.tsx
+++ b/src/explore-education-statistics-common/src/components/ErrorMessage.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const ErrorMessage = ({ children, id }: Props) => {
   return (
-    <span className="govuk-error-message" id={id}>
+    <span className="govuk-error-message" id={id} data-testid={id}>
       <VisuallyHidden>Error: </VisuallyHidden>
       {children}
     </span>

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -98,7 +98,9 @@ export const BaseFormCheckboxGroup = ({
   });
 
   const isAllChecked = useMemo(() => {
-    return options.every(option => value.includes(option.value));
+    return options.every(
+      option => option.value && value.includes(option.value),
+    );
   }, [options, value]);
 
   const handleAllChange: MouseEventHandler<HTMLButtonElement> = useCallback(
@@ -144,11 +146,11 @@ export const BaseFormCheckboxGroup = ({
           id={
             option.id
               ? `${id}-${option.id}`
-              : `${id}-${option.value.replace(/\s/g, '-')}`
+              : `${id}-${(option.value ?? '').replace(/\s/g, '-')}`
           }
           name={name}
           key={option.value}
-          checked={value.includes(option.value)}
+          checked={!!option.value && value.includes(option.value)}
           onBlur={onBlur}
           onChange={onChange}
           inputRef={inputRef}

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormBaseInput.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormBaseInput.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`FormTextInput renders correctly with error 1`] = `
 </label>
 <span class="govuk-error-message"
       id="test-input-error"
+      data-testid="test-input-error"
 >
   <span class="govuk-visually-hidden">
     Error:

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldset.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldset.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`FormFieldset renders correctly with error 1`] = `
     </legend>
     <span class="govuk-error-message"
           id="test-fieldset-error"
+          data-testid="test-fieldset-error"
     >
       <span class="govuk-visually-hidden">
         Error:

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormSelect.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormSelect.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`FormSelect renders with error message 1`] = `
 </label>
 <span class="govuk-error-message"
       id="test-select-error"
+      data-testid="test-select-error"
 >
   <span class="govuk-visually-hidden">
     Error:

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormTextArea.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormTextArea.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`FormTextArea renders correctly with error 1`] = `
 </label>
 <span class="govuk-error-message"
       id="test-input-error"
+      data-testid="test-input-error"
 >
   <span class="govuk-visually-hidden">
     Error:

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormTextSearchInput.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormTextSearchInput.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`FormTextSearchInput renders correctly with error 1`] = `
 </label>
 <span class="govuk-error-message"
       id="test-input-error"
+      data-testid="test-input-error"
 >
   <span class="govuk-visually-hidden">
     Error:

--- a/src/explore-education-statistics-common/src/components/form/rhf/FormProvider.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/FormProvider.tsx
@@ -32,6 +32,7 @@ interface FormProviderProps<TFormValues extends FieldValues> {
   fallbackErrorMapping?: FieldMessageMapper<TFormValues>;
   fallbackSubmitError?: string;
   initialValues?: UseFormProps<TFormValues>['defaultValues'];
+  resetAfterSubmit?: boolean;
   validationSchema?: ObjectSchema<TFormValues> & Schema<TFormValues>;
 }
 
@@ -43,6 +44,7 @@ export default function FormProvider<TFormValues extends FieldValues>({
   fallbackServerValidationError = 'The form submission is invalid and could not be processed',
   fallbackSubmitError = 'Something went wrong whilst submitting the form',
   initialValues,
+  resetAfterSubmit = false,
   validationSchema,
 }: FormProviderProps<TFormValues>) {
   const form = useForm<TFormValues>({
@@ -78,6 +80,9 @@ export default function FormProvider<TFormValues extends FieldValues>({
       return form.handleSubmit(async (values, event) => {
         try {
           await onValid(values, event);
+          if (resetAfterSubmit) {
+            form.reset();
+          }
         } catch (error) {
           if (isServerValidationError(error) && error.response?.data) {
             const fieldErrors = mapServerFieldErrors(

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormCheckbox.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormCheckbox.tsx
@@ -1,0 +1,109 @@
+import classNames from 'classnames';
+import React, {
+  ChangeEvent,
+  FocusEventHandler,
+  memo,
+  ReactNode,
+  Ref,
+} from 'react';
+
+export type OtherCheckboxChangeProps = Pick<RHFFormCheckboxProps, 'label'>;
+
+export type CheckboxChangeEventHandler = (
+  event: ChangeEvent<HTMLInputElement>,
+  otherCheckboxProps: OtherCheckboxChangeProps,
+) => void;
+
+export interface RHFFormCheckboxProps {
+  checked?: boolean;
+  defaultChecked?: boolean;
+  className?: string;
+  conditional?: ReactNode;
+  id: string;
+  hint?: string | ReactNode;
+  hintSmall?: boolean;
+  label: string;
+  boldLabel?: boolean;
+  name: string;
+  onBlur?: FocusEventHandler<HTMLInputElement>;
+  onChange?: CheckboxChangeEventHandler;
+  value?: string;
+  disabled?: boolean;
+  inputRef?: Ref<HTMLInputElement>;
+}
+
+const FormCheckbox = ({
+  checked,
+  defaultChecked,
+  className,
+  conditional,
+  id,
+  hint,
+  hintSmall = false,
+  label,
+  boldLabel = false,
+  name,
+  onBlur,
+  onChange,
+  value,
+  disabled = false,
+  inputRef,
+}: RHFFormCheckboxProps) => {
+  return (
+    <>
+      <div
+        className={classNames('govuk-checkboxes__item', className)}
+        data-testid={`Checkbox item for ${label}`}
+      >
+        <input
+          aria-describedby={hint ? `${id}-item-hint` : undefined}
+          className="govuk-checkboxes__input"
+          checked={checked}
+          defaultChecked={defaultChecked}
+          id={id}
+          name={name}
+          onBlur={onBlur}
+          onChange={event => {
+            if (onChange) {
+              onChange(event, { label });
+            }
+          }}
+          type="checkbox"
+          value={value}
+          disabled={disabled}
+          ref={inputRef}
+        />
+        <label
+          className={classNames('govuk-label govuk-checkboxes__label', {
+            'govuk-!-font-weight-bold': boldLabel,
+            'govuk-!-padding-bottom-1': hintSmall,
+          })}
+          htmlFor={id}
+        >
+          {label}
+        </label>
+        {hint && (
+          <div
+            id={`${id}-item-hint`}
+            className={classNames('govuk-hint govuk-checkboxes__hint', {
+              'govuk-!-font-size-14 govuk-!-margin-bottom-1': hintSmall,
+            })}
+          >
+            {hint}
+          </div>
+        )}
+      </div>
+      {conditional && (
+        <div
+          className={classNames('govuk-checkboxes__conditional', {
+            'govuk-checkboxes__conditional--hidden': !checked,
+          })}
+        >
+          {conditional}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default memo(FormCheckbox);

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckbox.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckbox.tsx
@@ -1,0 +1,41 @@
+import RHFFormField, {
+  FormFieldComponentProps,
+} from '@common/components/form/rhf/RHFFormField';
+import RHFFormCheckbox, {
+  RHFFormCheckboxProps,
+} from '@common/components/form/rhf/RHFFormCheckbox';
+import { useFormIdContext } from '@common/components/form/contexts/FormIdContext';
+import useRegister from '@common/components/form/rhf/hooks/useRegister';
+import classNames from 'classnames';
+import React from 'react';
+import { FieldValues, useFormContext } from 'react-hook-form';
+
+type Props<TFormValues extends FieldValues> = {
+  name: string;
+  small?: boolean;
+  formGroup?: boolean;
+} & FormFieldComponentProps<RHFFormCheckboxProps, TFormValues>;
+
+export default function RHFFormFieldCheckbox<TFormValues extends FieldValues>({
+  formGroup,
+  name,
+  small,
+  ...props
+}: Props<TFormValues>) {
+  const { register } = useFormContext<TFormValues>();
+  const { ref: inputRef, ...field } = useRegister(name, register);
+  const { fieldId } = useFormIdContext();
+  const id = fieldId(name, props.id);
+
+  return (
+    <RHFFormField {...props} name={name} formGroup={formGroup}>
+      <div
+        className={classNames('govuk-checkboxes', {
+          'govuk-checkboxes--small': small,
+        })}
+      >
+        <RHFFormCheckbox {...props} {...field} id={id} inputRef={inputRef} />
+      </div>
+    </RHFFormField>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldDateInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldDateInput.tsx
@@ -88,18 +88,18 @@ export default function RHFFormFieldDateInput<TFormValues extends FieldValues>({
         const date = parse(`${year}-${month}-${day}Z`, 'yyyy-M-dX', new Date());
 
         const newDateValue = isValid(date) ? date : undefined;
-
         setValue(
           name,
           newDateValue as PathValue<TFormValues, Path<TFormValues>>,
           { shouldTouch: true },
         );
       } else {
-        setValue(
-          name,
-          { day, month, year } as PathValue<TFormValues, Path<TFormValues>>,
-          { shouldTouch: true },
-        );
+        const nextValue =
+          !day && !month && !year ? undefined : { day, month, year };
+
+        setValue(name, nextValue as PathValue<TFormValues, Path<TFormValues>>, {
+          shouldTouch: true,
+        });
       }
 
       setValues({

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldFileInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldFileInput.tsx
@@ -1,0 +1,100 @@
+import Effect from '@common/components/Effect';
+import RHFFormField, {
+  FormFieldComponentProps,
+} from '@common/components/form/rhf/RHFFormField';
+import FormFileInput, {
+  FormFileInputProps,
+} from '@common/components/form/FormFileInput';
+import useToggle from '@common/hooks/useToggle';
+import React, { useState } from 'react';
+import { FieldValues, Path, PathValue, useFormContext } from 'react-hook-form';
+import useRegister from './hooks/useRegister';
+import { useFormIdContext } from '../contexts/FormIdContext';
+
+type Props<TFormValues extends FieldValues> = FormFieldComponentProps<
+  FormFileInputProps,
+  TFormValues
+>;
+
+export default function RHFFormFieldFileInput<TFormValues extends FieldValues>(
+  props: Props<TFormValues>,
+) {
+  // Have to do additional tracking as file inputs have
+  // weird quirks that mean we get a weird validation
+  // experience due to:
+  // 1. `onBlur` triggering immediately upon clicking
+  //     (should be after selecting file or cancelling)
+  // 2. `onChange` not triggering if nothing is selected
+  const [isClicked, toggleClicked] = useToggle(false);
+  // undefined is the initial state, null is unselected state
+  const [inputValue, setInputValue] = useState<File | null | undefined>();
+
+  const { name } = props;
+
+  const { getFieldState, register, setValue } = useFormContext<TFormValues>();
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { ref, ...field } = useRegister(name, register);
+  const { fieldId } = useFormIdContext();
+  const id = fieldId(name);
+
+  const { onChange } = props;
+
+  const fieldState = getFieldState(name);
+
+  return (
+    <RHFFormField {...props} name={name}>
+      <>
+        <Effect
+          value={fieldState.isTouched}
+          onChange={(touched, previousTouched) => {
+            // Form has been reset
+            if (previousTouched && !touched) {
+              toggleClicked.off();
+              setInputValue(undefined);
+            }
+          }}
+        />
+
+        <FormFileInput
+          {...props}
+          {...field}
+          error={fieldState.error?.message}
+          id={id}
+          onClick={toggleClicked.on}
+          onChange={event => {
+            onChange?.(event);
+
+            if (event.isDefaultPrevented()) {
+              return;
+            }
+
+            const file =
+              event.target.files && event.target.files.length > 0
+                ? event.target.files[0]
+                : null;
+
+            if (file) {
+              setInputValue(file);
+              setValue(
+                name,
+                file as PathValue<TFormValues, Path<TFormValues>>,
+                {
+                  shouldTouch: true,
+                },
+              );
+            }
+          }}
+          onBlur={event => {
+            if (isClicked && typeof inputValue === 'undefined') {
+              toggleClicked.off();
+              return;
+            }
+
+            field.onBlur(event);
+          }}
+        />
+      </>
+    </RHFFormField>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldCheckbox.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/RHFFormFieldCheckbox.test.tsx
@@ -1,0 +1,141 @@
+import RHFFormFieldCheckbox from '@common/components/form/rhf/RHFFormFieldCheckbox';
+import FormProvider from '@common/components/form/rhf/FormProvider';
+import RHFForm from '@common/components/form/rhf/RHFForm';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+describe('RHFFormFieldCheckbox', () => {
+  test('renders with correct defaults ids with form', () => {
+    render(
+      <FormProvider>
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldCheckbox
+            name="test"
+            label="Test values"
+            hint="Test hint"
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-test-item-hint',
+    );
+    expect(screen.getByLabelText('Test values')).toHaveAttribute(
+      'id',
+      'testForm-test',
+    );
+  });
+
+  test('renders with correct defaults ids without form', () => {
+    render(
+      <FormProvider>
+        <RHFFormFieldCheckbox
+          name="test"
+          label="Test values"
+          hint="Test hint"
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'test-item-hint',
+    );
+    expect(screen.getByLabelText('Test values')).toHaveAttribute('id', 'test');
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <FormProvider>
+        <RHFForm id="testForm" onSubmit={Promise.resolve}>
+          <RHFFormFieldCheckbox
+            name="test"
+            id="customId"
+            label="Test values"
+            hint="Test hint"
+          />
+        </RHFForm>
+      </FormProvider>,
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-customId-item-hint',
+    );
+    expect(screen.getByLabelText('Test values')).toHaveAttribute(
+      'id',
+      'testForm-customId',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <FormProvider>
+        <RHFFormFieldCheckbox
+          name="test"
+          id="customId"
+          label="Test values"
+          hint="Test hint"
+        />
+      </FormProvider>,
+    );
+
+    expect(screen.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'customId-item-hint',
+    );
+    expect(screen.getByLabelText('Test values')).toHaveAttribute(
+      'id',
+      'customId',
+    );
+  });
+
+  test('clicking the checkbox checks and unchecks it', async () => {
+    const user = userEvent.setup();
+    render(
+      <FormProvider>
+        <RHFFormFieldCheckbox name="test" id="select" label="Test values" />
+      </FormProvider>,
+    );
+
+    const checkbox = screen.getByLabelText('Test values');
+
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+
+    await waitFor(() => {
+      expect(checkbox).toBeChecked();
+    });
+
+    await user.click(checkbox);
+
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+    });
+  });
+
+  test('checks the checkbox if initial value is true', async () => {
+    render(
+      <FormProvider initialValues={{ test: true }}>
+        <RHFFormFieldCheckbox name="test" id="select" label="Test values" />
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test values')).toBeChecked();
+  });
+
+  test('does not check the checkbox if initial value is false', async () => {
+    render(
+      <FormProvider initialValues={{ test: false }}>
+        <RHFFormFieldCheckbox name="test" id="select" label="Test values" />
+      </FormProvider>,
+    );
+
+    expect(screen.getByLabelText('Test values')).not.toBeChecked();
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/rhf/__tests__/__snapshots__/RHFFormTextArea.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/rhf/__tests__/__snapshots__/RHFFormTextArea.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`RHFFormTextArea renders correctly with error 1`] = `
 </label>
 <span class="govuk-error-message"
       id="test-input-error"
+      data-testid="test-input-error"
 >
   <span class="govuk-visually-hidden">
     Error:

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -225,8 +225,8 @@ Check release approver can create a release note
     user clicks link    Content
     user adds a release note    Test release note one
     ${date}    get current datetime    %-d %B %Y
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) time    ${date}
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) p    Test release note one
+    user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
+    user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note one
 
 Check release approver can publish a release
     user clicks link    Sign off

--- a/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
@@ -68,6 +68,7 @@ Create Methodology with some content and images
     ...    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
     user adds content to accordion section text block    Methodology annex section 2    2
     ...    Adding Methodology annex 2 text block 2    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
+    user scrolls up    100
     user adds image to accordion section text block    Methodology annex section 2    2    test-infographic.png
     ...    Alt text for the uploaded annex image 3    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
 

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -145,11 +145,11 @@ Add basic release content
 
 Add release note to amendment
     user clicks button    Add note
-    user enters text into element    id:createReleaseNoteForm-reason    Test release note
+    user enters text into element    id:create-release-note-form-reason    Test release note
     user clicks button    Save note
     ${date}=    get current datetime    ${DATE_FORMAT_MEDIUM}
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) time    ${date}
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) p    Test release note
+    user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
+    user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note
 
 Check amendment has no prerelease users
     user clicks link    Pre-release access

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -63,8 +63,8 @@ Add summary content to release
 Add release note to release
     user adds a release note    Test release note one
     ${date}=    get current datetime    %-d %B %Y
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) time    ${date}
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) p    Test release note one
+    user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
+    user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note one
 
 Add Useful information related page link to release
     user clicks button    Add related page link
@@ -215,27 +215,27 @@ Validate two remaining content blocks
     user checks accordion section text block contains    Test section one    2    block three test text
     ...    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
 
-
 Verify that validation prevents adding an image without alt text
     user adds image without alt text to accordion section text block    Test section one    1
-    ...    test-infographic.png     ${RELEASE_CONTENT_EDITABLE_ACCORDION}
+    ...    test-infographic.png    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
 
     user checks page contains    All images must have alternative text
 
-    user clicks element    xpath://img     ${RELEASE_CONTENT_EDITABLE_ACCORDION}
+    user clicks element    xpath://img    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
     user clicks button    Change image text alternative
     user enters text into element    label:Text alternative    Alt text for the uploaded content image
     user clicks element    css:button.ck-button-save
 
     user checks accordion section text block contains image with alt text    Test section one    1
-    ...    Alt text for the uploaded content image     ${RELEASE_CONTENT_EDITABLE_ACCORDION}
+    ...    Alt text for the uploaded content image    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
 
     user clicks button    Save & close
 
     user checks page does not contain    All images must have alternative text
 
 Verify that validation prevents adding an invalid link
-    user adds link to accordion section text block    Test section one    1    https://gov     ${RELEASE_CONTENT_EDITABLE_ACCORDION}
+    user adds link to accordion section text block    Test section one    1    https://gov
+    ...    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
     user checks page contains    1 link has an invalid URL.
 
     user clicks element    xpath://a[text()='https://gov']
@@ -246,4 +246,3 @@ Verify that validation prevents adding an invalid link
     user clicks button    Save & close
 
     user checks page does not contain    1 link has an invalid URL.
-

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -713,11 +713,11 @@ Update embedded dashboard title and url
 
 Add release note to first amendment
     user clicks button    Add note
-    user enters text into element    id:createReleaseNoteForm-reason    Test release note one
+    user enters text into element    id:create-release-note-form-reason    Test release note one
     user clicks button    Save note
     ${date}=    get current datetime    ${DATE_FORMAT_MEDIUM}
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) time    ${date}
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) p    Test release note one
+    user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
+    user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note one
 
 Check public prerelease access list for amendment is same as original release
     user clicks link    Pre-release access
@@ -977,7 +977,7 @@ Return to Admin and create second amendment
 Add release note to second amendment
     user clicks link    Content
     user clicks button    Add note
-    user enters text into element    id:createReleaseNoteForm-reason    Test release note two
+    user enters text into element    id:create-release-note-form-reason    Test release note two
     user clicks button    Save note
 
 Remove the data block from the second amendment

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -184,6 +184,7 @@ Add embedded dashboard to third accordion section
     ...    Test embedded dashboard title
     ...    https://dfe-analytical-services.github.io/explore-education-statistics
 
+    user presses keys    TAB
     user waits until page does not contain    URL must be on a permitted domain
     user clicks button    Save    ${modal}
     user waits until modal is not visible    Embed a URL
@@ -698,6 +699,7 @@ Update embedded dashboard title and url
     ...    https://dfe-analytical-services.github.io/explore-education-statistics/tests/robot-tests
     ...    Edit embedded URL
 
+    user presses keys    TAB
     user clicks button    Save    ${modal}
     user waits until page does not contain    URL must be on a permitted domain
     user waits until modal is not visible    Edit embedded URL

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
@@ -290,11 +290,11 @@ Navigate to 'Content' page for release amendment
 
 Add release note to release amendment
     user clicks button    Add note
-    user enters text into element    id:createReleaseNoteForm-reason    Test release note one
+    user enters text into element    id:create-release-note-form-reason    Test release note one
     user clicks button    Save note
     ${date}    get current datetime    %-d %B %Y
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) time    ${date}
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) p    Test release note one
+    user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
+    user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note one
 
 Go to "Sign off" page
     user clicks link    Sign off
@@ -426,8 +426,8 @@ Add release note for new release amendment
     user clicks link    Content
     user adds a release note    Test release note two
     ${date}    get current datetime    %-d %B %Y
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) time    ${date}
-    user waits until element contains    css:#releaseNotes li:nth-of-type(1) p    Test release note two
+    user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
+    user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note two
 
 Go to "Sign off" to approve amended release for immediate publication
     user clicks link    Sign off

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -425,6 +425,9 @@ user adds image to accordion section text block
     choose file
     ...    xpath://button[span[.="Upload image from computer"]]/input[@type="file"]
     ...    ${FILES_DIR}${filename}
+
+    user scrolls down    200
+
     user clicks button    Change image text alternative
     user enters text into element    label:Text alternative    ${alt_text}
     user clicks element    css:button.ck-button-save

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -51,7 +51,7 @@ user adds a release note
     ...    ${display_date_month}=${EMPTY}
     ...    ${display_date_year}=${EMPTY}
     user clicks button    Add note
-    user enters text into element    id:createReleaseNoteForm-reason    ${body}
+    user enters text into element    id:create-release-note-form-reason    ${body}
     user clicks button    Save note
     user waits until page contains button    Add note
 


### PR DESCRIPTION
Updates the following forms to use React Hook Form instead of Formik:

- EditableContentForm 
- EditableEmbedForm
- EditableKeyStatDataBlockForm
- EditableKeyStatTextForm
- ReleaseStatusForm
- RelatedPagesSection 
- ReleaseNotesSection 
- ReleaseDataFilePage
- AncillaryFileForm
- DataFileUploadForm

I've done some refactoring as I've gone along to update components that haven't been touched in a while to use our current code style.
