### PR TITLE
EES-4711 Adding optional query parameter `types` to the metadata endpoint

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
@@ -1,9 +1,13 @@
 #nullable enable
-using System;
-using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Validators.AllowedValueValidator;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 
@@ -192,14 +196,29 @@ public static class ValidationProblemViewModelTestExtensions
             expectedPath: expectedPath,
             expectedKey: FluentValidationKeys.EnumValidator
         );
-
     public static ErrorViewModel AssertHasAllowedValueError(
         this ValidationProblemViewModel validationProblem,
-        string expectedPath)
-        => validationProblem.AssertHasFluentValidationError(
+        string expectedPath,
+        string? value,
+        IEnumerable<string> allowed)
+    {
+        var error = validationProblem.AssertHasFluentValidationError(
             expectedPath: expectedPath,
             expectedKey: ValidationMessages.AllowedValue.Code
         );
+
+        var errorDetail = GetErrorDetail(error);
+
+        Assert.Equal(2, errorDetail.Count);
+        Assert.Equal(value, errorDetail[nameof(AllowedErrorDetail<object>.Value).ToLowerFirst()].GetString());
+        Assert.Equal(
+            allowed,
+            errorDetail[nameof(AllowedErrorDetail<object>.Allowed).ToLowerFirst()]
+                .EnumerateArray()
+                .Select(e => e.GetString()!));
+
+        return error;
+    }
 
     public static ErrorViewModel AssertHasError(
         this ValidationProblemViewModel validationProblem,
@@ -221,5 +240,14 @@ public static class ValidationProblemViewModelTestExtensions
         var expectedCode = expectedKey.Replace("Validator", "");
 
         return AssertHasError(validationProblem, expectedPath, expectedCode);
+    }
+
+    private static Dictionary<string, JsonElement> GetErrorDetail(ErrorViewModel error)
+    {
+        var errorDetailJson = Assert.IsType<JsonElement>(error.Detail);
+        var errorDetail = errorDetailJson.Deserialize<Dictionary<string, JsonElement>>();
+
+        Assert.NotNull(errorDetail);
+        return errorDetail;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
@@ -193,6 +193,14 @@ public static class ValidationProblemViewModelTestExtensions
             expectedKey: FluentValidationKeys.EnumValidator
         );
 
+    public static ErrorViewModel AssertHasAllowedValueError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+        => validationProblem.AssertHasFluentValidationError(
+            expectedPath: expectedPath,
+            expectedKey: ValidationMessages.AllowedValue.Code
+        );
+
     public static ErrorViewModel AssertHasError(
         this ValidationProblemViewModel validationProblem,
         string expectedPath,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
@@ -17,20 +17,12 @@ using PublicationSummaryViewModel = GovUk.Education.ExploreEducationStatistics.P
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Controllers;
 
-public abstract class PublicationsControllerTests : IntegrationTestFixture
+public abstract class PublicationsControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
 {
     private const string BaseUrl = "api/v1/publications";
 
-    public PublicationsControllerTests(TestApplicationFactory testApp) : base(testApp)
+    public class ListPublicationsTests(TestApplicationFactory testApp) : PublicationsControllerTests(testApp)
     {
-    }
-
-    public class ListPublicationsTests : PublicationsControllerTests
-    {
-        public ListPublicationsTests(TestApplicationFactory testApp) : base(testApp)
-        {
-        }
-
         [Fact]
         public async Task PublishedDataSets_Returns200_FiltersPublicationsWithoutPublishedDataSets()
         {
@@ -281,12 +273,8 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
         }
     }
 
-    public class GetPublicationTests : PublicationsControllerTests
+    public class GetPublicationTests(TestApplicationFactory testApp) : PublicationsControllerTests(testApp)
     {
-        public GetPublicationTests(TestApplicationFactory testApp) : base(testApp)
-        {
-        }
-
         [Fact]
         public async Task PublicationExists_Returns200()
         {
@@ -407,12 +395,8 @@ public abstract class PublicationsControllerTests : IntegrationTestFixture
         }
     }
 
-    public class ListPublicationDataSetsTests : PublicationsControllerTests
+    public class ListPublicationDataSetsTests(TestApplicationFactory testApp) : PublicationsControllerTests(testApp)
     {
-        public ListPublicationDataSetsTests(TestApplicationFactory testApp) : base(testApp)
-        {
-        }
-
         [Theory]
         [InlineData(1, 2, 1)]
         [InlineData(1, 2, 2)]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Fixture/IntegrationTestFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Fixture/IntegrationTestFixture.cs
@@ -2,16 +2,11 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Fixture;
 
-public abstract class IntegrationTestFixture : IClassFixture<TestApplicationFactory>, IAsyncLifetime
+public abstract class IntegrationTestFixture(TestApplicationFactory testApp) : IClassFixture<TestApplicationFactory>, IAsyncLifetime
 {
     protected readonly DataFixture DataFixture = new();
 
-    protected readonly TestApplicationFactory TestApp;
-
-    public IntegrationTestFixture(TestApplicationFactory testApp)
-    {
-        TestApp = testApp;
-    }
+    protected readonly TestApplicationFactory TestApp = testApp;
 
     public async Task InitializeAsync()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/ContentApiClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/ContentApiClientTests.cs
@@ -14,13 +14,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Servi
 public abstract class ContentApiClientTests
 {
     private readonly MockHttpMessageHandler _mockHttp;
-    private readonly HttpClient _client;
     private readonly ContentApiClient _contentApiClient;
 
     public ContentApiClientTests()
     {
         _mockHttp = new MockHttpMessageHandler();
-        _client = _mockHttp.ToHttpClient();
+        var _client = _mockHttp.ToHttpClient();
         _client.BaseAddress = new Uri("http://localhost/");
         _contentApiClient = new ContentApiClient(Mock.Of<ILogger<ContentApiClient>>(), _client);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/ContentApiClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/ContentApiClientTests.cs
@@ -19,9 +19,9 @@ public abstract class ContentApiClientTests
     public ContentApiClientTests()
     {
         _mockHttp = new MockHttpMessageHandler();
-        var _client = _mockHttp.ToHttpClient();
-        _client.BaseAddress = new Uri("http://localhost/");
-        _contentApiClient = new ContentApiClient(Mock.Of<ILogger<ContentApiClient>>(), _client);
+        var client = _mockHttp.ToHttpClient();
+        client.BaseAddress = new Uri("http://localhost/");
+        _contentApiClient = new ContentApiClient(Mock.Of<ILogger<ContentApiClient>>(), client);
     }
 
     public class ListPublicationsTests : ContentApiClientTests

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -1,5 +1,6 @@
 using Asp.Versioning;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
@@ -98,14 +99,16 @@ public class DataSetsController(
     [SwaggerResponse(403)]
     [SwaggerResponse(404)]
     public async Task<ActionResult<DataSetMetaViewModel>> GetDataSetMeta(
-        [SwaggerParameter("The version of the data set to use e.g. 2.0, 1.1, etc.")] [FromQuery] string? dataSetVersion,
+        [FromQuery] DataSetMetaRequest request,
+        [FromQuery, SwaggerParameter("The version of the data set to use e.g. 2.0, 1.1, etc.")] string? dataSetVersion,
         [SwaggerParameter("The ID of the data set.")] Guid dataSetId,
         CancellationToken cancellationToken)
     {
         return await dataSetService
             .GetMeta(
                 dataSetId: dataSetId, 
-                dataSetVersion: dataSetVersion, 
+                dataSetVersion: dataSetVersion,
+                types: request.ParsedTypes(),
                 cancellationToken: cancellationToken)
             .HandleFailuresOrOk();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -12,9 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Controllers
 [ApiVersion(1.0)]
 [ApiController]
 [Route("api/v{version:apiVersion}/data-sets")]
-public class DataSetsController(
-    IDataSetService dataSetService)
-    : ControllerBase
+public class DataSetsController(IDataSetService dataSetService) : ControllerBase
 {
     /// <summary>
     /// Get a data set’s summary

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/PublicationsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/PublicationsController.cs
@@ -11,17 +11,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Controllers
 [ApiVersion(1.0)]
 [ApiController]
 [Route("api/v{version:apiVersion}/publications")]
-public class PublicationsController : ControllerBase
+public class PublicationsController(IPublicationService publicationService, IDataSetService dataSetService)
+    : ControllerBase
 {
-    private readonly IPublicationService _publicationService;
-    private readonly IDataSetService _dataSetService;
-
-    public PublicationsController(IPublicationService publicationService, IDataSetService dataSetService)
-    {
-        _publicationService = publicationService;
-        _dataSetService = dataSetService;
-    }
-
     /// <summary>
     /// List publications
     /// </summary>
@@ -36,7 +28,7 @@ public class PublicationsController : ControllerBase
         [FromQuery] PublicationListRequest request,
         CancellationToken cancellationToken)
     {
-        return await _publicationService
+        return await publicationService
             .ListPublications(
                 page: request.Page,
                 pageSize: request.PageSize,
@@ -60,7 +52,7 @@ public class PublicationsController : ControllerBase
         [SwaggerParameter("The ID of the publication.")] Guid publicationId,
         CancellationToken cancellationToken)
     {
-        return await _publicationService
+        return await publicationService
             .GetPublication(
                 publicationId: publicationId,
                 cancellationToken: cancellationToken)
@@ -82,7 +74,7 @@ public class PublicationsController : ControllerBase
         [SwaggerParameter("The ID of the publication.")] Guid publicationId,
         CancellationToken cancellationToken)
     {
-        return await _dataSetService
+        return await dataSetService
             .ListDataSets(
                 page: request.Page,
                 pageSize: request.PageSize,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Model/DataSetMetaType.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Model/DataSetMetaType.cs
@@ -1,6 +1,6 @@
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
 
-public enum MetadataType
+public enum DataSetMetaType
 {
     Filters,
     Indicators,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Model/MetadataType.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Model/MetadataType.cs
@@ -1,0 +1,9 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+
+public enum MetadataType
+{
+    Filters,
+    Indicators,
+    Locations,
+    TimePeriods,
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetMetaRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetMetaRequest.cs
@@ -4,25 +4,29 @@ using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.CodeAnalysis;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
 public record DataSetMetaRequest
 {
     /// <summary>
-    /// The types of metadata to return.
+    /// The types of meta to get for the requested data set version.
     /// 
     /// Can be any combination of the following:
-    /// - `Filters` - include all metadata associated with the *filters* of the requested data set version
-    /// - `Indicators` - include all metadata associated with the *indicators* of the requested data set version
-    /// - `Locations` - include all metadata associated with the *locations* of the requested data set version
-    /// - `TimePeriods` - include all metadata associated with the *time periods* of the requested data set version
+    /// - `Filters` - include all meta relating to *filters*
+    /// - `Indicators` - include all meta relating to *indicators*
+    /// - `Locations` - include all meta associated with the *locations*
+    /// - `TimePeriods` - include all meta associated with the *time periods*
     /// </summary>
-    [FromQuery, QuerySeparator]
+    [FromQuery]
+    [QuerySeparator]
+    [SwaggerEnum(type: typeof(DataSetMetaType), serializer: SwaggerEnumSerializer.String)]
     public IReadOnlyList<string>? Types { get; init; }
 
-    public IReadOnlySet<MetadataType>? ParsedTypes()
-        => Types?.Select(EnumUtil.GetFromEnumValue<MetadataType>).ToHashSet();
+    public IReadOnlySet<DataSetMetaType>? ParsedTypes()
+        => Types?.Select(EnumUtil.GetFromEnumValue<DataSetMetaType>).ToHashSet();
 
     public class Validator : AbstractValidator<DataSetMetaRequest>
     {
@@ -33,7 +37,7 @@ public record DataSetMetaRequest
                 RuleFor(request => request.Types)
                     .NotEmpty();
                 RuleForEach(request => request.Types)
-                    .AllowedValue(EnumUtil.GetEnumValues<MetadataType>());
+                    .AllowedValue(EnumUtil.GetEnumValues<DataSetMetaType>());
             });
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetMetaRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetMetaRequest.cs
@@ -17,8 +17,8 @@ public record DataSetMetaRequest
     /// Can be any combination of the following:
     /// - `Filters` - include all meta relating to *filters*
     /// - `Indicators` - include all meta relating to *indicators*
-    /// - `Locations` - include all meta associated with the *locations*
-    /// - `TimePeriods` - include all meta associated with the *time periods*
+    /// - `Locations` - include all meta relating to *locations*
+    /// - `TimePeriods` - include all meta relating to *time periods*
     /// </summary>
     [FromQuery]
     [QuerySeparator]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetMetaRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetMetaRequest.cs
@@ -1,0 +1,40 @@
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+public record DataSetMetaRequest
+{
+    /// <summary>
+    /// The types of metadata to return.
+    /// 
+    /// Can be any combination of the following:
+    /// - `Filters` - include all metadata associated with the *filters* of the requested data set version
+    /// - `Indicators` - include all metadata associated with the *indicators* of the requested data set version
+    /// - `Locations` - include all metadata associated with the *locations* of the requested data set version
+    /// - `TimePeriods` - include all metadata associated with the *time periods* of the requested data set version
+    /// </summary>
+    [FromQuery, QuerySeparator]
+    public IReadOnlyList<string>? Types { get; init; }
+
+    public IReadOnlySet<MetadataType>? ParsedTypes()
+        => Types?.Select(EnumUtil.GetFromEnumValue<MetadataType>).ToHashSet();
+
+    public class Validator : AbstractValidator<DataSetMetaRequest>
+    {
+        public Validator()
+        {
+            When(request => request.Types is not null, () =>
+            {
+                RuleFor(request => request.Types)
+                    .NotEmpty();
+                RuleForEach(request => request.Types)
+                    .AllowedValue(EnumUtil.GetEnumValues<MetadataType>());
+            });
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AnonymousAuthenticationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AnonymousAuthenticationHandler.cs
@@ -4,15 +4,12 @@ using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security;
 
-public class AnonymousAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+public class AnonymousAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
 {
-    public AnonymousAuthenticationHandler(
-        IOptionsMonitor<AuthenticationSchemeOptions> options,
-        ILoggerFactory logger,
-        UrlEncoder encoder) : base(options, logger, encoder)
-    {
-    }
-
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
         return Task.FromResult(AuthenticateResult.NoResult());

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/ContentApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/ContentApiClient.cs
@@ -9,17 +9,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
-internal class ContentApiClient : IContentApiClient
+internal class ContentApiClient(ILogger<ContentApiClient> logger, HttpClient httpClient) : IContentApiClient
 {
-    private readonly ILogger<ContentApiClient> _logger;
-    private readonly HttpClient _httpClient;
-
-    public ContentApiClient(ILogger<ContentApiClient> logger, HttpClient httpClient)
-    {
-        _logger = logger;
-        _httpClient = httpClient;
-    }
-
     public async Task<Either<ActionResult, PaginatedListViewModel<PublicationSearchResultViewModel>>> ListPublications(
         int page,
         int pageSize,
@@ -33,7 +24,7 @@ internal class ContentApiClient : IContentApiClient
             PageSize: pageSize,
             PublicationIds: publicationIds);
 
-        var response = await _httpClient.PostAsJsonAsync("api/publications", request, cancellationToken: cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("api/publications", request, cancellationToken: cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -43,7 +34,7 @@ internal class ContentApiClient : IContentApiClient
                     return new BadRequestObjectResult(await response.Content.ReadFromJsonAsync<ValidationProblemViewModel>());
                 default:
                     var message = await response.Content.ReadAsStringAsync();
-                    _logger.LogError(StringExtensions.TrimIndent(
+                    logger.LogError(StringExtensions.TrimIndent(
                         $"""
                          Failed to retrieve publications with status code: {response.StatusCode}. Message:
                          {message}
@@ -64,7 +55,7 @@ internal class ContentApiClient : IContentApiClient
         Guid publicationId,
         CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync($"api/publications/{publicationId}/summary", cancellationToken: cancellationToken);
+        var response = await httpClient.GetAsync($"api/publications/{publicationId}/summary", cancellationToken: cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -76,7 +67,7 @@ internal class ContentApiClient : IContentApiClient
                     return new NotFoundResult();
                 default:
                     var message = await response.Content.ReadAsStringAsync();
-                    _logger.LogError(StringExtensions.TrimIndent(
+                    logger.LogError(StringExtensions.TrimIndent(
                         $"""
                          Failed to retrieve publication '{publicationId}' with status code: {response.StatusCode}. Message:
                          {message}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetService.cs
@@ -1,4 +1,5 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 
@@ -30,5 +31,6 @@ public interface IDataSetService
     Task<Either<ActionResult, DataSetMetaViewModel>> GetMeta(
         Guid dataSetId,
         string? dataSetVersion = null,
+        IReadOnlySet<MetadataType>? types = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetService.cs
@@ -31,6 +31,6 @@ public interface IDataSetService
     Task<Either<ActionResult, DataSetMetaViewModel>> GetMeta(
         Guid dataSetId,
         string? dataSetVersion = null,
-        IReadOnlySet<MetadataType>? types = null,
+        IReadOnlySet<DataSetMetaType>? types = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PublicationService.cs
@@ -10,17 +10,9 @@ using PublicationSummaryViewModel = GovUk.Education.ExploreEducationStatistics.P
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
-internal class PublicationService : IPublicationService
+internal class PublicationService(PublicDataDbContext publicDataDbContext, IContentApiClient contentApiClient)
+    : IPublicationService
 {
-    private readonly PublicDataDbContext _publicDataDbContext;
-    private readonly IContentApiClient _contentApiClient;
-
-    public PublicationService(PublicDataDbContext publicDataDbContext, IContentApiClient contentApiClient)
-    {
-        _publicDataDbContext = publicDataDbContext;
-        _contentApiClient = contentApiClient;
-    }
-
     public async Task<Either<ActionResult, PublicationPaginatedListViewModel>> ListPublications(
         int page,
         int pageSize,
@@ -29,7 +21,7 @@ internal class PublicationService : IPublicationService
     {
         return await GetPublishedDataSetPublicationIds()
             .OnSuccess(async publicationIds =>
-                await _contentApiClient.ListPublications(
+                await contentApiClient.ListPublications(
                     page: page, 
                     pageSize: pageSize, 
                     search:search, 
@@ -55,7 +47,7 @@ internal class PublicationService : IPublicationService
         CancellationToken cancellationToken = default)
     {
         return await CheckPublicationIsPublished(publicationId, cancellationToken)
-            .OnSuccess(async _ => await _contentApiClient.GetPublication(publicationId, cancellationToken))
+            .OnSuccess(async _ => await contentApiClient.GetPublication(publicationId, cancellationToken))
             .OnSuccess(publication => new PublicationSummaryViewModel
             {
                 Id  = publication.Id,
@@ -69,7 +61,7 @@ internal class PublicationService : IPublicationService
     private async Task<Either<ActionResult, HashSet<Guid>>> GetPublishedDataSetPublicationIds(
         CancellationToken cancellationToken = default)
     {
-        return (await _publicDataDbContext.DataSets
+        return (await publicDataDbContext.DataSets
                 .Where(ds => ds.Status == DataSetStatus.Published)
                 .Select(ds => ds.PublicationId)
                 .ToListAsync(cancellationToken: cancellationToken)
@@ -93,7 +85,7 @@ internal class PublicationService : IPublicationService
         Guid publicationId,
         CancellationToken cancellationToken = default)
     {
-        var publicationIsPublished = await _publicDataDbContext.DataSets
+        var publicationIsPublished = await publicDataDbContext.DataSets
             .Where(ds => ds.PublicationId == publicationId)
             .AnyAsync(ds => ds.Status == DataSetStatus.Published, cancellationToken: cancellationToken);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -98,9 +98,9 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         // Options
 
         services.AddOptions<ContentApiOptions>()
-            .Bind(_configuration.GetRequiredSection(ContentApiOptions.Section));
+            .Bind(configuration.GetRequiredSection(ContentApiOptions.Section));
         services.AddOptions<ParquetFilesOptions>()
-            .Bind(_configuration.GetRequiredSection(ParquetFilesOptions.Section));
+            .Bind(configuration.GetRequiredSection(ParquetFilesOptions.Section));
 
         // Services
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -20,17 +20,8 @@ using Npgsql;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api;
 
 [ExcludeFromCodeCoverage]
-public class Startup
+public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironment)
 {
-    private readonly IConfiguration _configuration;
-    private readonly IHostEnvironment _hostEnvironment;
-
-    public Startup(IConfiguration configuration, IHostEnvironment hostEnvironment)
-    {
-        _configuration = configuration;
-        _hostEnvironment = hostEnvironment;
-    }
-
     // This method gets called by the runtime. Use this method to add services to the container.
     public void ConfigureServices(IServiceCollection services)
     {
@@ -78,10 +69,10 @@ public class Startup
         // Only set up the `PublicDataDbContext` in non-integration test
         // environments. Otherwise, the connection string will be null and
         // cause the data source builder to throw a host exception.
-        if (!_hostEnvironment.IsIntegrationTest())
+        if (!hostEnvironment.IsIntegrationTest())
         {
             var dataSourceBuilder = new NpgsqlDataSourceBuilder(
-                _configuration.GetConnectionString("PublicDataDb"));
+                configuration.GetConnectionString("PublicDataDb"));
 
             // Set up the data source outside the `AddDbContext` action as this
             // prevents `ManyServiceProvidersCreatedWarning` warnings due to EF
@@ -92,7 +83,7 @@ public class Startup
             {
                 options
                     .UseNpgsql(dbDataSource)
-                    .EnableSensitiveDataLogging(_hostEnvironment.IsDevelopment());
+                    .EnableSensitiveDataLogging(hostEnvironment.IsDevelopment());
             });
         }
 


### PR DESCRIPTION
Adding an optional query parameter, `types`, to the endpoint for retrieving the metadata for a single Data Set Version.

The endpoint lives at `api/v1/data-sets/{dataSetId}/meta?types=Filters,Indicators,Locations,TimePeriods`.

The `types` query parameter is _optional_, and expects a comma-separated list of metadata types to filter the results by. The accepted values are:
- `Filters` - include all metadata associated with the *filters* of the requested data set version
- `Indicators` - include all metadata associated with the *indicators* of the requested data set version
- `Locations` - include all metadata associated with the *locations* of the requested data set version
- `TimePeriods` - include all metadata associated with the *time periods* of the requested data set version

_(Any duplicate metadata types will be ignored)_

This new `types` query parameter allows you to specify any combination of metadata types you'd like to request the data for.

For example, if you're interested in all of the metadata except for locations, you can specify:
`?types=Filters,Indicators,TimePeriods`. 

If you're just interested in filters, you can specify:
`?types=Filters`.

By default, if the `types` query parameter is not specified, the endpoint will return the metadata for **ALL** metatdata types (`Filters`, `Indicators`, `Locations` and `TimePeriods`).

The endpoint returns the following status codes:
- 200
- 400 **(new after this change)**
- 403
- 404

For any metadata types that are not specified (except for the case where none are specified at all), the corresponding JSON fields in the response from the endpoint will contain **_empty arrays_** for those types. For example, where only `Filters` is requested, the endpoint will return the following schema:

```json
{
  "filters": [ ...
  ], // Not empty
  "indicators": [], // Empty
  "geographicLevels": [], // Empty
  "locations": [], // Empty
  "timePeriods": [] // Empty
}
```

The full JSON response, when the response is a 200 OK, looks like:

```json
{
  "filters": [
    {
      "id": "string",
      "hint": "string",
      "label": "string",
      "options": [
        {
          "id": "string",
          "label": "string",
          "isAggregate": true
        }
      ]
    }
  ],
  "indicators": [
    {
      "id": "string",
      "label": "string",
      "unit": "string",
      "decimalPlaces": 0
    }
  ],
  "geographicLevels": [
    "string"
  ],
  "locations": [
    {
      "level": "string",
      "options": [
        {
          "id": "string",
          "label": "string",
          "code": "string"
        }
      ]
    }
  ],
  "timePeriods": [
    {
      "code": "string",
      "year": 0,
      "label": "string"
    }
  ]
}
```