### PR TITLE
EES-5020 fix server rendered release pages

### DIFF
--- a/src/explore-education-statistics-common/src/components/Tabs.tsx
+++ b/src/explore-education-statistics-common/src/components/Tabs.tsx
@@ -25,9 +25,7 @@ interface Props {
 
 const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
-  const [hasCheckedHash, setHasCheckedHash] = useState<boolean>(
-    !window.location.hash,
-  );
+  const [hasCheckedHash, setHasCheckedHash] = useState<boolean>();
   const ref = useRef<HTMLDivElement>(null);
 
   const { onMedia } = useDesktopMedia();
@@ -97,6 +95,12 @@ const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
     },
     [sections],
   );
+
+  useEffect(() => {
+    if (window) {
+      setHasCheckedHash(!window.location.hash);
+    }
+  }, []);
 
   useEffect(() => {
     const handleHashChange = () => {


### PR DESCRIPTION
Release pages with tabs on were erroring when they were server rendered. This fixes that by moving the check for the `window.location.hash` into a `useEffect`, with a check that `window` exists to be doubly safe.