### PR TITLE
EES-5022 Give AcademicYear identifier precedence over '* term' identi…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifier.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifier.cs
@@ -11,6 +11,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     public enum TimeIdentifier
     {
+        [TimeIdentifierMeta("Autumn term", "T1", Term, Academic)]
+        AutumnTerm,
+
+        [TimeIdentifierMeta("Spring term", "T2", Term, Academic)]
+        SpringTerm,
+
+        [TimeIdentifierMeta("Autumn and spring term", "T1T2", Term, Academic)]
+        AutumnSpringTerm,
+
+        [TimeIdentifierMeta("Summer term", "T3", Term, Academic)]
+        SummerTerm,
+
         [TimeIdentifierMeta("Academic year", "AY", Category.AcademicYear, Academic, NoLabel)]
         AcademicYear,
 
@@ -81,18 +93,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
         [TimeIdentifierMeta("Reporting year", "RY", Category.ReportingYear, Default, NoLabel)]
         ReportingYear,
-
-        [TimeIdentifierMeta("Autumn term", "T1", Term, Academic)]
-        AutumnTerm,
-
-        [TimeIdentifierMeta("Autumn and spring term", "T1T2", Term, Academic)]
-        AutumnSpringTerm,
-
-        [TimeIdentifierMeta("Spring term", "T2", Term, Academic)]
-        SpringTerm,
-
-        [TimeIdentifierMeta("Summer term", "T3", Term, Academic)]
-        SummerTerm,
 
         [TimeIdentifierMeta("Week 1", "W1", Week)]
         Week1,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimeIdentifierUtilTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimeIdentifierUtilTests.cs
@@ -152,8 +152,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             Assert.Equal(new[]
             {
                 AutumnTerm,
-                AutumnSpringTerm,
                 SpringTerm,
+                AutumnSpringTerm,
                 SummerTerm
             }, TimeIdentifierUtil.GetTerms());
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodUtilTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodUtilTests.cs
@@ -561,8 +561,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 new List<(int Year, TimeIdentifier TimeIdentifier)>
                 {
                     (2019, AutumnTerm),
-                    (2019, AutumnSpringTerm),
                     (2019, SpringTerm),
+                    (2019, AutumnSpringTerm),
                     (2019, SummerTerm)
                 },
                 TimePeriodUtil.Range(new TimePeriodQuery(2019, AutumnTerm, 2019, SummerTerm)).ToList());
@@ -570,15 +570,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             CollectionAssert.AreEquivalent(
                 new List<(int Year, TimeIdentifier TimeIdentifier)>
                 {
-                    (2018, SpringTerm),
+                    (2018, AutumnSpringTerm),
                     (2018, SummerTerm),
                     (2019, AutumnTerm),
-                    (2019, AutumnSpringTerm),
                     (2019, SpringTerm),
+                    (2019, AutumnSpringTerm),
                     (2019, SummerTerm),
                     (2020, AutumnTerm)
                 },
-                TimePeriodUtil.Range(new TimePeriodQuery(2018, SpringTerm, 2020, AutumnTerm)).ToList());
+                TimePeriodUtil.Range(new TimePeriodQuery(2018, AutumnSpringTerm, 2020, AutumnTerm)).ToList());
         }
 
         [Fact]


### PR DESCRIPTION
…fiers

This will make this release the latest for it's publication:
https://explore-education-statistics.service.gov.uk/find-statistics/pupil-absence-in-schools-in-england/2022-23

Also reordered the terms as per Cam's instructions.

We haven't reordered any of the other time identifier's as we're keen to get this out ASAP.