### PR TITLE
Only perform URL lowercasing on decoded strings

### DIFF
--- a/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
@@ -76,6 +76,7 @@ describe('redirectPages', () => {
       expect.objectContaining({
         href: 'https://my-env/find-statistics',
       }),
+      301,
     );
     expect(nextSpy).not.toHaveBeenCalled();
 
@@ -92,6 +93,7 @@ describe('redirectPages', () => {
       expect.objectContaining({
         href: 'https://my-env/find-statistics/release-name?testParam=Something',
       }),
+      301,
     );
     expect(nextSpy).not.toHaveBeenCalled();
   });
@@ -109,6 +111,7 @@ describe('redirectPages', () => {
         expect.objectContaining({
           href: 'https://my-env/methodology/updated-slug-1',
         }),
+        301,
       );
       expect(nextSpy).not.toHaveBeenCalled();
     });
@@ -155,6 +158,7 @@ describe('redirectPages', () => {
         expect.objectContaining({
           href: 'https://my-env/methodology/updated-slug-1/child-page',
         }),
+        301,
       );
       expect(nextSpy).not.toHaveBeenCalled();
     });
@@ -173,6 +177,7 @@ describe('redirectPages', () => {
         expect.objectContaining({
           href: 'https://my-env/methodology/updated-slug-1?search=something',
         }),
+        301,
       );
       expect(nextSpy).not.toHaveBeenCalled();
     });
@@ -201,6 +206,7 @@ describe('redirectPages', () => {
         expect.objectContaining({
           href: 'https://my-env/methodology/updated-slug-1',
         }),
+        301,
       );
       expect(nextSpy).not.toHaveBeenCalled();
     });
@@ -219,6 +225,7 @@ describe('redirectPages', () => {
         expect.objectContaining({
           href: 'https://my-env/find-statistics/updated-slug-3',
         }),
+        301,
       );
       expect(nextSpy).not.toHaveBeenCalled();
     });
@@ -269,6 +276,7 @@ describe('redirectPages', () => {
         expect.objectContaining({
           href: 'https://my-env/find-statistics/updated-slug-3/child-page',
         }),
+        301,
       );
       expect(nextSpy).not.toHaveBeenCalled();
     });
@@ -288,6 +296,7 @@ describe('redirectPages', () => {
         expect.objectContaining({
           href: 'https://my-env/find-statistics/updated-slug-3?search=something',
         }),
+        301,
       );
       expect(nextSpy).not.toHaveBeenCalled();
     });
@@ -316,6 +325,7 @@ describe('redirectPages', () => {
         expect.objectContaining({
           href: 'https://my-env/find-statistics/updated-slug-3',
         }),
+        301,
       );
       expect(nextSpy).not.toHaveBeenCalled();
     });

--- a/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
@@ -26,7 +26,7 @@ export default async function redirectPages(request: NextRequest) {
   // Check for redirects for release and methodology pages
   if (
     Object.values(redirectPaths).find(path =>
-      decodedPathname.startsWith(path),
+      decodedPathname.toLowerCase().startsWith(path),
     ) &&
     decodedPathname.split('/').length > 2
   ) {
@@ -75,7 +75,7 @@ export default async function redirectPages(request: NextRequest) {
   if (decodedPathname !== decodedPathname.toLowerCase()) {
     const url = nextUrl.clone();
     url.pathname = decodedPathname.toLowerCase();
-    return NextResponse.redirect(url, 307);
+    return NextResponse.redirect(url, 301);
   }
 
   return NextResponse.next();

--- a/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
@@ -21,13 +21,14 @@ const redirectPaths = {
 
 export default async function redirectPages(request: NextRequest) {
   const { nextUrl } = request;
+  const decodedPathname = decodeURIComponent(request.nextUrl.pathname);
 
   // Check for redirects for release and methodology pages
   if (
     Object.values(redirectPaths).find(path =>
-      nextUrl.pathname.toLowerCase().startsWith(path),
+      decodedPathname.startsWith(path),
     ) &&
-    nextUrl.pathname.split('/').length > 2
+    decodedPathname.split('/').length > 2
   ) {
     const shouldRefetch =
       !cachedRedirects || cachedRedirects.fetchedAt + cacheTime < Date.now();
@@ -42,9 +43,9 @@ export default async function redirectPages(request: NextRequest) {
     const redirectPath = Object.keys(redirectPaths).reduce((acc, key) => {
       const redirectType = key as RedirectType;
       if (
-        nextUrl.pathname.toLowerCase().startsWith(redirectPaths[redirectType])
+        decodedPathname.toLowerCase().startsWith(redirectPaths[redirectType])
       ) {
-        const pathSegments = nextUrl.pathname.split('/');
+        const pathSegments = decodedPathname.split('/');
 
         const rewriteRule = cachedRedirects?.redirects[redirectType]?.find(
           ({ fromSlug }) => pathSegments[2].toLowerCase() === fromSlug,
@@ -66,15 +67,15 @@ export default async function redirectPages(request: NextRequest) {
     if (redirectPath) {
       const redirectUrl = nextUrl.clone();
       redirectUrl.pathname = redirectPath;
-      return NextResponse.redirect(redirectUrl);
+      return NextResponse.redirect(redirectUrl, 301);
     }
   }
 
   // Redirect any URLs with uppercase characters to lowercase.
-  if (nextUrl.pathname !== nextUrl.pathname.toLowerCase()) {
+  if (decodedPathname !== decodedPathname.toLowerCase()) {
     const url = nextUrl.clone();
-    url.pathname = url.pathname.toLowerCase();
-    return NextResponse.redirect(url);
+    url.pathname = decodedPathname.toLowerCase();
+    return NextResponse.redirect(url, 307);
   }
 
   return NextResponse.next();


### PR DESCRIPTION
Routes such as https://explore-education-statistics.service.gov.uk/methodology/%5bpublication%5d are getting infinitely redirected in the live environments (but not locally). 

In the Azure Portal we can see that on each redirect, characters that need to be URL encoded are being encoded with capitals (see attached pic 1). I still don't know why this is, but I suspect it might be getting picked up by the Redirects middleware which tries to redirect to a lowercased URL every time (see attached pic 2). 

This PR attempts to only invoke that redirect if the decoded URL contains capitals, hoping to leave url encoding alone. It also updates the redirects to use status code 301 rather than 307 while we're at it. 

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/63285990/2e69f8f0-90f1-4979-9772-de62968989f7)
![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/63285990/40d11470-0922-4c64-a6dd-f54eb0228e82)
