### PR TITLE
EES-5012 Test disabling the ability to trigger scheduled publishing of release versions immediately

### DIFF
--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -93,7 +93,7 @@
       "value": 268435456000
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
-      "value": true
+      "value": false
     }
   }
 }


### PR DESCRIPTION
This PR will allow us to test whether we can still disable the Azure Functions which trigger scheduled publishing of release versions immediately after the switch to use the 'Isolated worker' model by #4673.

With the switch from using the ‘In process’ model to the ‘Isolated worker’ model there is some uncertainty about whether functions using the ‘Isolated worker' model can be disabled, so we need to test this.

The functions which we allow to be disabled are `StageScheduledReleaseVersionsImmediately` and `PublishStagedReleaseVersionContentImmediately`.

The functions and how to use them are documented in the [Publisher's README](https://github.com/dfe-analytical-services/explore-education-statistics/tree/dev/src/GovUk.Education.ExploreEducationStatistics.Publisher#readme).

We will test the disabling functionality by configuring the two Azure Functions to be disabled in the Test environment, just like how they are currently disabled in the Prod environment.

Prior to deploying this we should test the functions are working in the Test environment as expected by following the [Publisher's README](https://github.com/dfe-analytical-services/explore-education-statistics/tree/dev/src/GovUk.Education.ExploreEducationStatistics.Publisher#readme).

Once we are sure they are working as expected already, we will need to make sure the Infrastructure build corresponding with this change has been deployed to the Test environment which should change the environment config of the Azure Publisher Function app as follows:

```
AzureWebJobs.StageScheduledReleaseVersionsImmediately.Disabled: true
AzureWebJobs.PublishStagedReleaseVersionContentImmediately.Disabled: true
```

We can then repeat the same test as before and make sure the Azure Functions are no longer available.

After this testing is complete, tidy up by reverting this change and deploy the infrastructure.

If this test is not successful we might need to temporarily implement our own way of disabling the functions which can be used until support for disabling functions is added.