### PR TITLE
EES-4535 Enable "Always on" in Notifier Azure Function app

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2811,6 +2811,7 @@
           "minTlsVersion": "[parameters('minTlsVersion')]",
           "ftpsState": "FtpsOnly",
           "netFrameworkVersion": "v8.0",
+          "AlwaysOn": true,
           "webSocketsEnabled": false,
           "requestTracingEnabled": true,
           "remoteDebuggingEnabled": false,


### PR DESCRIPTION
This PR enables "Always on" for the Notifier Azure Function app in the same way that it's enabled for the other two apps.

The documentation says the following:

> If you run on an App Service plan, you should enable the Always on setting so that your function app runs correctly.

It should also fix this warning we see in Azure Portal:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/4147126/0d8c3555-0d54-4e48-bff8-6f0ce67829ed)
