### PR TITLE
Revert config change made for EES-5012 in #4693

### DIFF
--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -93,7 +93,7 @@
       "value": 268435456000
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
-      "value": false
+      "value": true
     }
   }
 }


### PR DESCRIPTION
This reverts commit 67fde93c775d6288793ee64b15cc03814a271097 made by #4693.

That was a test to ensure we can disable some of the Publisher's Azure Functions after #4673.

The test was successful and we don't need to make any further changes.