### PR TITLE
EES-5029 Downgrade .NET 8 version to acceptable number for Linux

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.203",
+    "version": "8.0.202",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
This PR lowers the required .NET version from `8.0.203` to `8.0.202`. This is necessary as no `8.0.203` has been published to the Microsoft PPA on Linux, meaning any `dotnet` commands bail upon detecting the wrong installed version.