### PR TITLE
EES-4865 consistent order in bar chart tooltip, bars and legend

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -64,7 +64,7 @@ const HorizontalBarBlock = ({
   showDataLabels,
   dataLabelPosition,
 }: HorizontalBarProps) => {
-  const [legendProps, renderLegend] = useLegend();
+  const [legendProps, renderLegend] = useLegend({});
   const { isMedia: isMobileMedia } = useMobileMedia();
 
   if (

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -72,7 +72,7 @@ const LineChartBlock = ({
   showDataLabels,
   dataLabelPosition,
 }: LineChartProps) => {
-  const [legendProps, renderLegend] = useLegend();
+  const [legendProps, renderLegend] = useLegend({});
 
   if (
     axes === undefined ||
@@ -138,6 +138,7 @@ const LineChartBlock = ({
               <CustomTooltip
                 dataSetCategories={dataSetCategories}
                 dataSetCategoryConfigs={dataSetCategoryConfigs}
+                order="value"
               />
             }
             wrapperStyle={{ zIndex: 1000 }}

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -59,7 +59,7 @@ const VerticalBarBlock = ({
   stacked,
   width,
 }: VerticalBarProps) => {
-  const [legendProps, renderLegend] = useLegend();
+  const [legendProps, renderLegend] = useLegend({ reverseOrder: stacked });
   if (
     axes === undefined ||
     axes.major === undefined ||
@@ -164,6 +164,7 @@ const VerticalBarBlock = ({
               <CustomTooltip
                 dataSetCategories={dataSetCategories}
                 dataSetCategoryConfigs={dataSetCategoryConfigs}
+                order={stacked ? 'reverse' : 'default'}
               />
             }
             wrapperStyle={{ zIndex: 1000 }}

--- a/src/explore-education-statistics-common/src/modules/charts/components/hooks/useLegend.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/hooks/useLegend.ts
@@ -3,7 +3,11 @@ import { useCallback, useState } from 'react';
 import { LegendProps, DefaultLegendContentProps } from 'recharts';
 import { ContentType } from 'recharts/types/component/DefaultLegendContent';
 
-export default function useLegend(): [LegendProps | undefined, ContentType] {
+export default function useLegend({
+  reverseOrder = false,
+}: {
+  reverseOrder?: boolean;
+}): [LegendProps | undefined, ContentType] {
   const [legendProps, setLegendProps] = useState<LegendProps>();
 
   const renderLegend: ContentType = useCallback(
@@ -14,17 +18,22 @@ export default function useLegend(): [LegendProps | undefined, ContentType] {
         height: nextProps.height ? Number(nextProps.height) : undefined,
       };
 
+      const { payload = [] } = nextLegendProps;
+
       // Need to do a deep comparison of the props to
       // avoid falling into an infinite rendering loop.
       if (JSON.stringify(legendProps) !== JSON.stringify(nextLegendProps)) {
         setTimeout(() => {
-          setLegendProps(nextLegendProps);
+          setLegendProps({
+            ...nextLegendProps,
+            payload: reverseOrder ? [...payload].reverse() : payload,
+          });
         });
       }
 
       return null;
     },
-    [legendProps],
+    [legendProps, reverseOrder],
   );
 
   return [legendProps, renderLegend];


### PR DESCRIPTION
Fixes issues with inconsistent ordering in tooltips and legends

### Stacked vertical bar charts:

**Before:** three different orders!
- tooltip list is ordered by value
- legend list is ordered by data set order
- bars are ordered by reversed data set order
<img width="340" alt="Screenshot 2024-03-26 154019" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/34d11ab9-275c-4c41-a94b-29861978b832">

**After:** they are now consistently ordered by reversed data set order  (note that it's the reversed data set order as that's how recharts stacks them, it could be changed but not without affecting existing charts).

<img width="442" alt="Screenshot 2024-03-26 153842" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/25eb7f00-70b7-4e4f-b13f-905c399b807e">

### Vertical bar charts, horizontal bar charts and stacked horizontal bar charts

**Before:** tootlip list order is wrong
- tooltip list is ordered by value
- legend list is ordered by data set order
- bars are ordered by data set order

**After:** tooltip, legend and bars are ordered by data set order

### Line charts

No change - tooltip is ordered by value and legend is ordered by data set order. 
