### PR TITLE
EES-4705 EES-4706 Fix accessing ContentApiOptions while configuring ContentApiClient

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -15,6 +15,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Options;
 using MicroElements.Swashbuckle.FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Npgsql;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api;
@@ -109,8 +110,8 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
 
         services.AddHttpClient<IContentApiClient, ContentApiClient>((provider, httpClient) =>
         {
-            var options = provider.GetRequiredService<ContentApiOptions>();
-            httpClient.BaseAddress = new Uri(options.Url);
+            var options = provider.GetRequiredService<IOptions<ContentApiOptions>>();
+            httpClient.BaseAddress = new Uri(options.Value.Url);
             httpClient.DefaultRequestHeaders.Add(HeaderNames.UserAgent, "EES Public Data API");
         });
 


### PR DESCRIPTION
Previously we were seeing the error `System.InvalidOperationException: No service for type 'GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options.ContentApiOptions' has been registered.`

This PR changes the type of service from `ContentApiOptions` to `IOptions<ContentApiOptions>` in order to retrieve the options.