### PR TITLE
EES-5017, EES-5016 Add data set GET query endpoint

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/CollectionExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/CollectionExtensionTests.cs
@@ -8,7 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 
 public static class CollectionExtensionTests
 {
-    public class AddRange
+    public class AddRangeTests
     {
         [Fact]
         public void Set()
@@ -82,6 +82,48 @@ public static class CollectionExtensionTests
             Assert.Equal("a", list[0]);
             Assert.Equal("a", list[1]);
             Assert.Equal("b", list[2]);
+        }
+    }
+
+    public class LastIndexTests
+    {
+        [Theory]
+        [InlineData(0, "a")]
+        [InlineData(1, "a", "b")]
+        [InlineData(2, "a", "b", "c")]
+        [InlineData(3, "a", "b", "c", "d")]
+        public void CorrectLastIndex(int expectedLastIndex, params string[] values)
+        {
+            var list = new List<string>(values);
+
+            Assert.Equal(expectedLastIndex, list.LastIndex());
+        }
+    }
+
+    public class IsLastIndexTests
+    {
+        [Theory]
+        [InlineData(0, "a")]
+        [InlineData(1, "a", "b")]
+        [InlineData(2, "a", "b", "c")]
+        [InlineData(3, "a", "b", "c", "d")]
+        public void TrueForCorrectLastIndex(int correctIndex, params string[] values)
+        {
+            var list = new List<string>(values);
+
+            Assert.True(list.IsLastIndex(correctIndex));
+        }
+
+        [Theory]
+        [InlineData(1, "a")]
+        [InlineData(2, "a", "b")]
+        [InlineData(3, "a", "b", "c")]
+        [InlineData(4, "a", "b", "c", "d")]
+        public void FalseForIncorrectLastIndex(int incorrectIndex, params string[] values)
+        {
+            var list = new List<string>(values);
+
+            Assert.False(list.IsLastIndex(incorrectIndex));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/SqlBuilderExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/SqlBuilderExtensionsTests.cs
@@ -1,0 +1,241 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using InterpolatedSql;
+using InterpolatedSql.SqlBuilders;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public abstract class SqlBuilderExtensionsTests
+{
+    private const string ParamStr = "test";
+    private const int ParamInt = 10;
+    private const bool ParamBool = true;
+
+    public class AppendRangeTests : SqlBuilderExtensionsTests
+    {
+        [Theory]
+        [InlineData("some_field", "some_field")]
+        [InlineData("some_field = true", "some_field = true")]
+        [InlineData("some_field = true", "some_field", " = ", "true")]
+        [InlineData("where some_field = true", "where", "some_field = true")]
+        [InlineData("(where some_field = true)", "(", "where", "some_field = true", ")")]
+        public void LiteralsWithoutJoin(string expectedSql, params string[] literals)
+        {
+            var builder = new SqlBuilder();
+
+            builder.AppendRange(literals);
+
+            var sql = builder.Build();
+
+            Assert.Equal(expectedSql, sql.Sql);
+            Assert.Empty(sql.SqlParameters);
+        }
+
+        [Theory]
+        [InlineData("a, list, of, things", ", ", "a", "list", "of", "things")]
+        [InlineData("a, b, , d", ", ", "a", "b", "", "d")]
+        [InlineData("(@p0, @p1, @p2, @p3)", ", ", "(@p0", "@p1", "@p2", "@p3)")]
+        [InlineData("a = true AND b = false", " AND ", "a = true", "b = false")]
+        [InlineData("a = true OR b = false", " OR ", "a = true", "b = false")]
+        public void LiteralsWithJoin(string expectedSql, string joinString, params string[] literals)
+        {
+            var builder = new SqlBuilder();
+
+            builder.AppendRange(literals, joinString: joinString);
+
+            var sql = builder.Build();
+
+            Assert.Equal(expectedSql, sql.Sql);
+            Assert.Empty(sql.SqlParameters);
+        }
+
+        [Fact]
+        public void LiteralsWithInterpolations()
+        {
+            var literals = new[] { $"field_a = {ParamStr}", $"field_b = {ParamBool}" };
+
+            var builder = new SqlBuilder();
+
+            builder.AppendRange(literals, joinString: " OR ");
+
+            var sql = builder.Build();
+
+            Assert.Equal($"field_a = {ParamStr} OR field_b = {ParamBool}", sql.Sql);
+            Assert.Empty(sql.SqlParameters);
+        }
+
+        [Theory]
+        [MemberData(nameof(InterpolatedSqlData))]
+        public void InterpolatedSql(
+            string expectedSql,
+            object[] expectedParams,
+            string? joinString,
+            IInterpolatedSql[] fragments)
+        {
+            var builder = new SqlBuilder();
+
+            builder.AppendRange(fragments, joinString: joinString);
+
+            var sql = builder.Build();
+
+            Assert.Equal(expectedSql, sql.Sql);
+            Assert.Equal(expectedParams.Length, sql.SqlParameters.Count);
+            Assert.Equal(expectedParams, sql.SqlParameters.Select(p => p.Argument));
+        }
+
+        [Theory]
+        [MemberData(nameof(SqlBuildersData))]
+        public void SqlBuilders(
+            string expectedSql,
+            object[] expectedParams,
+            string? joinString,
+            SqlBuilder[] builders)
+        {
+            var builder = new SqlBuilder();
+
+            builder.AppendRange(builders, joinString: joinString);
+
+            var sql = builder.Build();
+
+            Assert.Equal(expectedSql, sql.Sql);
+            Assert.Equal(expectedParams.Length, sql.SqlParameters.Count);
+            Assert.Equal(expectedParams, sql.SqlParameters.Select(p => p.Argument));
+        }
+
+        [Theory]
+        [MemberData(nameof(FormattableStringsData))]
+        public void FormattableStrings(
+            string expectedSql,
+            object[] expectedParams,
+            string? joinString,
+            FormattableString[] strings)
+        {
+            var builder = new SqlBuilder();
+
+            builder.AppendRange(strings, joinString: joinString);
+
+            var sql = builder.Build();
+
+            Assert.Equal(expectedSql, sql.Sql);
+            Assert.Equal(expectedParams.Length, sql.SqlParameters.Count);
+            Assert.Equal(expectedParams, sql.SqlParameters.Select(p => p.Argument));
+        }
+
+        private static IEnumerable<SqlBuilderTestCase> SqlBuilderTestCases()
+        {
+            return new List<SqlBuilderTestCase>
+            {
+                new(
+                    ExpectedSql: "field_a = @p0 AND field_b = @p1",
+                    ExpectedParameters: [ParamBool, ParamInt],
+                    Builders:
+                    [
+                        new SqlBuilder($"field_a = {ParamBool}"),
+                        new SqlBuilder($"field_b = {ParamInt}")
+                    ],
+                    JoinString: " AND "
+                ),
+                new(
+                    ExpectedSql: "field_a = @param AND field_b = @otherParam",
+                    // Not binding any parameters as we're using literal text
+                    ExpectedParameters: [],
+                    Builders:
+                    [
+                        new SqlBuilder($"field_a = @param"),
+                        new SqlBuilder($"field_b = @otherParam")
+                    ],
+                    JoinString: "AND "
+                ),
+                new(
+                    ExpectedSql: "FieldB = @p0 OR FieldC = @p1",
+                    ExpectedParameters: [ParamStr, ParamInt],
+                    Builders:
+                    [
+                        new SqlBuilder($"FieldB = {ParamStr}"),
+                        new SqlBuilder($"FieldC = {ParamInt}")
+                    ],
+                    JoinString: " OR "
+                ),
+                new(
+                    ExpectedSql: "@p0, @p1, @p2",
+                    ExpectedParameters: [ParamStr, ParamBool, ParamInt],
+                    Builders:
+                    [
+                        new SqlBuilder($"{ParamStr}"),
+                        new SqlBuilder($"{ParamBool}"),
+                        new SqlBuilder($"{ParamInt}")
+                    ],
+                    JoinString: ", "
+                ),
+                new(
+                    ExpectedSql: "IN (@p0, @p1, @p2)",
+                    ExpectedParameters: [ParamStr, ParamBool, ParamInt],
+                    Builders:
+                    [
+                        new SqlBuilder($"IN ({ParamStr}"),
+                        new SqlBuilder($"{ParamBool}"),
+                        new SqlBuilder($"{ParamInt})")
+                    ],
+                    JoinString: ", "
+                ),
+                new(
+                    ExpectedSql: "some_field = @p0",
+                    ExpectedParameters: [ParamInt],
+                    Builders:
+                    [
+                        new SqlBuilder($"some_field"),
+                        new SqlBuilder($" = {ParamInt}")
+                    ]
+                ),
+                new(
+                    ExpectedSql: "WHERE field_a = @p0 AND field_b = @p1 OR field_c = @p2",
+                    ExpectedParameters: [ParamBool, ParamInt, ParamStr],
+                    Builders:
+                    [
+                        new SqlBuilder($"WHERE"),
+                        new SqlBuilder($"field_a = {ParamBool}"),
+                        new SqlBuilder($"AND field_b = {ParamInt}"),
+                        new SqlBuilder($"OR field_c = {ParamStr}")
+                    ]
+                ),
+            };
+        }
+
+        public static TheoryData<string, object[], string?, IInterpolatedSql[]> InterpolatedSqlData
+            => CreateData(b => b.Build());
+
+        public static TheoryData<string, object[], string?, SqlBuilder[]> SqlBuildersData
+            => CreateData(b => b);
+
+        public static TheoryData<string, object[], string?, FormattableString[]> FormattableStringsData
+            => CreateData(b => b.AsFormattableString());
+
+        private static TheoryData<string, object[], string?, TFragment[]> CreateData<TFragment>(
+            Func<SqlBuilder, TFragment> build)
+        {
+            var data = new TheoryData<string, object[], string?, TFragment[]>();
+
+            foreach (var testCase in SqlBuilderTestCases())
+            {
+                data.Add(
+                    testCase.ExpectedSql,
+                    testCase.ExpectedParameters,
+                    testCase.JoinString,
+                    testCase.Builders.Select(build).ToArray()
+                );
+            }
+
+            return data;
+        }
+
+        private record SqlBuilderTestCase(
+            string ExpectedSql,
+            object[] ExpectedParameters,
+            SqlBuilder[] Builders,
+            string? JoinString = null);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
@@ -1331,7 +1331,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model
         }
 
         [Fact]
-        public async Task OnFailureFailWith()
+        public async Task OnFailureFailWith_NoArg()
         {
             var result = await Task.FromResult(new Either<int, string>(500))
                 .OnFailureFailWith(() => 600);
@@ -1340,19 +1340,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model
         }
 
         [Fact]
-        public async Task OnFailureFailWith_GenericTask()
+        public async Task OnFailureFailWith_FailureArg()
         {
             var result = await Task.FromResult(new Either<int, string>(500))
-                .OnFailureFailWith(_ => Task.FromResult(600));
+                .OnFailureFailWith(failure => failure + 100);
 
             result.AssertLeft(600);
         }
 
         [Fact]
-        public async Task OnFailureFailWith_GenericTask_PriorFailure()
+        public async Task OnFailureFailWith_GenericTaskWithFailureArg()
+        {
+            var result = await Task.FromResult(new Either<int, string>(500))
+                .OnFailureFailWith(failure => Task.FromResult(failure + 100));
+
+            result.AssertLeft(600);
+        }
+
+        [Fact]
+        public async Task OnFailureFailWith_GenericTaskWithFailureArg_PriorSuccess()
         {
             var result = await Task.FromResult(new Either<int, string>("Success"))
-                .OnFailureFailWith(_ => Task.FromResult(500));
+                .OnFailureFailWith(failure => Task.FromResult(failure + 100));
 
             result.AssertRight("Success");
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Config/FluentValidationActionFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Config/FluentValidationActionFilter.cs
@@ -132,7 +132,7 @@ public class FluentValidationActionFilter : IAsyncActionFilter
 
     private static IDictionary<string, object?> GetErrorDetail(ValidationFailure failure)
     {
-        var detail = failure.FormattedMessagePlaceholderValues
+        var detail = (failure.FormattedMessagePlaceholderValues ?? [])
             .Where(kv => !IgnoredMessagePlaceholders.Contains(kv.Key))
             .ToDictionary(kv => kv.Key.ToLowerFirst(), kv => kv.Value)
             as Dictionary<string, object?>;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/CollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/CollectionExtensions.cs
@@ -16,4 +16,8 @@ public static class CollectionExtensions
             source.Add(item);
         }
     }
+
+    public static int LastIndex<T>(this ICollection<T> source) => source.Count - 1;
+
+    public static bool IsLastIndex<T>(this ICollection<T> source, int index) => index == source.LastIndex();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/InterpolatedSqlExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/InterpolatedSqlExtensions.cs
@@ -1,0 +1,9 @@
+using InterpolatedSql;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class InterpolatedSqlExtensions
+{
+    public static bool IsEmpty(this IInterpolatedSql sql)
+        => sql.Sql.IsNullOrWhitespace() && sql.SqlParameters.Count == 0;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/SqlBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/SqlBuilderExtensions.cs
@@ -1,0 +1,106 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using InterpolatedSql;
+using InterpolatedSql.SqlBuilders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class SqlBuilderExtensions
+{
+    /// <summary>
+    /// Append multiple literal fragments to the SQL builder.
+    /// </summary>
+    /// <param name="builder">The SQL builder</param>
+    /// <param name="literals">The literal fragments to append</param>
+    /// <param name="joinString">A string to join the fragments with</param>
+    /// <returns>The builder</returns>
+    public static TBuilder AppendRange<TBuilder>(
+        this TBuilder builder,
+        IEnumerable<string> literals,
+        string? joinString = null) where TBuilder : InterpolatedSqlBuilderBase
+    {
+        return builder.AppendRange(
+            items: literals,
+            append: builder.AppendLiteral,
+            joinString: joinString
+        );
+    }
+
+    /// <summary>
+    /// Append multiple <see cref="FormattableString"/> SQL fragments to the SQL builder.
+    /// </summary>
+    /// <param name="builder">The SQL builder</param>
+    /// <param name="fragments">The SQL fragments to append</param>
+    /// <param name="joinString">A string to join the fragments with</param>
+    /// <returns></returns>
+    public static TBuilder AppendRange<TBuilder>(
+        this TBuilder builder,
+        IEnumerable<FormattableString> fragments,
+        string? joinString = null) where TBuilder : InterpolatedSqlBuilderBase
+    {
+        return builder.AppendRange(
+            items: fragments,
+            append: builder.AppendFormattableString,
+            joinString: joinString
+        );
+    }
+
+    /// <summary>
+    /// Append multiple SQL builders to the SQL builder.
+    /// </summary>
+    /// <param name="builder">The SQL builder</param>
+    /// <param name="builders">The SQL builders to append</param>
+    /// <param name="joinString">A string to join the fragments with</param>
+    public static TBuilder AppendRange<TBuilder>(
+        this TBuilder builder,
+        IEnumerable<IBuildable<IInterpolatedSql>> builders,
+        string? joinString = null) where TBuilder : InterpolatedSqlBuilderBase
+    {
+        return builder.AppendRange(
+            items: builders,
+            append: b => builder.Append(b.Build()),
+            joinString: joinString
+        );
+    }
+
+    /// <summary>
+    /// Append multiple <see cref="IInterpolatedSql"/> fragments to the SQL builder.
+    /// </summary>
+    /// <param name="builder">The SQL builder</param>
+    /// <param name="fragments">The SQL fragments to append</param>
+    /// <param name="joinString">A string to join the fragments with</param>
+    public static TBuilder AppendRange<TBuilder>(
+        this TBuilder builder,
+        IEnumerable<IInterpolatedSql> fragments,
+        string? joinString = null) where TBuilder : InterpolatedSqlBuilderBase
+    {
+        return builder.AppendRange(
+            items: fragments,
+            append: builder.Append,
+            joinString: joinString
+        );
+    }
+
+    private static TBuilder AppendRange<TBuilder, TItem>(
+        this TBuilder builder,
+        IEnumerable<TItem> items,
+        Action<TItem> append,
+        string? joinString) where TBuilder : InterpolatedSqlBuilderBase
+    {
+        var itemsList = items.ToList();
+
+        foreach (var (item, index) in itemsList.WithIndex())
+        {
+            append(item);
+
+            if (!itemsList.IsLastIndex(index) && joinString is not null)
+            {
+                builder.AppendLiteral(joinString);
+            }
+        }
+
+        return builder;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -20,6 +20,7 @@
         <PackageReference Include="CsvHelper" Version="31.0.3" />
         <PackageReference Include="FluentValidation" Version="11.9.0" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
+        <PackageReference Include="InterpolatedSql" Version="2.3.0" />
         <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.3" />
         <!-- TODO EES-4202 DataMovement depends on deprecated Microsoft.Azure.Storage.Blob SDK v11 -->

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -441,9 +441,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             return Unit.Instance;
         }
 
-        public static async Task<Either<TFailure1, TFailure2>> OnFailureDo<TFailure1, TFailure2>(
-            this Task<Either<TFailure1, TFailure2>> task,
-            Func<TFailure1, Task> failureTask)
+        public static async Task<Either<TFailure, TSuccess>> OnFailureDo<TFailure, TSuccess>(
+            this Task<Either<TFailure, TSuccess>> task,
+            Func<TFailure, Task> failureTask)
         {
             var firstResult = await task;
 
@@ -456,9 +456,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             return firstResult.Left;
         }
 
-        public static async Task<Either<TFailure1, TFailure2>> OnFailureDo<TFailure1, TFailure2>(
-            this Task<Either<TFailure1, TFailure2>> task,
-            Action<TFailure1> failureAction)
+        public static async Task<Either<TFailure, TSuccess>> OnFailureDo<TFailure, TSuccess>(
+            this Task<Either<TFailure, TSuccess>> task,
+            Action<TFailure> failureAction)
         {
             var firstResult = await task;
 
@@ -471,20 +471,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             return firstResult.Left;
         }
 
-        public static async Task<Either<TFailure1, TFailure2>> OnFailureFailWith<TFailure1, TFailure2>(
-            this Task<Either<TFailure1, TFailure2>> task,
-            Func<TFailure1> failure)
+        /// <summary>
+        /// Map a failure result to a new failure result of the same type.
+        /// </summary>
+        public static async Task<Either<TFailure, TSuccess>> OnFailureFailWith<TFailure, TSuccess>(
+            this Task<Either<TFailure, TSuccess>> task,
+            Func<TFailure> func)
         {
-            return await task.OnFailureFailWith(async _ => await Task.FromResult(failure()));
+            return await task.OnFailureFailWith(async _ => await Task.FromResult(func()));
         }
 
-        /**
-         * If the previous Either failed, provide the errors to the given action and then return a new set of errors
-         * provided by the action.
-         */
-        public static async Task<Either<TFailure1, TFailure2>> OnFailureFailWith<TFailure1, TFailure2>(
-            this Task<Either<TFailure1, TFailure2>> task,
-            Func<TFailure1, Task<TFailure1>> func)
+        /// <summary>
+        /// Map a failure result to a new failure result of the same type.
+        /// </summary>
+        public static async Task<Either<TFailure, TSuccess>> OnFailureFailWith<TFailure, TSuccess>(
+            this Task<Either<TFailure, TSuccess>> task,
+            Func<TFailure, TFailure> func)
+        {
+            return await task.OnFailureFailWith(async result => await Task.FromResult(func(result)));
+        }
+
+        /// <summary>
+        /// Map a failure result to a new failure result of the same type.
+        /// </summary>
+        public static async Task<Either<TFailure, TSuccess>> OnFailureFailWith<TFailure, TSuccess>(
+            this Task<Either<TFailure, TSuccess>> task,
+            Func<TFailure, Task<TFailure>> func)
         {
             var firstResult = await task;
 
@@ -496,11 +508,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             return await func(firstResult.Left);
         }
 
-        /**
-         * If the previous Either failed, perform the given action and then handle it as a success case anyway.
-         * This allows a prior step to fail but overall be treated as a success (unless a subsequent step happens to
-         * fail after this one).
-        */
+        /// <summary>
+        /// If the previous Either failed, perform the given action and then handle it as a success case anyway.
+        /// This allows a prior step to fail but overall be treated as a success (unless a subsequent step happens to
+        /// fail after this one).
+        /// </summary>
         public static async Task<Either<TFailure, TSuccess>> OnFailureSucceedWith<TFailure, TSuccess>(
             this Task<Either<TFailure, TSuccess>> task,
             Func<TFailure, Task<TSuccess>> func)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ErrorDetails/NotFoundItemsErrorDetail.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ErrorDetails/NotFoundItemsErrorDetail.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+
+/// <summary>
+/// Provides details of items that could not be found.
+/// </summary>
+/// <param name="Items">The items that could not be found.</param>
+/// <typeparam name="T">The type of each item.</typeparam>
+public record NotFoundItemsErrorDetail<T>(IEnumerable<T> Items);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -10,7 +10,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils;
 using Microsoft.AspNetCore.WebUtilities;
-using System.Linq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Controllers;
 
@@ -56,7 +55,7 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
             Assert.Equal(dataSet.Summary, content.Summary);
             Assert.Equal(dataSet.Status, content.Status);
             Assert.Equal(dataSet.SupersedingDataSetId, content.SupersedingDataSetId);
-            Assert.Equal(dataSetVersion!.Version, content.LatestVersion.Number);
+            Assert.Equal(dataSetVersion.Version, content.LatestVersion.Number);
             Assert.Equal(
                 dataSetVersion.Published!.Value.ToUnixTimeSeconds(),
                 content.LatestVersion.Published.ToUnixTimeSeconds()
@@ -743,6 +742,7 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                     .WithDataSetId(dataSet.Id)
                     .WithFilterMetas(() => filterMetas)
                     .WithLocationMetas(() => locationMetas)
+                    .WithGeographicLevelMeta()
                     .WithIndicatorMetas(() =>
                         DataFixture
                         .DefaultIndicatorMeta()
@@ -1583,7 +1583,7 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
         {
             var query = new Dictionary<string, string?>
             {
-                { "dataSetVersion", dataSetVersion?.ToString() },
+                { "dataSetVersion", dataSetVersion },
             };
 
             if (types is not null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/LocationStringValidatorsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/LocationStringValidatorsTests.cs
@@ -111,8 +111,8 @@ public class LocationStringValidatorsTests
 
             var state = Assert.IsType<LocationStringValidators.AllowedLevelErrorDetail>(error.CustomState);
 
-            Assert.Equal(location, state.Value);
-            Assert.Equal(EnumUtil.GetEnumValues<GeographicLevel>().Order(), state.Allowed);
+            Assert.Equal(location, $"{state.Value.Level}|{state.Value.Property}|{state.Value.Value}");
+            Assert.Equal(EnumUtil.GetEnumValues<GeographicLevel>().Order(), state.AllowedLevels);
         }
 
         [Theory]
@@ -139,8 +139,8 @@ public class LocationStringValidatorsTests
 
             var state = Assert.IsType<LocationStringValidators.AllowedPropertyErrorDetail>(error.CustomState);
 
-            Assert.Equal(location, state.Value);
-            Assert.Equal(allowedProperties, state.Allowed);
+            Assert.Equal(location, $"{state.Value.Level}|{state.Value.Property}|{state.Value.Value}");
+            Assert.Equal(allowedProperties, state.AllowedProperties);
         }
 
         [Theory]
@@ -172,8 +172,8 @@ public class LocationStringValidatorsTests
 
             var state = Assert.IsType<LocationStringValidators.MaxValueLengthErrorDetail>(error.CustomState);
 
-            Assert.Equal(location, state.Value);
-            Assert.Equal(expectedMaxLength, state.MaxLength);
+            Assert.Equal(location, $"{state.Value.Level}|{state.Value.Property}|{state.Value.Value}");
+            Assert.Equal(expectedMaxLength, state.MaxValueLength);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/SortStringValidatorsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/SortStringValidatorsTests.cs
@@ -27,10 +27,12 @@ public class SortStringValidatorsTests
         private readonly Validator _validator = new();
 
         [Theory]
-        [InlineData("TimePeriod|Asc")]
-        [InlineData("TimePeriod|Desc")]
-        [InlineData("GeographicLevel|Asc")]
-        [InlineData("GeographicLevel|Desc")]
+        [InlineData("timePeriod|Asc")]
+        [InlineData("timePeriod|Desc")]
+        [InlineData("geographicLevel|Asc")]
+        [InlineData("geographicLevel|Desc")]
+        [InlineData("locations|REG|Desc")]
+        [InlineData("locations|LA|Desc")]
         [InlineData("characteristic|Asc")]
         [InlineData("characteristic|Desc")]
         [InlineData("school_type|Asc")]
@@ -50,14 +52,17 @@ public class SortStringValidatorsTests
         [InlineData("Asc")]
         [InlineData("|Asc")]
         [InlineData(" |Asc")]
-        [InlineData("TimePeriod:Asc")]
-        [InlineData("TimePeriod|")]
-        [InlineData(" TimePeriod|Asc")]
-        [InlineData("TimePeriod| ")]
-        [InlineData("TimePeriod| Asc")]
-        [InlineData(" TimePeriod|Asc ")]
-        [InlineData("TimePeriod |Asc ")]
-        [InlineData("TimePeriod|Asc1")]
+        [InlineData("timePeriod:Asc")]
+        [InlineData("timePeriod|")]
+        [InlineData(" timePeriod|Asc")]
+        [InlineData("timePeriod| ")]
+        [InlineData("timePeriod| Asc")]
+        [InlineData(" timePeriod|Asc ")]
+        [InlineData("timePeriod |Asc ")]
+        [InlineData("timePeriod|Asc1")]
+        [InlineData("locations||Asc")]
+        [InlineData("locations| |Asc")]
+        [InlineData("locations| |")]
         [InlineData("school-type|Asc")]
         [InlineData("school_type| Asc")]
         [InlineData("school_type|Asc ")]
@@ -99,14 +104,14 @@ public class SortStringValidatorsTests
 
             var state = Assert.IsType<SortStringValidators.MaxFieldLengthErrorDetail>(error.CustomState);
 
-            Assert.Equal(sort, state.Value);
-            Assert.Equal(40, state.MaxLength);
+            Assert.Equal(sort, $"{state.Value.Field}|{state.Value.Direction}");
+            Assert.Equal(40, state.MaxFieldLength);
         }
 
         [Theory]
-        [InlineData("TimePeriod|Invalid")]
-        [InlineData("TimePeriod|asc")]
-        [InlineData("TimePeriod|desc")]
+        [InlineData("timePeriod|Invalid")]
+        [InlineData("timePeriod|asc")]
+        [InlineData("timePeriod|desc")]
         public void Failure_InvalidDirection(string sort)
         {
             var testObj = new TestClass { Sort = sort };
@@ -123,8 +128,8 @@ public class SortStringValidatorsTests
 
             var state = Assert.IsType<SortStringValidators.DirectionErrorDetail>(error.CustomState);
 
-            Assert.Equal(sort, state.Value);
-            Assert.Equal([SortDirection.Asc.ToString(), SortDirection.Desc.ToString()], state.Allowed);
+            Assert.Equal(sort, $"{state.Value.Field}|{state.Value.Direction}");
+            Assert.Equal([SortDirection.Asc.ToString(), SortDirection.Desc.ToString()], state.AllowedDirections);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/TimePeriodStringValidatorsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/TimePeriodStringValidatorsTests.cs
@@ -117,7 +117,7 @@ public class TimePeriodStringValidatorsTests
 
             var state = Assert.IsType<TimePeriodStringValidators.RangeErrorDetail>(error.CustomState);
 
-            Assert.Equal(timePeriod, state.Value);
+            Assert.Equal(timePeriod, $"{state.Value.Period}|{state.Value.Code}");
         }
 
         [Theory]
@@ -141,8 +141,8 @@ public class TimePeriodStringValidatorsTests
 
             var state = Assert.IsType<TimePeriodStringValidators.AllowedCodeErrorDetail>(error.CustomState);
 
-            Assert.Equal(timePeriod, state.Value);
-            Assert.Equal(TimeIdentifierUtils.DataCodes.Order(), state.Allowed);
+            Assert.Equal(timePeriod, $"{state.Value.Period}|{state.Value.Code}");
+            Assert.Equal(TimeIdentifierUtils.DataCodes.Order(), state.AllowedCodes);
         }
 
         [Theory]
@@ -173,9 +173,9 @@ public class TimePeriodStringValidatorsTests
 
             var state = Assert.IsType<TimePeriodStringValidators.AllowedCodeErrorDetail>(error.CustomState);
 
-            Assert.Equal(timePeriod, state.Value);
+            Assert.Equal(timePeriod, $"{state.Value.Period}|{state.Value.Code}");
 
-            Assert.All(state.Allowed, code =>
+            Assert.All(state.AllowedCodes, code =>
             {
                 var yearFormat = EnumUtil
                     .GetFromEnumValue<TimeIdentifier>(code)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/appsettings.IntegrationTest.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/appsettings.IntegrationTest.json
@@ -2,6 +2,9 @@
   "ContentApi": {
     "Url": "http://localhost:5010"
   },
+  "MiniProfiler": {
+    "Enabled": false
+  },
   "ParquetFiles": {
     "BasePath": "Resources/ParquetFiles"
   }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -237,11 +237,17 @@ public class DataSetsController(IDataSetService dataSetService) : ControllerBase
     ///
     /// The `field` can be one of the following:
     ///
-    /// - `time_period` to sort by time period
-    /// - `geographic_level` to sort by the geographic level
-    /// - A location level code (e.g. `REG`, `LA`) to sort by the locations in that level
+    /// - `timePeriod` to sort by time period
+    /// - `geographicLevel` to sort by the geographic level of the data
+    /// - `location|{level}` to sort by locations in a geographic level where `{level}` is the level code (e.g. `REG`, `LA`)
     /// - A filter ID (e.g. `characteristic`, `school_type`) to sort by the options in that filter
     /// - An indicator ID (e.g. `sess_authorised`, `enrolments`) to sort by the values in that indicator
+    ///
+    /// ### Examples
+    ///
+    /// - `time_period|Desc` sorts by time period in descending order
+    /// - `geographic_level|Asc` sorts by geographic level in ascending order
+    /// - `location|REG|Asc` sorts by regions in ascending order
     /// </remarks>
     [HttpGet("{dataSetId:guid}/query")]
     [Produces("application/json")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -1,6 +1,5 @@
 using Asp.Versioning;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
@@ -12,7 +11,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Controllers
 [ApiVersion(1.0)]
 [ApiController]
 [Route("api/v{version:apiVersion}/data-sets")]
-public class DataSetsController(IDataSetService dataSetService) : ControllerBase
+public class DataSetsController(
+    IDataSetService dataSetService,
+    IDataSetQueryService dataSetQueryService)
+    : ControllerBase
 {
     /// <summary>
     /// Get a data set’s summary
@@ -261,6 +263,8 @@ public class DataSetsController(IDataSetService dataSetService) : ControllerBase
         [FromQuery] DataSetGetQueryRequest request,
         CancellationToken cancellationToken)
     {
-        return Ok();
+        return await dataSetQueryService
+            .Query(dataSetId, request, dataSetVersion, cancellationToken)
+            .HandleFailuresOrOk();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
@@ -25,7 +25,9 @@
         <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
         <PackageReference Include="AspectInjector" Version="2.8.2" />
         <PackageReference Include="Azure.Identity" Version="1.10.4" />
+        <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="DuckDB.NET.Data.Full" Version="0.10.1.2" />
+        <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0" />
         <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.0.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
@@ -34,6 +36,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.3" />
+        <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.3.8" />
+        <PackageReference Include="MiniProfiler.EntityFrameworkCore" Version="4.3.8" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
         <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Model/IdPublicIdPair.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Model/IdPublicIdPair.cs
@@ -1,0 +1,8 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+
+public record IdPublicIdPair
+{
+    public required int Id { get; init; }
+
+    public required string PublicId { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Model/Sort.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Model/Sort.cs
@@ -1,0 +1,5 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+
+public record Sort(string Field, SortDirection Direction);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/MiniProfilerOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/MiniProfilerOptions.cs
@@ -1,0 +1,8 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
+
+public class MiniProfilerOptions
+{
+    public static readonly string Section = "MiniProfiler";
+
+    public bool Enabled { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/Interfaces/IParquetDataRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/Interfaces/IParquetDataRepository.cs
@@ -1,0 +1,27 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using InterpolatedSql;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+
+public interface IParquetDataRepository
+{
+    Task<long> CountRows(
+        DataSetVersion dataSetVersion,
+        IInterpolatedSql where,
+        CancellationToken cancellationToken = default);
+
+    Task<IList<IDictionary<string, object?>>> ListRows(
+        DataSetVersion dataSetVersion,
+        IEnumerable<string> columns,
+        IInterpolatedSql where,
+        IEnumerable<Sort>? sorts = null,
+        int page = 1,
+        int pageSize = 1000,
+        CancellationToken cancellationToken = default);
+
+    Task<ISet<string>> ListColumns(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/Interfaces/IParquetFilterRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/Interfaces/IParquetFilterRepository.cs
@@ -1,0 +1,27 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+
+public interface IParquetFilterRepository
+{
+    Task<IList<ParquetFilterOption>> ListOptions(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> ids,
+        CancellationToken cancellationToken = default);
+
+    Task<IList<ParquetFilterOption>> ListOptions(
+        DataSetVersion dataSetVersion,
+        IEnumerable<string> publicIds,
+        CancellationToken cancellationToken = default);
+
+    Task<IList<IdPublicIdPair>> ListOptionPublicIds(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> ids,
+        CancellationToken cancellationToken = default);
+
+    Task<ISet<string>> ListFilterIds(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/Interfaces/IParquetIndicatorRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/Interfaces/IParquetIndicatorRepository.cs
@@ -1,0 +1,10 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+
+public interface IParquetIndicatorRepository
+{
+    Task<ISet<string>> ListIds(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/Interfaces/IParquetLocationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/Interfaces/IParquetLocationRepository.cs
@@ -1,0 +1,29 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+
+public interface IParquetLocationRepository
+{
+    Task<IList<ParquetLocationOption>> ListOptions(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> ids,
+        CancellationToken cancellationToken = default);
+
+    Task<IList<ParquetLocationOption>> ListOptions(
+        DataSetVersion dataSetVersion,
+        IEnumerable<DataSetQueryLocation> locations,
+        CancellationToken cancellationToken = default);
+
+    Task<IList<IdPublicIdPair>> ListOptionPublicIds(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> ids,
+        CancellationToken cancellationToken = default);
+
+    Task<ISet<GeographicLevel>> ListLevels(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/Interfaces/IParquetTimePeriodRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/Interfaces/IParquetTimePeriodRepository.cs
@@ -1,0 +1,18 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+
+public interface IParquetTimePeriodRepository
+{
+    Task<IList<ParquetTimePeriod>> List(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> ids,
+        CancellationToken cancellationToken = default);
+
+    Task<IList<ParquetTimePeriod>> List(
+        DataSetVersion dataSetVersion,
+        IEnumerable<DataSetQueryTimePeriod> timePeriods,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetDataRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetDataRepository.cs
@@ -1,0 +1,112 @@
+using Dapper;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using InterpolatedSql;
+using InterpolatedSql.Dapper;
+using StackExchange.Profiling;
+using DataTable = GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables.DataTable;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository;
+
+public class ParquetDataRepository(
+    IDuckDbConnection duckDbConnection,
+    IParquetPathResolver parquetPathResolver)
+    : IParquetDataRepository
+{
+    private const string DataIdsAlias = "data_ids";
+
+    public async Task<long> CountRows(
+        DataSetVersion dataSetVersion,
+        IInterpolatedSql where,
+        CancellationToken cancellationToken = default)
+    {
+        using var _ = MiniProfiler.Current
+            .Step($"{nameof(ParquetDataRepository)}.{nameof(CountRows)}");
+
+        var command = duckDbConnection.SqlBuilder(
+            $"""
+             SELECT count(*)
+             FROM '{parquetPathResolver.DataPath(dataSetVersion):raw}'
+             """
+        );
+
+        command.AppendIf(!where.IsEmpty(), $"WHERE {where}");
+
+        return await command.QuerySingleAsync<long>(cancellationToken: cancellationToken);
+    }
+
+    public async Task<IList<IDictionary<string, object?>>> ListRows(
+        DataSetVersion dataSetVersion,
+        IEnumerable<string> columns,
+        IInterpolatedSql where,
+        IEnumerable<Sort>? sorts = null,
+        int page = 1,
+        int pageSize = 1000,
+        CancellationToken cancellationToken = default)
+    {
+        using var _ = MiniProfiler.Current
+            .Step($"{nameof(ParquetDataRepository)}.{nameof(ListRows)}");
+
+        var dataPath = parquetPathResolver.DataPath(dataSetVersion);
+
+        var whereFragment = new DuckDbSqlBuilder()
+            .AppendIf(!where.IsEmpty(), $"WHERE {where}");
+
+        var orderings = (sorts ?? [])
+            .Select(s => $"{s.Field} {s.Direction.ToString().ToUpper()}")
+            .ToList();
+
+        var orderByFragment = new DuckDbSqlBuilder()
+            .AppendIf(orderings.Count != 0, $"ORDER BY")
+            .AppendRange(orderings, joinString: ",\n");
+
+        var pageOffset = (page - 1) * pageSize;
+
+        // We essentially split this query into two sub-queries:
+        //
+        // 1. The main query which is offset paginated and gathers the row ids
+        // 2. Another query to fetch the rows using the ids from the main query (i.e. a 'deferred' join)
+        //
+        // This 'deferred join' technique is more efficient than a single query and helps to reduce
+        // the performance penalty of using offset pagination having to scan through many rows.
+        var command = duckDbConnection.SqlBuilder(
+            $"""
+             WITH {DataIdsAlias:raw} AS (
+                SELECT {DataTable.Ref().Id:raw}
+                FROM '{dataPath:raw}' AS {DataTable.TableName:raw}
+                {whereFragment}
+                {orderByFragment}
+                LIMIT {pageSize}
+                OFFSET {pageOffset}
+             )
+             SELECT {columns.Select(DataTable.Ref().Col).JoinToString(",\n"):raw}
+             FROM '{dataPath:raw}' AS {DataTable.TableName:raw}
+             JOIN {DataIdsAlias:raw} ON {DataIdsAlias:raw}.id = {DataTable.Ref().Id:raw}
+             {orderByFragment}
+             """
+        );
+
+        return (await command.QueryAsync(cancellationToken: cancellationToken))
+            .Cast<IDictionary<string, object?>>()
+            .AsList();
+    }
+
+    public async Task<ISet<string>> ListColumns(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken = default)
+    {
+        var command = duckDbConnection.SqlBuilder(
+            $"DESCRIBE SELECT * FROM '{parquetPathResolver.DataPath(dataSetVersion):raw}' LIMIT 1");
+
+        var columns = await command.QueryAsync<ParquetColumn>(cancellationToken: cancellationToken);
+
+        return columns
+            .Select(col => col.ColumnName)
+            .ToHashSet();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetFilterRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetFilterRepository.cs
@@ -45,7 +45,7 @@ public class ParquetFilterRepository(
             $"""
              SELECT *
              FROM '{parquetPathResolver.FiltersPath(dataSetVersion):raw}'
-             WHERE {FiltersTable.Cols.PublicId:raw} IN ({publicIdsList})
+             WHERE {FilterOptionsTable.Cols.PublicId:raw} IN ({publicIdsList})
              """
         );
 
@@ -60,7 +60,7 @@ public class ParquetFilterRepository(
         return await ListOptionsById<IdPublicIdPair>(
             dataSetVersion: dataSetVersion,
             ids: ids.ToList(),
-            columns: [FiltersTable.Cols.Id, FiltersTable.Cols.PublicId],
+            columns: [FilterOptionsTable.Cols.Id, FilterOptionsTable.Cols.PublicId],
             cancellationToken: cancellationToken
         );
     }
@@ -87,7 +87,7 @@ public class ParquetFilterRepository(
             $"""
              SELECT {columnsFragments}
              FROM '{parquetPathResolver.FiltersPath(dataSetVersion):raw}'
-             WHERE {FiltersTable.Cols.Id:raw} IN ({ids})
+             WHERE {FilterOptionsTable.Cols.Id:raw} IN ({ids})
              """
         );
 
@@ -100,7 +100,7 @@ public class ParquetFilterRepository(
     {
         var command = duckDbConnection.SqlBuilder(
             $"""
-             SELECT DISTINCT {FiltersTable.Cols.ColumnName:raw}
+             SELECT DISTINCT {FilterOptionsTable.Cols.FilterId:raw}
              FROM '{parquetPathResolver.FiltersPath(dataSetVersion):raw}'
              """);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetFilterRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetFilterRepository.cs
@@ -1,0 +1,112 @@
+using Dapper;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using InterpolatedSql.Dapper;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository;
+
+public class ParquetFilterRepository(
+    IDuckDbConnection duckDbConnection,
+    IParquetPathResolver parquetPathResolver)
+    : IParquetFilterRepository
+{
+    public async Task<IList<ParquetFilterOption>> ListOptions(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> ids,
+        CancellationToken cancellationToken = default)
+    {
+        return await ListOptionsById<ParquetFilterOption>(
+            dataSetVersion: dataSetVersion,
+            ids: ids.ToList(),
+            columns: ["*"],
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public async Task<IList<ParquetFilterOption>> ListOptions(
+        DataSetVersion dataSetVersion,
+        IEnumerable<string> publicIds,
+        CancellationToken cancellationToken = default)
+    {
+        var publicIdsList = publicIds.ToList();
+
+        if (publicIdsList.Count == 0)
+        {
+            return new List<ParquetFilterOption>();
+        }
+
+        var command = duckDbConnection.SqlBuilder(
+            $"""
+             SELECT *
+             FROM '{parquetPathResolver.FiltersPath(dataSetVersion):raw}'
+             WHERE {FiltersTable.Cols.PublicId:raw} IN ({publicIdsList})
+             """
+        );
+
+        return (await command.QueryAsync<ParquetFilterOption>(cancellationToken: cancellationToken)).AsList();
+    }
+
+    public async Task<IList<IdPublicIdPair>> ListOptionPublicIds(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> ids,
+        CancellationToken cancellationToken = default)
+    {
+        return await ListOptionsById<IdPublicIdPair>(
+            dataSetVersion: dataSetVersion,
+            ids: ids.ToList(),
+            columns: [FiltersTable.Cols.Id, FiltersTable.Cols.PublicId],
+            cancellationToken: cancellationToken
+        );
+    }
+
+    private async Task<List<T>> ListOptionsById<T>(
+        DataSetVersion dataSetVersion,
+        IList<int> ids,
+        IList<string> columns,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids.Count == 0)
+        {
+            return [];
+        }
+
+        var columnsFragments = new DuckDbSqlBuilder();
+
+        columnsFragments.AppendRange(
+            columns.Select(col => (FormattableString)$"{col:raw}"),
+            joinString: ",\n"
+        );
+
+        var command = duckDbConnection.SqlBuilder(
+            $"""
+             SELECT {columnsFragments}
+             FROM '{parquetPathResolver.FiltersPath(dataSetVersion):raw}'
+             WHERE {FiltersTable.Cols.Id:raw} IN ({ids})
+             """
+        );
+
+        return (await command.QueryAsync<T>(cancellationToken: cancellationToken)).AsList();
+    }
+
+    public async Task<ISet<string>> ListFilterIds(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken = default)
+    {
+        var command = duckDbConnection.SqlBuilder(
+            $"""
+             SELECT DISTINCT {FiltersTable.Cols.ColumnName:raw}
+             FROM '{parquetPathResolver.FiltersPath(dataSetVersion):raw}'
+             """);
+
+        var cols = await command
+            .QueryAsync<string>(cancellationToken: cancellationToken);
+
+        return cols.ToHashSet();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetIndicatorRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetIndicatorRepository.cs
@@ -1,0 +1,29 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using InterpolatedSql.Dapper;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository;
+
+public class ParquetIndicatorRepository(
+    IDuckDbConnection duckDbConnection,
+    IParquetPathResolver parquetPathResolver)
+    : IParquetIndicatorRepository
+{
+    public async Task<ISet<string>> ListIds(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken = default)
+    {
+        var command = duckDbConnection.SqlBuilder(
+            $"""
+             SELECT DISTINCT {IndicatorsTable.Cols.Id:raw}
+             FROM '{parquetPathResolver.IndicatorsPath(dataSetVersion):raw}'
+             """);
+
+        var indicators = await command.QueryAsync<string>(cancellationToken: cancellationToken);
+
+        return indicators.ToHashSet();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetLocationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetLocationRepository.cs
@@ -86,23 +86,23 @@ public class ParquetLocationRepository(
         return location switch
         {
             DataSetQueryLocationCode locationCode =>
-                (Column: LocationsTable.Cols.Code, Value: locationCode.Code),
+                (Column: LocationOptionsTable.Cols.Code, Value: locationCode.Code),
 
             DataSetQueryLocationId locationId =>
-                (Column: LocationsTable.Cols.PublicId, Value: locationId.Id),
+                (Column: LocationOptionsTable.Cols.PublicId, Value: locationId.Id),
 
             DataSetQueryLocationLocalAuthorityCode localAuthority =>
-                (Column: LocationsTable.Cols.Code, Value: localAuthority.Code),
+                (Column: LocationOptionsTable.Cols.Code, Value: localAuthority.Code),
             DataSetQueryLocationLocalAuthorityOldCode localAuthority =>
-                (Column: LocationsTable.Cols.OldCode, Value: localAuthority.OldCode),
+                (Column: LocationOptionsTable.Cols.OldCode, Value: localAuthority.OldCode),
 
             DataSetQueryLocationProviderUkprn provider =>
-                (Column: LocationsTable.Cols.Ukprn, Value: provider.Ukprn),
+                (Column: LocationOptionsTable.Cols.Ukprn, Value: provider.Ukprn),
 
             DataSetQueryLocationSchoolUrn school =>
-                (Column: LocationsTable.Cols.Urn, Value: school.Urn),
+                (Column: LocationOptionsTable.Cols.Urn, Value: school.Urn),
             DataSetQueryLocationSchoolLaEstab { LaEstab: not null } school =>
-                (Column: LocationsTable.Cols.LaEstab, Value: school.LaEstab),
+                (Column: LocationOptionsTable.Cols.LaEstab, Value: school.LaEstab),
 
             _ => throw new ArgumentOutOfRangeException(nameof(location))
         };
@@ -116,7 +116,7 @@ public class ParquetLocationRepository(
         return await ListOptionsById<IdPublicIdPair>(
             dataSetVersion: dataSetVersion,
             ids: ids.ToList(),
-            columns: [LocationsTable.Cols.Id, LocationsTable.Cols.PublicId],
+            columns: [LocationOptionsTable.Cols.Id, LocationOptionsTable.Cols.PublicId],
             cancellationToken: cancellationToken);
     }
 
@@ -142,7 +142,7 @@ public class ParquetLocationRepository(
             $"""
              SELECT {columnsFragments}
              FROM '{parquetPathResolver.LocationsPath(dataSetVersion):raw}'
-             WHERE {LocationsTable.Cols.Id:raw} IN ({ids})
+             WHERE {LocationOptionsTable.Cols.Id:raw} IN ({ids})
              """
         );
 
@@ -155,7 +155,7 @@ public class ParquetLocationRepository(
     {
         var command = duckDbConnection.SqlBuilder(
             $"""
-             SELECT DISTINCT {LocationsTable.Cols.Level:raw}
+             SELECT DISTINCT {LocationOptionsTable.Cols.Level:raw}
              FROM '{parquetPathResolver.LocationsPath(dataSetVersion):raw}'
              """);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetLocationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetLocationRepository.cs
@@ -1,0 +1,169 @@
+using Dapper;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using InterpolatedSql.Dapper;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository;
+
+public class ParquetLocationRepository(
+    IDuckDbConnection duckDbConnection,
+    IParquetPathResolver parquetPathResolver)
+    : IParquetLocationRepository
+{
+    public async Task<IList<ParquetLocationOption>> ListOptions(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> ids,
+        CancellationToken cancellationToken = default)
+    {
+        return await ListOptionsById<ParquetLocationOption>(
+            dataSetVersion: dataSetVersion,
+            ids: ids.ToList(),
+            columns: ["*"],
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task<IList<ParquetLocationOption>> ListOptions(
+        DataSetVersion dataSetVersion,
+        IEnumerable<DataSetQueryLocation> locations,
+        CancellationToken cancellationToken = default)
+    {
+        var locationsByLevel = locations
+            .GroupBy(location => location.ParsedLevel)
+            .ToList();
+
+        var allOptions = new List<ParquetLocationOption>();
+
+        foreach (var levelGroup in locationsByLevel)
+        {
+            var columnValues = levelGroup
+                .Select(MapLocationToColumnValue)
+                .ToList();
+
+            var whereBuilder = new DuckDbSqlBuilder();
+
+            var groups = columnValues
+                .GroupBy(cv => cv.Column)
+                .ToList();
+
+            foreach (var (group, index) in groups.WithIndex())
+            {
+                whereBuilder.AppendLine($"{group.Key:raw} IN ({group.Select(cv => cv.Value)})");
+
+                if (!groups.IsLastIndex(index))
+                {
+                    whereBuilder.AppendLiteral("OR ");
+                }
+            }
+
+            var command = duckDbConnection.SqlBuilder(
+                $"""
+                 SELECT *
+                 FROM '{parquetPathResolver.LocationsPath(dataSetVersion):raw}'
+                 WHERE {whereBuilder}
+                 """
+            );
+
+            var optionMetas = await command
+                .QueryAsync<ParquetLocationOption>(cancellationToken: cancellationToken);
+
+            allOptions.AddRange(optionMetas);
+        }
+
+        return allOptions;
+    }
+
+    private static (string Column, string Value) MapLocationToColumnValue(DataSetQueryLocation location)
+    {
+        return location switch
+        {
+            DataSetQueryLocationCode locationCode =>
+                (Column: LocationsTable.Cols.Code, Value: locationCode.Code),
+
+            DataSetQueryLocationId locationId =>
+                (Column: LocationsTable.Cols.PublicId, Value: locationId.Id),
+
+            DataSetQueryLocationLocalAuthorityCode localAuthority =>
+                (Column: LocationsTable.Cols.Code, Value: localAuthority.Code),
+            DataSetQueryLocationLocalAuthorityOldCode localAuthority =>
+                (Column: LocationsTable.Cols.OldCode, Value: localAuthority.OldCode),
+
+            DataSetQueryLocationProviderUkprn provider =>
+                (Column: LocationsTable.Cols.Ukprn, Value: provider.Ukprn),
+
+            DataSetQueryLocationSchoolUrn school =>
+                (Column: LocationsTable.Cols.Urn, Value: school.Urn),
+            DataSetQueryLocationSchoolLaEstab { LaEstab: not null } school =>
+                (Column: LocationsTable.Cols.LaEstab, Value: school.LaEstab),
+
+            _ => throw new ArgumentOutOfRangeException(nameof(location))
+        };
+    }
+
+    public async Task<IList<IdPublicIdPair>> ListOptionPublicIds(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> ids,
+        CancellationToken cancellationToken = default)
+    {
+        return await ListOptionsById<IdPublicIdPair>(
+            dataSetVersion: dataSetVersion,
+            ids: ids.ToList(),
+            columns: [LocationsTable.Cols.Id, LocationsTable.Cols.PublicId],
+            cancellationToken: cancellationToken);
+    }
+
+    private async Task<List<T>> ListOptionsById<T>(
+        DataSetVersion dataSetVersion,
+        IList<int> ids,
+        IList<string> columns,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids.Count == 0)
+        {
+            return [];
+        }
+
+        var columnsFragments = new DuckDbSqlBuilder();
+
+        columnsFragments.AppendRange(
+            columns.Select(col => (FormattableString)$"{col:raw}"),
+            joinString: ",\n"
+        );
+
+        var command = duckDbConnection.SqlBuilder(
+            $"""
+             SELECT {columnsFragments}
+             FROM '{parquetPathResolver.LocationsPath(dataSetVersion):raw}'
+             WHERE {LocationsTable.Cols.Id:raw} IN ({ids})
+             """
+        );
+
+        return (await command.QueryAsync<T>(cancellationToken: cancellationToken)).AsList();
+    }
+
+    public async Task<ISet<GeographicLevel>> ListLevels(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken = default)
+    {
+        var command = duckDbConnection.SqlBuilder(
+            $"""
+             SELECT DISTINCT {LocationsTable.Cols.Level:raw}
+             FROM '{parquetPathResolver.LocationsPath(dataSetVersion):raw}'
+             """);
+
+        var levels = await command.QueryAsync<string>(cancellationToken: cancellationToken);
+
+        return levels
+            .Select(EnumUtil.GetFromEnumValue<GeographicLevel>)
+            .ToHashSet();
+    }
+
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetTimePeriodRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetTimePeriodRepository.cs
@@ -1,0 +1,75 @@
+using Dapper;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils;
+using InterpolatedSql.Dapper;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository;
+
+public class ParquetTimePeriodRepository(
+    IDuckDbConnection duckDbConnection,
+    IParquetPathResolver parquetPathResolver)
+    : IParquetTimePeriodRepository
+{
+    public async Task<IList<ParquetTimePeriod>> List(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> ids,
+        CancellationToken cancellationToken = default)
+    {
+        var idsList = ids.ToList();
+
+        if (idsList.Count == 0)
+        {
+            return new List<ParquetTimePeriod>();
+        }
+
+        var command = duckDbConnection.SqlBuilder(
+            $"""
+             SELECT *
+             FROM '{parquetPathResolver.TimePeriodsPath(dataSetVersion):raw}'
+             WHERE {TimePeriodsTable.Cols.Id:raw} IN ({idsList})
+             """
+        );
+
+        return (await command.QueryAsync<ParquetTimePeriod>(cancellationToken: cancellationToken)).AsList();
+    }
+
+    public async Task<IList<ParquetTimePeriod>> List(
+        DataSetVersion dataSetVersion,
+        IEnumerable<DataSetQueryTimePeriod> timePeriods,
+        CancellationToken cancellationToken = default)
+    {
+        var timePeriodsList = timePeriods.ToList();
+
+        if (timePeriodsList.Count == 0)
+        {
+            return new List<ParquetTimePeriod>();
+        }
+
+        var inFragment = new DuckDbSqlBuilder()
+            .AppendRange(
+                timePeriodsList.Select(
+                    tp => (FormattableString)
+                        $"({TimePeriodFormatter.FormatToCsv(tp.ParsedPeriod)}, {tp.ParsedCode.GetEnumLabel()})"
+                ),
+                joinString: ", "
+            );
+
+        var command = duckDbConnection.SqlBuilder(
+            $"""
+             SELECT *
+             FROM '{parquetPathResolver.TimePeriodsPath(dataSetVersion):raw}'
+             WHERE ({TimePeriodsTable.Cols.Period:raw}, {TimePeriodsTable.Cols.Identifier:raw})
+                IN ({inFragment})
+             """
+        );
+
+        return (await command.QueryAsync<ParquetTimePeriod>(cancellationToken: cancellationToken)).AsList();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryRequest.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
@@ -29,6 +31,7 @@ public record DataSetGetQueryRequest
     /// <summary>
     /// The IDs of indicators to return values for.
     /// </summary>
+    [FromQuery, QuerySeparator]
     public required IReadOnlyList<string> Indicators { get; init; }
 
     /// <summary>
@@ -37,6 +40,7 @@ public record DataSetGetQueryRequest
     ///
     /// By default, results are sorted by time period in descending order.
     /// </summary>
+    [FromQuery, QuerySeparator]
     public IReadOnlyList<string>? Sorts { get; init; }
 
     /// <summary>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFilters.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFilters.cs
@@ -24,4 +24,19 @@ public record DataSetQueryCriteriaFilters
     /// Filter the results to not have a filter option matching any of these IDs.
     /// </summary>
     public IReadOnlyList<string>? NotIn { get; init; }
+
+    public HashSet<string> GetOptions()
+    {
+        List<string?> filters =
+        [
+            Eq,
+            NotEq,
+            ..In ?? [],
+            ..NotIn ?? []
+        ];
+
+        return filters
+            .OfType<string>()
+            .ToHashSet();
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaGeographicLevels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaGeographicLevels.cs
@@ -44,4 +44,19 @@ public record DataSetQueryCriteriaGeographicLevels
     [JsonIgnore]
     public IReadOnlyList<GeographicLevel>? ParsedNotIn
         => NotIn?.Select(EnumUtil.GetFromEnumValue<GeographicLevel>).ToList();
+
+    public HashSet<GeographicLevel> GetOptions()
+    {
+        List<GeographicLevel?> options =
+        [
+            ParsedEq,
+            ParsedNotEq,
+            ..ParsedIn ?? [],
+            ..ParsedNotIn ?? []
+        ];
+
+        return options
+            .OfType<GeographicLevel>()
+            .ToHashSet();
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaLocations.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaLocations.cs
@@ -34,4 +34,19 @@ public record DataSetQueryCriteriaLocations
     /// Filter the results to not be in one of these locations.
     /// </summary>
     public IReadOnlyList<DataSetQueryLocation>? NotIn { get; init; }
+
+    public HashSet<DataSetQueryLocation> GetOptions()
+    {
+        List<DataSetQueryLocation?> locations =
+        [
+            Eq,
+            NotEq,
+            ..In ?? [],
+            ..NotIn ?? []
+        ];
+
+        return locations
+            .OfType<DataSetQueryLocation>()
+            .ToHashSet();
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaTimePeriods.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaTimePeriods.cs
@@ -48,4 +48,23 @@ public record DataSetQueryCriteriaTimePeriods
     /// chronologically less than or equal to the one specified.
     /// </summary>
     public DataSetQueryTimePeriod? Lte { get; init; }
+
+    public HashSet<DataSetQueryTimePeriod> GetOptions()
+    {
+        List<DataSetQueryTimePeriod?> timePeriods =
+        [
+            Eq,
+            NotEq,
+            Gt,
+            Gte,
+            Lt,
+            Lte,
+            ..In ?? [],
+            ..NotIn ?? []
+        ];
+
+        return timePeriods
+            .OfType<DataSetQueryTimePeriod>()
+            .ToHashSet();
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryLocation.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryLocation.cs
@@ -27,7 +27,7 @@ public abstract record DataSetQueryLocation
     [JsonIgnore]
     public GeographicLevel ParsedLevel => EnumUtil.GetFromEnumValue<GeographicLevel>(Level);
 
-    public abstract string Identifier();
+    public abstract string ToLocationString();
 
     public static DataSetQueryLocation Parse(string location)
     {
@@ -51,11 +51,11 @@ public abstract record DataSetQueryLocation
         {
             GeographicLevel.LocalAuthority => property switch
             {
-                nameof(DataSetQueryLocationLocalAuthority.Code) =>
-                    new DataSetQueryLocationLocalAuthority { Code = value },
+                nameof(DataSetQueryLocationLocalAuthorityCode.Code) =>
+                    new DataSetQueryLocationLocalAuthorityCode { Code = value },
 
-                nameof(DataSetQueryLocationLocalAuthority.OldCode) =>
-                    new DataSetQueryLocationLocalAuthority { OldCode = value },
+                nameof(DataSetQueryLocationLocalAuthorityOldCode.OldCode) =>
+                    new DataSetQueryLocationLocalAuthorityOldCode { OldCode = value },
 
                 _ => throw new ArgumentOutOfRangeException(
                     paramName: nameof(location),
@@ -63,8 +63,8 @@ public abstract record DataSetQueryLocation
             },
             GeographicLevel.Provider => property switch
             {
-                nameof(DataSetQueryLocationProvider.Ukprn) =>
-                    new DataSetQueryLocationProvider { Ukprn = value },
+                nameof(DataSetQueryLocationProviderUkprn.Ukprn) =>
+                    new DataSetQueryLocationProviderUkprn { Ukprn = value },
 
                 _ => throw new ArgumentOutOfRangeException(
                     paramName: nameof(location),
@@ -72,11 +72,11 @@ public abstract record DataSetQueryLocation
             },
             GeographicLevel.School => property switch
             {
-                nameof(DataSetQueryLocationSchool.Urn) =>
-                    new DataSetQueryLocationSchool { Urn = value },
+                nameof(DataSetQueryLocationSchoolUrn.Urn) =>
+                    new DataSetQueryLocationSchoolUrn { Urn = value },
 
-                nameof(DataSetQueryLocationSchool) =>
-                    new DataSetQueryLocationSchool { LaEstab = value },
+                nameof(DataSetQueryLocationSchoolLaEstab.LaEstab) =>
+                    new DataSetQueryLocationSchoolLaEstab { LaEstab = value },
 
                 _ => throw new ArgumentOutOfRangeException(
                     paramName: nameof(location),
@@ -85,7 +85,7 @@ public abstract record DataSetQueryLocation
             _ => property switch
             {
                 nameof(DataSetQueryLocationCode.Code) =>
-                    new DataSetQueryLocationCode { Code = value, Level = value },
+                    new DataSetQueryLocationCode { Code = value, Level = level },
 
                 _ => throw new ArgumentOutOfRangeException(
                     paramName: nameof(location),
@@ -108,7 +108,7 @@ public record DataSetQueryLocationId : DataSetQueryLocation
 
     public override required string Level { get; init; }
 
-    public override string Identifier() => Id;
+    public override string ToLocationString() => $"{Level}|id|{Id}";
 }
 
 public record DataSetQueryLocationCode : DataSetQueryLocation
@@ -124,34 +124,38 @@ public record DataSetQueryLocationCode : DataSetQueryLocation
 
     public override required string Level { get; init; }
 
-    public override string Identifier() => Code;
+    public override string ToLocationString() => $"{Level}|code|{Code}";
 }
 
-public record DataSetQueryLocationLocalAuthority : DataSetQueryLocation
+public record DataSetQueryLocationLocalAuthorityCode : DataSetQueryLocation
 {
     /// <summary>
     /// The ONS code of the local authority. This should be 9 characters
     /// in the standard ONS format for local authorities (e.g. `E08000019`).
     /// It can be a combination of two codes (e.g. `E09000021 / E09000027`).
     /// </summary>
-    public string? Code { get; init; }
+    public required string Code { get; init; }
 
+    public override string Level => GeographicLevel.LocalAuthority.GetEnumValue();
+
+    public override string ToLocationString() => $"{Level}|code|{Code}";
+}
+
+public record DataSetQueryLocationLocalAuthorityOldCode : DataSetQueryLocation
+{
     /// <summary>
     /// The old code (previously the LEA code) of the local authority.
     /// This should be a 3 digit number (e.g. `318`) or be
     /// a combination of two codes (e.g. `314 / 318`).
     /// </summary>
-    public string? OldCode { get; init; }
+    public required string OldCode { get; init; }
 
     public override string Level => GeographicLevel.LocalAuthority.GetEnumValue();
 
-    public override string Identifier()
-        => Code
-           ?? OldCode
-           ?? throw new NullReferenceException($"{nameof(Code)} or {nameof(OldCode)} must not be null");
+    public override string ToLocationString() => $"{Level}|oldCode|{OldCode}";
 }
 
-public record DataSetQueryLocationProvider : DataSetQueryLocation
+public record DataSetQueryLocationProviderUkprn : DataSetQueryLocation
 {
     /// <summary>
     /// The UKPRN (UK provider reference number) of the provider.
@@ -161,27 +165,31 @@ public record DataSetQueryLocationProvider : DataSetQueryLocation
 
     public override string Level => GeographicLevel.Provider.GetEnumValue();
 
-    public override string Identifier() => Ukprn;
+    public override string ToLocationString() => $"{Level}|ukprn|{Ukprn}";
 }
 
-public record DataSetQueryLocationSchool : DataSetQueryLocation
+public record DataSetQueryLocationSchoolUrn : DataSetQueryLocation
 {
     /// <summary>
     /// The URN (unique reference number) of the school.
     /// This should be a 6 digit number.
     /// </summary>
-    public string? Urn { get; init; }
+    public required string Urn { get; init; }
 
+    public override string Level => GeographicLevel.School.GetEnumValue();
+
+    public override string ToLocationString() => $"{Level}|urn|{Urn}";
+}
+
+public record DataSetQueryLocationSchoolLaEstab : DataSetQueryLocation
+{
     /// <summary>
     /// The LAESTAB (local authority establishment number) of the school.
     /// This should be a 7 digit number.
     /// </summary>
-    public string? LaEstab { get; init; }
+    public required string LaEstab { get; init; }
 
     public override string Level => GeographicLevel.School.GetEnumValue();
 
-    public override string Identifier()
-        => Urn
-           ?? LaEstab
-           ?? throw new NullReferenceException($"{nameof(Urn)} or {nameof(LaEstab)} must not be null");
+    public override string ToLocationString() => $"{Level}|laEstab|{LaEstab}";
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQuerySort.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQuerySort.cs
@@ -33,6 +33,8 @@ public record DataSetQuerySort
     [JsonIgnore]
     public SortDirection ParsedDirection => EnumUtil.GetFromEnumValue<SortDirection>(Direction);
 
+    public string ToSortString() => $"{Field}|{Direction}";
+
     public static DataSetQuerySort FromString(string sort)
     {
         var directionDelimiter = sort.LastIndexOf('|');

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQuerySort.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQuerySort.cs
@@ -14,9 +14,9 @@ public record DataSetQuerySort
     /// <summary>
     /// The name of the field to sort by. This can be one of the following:
     ///
-    /// - `time_period` to sort by time period
-    /// - `geographic_level` to sort by the geographic level
-    /// - A location level code (e.g. `REG`, `LA`) to sort by the locations in that level
+    /// - `timePeriod` to sort by time period
+    /// - `geographicLevel` to sort by the geographic level of the data
+    /// - `location|{level}` to sort by locations in a geographic level where `{level}` is the level code (e.g. `REG`, `LA`)
     /// - A filter ID (e.g. `characteristic`, `school_type`) to sort by the options in that filter
     /// - An indicator ID (e.g. `sess_authorised`, `enrolments`) to sort by the values in that indicator
     /// </summary>
@@ -35,12 +35,12 @@ public record DataSetQuerySort
 
     public static DataSetQuerySort FromString(string sort)
     {
-        var parts = sort.Split('|');
+        var directionDelimiter = sort.LastIndexOf('|');
 
         return new DataSetQuerySort
         {
-            Field = parts[0],
-            Direction = parts[1]
+            Field = sort[..directionDelimiter],
+            Direction = sort[(directionDelimiter + 1)..]
         };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryTimePeriod.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryTimePeriod.cs
@@ -1,4 +1,6 @@
 using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 
@@ -56,7 +58,15 @@ public record DataSetQueryTimePeriod
     public required string Code { get; init; }
 
     [JsonIgnore]
+    public string ParsedPeriod => GetParsedPeriod(Period, ParsedCode);
+
+    [JsonIgnore]
     public TimeIdentifier ParsedCode => EnumUtil.GetFromEnumValue<TimeIdentifier>(Code);
+
+    public string ToTimePeriodString()
+    {
+        return $"{Period}|{Code}";
+    }
 
     public static DataSetQueryTimePeriod FromString(string timePeriod)
     {
@@ -67,7 +77,26 @@ public record DataSetQueryTimePeriod
         return new DataSetQueryTimePeriod
         {
             Period = period,
-            Code = code
+            Code = code,
         };
+    }
+
+    private static string GetParsedPeriod(string period, TimeIdentifier identifier)
+    {
+        var metaAttribute = identifier.GetEnumAttribute<TimeIdentifierMetaAttribute>();
+
+        if (metaAttribute.YearFormat == TimePeriodYearFormat.Default)
+        {
+            return period;
+        }
+
+        if (period.Contains('/'))
+        {
+            return period;
+        }
+
+        var year = int.Parse(period);
+
+        return $"{year}/{year + 1}";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryParser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryParser.cs
@@ -1,0 +1,91 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Query;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+using InterpolatedSql;
+using StackExchange.Profiling;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
+
+internal class DataSetQueryParser(
+    IParquetFilterRepository filterRepository,
+    IParquetLocationRepository locationRepository,
+    IParquetTimePeriodRepository timePeriodRepository)
+    : IDataSetQueryParser
+{
+    public async Task<IInterpolatedSql> ParseCriteria(
+        DataSetQueryCriteria criteria,
+        DataSetVersion dataSetVersion,
+        QueryState queryState,
+        CancellationToken cancellationToken = default)
+    {
+        using var _ = MiniProfiler.Current
+            .Step($"{nameof(DataSetQueryParser)}.{nameof(ParseCriteria)}");
+
+        var facets = ExtractFacets(criteria);
+
+        var filterOptionMetas =
+            filterRepository.ListOptions(dataSetVersion, facets.Filters, cancellationToken);
+        var locationOptionMetas =
+            locationRepository.ListOptions(dataSetVersion, facets.Locations, cancellationToken);
+        var timePeriodMetas =
+            timePeriodRepository.List(dataSetVersion, facets.TimePeriods, cancellationToken);
+
+        await Task.WhenAll(filterOptionMetas, locationOptionMetas, timePeriodMetas);
+
+        IFacetsParser[] parsers =
+        [
+            new FilterFacetsParser(queryState, filterOptionMetas.Result),
+            new GeographicLevelFacetsParser(queryState, [..dataSetVersion.MetaSummary.GeographicLevels]),
+            new LocationFacetsParser(queryState, locationOptionMetas.Result),
+            new TimePeriodFacetsParser(queryState, timePeriodMetas.Result),
+        ];
+
+        return ParseCriteriaFragment(criteria, parsers);
+    }
+
+    private static Facets ExtractFacets(DataSetQueryCriteria criteria)
+    {
+        var facets = new Facets();
+
+        if (criteria is DataSetQueryCriteriaFacets criteriaFacets)
+        {
+            facets.Filters.AddRange(criteriaFacets.Filters?.GetOptions() ?? []);
+            facets.Locations.AddRange(criteriaFacets.Locations?.GetOptions() ?? []);
+            facets.TimePeriods.AddRange(criteriaFacets.TimePeriods?.GetOptions() ?? []);
+        }
+
+        return facets;
+    }
+
+    private static IInterpolatedSql ParseCriteriaFragment(
+        DataSetQueryCriteria criteria,
+        IEnumerable<IFacetsParser> facetParsers)
+    {
+        var path = "";
+        var builder = new DuckDbSqlBuilder();
+
+        if (criteria is DataSetQueryCriteriaFacets criteriaFacets)
+        {
+            var fragments = facetParsers
+                .Select(parser => parser.Parse(criteriaFacets, path))
+                .Where(fragment => !fragment.IsEmpty());
+
+            builder.AppendRange(fragments, joinString: "\nAND ");
+        }
+
+        return builder.Build();
+    }
+
+    private class Facets
+    {
+        public HashSet<string> Filters { get; init; } = [];
+
+        public HashSet<DataSetQueryLocation> Locations { get; init; } = [];
+
+        public HashSet<DataSetQueryTimePeriod> TimePeriods { get; init; } = [];
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
@@ -412,13 +412,13 @@ internal class DataSetQueryService(
             GeographicLevel = EnumUtil.GetFromEnumLabel<GeographicLevel>((string)row[DataTable.Cols.GeographicLevel]!),
             TimePeriod = timePeriodsById.Result[(int)row[DataTable.Cols.TimePeriodId]!],
             Filters = columnsByType.Filters
-                .Where(filter => row[filter] is int)
+                .Where(filter => row[filter] is int and not 0)
                 .ToDictionary(
                     filter => filter,
                     filter => filterOptionsById.Result[(int)row[filter]!]
                 ),
             Locations = locationColumnsByCode
-                .Where(kv => row[kv.Value] is int)
+                .Where(kv => row[kv.Value] is int and not 0)
                 .ToDictionary(
                     kv => kv.Key,
                     kv => locationOptionsById.Result[(int)row[kv.Value]!]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
@@ -1,0 +1,579 @@
+using System.Collections.Immutable;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Query;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using StackExchange.Profiling;
+using PagingViewModel = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels.PagingViewModel;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ValidationMessages;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
+
+internal class DataSetQueryService(
+    PublicDataDbContext publicDataDbContext,
+    IUserService userService,
+    IDataSetQueryParser dataSetQueryParser,
+    IParquetDataRepository dataRepository,
+    IParquetFilterRepository filterRepository,
+    IParquetIndicatorRepository indicatorRepository,
+    IParquetLocationRepository locationRepository,
+    IParquetTimePeriodRepository timePeriodRepository)
+    : IDataSetQueryService
+{
+    private static readonly Dictionary<string, string> ReservedSorts = new()
+    {
+        { "timePeriod", DataTable.Cols.TimePeriodId },
+        { "geographicLevel", DataTable.Cols.GeographicLevel },
+    };
+
+    private static readonly ImmutableHashSet<string> ReservedColumns =
+    [
+        DataTable.Cols.Id,
+        DataTable.Cols.GeographicLevel,
+        DataTable.Cols.TimePeriodId
+    ];
+
+    private static string LocationsSortField(GeographicLevel level) => $"locations|{level.GetEnumValue()}";
+
+    public async Task<Either<ActionResult, DataSetQueryPaginatedResultsViewModel>> Query(
+        Guid dataSetId,
+        DataSetGetQueryRequest request,
+        string? dataSetVersion = null,
+        CancellationToken cancellationToken = default)
+    {
+        using var _ = MiniProfiler.Current
+            .Step($"{nameof(DataSetQueryService)}.{nameof(Query)}");
+
+        var query = new DataSetQueryRequest
+        {
+            Criteria = new DataSetQueryCriteriaFacets
+            {
+                Locations = request.Locations?.ToCriteria(),
+                Filters = request.Filters?.ToCriteria(),
+                GeographicLevels = request.GeographicLevels?.ToCriteria(),
+                TimePeriods = request.TimePeriods?.ToCriteria(),
+            },
+            Indicators = request.Indicators,
+            Sorts = request.Sorts?.Select(DataSetQuerySort.FromString).ToList()
+        };
+
+        return await FindDataSetVersion(dataSetId, dataSetVersion, cancellationToken)
+            .OnSuccessDo(userService.CheckCanQueryDataSetVersion)
+            .OnSuccess(dsv => RunQuery(
+                dataSetVersion: dsv,
+                request: query,
+                page: request.Page,
+                pageSize: request.PageSize,
+                debug: request.Debug,
+                cancellationToken: cancellationToken
+            ))
+            .OnSuccess(results => results with
+            {
+                Warnings = results.Warnings.Select(MapGetQueryWarning).ToList()
+            })
+            .OnFailureFailWith(result =>
+                result is not BadRequestObjectResult { Value: ValidationProblemViewModel validationProblem }
+                ? result
+                : ValidationUtils.ValidationResult(validationProblem.Errors.Select(MapGetQueryError))
+            );
+    }
+
+    private async Task<Either<ActionResult, DataSetVersion>> FindDataSetVersion(
+        Guid dataSetId,
+        string? dataSetVersion,
+        CancellationToken cancellationToken)
+    {
+        using var _ = MiniProfiler.Current
+            .Step($"{nameof(DataSetQueryService)}.{nameof(FindDataSetVersion)}");
+
+        if (dataSetVersion is null)
+        {
+            return await publicDataDbContext.DataSets
+                .AsNoTracking()
+                .Include(ds => ds.LatestVersion)
+                .Where(ds => ds.Id == dataSetId)
+                .Select(ds => ds.LatestVersion!)
+                .SingleOrNotFoundAsync(cancellationToken);
+        }
+
+        if (!VersionUtils.TryParse(dataSetVersion, out var version))
+        {
+            return new NotFoundResult();
+        }
+
+        return await publicDataDbContext.DataSetVersions
+            .AsNoTracking()
+            .Where(dsv => dsv.DataSetId == dataSetId)
+            .Where(dsv => dsv.VersionMajor == version.Major)
+            .Where(dsv => dsv.VersionMinor == version.Minor)
+            .SingleOrNotFoundAsync(cancellationToken);
+    }
+
+    private async Task<Either<ActionResult, DataSetQueryPaginatedResultsViewModel>> RunQuery(
+        DataSetVersion dataSetVersion,
+        DataSetQueryRequest request,
+        int page,
+        int pageSize,
+        bool debug,
+        CancellationToken cancellationToken)
+    {
+        using var _ = MiniProfiler.Current
+            .Step($"{nameof(DataSetQueryService)}.{nameof(RunQuery)}");
+
+        var queryState = new QueryState();
+
+        var whereBuilder = new DuckDbSqlBuilder();
+
+        if (request.Criteria is not null)
+        {
+            whereBuilder += await dataSetQueryParser.ParseCriteria(
+                request.Criteria,
+                dataSetVersion,
+                queryState,
+                cancellationToken
+            );
+        }
+
+        var columnsTask = dataRepository.ListColumns(dataSetVersion, cancellationToken);
+        var indicatorsTask = indicatorRepository.ListIds(dataSetVersion, cancellationToken);
+
+        await Task.WhenAll(columnsTask, indicatorsTask);
+
+        var indicators = GetIndicators(request, indicatorsTask.Result, queryState);
+
+        var sorts = GetSorts(
+            request: request,
+            columns: columnsTask.Result,
+            indicators: indicators,
+            queryState: queryState);
+
+        if (queryState.Errors.Count != 0)
+        {
+            return ValidationUtils.ValidationResult(queryState.Errors);
+        }
+
+        var whereSql = whereBuilder.Build();
+
+        var columnsByType = GetColumnsByType(
+            columns: columnsTask.Result,
+            allIndicators: indicatorsTask.Result,
+            selectedIndicators: indicators);
+
+        var countTask = dataRepository.CountRows(
+            dataSetVersion: dataSetVersion,
+            where: whereSql,
+            cancellationToken: cancellationToken);
+
+        var rowsTask = dataRepository.ListRows(
+            dataSetVersion: dataSetVersion,
+            columns: [
+                DataTable.Cols.TimePeriodId,
+                DataTable.Cols.GeographicLevel,
+                ..columnsByType.All
+            ],
+            where: whereSql,
+            sorts: sorts,
+            page: page,
+            pageSize: pageSize,
+            cancellationToken: cancellationToken);
+
+        await Task.WhenAll(countTask, rowsTask);
+
+        if (debug)
+        {
+            queryState.Warnings.Add(new WarningViewModel
+            {
+                Code = ValidationMessages.DebugEnabled.Code,
+                Message = ValidationMessages.DebugEnabled.Message,
+            });
+        }
+
+        if (countTask.Result == 0)
+        {
+            queryState.Warnings.Add(new WarningViewModel
+            {
+                Code = ValidationMessages.QueryNoResults.Code,
+                Message = ValidationMessages.QueryNoResults.Message,
+            });
+        }
+
+        return new DataSetQueryPaginatedResultsViewModel
+        {
+            Paging = new PagingViewModel(page, pageSize, (int)countTask.Result),
+            Results = await MapQueryResults(
+                rows: rowsTask.Result,
+                dataSetVersion: dataSetVersion,
+                columnsByType: columnsByType,
+                debug: debug,
+                cancellationToken: cancellationToken),
+            Warnings = queryState.Warnings
+        };
+    }
+
+    private static HashSet<string> GetIndicators(
+        DataSetQueryRequest request,
+        ISet<string> allowedIndicators,
+        QueryState queryState)
+    {
+        var validIndicators = new HashSet<string>();
+        var invalidIndicators = new HashSet<string>();
+
+        foreach (var indicator in request.Indicators)
+        {
+            if (!allowedIndicators.Contains(indicator))
+            {
+                invalidIndicators.Add(indicator);
+            }
+            else
+            {
+                validIndicators.Add(indicator);
+            }
+        }
+
+        if (invalidIndicators.Count != 0)
+        {
+            queryState.Errors.Add(new ErrorViewModel
+            {
+                Code = ValidationMessages.IndicatorsNotFound.Code,
+                Message = ValidationMessages.IndicatorsNotFound.Message,
+                Path = "indicators",
+                Detail = new NotFoundItemsErrorDetail<string>(invalidIndicators)
+            });
+        }
+
+        return validIndicators;
+    }
+
+    private static List<Sort> GetSorts(
+        DataSetQueryRequest request,
+        IEnumerable<string> columns,
+        IEnumerable<string> indicators,
+        QueryState queryState)
+    {
+        if (request.Sorts is null)
+        {
+            return [new Sort(Field: DataTable.Cols.TimePeriodId, Direction: SortDirection.Desc)];
+        }
+
+        var locationLevels = GeographicLevelUtils.Levels
+            .Where(level => columns.Contains(DataTable.Cols.LocationId(level)))
+            .ToHashSet();
+
+        var fieldColumnMap = new Dictionary<string, string>(ReservedSorts);
+
+        foreach (var locationLevel in locationLevels)
+        {
+            fieldColumnMap[LocationsSortField(locationLevel)] = DataTable.Cols.LocationId(locationLevel);
+        }
+
+        var otherFields = columns
+            .Except([
+                DataTable.Cols.Id,
+                ..ReservedSorts.Keys,
+                ..locationLevels.Select(DataTable.Cols.LocationId),
+            ])
+            .Concat(indicators)
+            .ToHashSet();
+
+        var invalidSorts = new HashSet<DataSetQuerySort>();
+        var sorts = new List<Sort>();
+
+        foreach (var sort in request.Sorts)
+        {
+            if (fieldColumnMap.TryGetValue(sort.Field, out var field))
+            {
+                sorts.Add(new Sort(Field: field, Direction: sort.ParsedDirection));
+                continue;
+            }
+
+            if (otherFields.Contains(sort.Field))
+            {
+                sorts.Add(new Sort(Field: sort.Field, Direction: sort.ParsedDirection));
+                continue;
+            }
+
+            invalidSorts.Add(sort);
+        }
+
+        if (invalidSorts.Count != 0)
+        {
+            queryState.Errors.Add(new ErrorViewModel
+            {
+                Message = ValidationMessages.SortFieldsNotFound.Message,
+                Code = ValidationMessages.SortFieldsNotFound.Code,
+                Path = "sorts",
+                Detail = new NotFoundItemsErrorDetail<DataSetQuerySort>(invalidSorts)
+            });
+        }
+
+        return sorts;
+    }
+
+    private static ColumnsByType GetColumnsByType(
+        ISet<string> columns,
+        ISet<string> allIndicators,
+        ISet<string> selectedIndicators)
+    {
+        var locationLevels = GeographicLevelUtils.Levels
+            .Where(level => columns.Contains(DataTable.Cols.LocationId(level)))
+            .ToHashSet();
+
+        var filterColumns = columns
+            .Except([
+                ..ReservedColumns,
+                ..locationLevels.Select(DataTable.Cols.LocationId),
+                ..allIndicators
+            ])
+            .ToHashSet();
+
+        return new ColumnsByType
+        {
+            Filters = filterColumns,
+            LocationLevels = locationLevels,
+            Indicators = selectedIndicators
+        };
+    }
+
+    private async Task<List<DataSetQueryResultViewModel>> MapQueryResults(
+        IList<IDictionary<string, object?>> rows,
+        DataSetVersion dataSetVersion,
+        ColumnsByType columnsByType,
+        bool debug,
+        CancellationToken cancellationToken)
+    {
+        using var _ = MiniProfiler.Current.Step(
+            $"{nameof(DataSetQueryService)}.{nameof(MapQueryResults)}");
+
+        var locationColumnsByCode = columnsByType.LocationLevels
+            .ToDictionary(
+                level => level.GetEnumValue(),
+                DataTable.Cols.LocationId
+            );
+
+        var timePeriodIds = new HashSet<int>();
+        var locationOptionIds = new HashSet<int>();
+        var filterOptionIds = new HashSet<int>();
+
+        foreach (var row in rows)
+        {
+            timePeriodIds.Add((int)row[DataTable.Cols.TimePeriodId]!);
+
+            foreach (var (_, locationColumn) in locationColumnsByCode)
+            {
+                if (row[locationColumn] is int locationOptionId)
+                {
+                    locationOptionIds.Add(locationOptionId);
+                }
+            }
+
+            foreach (var filterColumn in columnsByType.Filters)
+            {
+                if (row[filterColumn] is int filterOptionId)
+                {
+                    filterOptionIds.Add(filterOptionId);
+                }
+            }
+        }
+
+        // Fetch options in parallel. We split out separate queries and merge back into the results
+        // instead of joining everything in one big data query as joins on larger data sets are
+        // quite expensive. This also avoids excessive data transfer over the wire and
+        // should be more efficient overall (despite the additional requests).
+        var filterOptionsById =
+            GetFilterOptionsById(dataSetVersion, filterOptionIds, debug, cancellationToken);
+        var locationOptionsById =
+            GetLocationOptionsById(dataSetVersion, locationOptionIds, debug, cancellationToken);
+        var timePeriodsById = 
+            GetTimePeriodsById(dataSetVersion, timePeriodIds, cancellationToken);
+
+        await Task.WhenAll(filterOptionsById, locationOptionsById, timePeriodsById);
+
+        return rows.Select(row => new DataSetQueryResultViewModel
+        {
+            GeographicLevel = EnumUtil.GetFromEnumLabel<GeographicLevel>((string)row[DataTable.Cols.GeographicLevel]!),
+            TimePeriod = timePeriodsById.Result[(int)row[DataTable.Cols.TimePeriodId]!],
+            Filters = columnsByType.Filters
+                .Where(filter => row[filter] is int)
+                .ToDictionary(
+                    filter => filter,
+                    filter => filterOptionsById.Result[(int)row[filter]!]
+                ),
+            Locations = locationColumnsByCode
+                .Where(kv => row[kv.Value] is int)
+                .ToDictionary(
+                    kv => kv.Key,
+                    kv => locationOptionsById.Result[(int)row[kv.Value]!]
+                ),
+            Values = columnsByType.Indicators.ToDictionary(
+                indicator => indicator,
+                indicator => row[indicator] as string ?? string.Empty
+            )
+        })
+        .ToList();
+    }
+
+    private static WarningViewModel MapGetQueryWarning(WarningViewModel warning)
+    {
+        if (warning.Code == ValidationMessages.LocationsNotFound.Code
+            && warning.Detail is NotFoundItemsErrorDetail<DataSetQueryLocation> notFoundLocations)
+        {
+            return warning with
+            {
+                Detail = new NotFoundItemsErrorDetail<string>(
+                    notFoundLocations.Items.Select(item => item.ToLocationString())
+                )
+            };
+        }
+
+        if (warning.Code == ValidationMessages.TimePeriodsNotFound.Code
+            && warning.Detail is NotFoundItemsErrorDetail<DataSetQueryTimePeriod> notFoundTimePeriods)
+        {
+            return warning with
+            {
+                Detail = new NotFoundItemsErrorDetail<string>(
+                    notFoundTimePeriods.Items.Select(item => item.ToTimePeriodString())
+                )
+            };
+        }
+
+        return warning;
+    }
+
+    private static ErrorViewModel MapGetQueryError(ErrorViewModel error)
+    {
+        if (error.Code == ValidationMessages.SortFieldsNotFound.Code
+            && error.Detail is NotFoundItemsErrorDetail<DataSetQuerySort> notFoundSortFields)
+        {
+            return error with
+            {
+                Detail = new NotFoundItemsErrorDetail<string>(
+                    notFoundSortFields.Items.Select(item => item.ToSortString())
+                )
+            };
+        }
+
+        return error;
+    }
+
+    private async Task<Dictionary<int, string>> GetFilterOptionsById(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> filterOptionIds,
+        bool debug,
+        CancellationToken cancellationToken)
+    {
+        if (debug)
+        {
+            var options =
+                await filterRepository.ListOptions(dataSetVersion, filterOptionIds, cancellationToken);
+
+            return options.ToDictionary(
+                option => option.Id,
+                option => $"{option.PublicId} :: {option.Label}"
+            );
+        }
+
+        var publicIds =
+            await filterRepository.ListOptionPublicIds(dataSetVersion, filterOptionIds, cancellationToken);
+
+        return publicIds.ToDictionary(
+            option => option.Id,
+            option => option.PublicId
+        );
+    }
+
+    private async Task<Dictionary<int, string>> GetLocationOptionsById(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> locationOptionIds,
+        bool debug,
+        CancellationToken cancellationToken)
+    {
+        if (debug)
+        {
+            var options =
+                await locationRepository.ListOptions(dataSetVersion, locationOptionIds, cancellationToken);
+
+            return options.ToDictionary(
+                o => o.Id,
+                GetLocationOptionDebugLabel);
+        }
+
+        var publicIds =
+            await locationRepository.ListOptionPublicIds(dataSetVersion, locationOptionIds, cancellationToken);
+
+        return publicIds.ToDictionary(
+            option => option.Id,
+            option => option.PublicId
+        );
+    }
+
+    private async Task<Dictionary<int, TimePeriodViewModel>> GetTimePeriodsById(
+        DataSetVersion dataSetVersion,
+        IEnumerable<int> timePeriodIds,
+        CancellationToken cancellationToken)
+    {
+        var timePeriods =
+            await timePeriodRepository.List(dataSetVersion, timePeriodIds, cancellationToken);
+
+        return timePeriods.ToDictionary(
+            timePeriod => timePeriod.Id,
+            timePeriod => new TimePeriodViewModel
+            {
+                Code = EnumUtil.GetFromEnumLabel<TimeIdentifier>(timePeriod.Identifier),
+                Period = TimePeriodFormatter.FormatFromCsv(timePeriod.Period),
+            }
+        );
+    }
+
+    private static string GetLocationOptionDebugLabel(ParquetLocationOption option)
+    {
+        var level = EnumUtil.GetFromEnumValue<GeographicLevel>(option.Level);
+
+        return level switch
+        {
+            GeographicLevel.LocalAuthority =>
+                $"{option.PublicId} :: {option.Label} (code = {option.Code}, oldCode = {option.OldCode})",
+            GeographicLevel.Provider =>
+                $"{option.PublicId} :: {option.Label} (ukprn = {option.Ukprn})",
+            GeographicLevel.RscRegion =>
+                $"{option.PublicId} :: {option.Label}",
+            GeographicLevel.School =>
+                $"{option.PublicId} :: {option.Label} (urn = {option.Urn}, laEstab = {option.LaEstab})",
+            _ => $"{option.PublicId} :: {option.Label} (code = {option.Code})"
+        };
+    }
+
+    private class ColumnsByType
+    {
+        public required IEnumerable<GeographicLevel> LocationLevels { get; init; } = [];
+
+        public required IEnumerable<string> Filters { get; init; } = [];
+
+        public required IEnumerable<string> Indicators { get; init; } = [];
+
+        public IEnumerable<string> All =>
+        [
+            ..LocationLevels.Select(DataTable.Cols.LocationId),
+            ..Filters,
+            ..Indicators
+        ];
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetQueryParser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetQueryParser.cs
@@ -1,0 +1,15 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Query;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using InterpolatedSql;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+
+public interface IDataSetQueryParser
+{
+    Task<IInterpolatedSql> ParseCriteria(
+        DataSetQueryCriteria criteria,
+        DataSetVersion dataSetVersion,
+        QueryState queryState,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetQueryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetQueryService.cs
@@ -1,0 +1,15 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+
+public interface IDataSetQueryService
+{
+    Task<Either<ActionResult, DataSetQueryPaginatedResultsViewModel>> Query(
+        Guid dataSetId,
+        DataSetGetQueryRequest request,
+        string? dataSetVersion = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/FilterFacetsParser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/FilterFacetsParser.cs
@@ -1,0 +1,152 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+using InterpolatedSql;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Query;
+
+internal class FilterFacetsParser : IFacetsParser
+{
+    private readonly QueryState _queryState;
+    private readonly Dictionary<string, ParquetFilterOption> _allowedFilterOptionsByPublicId;
+
+    public FilterFacetsParser(QueryState queryState, IEnumerable<ParquetFilterOption> filterOptions)
+    {
+        _queryState = queryState;
+        _allowedFilterOptionsByPublicId = filterOptions.ToDictionary(o => o.PublicId);
+    }
+
+    public IInterpolatedSql Parse(DataSetQueryCriteriaFacets facets, string path)
+    {
+        var fragments = new List<IInterpolatedSql>();
+
+        if (facets.Filters?.Eq is not null)
+        {
+            fragments.Add(
+                EqFragment(
+                    filterOptionId: facets.Filters.Eq,
+                    path: QueryUtils.Path(path, "filters.eq")
+                )
+            );
+        }
+
+        if (facets.Filters?.NotEq is not null)
+        {
+            fragments.Add(
+                EqFragment(
+                    filterOptionId: facets.Filters.NotEq,
+                    path: QueryUtils.Path(path, "filters.notEq"),
+                    negate: true
+                )
+            );
+        }
+
+        if (facets.Filters?.In is not null && facets.Filters.In.Count != 0)
+        {
+            fragments.Add(
+                InFragment(
+                    filterOptionIds: [..facets.Filters.In],
+                    path: QueryUtils.Path(path, "filters.in")
+                )
+            );
+        }
+
+        if (facets.Filters?.NotIn is not null && facets.Filters.NotIn.Count != 0)
+        {
+            fragments.Add(
+                InFragment(
+                    filterOptionIds: [..facets.Filters.NotIn],
+                    path: QueryUtils.Path(path, "filters.notIn"),
+                    negate: true
+                )
+            );
+        }
+
+        return new DuckDbSqlBuilder()
+            .AppendRange(fragments, "\nAND ")
+            .Build();
+    }
+
+    private IInterpolatedSql EqFragment(
+        string filterOptionId,
+        string path,
+        bool negate = false)
+    {
+        var builder = new DuckDbSqlBuilder();
+
+        if (!_allowedFilterOptionsByPublicId.TryGetValue(filterOptionId, out var option))
+        {
+            _queryState.Warnings.Add(CreateNotFoundWarning([filterOptionId], path));
+
+            return builder
+                .AppendLiteral(negate ? "true" : "false")
+                .Build();
+        }
+
+        builder += $"{DataTable.Ref().Col(option.ColumnName):raw} {(negate ? "!=" : "="):raw} {option.Id}";
+
+        return builder.Build();
+    }
+
+    private IInterpolatedSql InFragment(
+        HashSet<string> filterOptionIds,
+        string path,
+        bool negate = false)
+    {
+        var builder = new DuckDbSqlBuilder();
+
+        var options = filterOptionIds
+            .Where(_allowedFilterOptionsByPublicId.ContainsKey)
+            .Select(id => _allowedFilterOptionsByPublicId[id])
+            .ToList();
+
+        if (options.Count < filterOptionIds.Count)
+        {
+            _queryState.Warnings.Add(CreateNotFoundWarning(filterOptionIds, path));
+        }
+
+        if (options.Count == 0)
+        {
+            return builder
+                .AppendLiteral(negate ? "true" : "false")
+                .Build();
+        }
+
+        var fragments = options
+            .GroupBy(o => o.ColumnName)
+            .Select(group =>
+            {
+                var ids = group.Select(o => o.Id);
+
+                return (FormattableString)
+                    $"{DataTable.Ref().Col(group.Key):raw} {(negate ? "NOT IN" : "IN"):raw} ({ids})";
+            })
+            .ToList();
+
+        return fragments.Count == 1
+            ? builder
+                .AppendFormattableString(fragments[0])
+                .Build()
+            : builder
+                .AppendLiteral("(")
+                .AppendRange(fragments, joinString: negate ? "\n AND " : "\n OR ")
+                .AppendLiteral(")")
+                .Build();
+    }
+
+    private WarningViewModel CreateNotFoundWarning(HashSet<string> filterOptionIds, string path) => new()
+    {
+        Code = ValidationMessages.FiltersNotFound.Code,
+        Message = ValidationMessages.FiltersNotFound.Message,
+        Path = path,
+        Detail = new NotFoundItemsErrorDetail<string>(
+            filterOptionIds.Where(optionId => !_allowedFilterOptionsByPublicId.ContainsKey(optionId))
+        )
+    };
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/GeographicLevelFacetsParser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/GeographicLevelFacetsParser.cs
@@ -1,0 +1,144 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+using InterpolatedSql;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Query;
+
+internal class GeographicLevelFacetsParser(
+    QueryState queryState,
+    HashSet<GeographicLevel> allowedGeographicLevels)
+    : IFacetsParser
+{
+    public IInterpolatedSql Parse(DataSetQueryCriteriaFacets facets, string path)
+    {
+        var fragments = new List<IInterpolatedSql>();
+
+        var parsedEq = facets.GeographicLevels?.ParsedEq;
+
+        if (parsedEq is not null)
+        {
+            fragments.Add(
+                EqFragment(
+                    geographicLevel: parsedEq.Value,
+                    path: QueryUtils.Path(path, "geographicLevels.eq")
+                )
+            );
+        }
+
+        var parsedNotEq = facets.GeographicLevels?.ParsedNotEq;
+
+        if (parsedNotEq is not null)
+        {
+            fragments.Add(
+                EqFragment(
+                    geographicLevel: parsedNotEq.Value,
+                    path: QueryUtils.Path(path, "geographicLevels.notEq"),
+                    negate: true
+                )
+            );
+        }
+
+        var parsedIn = facets.GeographicLevels?.ParsedIn;
+
+        if (parsedIn is not null && parsedIn.Count != 0)
+        {
+            fragments.Add(
+                InFragment(
+                    geographicLevels: parsedIn,
+                    path: QueryUtils.Path(path, "geographicLevels.in")
+                )
+            );
+        }
+
+        var parsedNotIn = facets.GeographicLevels?.ParsedNotIn;
+
+        if (parsedNotIn is not null && parsedNotIn.Count != 0)
+        {
+            fragments.Add(
+                InFragment(
+                    geographicLevels: parsedNotIn,
+                    path: QueryUtils.Path(path, "geographicLevels.notIn"),
+                    negate: true
+                )
+            );
+        }
+
+        return new DuckDbSqlBuilder()
+            .AppendRange(fragments, "\nAND ")
+            .Build();
+    }
+
+    private IInterpolatedSql EqFragment(
+        GeographicLevel geographicLevel,
+        string path,
+        bool negate = false)
+    {
+        var builder = new DuckDbSqlBuilder();
+
+        if (!allowedGeographicLevels.Contains(geographicLevel))
+        {
+            queryState.Warnings.Add(CreateNotFoundWarning([geographicLevel], path));
+
+            return builder
+                .AppendLiteral(negate ? "true" : "false")
+                .Build();
+        }
+
+        builder +=
+            $"{DataTable.Ref().GeographicLevel:raw} {(negate ? "!=" : "="):raw} {geographicLevel.GetEnumLabel()}";
+
+        return builder.Build();
+    }
+
+    private IInterpolatedSql InFragment(
+        IReadOnlyList<GeographicLevel> geographicLevels,
+        string path,
+        bool negate = false)
+    {
+        var builder = new DuckDbSqlBuilder();
+
+        var levels = geographicLevels
+            .Where(allowedGeographicLevels.Contains)
+            .ToHashSet();
+
+        if (levels.Count < geographicLevels.Count)
+        {
+            queryState.Warnings.Add(CreateNotFoundWarning(geographicLevels, path));
+        }
+
+        if (levels.Count == 0)
+        {
+            return builder
+                .AppendLiteral(negate ? "true" : "false")
+                .Build();
+        }
+
+        var parameters = levels
+            .Select(level => level.GetEnumLabel())
+            .ToList();
+
+        builder += $"{DataTable.Ref().GeographicLevel:raw} {(negate ? "NOT IN" : "IN"):raw} ({parameters})";
+
+        return builder.Build();
+    }
+
+    private WarningViewModel CreateNotFoundWarning(IEnumerable<GeographicLevel> geographicLevels, string path) => new()
+    {
+        Code = ValidationMessages.GeographicLevelsNotFound.Code,
+        Message = ValidationMessages.GeographicLevelsNotFound.Message,
+        Path = path,
+        Detail = new NotFoundItemsErrorDetail<string>(
+            geographicLevels
+                .Where(level => !allowedGeographicLevels.Contains(level))
+                .Select(level => level.GetEnumValue())
+                .ToList()
+        )
+    };
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/IFacetsParser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/IFacetsParser.cs
@@ -1,0 +1,9 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using InterpolatedSql;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Query;
+
+public interface IFacetsParser
+{
+    public IInterpolatedSql Parse(DataSetQueryCriteriaFacets facets, string path);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/LocationFacetsParser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/LocationFacetsParser.cs
@@ -1,0 +1,208 @@
+using System.Diagnostics.CodeAnalysis;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+using InterpolatedSql;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Query;
+
+internal class LocationFacetsParser : IFacetsParser
+{
+    private readonly QueryState _queryState;
+    private readonly Dictionary<GeographicLevel, List<ParquetLocationOption>> _allowedLocationOptionsByLevel;
+
+    public LocationFacetsParser(
+        QueryState queryState,
+        IEnumerable<ParquetLocationOption> locationOptionMetas)
+    {
+        _queryState = queryState;
+        _allowedLocationOptionsByLevel = locationOptionMetas
+            .GroupBy(location => EnumUtil.GetFromEnumValue<GeographicLevel>(location.Level))
+            .ToDictionary(
+                group => group.Key,
+                group => group.ToList()
+            );
+    }
+
+    public IInterpolatedSql Parse(DataSetQueryCriteriaFacets facets, string path)
+    {
+        var fragments = new List<IInterpolatedSql>();
+
+        if (facets.Locations?.Eq is not null)
+        {
+            fragments.Add(
+                EqFragment(
+                    location: facets.Locations.Eq,
+                    path: QueryUtils.Path(path, "locations.eq")
+                )
+            );
+        }
+
+        if (facets.Locations?.NotEq is not null)
+        {
+            fragments.Add(
+                EqFragment(
+                    location: facets.Locations.NotEq,
+                    path: QueryUtils.Path(path, "locations.notEq"),
+                    negate: true
+                )
+            );
+        }
+
+        if (facets.Locations?.In is not null && facets.Locations.In.Count != 0)
+        {
+            fragments.Add(
+                InFragment(
+                    locations: [..facets.Locations.In],
+                    path: QueryUtils.Path(path, "locations.in")
+                )
+            );
+        }
+
+        if (facets.Locations?.NotIn is not null && facets.Locations.NotIn.Count != 0)
+        {
+            fragments.Add(
+                InFragment(
+                    locations: [..facets.Locations.NotIn],
+                    path: QueryUtils.Path(path, "locations.notIn"),
+                    negate: true
+                )
+            );
+        }
+
+        return new DuckDbSqlBuilder()
+            .AppendRange(fragments, "\nAND ")
+            .Build();
+    }
+
+    private IInterpolatedSql EqFragment(
+        DataSetQueryLocation location,
+        string path,
+        bool negate = false)
+    {
+        var builder = new DuckDbSqlBuilder();
+
+        if (!TryGetLocationOption(location, out var option))
+        {
+            _queryState.Warnings.Add(CreateNotFoundWarning([location], path));
+
+            return builder
+                .AppendLiteral(negate ? "true" : "false")
+                .Build();
+        }
+
+        builder += $"{DataTable.Ref().LocationId(location.ParsedLevel):raw} {(negate ? "!=" : "="):raw} {option.Id}";
+
+        return builder.Build();
+    }
+
+    private IInterpolatedSql InFragment(
+        HashSet<DataSetQueryLocation> locations,
+        string path,
+        bool negate = false)
+    {
+        var builder = new DuckDbSqlBuilder();
+
+
+        var options = new List<ParquetLocationOption>();
+        var notFoundLocations = new List<DataSetQueryLocation>();
+
+        foreach (var location in locations)
+        {
+            if (TryGetLocationOption(location, out var option))
+            {
+                options.Add(option);
+                continue;
+            }
+
+            notFoundLocations.Add(location);
+        }
+        
+        if (notFoundLocations.Count != 0)
+        {
+            _queryState.Warnings.Add(CreateNotFoundWarning(notFoundLocations, path));
+        }
+
+        if (options.Count == 0)
+        {
+            return builder
+                .AppendLiteral(negate ? "true" : "false")
+                .Build();
+        }
+
+        var fragments = options
+            .GroupBy(l => l.Level)
+            .Select(
+                group =>
+                {
+                    var level = EnumUtil.GetFromEnumValue<GeographicLevel>(group.Key);
+                    var ids = group.Select(l => l.Id);
+
+                    return (FormattableString)
+                        $"{DataTable.Ref().LocationId(level):raw} {(negate ? "NOT IN" : "IN"):raw} ({ids})";
+                })
+            .ToList();
+
+        return fragments.Count == 1
+            ? builder
+                .AppendFormattableString(fragments[0])
+                .Build()
+            : builder
+                .AppendLiteral("(")
+                .AppendRange(fragments, joinString: negate ? "\n AND " : "\n OR ")
+                .AppendLiteral(")")
+                .Build();
+    }
+
+    private bool TryGetLocationOption(
+        DataSetQueryLocation queryLocation,
+        [MaybeNullWhen(false)] out ParquetLocationOption locationOption)
+    {
+        locationOption = null;
+
+        if (!_allowedLocationOptionsByLevel.TryGetValue(queryLocation.ParsedLevel, out var options))
+        {
+            return false;
+        }
+
+        var matchingOption = options.FirstOrDefault(option => IsMatchingLocationOption(option, queryLocation));
+
+        if (matchingOption is null)
+        {
+            return false;
+        }
+
+        locationOption = matchingOption;
+
+        return true;
+    }
+
+    private static bool IsMatchingLocationOption(ParquetLocationOption option, DataSetQueryLocation queryLocation)
+        => queryLocation switch
+        {
+            DataSetQueryLocationId locationId => option.PublicId == locationId.Id,
+            DataSetQueryLocationCode locationCode => option.Code == locationCode.Code,
+            DataSetQueryLocationSchoolUrn school => option.Urn == school.Urn,
+            DataSetQueryLocationSchoolLaEstab school => option.LaEstab == school.LaEstab,
+            DataSetQueryLocationProviderUkprn provider => option.Ukprn == provider.Ukprn,
+            DataSetQueryLocationLocalAuthorityCode localAuthority => option.Code == localAuthority.Code,
+            DataSetQueryLocationLocalAuthorityOldCode localAuthority => option.OldCode == localAuthority.OldCode,
+            _ => false
+        };
+
+    private WarningViewModel CreateNotFoundWarning(IEnumerable<DataSetQueryLocation> locations, string path) => new()
+    {
+        Code = ValidationMessages.LocationsNotFound.Code,
+        Message = ValidationMessages.LocationsNotFound.Message,
+        Path = path,
+        Detail = new NotFoundItemsErrorDetail<DataSetQueryLocation>(locations)
+    };
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/QueryState.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/QueryState.cs
@@ -1,0 +1,11 @@
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Query;
+
+public class QueryState
+{
+    public List<ErrorViewModel> Errors { get; } = [];
+
+    public List<WarningViewModel> Warnings { get; } = [];
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/TimePeriodFacetsParser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/TimePeriodFacetsParser.cs
@@ -1,0 +1,223 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils;
+using InterpolatedSql;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Query;
+
+internal class TimePeriodFacetsParser : IFacetsParser
+{
+    private readonly QueryState _queryState;
+    private readonly Dictionary<TimePeriodKey, ParquetTimePeriod> _allowedTimePeriods;
+
+    public TimePeriodFacetsParser(QueryState queryState, IEnumerable<ParquetTimePeriod> timePeriods)
+    {
+        _queryState = queryState;
+        _allowedTimePeriods = timePeriods.ToDictionary(timePeriod => new TimePeriodKey(timePeriod));
+    }
+
+    public IInterpolatedSql Parse(DataSetQueryCriteriaFacets facets, string path)
+    {
+        var fragments = new List<IInterpolatedSql>();
+
+        if (facets.TimePeriods?.Eq is not null)
+        {
+            fragments.Add(
+                EqFragment(
+                    timePeriod: facets.TimePeriods.Eq,
+                    path: QueryUtils.Path(path, "timePeriods.eq")
+                )
+            );
+        }
+
+        if (facets.TimePeriods?.NotEq is not null)
+        {
+            fragments.Add(
+                EqFragment(
+                    timePeriod: facets.TimePeriods.NotEq,
+                    path: QueryUtils.Path(path, "timePeriods.notEq"),
+                    negate: true
+                )
+            );
+        }
+
+        if (facets.TimePeriods?.In is not null && facets.TimePeriods.In.Count != 0)
+        {
+            fragments.Add(
+                InFragment(
+                    timePeriods: [..facets.TimePeriods.In],
+                    path: QueryUtils.Path(path, "timePeriods.in")
+                )
+            );
+        }
+
+        if (facets.TimePeriods?.NotIn is not null && facets.TimePeriods.NotIn.Count != 0)
+        {
+            fragments.Add(
+                InFragment(
+                    timePeriods: [..facets.TimePeriods.NotIn],
+                    path: QueryUtils.Path(path, "timePeriods.notIn"),
+                    negate: true
+                )
+            );
+        }
+
+        if (facets.TimePeriods?.Gt is not null)
+        {
+            fragments.Add(
+                ComparisonFragment(
+                    timePeriod: facets.TimePeriods.Gt,
+                    comparator: ">",
+                    path: QueryUtils.Path(path, "timePeriods.gt")
+                )
+            );
+        }
+
+        if (facets.TimePeriods?.Gte is not null)
+        {
+            fragments.Add(
+                ComparisonFragment(
+                    timePeriod: facets.TimePeriods.Gte,
+                    comparator: ">=",
+                    path: QueryUtils.Path(path, "timePeriods.gte")
+                )
+            );
+        }
+
+        if (facets.TimePeriods?.Lt is not null)
+        {
+            fragments.Add(
+                ComparisonFragment(
+                    timePeriod: facets.TimePeriods.Lt,
+                    comparator: "<",
+                    path: QueryUtils.Path(path, "timePeriods.lt")
+                )
+            );
+        }
+
+        if (facets.TimePeriods?.Lte is not null)
+        {
+            fragments.Add(
+                ComparisonFragment(
+                    timePeriod: facets.TimePeriods.Lte,
+                    comparator: "<=",
+                    path: QueryUtils.Path(path, "timePeriods.lte")
+                )
+            );
+        }
+
+        return new DuckDbSqlBuilder()
+            .AppendRange(fragments, "\nAND ")
+            .Build();
+    }
+
+    private IInterpolatedSql EqFragment(
+        DataSetQueryTimePeriod timePeriod,
+        string path,
+        bool negate = false)
+    {
+        var builder = new DuckDbSqlBuilder();
+
+        if (!_allowedTimePeriods.TryGetValue(new TimePeriodKey(timePeriod), out var meta))
+        {
+            _queryState.Warnings.Add(CreateNotFoundWarning([timePeriod], path));
+
+            return builder
+                .AppendLiteral(negate ? "true" : "false")
+                .Build();
+        }
+
+        builder += $"{DataTable.Ref().TimePeriodId:raw} {(negate ? "!=" : "="):raw} {meta.Id}";
+
+        return builder.Build();
+    }
+
+    private IInterpolatedSql ComparisonFragment(
+        DataSetQueryTimePeriod timePeriod,
+        string comparator,
+        string path)
+    {
+        var builder = new DuckDbSqlBuilder();
+
+        if (!_allowedTimePeriods.TryGetValue(new TimePeriodKey(timePeriod), out var meta))
+        {
+            _queryState.Warnings.Add(CreateNotFoundWarning([timePeriod], path));
+
+            return builder
+                .AppendLiteral("false")
+                .Build();
+        }
+
+        builder += $"{DataTable.Ref().TimePeriodId:raw} {comparator:raw} {meta.Id}";
+
+        return builder.Build();
+    }
+
+    private IInterpolatedSql InFragment(
+        HashSet<DataSetQueryTimePeriod> timePeriods,
+        string path,
+        bool negate = false)
+    {
+        var builder = new DuckDbSqlBuilder();
+
+        var ids = timePeriods
+            .Select(timePeriod => new TimePeriodKey(timePeriod))
+            .Where(_allowedTimePeriods.ContainsKey)
+            .Select(timePeriod => _allowedTimePeriods[timePeriod].Id)
+            .ToList();
+
+        if (ids.Count < timePeriods.Count)
+        {
+            _queryState.Warnings.Add(CreateNotFoundWarning(timePeriods, path));
+        }
+
+        if (ids.Count == 0)
+        {
+            return builder
+                .AppendLiteral(negate ? "true" : "false")
+                .Build();
+        }
+
+        builder += $"{DataTable.Ref().TimePeriodId:raw} {(negate ? "NOT IN" : "IN"):raw} ({ids})";
+
+        return builder.Build();
+    }
+
+    private WarningViewModel CreateNotFoundWarning(HashSet<DataSetQueryTimePeriod> timePeriods, string path) => new()
+    {
+        Code = ValidationMessages.TimePeriodsNotFound.Code,
+        Message = ValidationMessages.TimePeriodsNotFound.Message,
+        Path = path,
+        Detail = new NotFoundItemsErrorDetail<DataSetQueryTimePeriod>(
+            timePeriods.Where(timePeriod => !_allowedTimePeriods.ContainsKey(new TimePeriodKey(timePeriod)))
+        )
+    };
+
+    private record TimePeriodKey
+    {
+        public string Period { get; init; }
+
+        public TimeIdentifier Identifier { get; init; }
+
+        public TimePeriodKey(ParquetTimePeriod parquetTimePeriod)
+        {
+            Period = parquetTimePeriod.Period;
+            Identifier = EnumUtil.GetFromEnumLabel<TimeIdentifier>(parquetTimePeriod.Identifier);
+        }
+
+        public TimePeriodKey(DataSetQueryTimePeriod timePeriod)
+        {
+            Period = TimePeriodFormatter.FormatToCsv(timePeriod.ParsedPeriod);
+            Identifier = timePeriod.ParsedCode;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -9,6 +9,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Rules;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
@@ -175,6 +177,14 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         services.AddSingleton<IParquetPathResolver, ParquetPathResolver>();
         services.AddScoped<IPublicationService, PublicationService>();
         services.AddScoped<IDataSetService, DataSetService>();
+        services.AddScoped<IDataSetQueryService, DataSetQueryService>();
+        services.AddScoped<IDataSetQueryParser, DataSetQueryParser>();
+
+        services.AddScoped<IParquetDataRepository, ParquetDataRepository>();
+        services.AddScoped<IParquetFilterRepository, ParquetFilterRepository>();
+        services.AddScoped<IParquetIndicatorRepository, ParquetIndicatorRepository>();
+        services.AddScoped<IParquetLocationRepository, ParquetLocationRepository>();
+        services.AddScoped<IParquetTimePeriodRepository, ParquetTimePeriodRepository>();
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Utils/QueryUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Utils/QueryUtils.cs
@@ -1,0 +1,11 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Utils;
+
+public static class QueryUtils
+{
+    public static string Path(params string[] segments)
+        => segments
+            .Where(s => !s.IsNullOrWhitespace())
+            .JoinToString('.');
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/TimePeriodStringValidators.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/TimePeriodStringValidators.cs
@@ -20,7 +20,7 @@ public static partial class TimePeriodStringValidators
             {
                 context.AddFailure(
                     message: ValidationMessages.TimePeriodFormat,
-                    detail: new FormatErrorDetail(value, ExpectedFormat: ExpectedFormat)
+                    detail: new FormatErrorDetail(Value: value, ExpectedFormat: ExpectedFormat)
                 );
                 return;
             }
@@ -31,7 +31,7 @@ public static partial class TimePeriodStringValidators
             {
                 context.AddFailure(
                     message: ValidationMessages.TimePeriodYearRange,
-                    detail: new RangeErrorDetail(timePeriod.String)
+                    detail: new RangeErrorDetail(timePeriod)
                 );
             }
 
@@ -39,10 +39,10 @@ public static partial class TimePeriodStringValidators
             {
                 context.AddFailure(
                     message: ValidationMessages.TimePeriodAllowedCode,
-                    detail: new AllowedCodeErrorDetail(timePeriod.String)
-                    {
-                        Allowed = timePeriod.HasRangePeriod() ? AllowedRangeCodes : AllowedCodes
-                    }
+                    detail: new AllowedCodeErrorDetail(
+                        Value: timePeriod,
+                        AllowedCodes: timePeriod.HasRangePeriod() ? AllowedRangeCodes : AllowedCodes
+                    )
                 );
             }
         });
@@ -106,17 +106,13 @@ public static partial class TimePeriodStringValidators
             : AllowedTimeIdentifiers.Contains(code);
     }
 
-    public record RangeErrorDetail(string Value) : InvalidErrorDetail<string>(Value);
+    public record RangeErrorDetail(ParsedTimePeriod Value) : InvalidErrorDetail<ParsedTimePeriod>(Value);
 
-    public record AllowedCodeErrorDetail(string Value) : InvalidErrorDetail<string>(Value)
-    {
-        public required IReadOnlyList<string> Allowed { get; init; }
-    }
+    public record AllowedCodeErrorDetail(ParsedTimePeriod Value, IReadOnlyList<string> AllowedCodes)
+        : InvalidErrorDetail<ParsedTimePeriod>(Value);
 
     public record ParsedTimePeriod
     {
-        public string String { get; init; }
-        
         public string Period { get; init; }
         
         public string Code { get; init; }
@@ -125,7 +121,6 @@ public static partial class TimePeriodStringValidators
         {
             var parts = value.Split('|');
 
-            String = value;
             Period = parts[0];
             Code = parts[1];
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
@@ -4,6 +4,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
 
 public static class ValidationMessages
 {
+    public static readonly LocalizableMessage DebugEnabled = new(
+        Code: "DebugEnabled",
+        Message: "Debug mode is enabled. Do not enable debug mode in a production environment."
+    );
+
+    public static readonly LocalizableMessage FiltersNotFound = new(
+        Code: "FiltersNotFound",
+        Message: "One or more filters could not be found."
+    );
+
+    public static readonly LocalizableMessage GeographicLevelsNotFound = new(
+        Code: "GeographicLevelsNotFound",
+        Message: "One or more geographic levels could not be found."
+    );
+
+    public static readonly LocalizableMessage IndicatorsNotFound = new(
+        Code: "IndicatorsNotFound",
+        Message: "One or more indicators could not be found."
+    );
+
     public static readonly LocalizableMessage LocationFormat = new(
         Code: "LocationFormat",
         Message: "Must be a location in the correct format."
@@ -24,6 +44,11 @@ public static class ValidationMessages
         Message: "Must be a location with an identifying value that is {MaxValueLength} characters or fewer."
     );
 
+    public static readonly LocalizableMessage LocationsNotFound = new(
+        Code: "LocationsNotFound",
+        Message: "One or more locations could not be found."
+    );
+
     public static readonly LocalizableMessage TimePeriodFormat = new(
         Code: "TimePeriodFormat",
         Message: "Must be a time period in the correct format."
@@ -39,6 +64,16 @@ public static class ValidationMessages
         Message: "Must be a time period with an allowed code."
     );
 
+    public static readonly LocalizableMessage TimePeriodsNotFound = new(
+        Code: "TimePeriodsNotFound",
+        Message: "One or more time periods could not be found."
+    );
+
+    public static readonly LocalizableMessage QueryNoResults = new(
+        Code: "QueryNoResults",
+        Message: "The query did not match any results. You may need to refine your criteria."
+    );
+
     public static readonly LocalizableMessage SortFormat = new(
         Code: "SortFormat",
         Message: "Must be a sort in the correct format."
@@ -51,6 +86,11 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage SortDirection = new(
         Code: "SortDirection",
-        Message: "Must be a sort with an allowed direction."
+        Message: "Must be a sort in an allowed direction."
+    );
+
+    public static readonly LocalizableMessage SortFieldsNotFound = new(
+        Code: "SortFieldsNotFound",
+        Message: "One or more sort fields could not be found."
     );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
@@ -21,7 +21,7 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage LocationMaxValueLength = new(
         Code: "LocationMaxLengthValue",
-        Message: "Must be a location with an identifying value that is {MaxLength} characters or fewer."
+        Message: "Must be a location with an identifying value that is {MaxValueLength} characters or fewer."
     );
 
     public static readonly LocalizableMessage TimePeriodFormat = new(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
@@ -46,7 +46,7 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage SortMaxFieldLength = new(
         Code: "SortMaxFieldLength",
-        Message: "Must be a sort with a field that is {MaxLength} characters or fewer."
+        Message: "Must be a sort with a field that is {MaxFieldLength} characters or fewer."
     );
 
     public static readonly LocalizableMessage SortDirection = new(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/DataSetQueryResultViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/DataSetQueryResultViewModels.cs
@@ -40,7 +40,7 @@ public record DataSetQueryResultViewModel
     /// This is a dictionary where the key is the location's geographic
     /// level and the value is the location's ID.
     /// </summary>
-    public required Dictionary<string, string?> Locations { get; init; }
+    public required Dictionary<string, string> Locations { get; init; }
 
     /// <summary>
     /// The data values for the result's indicators.

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/DataSetQueryResultViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/DataSetQueryResultViewModels.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Common.Converters.SystemJson;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
@@ -29,6 +31,7 @@ public record DataSetQueryResultViewModel
     /// <summary>
     /// The geographic level relevant to this result's data.
     /// </summary>
+    [JsonConverter(typeof(EnumToEnumValueJsonConverter<GeographicLevel>))]
     public required GeographicLevel GeographicLevel { get; init; }
 
     /// <summary>
@@ -37,7 +40,7 @@ public record DataSetQueryResultViewModel
     /// This is a dictionary where the key is the location's geographic
     /// level and the value is the location's ID.
     /// </summary>
-    public required Dictionary<string, string> Locations { get; init; }
+    public required Dictionary<string, string?> Locations { get; init; }
 
     /// <summary>
     /// The data values for the result's indicators.

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/DataSetQueryResultViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/DataSetQueryResultViewModels.cs
@@ -21,12 +21,9 @@ public record DataSetQueryPaginatedResultsViewModel : PaginatedListViewModel<Dat
 public record DataSetQueryResultViewModel
 {
     /// <summary>
-    /// The filters associated with this result.
-    ///
-    /// This is a dictionary where the key is the filter ID and
-    /// the value is the specific filter option ID.
+    /// The time period relevant to this result's data.
     /// </summary>
-    public required Dictionary<string, string> Filters { get; init; }
+    public required TimePeriodViewModel TimePeriod { get; init; }
 
     /// <summary>
     /// The geographic level relevant to this result's data.
@@ -43,15 +40,18 @@ public record DataSetQueryResultViewModel
     public required Dictionary<string, string> Locations { get; init; }
 
     /// <summary>
+    /// The filters associated with this result.
+    ///
+    /// This is a dictionary where the key is the filter ID and
+    /// the value is the specific filter option ID.
+    /// </summary>
+    public required Dictionary<string, string> Filters { get; init; }
+
+    /// <summary>
     /// The data values for the result's indicators.
     ///
     /// This is a dictionary where the key is the indicator ID
     /// and the value is the data value.
     /// </summary>
     public required Dictionary<string, string> Values { get; init; }
-
-    /// <summary>
-    /// The time period relevant to this result's data.
-    /// </summary>
-    public required TimePeriodViewModel TimePeriod { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/PaginatedListViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/PaginatedListViewModel.cs
@@ -3,14 +3,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
 public abstract record PaginatedListViewModel<T>
 {
     /// <summary>
-    /// The list of results for this page.
-    /// </summary>
-    public required List<T> Results { get; init; }
-
-    /// <summary>
     /// Provides metadata for use in pagination.
     /// </summary>
     public required PagingViewModel Paging { get; init; }
+
+    /// <summary>
+    /// The list of results for this page.
+    /// </summary>
+    public required List<T> Results { get; init; }
 }
 
 public record PagingViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/TimePeriodViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/TimePeriodViewModel.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Common.Converters.SystemJson;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
@@ -7,6 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
 /// </summary>
 public record TimePeriodViewModel
 {
+    [JsonConverter(typeof(EnumToEnumValueJsonConverter<TimeIdentifier>))]
     public required TimeIdentifier Code { get; init; }
 
     /// <summary>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
@@ -13,6 +13,9 @@
   "ContentApi": {
     "Url": "http://localhost:5010"
   },
+  "MiniProfiler": {
+    "Enabled": true
+  },
   "ParquetFiles": {
     "BasePath": "data/public-api-parquet"
   }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
@@ -25,6 +25,7 @@ public static class DataSetVersionGeneratorExtensions
             .WithLocationMetas(faker => fixture
                 .DefaultLocationMeta(options: faker.Random.Int(1, maxLocationOptions))
                 .Generate(locations))
+            .WithGeographicLevelMeta()
             .WithTimePeriodMetas(() => fixture.DefaultTimePeriodMeta().Generate(timePeriods))
             .WithMetaSummary();
 
@@ -98,6 +99,20 @@ public static class DataSetVersionGeneratorExtensions
     public static Generator<DataSetVersion> WithMetaSummary(
         this Generator<DataSetVersion> generator)
         => generator.ForInstance(s => s.SetMetaSummary());
+
+    public static Generator<DataSetVersion> WithGeographicLevelMeta(
+        this Generator<DataSetVersion> generator,
+        GeographicLevelMeta meta)
+        => generator.ForInstance(s => s.SetGeographicLevelMeta(meta));
+
+    public static Generator<DataSetVersion> WithGeographicLevelMeta(
+        this Generator<DataSetVersion> generator,
+        Func<GeographicLevelMeta> meta)
+        => generator.ForInstance(s => s.SetGeographicLevelMeta(meta));
+
+    public static Generator<DataSetVersion> WithGeographicLevelMeta(
+        this Generator<DataSetVersion> generator)
+        => generator.ForInstance(s => s.SetGeographicLevelMeta());
 
     public static Generator<DataSetVersion> WithLocationMetas(
         this Generator<DataSetVersion> generator,
@@ -262,6 +277,27 @@ public static class DataSetVersionGeneratorExtensions
         => instanceSetter.Set(
             dsv => dsv.MetaSummary,
             (_, dsv) => DataSetVersionMetaSummary.Create(dsv));
+
+    public static InstanceSetters<DataSetVersion> SetGeographicLevelMeta(
+        this InstanceSetters<DataSetVersion> instanceSetter,
+        GeographicLevelMeta meta)
+        => instanceSetter.SetGeographicLevelMeta(() => meta);
+
+    public static InstanceSetters<DataSetVersion> SetGeographicLevelMeta(
+        this InstanceSetters<DataSetVersion> instanceSetter,
+        Func<GeographicLevelMeta> meta)
+        => instanceSetter.Set(dsv => dsv.GeographicLevelMeta, meta);
+
+    public static InstanceSetters<DataSetVersion> SetGeographicLevelMeta(
+        this InstanceSetters<DataSetVersion> instanceSetter)
+        => instanceSetter.Set(
+            dsv => dsv.GeographicLevelMeta,
+            (_, dsv) => new GeographicLevelMeta
+            {
+                DataSetVersionId = dsv.Id,
+                Levels = dsv.LocationMetas.Select(m => m.Level).ToList()
+            }
+        );
 
     public static InstanceSetters<DataSetVersion> SetLocationMetas(
         this InstanceSetters<DataSetVersion> instanceSetter,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -69,6 +69,8 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public string FiltersParquetPath => ParquetPaths.FiltersPath(this);
 
+    public string IndicatorsParquetPath  => ParquetPaths.IndicatorsPath(this);
+
     public string LocationsParquetPath => ParquetPaths.LocationsPath(this);
 
     public string TimePeriodsParquetPath => ParquetPaths.TimePeriodsPath(this);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMetaSummary.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMetaSummary.cs
@@ -28,7 +28,7 @@ public class DataSetVersionMetaSummary
         {
             Filters = dataSetVersion.FilterMetas.Select(f => f.Label).ToList(),
             Indicators = dataSetVersion.IndicatorMetas.Select(i => i.Label).ToList(),
-            GeographicLevels = dataSetVersion.LocationMetas.Select(l => l.Level).ToList(),
+            GeographicLevels = dataSetVersion.GeographicLevelMeta.Levels,
             TimePeriodRange = new TimePeriodRange
             {
                 Start = TimePeriodRangeBound.Create(timePeriods[0]),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbCommand.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbCommand.cs
@@ -1,0 +1,12 @@
+using System.Data.Common;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+
+/// <summary>
+/// Wrapper around underlying DuckDB.NET implementation to patch
+/// functionality that isn't working correctly.
+/// </summary>
+public class DuckDbCommand : DuckDB.NET.Data.DuckDbCommand
+{
+    protected override DbParameter CreateDbParameter() => new DuckDbParameter();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbConnection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbConnection.cs
@@ -1,0 +1,21 @@
+using DuckDB.NET.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+
+public class DuckDbConnection(string connectionString = "DataSource=:memory:")
+    : DuckDBConnection(connectionString), IDuckDbConnection
+{
+    public override DuckDbCommand CreateCommand()
+    {
+        // Bit rubbish to do this but we don't have access to the
+        // underlying `Transaction` so we need to get a reference
+        // to it through by creating a base command object first.
+        var wrappedCommand = base.CreateCommand();
+
+        return new DuckDbCommand
+        {
+            Connection = this,
+            Transaction = wrappedCommand.Transaction
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbConnectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbConnectionExtensions.cs
@@ -1,0 +1,53 @@
+using InterpolatedSql;
+using InterpolatedSql.SqlBuilders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+
+public static class DuckDbConnectionExtensions
+{
+    public static DuckDbDapperSqlBuilder SqlBuilder(this IDuckDbConnection connection)
+    {
+        return new DuckDbDapperSqlBuilder(connection);
+    }
+
+    public static DuckDbDapperSqlBuilder SqlBuilder(
+        this IDuckDbConnection connection,
+        FormattableString command,
+        InterpolatedSqlBuilderOptions? options = null)
+    {
+        return new DuckDbDapperSqlBuilder(connection, command, options);
+    }
+
+    public static DuckDbDapperSqlBuilder SqlBuilder(
+        this IDuckDbConnection connection,
+        InterpolatedSqlBuilderOptions options)
+    {
+        return new DuckDbDapperSqlBuilder(connection, options);
+    }
+
+    public static DuckDbDapperSqlBuilder SqlBuilder(
+        this IDuckDbConnection connection,
+        ref InterpolatedSqlHandler command)
+    {
+        if (command.InterpolatedSqlBuilder.Options.AutoAdjustMultilineString)
+        {
+            command.AdjustMultilineString();
+        }
+
+        return new DuckDbDapperSqlBuilder(connection, command.InterpolatedSqlBuilder.AsFormattableString());
+    }
+
+    public static DuckDbDapperSqlBuilder SqlBuilder(
+        this IDuckDbConnection connection,
+        InterpolatedSqlBuilderOptions options,
+        [System.Runtime.CompilerServices.InterpolatedStringHandlerArgument("options")]
+        ref InterpolatedSqlHandler command)
+    {
+        if (command.InterpolatedSqlBuilder.Options.AutoAdjustMultilineString)
+        {
+            command.AdjustMultilineString();
+        }
+
+        return new DuckDbDapperSqlBuilder(connection, command.InterpolatedSqlBuilder.AsFormattableString(), options);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbDapperSqlBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbDapperSqlBuilder.cs
@@ -1,0 +1,57 @@
+using System.Data;
+using System.Text;
+using InterpolatedSql;
+using InterpolatedSql.Dapper;
+using InterpolatedSql.Dapper.SqlBuilders;
+using InterpolatedSql.SqlBuilders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+
+public class DuckDbDapperSqlBuilder : DuckDbSqlBuilder, IDapperSqlBuilder
+{
+    public DuckDbDapperSqlBuilder(IDbConnection connection, InterpolatedSqlBuilderOptions? options = null)
+        : base(options)
+    {
+        DbConnection = connection;
+    }
+
+    public DuckDbDapperSqlBuilder(IDbConnection connection, FormattableString value)
+        : base(value)
+    {
+        DbConnection = connection;
+    }
+
+    public DuckDbDapperSqlBuilder(
+        IDbConnection connection,
+        FormattableString value,
+        InterpolatedSqlBuilderOptions? options = null)
+        : base(value, options)
+    {
+        DbConnection = connection;
+    }
+
+    protected internal DuckDbDapperSqlBuilder(
+        IDbConnection connection,
+        InterpolatedSqlBuilderOptions? options,
+        StringBuilder? format,
+        List<InterpolatedSqlParameter>? arguments)
+        : base(options, format, arguments)
+    {
+        DbConnection = connection;
+    }
+
+    public override IDapperSqlCommand Build() => ToDapperSqlCommand();
+
+    public IDapperSqlCommand ToDapperSqlCommand()
+    {
+        var format = _format.ToString();
+
+        return new ImmutableDapperCommand(
+            this.DbConnection!,
+            BuildSql(format, _sqlParameters),
+            format,
+            _sqlParameters,
+            _explicitParameters
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbParameter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbParameter.cs
@@ -1,0 +1,23 @@
+using DuckDB.NET.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+
+/// <summary>
+/// Wrapper around underlying DuckDB.NET implementation to patch
+/// functionality that isn't working correctly.
+/// </summary>
+public class DuckDbParameter : DuckDBParameter
+{
+    public override string ParameterName
+    {
+        // Hack to prevent `ParameterName` being set. We need to do this as a workaround because
+        // named parameters (e.g. $param) don't seem to work correctly in all environments:
+        // https://github.com/Giorgi/DuckDB.NET/issues/178
+        // Unfortunately, this makes the library pretty incompatible with Dapper which
+        // relies heavily on auto-generated named parameters (e.g. $p0, $p1, $p2).
+        // By not setting `ParameterName`, we go force the usage of auto-incrementing
+        // positional parameters (i.e. ?) which seem to work reliably.
+        get => string.Empty;
+        set => base.ParameterName = string.Empty;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbSqlBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/DuckDbSqlBuilder.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using System.Text;
+using InterpolatedSql;
+using InterpolatedSql.SqlBuilders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+
+public class DuckDbSqlBuilder : InterpolatedSqlBuilderBase<DuckDbSqlBuilder, IInterpolatedSql>
+{
+    private static readonly InterpolatedSqlBuilderOptions DefaultOptions = new()
+    {
+        // Use auto-incrementing positional parameters (i.e. ?), to avoid issues
+        // with named parameters which don't seem to work reliably in all environments.
+        // See: https://github.com/Giorgi/DuckDB.NET/issues/178
+        DatabaseParameterSymbol = "?",
+        CalculateAutoParameterName = (_, _) => string.Empty,
+    };
+
+    public DuckDbSqlBuilder() : this(options: null, format: null, arguments: null)
+    {
+    }
+
+    public DuckDbSqlBuilder(FormattableString value, InterpolatedSqlBuilderOptions? options = null)
+        : this(options: options, format: null, arguments: null)
+    {
+        Options.Parser.ParseAppend(this, value);
+        ResetAutoSpacing();
+    }
+
+    public DuckDbSqlBuilder(IInterpolatedSql value, InterpolatedSqlBuilderOptions? options = null)
+        : this(options: options, format: null, arguments: null)
+    {
+        Append(value);
+        ResetAutoSpacing();
+    }
+
+    protected DuckDbSqlBuilder(
+        InterpolatedSqlBuilderOptions? options = null,
+        StringBuilder? format = null,
+        List<InterpolatedSqlParameter>? arguments = null)
+        : base(options: options ?? DefaultOptions, format: format, arguments: arguments)
+    {
+    }
+
+    public override void AppendArgument(object? argument, int alignment = 0, string? format = null)
+    {
+        // Reformat enumerable arguments as a series of parameter
+        // placeholders e.g. three item list becomes ?, ?, ?
+        if (argument is not string and IEnumerable enumerable)
+        {
+            var args = enumerable.Cast<object>().ToArray();
+            var index = 0;
+
+            foreach (var arg in args)
+            {
+                base.AppendArgument(arg, alignment, format);
+
+                if (index < args.Length - 1)
+                {
+                    base.AppendLiteral(", ");
+                }
+
+                index += 1;
+            }
+        }
+        else
+        {
+            base.AppendArgument(argument, alignment, format);
+        }
+    }
+
+    public override IInterpolatedSql Build() => base.AsSql();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/IDuckDbConnection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/IDuckDbConnection.cs
@@ -1,0 +1,5 @@
+using System.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+
+public interface IDuckDbConnection : IDbConnection;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/ProfiledDuckDbConnection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DuckDb/ProfiledDuckDbConnection.cs
@@ -1,0 +1,10 @@
+using StackExchange.Profiling;
+using StackExchange.Profiling.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
+
+/// <summary>
+/// DuckDB connection profiled using MiniProfiler.
+/// </summary>
+public class ProfiledDuckDbConnection(string connectionString = "DataSource=:memory:", IDbProfiler? profiler = null)
+    : ProfiledDbConnection(new DuckDbConnection(connectionString), profiler ?? MiniProfiler.Current), IDuckDbConnection;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
@@ -15,13 +15,15 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="JsonKnownTypes" Version="0.5.5" />
+        <PackageReference Include="DuckDB.NET.Data.Full" Version="0.10.1.2" />
+        <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0" />
         <PackageReference Include="linq2db.EntityFrameworkCore" Version="8.1.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="MiniProfiler.Shared" Version="4.3.8" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
     </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetColumn.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetColumn.cs
@@ -1,0 +1,16 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+
+public record ParquetColumn
+{
+    public required string ColumnName { get; init; }
+
+    public required string ColumnType { get; init; }
+
+    public required string Null { get; init; }
+
+    public required string Key { get; init; }
+
+    public required string Default { get; init; }
+
+    public required string Extra { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetFilterOption.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetFilterOption.cs
@@ -1,0 +1,12 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+
+public record ParquetFilterOption
+{
+    public required int Id { get; set; }
+
+    public required string Label { get; set; }
+
+    public required string PublicId { get; set; }
+
+    public required string ColumnName { get; set; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetIndicator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetIndicator.cs
@@ -1,0 +1,12 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+
+public class ParquetIndicator
+{
+    public required string Id { get; set; }
+
+    public required string Label { get; set; }
+
+    public string Unit { get; set; } = string.Empty;
+
+    public byte DecimalPlaces { get; set; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetLocationOption.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetLocationOption.cs
@@ -1,0 +1,22 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+
+public record ParquetLocationOption
+{
+    public required int Id { get; set; }
+
+    public required string Label { get; set; }
+
+    public required string Level { get; set; }
+
+    public required string PublicId { get; set; }
+
+    public string? Code { get; set; }
+
+    public string? OldCode { get; set; }
+
+    public string? Ukprn { get; set; }
+
+    public string? Urn { get; set; }
+
+    public string? LaEstab { get; set; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetPaths.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetPaths.cs
@@ -16,12 +16,12 @@ public static class ParquetPaths
 
     public static string FiltersPath(DataSetVersion dataSetVersion) => Path.Combine(
         DirectoryPath(dataSetVersion),
-        $"{FiltersTable.TableName}.parquet"
+        $"{FilterOptionsTable.TableName}.parquet"
     );
 
     public static string LocationsPath(DataSetVersion dataSetVersion) => Path.Combine(
         DirectoryPath(dataSetVersion),
-        $"{LocationsTable.TableName}.parquet"
+        $"{LocationOptionsTable.TableName}.parquet"
     );
 
     public static string TimePeriodsPath(DataSetVersion dataSetVersion) => Path.Combine(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetPaths.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetPaths.cs
@@ -28,4 +28,9 @@ public static class ParquetPaths
         DirectoryPath(dataSetVersion),
         $"{TimePeriodsTable.TableName}.parquet"
     );
+
+    public static string IndicatorsPath(DataSetVersion dataSetVersion) => Path.Combine(
+        DirectoryPath(dataSetVersion),
+        $"{IndicatorsTable.TableName}.parquet"
+    );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetTimePeriod.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/ParquetTimePeriod.cs
@@ -1,0 +1,10 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+
+public record ParquetTimePeriod
+{
+    public required int Id { get; set; }
+
+    public required string Period { get; set; }
+
+    public required string Identifier { get; set; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/Tables/FilterOptionsTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/Tables/FilterOptionsTable.cs
@@ -1,15 +1,15 @@
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
 
-public static class FiltersTable
+public static class FilterOptionsTable
 {
-    public const string TableName = "filters";
+    public const string TableName = "filter_options";
 
     public static class Cols
     {
         public const string Id = "id";
         public const string PublicId = "public_id";
         public const string Label = "label";
-        public const string ColumnName = "column_name";
+        public const string FilterId = "filter_id";
     }
 
     public static string Alias(FilterMeta filter) => $"\"{filter.PublicId}\"";
@@ -24,7 +24,7 @@ public static class FiltersTable
         public readonly string Id = $"{table}.{Cols.Id}";
         public readonly string PublicId = $"{table}.{Cols.PublicId}";
         public readonly string Label = $"{table}.{Cols.Label}";
-        public readonly string ColumnName = $"{table}.{Cols.ColumnName}";
+        public readonly string FilterId = $"{table}.{Cols.FilterId}";
 
         public string Col(string column) => $"{table}.\"{column}\"";
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/Tables/IndicatorsTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/Tables/IndicatorsTable.cs
@@ -1,0 +1,31 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+
+public static class IndicatorsTable
+{
+    public const string TableName = "indicators";
+
+    public static class Cols
+    {
+        public const string Id = "id";
+        public const string Label = "label";
+        public const string Unit = "unit";
+        public const string DecimalPlaces = "decimal_places";
+    }
+
+    public static string Alias(IndicatorMeta indicator) => $"\"{indicator.PublicId}\"";
+
+    private static readonly TableRef DefaultRef = new(TableName);
+
+    public static TableRef Ref(IndicatorMeta? indicator = null)
+        => indicator is not null ? new(Alias(indicator)) : DefaultRef;
+
+    public class TableRef(string table)
+    {
+        public readonly string Id = $"{table}.{Cols.Id}";
+        public readonly string Label = $"{table}.{Cols.Label}";
+        public readonly string Unit = $"{table}.{Cols.Unit}";
+        public readonly string DecimalPlaces = $"{table}.{Cols.DecimalPlaces}";
+
+        public string Col(string column) => $"{table}.\"{column}\"";
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/Tables/LocationOptionsTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Parquet/Tables/LocationOptionsTable.cs
@@ -3,9 +3,9 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
 
-public static class LocationsTable
+public static class LocationOptionsTable
 {
-    public const string TableName = "locations";
+    public const string TableName = "location_options";
 
     public static class Cols
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
@@ -744,9 +744,9 @@ public class SeedDataCommand : ICommand
                 $"{TimePeriodsTable.Ref().Id} AS {DataTable.Cols.TimePeriodId}",
                 DataSourceTable.Ref.GeographicLevel,
                 ..version.LocationMetas.Select(location =>
-                    $"COALESCE({LocationsTable.Ref(location).Id}, 0) AS {DataTable.Cols.LocationId(location)}"),
+                    $"COALESCE({LocationOptionsTable.Ref(location).Id}, 0) AS {DataTable.Cols.LocationId(location)}"),
                 ..version.FilterMetas.Select(filter => 
-                    $"COALESCE({FiltersTable.Ref(filter).Id}, 0) AS {DataTable.Cols.Filter(filter)}"),
+                    $"COALESCE({FilterOptionsTable.Ref(filter).Id}, 0) AS {DataTable.Cols.Filter(filter)}"),
                 ..version.IndicatorMetas.Select(DataTable.Cols.Indicator),
             ];
 
@@ -760,21 +760,21 @@ public class SeedDataCommand : ICommand
                         string[] conditions =
                         [
                             ..codeColumns.Select(col =>
-                                $"{LocationsTable.Ref(location).Col(col.Name)} = {DataSourceTable.Ref.Col(col.CsvName)}"),
-                            $"{LocationsTable.Ref(location).Label} = {DataSourceTable.Ref.Col(location.Level.CsvNameColumn())}"
+                                $"{LocationOptionsTable.Ref(location).Col(col.Name)} = {DataSourceTable.Ref.Col(col.CsvName)}"),
+                            $"{LocationOptionsTable.Ref(location).Label} = {DataSourceTable.Ref.Col(location.Level.CsvNameColumn())}"
                         ];
 
                         return $"""
-                                LEFT JOIN {LocationsTable.TableName} AS {LocationsTable.Alias(location)}
+                                LEFT JOIN {LocationOptionsTable.TableName} AS {LocationOptionsTable.Alias(location)}
                                 ON {conditions.JoinToString(" AND ")}
                                 """;
                     }
                 ),
                 ..version.FilterMetas.Select(
                     filter => $"""
-                               LEFT JOIN {FiltersTable.TableName} AS {FiltersTable.Alias(filter)}
-                               ON {FiltersTable.Ref(filter).ColumnName} = '{filter.PublicId}'
-                               AND {FiltersTable.Ref(filter).Label} = {DataSourceTable.Ref.Col(filter.PublicId)}
+                               LEFT JOIN {FilterOptionsTable.TableName} AS {FilterOptionsTable.Alias(filter)}
+                               ON {FilterOptionsTable.Ref(filter).FilterId} = '{filter.PublicId}'
+                               AND {FilterOptionsTable.Ref(filter).Label} = {DataSourceTable.Ref.Col(filter.PublicId)}
                                """
                 ),
                 $"""
@@ -892,16 +892,16 @@ public class SeedDataCommand : ICommand
         {
             await _duckDb.ExecuteAsync(
                 $"""
-                 CREATE TABLE {LocationsTable.TableName}(
-                     {LocationsTable.Cols.Id} INTEGER PRIMARY KEY,
-                     {LocationsTable.Cols.Label} VARCHAR,
-                     {LocationsTable.Cols.Level} VARCHAR,
-                     {LocationsTable.Cols.PublicId} VARCHAR,
-                     {LocationsTable.Cols.Code} VARCHAR,
-                     {LocationsTable.Cols.OldCode} VARCHAR,
-                     {LocationsTable.Cols.Urn} VARCHAR,
-                     {LocationsTable.Cols.LaEstab} VARCHAR,
-                     {LocationsTable.Cols.Ukprn} VARCHAR
+                 CREATE TABLE {LocationOptionsTable.TableName}(
+                     {LocationOptionsTable.Cols.Id} INTEGER PRIMARY KEY,
+                     {LocationOptionsTable.Cols.Label} VARCHAR,
+                     {LocationOptionsTable.Cols.Level} VARCHAR,
+                     {LocationOptionsTable.Cols.PublicId} VARCHAR,
+                     {LocationOptionsTable.Cols.Code} VARCHAR,
+                     {LocationOptionsTable.Cols.OldCode} VARCHAR,
+                     {LocationOptionsTable.Cols.Urn} VARCHAR,
+                     {LocationOptionsTable.Cols.LaEstab} VARCHAR,
+                     {LocationOptionsTable.Cols.Ukprn} VARCHAR
                  )
                  """
             );
@@ -910,7 +910,7 @@ public class SeedDataCommand : ICommand
 
             foreach (var location in version.LocationMetas)
             {
-                using var appender = _duckDb.CreateAppender(table: LocationsTable.TableName);
+                using var appender = _duckDb.CreateAppender(table: LocationOptionsTable.TableName);
 
                 var insertRow = appender.CreateRow();
 
@@ -964,11 +964,11 @@ public class SeedDataCommand : ICommand
         {
             await _duckDb.ExecuteAsync(
                 $"""
-                 CREATE TABLE {FiltersTable.TableName}(
-                     {FiltersTable.Cols.Id} INTEGER PRIMARY KEY,
-                     {FiltersTable.Cols.Label} VARCHAR,
-                     {FiltersTable.Cols.PublicId} VARCHAR,
-                     {FiltersTable.Cols.ColumnName} VARCHAR
+                 CREATE TABLE {FilterOptionsTable.TableName}(
+                     {FilterOptionsTable.Cols.Id} INTEGER PRIMARY KEY,
+                     {FilterOptionsTable.Cols.Label} VARCHAR,
+                     {FilterOptionsTable.Cols.PublicId} VARCHAR,
+                     {FilterOptionsTable.Cols.FilterId} VARCHAR
                  )
                  """
             );
@@ -977,7 +977,7 @@ public class SeedDataCommand : ICommand
 
             foreach (var filter in version.FilterMetas)
             {
-                using var appender = _duckDb.CreateAppender(table: FiltersTable.TableName);
+                using var appender = _duckDb.CreateAppender(table: FilterOptionsTable.TableName);
 
                 foreach (var link in filter.OptionLinks.OrderBy(l => l.Option.Label))
                 {
@@ -1030,22 +1030,22 @@ public class SeedDataCommand : ICommand
             {
                 GeographicLevel.LocalAuthority =>
                 [
-                    new LocationColumn(Name: LocationsTable.Cols.Code, CsvName: LocalAuthorityCsvColumns.NewCode),
-                    new LocationColumn(Name: LocationsTable.Cols.OldCode, CsvName: LocalAuthorityCsvColumns.OldCode)
+                    new LocationColumn(Name: LocationOptionsTable.Cols.Code, CsvName: LocalAuthorityCsvColumns.NewCode),
+                    new LocationColumn(Name: LocationOptionsTable.Cols.OldCode, CsvName: LocalAuthorityCsvColumns.OldCode)
                 ],
                 GeographicLevel.Provider =>
                 [
-                    new LocationColumn(Name: LocationsTable.Cols.Ukprn, CsvName: ProviderCsvColumns.Ukprn)
+                    new LocationColumn(Name: LocationOptionsTable.Cols.Ukprn, CsvName: ProviderCsvColumns.Ukprn)
                 ],
                 GeographicLevel.RscRegion => [],
                 GeographicLevel.School =>
                 [
-                    new LocationColumn(Name: LocationsTable.Cols.Urn, CsvName: SchoolCsvColumns.Urn),
-                    new LocationColumn(Name: LocationsTable.Cols.LaEstab, CsvName: SchoolCsvColumns.LaEstab)
+                    new LocationColumn(Name: LocationOptionsTable.Cols.Urn, CsvName: SchoolCsvColumns.Urn),
+                    new LocationColumn(Name: LocationOptionsTable.Cols.LaEstab, CsvName: SchoolCsvColumns.LaEstab)
                 ],
                 _ =>
                 [
-                    new LocationColumn(Name: LocationsTable.Cols.Code, CsvName: geographicLevel.CsvCodeColumns().First())
+                    new LocationColumn(Name: LocationOptionsTable.Cols.Code, CsvName: geographicLevel.CsvCodeColumns().First())
                 ],
             };
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
@@ -728,12 +728,12 @@ public class SeedDataCommand : ICommand
 
             string[] columns =
             [
-                $"{DataTable.Cols.Id} UINTEGER PRIMARY KEY",
-                $"{DataTable.Cols.TimePeriodId} INTEGER",
-                $"{DataTable.Cols.GeographicLevel} VARCHAR",
-                ..version.LocationMetas.Select(location => $"{DataTable.Cols.LocationId(location)} INTEGER"),
-                ..version.FilterMetas.Select(filter => $"{DataTable.Cols.Filter(filter)} INTEGER"),
-                ..version.IndicatorMetas.Select(indicator => $"{DataTable.Cols.Indicator(indicator)} VARCHAR"),
+                $"{DataTable.Cols.Id} UINTEGER NOT NULL PRIMARY KEY",
+                $"{DataTable.Cols.TimePeriodId} INTEGER NOT NULL",
+                $"{DataTable.Cols.GeographicLevel} VARCHAR NOT NULL",
+                ..version.LocationMetas.Select(location => $"{DataTable.Cols.LocationId(location)} INTEGER NOT NULL"),
+                ..version.FilterMetas.Select(filter => $"{DataTable.Cols.Filter(filter)} INTEGER NOT NULL"),
+                ..version.IndicatorMetas.Select(indicator => $"{DataTable.Cols.Indicator(indicator)} VARCHAR NOT NULL"),
             ];
 
             await _duckDb.ExecuteAsync($"CREATE TABLE {DataTable.TableName}({columns.JoinToString(",\n")})");
@@ -744,9 +744,9 @@ public class SeedDataCommand : ICommand
                 $"{TimePeriodsTable.Ref().Id} AS {DataTable.Cols.TimePeriodId}",
                 DataSourceTable.Ref.GeographicLevel,
                 ..version.LocationMetas.Select(location =>
-                    $"{LocationsTable.Ref(location).Id} AS {DataTable.Cols.LocationId(location)}"),
+                    $"COALESCE({LocationsTable.Ref(location).Id}, 0) AS {DataTable.Cols.LocationId(location)}"),
                 ..version.FilterMetas.Select(filter => 
-                    $"{FiltersTable.Ref(filter).Id} AS {DataTable.Cols.Filter(filter)}"),
+                    $"COALESCE({FiltersTable.Ref(filter).Id}, 0) AS {DataTable.Cols.Filter(filter)}"),
                 ..version.IndicatorMetas.Select(DataTable.Cols.Indicator),
             ];
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/ParquetPathResolverTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/ParquetPathResolverTests.cs
@@ -69,6 +69,10 @@ public abstract class ParquetPathResolverTests
                 resolver.FiltersPath(version)
             );
             Assert.Equal(
+                Path.Combine(expectedBasePath, version.IndicatorsParquetPath),
+                resolver.IndicatorsPath(version)
+            );
+            Assert.Equal(
                 Path.Combine(expectedBasePath, version.LocationsParquetPath),
                 resolver.LocationsPath(version)
             );
@@ -111,6 +115,10 @@ public abstract class ParquetPathResolverTests
                 resolver.FiltersPath(version)
             );
             Assert.Equal(
+                Path.Combine(expectedBasePath, version.IndicatorsParquetPath),
+                resolver.IndicatorsPath(version)
+            );
+            Assert.Equal(
                 Path.Combine(expectedBasePath, version.LocationsParquetPath),
                 resolver.LocationsPath(version)
             );
@@ -150,6 +158,10 @@ public abstract class ParquetPathResolverTests
             Assert.Equal(
                 Path.Combine(expectedBasePath, version.FiltersParquetPath),
                 resolver.FiltersPath(version)
+            );
+            Assert.Equal(
+                Path.Combine(expectedBasePath, version.IndicatorsParquetPath),
+                resolver.IndicatorsPath(version)
             );
             Assert.Equal(
                 Path.Combine(expectedBasePath, version.LocationsParquetPath),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IParquetPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IParquetPathResolver.cs
@@ -10,6 +10,8 @@ public interface IParquetPathResolver
 
     string FiltersPath(DataSetVersion dataSetVersion);
 
+    string IndicatorsPath(DataSetVersion dataSetVersion);
+
     string LocationsPath(DataSetVersion dataSetVersion);
 
     string TimePeriodsPath(DataSetVersion dataSetVersion);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/ParquetPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/ParquetPathResolver.cs
@@ -42,6 +42,9 @@ public class ParquetPathResolver : IParquetPathResolver
     public string FiltersPath(DataSetVersion dataSetVersion)
         => Path.Combine(_basePath, dataSetVersion.FiltersParquetPath);
 
+    public string IndicatorsPath(DataSetVersion dataSetVersion)
+        => Path.Combine(_basePath, dataSetVersion.IndicatorsParquetPath);
+
     public string LocationsPath(DataSetVersion dataSetVersion)
         => Path.Combine(_basePath, dataSetVersion.LocationsParquetPath);
 


### PR DESCRIPTION
This PR adds the data set GET query endpoint - `/api/v1/data-sets/{dataSetId}/query`. This provides functionality to let users make data set queries using query parameters e.g. `?indicators=headcount&filters.in=kaNhs,zvUFQ&sorts=geographicLevel|Asc`

Note that this doesn't provide test coverage for most of this functionality. This will be covered in EES-5015.

## Query parsing

Parsing data set queries to this endpoint roughly proceeds like so:

1. Validate the GET query string (as `DataSetGetQueryRequest`)
2. Convert to `DataSetQueryRequest` (will be used in POST query variant) in `DataSetQueryService`
3. Parse and validate query criteria using `DataSetQueryParser`, producing a SQL WHERE fragment
4. Parse and validate indicators from data set query
5. Parse and validate sorts and their respective column orderings from the data set query
6. Execute data set query using all requisite parts (where, columns and sorts)
7. Return the paginated results

We've now implemented the majority of the base query criteria parsing functionality to handle the various facet types and their comparators. This doesn't include handling of more complex operators like `and`, `or` and `not`. This will be implemented in EES-4722.

## Dapper and SQL builders

As there is no ORM support for DuckDB, the querying functionality has been implemented using a combination of [Dapper](https://github.com/DapperLib/Dapper) and [InterpolatedSql](https://github.com/Drizin/InterpolatedSql).

Dapper itself is very simplistic and only works with raw SQL strings out of the box. This isn't particularly safe in the context of SQL injection, so we've complemented it with InterpolatedSql which provides protection using its `SqlBuilder` API e.g.

```cs
var myParam = "test";
var builder = new SqlBuilder($"SELECT * FROM something WHERE field = {myParam}");

var sql = builder.Build(); 
sql.Sql; // Outputs: "SELECT * FROM something WHERE field = @p0"
sql.SqlParameters; // Outputs: Single parameter with value "test"
```

For real usages of this, check out the various repositories that have been created. We use a modified variant of InterpolatedSql's Dapper integration to make it a bit nicer to build and execute queries.

## DuckDB issues

Unfortunately, there were some issues with DuckDB that we've had to work around, primarily around named parameters. Dapper only really works with named parameters, but this seems to cause issues with the DuckDB.NET library that we're using. 

When using named parameters, DuckDB.NET would consistently fail to throw exceptions around parameter binding (need to create an issue for this), or [memory access violations when debugging](https://github.com/Giorgi/DuckDB.NET/issues/178). 

I'm communicating with the library maintainer to see if there's anything we can do here. For the time-being, I've been able to implement workarounds by wrapping the DuckDB.NET database connection code and forcing the use of positional auto-incrementing parameters (i.e. `?` parameters) in generated SQL.

## MiniProfiler

To help with debugging and performance, we've added [MiniProfiler](https://miniprofiler.com/) which lets us profile our code. This is particularly useful for data set queries, where it can help identify performance bottlenecks.

MiniProfiler is enabled via the `MiniProfiler.Enabled` app setting, so it can be disabled or enabled on a per-environment basis.

## Related changes

- Fixes `GeographicLevels` in the data set meta summary not being populated correctly from a data set version. This now uses the `GeographicLevelMeta` instead of `LocationMetas` to populate it.

## Other changes

- Improve error details for location, time period and sort string validators by now showing the parsed fields.
- Fixed null pointer exception being thrown when gathering message placeholders from `ValidationFailure` in `FluentValidationActionFilter`