### PR TITLE
EES-5034 update user testing banner

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/UserTestingBanner.tsx
+++ b/src/explore-education-statistics-frontend/src/components/UserTestingBanner.tsx
@@ -29,7 +29,7 @@ export default function UserTestingBanner() {
         <p className="govuk-!-margin-bottom-2">
           <Link
             className="govuk-link--inverse"
-            to="https://forms.office.com/e/k5uF3g24rJ"
+            to="https://forms.office.com/e/QVWqCbbxCj"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/src/explore-education-statistics-frontend/src/hooks/useCookies.ts
+++ b/src/explore-education-statistics-frontend/src/hooks/useCookies.ts
@@ -13,7 +13,7 @@ import {
 } from 'nookies';
 import { useState } from 'react';
 
-export const userTestingBannerVersion = 1;
+export const userTestingBannerVersion = 2;
 
 interface Cookie {
   name: string;


### PR DESCRIPTION
Updates the link in the user testing banner and the cookie version so it will be re-shown to all users.