### PR TITLE
Remove the .next folder during the pnpm clean command

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-./node_modules/.bin/lint-staged
+if [ -d "./node_modules/.bin/lint-staged" ]; then
+    ./node_modules/.bin/lint-staged
+fi

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "prepare": "husky install",
     "preinstall": "pnpm check:node",
-    "clean": "pnpm -r --parallel exec rm -rf node_modules && rm -rf node_modules",
+    "clean": "pnpm -r --parallel exec rm -rf node_modules && rm -rf node_modules && rm -rf src/explore-education-statistics-frontend/.next",
     "check:node": "check-node-version --package",
     "fix": "pnpm fix:js && pnpm fix:style",
     "fix:js": "eslint --fix --ext .ts,.tsx,.js,.jsx .",


### PR DESCRIPTION
Removes the `.next` folder during a `pnpm clean` command. Also checks for the existence of `node_modules` before running `lint-staged`, as this command otherwise throws an error if you haven't ever ran `pnpm i`. 