### PR TITLE
Ees 4807 small tweaks after merge

### DIFF
--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -14,7 +14,7 @@ parameters:
 variables:
   - group: Public API Infrastructure - common
   - name: isDev
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/EES-4807-small-tweaks-after-merge')]
   - name: isTest
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/test')]
   - name: isMaster
@@ -44,42 +44,44 @@ pool:
   vmImage: $(vmImageName)
 
 stages:
-- ${{ if eq(variables.isDev, true) }}:
-  - template: validate-stage-template.yml
-    parameters:
-      stageName: 'Validate_Against_Development'
-      environment: 'Development'
-      serviceConnection: $(serviceConnectionDevelopment)
-      parameterFile: $(devParamFile)
+- template: validate-stage-template.yml
+  parameters:
+    stageName: 'Validate_Against_Development'
+    condition: eq(variables.isDev, true)
+    environment: 'Development'
+    serviceConnection: $(serviceConnectionDevelopment)
+    parameterFile: $(devParamFile)
 
-  - template: deploy-stage-template.yml
-    parameters:
-      stageName: 'Deploy_to_Development'
-      dependsOn: 'Validate_Against_Development'
-      environment: 'Development'
-      serviceConnection: $(serviceConnectionDevelopment)
-      parameterFile: $(devParamFile)
+- template: deploy-stage-template.yml
+  parameters:
+    stageName: 'Deploy_to_Development'
+    condition: and(succeeded(), eq(variables.isDev, true))
+    dependsOn: 'Validate_Against_Development'
+    environment: 'Development'
+    serviceConnection: $(serviceConnectionDevelopment)
+    parameterFile: $(devParamFile)
 
-- ${{ if eq(variables.isTest, true) }}:
-  - template: validate-stage-template.yml
-    parameters:
-      stageName: 'Validate_Against_Test'
-      environment: 'Test'
-      serviceConnection: $(serviceConnectionTest)
-      parameterFile: $(testParamFile)
+- template: validate-stage-template.yml
+  parameters:
+    stageName: 'Validate_Against_Test'
+    condition: eq(variables.isTest, true)
+    environment: 'Test'
+    serviceConnection: $(serviceConnectionTest)
+    parameterFile: $(testParamFile)
 
-  - template: deploy-stage-template.yml
-    parameters:
-      stageName: 'Deploy_to_Test'
-      dependsOn: 'Validate_Against_Test'
-      environment: 'Test'
-      serviceConnection: $(serviceConnectionTest)
-      parameterFile: $(testParamFile)
+- template: deploy-stage-template.yml
+  parameters:
+    stageName: 'Deploy_to_Test'
+    dependsOn: 'Validate_Against_Test'
+    condition: and(succeeded(), eq(variables.isTest, true))
+    environment: 'Test'
+    serviceConnection: $(serviceConnectionTest)
+    parameterFile: $(testParamFile)
 
-#- ${{ if eq(variables.isMaster, true) }}:
 #  - template: validate-stage-template.yml
 #    parameters:
 #      stageName: 'Validate_Against_PreProduction'
+#      condition: eq(variables.isMaster, true)
 #      environment: 'Pre-production'
 #      serviceConnection: $(serviceConnectionPreProduction)
 #      parameterFile: $(preProdParamFile)
@@ -87,6 +89,7 @@ stages:
 #  - template: deploy-stage-template.yml
 #    parameters:
 #      stageName: 'Deploy_to_PreProduction'
+#      condition: and(succeeded(), eq(variables.isMaster, true))
 #      dependsOn: 'Validate_Against_PreProduction'
 #      environment: 'Pre-production'
 #      serviceConnection: $(serviceConnectionPreProduction)
@@ -95,6 +98,7 @@ stages:
 #  - template: validate-stage-template.yml
 #    parameters:
 #      stageName: 'Validate_Against_Production'
+#      condition: and(succeeded(), eq(variables.isMaster, true))
 #      environment: 'Production'
 #      serviceConnection: $(serviceConnectionProduction)
 #      parameterFile: $(prodParamFile)
@@ -102,6 +106,7 @@ stages:
 #  - template: deploy-stage-template.yml
 #    parameters:
 #      stageName: 'Deploy_to_Production'
+#      condition: and(succeeded(), eq(variables.isMaster, true))
 #      dependsOn: 'Validate_Against_Production'
 #      environment: 'Production'
 #      serviceConnection: $(serviceConnectionProduction)

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -37,8 +37,8 @@ variables:
     value: $(paramDirectory)/main-prod.bicepparam
   - name: upstreamPipelineBuildNumber
     value: $(resources.pipeline.EESBuildPipeline.runName)
-  - name: psqlDbUsersAdded
-    value: ${{parameters.psqlDbUsersAdded}}
+  - name: deployContainerApp
+    value: ${{parameters.deployContainerApp}}
 
 pool:
   vmImage: $(vmImageName)

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -10,6 +10,9 @@ parameters:
   - name: deployContainerApp
     displayName: Can we deploy the Container App yet?  This is dependent on the user-assigned Managed Identity for the API Container App being created with the AcrPull role, and the database users added to PSQL.
     default: true
+  - name: updatePsqlFlexibleServer
+    displayName: Does the PostgreSQL Flexible Server require any updates? False by default to avoid unnecessarily lengthy deploys.
+    default: false
 
 variables:
   - group: Public API Infrastructure - common
@@ -39,6 +42,8 @@ variables:
     value: $(resources.pipeline.EESBuildPipeline.runName)
   - name: deployContainerApp
     value: ${{parameters.deployContainerApp}}
+  - name: updatePsqlFlexibleServer
+    value: ${{parameters.updatePsqlFlexibleServer}}
 
 pool:
   vmImage: $(vmImageName)

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -7,6 +7,9 @@ resources:
       trigger: none
 
 parameters:
+  - name: apiContainerAppUserCreatedWithAcrPull
+    displayName: Has the user-assigned Managed Identity for the API Container App been created and been assigned the AcrPull role yet?
+    default: true
   - name: psqlDbUsersAdded
     displayName: Have database users been added to PSQL yet for Container App and Function App?
     default: true
@@ -14,7 +17,7 @@ parameters:
 variables:
   - group: Public API Infrastructure - common
   - name: isDev
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/EES-4807-small-tweaks-after-merge')]
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
   - name: isTest
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/test')]
   - name: isMaster

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -17,7 +17,7 @@ parameters:
 variables:
   - group: Public API Infrastructure - common
   - name: isDev
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/EES-4807-small-tweaks-after-merge')]
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
   - name: isTest
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/test')]
   - name: isMaster

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -7,11 +7,8 @@ resources:
       trigger: none
 
 parameters:
-  - name: apiContainerAppUserCreatedWithAcrPull
-    displayName: Has the user-assigned Managed Identity for the API Container App been created and been assigned the AcrPull role yet?
-    default: true
-  - name: psqlDbUsersAdded
-    displayName: Have database users been added to PSQL yet?
+  - name: deployContainerApp
+    displayName: Can we deploy the Container App yet?  This is dependent on the user-assigned Managed Identity for the API Container App being created with the AcrPull role, and the database users added to PSQL.
     default: true
 
 variables:

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -17,7 +17,7 @@ parameters:
 variables:
   - group: Public API Infrastructure - common
   - name: isDev
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/EES-4807-small-tweaks-after-merge')]
   - name: isTest
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/test')]
   - name: isMaster

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -11,7 +11,7 @@ parameters:
     displayName: Has the user-assigned Managed Identity for the API Container App been created and been assigned the AcrPull role yet?
     default: true
   - name: psqlDbUsersAdded
-    displayName: Have database users been added to PSQL yet for Container App and Function App?
+    displayName: Have database users been added to PSQL yet?
     default: true
 
 variables:

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -10,16 +10,26 @@ param resourcePrefix string
 @description('Specifies the name suffix of the Data Processor Function App')
 param dataProcessorFunctionAppName string
 
+/* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
+   Security Group guidance on accessing resources behind VNet protection.
 @description('Specifies the name suffix of the PostgreSQL Flexible Server')
 param postgreSqlServerName string
-
+*/
 var dataProcessorSubnetName = '${resourcePrefix}-snet-fa-${dataProcessorFunctionAppName}'
+
+/* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
+   Security Group guidance on accessing resources behind VNet protection.
 var postgreSqlSubnetName = '${subscription}-ees-snet-${postgreSqlServerName}'
+*/
 var containerAppEnvironmentSubnetName = '${subscription}-ees-snet-cae-01'
 
 // Note that the current vNet has subnets with reserved address ranges up to 10.0.5.0/24 currently.
 var dataProcessorSubnetRange = '10.0.6.0/24'
+
+/* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
+   Security Group guidance on accessing resources behind VNet protection.
 var postgreSqlSubnetRange = '10.0.7.0/24'
+*/
 var containerAppEnvironmentSubnetRange = '10.0.8.0/24'
 
 // Reference the existing VNet.
@@ -47,6 +57,8 @@ var dataProcessorSubnet = {
   }
 }
 
+/* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
+   Security Group guidance on accessing resources behind VNet protection.
 var postgreSqlSubnet = {
   name: postgreSqlSubnetName
   properties: {
@@ -60,6 +72,7 @@ var postgreSqlSubnet = {
     }]
   }
 }
+*/
 
 var containerAppEnvironmentSubnet = {
   name: containerAppEnvironmentSubnetName
@@ -78,7 +91,10 @@ var containerAppEnvironmentSubnet = {
 
 var subnets = [
   dataProcessorSubnet
+  /* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
+     Security Group guidance on accessing resources behind VNet protection.
   postgreSqlSubnet
+  */
   containerAppEnvironmentSubnet
 ]
 
@@ -90,6 +106,11 @@ resource subnetResources 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' 
   name: subnet.name
   properties: subnet.properties
 }]
+
+resource adminSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' existing = {
+  name: '${subscription}-snet-ees-admin'
+  parent: vNet
+}
 
 @description('The fully qualified Azure resource ID of the Network.')
 output vNetRef string = resourceId('Microsoft.Network/VirtualNetworks', vNetName)
@@ -103,9 +124,11 @@ output dataProcessorSubnetStartIpAddress string = parseCidr(dataProcessorSubnetR
 @description('The last usable IP address for the Data Processor Function App Subnet.')
 output dataProcessorSubnetEndIpAddress string = parseCidr(dataProcessorSubnetRange).lastUsable
 
+/* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
+   Security Group guidance on accessing resources behind VNet protection.
 @description('The fully qualified Azure resource ID of the PostgreSQL Flexible Server Subnet.')
 output postgreSqlSubnetRef string = resourceId('Microsoft.Network/VirtualNetworks/subnets', vNetName, postgreSqlSubnetName)
-
+*/
 @description('The fully qualified Azure resource ID of the API Container App Subnet.')
 output containerAppEnvironmentSubnetRef string = resourceId('Microsoft.Network/VirtualNetworks/subnets', vNetName, containerAppEnvironmentSubnetName)
 
@@ -114,3 +137,9 @@ output containerAppEnvironmentSubnetStartIpAddress string = parseCidr(containerA
 
 @description('The last usable IP address for the API Container App Subnet.')
 output containerAppEnvironmentSubnetEndIpAddress string = parseCidr(containerAppEnvironmentSubnetRange).lastUsable
+
+@description('The first usable IP address for the Admin App Service Subnet.')
+output adminAppServiceSubnetStartIpAddress string = parseCidr(adminSubnet.properties.addressPrefix).firstUsable
+
+@description('The last usable IP address for the Admin App Service Subnet.')
+output adminAppServiceSubnetEndIpAddress string = parseCidr(adminSubnet.properties.addressPrefix).lastUsable

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -11,7 +11,7 @@ param resourcePrefix string
 param dataProcessorFunctionAppNameSuffix string
 
 @description('Specifies the name suffix of the Container App Environment')
-var containerAppEnvironmentNameSuffix string
+param containerAppEnvironmentNameSuffix string
 
 resource vNet 'Microsoft.Network/virtualNetworks@2023-09-01' existing = {
   name: vNetName
@@ -43,9 +43,9 @@ output dataProcessorSubnetStartIpAddress string = parseCidr(dataProcessorSubnet.
 
 @description('The last usable IP address for the Data Processor Function App Subnet.')
 output dataProcessorSubnetEndIpAddress string = parseCidr(dataProcessorSubnet.properties.addressPrefix).lastUsable
-*/
+
 @description('The fully qualified Azure resource ID of the API Container App Subnet.')
-output containerAppEnvironmentSubnetRef string = containerAppEnvironmentSubnet.Id
+output containerAppEnvironmentSubnetRef string = containerAppEnvironmentSubnet.id
 
 @description('The first usable IP address for the API Container App Subnet.')
 output containerAppEnvironmentSubnetStartIpAddress string = parseCidr(containerAppEnvironmentSubnet.properties.addressPrefix).firstUsable

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -14,13 +14,13 @@ param dataProcessorFunctionAppName string
 param postgreSqlServerName string
 
 var dataProcessorSubnetName = '${resourcePrefix}-snet-fa-${dataProcessorFunctionAppName}'
-var postgreSqlSubnetName = '${subscription}-snet-${postgreSqlServerName}'
-var containerAppEnvironmentSubnetName = '${subscription}-snet-cae-01'
+var postgreSqlSubnetName = '${subscription}-ees-snet-${postgreSqlServerName}'
+var containerAppEnvironmentSubnetName = '${subscription}-ees-snet-cae-01'
 
 // Note that the current vNet has subnets with reserved address ranges up to 10.0.5.0/24 currently.
 var dataProcessorSubnetRange = '10.0.6.0/24'
 var postgreSqlSubnetRange = '10.0.7.0/24'
-var containerAppEnvironmentSubnetRange = '10.0.10.0/23'
+var containerAppEnvironmentSubnetRange = '10.0.8.0/24'
 
 // Reference the existing VNet.
 resource vNet 'Microsoft.Network/virtualNetworks@2023-09-01' existing = {
@@ -65,6 +65,14 @@ var containerAppEnvironmentSubnet = {
   name: containerAppEnvironmentSubnetName
   properties: {
     addressPrefix: containerAppEnvironmentSubnetRange
+    delegations: [
+      {
+        name: '${resourcePrefix}-snet-delegation-cae'
+        properties: {
+          serviceName: 'Microsoft.App/environments'
+        }
+      }
+    ]
   }
 }
 

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -8,107 +8,27 @@ param subscription string
 param resourcePrefix string
 
 @description('Specifies the name suffix of the Data Processor Function App')
-param dataProcessorFunctionAppName string
+param dataProcessorFunctionAppNameSuffix string
 
-/* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
-   Security Group guidance on accessing resources behind VNet protection.
-@description('Specifies the name suffix of the PostgreSQL Flexible Server')
-param postgreSqlServerName string
-*/
-var dataProcessorSubnetName = '${resourcePrefix}-snet-fa-${dataProcessorFunctionAppName}'
+@description('Specifies the name suffix of the Container App Environment')
+var containerAppEnvironmentNameSuffix string
 
-/* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
-   Security Group guidance on accessing resources behind VNet protection.
-var postgreSqlSubnetName = '${subscription}-ees-snet-${postgreSqlServerName}'
-*/
-var containerAppEnvironmentSubnetName = '${subscription}-ees-snet-cae-01'
-
-// Note that the current vNet has subnets with reserved address ranges up to 10.0.5.0/24 currently.
-var dataProcessorSubnetRange = '10.0.6.0/24'
-
-/* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
-   Security Group guidance on accessing resources behind VNet protection.
-var postgreSqlSubnetRange = '10.0.7.0/24'
-*/
-var containerAppEnvironmentSubnetRange = '10.0.8.0/24'
-
-// Reference the existing VNet.
 resource vNet 'Microsoft.Network/virtualNetworks@2023-09-01' existing = {
   name: vNetName
 }
 
-var dataProcessorSubnet = {
-  name: dataProcessorSubnetName
-  properties: {
-    addressPrefix: dataProcessorSubnetRange
-    delegations: [
-      {
-        name: '${resourcePrefix}-snet-delegation-fa-${dataProcessorFunctionAppName}'
-        properties: {
-          serviceName: 'Microsoft.Web/serverFarms'
-        }
-      }
-    ]
-    serviceEndpoints: [
-      {
-         service: 'Microsoft.Storage'
-      }
-    ]
-  }
-}
-
-/* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
-   Security Group guidance on accessing resources behind VNet protection.
-var postgreSqlSubnet = {
-  name: postgreSqlSubnetName
-  properties: {
-    addressPrefix: postgreSqlSubnetRange
-    delegations: [
-    {
-      name: '${resourcePrefix}-snet-delegation-${postgreSqlServerName}'
-      properties: {
-        serviceName: 'Microsoft.DBforPostgreSQL/flexibleServers'
-      }
-    }]
-  }
-}
-*/
-
-var containerAppEnvironmentSubnet = {
-  name: containerAppEnvironmentSubnetName
-  properties: {
-    addressPrefix: containerAppEnvironmentSubnetRange
-    delegations: [
-      {
-        name: '${resourcePrefix}-snet-delegation-cae'
-        properties: {
-          serviceName: 'Microsoft.App/environments'
-        }
-      }
-    ]
-  }
-}
-
-var subnets = [
-  dataProcessorSubnet
-  /* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
-     Security Group guidance on accessing resources behind VNet protection.
-  postgreSqlSubnet
-  */
-  containerAppEnvironmentSubnet
-]
-
-// Create the subnets sequentially rather than in parallel to avoid "AnotherOperationInProgress" errors when multiple
-// subnets attempt to update the parent VNet at the same time.
-@batchSize(1)
-resource subnetResources 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' = [for subnet in subnets: {
-  parent: vNet
-  name: subnet.name
-  properties: subnet.properties
-}]
-
 resource adminSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' existing = {
   name: '${subscription}-snet-ees-admin'
+  parent: vNet
+}
+
+resource dataProcessorSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' existing = {
+  name: '${resourcePrefix}-snet-fa-${dataProcessorFunctionAppNameSuffix}'
+  parent: vNet
+}
+
+resource containerAppEnvironmentSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' existing = {
+  name: '${subscription}-ees-snet-cae-${containerAppEnvironmentNameSuffix}'
   parent: vNet
 }
 
@@ -116,27 +36,22 @@ resource adminSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' exis
 output vNetRef string = resourceId('Microsoft.Network/VirtualNetworks', vNetName)
 
 @description('The fully qualified Azure resource ID of the Data Processor Function App Subnet.')
-output dataProcessorSubnetRef string = resourceId('Microsoft.Network/VirtualNetworks/subnets', vNetName, dataProcessorSubnetName)
+output dataProcessorSubnetRef string = dataProcessorSubnet.id
 
 @description('The first usable IP address for the Data Processor Function App Subnet.')
-output dataProcessorSubnetStartIpAddress string = parseCidr(dataProcessorSubnetRange).firstUsable
+output dataProcessorSubnetStartIpAddress string = parseCidr(dataProcessorSubnet.properties.addressPrefix).firstUsable
 
 @description('The last usable IP address for the Data Processor Function App Subnet.')
-output dataProcessorSubnetEndIpAddress string = parseCidr(dataProcessorSubnetRange).lastUsable
-
-/* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
-   Security Group guidance on accessing resources behind VNet protection.
-@description('The fully qualified Azure resource ID of the PostgreSQL Flexible Server Subnet.')
-output postgreSqlSubnetRef string = resourceId('Microsoft.Network/VirtualNetworks/subnets', vNetName, postgreSqlSubnetName)
+output dataProcessorSubnetEndIpAddress string = parseCidr(dataProcessorSubnet.properties.addressPrefix).lastUsable
 */
 @description('The fully qualified Azure resource ID of the API Container App Subnet.')
-output containerAppEnvironmentSubnetRef string = resourceId('Microsoft.Network/VirtualNetworks/subnets', vNetName, containerAppEnvironmentSubnetName)
+output containerAppEnvironmentSubnetRef string = containerAppEnvironmentSubnet.Id
 
 @description('The first usable IP address for the API Container App Subnet.')
-output containerAppEnvironmentSubnetStartIpAddress string = parseCidr(containerAppEnvironmentSubnetRange).firstUsable
+output containerAppEnvironmentSubnetStartIpAddress string = parseCidr(containerAppEnvironmentSubnet.properties.addressPrefix).firstUsable
 
 @description('The last usable IP address for the API Container App Subnet.')
-output containerAppEnvironmentSubnetEndIpAddress string = parseCidr(containerAppEnvironmentSubnetRange).lastUsable
+output containerAppEnvironmentSubnetEndIpAddress string = parseCidr(containerAppEnvironmentSubnet.properties.addressPrefix).lastUsable
 
 @description('The first usable IP address for the Admin App Service Subnet.')
 output adminAppServiceSubnetStartIpAddress string = parseCidr(adminSubnet.properties.addressPrefix).firstUsable

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -22,6 +22,11 @@ resource adminSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' exis
   parent: vNet
 }
 
+resource publisherSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' existing = {
+  name: '${subscription}-snet-ees-publisher'
+  parent: vNet
+}
+
 resource dataProcessorSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' existing = {
   name: '${resourcePrefix}-snet-fa-${dataProcessorFunctionAppNameSuffix}'
   parent: vNet
@@ -58,3 +63,9 @@ output adminAppServiceSubnetStartIpAddress string = parseCidr(adminSubnet.proper
 
 @description('The last usable IP address for the Admin App Service Subnet.')
 output adminAppServiceSubnetEndIpAddress string = parseCidr(adminSubnet.properties.addressPrefix).lastUsable
+
+@description('The first usable IP address for the Publisher Function App Subnet.')
+output publisherFunctionAppSubnetStartIpAddress string = parseCidr(publisherSubnet.properties.addressPrefix).firstUsable
+
+@description('The last usable IP address for the Publisher Function App Subnet.')
+output publisherFunctionAppSubnetEndIpAddress string = parseCidr(publisherSubnet.properties.addressPrefix).lastUsable

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -18,9 +18,9 @@ var postgreSqlSubnetName = '${subscription}-snet-${postgreSqlServerName}'
 var containerAppEnvironmentSubnetName = '${subscription}-snet-cae-01'
 
 // Note that the current vNet has subnets with reserved address ranges up to 10.0.5.0/24 currently.
-var dataProcessorSubnetPrefix = '10.0.6.0/24'
-var postgreSqlSubnetPrefix = '10.0.7.0/24'
-var containerAppEnvironmentSubnetPrefix = '10.0.10.0/23'
+var dataProcessorSubnetRange = '10.0.6.0/24'
+var postgreSqlSubnetRange = '10.0.7.0/24'
+var containerAppEnvironmentSubnetRange = '10.0.10.0/23'
 
 // Reference the existing VNet.
 resource vNet 'Microsoft.Network/virtualNetworks@2023-09-01' existing = {
@@ -30,7 +30,7 @@ resource vNet 'Microsoft.Network/virtualNetworks@2023-09-01' existing = {
 var dataProcessorSubnet = {
   name: dataProcessorSubnetName
   properties: {
-    addressPrefix: dataProcessorSubnetPrefix
+    addressPrefix: dataProcessorSubnetRange
     delegations: [
       {
         name: '${resourcePrefix}-snet-delegation-fa-${dataProcessorFunctionAppName}'
@@ -50,7 +50,7 @@ var dataProcessorSubnet = {
 var postgreSqlSubnet = {
   name: postgreSqlSubnetName
   properties: {
-    addressPrefix: postgreSqlSubnetPrefix
+    addressPrefix: postgreSqlSubnetRange
     delegations: [
     {
       name: '${resourcePrefix}-snet-delegation-${postgreSqlServerName}'
@@ -64,7 +64,7 @@ var postgreSqlSubnet = {
 var containerAppEnvironmentSubnet = {
   name: containerAppEnvironmentSubnetName
   properties: {
-    addressPrefix: containerAppEnvironmentSubnetPrefix
+    addressPrefix: containerAppEnvironmentSubnetRange
   }
 }
 
@@ -89,8 +89,20 @@ output vNetRef string = resourceId('Microsoft.Network/VirtualNetworks', vNetName
 @description('The fully qualified Azure resource ID of the Data Processor Function App Subnet.')
 output dataProcessorSubnetRef string = resourceId('Microsoft.Network/VirtualNetworks/subnets', vNetName, dataProcessorSubnetName)
 
+@description('The first usable IP address for the Data Processor Function App Subnet.')
+output dataProcessorSubnetStartIpAddress string = parseCidr(dataProcessorSubnetRange).firstUsable
+
+@description('The last usable IP address for the Data Processor Function App Subnet.')
+output dataProcessorSubnetEndIpAddress string = parseCidr(dataProcessorSubnetRange).lastUsable
+
 @description('The fully qualified Azure resource ID of the PostgreSQL Flexible Server Subnet.')
 output postgreSqlSubnetRef string = resourceId('Microsoft.Network/VirtualNetworks/subnets', vNetName, postgreSqlSubnetName)
 
 @description('The fully qualified Azure resource ID of the API Container App Subnet.')
 output containerAppEnvironmentSubnetRef string = resourceId('Microsoft.Network/VirtualNetworks/subnets', vNetName, containerAppEnvironmentSubnetName)
+
+@description('The first usable IP address for the API Container App Subnet.')
+output containerAppEnvironmentSubnetStartIpAddress string = parseCidr(containerAppEnvironmentSubnetRange).firstUsable
+
+@description('The last usable IP address for the API Container App Subnet.')
+output containerAppEnvironmentSubnetEndIpAddress string = parseCidr(containerAppEnvironmentSubnetRange).lastUsable

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -15,12 +15,12 @@ param postgreSqlServerName string
 
 var dataProcessorSubnetName = '${resourcePrefix}-snet-fa-${dataProcessorFunctionAppName}'
 var postgreSqlSubnetName = '${subscription}-snet-${postgreSqlServerName}'
-var containerAppEnvironmentSubnetName = '${subscription}-snet-cae'
+var containerAppEnvironmentSubnetName = '${subscription}-snet-cae-01'
 
 // Note that the current vNet has subnets with reserved address ranges up to 10.0.5.0/24 currently.
 var dataProcessorSubnetPrefix = '10.0.6.0/24'
 var postgreSqlSubnetPrefix = '10.0.7.0/24'
-var containerAppEnvironmentSubnetPrefix = '10.0.8.0/24'
+var containerAppEnvironmentSubnetPrefix = '10.0.10.0/23'
 
 // Reference the existing VNet.
 resource vNet 'Microsoft.Network/virtualNetworks@2023-09-01' existing = {
@@ -65,14 +65,6 @@ var containerAppEnvironmentSubnet = {
   name: containerAppEnvironmentSubnetName
   properties: {
     addressPrefix: containerAppEnvironmentSubnetPrefix
-    delegations: [
-      {
-        name: '${resourcePrefix}-snet-delegation-cae'
-        properties: {
-          serviceName: 'Microsoft.App/environments'
-        }
-      }
-    ]
   }
 }
 

--- a/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
+++ b/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
@@ -25,6 +25,9 @@ param workloadProfiles {
 @description('Specifies a set of tags with which to tag the resource in Azure')
 param tagValues object
 
+@description('Specifies the name of the new Resource Group created to host the resources of the Container App Environment')
+param infrastructureResourceGroupName string
+
 var containerAppEnvironmentName = '${subscription}-ees-cae'
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
@@ -46,6 +49,7 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' 
         sharedKey: logAnalyticsWorkspace.listKeys().primarySharedKey
       }
     }
+    infrastructureResourceGroup: infrastructureResourceGroupName
     workloadProfiles: workloadProfiles
   }
   tags: tagValues

--- a/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
+++ b/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
@@ -17,12 +17,20 @@ param applicationInsightsKey string
 param workloadProfiles {
  name: string
  workloadProfileType: string
-}[]?
+}[] = [{
+ name: 'Consumption'
+ workloadProfileType: 'Consumption'
+}]
 
 @description('Specifies a set of tags with which to tag the resource in Azure')
 param tagValues object
 
-var containerAppEnvironmentName = '${subscription}-ees-cae-01'
+@description('Specifies a suffix to append to the full name of the Container App Environment')
+param containerAppEnvironmentNameSuffix string = ''
+
+var containerAppEnvironmentName = empty(containerAppEnvironmentNameSuffix)
+  ? '${subscription}-ees-cae'
+  : '${subscription}-ees-cae-${containerAppEnvironmentNameSuffix}'
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
   name: logAnalyticsWorkspaceName
@@ -32,9 +40,9 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' 
   name: containerAppEnvironmentName
   location: location
   properties: {
-    //vnetConfiguration: {
-    //  infrastructureSubnetId: subnetId
-    //}
+    vnetConfiguration: {
+      infrastructureSubnetId: subnetId
+    }
     daprAIInstrumentationKey: applicationInsightsKey
     appLogsConfiguration: {
       destination: 'log-analytics'

--- a/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
+++ b/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
@@ -7,6 +7,9 @@ param location string
 @description('Specifies the dedicated subnet created for the Container App Environment within the main VNet')
 param subnetId string
 
+@description('Specifies whether or not this Container App Environment is internal-only or will be provisioned with a Public IP address')
+param internal bool = true
+
 @description('Specifies the name of the Log Analytics workspace responsible for capturing logging from this resource')
 param logAnalyticsWorkspaceName string
 
@@ -42,6 +45,7 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' 
   properties: {
     vnetConfiguration: {
       infrastructureSubnetId: subnetId
+      internal: internal
     }
     daprAIInstrumentationKey: applicationInsightsKey
     appLogsConfiguration: {

--- a/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
+++ b/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
@@ -17,18 +17,12 @@ param applicationInsightsKey string
 param workloadProfiles {
  name: string
  workloadProfileType: string
-}[] = [{
- name: 'Consumption'
- workloadProfileType: 'Consumption'
-}]
+}[]?
 
 @description('Specifies a set of tags with which to tag the resource in Azure')
 param tagValues object
 
-@description('Specifies the name of the new Resource Group created to host the resources of the Container App Environment')
-param infrastructureResourceGroupName string
-
-var containerAppEnvironmentName = '${subscription}-ees-cae'
+var containerAppEnvironmentName = '${subscription}-ees-cae-01'
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
   name: logAnalyticsWorkspaceName
@@ -38,9 +32,9 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' 
   name: containerAppEnvironmentName
   location: location
   properties: {
-    vnetConfiguration: {
-      infrastructureSubnetId: subnetId
-    }
+    //vnetConfiguration: {
+    //  infrastructureSubnetId: subnetId
+    //}
     daprAIInstrumentationKey: applicationInsightsKey
     appLogsConfiguration: {
       destination: 'log-analytics'
@@ -49,7 +43,6 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' 
         sharedKey: logAnalyticsWorkspace.listKeys().primarySharedKey
       }
     }
-    infrastructureResourceGroup: infrastructureResourceGroupName
     workloadProfiles: workloadProfiles
   }
   tags: tagValues

--- a/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
+++ b/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
@@ -50,14 +50,6 @@ param backupRetentionDays int = 7
 @description('Geo-Redundant Backup setting')
 param geoRedundantBackup string = 'Disabled'
 
-/*
-TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
-Security Group guidance on accessing resources behind VNet protection. Replacing for now with public access
-but only on specific subnets.
-@description('Specifies the subnet id')
-param subnetId string
-*/
-
 @description('An array of database names')
 param databaseNames string[]
 
@@ -70,9 +62,6 @@ param firewallRules {
 
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
-
-// @description('Id of the PostgreSQL Private DNS Zone')
-// param privateDnsZoneId string
 
 @description('Create mode for the PostgreSQL Flexible Server resource')
 @allowed([
@@ -118,15 +107,6 @@ resource postgreSQLDatabase 'Microsoft.DBforPostgreSQL/flexibleServers@2023-03-0
     highAvailability: {
       mode: 'Disabled'
     }
-
-    /*
-    TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
-    Security Group guidance on accessing resources behind VNet protection. Replacing for now with public access
-    but only on specific subnets.
-    network: {
-      delegatedSubnetResourceId: subnetId
-      privateDnsZoneArmResourceId: privateDnsZoneId
-    }*/
   }
 
   resource database 'databases' = [for name in databaseNames: {

--- a/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
+++ b/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
@@ -71,8 +71,8 @@ param firewallRules {
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
 
-@description('Id of the PostgreSQL Private DNS Zone')
-param privateDnsZoneId string
+// @description('Id of the PostgreSQL Private DNS Zone')
+// param privateDnsZoneId string
 
 @description('Create mode for the PostgreSQL Flexible Server resource')
 @allowed([

--- a/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
+++ b/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
@@ -146,5 +146,3 @@ resource postgreSQLDatabase 'Microsoft.DBforPostgreSQL/flexibleServers@2023-03-0
 
 @description('The fully qualified Azure resource ID of the Database Server.')
 output databaseRef string = resourceId('Microsoft.DBforPostgreSQL/flexibleServers', databaseServerName)
-
-output managedIdentityConnectionStringTemplate string = 'Server=${postgreSQLDatabase.name}.postgres.database.azure.com;Database=[database_name];Port=5432;User Id=[managed_identity_name];Password=[access_token]'

--- a/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
+++ b/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
@@ -50,7 +50,11 @@ param backupRetentionDays int = 7
 @description('Geo-Redundant Backup setting')
 param geoRedundantBackup string = 'Disabled'
 
-/*@description('Specifies the subnet id')
+/*
+TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
+Security Group guidance on accessing resources behind VNet protection. Replacing for now with public access
+but only on specific subnets.
+@description('Specifies the subnet id')
 param subnetId string
 */
 
@@ -114,7 +118,12 @@ resource postgreSQLDatabase 'Microsoft.DBforPostgreSQL/flexibleServers@2023-03-0
     highAvailability: {
       mode: 'Disabled'
     }
-    /*network: {
+
+    /*
+    TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
+    Security Group guidance on accessing resources behind VNet protection. Replacing for now with public access
+    but only on specific subnets.
+    network: {
       delegatedSubnetResourceId: subnetId
       privateDnsZoneArmResourceId: privateDnsZoneId
     }*/

--- a/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
+++ b/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
@@ -50,8 +50,9 @@ param backupRetentionDays int = 7
 @description('Geo-Redundant Backup setting')
 param geoRedundantBackup string = 'Disabled'
 
-@description('Specifies the subnet id')
+/*@description('Specifies the subnet id')
 param subnetId string
+*/
 
 @description('An array of database names')
 param databaseNames string[]
@@ -113,10 +114,10 @@ resource postgreSQLDatabase 'Microsoft.DBforPostgreSQL/flexibleServers@2023-03-0
     highAvailability: {
       mode: 'Disabled'
     }
-    network: {
+    /*network: {
       delegatedSubnetResourceId: subnetId
       privateDnsZoneArmResourceId: privateDnsZoneId
-    }
+    }*/
   }
 
   resource database 'databases' = [for name in databaseNames: {

--- a/infrastructure/templates/public-api/deploy-stage-template.yml
+++ b/infrastructure/templates/public-api/deploy-stage-template.yml
@@ -66,6 +66,7 @@ stages:
                       postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
                       dockerImagesTag='$(upstreamPipelineBuildNumber)' \
                       deployContainerApp=$(deployContainerApp) \
+                      updatePsqlFlexibleServer=$(updatePsqlFlexibleServer)
                       dataProcessorFunctionAppExists=$dataProcessorExists
 
           - template: pipeline-variables-from-bicep-outputs-template.yml

--- a/infrastructure/templates/public-api/deploy-stage-template.yml
+++ b/infrastructure/templates/public-api/deploy-stage-template.yml
@@ -65,8 +65,8 @@ stages:
                       postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
                       postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
                       dockerImagesTag='$(upstreamPipelineBuildNumber)' \
-                      psqlDbUsersAdded='$(psqlDbUsersAdded)' \
-                      apiContainerAppUserCreatedWithAcrPull='$(apiContainerAppUserCreatedWithAcrPull)'
+                      psqlDbUsersAdded=$(psqlDbUsersAdded) \
+                      apiContainerAppUserCreatedWithAcrPull=$(apiContainerAppUserCreatedWithAcrPull)
                       dataProcessorFunctionAppExists=$dataProcessorExists
 
           - template: pipeline-variables-from-bicep-outputs-template.yml

--- a/infrastructure/templates/public-api/deploy-stage-template.yml
+++ b/infrastructure/templates/public-api/deploy-stage-template.yml
@@ -65,6 +65,7 @@ stages:
                       postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
                       dockerImagesTag='$(upstreamPipelineBuildNumber)' \
                       psqlDbUsersAdded='$(psqlDbUsersAdded)' \
+                      apiContainerAppUserCreatedWithAcrPull='$(apiContainerAppUserCreatedWithAcrPull)'
                       dataProcessorFunctionAppExists=$dataProcessorExists
 
           - template: pipeline-variables-from-bicep-outputs-template.yml

--- a/infrastructure/templates/public-api/deploy-stage-template.yml
+++ b/infrastructure/templates/public-api/deploy-stage-template.yml
@@ -65,8 +65,7 @@ stages:
                       postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
                       postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
                       dockerImagesTag='$(upstreamPipelineBuildNumber)' \
-                      psqlDbUsersAdded=$(psqlDbUsersAdded) \
-                      apiContainerAppUserCreatedWithAcrPull=$(apiContainerAppUserCreatedWithAcrPull)
+                      deployContainerApp=$(deployContainerApp) \
                       dataProcessorFunctionAppExists=$dataProcessorExists
 
           - template: pipeline-variables-from-bicep-outputs-template.yml

--- a/infrastructure/templates/public-api/deploy-stage-template.yml
+++ b/infrastructure/templates/public-api/deploy-stage-template.yml
@@ -63,6 +63,7 @@ stages:
                       publicUrls='$(publicUrls)' \
                       postgreSqlAdminName='$(postgreSqlAdminName)' \
                       postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
+                      postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
                       dockerImagesTag='$(upstreamPipelineBuildNumber)' \
                       psqlDbUsersAdded='$(psqlDbUsersAdded)' \
                       apiContainerAppUserCreatedWithAcrPull='$(apiContainerAppUserCreatedWithAcrPull)'

--- a/infrastructure/templates/public-api/deploy-stage-template.yml
+++ b/infrastructure/templates/public-api/deploy-stage-template.yml
@@ -13,14 +13,16 @@ parameters:
     default: ''
   - name: parameterFile
     type: string
+  - name: condition
+    type: string
 
 stages:
 - stage: ${{parameters.stageName}}
+  displayName: 'Deploy ${{parameters.environment}} Infrastructure and Applications'
+  condition: ${{parameters.condition}}
   variables:
     - group: Public API Infrastructure - ${{parameters.environment}}
     - group: Public API Infrastructure - ${{parameters.environment}} secrets
-  displayName: 'Deploy ${{parameters.environment}} Infrastructure and Applications'
-  condition: succeeded()
   ${{ if not(eq(parameters.dependsOn, '')) }}:
     dependsOn: ${{parameters.dependsOn}}
   jobs:

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -181,6 +181,12 @@ resource postgreSqlPrivateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01'
 }
 */
 
+var formattedPostgreSqlFirewallRules = map(postgreSqlFirewallRules, rule => {
+  name: replace(rule.name, ' ', '_')
+  startIpAddress: rule.startIpAddress
+  endIpAddress: rule.endIpAddress
+})
+
 // Deploy PostgreSQL Database.
 module postgreSqlServerModule 'components/postgresqlDatabase.bicep' = {
   name: 'postgreSQLDatabaseDeploy'
@@ -202,7 +208,7 @@ module postgreSqlServerModule 'components/postgresqlDatabase.bicep' = {
     */
     // privateDnsZoneId: postgreSqlPrivateDnsZone.id
     // subnetId: vNetModule.outputs.postgreSqlSubnetRef
-    firewallRules: concat(postgreSqlFirewallRules, [
+    firewallRules: concat(formattedPostgreSqlFirewallRules, [
       {
         name: '${resourcePrefix}-ca-${apiContainerAppName}-subnet'
         startIpAddress: vNetModule.outputs.containerAppEnvironmentSubnetStartIpAddress

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -218,28 +218,7 @@ module postgreSqlServerModule 'components/postgresqlDatabase.bicep' = if (update
     */
     // privateDnsZoneId: postgreSqlPrivateDnsZone.id
     // subnetId: vNetModule.outputs.postgreSqlSubnetRef
-    firewallRules: concat(formattedPostgreSqlFirewallRules, [
-      {
-        name: '${resourcePrefix}-ca-${apiContainerAppName}-subnet'
-        startIpAddress: vNetModule.outputs.containerAppEnvironmentSubnetStartIpAddress
-        endIpAddress: vNetModule.outputs.containerAppEnvironmentSubnetEndIpAddress
-      }
-      {
-        name: '${dataProcessorFunctionAppFullName}-subnet'
-        startIpAddress: vNetModule.outputs.dataProcessorSubnetStartIpAddress
-        endIpAddress: vNetModule.outputs.dataProcessorSubnetEndIpAddress
-      }
-      {
-        name: '${subscription}-as-ees-admin-subnet'
-        startIpAddress: vNetModule.outputs.adminAppServiceSubnetStartIpAddress
-        endIpAddress: vNetModule.outputs.adminAppServiceSubnetEndIpAddress
-      }
-      {
-        name: '${subscription}-fa-ees-publisher-subnet'
-        startIpAddress: vNetModule.outputs.publisherFunctionAppSubnetStartIpAddress
-        endIpAddress: vNetModule.outputs.publisherFunctionAppSubnetEndIpAddress
-      }
-    ])
+    firewallRules: formattedPostgreSqlFirewallRules
     databaseNames: ['public_data']
   }
 }

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -115,10 +115,6 @@ module vNetModule 'application/virtualNetwork.bicep' = {
     subscription: subscription
     dataProcessorFunctionAppNameSuffix: dataProcessorFunctionAppName
     containerAppEnvironmentNameSuffix: containerAppEnvironmentNameSuffix
-    /* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
-       Security Group guidance on accessing resources behind VNet protection.
-    postgreSqlServerName: psqlServerName
-    */
   }
 }
 
@@ -167,26 +163,6 @@ module fileShareModule 'components/fileShares.bicep' = {
   }
 }
 
-/* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
-   Security Group guidance on accessing resources behind VNet protection.
-// In order to link PostgreSQL Flexible Server to a VNet, it must have a Private DNS zone available with a name ending
-// with "postgres.database.azure.com".
-resource postgreSqlPrivateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
-  name: 'private.postgres.database.azure.com'
-  location: 'global'
-  resource vNetLink 'virtualNetworkLinks' = {
-    name: '${subscription}-ees-${psqlServerName}-vnet-link'
-    location: 'global'
-    properties: {
-      registrationEnabled: false
-      virtualNetwork: {
-        id: vNetModule.outputs.vNetRef
-      }
-    }
-  }
-}
-*/
-
 var formattedPostgreSqlFirewallRules = map(postgreSqlFirewallRules, rule => {
   name: replace(rule.name, ' ', '_')
   startIpAddress: rule.startIpAddress
@@ -211,13 +187,6 @@ module postgreSqlServerModule 'components/postgresqlDatabase.bicep' = if (update
     dbAutoGrowStatus: postgreSqlAutoGrowStatus
     postgreSqlVersion: '16'
     tagValues: tagValues
-    /*
-    TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
-    Security Group guidance on accessing resources behind VNet protection. Replacing for now with public access
-    but only on specific subnets.
-    */
-    // privateDnsZoneId: postgreSqlPrivateDnsZone.id
-    // subnetId: vNetModule.outputs.postgreSqlSubnetRef
     firewallRules: formattedPostgreSqlFirewallRules
     databaseNames: ['public_data']
   }

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -74,6 +74,7 @@ var resourcePrefix = '${subscription}-ees-papi'
 var apiContainerAppName = 'api'
 var apiContainerAppManagedIdentityName = '${resourcePrefix}-id-${apiContainerAppName}'
 var adminAppServiceFullName = '${subscription}-as-ees-admin'
+var publisherFunctionAppFullName = '${subscription}-fa-ees-publisher'
 var dataProcessorFunctionAppName = 'processor'
 var dataProcessorFunctionAppFullName = '${resourcePrefix}-fa-${dataProcessorFunctionAppName}'
 var psqlServerName = 'psql-flexibleserver'
@@ -277,6 +278,13 @@ module apiContainerAppModule 'components/containerApp.bicep' = if (apiContainerA
         // tables in the "public_data" database successfully.
         name: 'DataProcessorFunctionAppIdentityName'
         value: dataProcessorFunctionAppFullName
+      }
+      {
+        // This property informs the Container App of the name of the Publisher's system-assigned identity.
+        // It uses this to grant permissions to the Publisher user in order for it to be able to access
+        // tables in the "public_data" database successfully.
+        name: 'PublisherFunctionAppIdentityName'
+        value: publisherFunctionAppFullName
       }
     ]
     tagValues: tagValues

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -59,7 +59,7 @@ param dockerImagesTag string = ''
 @description('Has the user-assigned Managed Identity for the API Container App been created and been assigned the AcrPull role yet?')
 param apiContainerAppUserCreatedWithAcrPull bool = true
 
-@description('Have database users been added to PSQL yet for Container App and Function App?')
+@description('Have database users been added to PSQL yet?')
 param psqlDbUsersAdded bool = true
 
 @description('Public URLs of other components in the service.')

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -56,11 +56,8 @@ param dateProvisioned string = utcNow('u')
 @description('The tags of the Docker images to deploy.')
 param dockerImagesTag string = ''
 
-@description('Has the user-assigned Managed Identity for the API Container App been created and been assigned the AcrPull role yet?')
-param apiContainerAppUserCreatedWithAcrPull bool = true
-
-@description('Have database users been added to PSQL yet?')
-param psqlDbUsersAdded bool = true
+@description('Can we deploy the Container App yet?  This is dependent on the user-assigned Managed Identity for the API Container App being created with the AcrPull role, and the database users added to PSQL.')
+param deployContainerApp bool = true
 
 @description('Public URLs of other components in the service.')
 param publicUrls {
@@ -232,12 +229,12 @@ module postgreSqlServerModule 'components/postgresqlDatabase.bicep' = {
   }
 }
 
-resource apiContainerAppManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = if (apiContainerAppUserCreatedWithAcrPull) {
+resource apiContainerAppManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = if (deployContainerApp) {
   name: apiContainerAppManagedIdentityName
 }
 
 // Deploy main Public API Container App.
-module apiContainerAppModule 'components/containerApp.bicep' = if (apiContainerAppUserCreatedWithAcrPull && psqlDbUsersAdded) {
+module apiContainerAppModule 'components/containerApp.bicep' = if (deployContainerApp) {
   name: 'apiContainerAppDeploy'
   params: {
     resourcePrefix: resourcePrefix

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -139,6 +139,7 @@ module containerAppEnvironmentModule 'components/containerAppEnvironment.bicep' 
   params: {
     subscription: subscription
     location: location
+    containerAppEnvironmentNameSuffix: '01'
     subnetId: vNetModule.outputs.containerAppEnvironmentSubnetRef
     logAnalyticsWorkspaceName: logAnalyticsWorkspaceModule.outputs.logAnalyticsWorkspaceName
     applicationInsightsKey: applicationInsightsModule.outputs.applicationInsightsKey
@@ -189,6 +190,11 @@ module postgreSqlServerModule 'components/postgresqlDatabase.bicep' = {
     postgreSqlVersion: '16'
     tagValues: tagValues
     privateDnsZoneId: postgreSqlPrivateDnsZone.id
+    /*
+    TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
+    Security Group guidance on accessing resources behind VNet protection. Replacing for now with public access
+    but only on specific subnets.
+    */
     firewallRules: concat(postgreSqlFirewallRules, [
       {
         name: '${resourcePrefix}-ca-${apiContainerAppName}-subnet'

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -81,6 +81,7 @@ var coreStorageAccountName = '${subscription}saeescore'
 var keyVaultName = '${subscription}-kv-ees-01'
 var acrName = 'eesacr'
 var vNetName = '${subscription}-vnet-ees'
+var containerAppEnvironmentNameSuffix = '01'
 
 var tagValues = union(resourceTags ?? {}, {
   Environment: environmentName
@@ -108,7 +109,8 @@ module vNetModule 'application/virtualNetwork.bicep' = {
     vNetName: vNetName
     resourcePrefix: resourcePrefix
     subscription: subscription
-    dataProcessorFunctionAppName: dataProcessorFunctionAppName
+    dataProcessorFunctionAppNameSuffix: dataProcessorFunctionAppName
+    containerAppEnvironmentName: containerAppEnvironmentNameSuffix
     /* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
        Security Group guidance on accessing resources behind VNet protection.
     postgreSqlServerName: psqlServerName
@@ -142,7 +144,7 @@ module containerAppEnvironmentModule 'components/containerAppEnvironment.bicep' 
   params: {
     subscription: subscription
     location: location
-    containerAppEnvironmentNameSuffix: '01'
+    containerAppEnvironmentNameSuffix: containerAppEnvironmentNameSuffix
     subnetId: vNetModule.outputs.containerAppEnvironmentSubnetRef
     logAnalyticsWorkspaceName: logAnalyticsWorkspaceModule.outputs.logAnalyticsWorkspaceName
     applicationInsightsKey: applicationInsightsModule.outputs.applicationInsightsKey

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -142,7 +142,6 @@ module containerAppEnvironmentModule 'components/containerAppEnvironment.bicep' 
     subnetId: vNetModule.outputs.containerAppEnvironmentSubnetRef
     logAnalyticsWorkspaceName: logAnalyticsWorkspaceModule.outputs.logAnalyticsWorkspaceName
     applicationInsightsKey: applicationInsightsModule.outputs.applicationInsightsKey
-    infrastructureResourceGroupName: '${subscription}-ees-cae-rg'
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -59,8 +59,8 @@ param dockerImagesTag string = ''
 @description('Can we deploy the Container App yet?  This is dependent on the user-assigned Managed Identity for the API Container App being created with the AcrPull role, and the database users added to PSQL.')
 param deployContainerApp bool = true
 
-// Note that this has been added temporarily to avoid 10+ minute deploys where it appears that PSQL will redeploy even if no changes exist in
-// this deploy from the previous one.
+// TODO EES-5128 - Note that this has been added temporarily to avoid 10+ minute deploys where it appears that PSQL 
+// will redeploy even if no changes exist in this deploy from the previous one.
 @description('Does the PostgreSQL Flexible Server require any updates? False by default to avoid unnecessarily lengthy deploys.')
 param updatePsqlFlexibleServer bool = false
 
@@ -169,6 +169,9 @@ var formattedPostgreSqlFirewallRules = map(postgreSqlFirewallRules, rule => {
   endIpAddress: rule.endIpAddress
 })
 
+// TODO EES-5128 - if keeping the flag for the future, move this conditional logic into the postgresqlDatabase.bicep 
+// module itself so that we always have a set of outputs that we can use. This will in turn allow us to move 
+// psqlManagedIdentityConnectionStringTemplate into the module's outputs.
 resource postgreSqlServer 'Microsoft.DBforPostgreSQL/flexibleServers@2023-03-01-preview' existing = if (!updatePsqlFlexibleServer) {
   name: psqlServerFullName
 }
@@ -194,6 +197,7 @@ module postgreSqlServerModule 'components/postgresqlDatabase.bicep' = if (update
 
 var psqlManagedIdentityConnectionStringTemplate = 'Server=${psqlServerFullName}.postgres.database.azure.com;Database=[database_name];Port=5432;User Id=[managed_identity_name];Password=[access_token]'
 
+// TODO EES-5128 - move into the Container App module?
 resource apiContainerAppManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = if (deployContainerApp) {
   name: apiContainerAppManagedIdentityName
 }

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -110,7 +110,7 @@ module vNetModule 'application/virtualNetwork.bicep' = {
     resourcePrefix: resourcePrefix
     subscription: subscription
     dataProcessorFunctionAppNameSuffix: dataProcessorFunctionAppName
-    containerAppEnvironmentName: containerAppEnvironmentNameSuffix
+    containerAppEnvironmentNameSuffix: containerAppEnvironmentNameSuffix
     /* TODO EES-5052 - temporarily disconnecting PostgreSQL Flexible Server from VNet integration whilst awaiting
        Security Group guidance on accessing resources behind VNet protection.
     postgreSqlServerName: psqlServerName

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -142,6 +142,7 @@ module containerAppEnvironmentModule 'components/containerAppEnvironment.bicep' 
     subnetId: vNetModule.outputs.containerAppEnvironmentSubnetRef
     logAnalyticsWorkspaceName: logAnalyticsWorkspaceModule.outputs.logAnalyticsWorkspaceName
     applicationInsightsKey: applicationInsightsModule.outputs.applicationInsightsKey
+    infrastructureResourceGroupName: '${subscription}-ees-cae-rg'
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -189,8 +189,19 @@ module postgreSqlServerModule 'components/postgresqlDatabase.bicep' = {
     postgreSqlVersion: '16'
     tagValues: tagValues
     privateDnsZoneId: postgreSqlPrivateDnsZone.id
-    firewallRules: postgreSqlFirewallRules
-    subnetId: vNetModule.outputs.postgreSqlSubnetRef
+    firewallRules: concat(postgreSqlFirewallRules, [
+      {
+        name: '${resourcePrefix}-ca-${apiContainerAppName}-subnet'
+        startIpAddress: vNetModule.outputs.containerAppEnvironmentSubnetStartIpAddress
+        endIpAddress: vNetModule.outputs.containerAppEnvironmentSubnetEndIpAddress
+      }
+      {
+        name: '${dataProcessorFunctionAppFullName}-subnet'
+        startIpAddress: vNetModule.outputs.dataProcessorSubnetStartIpAddress
+        endIpAddress: vNetModule.outputs.dataProcessorSubnetEndIpAddress
+      }
+    ])
+    // subnetId: vNetModule.outputs.postgreSqlSubnetRef
     databaseNames: ['public_data']
   }
 }

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -280,6 +280,14 @@ module apiContainerAppModule 'components/containerApp.bicep' = if (deployContain
         value: publicUrls!.contentApi
       }
       {
+        name: 'MiniProfiler__Enabled'
+        value: 'true'
+      }
+      {
+        name: 'ParquetFiles__BasePath'
+        value: 'data/public-api-parquet'
+      }
+      {
         // This property informs the Container App of the name of the Admin's system-assigned identity.
         // It uses this to grant permissions to the Admin user in order for it to be able to access
         // tables in the "public_data" database successfully.

--- a/infrastructure/templates/public-api/validate-stage-template.yml
+++ b/infrastructure/templates/public-api/validate-stage-template.yml
@@ -53,6 +53,5 @@ stages:
                     postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
                     postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
                     dockerImagesTag='$(upstreamPipelineBuildNumber)' \
-                    psqlDbUsersAdded=true \
-                    apiContainerAppUserCreatedWithAcrPull=true \
+                    deployContainerApp=true \
                     dataProcessorFunctionAppExists=true

--- a/infrastructure/templates/public-api/validate-stage-template.yml
+++ b/infrastructure/templates/public-api/validate-stage-template.yml
@@ -10,15 +10,18 @@ parameters:
     type: string
   - name: parameterFile
     type: string
+  - name: condition
+    type: string
 
 stages:
   - stage: ${{parameters.stageName}}
     displayName: 'Validate ${{parameters.environment}} Infrastructure'
+    condition: ${{parameters.condition}}
+    variables:
+      - group: Public API Infrastructure - ${{parameters.environment}}
+      - group: Public API Infrastructure - ${{parameters.environment}} secrets
     jobs:
       - job: Validate_Infrastructure
-        variables:
-          - group: Public API Infrastructure - ${{parameters.environment}}
-          - group: Public API Infrastructure - ${{parameters.environment}} secrets
         steps:
           - checkout: self
 

--- a/infrastructure/templates/public-api/validate-stage-template.yml
+++ b/infrastructure/templates/public-api/validate-stage-template.yml
@@ -51,6 +51,7 @@ stages:
                     publicUrls='$(publicUrls)' \
                     postgreSqlAdminName='$(postgreSqlAdminName)' \
                     postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
+                    postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
                     dockerImagesTag='$(upstreamPipelineBuildNumber)' \
                     psqlDbUsersAdded=true \
                     apiContainerAppUserCreatedWithAcrPull=true \

--- a/infrastructure/templates/public-api/validate-stage-template.yml
+++ b/infrastructure/templates/public-api/validate-stage-template.yml
@@ -54,4 +54,5 @@ stages:
                     postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
                     dockerImagesTag='$(upstreamPipelineBuildNumber)' \
                     deployContainerApp=true \
+                    updatePsqlFlexibleServer=true \
                     dataProcessorFunctionAppExists=true

--- a/infrastructure/templates/public-api/validate-stage-template.yml
+++ b/infrastructure/templates/public-api/validate-stage-template.yml
@@ -53,4 +53,5 @@ stages:
                     postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
                     dockerImagesTag='$(upstreamPipelineBuildNumber)' \
                     psqlDbUsersAdded=true \
+                    apiContainerAppUserCreatedWithAcrPull=true \
                     dataProcessorFunctionAppExists=true

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1039,6 +1039,8 @@
     "containerAppEnvironmentSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('containerAppEnvironmentSubnetName'))]",
     "applicationGatewaySubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-agw-01')]",
     "applicationGatewaySubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('applicationGatewaySubnetName'))]",
+    "psqlFlexibleServerSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-psql-flexibleserver')]",
+    "psqlFlexibleServerSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('psqlFlexibleServerSubnetName'))]",
     "sqlAllowedSubnets": [
       {
         "name": "admin",
@@ -3505,6 +3507,12 @@
             "name": "[variables('applicationGatewaySubnetName')]",
             "properties": {
               "addressPrefix": "10.0.10.0/24"
+            }
+          },
+          {
+            "name": "[variables('psqlFlexibleServerSubnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.12.0/24"
             }
           }
         ]

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1034,7 +1034,11 @@
     "dataSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-data')]",
     "dataSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('dataSubnetName'))]",
     "publicApiDataProcessorSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-snet-fa-processor')]",
+    "publicApiDataProcessorSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('publicApiDataProcessorSubnetName'))]",
     "containerAppEnvironmentSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-cae-01')]",
+    "containerAppEnvironmentSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('containerAppEnvironmentSubnetName'))]",
+    "applicationGatewaySubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-agw-01')]",
+    "applicationGatewaySubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('applicationGatewaySubnetName'))]",
     "sqlAllowedSubnets": [
       {
         "name": "admin",
@@ -1055,6 +1059,10 @@
       {
         "name": "data",
         "id": "[variables('dataSubnetRef')]"
+      },
+      {
+        "name": "publicApiDataProcessor",
+        "id": "[variables('publicApiDataProcessorSubnetRef')]"
       }
     ],
     "publicSqlAllowedSubnets": [
@@ -3463,6 +3471,9 @@
               "addressPrefix": "10.0.6.0/24",
               "serviceEndpoints": [
                 {
+                  "service": "Microsoft.Sql"
+                },
+                {
                   "service": "Microsoft.Storage"
                 }
               ],
@@ -3479,7 +3490,7 @@
           {
             "name": "[variables('containerAppEnvironmentSubnetName')]",
             "properties": {
-              "addressPrefix": "10.0.8.0/24",
+              "addressPrefix": "10.0.8.0/23",
               "delegations": [
                 {
                   "name": "environment",
@@ -3488,6 +3499,12 @@
                   }
                 }
               ]
+            }
+          },
+          {
+            "name": "[variables('applicationGatewaySubnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.10.0/24"
             }
           }
         ]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240427023845_InitialMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240427023845_InitialMigration.cs
@@ -578,6 +578,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
             {
                 migrationBuilder.Sql(
                     $"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO \"{adminAppServiceIdentityName}\"");
+                migrationBuilder.Sql(
+                    $"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO \"{adminAppServiceIdentityName}\"");
             }
 
             // Grant permissions on database tables created by this resource's database user to the
@@ -587,6 +589,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
             {
                 migrationBuilder.Sql(
                     $"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO \"{dataProcessorFunctionAppIdentityName}\"");
+                migrationBuilder.Sql(
+                    $"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO \"{dataProcessorFunctionAppIdentityName}\"");
             }
 
             // Grant permissions on database tables created by this resource's database user to the
@@ -596,6 +600,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
             {
                 migrationBuilder.Sql(
                     $"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO \"{publisherFunctionAppIdentityName}\"");
+                migrationBuilder.Sql(
+                    $"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO \"{publisherFunctionAppIdentityName}\"");
             }
         }
 


### PR DESCRIPTION
This PR:
- changes Container App Environment to be internal rather than having a Public IP address, in preparation for adding an Application Gateway in front, as requested by the Security Architecture group.
- adds in a conditional flag to omit the Container App from deployment until a user-assigned managed identity has been created and assigned the AcrPull role.
- swaps out the conditional inclusion of chunks of YAML in the pipeline for different environments (which turned out not to be working!) with "condition" property on Stages based on the current branch.
- removes PSQL VNet integration in favour of enabling public SQL access to whitelisted IP address ranges, as per existing SQL Server setups.  In the future this will be resolved for VNet traffic by EES-5052, by adding a Private Endpoint linking PSQL to the VNet.
- adds additional necessary subnets to the main ARM template's control.
- adds new appsettings to Container App, and SQL connection string secret creation for Admin, Publisher and Data Processor.
- amends the initial migration of the Container App to allow all PSQL db users to have access to future tables as well as initial ones.

## Optimisation flag for PSQL

I've added a flag for effectively skipping the PSQL stage of the deploy, as currently it seems that PSQL attempts to update every single time that we do a Public API Inf deploy, which leads to at least 5 minutes extra deploy time and at worst about 13 minutes extra.  We need to work out what is causing it to redeploy each time even when nothing has changed.  It may be down to the child "databases" and "firewallRules" resources, which could potentially be solved by moving them out into top-level resources in the postgres module rather than as child resources, but haven't investigated yet.