### PR TITLE
EES-5036 Accomodate BST and GMT changes in PRA frontend

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,6 +648,9 @@ importers:
       date-fns:
         specifier: ^2.16.1
         version: 2.30.0
+      date-fns-tz:
+        specifier: ^2.0.1
+        version: 2.0.1(date-fns@2.30.0)
       domhandler:
         specifier: ^4.2.2
         version: 4.3.1
@@ -880,6 +883,9 @@ importers:
       date-fns:
         specifier: ^2.16.1
         version: 2.30.0
+      date-fns-tz:
+        specifier: ^2.0.1
+        version: 2.0.1(date-fns@2.30.0)
       explore-education-statistics-common:
         specifier: workspace:*
         version: link:../explore-education-statistics-common

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0
+      date-fns-tz:
+        specifier: ^2.0.1
+        version: 2.0.1(date-fns@2.30.0)
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -644,7 +647,7 @@ importers:
         version: 3.1.5
       date-fns:
         specifier: ^2.16.1
-        version: 2.29.3
+        version: 2.30.0
       domhandler:
         specifier: ^4.2.2
         version: 4.3.1
@@ -876,7 +879,7 @@ importers:
         version: 3.1.5
       date-fns:
         specifier: ^2.16.1
-        version: 2.29.3
+        version: 2.30.0
       explore-education-statistics-common:
         specifier: workspace:*
         version: link:../explore-education-statistics-common
@@ -9621,16 +9624,19 @@ packages:
       whatwg-url: 11.0.0
     dev: true
 
-  /date-fns@2.29.3:
-    resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
-    engines: {node: '>=0.11'}
+  /date-fns-tz@2.0.1(date-fns@2.30.0):
+    resolution: {integrity: sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==}
+    peerDependencies:
+      date-fns: 2.x
+    dependencies:
+      date-fns: 2.30.0
     dev: false
 
   /date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
     dev: false
 
   /debug@2.6.9:

--- a/src/explore-education-statistics-admin/package.json
+++ b/src/explore-education-statistics-admin/package.json
@@ -32,6 +32,7 @@
     "css-loader": "^6.7.3",
     "css-minimizer-webpack-plugin": "^3.4.1",
     "date-fns": "^2.30.0",
+    "date-fns-tz": "^2.0.1",
     "deepmerge": "^4.3.1",
     "dotenv": "^9.0.2",
     "dotenv-expand": "^5.1.0",

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -37,13 +37,13 @@ export const calculatePraPeriodAdvice = (
     'd MMMM yyyy',
   );
   const timeOfPraStart = formatInTimeZone(start, 'Europe/London', 'HH:mm');
-  const dayScheduledForPublish = formatInTimeZone(
+  const dateScheduledForPublish = formatInTimeZone(
     scheduledPublishDate,
     'Europe/London',
     'd MMMM yyyy',
   );
 
-  return `Pre-release access will be available from ${dateOfPraStart} at ${timeOfPraStart} until it is published on ${dayScheduledForPublish}.`;
+  return `Pre-release access will be available from ${dateOfPraStart} at ${timeOfPraStart} until it is published on ${dateScheduledForPublish}.`;
 };
 
 const PreReleasePageContainer = ({
@@ -123,8 +123,6 @@ const PreReleasePageContainer = ({
     }
 
     if (access === 'Before') {
-      // const utcStart = zonedTimeToUtc(start, start.getTimezoneOffset);
-
       return (
         <>
           <h1>Pre-release access is not yet available</h1>

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -17,7 +17,7 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import NotificationBanner from '@common/components/NotificationBanner';
 import { useErrorControl } from '@common/contexts/ErrorControlContext';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import { utcToZonedTime, format } from 'date-fns-tz';
+import { formatInTimeZone } from 'date-fns-tz';
 import React from 'react';
 import { generatePath } from 'react-router';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
@@ -26,6 +26,25 @@ interface Model {
   preReleaseWindowStatus: PreReleaseWindowStatus;
   preReleaseSummary: PreReleaseSummary;
 }
+
+export const calculatePraPeriodAdvice = (
+  start: Date,
+  scheduledPublishDate: Date,
+): string => {
+  const dateOfPraStart = formatInTimeZone(
+    start,
+    'Europe/London',
+    'd MMMM yyyy',
+  );
+  const timeOfPraStart = formatInTimeZone(start, 'Europe/London', 'HH:mm');
+  const dayScheduledForPublish = formatInTimeZone(
+    scheduledPublishDate,
+    'Europe/London',
+    'd MMMM yyyy',
+  );
+
+  return `Pre-release access will be available from ${dateOfPraStart} at ${timeOfPraStart} until it is published on ${dayScheduledForPublish}.`;
+};
 
 const PreReleasePageContainer = ({
   match,
@@ -104,13 +123,7 @@ const PreReleasePageContainer = ({
     }
 
     if (access === 'Before') {
-      const zonedStartDate = utcToZonedTime(start, 'Europe/London');
-      const dateOfPraStart = format(zonedStartDate, 'd MMMM yyyy');
-      const timeOfPraStart = format(zonedStartDate, 'HH:mm');
-      const dayScheduledForPublish = format(
-        scheduledPublishDate,
-        'd MMMM yyyy',
-      );
+      // const utcStart = zonedTimeToUtc(start, start.getTimezoneOffset);
 
       return (
         <>
@@ -121,9 +134,7 @@ const PreReleasePageContainer = ({
             of <strong>{publicationTitle}</strong> is not yet available.
           </p>
 
-          <p>
-            {`Pre-release access will be available from ${dateOfPraStart} at ${timeOfPraStart} until it is published on ${dayScheduledForPublish}.`}
-          </p>
+          <p>{calculatePraPeriodAdvice(start, scheduledPublishDate)}</p>
 
           <p>
             If you believe that this release should be available and you are

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -17,7 +17,7 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import NotificationBanner from '@common/components/NotificationBanner';
 import { useErrorControl } from '@common/contexts/ErrorControlContext';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import { format } from 'date-fns';
+import { utcToZonedTime, format } from 'date-fns-tz';
 import React from 'react';
 import { generatePath } from 'react-router';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
@@ -104,6 +104,18 @@ const PreReleasePageContainer = ({
     }
 
     if (access === 'Before') {
+      const zonedStartDate = utcToZonedTime(start, 'Europe/Berlin');
+      const dateOfPraStart = format(
+        utcToZonedTime(zonedStartDate, 'Europe/London'),
+        'd MMMM yyyy',
+        { timeZone: 'Europe/London' },
+      );
+      const timeOfPraStart = format(zonedStartDate, 'HH:mm');
+      const dayScheduledForPublish = format(
+        scheduledPublishDate,
+        'd MMMM yyyy',
+      );
+
       return (
         <>
           <h1>Pre-release access is not yet available</h1>
@@ -114,13 +126,7 @@ const PreReleasePageContainer = ({
           </p>
 
           <p>
-            {`Pre-release access will be available from ${format(
-              start,
-              'd MMMM yyyy',
-            )} at ${format(start, 'HH:mm')} until it is published on ${format(
-              scheduledPublishDate,
-              'd MMMM yyyy',
-            )}.`}
+            {`Pre-release access will be available from ${dateOfPraStart} at ${timeOfPraStart} until it is published on ${dayScheduledForPublish}.`}
           </p>
 
           <p>

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -104,12 +104,8 @@ const PreReleasePageContainer = ({
     }
 
     if (access === 'Before') {
-      const zonedStartDate = utcToZonedTime(start, 'Europe/Berlin');
-      const dateOfPraStart = format(
-        utcToZonedTime(zonedStartDate, 'Europe/London'),
-        'd MMMM yyyy',
-        { timeZone: 'Europe/London' },
-      );
+      const zonedStartDate = utcToZonedTime(start, 'Europe/London');
+      const dateOfPraStart = format(zonedStartDate, 'd MMMM yyyy');
       const timeOfPraStart = format(zonedStartDate, 'HH:mm');
       const dayScheduledForPublish = format(
         scheduledPublishDate,

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
@@ -76,9 +76,10 @@ describe('PreReleasePageContainer', () => {
       }),
     ).toBeInTheDocument();
 
+    // Need to match both 09:00 and 10:00, because mocking out the "London/Europe" timezone for BST/GMT testing isn't really feasible
     expect(
       screen.getByText(
-        'Pre-release access will be available from 12 December 3000 at 09:00 until it is published on 13 December 3000.',
+        /Pre-release access will be available from 12 December 3000 at (09:00)|(10:00) until it is published on 13 December 3000./,
       ),
     ).toBeInTheDocument();
 

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
@@ -100,10 +100,9 @@ describe('PreReleasePageContainer', () => {
       }),
     ).toBeInTheDocument();
 
-    // Need to match both 09:00 and 10:00, because mocking out the "London/Europe" timezone for BST/GMT testing isn't really feasible
     expect(
       screen.getByText(
-        /Pre-release access will be available from 12 December 3000 at (09:00)|(10:00) until it is published on 13 December 3000./,
+        'Pre-release access will be available from 12 December 3000 at 09:00 until it is published on 13 December 3000.',
       ),
     ).toBeInTheDocument();
 

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
@@ -1,5 +1,7 @@
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
-import PreReleasePageContainer from '@admin/pages/release/pre-release/PreReleasePageContainer';
+import PreReleasePageContainer, {
+  calculatePraPeriodAdvice,
+} from '@admin/pages/release/pre-release/PreReleasePageContainer';
 import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
 import { preReleaseRoute } from '@admin/routes/routes';
 import _permissionService from '@admin/services/permissionService';
@@ -31,6 +33,28 @@ describe('PreReleasePageContainer', () => {
     contactEmail: 'test@test.com',
     contactTeam: 'Test team',
   };
+
+  test('calculates PRA period advice during winter', () => {
+    const result = calculatePraPeriodAdvice(
+      new Date('2020-12-09T00:00:00Z'),
+      new Date('2020-12-10T09:30:00Z'),
+    );
+
+    expect(result).toBe(
+      'Pre-release access will be available from 9 December 2020 at 00:00 until it is published on 10 December 2020.',
+    );
+  });
+
+  test('calculates PRA period advice during summer', () => {
+    const result = calculatePraPeriodAdvice(
+      new Date('2020-06-08T23:00:00Z'),
+      new Date('2020-06-10T08:30:00Z'),
+    );
+
+    expect(result).toBe(
+      'Pre-release access will be available from 9 June 2020 at 00:00 until it is published on 10 June 2020.',
+    );
+  });
 
   test('renders correctly when pre-release has ended', async () => {
     permissionService.getPreReleaseWindowStatus.mockResolvedValue({

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -17,6 +17,7 @@
     "core-js": "^3.31.1",
     "cross-fetch": "^3.0.6",
     "date-fns": "^2.16.1",
+    "date-fns-tz": "^2.0.1",
     "domhandler": "^4.2.2",
     "formik": "^2.4.2",
     "geojson": "^0.5.0",

--- a/src/explore-education-statistics-frontend/package.json
+++ b/src/explore-education-statistics-frontend/package.json
@@ -13,6 +13,7 @@
     "cross-env": "^7.0.2",
     "cross-fetch": "^3.0.6",
     "date-fns": "^2.16.1",
+    "date-fns-tz": "^2.0.1",
     "explore-education-statistics-common": "workspace:*",
     "express": "^4.18.2",
     "express-basic-auth": "^1.2.0",

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -141,8 +141,8 @@ Validate prerelease has not started
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
 
-    ${tomorrow}=    get current datetime    %Y-%m-%dT00:00:00    1
-    ${day_after_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    2
+    ${tomorrow}=    get current datetime    %Y-%m-%dT00:00:00    1    Europe/London
+    ${day_after_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    2    Europe/London
 
     ${time_start}=    format uk to local datetime    ${tomorrow}    %-d %B %Y at %H:%M
     ${time_end}=    format uk to local datetime    ${day_after_tomorrow}    %-d %B %Y

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -219,8 +219,8 @@ def format_uk_to_local_datetime(uk_local_datetime: str, strf: str) -> str:
     return tz.localize(datetime.datetime.fromisoformat(uk_local_datetime)).astimezone().strftime(strf)
 
 
-def get_current_datetime(strf: str, offset_days: int = 0) -> str:
-    return format_datetime(datetime.datetime.now() + datetime.timedelta(days=offset_days), strf)
+def get_current_datetime(strf: str, offset_days: int = 0, timezone: str = "UTC") -> str:
+    return format_datetime(datetime.datetime.now(pytz.timezone(timezone)) + datetime.timedelta(days=offset_days), strf)
 
 
 def format_datetime(datetime: datetime, strf: str) -> str:


### PR DESCRIPTION
There's a frontend bug caused by the Pre-Release Access screen not correctly accommodating GMT/BST changes. 

The `start` date of the PRA period comes from the backend as GMT. During winter this will be midnight on the first day of PRA, but during summer this will be 23:00 on the day BEFORE the start of PRA. The frontend needs to convert the GMT time to BST, but only during BST dates. 

Native Javascript dates don't accommodate timezones at all, and neither does the `date-fns` package that we use out of the box. Luckily, there's an extension to it which lets us do this -> https://www.npmjs.com/package/date-fns-tz  