### PR TITLE
EES-4704: Rewrite existing Slack Integrations from webhooks to Slack Apps

### DIFF
--- a/.github/workflows/validate-snapshots.yml
+++ b/.github/workflows/validate-snapshots.yml
@@ -78,13 +78,35 @@ jobs:
       - test
     
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ env.GH_TOKEN }}
+
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "Workflow ${{ needs.test.result }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Workflow ${{ needs.test.result }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Workflow*: <https://github.com/dfe-analytical-services/explore-education-statistics/actions/workflows/validate-snapshots.yml|${{ github.workflow }}>\n*Details*: Notification from action run `${{ github.run_number }}`, which ran against commit `${{ github.sha }}` from branch `${{ github.ref_name }}` of the `${{ github.repository }}` repository."
+                  }
+                }
+              ]
+            }
         env:
-          SLACK_USERNAME: Alertbot
-          SLACK_ICON_EMOJI: ':x:'
-          SLACK_COLOR: '#a30200'
-          SLACK_TITLE: Workflow ${{ needs.test.result }}
-          MSG_MINIMAL: actions url
-          SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -24,7 +24,7 @@
       "value": "B1 Basic"
     },
     "slackAlertsChannel": {
-      "value": "#alerts-dev"
+      "value": "C067Z1K68UD"
     },
     "publishReleasesCronSchedule": {
       "value": "0 0 * * * *"

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -27,7 +27,7 @@
       "value": "S1 Standard"
     },
     "slackAlertsChannel": {
-      "value": "#alerts-preprod"
+      "value": "C0681S50SP5"
     },
     "useSubnets": {
       "value": true

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -27,7 +27,7 @@
       "value": "S1 Standard"
     },
     "slackAlertsChannel": {
-      "value": "#alerts"
+      "value": "C01MCTX47E3"
     },
     "publicAppBasicAuth": {
       "value": "false"

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -24,7 +24,7 @@
       "value": "B1 Basic"
     },
     "slackAlertsChannel": {
-      "value": "#alerts-test"
+      "value": "C0681S23291"
     },
     "publishReleasesCronSchedule": {
       "value": "0 0 * * * *"

--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -14,10 +14,10 @@
         "description": "The name of the key vault"
       }
     },
-    "slackWebhook": {
+    "slackAppToken": {
       "type": "string",
       "metadata": {
-        "description": "Slack webhook URI for alerts"
+        "description": "Slack bot user OAuth token for posting alerts"
       }
     },
     "slackAlertsChannel": {
@@ -125,13 +125,15 @@
             },
             "userProperties": [],
             "typeProperties": {
-              "url": "[parameters('slackWebhook')]",
+              "url": "https://slack.com/api/chat.postMessage",
               "method": "POST",
+              "headers": {
+                "Content-Type": "application/json",
+                "Authorization": "[concat('Bearer ', [parameters('slackAppToken'))]"
+              },
               "body": {
                 "channel": "[parameters('slackAlertsChannel')]",
-                "icon_emoji": ":smile",
                 "text": "Data Factory Success!",
-                "username": "Alertbot",
                 "attachments": [{
                   "color": "good",
                   "fields": [{
@@ -173,13 +175,15 @@
             },
             "userProperties": [],
             "typeProperties": {
-              "url": "[parameters('slackWebhook')]",
+              "url": "https://slack.com/api/chat.postMessage",
               "method": "POST",
+              "headers": {
+                "Content-Type": "application/json",
+                "Authorization": "[concat('Bearer ', [parameters('slackAppToken'))]"
+              },
               "body": {
                 "channel": "[parameters('slackAlertsChannel')]",
-                "icon_emoji": ":face_vomiting",
                 "text": "Data Factory Failure!",
-                "username": "Alertbot",
                 "attachments": [
                   {
                     "color": "warning",
@@ -293,13 +297,15 @@
             },
             "userProperties": [],
             "typeProperties": {
-              "url": "[parameters('slackWebhook')]",
+              "url": "https://slack.com/api/chat.postMessage",
               "method": "POST",
+              "headers": {
+                "Content-Type": "application/json",
+                "Authorization": "[concat('Bearer ', [parameters('slackAppToken'))]"
+              },
               "body": {
                 "channel": "[parameters('slackAlertsChannel')]",
-                "icon_emoji": ":smile",
                 "text": "Data Factory Success!",
-                "username": "Alertbot",
                 "attachments": [{
                   "color": "good",
                   "fields": [{
@@ -341,13 +347,15 @@
             },
             "userProperties": [],
             "typeProperties": {
-              "url": "[parameters('slackWebhook')]",
+              "url": "https://slack.com/api/chat.postMessage",
               "method": "POST",
+              "headers": {
+                "Content-Type": "application/json",
+                "Authorization": "[concat('Bearer ', [parameters('slackAppToken'))]"
+              },
               "body": {
                 "channel": "[parameters('slackAlertsChannel')]",
-                "icon_emoji": ":face_vomiting",
                 "text": "Data Factory Failure!",
-                "username": "Alertbot",
                 "attachments": [
                   {
                     "color": "warning",

--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -129,7 +129,7 @@
               "method": "POST",
               "headers": {
                 "Content-Type": "application/json",
-                "Authorization": "[concat('Bearer ', [parameters('slackAppToken'))]"
+                "Authorization": "[concat('Bearer ', [variables('ees-alerts-slackapptoken'))]"
               },
               "body": {
                 "channel": "[parameters('slackAlertsChannel')]",
@@ -179,7 +179,7 @@
               "method": "POST",
               "headers": {
                 "Content-Type": "application/json",
-                "Authorization": "[concat('Bearer ', [parameters('slackAppToken'))]"
+                "Authorization": "[concat('Bearer ', [variables('ees-alerts-slackapptoken'))]"
               },
               "body": {
                 "channel": "[parameters('slackAlertsChannel')]",
@@ -301,7 +301,7 @@
               "method": "POST",
               "headers": {
                 "Content-Type": "application/json",
-                "Authorization": "[concat('Bearer ', [parameters('slackAppToken'))]"
+                "Authorization": "[concat('Bearer ', [variables('ees-alerts-slackapptoken'))]"
               },
               "body": {
                 "channel": "[parameters('slackAlertsChannel')]",
@@ -351,7 +351,7 @@
               "method": "POST",
               "headers": {
                 "Content-Type": "application/json",
-                "Authorization": "[concat('Bearer ', [parameters('slackAppToken'))]"
+                "Authorization": "[concat('Bearer ', [variables('ees-alerts-slackapptoken'))]"
               },
               "body": {
                 "channel": "[parameters('slackAlertsChannel')]",

--- a/infrastructure/templates/datafactory/template.json
+++ b/infrastructure/templates/datafactory/template.json
@@ -47,12 +47,6 @@
     "actionGroupAlerts": {
       "type": "string"
     },
-    "slackAppToken": {
-      "type": "string",
-      "metadata": {
-        "description": "Slack bot user OAuth token for posting alerts"
-      }
-    },
     "slackAlertsChannel": {
       "type": "string",
       "metadata": {
@@ -61,7 +55,8 @@
     }
   },
   "variables":{
-    "templateBaseUrl": "[concat('https://raw.githubusercontent.com/dfe-analytical-services/explore-education-statistics/', parameters('branch'), '/infrastructure/templates/')]"
+    "templateBaseUrl": "[concat('https://raw.githubusercontent.com/dfe-analytical-services/explore-education-statistics/', parameters('branch'), '/infrastructure/templates/')]",
+    "ees-alerts-slackapptoken": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-alerts-slackapptoken')]"
   },
   "resources":[
     {
@@ -93,7 +88,7 @@
             "value": "[parameters('keyVaultName')]"
           },
           "slackAppToken": {
-            "value": "[parameters('slackAppToken')]"
+            "value": "[variables('ees-alerts-slackapptoken')]"
           },
           "slackAlertsChannel": {
             "value": "[parameters('slackAlertsChannel')]"

--- a/infrastructure/templates/datafactory/template.json
+++ b/infrastructure/templates/datafactory/template.json
@@ -47,10 +47,10 @@
     "actionGroupAlerts": {
       "type": "string"
     },
-    "slackWebhook": {
+    "slackAppToken": {
       "type": "string",
       "metadata": {
-        "description": "Slack webhook URI for alerts"
+        "description": "Slack bot user OAuth token for posting alerts"
       }
     },
     "slackAlertsChannel": {
@@ -92,8 +92,8 @@
           "keyVaultName": {
             "value": "[parameters('keyVaultName')]"
           },
-          "slackWebhook": {
-            "value": "[parameters('slackWebhook')]"
+          "slackAppToken": {
+            "value": "[parameters('slackAppToken')]"
           },
           "slackAlertsChannel": {
             "value": "[parameters('slackAlertsChannel')]"

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -621,10 +621,10 @@
       "type": "int",
       "defaultValue": 268435456000
     },
-    "slackWebhook": {
+    "slackAppToken": {
       "type": "string",
       "metadata": {
-        "description": "Slack webhook URI for alerts"
+        "description": "Slack bot user OAuth token for posting alerts"
       }
     },
     "slackAlertsChannel": {
@@ -3480,8 +3480,8 @@
           "actionGroupAlerts": {
             "value": "[variables('actionGroupAlerts')]"
           },
-          "slackWebhook": {
-            "value": "[parameters('slackWebhook')]"
+          "slackAppToken": {
+            "value": "[parameters('slackAppToken')]"
           },
           "slackAlertsChannel": {
             "value": "[parameters('slackAlertsChannel')]"
@@ -4037,13 +4037,15 @@
               "inputs": {
                 "subscribe": {
                   "body": {
-                    "username": "Alertbot",
-                    "icon_emoji": ":face_with_monocle",
                     "channel": "[parameters('slackAlertsChannel')]",
                     "text": "Alert @{triggerBody()?['data']?['essentials']?['monitorCondition']}!\n@{triggerBody()?['data']?['essentials']?['alertRule']}\n@{triggerBody()?['data']?['essentials']?['description']}"
                   },
                   "method": "POST",
-                  "uri": "[parameters('slackWebhook')]"
+                  "uri": "https://slack.com/api/chat.postMessage",
+                  "headers": {
+                    "Content-Type": "application/json",
+                    "Authorization": "[concat('Bearer ', [parameters('slackAppToken'))]"
+                  }
                 },
                 "unsubscribe": {}
               }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -621,12 +621,6 @@
       "type": "int",
       "defaultValue": 268435456000
     },
-    "slackAppToken": {
-      "type": "string",
-      "metadata": {
-        "description": "Slack bot user OAuth token for posting alerts"
-      }
-    },
     "slackAlertsChannel": {
       "type": "string",
       "metadata": {
@@ -1073,6 +1067,8 @@
     "keyVaultName": "[concat(parameters('subscription'), '-kv-', parameters('environment'), '-01')]",
 
     "ees-admin-govuknotify-api-key": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-admin-govuknotify-api-key')]",
+
+    "ees-alerts-slackapptoken": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-alerts-slackapptoken')]",
 
     "ees-notifier-govuknotify-api-key": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-notifier-govuknotify-api-key')]",
     "ees-notifier-token-secret-key": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-notifier-token-secret-key')]",
@@ -3481,7 +3477,7 @@
             "value": "[variables('actionGroupAlerts')]"
           },
           "slackAppToken": {
-            "value": "[parameters('slackAppToken')]"
+            "value": "[variables('ees-alerts-slackapptoken')]"
           },
           "slackAlertsChannel": {
             "value": "[parameters('slackAlertsChannel')]"
@@ -4044,7 +4040,7 @@
                   "uri": "https://slack.com/api/chat.postMessage",
                   "headers": {
                     "Content-Type": "application/json",
-                    "Authorization": "[concat('Bearer ', [parameters('slackAppToken'))]"
+                    "Authorization": "[concat('Bearer ', [variables('ees-alerts-slackapptoken'))]"
                   }
                 },
                 "unsubscribe": {}

--- a/tests/robot-tests/.env.example
+++ b/tests/robot-tests/.env.example
@@ -25,3 +25,4 @@ IMPLICIT_WAIT=15 # Variable used throughout tests (in seconds)
 FAIL_TEST_SUITES_FAST=1 # ("0" or "1") Fails entire test suite after any failure
 IDENTITY_PROVIDER= # ("AZURE" or "KEYCLOAK") opt into using either a Keycloak or Azure based identity provider
 PUBLISHER_FUNCTIONS_URL=http://localhost:7072 # The base URL for the Publisher Functions project for the environment
+SLACK_BOT_TOKEN= # The "Bot User OAuth Token" used by the Slack app to send channel alerts

--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -238,21 +238,14 @@ class SnapshotService:
                 blocks=[
                     {
                         "type": "header",
-                        "text": {
-                            "type": "plain_text",
-                            "text": "Snapshots do not match. See pull request for more details",
-                        },
+                        "text": {"type": "plain_text", "text": ":warning: Snapshots do not match"},
                     },
                     {
-                        "type": "actions",
-                        "elements": [
-                            {
-                                "type": "button",
-                                "style": "danger",
-                                "text": {"type": "plain_text", "text": "View pull request"},
-                                "url": "https://github.com/dfe-analytical-services/explore-education-statistics/pulls/dfe-sdt",
-                            }
-                        ],
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "See <https://github.com/dfe-analytical-services/explore-education-statistics/pulls/dfe-sdt|pull request> for more details",
+                        },
                     },
                 ]
             ) if self.slack_webhook_url else print("Snapshot script complete. Snapshots do not match")

--- a/tests/robot-tests/tests/libs/slack.py
+++ b/tests/robot-tests/tests/libs/slack.py
@@ -1,9 +1,7 @@
 import datetime
-import json
 import os
 import shutil
 
-import requests
 from bs4 import BeautifulSoup
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
@@ -17,13 +15,9 @@ PATH = f"{os.getcwd()}{os.sep}test-results"
 class SlackService:
     def __init__(self):
         self.slack_bot_token = os.getenv("SLACK_BOT_TOKEN")
-        self.report_webhook_url = os.getenv("SLACK_TEST_REPORT_WEBHOOK_URL")
 
         if self.slack_bot_token is None:
             raise AssertionError(f"SLACK_BOT_TOKEN is not set")
-
-        if self.report_webhook_url is None:
-            raise AssertionError(f"SLACK_TEST_REPORT_WEBHOOK_URL is not set")
 
         self.client = WebClient(token=self.slack_bot_token)
 
@@ -38,77 +32,97 @@ class SlackService:
         failed_tests = int(tests["fail"])
         passed_tests = int(tests["pass"])
 
-        failed_test_suites_field = ({},)
-
-        if suites_failed:
-            failed_test_suites_field = {"title": "Failed test suites", "value": "\n".join(suites_failed)}
-        return [
+        blocks = [
             {
-                "pretext": "All results",
-                "color": "danger" if suites_failed else "good",
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": f"{':warning:' if suites_failed else ':white_check_mark:'} All results",
+                },
+            },
+            {
+                "type": "section",
                 "fields": [
-                    {"title": "Environment", "value": env},
-                    {"title": "Suite", "value": suites_ran.replace("tests/", "")},
-                    {"title": "Total runs", "value": run_index + 1},
-                    {"title": "Total test cases", "value": passed_tests + failed_tests},
-                    {"title": "Passed test cases", "value": passed_tests},
-                    {"title": "Failed test cases", "value": failed_tests},
-                    {"title": "Failed test suites", "value": len(suites_failed)},
-                    failed_test_suites_field,
+                    {"type": "mrkdwn", "text": f"*Environment*\n{env}"},
+                    {"type": "mrkdwn", "text": f"*Suite*\n{suites_ran.replace('tests/', '')}"},
+                    {"type": "mrkdwn", "text": f"*Total runs*\n{run_index + 1}"},
+                    {"type": "mrkdwn", "text": f"*Total test cases*\n{passed_tests + failed_tests}"},
+                    {"type": "mrkdwn", "text": f"*Passed test cases*\n{passed_tests}"},
+                    {"type": "mrkdwn", "text": f"*Failed test cases*\n{failed_tests}"},
                 ],
-            }
+            },
         ]
 
+        if suites_failed:
+            failed_test_suites_list_items = []
+
+            for suite in suites_failed:
+                failed_test_suites_list_items.append(
+                    {"type": "rich_text_section", "elements": [{"type": "text", "text": suite}]}
+                )
+
+            blocks += [
+                {"type": "divider"},
+                {"type": "section", "text": {"type": "mrkdwn", "text": f"*Failed test suites* ({len(suites_failed)})"}},
+                {
+                    "type": "rich_text",
+                    "elements": [
+                        {"type": "rich_text_list", "style": "bullet", "elements": failed_test_suites_list_items}
+                    ],
+                },
+            ]
+
+        return blocks
+
     def _build_exception_details_attachments(self, env: str, suites_ran: str, run_index: int, ex: Exception):
+        ex_stripped = repr(ex).replace("\n", "")
+        suites_ran_conditional = "N/A" if not suites_ran else suites_ran.replace("tests/", "")
+
         return [
+            {"type": "header", "text": {"type": "plain_text", "text": ":x: UI test pipeline failure"}},
             {
-                "pretext": "UI test pipeline failure",
-                "color": "danger",
+                "type": "section",
                 "fields": [
-                    {"title": "Environment", "value": env},
-                    {"title": "Suite", "value": suites_ran.replace("tests/", "")},
-                    {"title": "Run number", "value": run_index + 1},
-                    {"title": "Error encountered", "value": f"{ex}"},
+                    {"type": "mrkdwn", "text": f"*Environment*\n{env}"},
+                    {"type": "mrkdwn", "text": f"*Suite*\n{suites_ran_conditional}"},
+                    {"type": "mrkdwn", "text": f"*Run number*\n{run_index + 1}"},
                 ],
-            }
+            },
+            {"type": "divider"},
+            {"type": "section", "text": {"type": "mrkdwn", "text": f"*Error details*\n{ex_stripped}"}},
         ]
 
     def send_test_report(self, env: str, suites_ran: str, suites_failed: [], run_index: int):
         attachments = self._build_test_results_attachments(env, suites_ran, suites_failed, run_index)
 
-        webhook_url = self.report_webhook_url
-        slack_bot_token = self.slack_bot_token
-
-        response = requests.post(
-            url=webhook_url, data=json.dumps({"attachments": attachments}), headers={"Content-Type": "application/json"}
-        )
-        assert response.status_code == 200, logger.warn(f"Response wasn't 200, it was {response}")
-
-        logger.info("Sent UI test statistics to #build")
+        response = self.client.chat_postMessage(channel="CGNHH80CV", text="All results", blocks=attachments)
 
         if suites_failed:
-            client = WebClient(token=slack_bot_token)
-
             date = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
 
             report_name = f"UI-test-report-{suites_ran.replace('tests/', '')}-{env}-{date}.zip"
 
             shutil.make_archive(report_name.replace(".zip", ""), "zip", PATH)
             try:
-                client.files_upload(channels="#build", file=report_name, title=report_name)
+                self.client.files_upload_v2(
+                    channel="CGNHH80CV", file=report_name, title=report_name, thread_ts=response.data["ts"]
+                )
             except SlackApiError as e:
                 logger.error(f"Error uploading test report: {e}")
             os.remove(report_name)
             logger.info("Sent UI test report to #build")
 
+        assert response.status_code == 200, logger.warn(f"Response wasn't 200, it was {response}")
+
+        logger.info("Sent UI test statistics to #build")
+
     def send_exception_details(self, env: str, suites_ran: str, run_index: int, ex: Exception):
         attachments = self._build_exception_details_attachments(env, suites_ran, run_index, ex)
 
-        webhook_url = self.report_webhook_url
-
-        response = requests.post(
-            url=webhook_url, data=json.dumps({"attachments": attachments}), headers={"Content-Type": "application/json"}
+        response = self.client.chat_postMessage(
+            text=":x: UI test pipeline failure", channel="CGNHH80CV", blocks=attachments
         )
+
         assert response.status_code == 200, logger.warn(f"Response wasn't 200, it was {response}")
 
         logger.info("Sent UI exception details to #build")


### PR DESCRIPTION
Various webhooks were implemented by a colleague who has since left the team. Deactivating their Slack account causes the integrations to be removed, thus losing the various features integrated by custom scripts and third party apps. The independent "Incoming Webhooks" Slack app is also deprecated, and has been superseded by webhooks and APIs which can be implemented by a custom Slack workspace app. This method also allows additional "collaborators" to view and edit the app's config, and reinstall to the workspace when necessary, without the reliance on a single user account.

The changes replace existing "Incoming Webook" and custom app behaviour with a single custom app, currently named EESBot".

The options considered during development were:

1. Custom hand-written API, implementing the Slack API to funnel all messages through
**Pro**: full control of message content
**Con**: excessive amount of work compared with alternatives (i.e. an additional deployment and codebase to maintain), most of the existing implementations only needed a simple message posting (which can just be done with a webhook), potential difficulties integrating 3rd party app notifications

2. An app for each purpose/integration
**Pro**: would be clear from the app name/description what the purpose/source of the notifications were
**Con**: multiple apps to configure and maintain. New integrations would require a new app creating/configuring alongside the task, rather than just adding another webhook to the existing app

3. A single app to funnels all integrations through 👈
**Pro**: easier to configure and maintain a single, central app
**Con**: some third party integrations post a pre-defined message which can't be customised, so it's not always clear where the messages originated from