### PR TITLE
Remove ad hoc Playwright test from pipeline

### DIFF
--- a/tests/playwright-tests/.env.example
+++ b/tests/playwright-tests/.env.example
@@ -1,6 +1,6 @@
 PUBLIC_URL=http://localhost:3000  # URL of the public frontend
-PUBLIC_USERNAME=dfe
-PUBLIC_PASSWORD=dataresearch
+PUBLIC_USERNAME=PUBLIC_USERNAME
+PUBLIC_PASSWORD=PUBLIC_PASSWORD
 ADMIN_URL=https://localhost:5021  # URL for the Admin frontend
 ADMIN_EMAIL=ADMIN_EMAIL  # BAU1 user email
 ADMIN_PASSWORD=ADMIN_PASSWORD  # BAU1 user password

--- a/tests/playwright-tests/.env.example
+++ b/tests/playwright-tests/.env.example
@@ -1,4 +1,6 @@
 PUBLIC_URL=http://localhost:3000  # URL of the public frontend
+PUBLIC_USERNAME=dfe
+PUBLIC_PASSWORD=dataresearch
 ADMIN_URL=https://localhost:5021  # URL for the Admin frontend
 ADMIN_EMAIL=ADMIN_EMAIL  # BAU1 user email
 ADMIN_PASSWORD=ADMIN_PASSWORD  # BAU1 user password

--- a/tests/playwright-tests/playwright.config.ts
+++ b/tests/playwright-tests/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
+import environment from '@util/env';
+
+const { PUBLIC_USERNAME, PUBLIC_PASSWORD } = environment;
 
 /**
  * Read environment variables from file.
@@ -6,6 +9,11 @@ import { defineConfig, devices } from '@playwright/test';
  */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
+
+const encodeBasicAuth = (username: string, password: string) => {
+  const unencodedString = `${username}:${password}`;
+  return `Basic ${btoa(unencodedString)}`;
+};
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -25,6 +33,9 @@ export default defineConfig({
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
+    extraHTTPHeaders: {
+      Authorization: encodeBasicAuth(PUBLIC_USERNAME, PUBLIC_PASSWORD),
+    },
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: ' ',
 

--- a/tests/playwright-tests/tests/public/redirects.spec.ts
+++ b/tests/playwright-tests/tests/public/redirects.spec.ts
@@ -41,11 +41,11 @@ test.describe('Redirect behaviour', () => {
   test('Routes without an absolute path still permit trailing slashes', async ({
     page,
   }) => {
-    await page.goto('http://localhost:3000');
-    await expect(page).toHaveURL('http://localhost:3000/');
+    await page.goto(`${PUBLIC_URL}`);
+    await expect(page).toHaveURL(`${PUBLIC_URL}/`);
 
-    await page.goto('http://localhost:3000/');
-    await expect(page).toHaveURL('http://localhost:3000/');
+    await page.goto(`${PUBLIC_URL}/`);
+    await expect(page).toHaveURL(`${PUBLIC_URL}/`);
   });
 
   test('meta-guidance is redirected to data-guidance', async ({ page }) => {
@@ -77,7 +77,7 @@ test.describe('Redirect behaviour', () => {
   // Not ideal, I'd rather it.each like Jest has. But from the docs:
   // https://playwright.dev/docs/test-parameterize
   for (const redirect of seoRedirects) {
-    test(`Redirects from ${redirect.from}`, async ({ page }) => {
+    test.skip(`Redirects from ${redirect.from}`, async ({ page }) => {
       await page.goto(`${PUBLIC_URL}${redirect.from}`);
       await expect(page).toHaveURL(`${PUBLIC_URL}${redirect.to}`);
     });

--- a/tests/playwright-tests/utils/env.ts
+++ b/tests/playwright-tests/utils/env.ts
@@ -5,6 +5,8 @@ dotenv.config();
 
 const environment = {
   PUBLIC_URL: process.env.PUBLIC_URL ?? '',
+  PUBLIC_USERNAME: process.env.PUBLIC_USERNAME ?? '',
+  PUBLIC_PASSWORD: process.env.PUBLIC_PASSWORD ?? '',
   ADMIN_URL: process.env.ADMIN_URL ?? '',
   ADMIN_EMAIL: process.env.ADMIN_EMAIL ?? '',
   ADMIN_PASSWORD: process.env.ADMIN_PASSWORD ?? '',


### PR DESCRIPTION
Whilst we were reviewing Playwright as a tool and deciding whether or not to proceed, I used it to automate my testing of all the new SEO redirects locally. 
I then forgot to go back and remove this before the Playwright tests were included in the pipelines. 

This PR skips the big lengthy redirect test, and also replaces an occurrence of `localhost` with the correct environment base url. 