### PR TITLE
EES-4662 Set DataSetFileMeta after importing a new data set

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataSetFileMetaMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataSetFileMetaMigrationController.cs
@@ -1,0 +1,133 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+[Route("api")]
+[ApiController]
+[Authorize(Roles = RoleNames.BauUser)]
+public class DataSetFileMetaMigrationController : ControllerBase
+{
+    private readonly ContentDbContext _contentDbContext;
+    private readonly StatisticsDbContext _statisticsDbContext;
+
+    public DataSetFileMetaMigrationController(
+        ContentDbContext contentDbContext,
+        StatisticsDbContext statisticsDbContext)
+    {
+        _contentDbContext = contentDbContext;
+        _statisticsDbContext = statisticsDbContext;
+    }
+
+    public class DataSetFileMetaMigrationResult
+    {
+        public bool IsDryRun;
+        public int Processed;
+        public int LeftToProcess;
+    }
+
+    public class Observation
+    {
+        public GeographicLevel GeographicLevel;
+        public int Year;
+        public TimeIdentifier TimeIdentifier;
+    }
+
+    [HttpPatch("bau/migrate-datasetfilemeta")]
+    public async Task<DataSetFileMetaMigrationResult> MigrateReleaseSeries(
+        [FromQuery] bool dryRun = true,
+        [FromQuery] int? num = null,
+        CancellationToken cancellationToken = default)
+    {
+        var filesQueryable = _contentDbContext.Files
+            .Where(f =>
+                f.DataSetFileMeta == null
+                && f.Type == FileType.Data);
+
+        if (num is > 0)
+        {
+            filesQueryable = filesQueryable.Take(num.Value);
+        }
+
+        var files = await filesQueryable.ToListAsync(cancellationToken: cancellationToken);
+
+        var numDataSetFileMetaSet = 0;
+
+        foreach (var file in files)
+        {
+            var observations = await _statisticsDbContext.Observation
+                .AsNoTracking()
+                .Where(o => o.SubjectId == file.SubjectId)
+                .Select(o => new Observation
+                {
+                    GeographicLevel = o.Location.GeographicLevel,
+                    Year = o.Year,
+                    TimeIdentifier = o.TimeIdentifier,
+                })
+                .ToListAsync(cancellationToken: cancellationToken);
+
+            var geographicLevels = observations
+                .Select(o => o.GeographicLevel.GetEnumLabel())
+                .Distinct()
+                .OrderBy(gl => gl)
+                .ToList();
+
+            var timePeriods = observations
+                .Select(o => (o.Year, o.TimeIdentifier))
+                .Distinct()
+                .OrderBy(tp => tp.Year)
+                .ToList();
+
+            var filters = await _statisticsDbContext.Filter
+                .Where(f => f.SubjectId == file.SubjectId)
+                .Select(f => new FilterMeta { Id = f.Id, Label = f.Label, })
+                .ToListAsync(cancellationToken: cancellationToken);
+
+            var indicators = await _statisticsDbContext.Indicator
+                .Where(i => i.IndicatorGroup.SubjectId == file.SubjectId)
+                .Select(i => new IndicatorMeta
+                {
+                    Id = i.Id,
+                    Label = i.Label,
+                }).ToListAsync(cancellationToken: cancellationToken);
+
+            file.DataSetFileMeta = new DataSetFileMeta
+            {
+                GeographicLevels = geographicLevels,
+                TimeIdentifier = timePeriods[0].TimeIdentifier,
+                Years = timePeriods.Select(tp => tp.Year).ToList(),
+                Filters = filters,
+                Indicators = indicators,
+            };
+
+            numDataSetFileMetaSet++;
+        }
+
+        if (!dryRun)
+        {
+            await _contentDbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return new DataSetFileMetaMigrationResult
+        {
+            IsDryRun = dryRun,
+            Processed = numDataSetFileMetaSet,
+            LeftToProcess = _contentDbContext.Files
+                .Count(f =>
+                    f.DataSetFileMeta == null
+                    && f.Type == FileType.Data),
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240411101622_EES4662_AddDataSetFileMetaColumnToFilesTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240411101622_EES4662_AddDataSetFileMetaColumnToFilesTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240411101622_EES4662_AddDataSetFileMetaColumnToFilesTable")]
+    partial class EES4662_AddDataSetFileMetaColumnToFilesTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240411101622_EES4662_AddDataSetFileMetaColumnToFilesTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240411101622_EES4662_AddDataSetFileMetaColumnToFilesTable.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES4662_AddDataSetFileMetaColumnToFilesTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DataSetFileMeta",
+                table: "Files",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataSetFileMeta",
+                table: "Files");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -23,6 +23,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -1826,7 +1827,8 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
     }
 
     private WebApplicationFactory<TestStartup> BuildApp(
-        ContentDbContext? contentDbContext = null)
+        ContentDbContext? contentDbContext = null,
+        StatisticsDbContext? statisticsDbContext = null)
     {
         return TestApp
             .ResetDbContexts()
@@ -1837,6 +1839,7 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                 services.AddTransient<IDataSetFileService>(
                     s => new DataSetFileService(
                         contentDbContext ?? s.GetRequiredService<ContentDbContext>(),
+                        statisticsDbContext ?? s.GetRequiredService<StatisticsDbContext>(),
                         s.GetRequiredService<IReleaseVersionRepository>()));
             });
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+public class DataSetFileMeta
+{
+    public List<string> GeographicLevels { get; set; } = new();
+
+    [JsonConverter(typeof(TimeIdentifierJsonConverter))]
+    public TimeIdentifier TimeIdentifier { get; set; }
+
+    public List<int> Years { get; set; } = new();
+
+    public List<FilterMeta> Filters { get; set; } = new();
+
+    public List<IndicatorMeta> Indicators { get; set; } = new();
+}
+
+public class FilterMeta
+{
+    public Guid Id { get; set; }
+    public string Label { get; set; }
+}
+
+public class IndicatorMeta
+{
+    public Guid Id { get; set; }
+    public string Label { get; set; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -418,7 +418,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 entity.Property(e => e.Created)
                     .HasConversion(
                         v => v,
-                        v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
+                        v => v.HasValue
+                            ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
+                            : null);
+                entity.Property(p => p.DataSetFileMeta)
+                    .HasConversion(
+                        v => JsonConvert.SerializeObject(v),
+                        v => JsonConvert.DeserializeObject<DataSetFileMeta>(v));
             });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -22,6 +22,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public int? DataSetFileVersion { get; set; }
 
+        public DataSetFileMeta?  DataSetFileMeta { get; set; }
+
         public Guid? ReplacedById { get; set; }
 
         public File? ReplacedBy { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseDataFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseDataFileRepository.cs
@@ -64,6 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                     DataSetFileVersion = type != Data
                         ? null
                         : replacingDataFile?.DataSetFileVersion + 1 ?? 0,
+                    DataSetFileMeta = null, // If FileType.Data, this is set when import is complete
                     Filename = filename,
                     ContentLength = contentLength,
                     ContentType = "text/csv",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
@@ -1,0 +1,16 @@
+namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+
+public record DataSetFileMetaViewModel
+{
+    public List<string> GeographicLevels { get; init; } = new();
+    public DataSetFileTimePeriodViewModel TimePeriod { get; init; } = new();
+    public List<string> Filters { get; init; } = new();
+    public List<string> Indicators { get; init; } = new();
+}
+
+public record DataSetFileTimePeriodViewModel
+{
+    public string TimeIdentifier { get; init; } = string.Empty;
+    public string From { get; init; } = string.Empty;
+    public string To { get; init; } = string.Empty;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileSummaryViewModel.cs
@@ -27,4 +27,6 @@ public record DataSetFileSummaryViewModel
     public bool LatestData { get; init; }
 
     public DateTime Published { get; init; }
+
+    public DataSetFileMetaViewModel Meta { get; init; } = null!;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileViewModel.cs
@@ -15,6 +15,8 @@ public record DataSetFileViewModel
     public DataSetFileFileViewModel File { get; init; } = null!;
 
     public DataSetFileReleaseViewModel Release { get; init; } = null!;
+
+    public DataSetFileMetaViewModel Meta { get; init; } = null!;
 }
 
 public record DataSetFilePublicationViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
@@ -58,6 +58,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     import.Id, COMPLETE, 100))
                 .Returns(Task.CompletedTask);
 
+            dataImportService
+                .Setup(s => s.WriteDataSetFileMeta(
+                    import.SubjectId))
+                .Returns(Task.CompletedTask);
+
             var statisticsDbContextId = Guid.NewGuid().ToString();
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -206,7 +211,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     var file = new File
                     {
                         Id = Guid.NewGuid(),
-                        Filename = "my_data_file.csv"
+                        Filename = "my_data_file.csv",
                     };
 
                     var import = new DataImport
@@ -223,7 +228,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     var statisticsDbContextId = Guid.NewGuid().ToString();
 
                     await using var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId);
-                    var service = BuildFileImportService();
+
+                    var dataImportService = new Mock<IDataImportService>(Strict);
+                    dataImportService.Setup(mock => mock.WriteDataSetFileMeta(import.SubjectId))
+                        .Returns(Task.CompletedTask);
+
+                    var service = BuildFileImportService(dataImportService: dataImportService.Object);
                     await service.CheckComplete(import, statisticsDbContext);
                 });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -102,6 +102,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     "mark as completed or failed",
                     import.File.Filename,
                     import.Status);
+
+                if (import.Status == COMPLETE)
+                {
+                    await _dataImportService.WriteDataSetFileMeta(import.SubjectId);
+                }
+
                 return;
             }
 
@@ -133,6 +139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 if (import.Errors.Count == 0)
                 {
                     await _dataImportService.UpdateStatus(import.Id, COMPLETE, 100);
+                    await _dataImportService.WriteDataSetFileMeta(import.SubjectId);
                 }
                 else
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
@@ -19,6 +19,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Int
 
         Task UpdateStatus(Guid id, DataImportStatus newStatus, double percentageComplete);
 
+        Task WriteDataSetFileMeta(Guid subjectId);
+
         Task Update(
             Guid id,
             int? expectedImportedRows = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
@@ -61,6 +61,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                         expectedImportedRows: result.ImportableRowCount,
                         totalRows: result.TotalRowCount,
                         geographicLevels: result.GeographicLevels);
+                    // @MarkFix Can we get everything we need for DataSetFileMeta here,
+                    // so we can set it?
                 })
                 .OnFailureDo(async errors =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
@@ -262,6 +262,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     fixedInformationReader.GetTimeIdentifier(rowValues);
                     fixedInformationReader.GetYear(rowValues);
 
+                    // @MarkFix alongside GeogLvl, also get Filters/Indicators/TimePeriods here?
+
                     var level = fixedInformationReader.GetGeographicLevel(rowValues);
                     
                     if (rowCountByGeographicLevel.ContainsKey(level))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
@@ -83,7 +83,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                         {
                             var releaseFile = releaseFiles.First(rf => rf.File.SubjectId == rs.SubjectId);
 
-                            return new SubjectViewModel(
+                            return new SubjectViewModel( // @MarkFix how to get what I need
                                 id: rs.SubjectId,
                                 name: releaseFile.Name ?? string.Empty,
                                 order: releaseFile.Order,

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -105,12 +105,9 @@ export default function DataSetFilePage({ dataSetFileId }: Props) {
 
   const {
     file,
-    filters,
-    geographicLevels,
-    indicators,
     release,
     summary,
-    timePeriods,
+    meta: { timePeriod, filters, geographicLevels, indicators },
     title,
   } = dataSetFile;
 
@@ -255,9 +252,9 @@ export default function DataSetFilePage({ dataSetFileId }: Props) {
                       </CollapsibleList>
                     </SummaryListItem>
                   )}
-                  {timePeriods && (timePeriods.from || timePeriods.to) && (
+                  {timePeriod && (timePeriod.from || timePeriod.to) && (
                     <SummaryListItem term="Time period">
-                      {getTimePeriodString(timePeriods)}
+                      {getTimePeriodString(timePeriod)}
                     </SummaryListItem>
                   )}
                 </SummaryList>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
@@ -10,9 +10,16 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     fileId: 'file-id-1',
     filename: 'file-name-1',
     fileSize: '100 kb',
-    filters: ['Filter 1', 'Filter 2'],
-    geographicLevels: ['National', 'Regional'],
-    indicators: ['Indicator 1', 'Indicator 2'],
+    meta: {
+      timePeriod: {
+        timeIdentifier: 'Calendar year',
+        from: '2010',
+        to: '2020',
+      },
+      filters: ['Filter 1', 'Filter 2'],
+      geographicLevels: ['National', 'Regional'],
+      indicators: ['Indicator 1', 'Indicator 2'],
+    },
     latestData: true,
     publication: {
       id: 'publication-1',
@@ -28,10 +35,6 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
       id: 'theme-1',
       title: 'Theme 1',
     },
-    timePeriods: {
-      from: '2010',
-      to: '2020',
-    },
     title: 'Data set 1',
   },
   {
@@ -40,9 +43,16 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     fileId: 'file-id-2',
     filename: 'file-name-2',
     fileSize: '100 kb',
-    filters: ['Filter 1', 'Filter 2'],
-    geographicLevels: ['National', 'Regional'],
-    indicators: ['Indicator 1', 'Indicator 2'],
+    meta: {
+      timePeriod: {
+        timeIdentifier: 'Calendar year',
+        from: '2010',
+        to: '2020',
+      },
+      filters: ['Filter 1', 'Filter 2'],
+      geographicLevels: ['National', 'Regional'],
+      indicators: ['Indicator 1', 'Indicator 2'],
+    },
     latestData: true,
     publication: {
       id: 'publication-1',
@@ -58,10 +68,6 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
       id: 'theme-2',
       title: 'Theme 2',
     },
-    timePeriods: {
-      from: '2010',
-      to: '2020',
-    },
     title: 'Data set 2',
   },
   {
@@ -70,9 +76,16 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     fileId: 'file-id-3',
     filename: 'file-name-3',
     fileSize: '100 kb',
-    filters: ['Filter 1', 'Filter 2'],
-    geographicLevels: ['National', 'Regional'],
-    indicators: ['Indicator 1', 'Indicator 2'],
+    meta: {
+      timePeriod: {
+        timeIdentifier: 'Calendar year',
+        from: '2010',
+        to: '2020',
+      },
+      filters: ['Filter 1', 'Filter 2'],
+      geographicLevels: ['National', 'Regional'],
+      indicators: ['Indicator 1', 'Indicator 2'],
+    },
     latestData: true,
     publication: {
       id: 'publication-2',
@@ -87,10 +100,6 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     theme: {
       id: 'theme-2',
       title: 'Theme 2',
-    },
-    timePeriods: {
-      from: '2010',
-      to: '2020',
     },
     title: 'Data set 3',
   },
@@ -115,12 +124,14 @@ export const testDataSet: DataSetFile = {
   },
   summary: 'Data set 1 summary',
   title: 'Data set 1',
-  // These aren't in the backend yet, so may change.
-  filters: ['Filter 1', 'Filter 2'],
-  geographicLevels: ['Local authority', 'National'],
-  indicators: ['Indicator 1', 'Indicator 2'],
-  timePeriods: {
-    from: '2023',
-    to: '2024',
+  meta: {
+    timePeriod: {
+      timeIdentifier: 'Calendar year',
+      from: '2023',
+      to: '2024',
+    },
+    filters: ['Filter 1', 'Filter 2'],
+    geographicLevels: ['Local authority', 'National'],
+    indicators: ['Indicator 1', 'Indicator 2'],
   },
 };

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
@@ -37,15 +37,21 @@ export default function DataSetFileSummary({
     id: dataSetFileId,
     content,
     fileId,
-    filters = [],
-    geographicLevels = [],
-    indicators = [],
+    meta: {
+      timePeriod = {
+        timeIdentifier: undefined,
+        from: undefined,
+        to: undefined,
+      },
+      filters = [],
+      geographicLevels = [],
+      indicators = [],
+    },
     latestData,
     publication,
     published,
     release,
     theme,
-    timePeriods = {},
     title,
   } = dataSetFile;
   const [showMoreContent, toggleMoreContent] = useToggle(false);
@@ -176,14 +182,14 @@ export default function DataSetFileSummary({
             </CollapsibleList>
           </SummaryListItem>
         )}
-        {(timePeriods.from || timePeriods.to) && (
+        {(timePeriod.from || timePeriod.to) && (
           <SummaryListItem
             className={classNames({
               'dfe-js-hidden': !showDetails,
             })}
             term="Time period"
           >
-            {getTimePeriodString(timePeriods)}
+            {getTimePeriodString(timePeriod)}
           </SummaryListItem>
         )}
         <SummaryListItem

--- a/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
+++ b/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
@@ -5,6 +5,8 @@ import { SortDirection } from '@common/services/types/sort';
 
 export interface DataSetFile {
   id: string;
+  title: string;
+  summary: string;
   file: { id: string; name: string; size: string };
   release: {
     id: string;
@@ -20,26 +22,26 @@ export interface DataSetFile {
     title: string;
     type: ReleaseType;
   };
-  summary: string;
-  title: string;
-  // These aren't in the backend yet, so may change.
-  filters: string[];
-  geographicLevels: string[];
-  indicators: string[];
-  timePeriods: {
-    from?: string;
-    to?: string;
+  meta: {
+    geographicLevels: string[];
+    timePeriod: {
+      timeIdentifier: string;
+      from: string;
+      to: string;
+    };
+    filters: string[];
+    indicators: string[];
   };
 }
 
 export interface DataSetFileSummary {
   id: string;
-  content: string;
   fileId: string;
   filename: string;
   fileSize: string;
   fileExtension: string;
   title: string;
+  content: string;
   theme: {
     id: string;
     title: string;
@@ -54,14 +56,16 @@ export interface DataSetFileSummary {
   };
   latestData: boolean;
   published: Date;
-  // These aren't in the backend yet, so may change.
-  timePeriods: {
-    from?: string;
-    to?: string;
+  meta: {
+    geographicLevels: string[];
+    timePeriod: {
+      timeIdentifier: string;
+      from: string;
+      to: string;
+    };
+    filters: string[];
+    indicators: string[];
   };
-  geographicLevels: string[];
-  filters: string[];
-  indicators: string[];
 }
 
 export const dataSetFileSortOptions = [


### PR DESCRIPTION
Draft PR to review the changes made so far.

The unit tests are broken, but the functionality of displaying filters/indicators/etc. on the Data catalogue page and the Data catalogue's data set pages is working.

If you run this locally, you'll need to use the Admin endpoint `PATCH {admin_api_url}/bau/migrate-datasetfilemeta?dryRun=false` to set the DataSetFileMeta for existing files.