### PR TITLE
EES-5049 Configure Admin's connection to the Public Data PostgreSQL database in Azure environments

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -112,6 +112,9 @@
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
+    },
+    "publicDataDbExists": {
+      "value": false
     }
   }
 }

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -88,6 +88,9 @@
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
+    },
+    "publicDataDbExists": {
+      "value": false
     }
   }
 }

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -91,6 +91,9 @@
     },
     "maxStatsDbSizeBytes": {
       "value": 1020054732800
+    },
+    "publicDataDbExists": {
+      "value": false
     }
   }
 }

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -94,6 +94,9 @@
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
+    },
+    "publicDataDbExists": {
+      "value": false
     }
   }
 }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -664,6 +664,13 @@
       "metadata": {
         "description": "The password to log in to the Container registry"
       }
+    },
+    "publicDataDbExists": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Flag to determine if the public data database exists. TODO EES-5073 remove this when the public data database is available in every environment"
+      }
     }
   },
   "variables": {
@@ -1722,7 +1729,8 @@
         "enableThemeDeletion": "[parameters('enableThemeDeletion')]",
         "ReleaseApproval:PublishReleasesCronSchedule": "[parameters('publishReleasesCronSchedule')]",
         "ReleaseApproval:PublishReleaseContentCronSchedule": "[parameters('publishReleaseContentCronSchedule')]",
-        "TableBuilder:MaxTableCellsAllowed": "[parameters('tableBuilderMaxTableCellsAllowed')]"
+        "TableBuilder:MaxTableCellsAllowed": "[parameters('tableBuilderMaxTableCellsAllowed')]",
+        "PublicDataDbExists": "[parameters('publicDataDbExists')]"
       }
     },
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -38,5 +38,6 @@
   "ReleaseApproval": {
     "PublishReleasesCronSchedule": "0 0-58/2 * * * *",
     "PublishReleaseContentCronSchedule": "0 1-59/2 * * * *"
-  }
+  },
+  "PublicDataDbExists": true
 }


### PR DESCRIPTION
This PR configures the Admin's connection to the Public Data PostgreSQL database in Azure environments.

It builds on configuration for the Admin's connection to this database already added by EES-4908 in https://github.com/dfe-analytical-services/explore-education-statistics/pull/4745. This added configuration for the database connection in the local environment.

Connecting in Azure environments depends on the Admin having its own database principal in the Public Data database.
This is a manual step that will happen when the database is available in each environment.

It also relies on the Admin's database principal being granted permissions on tables in the database. Configuration to add this automatically was added by https://github.com/dfe-analytical-services/explore-education-statistics/pull/4750.

When the database is available and the Admin's database principal has been granted permissions in each environment we can enable the connection by changing the appropriate `<env>.parameters.json`.

```json
    "publicDataDbExists": {
      "value": false
    }
```

needs changing to 

```json
    "publicDataDbExists": {
      "value": true
    }
```