### PR TITLE
EES-5070 Add `DataSetVersionImport` to the Public Data model

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
@@ -114,6 +114,11 @@ public static class DataSetVersionGeneratorExtensions
         this Generator<DataSetVersion> generator)
         => generator.ForInstance(s => s.SetGeographicLevelMeta());
 
+    public static Generator<DataSetVersion> WithImports(
+        this Generator<DataSetVersion> generator,
+        Func<IEnumerable<DataSetVersionImport>> imports)
+        => generator.ForInstance(s => s.SetImports(imports));
+
     public static Generator<DataSetVersion> WithLocationMetas(
         this Generator<DataSetVersion> generator,
         Func<IEnumerable<LocationMeta>> metas)
@@ -299,6 +304,27 @@ public static class DataSetVersionGeneratorExtensions
             }
         );
 
+    public static InstanceSetters<DataSetVersion> SetImports(
+        this InstanceSetters<DataSetVersion> instanceSetter,
+        Func<IEnumerable<DataSetVersionImport>> imports)
+        => instanceSetter.SetImports(_ => imports());
+
+    public static InstanceSetters<DataSetVersion> SetImports(
+        this InstanceSetters<DataSetVersion> instanceSetter,
+        Func<Faker, IEnumerable<DataSetVersionImport>> imports)
+        => instanceSetter.Set(
+            (faker, dsv) =>
+            {
+                dsv.Imports = imports(faker).ToList();
+
+                foreach (var import in dsv.Imports)
+                {
+                    import.DataSetVersion = dsv;
+                    import.DataSetVersionId = dsv.Id;
+                }
+            }
+        );
+
     public static InstanceSetters<DataSetVersion> SetLocationMetas(
         this InstanceSetters<DataSetVersion> instanceSetter,
         Func<IEnumerable<LocationMeta>> metas)
@@ -317,7 +343,6 @@ public static class DataSetVersionGeneratorExtensions
                     meta.DataSetVersion = dsv;
                     meta.DataSetVersionId = dsv.Id;
                 }
-
             }
         );
 
@@ -339,7 +364,6 @@ public static class DataSetVersionGeneratorExtensions
                     meta.DataSetVersion = dsv;
                     meta.DataSetVersionId = dsv.Id;
                 }
-
             }
         );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionImportGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionImportGeneratorExtensions.cs
@@ -1,0 +1,49 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+
+public static class DataSetVersionImportGeneratorExtensions
+{
+    public static Generator<DataSetVersionImport> DefaultDataSetVersionImport(this DataFixture fixture)
+        => fixture.Generator<DataSetVersionImport>().WithDefaults();
+
+    public static Generator<DataSetVersionImport> WithDefaults(this Generator<DataSetVersionImport> generator)
+        => generator.ForInstance(s => s.SetDefaults());
+
+    public static Generator<DataSetVersionImport> WithDataSetVersion(
+        this Generator<DataSetVersionImport> generator,
+        DataSetVersion dataSetVersion)
+        => generator.ForInstance(s => s.SetDataSetVersion(dataSetVersion));
+
+    public static Generator<DataSetVersionImport> WithDataSetVersionId(
+        this Generator<DataSetVersionImport> generator,
+        Guid dataSetVersionId)
+        => generator.ForInstance(s => s.SetDataSetVersionId(dataSetVersionId));
+
+    public static Generator<DataSetVersionImport> WithStatus(this Generator<DataSetVersionImport> generator,
+        DataSetVersionImportStatus status)
+        => generator.ForInstance(s => s.SetStatus(status));
+
+    public static InstanceSetters<DataSetVersionImport> SetDefaults(this InstanceSetters<DataSetVersionImport> setters)
+        => setters
+            .SetDefault(i => i.Id)
+            .SetDefault(i => i.DataSetVersionId)
+            .SetStatus(DataSetVersionImportStatus.Queued);
+
+    public static InstanceSetters<DataSetVersionImport> SetDataSetVersion(
+        this InstanceSetters<DataSetVersionImport> instanceSetter,
+        DataSetVersion dataSetVersion)
+        => instanceSetter
+            .Set(i => i.DataSetVersion, dataSetVersion)
+            .SetDataSetVersionId(dataSetVersion.Id);
+
+    public static InstanceSetters<DataSetVersionImport> SetDataSetVersionId(
+        this InstanceSetters<DataSetVersionImport> instanceSetter,
+        Guid dataSetVersionId)
+        => instanceSetter.Set(i => i.DataSetVersionId, dataSetVersionId);
+
+    public static InstanceSetters<DataSetVersionImport> SetStatus(
+        this InstanceSetters<DataSetVersionImport> instanceSetter,
+        DataSetVersionImportStatus status)
+        => instanceSetter.Set(i => i.Status, status);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -31,6 +31,8 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public required GeographicLevelMeta GeographicLevelMeta { get; set; }
 
+    public List<DataSetVersionImport> Imports { get; set; } = [];
+
     public List<LocationMeta> LocationMetas { get; set; } = [];
 
     public List<FilterMeta> FilterMetas { get; set; } = [];
@@ -59,7 +61,7 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public string Version => $"{VersionMajor}.{VersionMinor}";
 
-    public DataSetVersionType VersionType 
+    public DataSetVersionType VersionType
         => VersionMinor == 0 ? DataSetVersionType.Major : DataSetVersionType.Minor;
 
     internal class Config : IEntityTypeConfiguration<DataSetVersion>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionImport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionImport.cs
@@ -1,0 +1,28 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+
+public class DataSetVersionImport : ICreatedUpdatedTimestamps<DateTimeOffset, DateTimeOffset?>
+{
+    public Guid Id { get; init; }
+
+    public required Guid DataSetVersionId { get; set; }
+
+    public DataSetVersion DataSetVersion { get; set; } = null!;
+
+    public required DataSetVersionImportStatus Status { get; set; }
+
+    public DateTimeOffset Created { get; set; }
+
+    public DateTimeOffset? Updated { get; set; }
+
+    internal class Config : IEntityTypeConfiguration<DataSetVersionImport>
+    {
+        public void Configure(EntityTypeBuilder<DataSetVersionImport> builder)
+        {
+            builder.Property(i => i.Status).HasConversion<string>();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionImportStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionImportStatus.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum DataSetVersionImportStatus
+{
+    Queued,
+    Validating,
+    Importing,
+    Complete,
+    Cancelled,
+    Failed,
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
@@ -26,6 +26,7 @@ public class PublicDataDbContext : DbContext
 
     public DbSet<DataSet> DataSets { get; init; } = null!;
     public DbSet<DataSetVersion> DataSetVersions { get; init; } = null!;
+    public DbSet<DataSetVersionImport> DataSetVersionImports { get; init; } = null!;
     public DbSet<GeographicLevelMeta> GeographicLevelMetas { get; init; } = null!;
     public DbSet<LocationMeta> LocationMetas { get; init; } = null!;
     public DbSet<LocationOptionMeta> LocationOptionMetas { get; init; } = null!;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240416122016_InitialMigration.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240416122016_InitialMigration.Designer.cs
@@ -13,7 +13,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
 {
     [DbContext(typeof(PublicDataDbContext))]
-    [Migration("20240415084934_InitialMigration")]
+    [Migration("20240416122016_InitialMigration")]
     partial class InitialMigration
     {
         /// <inheritdoc />
@@ -237,6 +237,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.HasIndex("DataSetId");
 
                     b.ToTable("DataSetVersions");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersionImport", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("DataSetVersionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTimeOffset?>("Updated")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DataSetVersionId");
+
+                    b.ToTable("DataSetVersionImports");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMeta", b =>
@@ -1204,6 +1230,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         .IsRequired();
                 });
 
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersionImport", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
+                        .WithMany("Imports")
+                        .HasForeignKey("DataSetVersionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("DataSetVersion");
+                });
+
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMeta", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
@@ -1312,6 +1349,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
                     b.Navigation("GeographicLevelMeta")
                         .IsRequired();
+
+                    b.Navigation("Imports");
 
                     b.Navigation("IndicatorChanges");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240416122016_InitialMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240416122016_InitialMigration.cs
@@ -178,6 +178,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                 });
 
             migrationBuilder.CreateTable(
+                name: "DataSetVersionImports",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Status = table.Column<string>(type: "text", nullable: false),
+                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataSetVersionImports", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DataSetVersionImports_DataSetVersions_DataSetVersionId",
+                        column: x => x.DataSetVersionId,
+                        principalTable: "DataSetVersions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "FilterMetas",
                 columns: table => new
                 {
@@ -386,6 +407,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                 column: "SupersedingDataSetId");
 
             migrationBuilder.CreateIndex(
+                name: "IX_DataSetVersionImports_DataSetVersionId",
+                table: "DataSetVersionImports",
+                column: "DataSetVersionId");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_DataSetVersions_DataSetId",
                 table: "DataSetVersions",
                 column: "DataSetId");
@@ -578,6 +604,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
             migrationBuilder.DropTable(
                 name: "ChangeSetTimePeriods");
+
+            migrationBuilder.DropTable(
+                name: "DataSetVersionImports");
 
             migrationBuilder.DropTable(
                 name: "FilterOptionMetaLinks");

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
@@ -236,6 +236,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.ToTable("DataSetVersions");
                 });
 
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersionImport", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("DataSetVersionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTimeOffset?>("Updated")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DataSetVersionId");
+
+                    b.ToTable("DataSetVersionImports");
+                });
+
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMeta", b =>
                 {
                     b.Property<int>("Id")
@@ -1201,6 +1227,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         .IsRequired();
                 });
 
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersionImport", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
+                        .WithMany("Imports")
+                        .HasForeignKey("DataSetVersionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("DataSetVersion");
+                });
+
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMeta", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
@@ -1309,6 +1346,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
                     b.Navigation("GeographicLevelMeta")
                         .IsRequired();
+
+                    b.Navigation("Imports");
 
                     b.Navigation("IndicatorChanges");
 


### PR DESCRIPTION
This PR adds `DataSetVersionImport` to the Public Data model in advance of the Public Data Processor being developed to allow files to be imported.

This is being added early to unblock other tickets which are going to rely on checking the status of imports.

[EES-4905 - Create an endpoint for API dataset import statuses](https://dfedigital.atlassian.net/browse/EES-4905)
[EES-4906 - Create an endpoint for listing subjects that can become API datasets](https://dfedigital.atlassian.net/browse/EES-4906)
[EES-4909 - Include API Datasets in the publishing model](https://dfedigital.atlassian.net/browse/EES-4909)

# New database seed data

After the new database table is added there is a new version of `InitialMigration` and a new seed data database `public-api-8.zip`.