### PR TITLE
Resolve caniuse warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/split2": "^4.2.0",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.61.0",
-    "caniuse-lite": "^1.0.30001314",
+    "caniuse-lite": "^1.0.30001610",
     "chalk": "^5.3.0",
     "check-node-version": "^4.2.1",
     "commander": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^5.61.0
         version: 5.61.0(eslint@8.43.0)(typescript@5.1.6)
       caniuse-lite:
-        specifier: ^1.0.30001314
-        version: 1.0.30001451
+        specifier: ^1.0.30001610
+        version: 1.0.30001610
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
@@ -180,8 +180,8 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       caniuse-lite:
-        specifier: ^1.0.30001272
-        version: 1.0.30001451
+        specifier: ^1.0.30001610
+        version: 1.0.30001610
       case-sensitive-paths-webpack-plugin:
         specifier: ^2.4.0
         version: 2.4.0
@@ -8031,7 +8031,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.5
-      caniuse-lite: 1.0.30001451
+      caniuse-lite: 1.0.30001610
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -8505,7 +8505,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001451
+      caniuse-lite: 1.0.30001610
       electron-to-chromium: 1.4.295
       node-releases: 2.0.10
       update-browserslist-db: 1.0.10(browserslist@4.21.5)
@@ -8515,7 +8515,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001514
+      caniuse-lite: 1.0.30001610
       electron-to-chromium: 1.4.454
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.9)
@@ -8667,15 +8667,12 @@ packages:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
       browserslist: 4.21.9
-      caniuse-lite: 1.0.30001514
+      caniuse-lite: 1.0.30001610
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  /caniuse-lite@1.0.30001451:
-    resolution: {integrity: sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==}
-
-  /caniuse-lite@1.0.30001514:
-    resolution: {integrity: sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==}
+  /caniuse-lite@1.0.30001610:
+    resolution: {integrity: sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==}
 
   /case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
@@ -14190,7 +14187,7 @@ packages:
     dependencies:
       '@next/env': 12.3.4
       '@swc/helpers': 0.4.11
-      caniuse-lite: 1.0.30001451
+      caniuse-lite: 1.0.30001610
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -14235,7 +14232,7 @@ packages:
     dependencies:
       '@next/env': 12.3.4
       '@swc/helpers': 0.4.11
-      caniuse-lite: 1.0.30001451
+      caniuse-lite: 1.0.30001610
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)

--- a/src/explore-education-statistics-admin/package.json
+++ b/src/explore-education-statistics-admin/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-named-asset-import": "^0.3.8",
     "babel-preset-react-app": "^10.0.1",
     "bfj": "^7.0.2",
-    "caniuse-lite": "^1.0.30001272",
+    "caniuse-lite": "^1.0.30001610",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "classnames": "^2.3.2",
     "core-js": "^3.31.1",


### PR DESCRIPTION
<img width="778" alt="caniuse-warning" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/63285990/10a6f338-690f-4de5-86c1-e6acefaf3051">

We've been getting warnings about an outdated version of `caniuse` each we start the frontend. This PR removes them