### PR TITLE
Resolve GovUk-Frontend warnings

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/FilterClearButton.module.scss
+++ b/src/explore-education-statistics-frontend/src/components/FilterClearButton.module.scss
@@ -23,7 +23,7 @@
 }
 
 .filterType {
-  @include govuk-font($size: 14);
+  @include govuk-font($size: 16);
   display: block;
   text-transform: uppercase;
 }


### PR DESCRIPTION
Each time we start the frontend project we're currently getting warnings produced by the `GovUk Frontend` package because we're using a font value that will be deprecated in the next version. Following the guidance here - https://design-system.service.gov.uk/get-started/new-type-scale/ - this PR updates the font to the next lowest value. 

<img width="627" alt="button-after-change" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/63285990/c630d212-8f5e-4cfb-8bd0-e8c336d80b90">
<img width="335" alt="button-after-change-mobile" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/63285990/8e506ffb-be94-4c53-8ff8-cdb83c8f445a">
<img width="944" alt="govuk-warning" src="https://github.com/dfe-analytical-services/explore-education-statistics/assets/63285990/b010593b-72d6-4f7d-9843-ed888848b127">
