### PR TITLE
EES-5067 fix perpendicular ref line bugs

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
@@ -59,6 +59,7 @@ export default function ChartReferenceLinesConfiguration({
       return lines.filter(line => {
         if (line.position === otherAxisPositionTypes.betweenDataPoints) {
           return (
+            chartType === 'verticalbar' &&
             majorAxisOptions.some(
               option => option.value === line.otherAxisEnd,
             ) &&
@@ -72,7 +73,7 @@ export default function ChartReferenceLinesConfiguration({
     }
 
     return lines;
-  }, [type, lines, majorAxisOptions]);
+  }, [chartType, type, lines, majorAxisOptions]);
 
   return (
     <div className="dfe-overflow-x--auto">

--- a/src/explore-education-statistics-common/src/modules/charts/components/CustomReferenceLineLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/CustomReferenceLineLabel.tsx
@@ -57,6 +57,7 @@ const CustomReferenceLineLabel = ({
     otherAxisDomainMin: axisType === 'major' ? otherAxisDomainMin : 0,
     otherAxisDomainMax: axisType === 'major' ? otherAxisDomainMax : 100, // otherAxisPosition is set as a percentage on minor axis lines
     otherAxisPosition,
+    perpendicularLine,
     viewBox,
   });
 

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/getReferenceLineLabelPosition.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/getReferenceLineLabelPosition.ts
@@ -12,6 +12,7 @@ export default function getReferenceLineLabelPosition({
   otherAxisDomainMax,
   otherAxisDomainMin,
   otherAxisPosition,
+  perpendicularLine,
   viewBox,
 }: {
   axis: Axis;
@@ -19,6 +20,7 @@ export default function getReferenceLineLabelPosition({
   otherAxisDomainMax?: number;
   otherAxisDomainMin?: number;
   otherAxisPosition?: number;
+  perpendicularLine?: boolean;
   viewBox?: CartesianViewBox;
 }): LabelPosition {
   const { height = 0, width = 0, x = 0, y = 0 } = viewBox ?? {};
@@ -31,7 +33,8 @@ export default function getReferenceLineLabelPosition({
     otherAxisDomainMax === undefined ||
     otherAxisDomainMin === undefined ||
     otherAxisPosition < otherAxisDomainMin ||
-    otherAxisPosition > otherAxisDomainMax
+    otherAxisPosition > otherAxisDomainMax ||
+    perpendicularLine
   ) {
     return {
       x: defaultXPosition,


### PR DESCRIPTION
Fixes two issues found in testing reference lines between data points on the x axis:

- when the y axis is in percentages and the y axis position is not the top value the label was being positioned in the wrong place. 
- if you added a line between data points and changed to a chart type that doesn't support them the line would still be in the list.