### PR TITLE
EES-5062 Move FilterSequence and IndicatorSequence from ReleaseSubject to ReleaseFile

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
@@ -280,7 +280,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Id = Guid.NewGuid(),
                 Filename = "Filename 1",
-                SubjectId = Guid.NewGuid()
+                SubjectId = Guid.NewGuid(),
             };
 
             var dataFile2 = new File
@@ -298,7 +298,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     ReleaseVersion = originalReleaseVersion,
                     ReleaseVersionId = originalReleaseVersion.Id,
                     File = dataFile1,
-                    FileId = dataFile1.Id
+                    FileId = dataFile1.Id,
+                    FilterSequence = new List<FilterSequenceEntry>
+                    {
+                        new(
+                            Guid.NewGuid(),
+                            new List<FilterGroupSequenceEntry>
+                            {
+                                new(Guid.NewGuid(), new List<Guid> { Guid.NewGuid() })
+                            }
+                        )
+                    },
+                    IndicatorSequence = new List<IndicatorGroupSequenceEntry>
+                    {
+                        new(
+                            Guid.NewGuid(),
+                            new List<Guid> { Guid.NewGuid() }
+                        )
+                    },
                 },
                 new()
                 {
@@ -319,23 +336,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 SubjectId = subject.Id,
                 Created = DateTime.UtcNow.AddDays(-2),
                 Updated = DateTime.UtcNow.AddDays(-1),
-                FilterSequence = new List<FilterSequenceEntry>
-                {
-                    new(
-                        Guid.NewGuid(),
-                        new List<FilterGroupSequenceEntry>
-                        {
-                            new(Guid.NewGuid(), new List<Guid> { Guid.NewGuid() })
-                        }
-                    )
-                },
-                IndicatorSequence = new List<IndicatorGroupSequenceEntry>
-                {
-                    new(
-                        Guid.NewGuid(),
-                        new List<Guid> { Guid.NewGuid() }
-                    )
-                }
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -1167,6 +1167,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             Assert.Equal(amendment.Id, amendmentDataFile.ReleaseVersionId);
             Assert.Equal(originalFile.Name, amendmentDataFile.Name);
             Assert.Equal(originalFile.Order, amendmentDataFile.Order);
+            originalFile.FilterSequence.AssertDeepEqualTo(amendmentDataFile.FilterSequence);
+            originalFile.IndicatorSequence.AssertDeepEqualTo(amendmentDataFile.IndicatorSequence);
 
             // And assert that the file referenced is the SAME file reference as linked from the original Release's
             // link table entry

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
@@ -299,23 +299,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     ReleaseVersionId = originalReleaseVersion.Id,
                     File = dataFile1,
                     FileId = dataFile1.Id,
-                    FilterSequence = new List<FilterSequenceEntry>
-                    {
-                        new(
+                    FilterSequence =
+                    [
+                        new FilterSequenceEntry(
                             Guid.NewGuid(),
-                            new List<FilterGroupSequenceEntry>
-                            {
-                                new(Guid.NewGuid(), new List<Guid> { Guid.NewGuid() })
-                            }
+                            [new(Guid.NewGuid(), [Guid.NewGuid()])]
                         )
-                    },
-                    IndicatorSequence = new List<IndicatorGroupSequenceEntry>
-                    {
-                        new(
+                    ],
+                    IndicatorSequence =
+                    [
+                        new IndicatorGroupSequenceEntry(
                             Guid.NewGuid(),
-                            new List<Guid> { Guid.NewGuid() }
+                            [Guid.NewGuid()]
                         )
-                    },
+                    ],
                 },
                 new()
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using Xunit;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
@@ -110,7 +110,7 @@ public class ReplacementServiceHelperTests
         };
 
         // Define a sequence for the original subject which is expected to be updated after the replacement
-        var originalReleaseSubject = new ReleaseSubject
+        var originalReleaseFile = new ReleaseFile
         {
             FilterSequence = new List<FilterSequenceEntry>
             {
@@ -341,7 +341,7 @@ public class ReplacementServiceHelperTests
         var updatedSequence = ReplacementServiceHelper.ReplaceFilterSequence(
             originalFilters: originalFilters,
             replacementFilters: replacementFilters,
-            originalReleaseSubject);
+            originalReleaseFile);
 
         // Verify the updated sequence of filters
         Assert.NotNull(updatedSequence);
@@ -527,7 +527,7 @@ public class ReplacementServiceHelperTests
         };
 
         // Define a sequence for the original subject which is expected to be updated after the replacement
-        var originalReleaseSubject = new ReleaseSubject
+        var originalReleaseFile = new ReleaseFile
         {
             IndicatorSequence = new List<IndicatorGroupSequenceEntry>
             {
@@ -673,7 +673,7 @@ public class ReplacementServiceHelperTests
         var updatedSequence = ReplacementServiceHelper.ReplaceIndicatorSequence(
             originalIndicatorGroups: originalGroups,
             replacementIndicatorGroups: replacementGroups,
-            originalReleaseSubject);
+            originalReleaseFile);
 
         // Verify the updated sequence of indicators
         Assert.NotNull(updatedSequence);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -3179,16 +3179,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var updatedReleaseFile = await contentDbContext.ReleaseFiles
                     .FirstAsync(rf => rf.ReleaseVersionId == releaseVersion.Id
                                       && rf.FileId == replacementFile.Id);
-
                 Assert.Equal("Original data set guidance", updatedReleaseFile.Summary);
 
-                // Check the sequence of filters and indicators remains untouched
-                var replacedReleaseSubject = await statisticsDbContext.ReleaseSubject
-                    .FirstAsync(rs => rs.ReleaseVersionId == statsReleaseVersion.Id
-                                      && rs.SubjectId == replacementReleaseSubject.SubjectId);
-
-                Assert.Null(replacedReleaseSubject.FilterSequence);
-                Assert.Null(replacedReleaseSubject.IndicatorSequence);
+                Assert.Null(updatedReleaseFile.FilterSequence);
+                Assert.Null(updatedReleaseFile.IndicatorSequence);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -31,6 +31,7 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.Validat
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.StatisticsDbUtils;
 using static Moq.MockBehavior;
 using IReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseService;
@@ -3916,7 +3917,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             };
 
             // Define a sequence for the original subject which is expected to be updated after the replacement
-            originalReleaseSubject.FilterSequence = new List<FilterSequenceEntry>
+            originalReleaseFile.FilterSequence = new List<FilterSequenceEntry>
             {
                 // Filter a
                 new(originalFilters[0].Id,
@@ -4025,14 +4026,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 result.AssertRight();
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var replacedReleaseSubject = await statisticsDbContext.ReleaseSubject
-                    .SingleAsync(rs => rs.ReleaseVersionId == statsReleaseVersion.Id
-                                       && rs.SubjectId == replacementReleaseSubject.SubjectId);
+                var replacedReleaseFile = await contentDbContext.ReleaseFiles
+                    .SingleAsync(rf => rf.ReleaseVersionId == statsReleaseVersion.Id
+                                       && rf.File.SubjectId == replacementReleaseSubject.SubjectId);
 
                 // Verify the updated sequence of filters on the replacement subject
-                var updatedSequence = replacedReleaseSubject.FilterSequence;
+                var updatedSequence = replacedReleaseFile.FilterSequence;
                 Assert.NotNull(updatedSequence);
 
                 // 'Filter a' should be the only filter in the sequence
@@ -4123,7 +4124,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             };
 
             // Define a sequence for the original subject which is expected to be updated after the replacement
-            originalReleaseSubject.IndicatorSequence = new List<IndicatorGroupSequenceEntry>
+            originalReleaseFile.IndicatorSequence = new List<IndicatorGroupSequenceEntry>
             {
                 // Group a
                 new(
@@ -4220,14 +4221,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 result.AssertRight();
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var replacedReleaseSubject = await statisticsDbContext.ReleaseSubject
-                    .SingleAsync(rs => rs.ReleaseVersionId == statsRelease.Id
-                                       && rs.SubjectId == replacementReleaseSubject.SubjectId);
+                var replacedReleaseFile = await contentDbContext.ReleaseFiles
+                    .SingleAsync(rf => rf.ReleaseVersionId == statsRelease.Id
+                                       && rf.File.SubjectId == replacementReleaseSubject.SubjectId);
 
                 // Verify the updated sequence of indicators on the replacement subject
-                var updatedSequence = replacedReleaseSubject.IndicatorSequence;
+                var updatedSequence = replacedReleaseFile.IndicatorSequence;
                 Assert.NotNull(updatedSequence);
 
                 // 'Group a' should be the only group in the sequence

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/ReleaseFileSequenceMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/ReleaseFileSequenceMigrationController.cs
@@ -40,11 +40,11 @@ public class ReleaseFileSequenceMigrationController(
         foreach (var releaseSubject in releaseSubjects)
         {
             var releaseFile = await contentDbContext.ReleaseFiles
-                .Where(rf =>
-                    rf.File.Type == FileType.Data
-                    && rf.File.SubjectId == releaseSubject.SubjectId
-                    && rf.ReleaseVersionId == releaseSubject.ReleaseVersionId)
-                .SingleAsync(cancellationToken: cancellationToken);
+                .SingleAsync(rf =>
+                        rf.File.Type == FileType.Data
+                        && rf.File.SubjectId == releaseSubject.SubjectId
+                        && rf.ReleaseVersionId == releaseSubject.ReleaseVersionId,
+                    cancellationToken: cancellationToken);
 
             releaseFile.FilterSequence = releaseSubject.FilterSequence;
             releaseFile.IndicatorSequence = releaseSubject.IndicatorSequence;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/ReleaseFileSequenceMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/ReleaseFileSequenceMigrationController.cs
@@ -1,0 +1,66 @@
+#nullable enable
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+[Route("api")]
+[ApiController]
+[Authorize(Roles = RoleNames.BauUser)]
+public class ReleaseFileSequenceMigrationController(
+    ContentDbContext contentDbContext,
+    StatisticsDbContext statisticsDbContext)
+    : ControllerBase
+{
+    public class ReleaseFileSequenceMigrationResult
+    {
+        public bool IsDryRun;
+        public int NumReleaseSubjectsMigrated;
+    }
+
+    [HttpPatch("bau/migrate-release-file")]
+    public async Task<ReleaseFileSequenceMigrationResult> MigrateReleaseFileSequence(
+        [FromQuery] bool dryRun = true,
+        CancellationToken cancellationToken = default)
+    {
+        var releaseSubjects = await statisticsDbContext.ReleaseSubject
+            .Where(rs => rs.FilterSequence != null || rs.IndicatorSequence != null)
+            .ToListAsync(cancellationToken: cancellationToken);
+
+        var numReleaseSubjectsMigrated = 0;
+
+        foreach (var releaseSubject in releaseSubjects)
+        {
+            var releaseFile = await contentDbContext.ReleaseFiles
+                .Where(rf =>
+                    rf.File.Type == FileType.Data
+                    && rf.File.SubjectId == releaseSubject.SubjectId
+                    && rf.ReleaseVersionId == releaseSubject.ReleaseVersionId)
+                .SingleAsync(cancellationToken: cancellationToken);
+
+            releaseFile.FilterSequence = releaseSubject.FilterSequence;
+            releaseFile.IndicatorSequence = releaseSubject.IndicatorSequence;
+
+            numReleaseSubjectsMigrated++;
+        }
+
+        if (!dryRun)
+        {
+            await contentDbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return new ReleaseFileSequenceMigrationResult
+        {
+            IsDryRun = dryRun,
+            NumReleaseSubjectsMigrated = numReleaseSubjectsMigrated,
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240412142956_EES5062_AddFilterSequenceAndIndicatorSequenceToReleaseFile.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240412142956_EES5062_AddFilterSequenceAndIndicatorSequenceToReleaseFile.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240412142956_EES5062_AddFilterSequenceAndIndicatorSequenceToReleaseFile")]
+    partial class EES5062_AddFilterSequenceAndIndicatorSequenceToReleaseFile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -438,9 +441,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<Guid?>("PublicDataSetVersionId")
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<Guid?>("ReplacedById")
                         .HasColumnType("uniqueidentifier");
 
@@ -464,8 +464,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasKey("Id");
 
                     b.HasIndex("CreatedById");
-
-                    b.HasIndex("PublicDataSetVersionId");
 
                     b.HasIndex("ReplacedById")
                         .IsUnique()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240412142956_EES5062_AddFilterSequenceAndIndicatorSequenceToReleaseFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240412142956_EES5062_AddFilterSequenceAndIndicatorSequenceToReleaseFile.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES5062_AddFilterSequenceAndIndicatorSequenceToReleaseFile : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FilterSequence",
+                table: "ReleaseFiles",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "IndicatorSequence",
+                table: "ReleaseFiles",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FilterSequence",
+                table: "ReleaseFiles");
+
+            migrationBuilder.DropColumn(
+                name: "IndicatorSequence",
+                table: "ReleaseFiles");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseAmendmentService.cs
@@ -520,10 +520,7 @@ public class ReleaseAmendmentService : IReleaseAmendmentService
 
                     // Copy certain fields from the original.
                     SubjectId = originalReleaseSubject.SubjectId,
-                    FilterSequence = originalReleaseSubject.FilterSequence,
-                    IndicatorSequence = originalReleaseSubject.IndicatorSequence
                 });
-
             _statisticsDbContext.ReleaseVersion.Add(statsAmendmentVersion);
             _statisticsDbContext.ReleaseSubject.AddRange(statsAmendmentSubjectLinks);
 
@@ -623,7 +620,9 @@ public class ReleaseAmendmentService : IReleaseAmendmentService
                 FileId = originalFile.FileId,
                 Order = originalFile.Order,
                 Name = originalFile.Name,
-                Summary = originalFile.Summary
+                Summary = originalFile.Summary,
+                FilterSequence = originalFile.FilterSequence,
+                IndicatorSequence = originalFile.IndicatorSequence,
             })
             .ToList();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -157,9 +157,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .ForEachAwaitAsync(footnotePlan =>
                             ReplaceLinksForFootnote(footnotePlan, originalSubjectId, replacementSubjectId));
 
-                    await ReplaceReleaseFileFilterAndIndicatorSequence(releaseVersionId: releaseVersionId,
-                        originalSubjectId: originalSubjectId,
-                        replacementSubjectId: replacementSubjectId);
+                    replacementReleaseFile.FilterSequence =
+                        await ReplaceFilterSequence(originalReleaseFile, replacementReleaseFile);
+                    replacementReleaseFile.IndicatorSequence =
+                        await ReplaceIndicatorSequence(originalReleaseFile, replacementReleaseFile);
 
                     // Replace data guidance
                     replacementReleaseFile.Summary = originalReleaseFile.Summary;
@@ -1096,32 +1097,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 FootnoteId = footnoteId,
                 IndicatorId = plan.TargetValue
             });
-        }
-
-        private async Task ReplaceReleaseFileFilterAndIndicatorSequence(Guid releaseVersionId,
-            Guid originalSubjectId,
-            Guid replacementSubjectId)
-        {
-            var originalReleaseFile = await _contentDbContext.ReleaseFiles
-                .Include(rf => rf.File)
-                .SingleAsync(rf =>
-                    rf.ReleaseVersionId == releaseVersionId
-                    && rf.File.SubjectId == originalSubjectId
-                    && rf.File.Type == FileType.Data);
-
-            var replacementReleaseFile = await _contentDbContext.ReleaseFiles
-                .Include(rf => rf.File)
-                .SingleAsync(rf =>
-                    rf.ReleaseVersionId == releaseVersionId
-                    && rf.File.SubjectId == replacementSubjectId
-                    && rf.File.Type == FileType.Data);
-
-            _contentDbContext.Update(replacementReleaseFile);
-
-            replacementReleaseFile.FilterSequence =
-                await ReplaceFilterSequence(originalReleaseFile, replacementReleaseFile);
-            replacementReleaseFile.IndicatorSequence =
-                await ReplaceIndicatorSequence(originalReleaseFile, replacementReleaseFile);
         }
 
         private async Task<List<FilterSequenceEntry>?> ReplaceFilterSequence(ReleaseFile originalReleaseFile,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Services;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
@@ -16,10 +16,10 @@ public class ReplacementServiceHelper
     public static List<FilterSequenceEntry>? ReplaceFilterSequence(
         List<Filter> originalFilters,
         List<Filter> replacementFilters,
-        ReleaseSubject originalReleaseSubject)
+        ReleaseFile originalReleaseFile)
     {
         // If the sequence is undefined then leave it so we continue to fallback to ordering by label alphabetically
-        if (originalReleaseSubject.FilterSequence == null)
+        if (originalReleaseFile.FilterSequence == null)
         {
             return null;
         }
@@ -95,7 +95,7 @@ public class ReplacementServiceHelper
         // - Swap the remaining id's with their replacements
         // - Append new entries that were added in the replacement
 
-        var filterSequence = originalReleaseSubject.FilterSequence
+        var filterSequence = originalReleaseFile.FilterSequence
             .Where(filter => filtersMap.ContainsKey(filter.Id))
             .Select(filter =>
             {
@@ -158,10 +158,10 @@ public class ReplacementServiceHelper
     public static List<IndicatorGroupSequenceEntry>? ReplaceIndicatorSequence(
         List<IndicatorGroup> originalIndicatorGroups,
         List<IndicatorGroup> replacementIndicatorGroups,
-        ReleaseSubject originalReleaseSubject)
+        ReleaseFile originalReleaseFile)
     {
         // If the sequence is undefined then leave it so we continue to fallback to ordering by label alphabetically
-        if (originalReleaseSubject.IndicatorSequence == null)
+        if (originalReleaseFile.IndicatorSequence == null)
         {
             return null;
         }
@@ -214,7 +214,7 @@ public class ReplacementServiceHelper
         // - Swap the remaining id's with their replacements
         // - Append new entries that were added in the replacement
 
-        var indicatorSequence = originalReleaseSubject.IndicatorSequence
+        var indicatorSequence = originalReleaseFile.IndicatorSequence
             .Where(indicatorGroup => indicatorGroupsMap.ContainsKey(indicatorGroup.Id))
             .Select(indicatorGroup =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -394,6 +394,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 entity.HasOne(rf => rf.File)
                     .WithMany()
                     .OnDelete(DeleteBehavior.NoAction);
+                entity.Property(rf => rf.FilterSequence)
+                    .HasConversion(
+                        v => JsonConvert.SerializeObject(v),
+                        v => JsonConvert.DeserializeObject<List<FilterSequenceEntry>>(v));
+                entity.Property(rf => rf.IndicatorSequence)
+                    .HasConversion(
+                        v => JsonConvert.SerializeObject(v),
+                        v => JsonConvert.DeserializeObject<List<IndicatorGroupSequenceEntry>>(v));
             });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
@@ -25,7 +25,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public List<FilterSequenceEntry>? FilterSequence { get; set; }
 
         public List<IndicatorGroupSequenceEntry>? IndicatorSequence { get; set; }
-
     }
 
     public abstract record SequenceEntry<TEntry, TChild>(TEntry Id, List<TChild> ChildSequence);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
@@ -20,5 +21,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public string? Summary { get; set; }
 
         public int Order { get; set; }
+
+        public List<FilterSequenceEntry>? FilterSequence { get; set; }
+
+        public List<IndicatorGroupSequenceEntry>? IndicatorSequence { get; set; }
+
     }
+
+    public abstract record SequenceEntry<TEntry, TChild>(TEntry Id, List<TChild> ChildSequence);
+
+    public record FilterSequenceEntry(Guid Id, List<FilterGroupSequenceEntry> ChildSequence) :
+        SequenceEntry<Guid, FilterGroupSequenceEntry>(Id, ChildSequence);
+
+    public record FilterGroupSequenceEntry(Guid Id, List<Guid> ChildSequence) :
+        SequenceEntry<Guid, Guid>(Id, ChildSequence);
+
+    public record IndicatorGroupSequenceEntry(Guid Id, List<Guid> ChildSequence) :
+        SequenceEntry<Guid, Guid>(Id, ChildSequence);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using Thinktecture;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
-    <!-- @MarkFix Remove below row after removing Filter/IndicatorSequence from ReleaseSubject -->
+    <!-- Remove below row after removing Filter/IndicatorSequence from ReleaseSubject -->
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model\GovUk.Education.ExploreEducationStatistics.Content.Model.csproj" />
   </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
@@ -24,6 +24,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
+    <!-- @MarkFix Remove below row after removing Filter/IndicatorSequence from ReleaseSubject -->
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model\GovUk.Education.ExploreEducationStatistics.Content.Model.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ReleaseSubject.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ReleaseSubject.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
@@ -23,15 +24,4 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 
         public DateTime? Updated { get; set; }
     }
-
-    public abstract record SequenceEntry<TEntry, TChild>(TEntry Id, List<TChild> ChildSequence);
-
-    public record FilterSequenceEntry(Guid Id, List<FilterGroupSequenceEntry> ChildSequence) :
-        SequenceEntry<Guid, FilterGroupSequenceEntry>(Id, ChildSequence);
-
-    public record FilterGroupSequenceEntry(Guid Id, List<Guid> ChildSequence) :
-        SequenceEntry<Guid, Guid>(Id, ChildSequence);
-
-    public record IndicatorGroupSequenceEntry(Guid Id, List<Guid> ChildSequence) :
-        SequenceEntry<Guid, Guid>(Id, ChildSequence);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
@@ -603,12 +603,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 ReleaseVersion = statisticsReleaseVersion,
                 Subject = new Subject(),
-                FilterSequence = new List<FilterSequenceEntry>
-                {
-                    new (subject1Filter2Id, new List<FilterGroupSequenceEntry>()),
-                    new (subject1Filter1Id, new List<FilterGroupSequenceEntry>()),
-                    new (subject1Filter3Id, new List<FilterGroupSequenceEntry>()),
-                },
             };
 
             var subject1Filter1 = new Filter
@@ -667,6 +661,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     ContentLength = 10240,
                     Type = FileType.Data,
                     SubjectId = releaseSubject1.Subject.Id
+                },
+                FilterSequence = new List<FilterSequenceEntry>
+                {
+                    new (subject1Filter2Id, new List<FilterGroupSequenceEntry>()),
+                    new (subject1Filter1Id, new List<FilterGroupSequenceEntry>()),
+                    new (subject1Filter3Id, new List<FilterGroupSequenceEntry>()),
                 },
             };
 
@@ -741,11 +741,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 ReleaseVersion = statisticsReleaseVersion,
                 Subject = new Subject(),
-                IndicatorSequence = new List<IndicatorGroupSequenceEntry>
-                {
-                    new(Guid.NewGuid(), new List<Guid> { subject1Indicator2.Id, subject1Indicator1.Id, }),
-                    new(Guid.NewGuid(), new List<Guid> { subject1Indicator3.Id, }),
-                },
             };
 
             var subject1Filter1 = new Filter
@@ -797,6 +792,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     ContentLength = 10240,
                     Type = FileType.Data,
                     SubjectId = releaseSubject1.Subject.Id
+                },
+                IndicatorSequence = new List<IndicatorGroupSequenceEntry>
+                {
+                    new(Guid.NewGuid(), new List<Guid> { subject1Indicator2.Id, subject1Indicator1.Id, }),
+                    new(Guid.NewGuid(), new List<Guid> { subject1Indicator3.Id, }),
                 },
             };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServicePermissionTests.cs
@@ -20,7 +20,6 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.Permi
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.StatisticsDbUtils;
 using static Moq.MockBehavior;
-using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
@@ -372,8 +372,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         {
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
-                Subject = new Subject { Id = Guid.NewGuid(), }
+                ReleaseVersion = new ReleaseVersion(),
+                Subject = new Subject(),
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -10,6 +11,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -58,18 +60,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         [Fact]
         public async Task GetSubjectMeta_EmptyModelReturned()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
@@ -94,16 +113,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .ReturnsAsync(new List<Location>());
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = BuildSubjectMetaService(
                     statisticsDbContext,
+                    contentDbContext,
                     filterRepository: filterRepository.Object,
                     indicatorGroupRepository: indicatorGroupRepository.Object,
                     locationRepository: locationRepository.Object,
                     timePeriodService: timePeriodService.Object
                 );
 
-                var result = (await service.GetSubjectMeta(releaseVersionId: releaseSubject.ReleaseVersionId,
+                var result = (await service.GetSubjectMeta(
+                        releaseVersionId: releaseSubject.ReleaseVersionId,
                         subjectId: releaseSubject.SubjectId))
                     .AssertRight();
 
@@ -125,10 +147,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         [Fact]
         public async Task GetSubjectMeta_LocationsForSubject()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File { SubjectId = releaseSubject.SubjectId, Type = FileType.Data, },
             };
 
             // Setup multiple geographic levels of data where some but not all of the levels have a hierarchy applied.
@@ -193,11 +222,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             });
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
+                statisticsDbContext.ReleaseSubject.Add(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
@@ -221,10 +256,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .Setup(s => s.GetDistinctForSubject(releaseSubject.SubjectId))
                 .ReturnsAsync(locations);
 
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 var service = BuildSubjectMetaService(
                     statisticsDbContext,
+                    contentDbContext,
                     filterRepository: filterRepository.Object,
                     indicatorGroupRepository: indicatorGroupRepository.Object,
                     locationRepository: locationRepository.Object,
@@ -335,12 +372,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         {
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                Subject = new Subject { Id = Guid.NewGuid(), }
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
@@ -608,20 +644,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         [Fact]
         public async Task FilterSubjectMeta_FiltersAndIndicators()
         {
-            var subject = new Subject
-            {
-                Id = Guid.NewGuid()
-            };
-
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = subject
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion
+                {
+                    Id = releaseSubject.ReleaseVersion.Id,
+                    Published = DateTime.UtcNow,
+                },
+                File =  new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var query = new ObservationQueryContext
             {
-                SubjectId = subject.Id,
+                SubjectId = releaseSubject.SubjectId,
                 LocationIds = ListOf(Guid.NewGuid()),
                 TimePeriod = new TimePeriodQuery
                 {
@@ -632,8 +678,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 }
             };
 
-            var statisticsDbContextId = Guid.NewGuid().ToString();
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
 
+            var statisticsDbContextId = Guid.NewGuid().ToString();
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
@@ -644,6 +696,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 await statisticsDbContext.SaveChangesAsync();
             }
 
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 var cancellationToken = new CancellationTokenSource().Token;
@@ -659,7 +712,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 var filter1 = new Filter
                 {
                     Id = Guid.NewGuid(),
-                    SubjectId = subject.Id,
+                    SubjectId = releaseSubject.SubjectId,
                     Label = "Filter 1"
                 };
                 filter1.FilterGroups = CreateFilterGroups(filter1, 2, 1);
@@ -667,7 +720,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 var filter2 = new Filter
                 {
                     Id = Guid.NewGuid(),
-                    SubjectId = subject.Id,
+                    SubjectId = releaseSubject.SubjectId,
                     Label = "Filter 2"
                 };
                 filter2.FilterGroups = CreateFilterGroups(filter2, 2);
@@ -687,7 +740,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 filterItemRepository
                     .Setup(s => s.GetFilterItemsFromMatchedObservationIds(
                         // ReSharper disable once AccessToDisposedClosure
-                        subject.Id, statisticsDbContext.MatchedObservations))
+                        releaseSubject.SubjectId, statisticsDbContext.MatchedObservations))
                     .ReturnsAsync(allFilterItems);
 
                 var indicatorGroupRepository = new Mock<IIndicatorGroupRepository>(MockBehavior.Strict);
@@ -719,11 +772,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     });
 
                 indicatorGroupRepository
-                    .Setup(s => s.GetIndicatorGroups(subject.Id))
+                    .Setup(s => s.GetIndicatorGroups(releaseSubject.SubjectId))
                     .ReturnsAsync(indicatorGroups);
 
                 var service = BuildSubjectMetaService(
-                    statisticsDbContext,
+                    statisticsDbContext: statisticsDbContext,
+                    contentDbContext: contentDbContext,
                     observationService: observationService.Object,
                     filterItemRepository: filterItemRepository.Object,
                     indicatorGroupRepository: indicatorGroupRepository.Object);
@@ -863,7 +917,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
@@ -885,10 +938,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         [Fact]
         public async Task UpdateSubjectFilters()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var filters = new List<Filter>
@@ -963,11 +1027,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 }).ToList();
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var cacheService = new Mock<IBlobCacheService>(MockBehavior.Strict);
@@ -983,8 +1053,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .ReturnsAsync(filters);
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     cacheService: cacheService.Object,
                     filterRepository: filterRepository.Object);
 
@@ -999,13 +1072,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertRight();
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseSubject.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                var savedSequence = savedReleaseSubject.FilterSequence;
+                var savedSequence = savedReleaseFile.FilterSequence;
 
                 Assert.NotNull(savedSequence);
                 Assert.Equal(2, savedSequence!.Count);
@@ -1046,10 +1119,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         [Fact]
         public async Task UpdateSubjectFilters_FilterMissing()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var filters = new List<Filter>
@@ -1113,11 +1197,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
@@ -1125,9 +1215,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             filterRepository.Setup(mock => mock.GetFiltersIncludingItems(releaseSubject.SubjectId))
                 .ReturnsAsync(filters);
 
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     filterRepository: filterRepository.Object);
 
                 var result = await service.UpdateSubjectFilters(
@@ -1141,24 +1234,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertBadRequest(FiltersDifferFromSubject);
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseSubject.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
                 // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.FilterSequence);
+                Assert.Null(savedReleaseFile.FilterSequence);
             }
         }
 
         [Fact]
         public async Task UpdateSubjectFilters_FilterGroupMissing()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion{ Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var filters = new List<Filter>
@@ -1215,11 +1319,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
@@ -1227,9 +1337,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             filterRepository.Setup(mock => mock.GetFiltersIncludingItems(releaseSubject.SubjectId))
                 .ReturnsAsync(filters);
 
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     filterRepository: filterRepository.Object);
 
                 var result = await service.UpdateSubjectFilters(
@@ -1243,24 +1356,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertBadRequest(FilterGroupsDifferFromSubject);
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.FilterSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.FilterSequence);
             }
         }
 
         [Fact]
         public async Task UpdateSubjectFilters_FilterItemMissing()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var filters = new List<Filter>
@@ -1310,11 +1434,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
@@ -1323,8 +1453,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .ReturnsAsync(filters);
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     filterRepository: filterRepository.Object);
 
                 var result = await service.UpdateSubjectFilters(
@@ -1338,24 +1471,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertBadRequest(FilterItemsDifferFromSubject);
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.FilterSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.FilterSequence);
             }
         }
 
         [Fact]
         public async Task UpdateSubjectFilters_FilterNotForSubject()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var filters = new List<Filter>
@@ -1416,11 +1560,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
@@ -1429,8 +1579,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .ReturnsAsync(filters);
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     filterRepository: filterRepository.Object);
 
                 var result = await service.UpdateSubjectFilters(
@@ -1444,24 +1597,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertBadRequest(FiltersDifferFromSubject);
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.FilterSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.FilterSequence);
             }
         }
 
         [Fact]
         public async Task UpdateSubjectFilters_FilterGroupNotForSubject()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var filters = new List<Filter>
@@ -1515,11 +1679,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
@@ -1528,8 +1698,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .ReturnsAsync(filters);
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     filterRepository: filterRepository.Object);
 
                 var result = await service.UpdateSubjectFilters(
@@ -1543,24 +1716,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertBadRequest(FilterGroupsDifferFromSubject);
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.FilterSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.FilterSequence);
             }
         }
 
         [Fact]
         public async Task UpdateSubjectFilters_FilterItemNotForSubject()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var filters = new List<Filter>
@@ -1607,11 +1791,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var filterRepository = new Mock<IFilterRepository>(MockBehavior.Strict);
@@ -1620,8 +1810,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .ReturnsAsync(filters);
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     filterRepository: filterRepository.Object);
 
                 var result = await service.UpdateSubjectFilters(
@@ -1635,14 +1828,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertBadRequest(FilterItemsDifferFromSubject);
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.FilterSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.FilterSequence);
             }
         }
 
@@ -1650,18 +1843,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         public async Task UpdateSubjectFilters_ReleaseNotFound()
         {
             // Create a ReleaseSubject but for a different release than the one which will be used in the update
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -1683,14 +1893,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertNotFound();
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.FilterSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.FilterSequence);
             }
         }
 
@@ -1698,18 +1908,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         public async Task UpdateSubjectFilters_SubjectNotFound()
         {
             // Create a ReleaseSubject but for a different release than the one which will be used in the update
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -1731,24 +1958,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertNotFound();
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.FilterSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.FilterSequence);
             }
         }
 
         [Fact]
         public async Task UpdateSubjectIndicators()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var indicatorGroups = new List<IndicatorGroup>
@@ -1790,11 +2028,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 }).ToList();
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var cacheService = new Mock<IBlobCacheService>(MockBehavior.Strict);
@@ -1810,13 +2054,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .ReturnsAsync(indicatorGroups);
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     cacheService: cacheService.Object,
                     indicatorGroupRepository: indicatorGroupRepository.Object);
 
                 var result = await service.UpdateSubjectIndicators(
-                    releaseVersionId: releaseSubject.ReleaseVersionId,
+                    releaseVersionId: releaseSubject.ReleaseVersion.Id,
                     subjectId: releaseSubject.SubjectId,
                     request
                 );
@@ -1826,13 +2073,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertRight();
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersion.Id
+                    && rf.File.SubjectId == releaseSubject.SubjectId
+                    && rf.File.Type == FileType.Data);
 
-                var savedSequence = savedReleaseSubject.IndicatorSequence;
+                var savedSequence = savedReleaseFile.IndicatorSequence;
 
                 Assert.NotNull(savedSequence);
                 Assert.Equal(2, savedSequence!.Count);
@@ -1857,10 +2105,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         [Fact]
         public async Task UpdateSubjectIndicators_IndicatorGroupMissing()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var indicatorGroups = new List<IndicatorGroup>
@@ -1903,11 +2162,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var indicatorGroupRepository = new Mock<IIndicatorGroupRepository>(MockBehavior.Strict);
@@ -1916,8 +2181,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .ReturnsAsync(indicatorGroups);
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     indicatorGroupRepository: indicatorGroupRepository.Object);
 
                 var result = await service.UpdateSubjectIndicators(
@@ -1931,24 +2199,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertBadRequest(IndicatorGroupsDifferFromSubject);
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.IndicatorSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.IndicatorSequence);
             }
         }
 
         [Fact]
         public async Task UpdateSubjectIndicators_IndicatorMissing()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var indicatorGroups = new List<IndicatorGroup>
@@ -1984,11 +2263,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var indicatorGroupRepository = new Mock<IIndicatorGroupRepository>(MockBehavior.Strict);
@@ -1997,8 +2282,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .ReturnsAsync(indicatorGroups);
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     indicatorGroupRepository: indicatorGroupRepository.Object);
 
                 var result = await service.UpdateSubjectIndicators(
@@ -2012,24 +2300,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertBadRequest(IndicatorsDifferFromSubject);
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.IndicatorSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.IndicatorSequence);
             }
         }
 
         [Fact]
         public async Task UpdateSubjectIndicators_IndicatorGroupNotForSubject()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var indicatorGroups = new List<IndicatorGroup>
@@ -2069,11 +2368,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var indicatorGroupRepository = new Mock<IIndicatorGroupRepository>(MockBehavior.Strict);
@@ -2082,8 +2387,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .ReturnsAsync(indicatorGroups);
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     indicatorGroupRepository: indicatorGroupRepository.Object);
 
                 var result = await service.UpdateSubjectIndicators(
@@ -2097,24 +2405,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertBadRequest(IndicatorGroupsDifferFromSubject);
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.IndicatorSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.IndicatorSequence);
             }
         }
 
         [Fact]
         public async Task UpdateSubjectIndicators_IndicatorNotForSubject()
         {
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var indicatorGroups = new List<IndicatorGroup>
@@ -2147,11 +2466,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             var indicatorGroupRepository = new Mock<IIndicatorGroupRepository>(MockBehavior.Strict);
@@ -2160,8 +2485,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .ReturnsAsync(indicatorGroups);
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = BuildSubjectMetaService(statisticsDbContext,
+                var service = BuildSubjectMetaService(
+                    statisticsDbContext,
+                    contentDbContext,
                     indicatorGroupRepository: indicatorGroupRepository.Object);
 
                 var result = await service.UpdateSubjectIndicators(
@@ -2175,14 +2503,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertBadRequest(IndicatorsDifferFromSubject);
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.IndicatorSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.IndicatorSequence);
             }
         }
 
@@ -2190,18 +2518,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         public async Task UpdateSubjectIndicators_ReleaseNotFound()
         {
             // Create a ReleaseSubject but for a different release than the one which will be used in the update
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
+            };
+
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
             };
 
             var statisticsDbContextId = Guid.NewGuid().ToString();
-
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -2223,14 +2568,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertNotFound();
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.IndicatorSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.IndicatorSequence);
             }
         }
 
@@ -2238,18 +2583,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         public async Task UpdateSubjectIndicators_SubjectNotFound()
         {
             // Create a ReleaseSubject but for a different release than the one which will be used in the update
+            var subject = new Subject { Id = Guid.NewGuid(), };
             var releaseSubject = new ReleaseSubject
             {
-                ReleaseVersion = new ReleaseVersion(),
-                Subject = new Subject()
+                ReleaseVersion = new ReleaseVersion { Id = Guid.NewGuid(), },
+                SubjectId = subject.Id,
             };
 
-            var statisticsDbContextId = Guid.NewGuid().ToString();
+            var releaseFile = new ReleaseFile
+            {
+                ReleaseVersion = new Content.Model.ReleaseVersion { Id = releaseSubject.ReleaseVersion.Id, },
+                File = new File
+                {
+                    SubjectId = releaseSubject.SubjectId,
+                    Type = FileType.Data,
+                },
+            };
 
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 await statisticsDbContext.ReleaseSubject.AddAsync(releaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.ReleaseFiles.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -2271,14 +2634,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 result.AssertNotFound();
             }
 
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var savedReleaseSubject = statisticsDbContext.ReleaseSubject.Single(rs =>
-                    rs.ReleaseVersionId == releaseSubject.ReleaseVersionId
-                    && rs.SubjectId == releaseSubject.SubjectId);
+                var savedReleaseFile = contentDbContext.ReleaseFiles.Single(rf =>
+                    rf.ReleaseVersionId == releaseFile.ReleaseVersionId
+                    && rf.File.SubjectId == releaseSubject.SubjectId);
 
-                // Verify that the ReleaseSubject remains untouched
-                Assert.Null(savedReleaseSubject.IndicatorSequence);
+                // Verify that the ReleaseFile remains untouched
+                Assert.Null(savedReleaseFile.IndicatorSequence);
             }
         }
 
@@ -2334,6 +2697,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             return new(
                 statisticsDbContext,
+                contentDbContextInstance,
                 cacheService ?? Mock.Of<IBlobCacheService>(MockBehavior.Strict),
                 releaseSubjectService ?? new ReleaseSubjectService(statisticsDbContext, contentDbContextInstance),
                 filterRepository ?? Mock.Of<IFilterRepository>(MockBehavior.Strict),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Utils/FiltersMetaViewModelBuilderTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Utils/FiltersMetaViewModelBuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
 using Xunit;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Utils/IndicatorsMetaViewModelBuilderTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Utils/IndicatorsMetaViewModelBuilderTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
 using Xunit;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
@@ -90,8 +90,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                                 content: releaseFile.Summary ?? string.Empty,
                                 timePeriods: await _timePeriodService.GetTimePeriodLabels(rs.SubjectId),
                                 geographicLevels: await _dataGuidanceDataSetService.ListGeographicLevels(rs.SubjectId),
-                                filters: await GetFilters(rs.SubjectId, rs.FilterSequence),
-                                indicators: await GetIndicators(rs.SubjectId, rs.IndicatorSequence),
+                                filters: await GetFilters(rs.SubjectId, releaseFile.FilterSequence),
+                                indicators: await GetIndicators(rs.SubjectId, releaseFile.IndicatorSequence),
                                 file: releaseFile.ToFileInfo()
                             );
                         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -23,7 +23,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.Services.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using static GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
@@ -233,7 +232,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             }
         }
 
-        private async Task<Dictionary<string, FilterMetaViewModel>> GetFilters(Guid subjectId, List<FilterSequenceEntry>? filterSequence)
+        private async Task<Dictionary<string, FilterMetaViewModel>> GetFilters(
+            Guid subjectId, List<FilterSequenceEntry>? filterSequence)
         {
             var filters = await filterRepository.GetFiltersIncludingItems(subjectId);
             return FiltersMetaViewModelBuilder.BuildFilters(filters, filterSequence);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -11,6 +11,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Utils/FiltersMetaViewModelBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Utils/FiltersMetaViewModelBuilder.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
 using static GovUk.Education.ExploreEducationStatistics.Data.Services.Utils.MetaViewModelBuilderUtils;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Utils/IndicatorsMetaViewModelBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Utils/IndicatorsMetaViewModelBuilder.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
 using static GovUk.Education.ExploreEducationStatistics.Data.Services.Utils.MetaViewModelBuilderUtils;


### PR DESCRIPTION
This PR moves `ReleaseSubject.FilterSequence` and `IndicatorSequence` into `ReleaseFile`.

This is being done in preparation for introducing `DataSetFileMeta`. Without moving these values first, when listing all data sets on the Data catalogue page, we'd be forced to query both the content and statistics databases.

After this work is deployed, we can then remove `FilterSequence` and `IndicatorSequence` from `ReleaseSubject`.