### PR TITLE
EES-4662 Add data set file meta info to Data catalogue and Data set pages

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataSetFileMetaMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataSetFileMetaMigrationController.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
@@ -83,8 +84,14 @@ public class DataSetFileMetaMigrationController : ControllerBase
 
             var filters = await _statisticsDbContext.Filter
                 .Where(f => f.SubjectId == file.SubjectId)
-                .Select(f => new FilterMeta { Id = f.Id, Label = f.Label, })
                 .OrderBy(f => f.Label)
+                .Select(f => new FilterMeta
+                {
+                    Id = f.Id,
+                    Label = f.Label,
+                    Hint = f.Hint,
+                    ColumnName = f.Name,
+                })
                 .ToListAsync(cancellationToken: cancellationToken);
 
             var indicators = await _statisticsDbContext.Indicator
@@ -93,6 +100,7 @@ public class DataSetFileMetaMigrationController : ControllerBase
                 {
                     Id = i.Id,
                     Label = i.Label,
+                    ColumnName = i.Name,
                 })
                 .OrderBy(i => i.Label)
                 .ToListAsync(cancellationToken: cancellationToken);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataSetFileMetaMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataSetFileMetaMigrationController.cs
@@ -1,0 +1,136 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+[Route("api")]
+[ApiController]
+[Authorize(Roles = RoleNames.BauUser)]
+public class DataSetFileMetaMigrationController : ControllerBase
+{
+    private readonly ContentDbContext _contentDbContext;
+    private readonly StatisticsDbContext _statisticsDbContext;
+
+    public DataSetFileMetaMigrationController(
+        ContentDbContext contentDbContext,
+        StatisticsDbContext statisticsDbContext)
+    {
+        _contentDbContext = contentDbContext;
+        _statisticsDbContext = statisticsDbContext;
+    }
+
+    public class DataSetFileMetaMigrationResult
+    {
+        public bool IsDryRun;
+        public int Processed;
+        public int LeftToProcess;
+    }
+
+    public class Observation
+    {
+        public GeographicLevel GeographicLevel;
+        public int Year;
+        public TimeIdentifier TimeIdentifier;
+    }
+
+    [HttpPatch("bau/migrate-datasetfilemeta")]
+    public async Task<DataSetFileMetaMigrationResult> MigrateReleaseSeries(
+        [FromQuery] bool dryRun = true,
+        [FromQuery] int? num = null,
+        CancellationToken cancellationToken = default)
+    {
+        var filesQueryable = _contentDbContext.Files
+            .Where(f =>
+                f.DataSetFileMeta == null
+                && f.Type == FileType.Data);
+
+        if (num is > 0)
+        {
+            filesQueryable = filesQueryable.Take(num.Value);
+        }
+
+        var files = await filesQueryable.ToListAsync(cancellationToken: cancellationToken);
+
+        var numDataSetFileMetaSet = 0;
+
+        foreach (var file in files)
+        {
+            var observations = await _statisticsDbContext.Observation
+                .AsNoTracking()
+                .Where(o => o.SubjectId == file.SubjectId)
+                .Select(o => new Observation
+                {
+                    GeographicLevel = o.Location.GeographicLevel,
+                    Year = o.Year,
+                    TimeIdentifier = o.TimeIdentifier,
+                })
+                .ToListAsync(cancellationToken: cancellationToken);
+
+            var geographicLevels = observations
+                .Select(o => o.GeographicLevel.GetEnumLabel())
+                .Distinct()
+                .OrderBy(gl => gl)
+                .ToList();
+
+            var timePeriods = observations
+                .Select(o => (o.Year, o.TimeIdentifier))
+                .Distinct()
+                .OrderBy(tp => tp.Year)
+                .ToList();
+
+            var filters = await _statisticsDbContext.Filter
+                .Where(f => f.SubjectId == file.SubjectId)
+                .Select(f => new FilterMeta { Id = f.Id, Label = f.Label, })
+                .OrderBy(f => f.Label)
+                .ToListAsync(cancellationToken: cancellationToken);
+
+            var indicators = await _statisticsDbContext.Indicator
+                .Where(i => i.IndicatorGroup.SubjectId == file.SubjectId)
+                .Select(i => new IndicatorMeta
+                {
+                    Id = i.Id,
+                    Label = i.Label,
+                })
+                .OrderBy(i => i.Label)
+                .ToListAsync(cancellationToken: cancellationToken);
+
+            file.DataSetFileMeta = new DataSetFileMeta
+            {
+                GeographicLevels = geographicLevels,
+                TimeIdentifier = timePeriods[0].TimeIdentifier,
+                Years = timePeriods.Select(tp => tp.Year).ToList(),
+                Filters = filters,
+                Indicators = indicators,
+            };
+
+            numDataSetFileMetaSet++;
+        }
+
+        if (!dryRun)
+        {
+            await _contentDbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return new DataSetFileMetaMigrationResult
+        {
+            IsDryRun = dryRun,
+            Processed = numDataSetFileMetaSet,
+            LeftToProcess = _contentDbContext.Files
+                .Count(f =>
+                    f.DataSetFileMeta == null
+                    && f.Type == FileType.Data),
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240411101622_EES4662_AddDataSetFileMetaColumnToFilesTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240411101622_EES4662_AddDataSetFileMetaColumnToFilesTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240411101622_EES4662_AddDataSetFileMetaColumnToFilesTable")]
+    partial class EES4662_AddDataSetFileMetaColumnToFilesTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -441,9 +444,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<Guid?>("PublicDataSetVersionId")
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<Guid?>("ReplacedById")
                         .HasColumnType("uniqueidentifier");
 
@@ -467,8 +467,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasKey("Id");
 
                     b.HasIndex("CreatedById");
-
-                    b.HasIndex("PublicDataSetVersionId");
 
                     b.HasIndex("ReplacedById")
                         .IsUnique()
@@ -560,6 +558,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.ToTable("KeyStatistics");
 
                     b.UseTptMappingStrategy();
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.LegacyRelease", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<int>("Order")
+                        .HasColumnType("int");
+
+                    b.Property<Guid>("PublicationId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Url")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("PublicationId");
+
+                    b.ToTable("LegacyReleases");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", b =>
@@ -917,12 +942,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.Property<Guid>("FileId")
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("FilterSequence")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("IndicatorSequence")
-                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
                         .HasColumnType("nvarchar(max)");
@@ -1662,6 +1681,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Navigation("UpdatedBy");
                 });
 
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.LegacyRelease", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", "Publication")
+                        .WithMany("LegacyReleases")
+                        .HasForeignKey("PublicationId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Publication");
+                });
+
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", "LatestPublishedVersion")
@@ -2145,6 +2175,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", b =>
                 {
+                    b.Navigation("LegacyReleases");
+
                     b.Navigation("Methodologies");
 
                     b.Navigation("ReleaseVersions");

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240411101622_EES4662_AddDataSetFileMetaColumnToFilesTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240411101622_EES4662_AddDataSetFileMetaColumnToFilesTable.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES4662_AddDataSetFileMetaColumnToFilesTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DataSetFileMeta",
+                table: "Files",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataSetFileMeta",
+                table: "Files");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
@@ -108,7 +108,7 @@ public class DataSetFilesControllerCachingTests
 
             var controller = BuildController(dataSetFileService.Object);
 
-            var result = await controller.ListDataSets(_query);
+            var result = await controller.ListDataSetFiles(_query);
 
             VerifyAllMocks(MemoryCacheService, dataSetFileService);
 
@@ -126,7 +126,7 @@ public class DataSetFilesControllerCachingTests
 
             var controller = BuildController();
 
-            var result = await controller.ListDataSets(_query);
+            var result = await controller.ListDataSetFiles(_query);
 
             VerifyAllMocks(MemoryCacheService);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -23,6 +23,9 @@ using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Fixtures;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +33,7 @@ using MockQueryable.Moq;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers;
 
@@ -1714,6 +1718,7 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
             return _fixture.DefaultReleaseFile()
                 .WithReleaseVersion(releaseVersion)
                 .WithFiles(_fixture.DefaultFile()
+                    .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta())
                     .GenerateList(numberOfDataSets))
                 .GenerateList();
         }
@@ -1752,7 +1757,8 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
 
             ReleaseFile releaseFile = _fixture.DefaultReleaseFile()
                 .WithReleaseVersion(publication.ReleaseVersions[0])
-                .WithFile(_fixture.DefaultFile());
+                .WithFile(_fixture.DefaultFile()
+                    .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()));
 
             var client = BuildApp()
                 .AddContentDbTestData(context =>
@@ -1854,7 +1860,8 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                 .WithTopic(_fixture.DefaultTopic()
                     .WithTheme(_fixture.DefaultTheme()));
 
-            File file = _fixture.DefaultFile();
+            File file = _fixture.DefaultFile()
+                .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta());
 
             ReleaseFile releaseFile0 = _fixture.DefaultReleaseFile()
                 .WithReleaseVersion(publication.ReleaseVersions[0]) // the previous published version

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -23,9 +24,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Data.Model;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Fixtures;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -1597,6 +1595,82 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
             }
 
             [Fact]
+            public async Task DataSetFileMetaCorrectlyReturned_Success()
+            {
+                var publication = _fixture
+                    .DefaultPublication()
+                    .WithReleases(_fixture.DefaultRelease(publishedVersions: 1)
+                        .Generate(1))
+                    .WithTopic(_fixture.DefaultTopic()
+                        .WithTheme(_fixture.DefaultTheme()))
+                    .Generate();
+
+                var releaseFile = _fixture.DefaultReleaseFile()
+                    .WithReleaseVersion(publication.ReleaseVersions[0])
+                    .WithFile(_fixture.DefaultFile()
+                        .WithType(FileType.Data)
+                        .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
+                            .WithGeographicLevels(["National", "Local authority"])
+                            .WithTimeIdentifier(TimeIdentifier.AcademicYear)
+                            .WithYears([2000, 2001, 2002])
+                            .WithFilters([
+                                new FilterMeta{ Label = "Filter 1" },
+                                new FilterMeta{ Label = "Filter 2" },
+                                new FilterMeta{ Label = "Filter 3" },
+                            ])
+                            .WithIndicators([
+                                new IndicatorMeta { Label = "Indicator 1"},
+                                new IndicatorMeta { Label = "Indicator 2"},
+                                new IndicatorMeta { Label = "Indicator 3"},
+                            ])
+                        ))
+                    .Generate();
+
+                MemoryCacheService
+                    .SetupNotFoundForAnyKey<ListDataSetFilesCacheKey,
+                        PaginatedListViewModel<DataSetFileSummaryViewModel>>();
+
+                var client = BuildApp()
+                    .AddContentDbTestData(context =>
+                    {
+                        context.ReleaseFiles.Add(releaseFile);
+                    })
+                    .CreateClient();
+
+                var query = new DataSetFileListRequest();
+                var response = await ListDataSets(client, query);
+
+                MockUtils.VerifyAllMocks(MemoryCacheService);
+
+                var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
+
+                var dataSetFileSummaryViewModel = Assert.Single(pagedResult.Results);
+                var dataSetFileMetaViewModel = dataSetFileSummaryViewModel.Meta;
+
+                var originalMeta = releaseFile.File.DataSetFileMeta;
+
+                originalMeta!.GeographicLevels
+                    .AssertDeepEqualTo(dataSetFileMetaViewModel.GeographicLevels);
+
+                new DataSetFileTimePeriodViewModel
+                {
+                    TimeIdentifier = originalMeta.TimeIdentifier.GetEnumLabel(),
+                    From = TimePeriodLabelFormatter.Format(originalMeta.Years.First(), originalMeta.TimeIdentifier),
+                    To = TimePeriodLabelFormatter.Format(originalMeta.Years.Last(), originalMeta.TimeIdentifier),
+                }.AssertDeepEqualTo(dataSetFileMetaViewModel.TimePeriod);
+
+                originalMeta.Filters
+                    .Select(f => f.Label)
+                    .ToList()
+                    .AssertDeepEqualTo(dataSetFileMetaViewModel.Filters);
+
+                originalMeta.Indicators
+                    .Select(i => i.Label)
+                    .ToList()
+                    .AssertDeepEqualTo(dataSetFileMetaViewModel.Indicators);
+            }
+
+            [Fact]
             public async Task NoPublishedDataSets_ReturnsEmpty()
             {
                 MemoryCacheService
@@ -1704,9 +1778,11 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                     () => Assert.Equal(publication.Title, viewModel.Publication.Title),
                     () => Assert.Equal(theme.Id, viewModel.Theme.Id),
                     () => Assert.Equal(theme.Title, viewModel.Theme.Title),
-                    () => Assert.Equal(releaseVersion.Id == publication.LatestPublishedReleaseVersionId, viewModel.LatestData),
+                    () => Assert.Equal(releaseVersion.Id == publication.LatestPublishedReleaseVersionId,
+                        viewModel.LatestData),
                     () => Assert.Equal(releaseFile.ReleaseVersion.Published!.Value, viewModel.Published),
-                    () => Assert.Equal(releaseFile.File.PublicDataSetVersionId.HasValue, viewModel.HasApiDataSet)
+                    () => Assert.Equal(releaseFile.File.PublicDataSetVersionId.HasValue,
+                        viewModel.HasApiDataSet)
                 );
             });
         }
@@ -1792,6 +1868,129 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
             Assert.Equal(publication.Title, viewModel.Release.Publication.Title);
             Assert.Equal(publication.Slug, viewModel.Release.Publication.Slug);
             Assert.Equal(publication.Topic.Theme.Title, viewModel.Release.Publication.ThemeTitle);
+
+            var dataSetFileMeta = file.DataSetFileMeta;
+
+            dataSetFileMeta!.GeographicLevels
+                .AssertDeepEqualTo(viewModel.Meta.GeographicLevels);
+
+            new DataSetFileTimePeriodViewModel
+            {
+                TimeIdentifier = dataSetFileMeta.TimeIdentifier.GetEnumLabel(),
+                From =
+                    TimePeriodLabelFormatter.Format(dataSetFileMeta.Years.First(), dataSetFileMeta.TimeIdentifier),
+                To = TimePeriodLabelFormatter.Format(dataSetFileMeta.Years.Last(), dataSetFileMeta.TimeIdentifier),
+            }.AssertDeepEqualTo(viewModel.Meta.TimePeriod);
+
+            dataSetFileMeta.Filters
+                .Select(f => f.Label)
+                .ToList()
+                .AssertDeepEqualTo(viewModel.Meta.Filters);
+
+            dataSetFileMeta.Indicators
+                .Select(i => i.Label)
+                .ToList()
+                .AssertDeepEqualTo(viewModel.Meta.Indicators);
+        }
+
+        [Fact]
+        public async Task FetchDataSetFiltersOrdered_Success()
+        {
+            Publication publication = _fixture.DefaultPublication()
+                .WithReleases(
+                    _fixture.DefaultRelease(publishedVersions: 1)
+                        .Generate(1))
+                .WithTopic(_fixture.DefaultTopic()
+                    .WithTheme(_fixture.DefaultTheme()));
+
+            var filter1Id = Guid.NewGuid();
+            var filter2Id = Guid.NewGuid();
+            var filter3Id = Guid.NewGuid();
+
+            ReleaseFile releaseFile = _fixture.DefaultReleaseFile()
+                .WithReleaseVersion(publication.ReleaseVersions[0])
+                .WithFilterSequence([
+                    new FilterSequenceEntry(filter1Id, new List<FilterGroupSequenceEntry>()),
+                    new FilterSequenceEntry(filter2Id, new List<FilterGroupSequenceEntry>()),
+                    new FilterSequenceEntry(filter3Id, new List<FilterGroupSequenceEntry>()),
+                ])
+                .WithFile(_fixture.DefaultFile()
+                    .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
+                        .WithFilters([
+                            new FilterMeta { Id = filter3Id, Label = "Filter 3", },
+                            new FilterMeta { Id = filter1Id, Label = "Filter 1", },
+                            new FilterMeta { Id = filter2Id, Label = "Filter 2", },
+                        ])));
+
+            var client = BuildApp()
+                .AddContentDbTestData(context =>
+                {
+                    context.ReleaseFiles.Add(releaseFile);
+                })
+                .CreateClient();
+
+            var uri = $"/api/data-set-files/{releaseFile.File.DataSetFileId}";
+
+            var response = await client.GetAsync(uri);
+            var viewModel = response.AssertOk<DataSetFileViewModel>();
+
+            Assert.Equal(3, viewModel.Meta.Filters.Count);
+            Assert.Equal("Filter 1", viewModel.Meta.Filters[0]);
+            Assert.Equal("Filter 2", viewModel.Meta.Filters[1]);
+            Assert.Equal("Filter 3", viewModel.Meta.Filters[2]);
+        }
+
+        [Fact]
+        public async Task FetchDataSetIndicatorsOrdered_Success()
+        {
+            Publication publication = _fixture.DefaultPublication()
+                .WithReleases(
+                    _fixture.DefaultRelease(publishedVersions: 1)
+                        .Generate(1))
+                .WithTopic(_fixture.DefaultTopic()
+                    .WithTheme(_fixture.DefaultTheme()));
+
+            var indicator1Id = Guid.NewGuid();
+            var indicator2Id = Guid.NewGuid();
+            var indicator3Id = Guid.NewGuid();
+            var indicator4Id = Guid.NewGuid();
+
+            ReleaseFile releaseFile = _fixture.DefaultReleaseFile()
+                .WithReleaseVersion(publication.ReleaseVersions[0])
+                .WithIndicatorSequence([
+                    new IndicatorGroupSequenceEntry(Guid.NewGuid(),
+                        new List<Guid> { indicator1Id, }),
+                    new IndicatorGroupSequenceEntry(Guid.NewGuid(),
+                        new List<Guid> { indicator2Id, }),
+                    new IndicatorGroupSequenceEntry(Guid.NewGuid(),
+                        new List<Guid> { indicator3Id, indicator4Id })
+                ])
+                .WithFile(_fixture.DefaultFile()
+                    .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
+                        .WithIndicators([
+                            new IndicatorMeta { Id = indicator3Id, Label = "Indicator 3", },
+                            new IndicatorMeta { Id = indicator2Id, Label = "Indicator 2", },
+                            new IndicatorMeta { Id = indicator1Id, Label = "Indicator 1", },
+                            new IndicatorMeta { Id = indicator4Id, Label = "Indicator 4", },
+                        ])));
+
+            var client = BuildApp()
+                .AddContentDbTestData(context =>
+                {
+                    context.ReleaseFiles.Add(releaseFile);
+                })
+                .CreateClient();
+
+            var uri = $"/api/data-set-files/{releaseFile.File.DataSetFileId}";
+
+            var response = await client.GetAsync(uri);
+            var viewModel = response.AssertOk<DataSetFileViewModel>();
+
+            Assert.Equal(4, viewModel.Meta.Indicators.Count);
+            Assert.Equal("Indicator 1", viewModel.Meta.Indicators[0]);
+            Assert.Equal("Indicator 2", viewModel.Meta.Indicators[1]);
+            Assert.Equal("Indicator 3", viewModel.Meta.Indicators[2]);
+            Assert.Equal("Indicator 4", viewModel.Meta.Indicators[3]);
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -1614,14 +1614,14 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                             .WithTimeIdentifier(TimeIdentifier.AcademicYear)
                             .WithYears([2000, 2001, 2002])
                             .WithFilters([
-                                new FilterMeta{ Label = "Filter 1" },
-                                new FilterMeta{ Label = "Filter 2" },
-                                new FilterMeta{ Label = "Filter 3" },
+                                new FilterMeta { Label = "Filter 1" },
+                                new FilterMeta { Label = "Filter 2" },
+                                new FilterMeta { Label = "Filter 3" },
                             ])
                             .WithIndicators([
-                                new IndicatorMeta { Label = "Indicator 1"},
-                                new IndicatorMeta { Label = "Indicator 2"},
-                                new IndicatorMeta { Label = "Indicator 3"},
+                                new IndicatorMeta { Label = "Indicator 1" },
+                                new IndicatorMeta { Label = "Indicator 2" },
+                                new IndicatorMeta { Label = "Indicator 3" },
                             ])
                         ))
                     .Generate();
@@ -1649,25 +1649,26 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
 
                 var originalMeta = releaseFile.File.DataSetFileMeta;
 
-                originalMeta!.GeographicLevels
-                    .AssertDeepEqualTo(dataSetFileMetaViewModel.GeographicLevels);
+                dataSetFileMetaViewModel.GeographicLevels
+                    .AssertDeepEqualTo(originalMeta!.GeographicLevels);
 
-                new DataSetFileTimePeriodViewModel
-                {
-                    TimeIdentifier = originalMeta.TimeIdentifier.GetEnumLabel(),
-                    From = TimePeriodLabelFormatter.Format(originalMeta.Years.First(), originalMeta.TimeIdentifier),
-                    To = TimePeriodLabelFormatter.Format(originalMeta.Years.Last(), originalMeta.TimeIdentifier),
-                }.AssertDeepEqualTo(dataSetFileMetaViewModel.TimePeriod);
+                dataSetFileMetaViewModel.TimePeriod.AssertDeepEqualTo(
+                    new DataSetFileTimePeriodViewModel
+                    {
+                        TimeIdentifier = originalMeta.TimeIdentifier.GetEnumLabel(),
+                        From = TimePeriodLabelFormatter.Format(originalMeta.Years.First(), originalMeta.TimeIdentifier),
+                        To = TimePeriodLabelFormatter.Format(originalMeta.Years.Last(), originalMeta.TimeIdentifier),
+                    });
 
-                originalMeta.Filters
-                    .Select(f => f.Label)
-                    .ToList()
-                    .AssertDeepEqualTo(dataSetFileMetaViewModel.Filters);
+                dataSetFileMetaViewModel.Filters
+                    .AssertDeepEqualTo(originalMeta.Filters
+                        .Select(f => f.Label)
+                        .ToList());
 
-                originalMeta.Indicators
-                    .Select(i => i.Label)
-                    .ToList()
-                    .AssertDeepEqualTo(dataSetFileMetaViewModel.Indicators);
+                dataSetFileMetaViewModel.Indicators
+                    .AssertDeepEqualTo(originalMeta.Indicators
+                        .Select(i => i.Label)
+                        .ToList());
             }
 
             [Fact]
@@ -1871,26 +1872,27 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
 
             var dataSetFileMeta = file.DataSetFileMeta;
 
-            dataSetFileMeta!.GeographicLevels
-                .AssertDeepEqualTo(viewModel.Meta.GeographicLevels);
+            viewModel.Meta.GeographicLevels
+                .AssertDeepEqualTo(dataSetFileMeta!.GeographicLevels);
 
-            new DataSetFileTimePeriodViewModel
-            {
-                TimeIdentifier = dataSetFileMeta.TimeIdentifier.GetEnumLabel(),
-                From =
-                    TimePeriodLabelFormatter.Format(dataSetFileMeta.Years.First(), dataSetFileMeta.TimeIdentifier),
-                To = TimePeriodLabelFormatter.Format(dataSetFileMeta.Years.Last(), dataSetFileMeta.TimeIdentifier),
-            }.AssertDeepEqualTo(viewModel.Meta.TimePeriod);
+            viewModel.Meta.TimePeriod.AssertDeepEqualTo(
+                new DataSetFileTimePeriodViewModel
+                {
+                    TimeIdentifier = dataSetFileMeta.TimeIdentifier.GetEnumLabel(),
+                    From = TimePeriodLabelFormatter.Format(
+                        dataSetFileMeta.Years.First(), dataSetFileMeta.TimeIdentifier),
+                    To = TimePeriodLabelFormatter.Format(dataSetFileMeta.Years.Last(), dataSetFileMeta.TimeIdentifier),
+                });
 
-            dataSetFileMeta.Filters
-                .Select(f => f.Label)
-                .ToList()
-                .AssertDeepEqualTo(viewModel.Meta.Filters);
+            viewModel.Meta.Filters
+                .AssertDeepEqualTo(dataSetFileMeta.Filters
+                    .Select(f => f.Label)
+                    .ToList());
 
-            dataSetFileMeta.Indicators
-                .Select(i => i.Label)
-                .ToList()
-                .AssertDeepEqualTo(viewModel.Meta.Indicators);
+            viewModel.Meta.Indicators
+                .AssertDeepEqualTo(dataSetFileMeta.Indicators
+                    .Select(i => i.Label)
+                    .ToList());
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
@@ -29,7 +29,7 @@ public class DataSetFilesController : ControllerBase
 
     [HttpGet("data-set-files")]
     [MemoryCache(typeof(ListDataSetFilesCacheKey), durationInSeconds: 10, expiryScheduleCron: HalfHourlyExpirySchedule)]
-    public async Task<ActionResult<PaginatedListViewModel<DataSetFileSummaryViewModel>>> ListDataSets(
+    public async Task<ActionResult<PaginatedListViewModel<DataSetFileSummaryViewModel>>> ListDataSetFiles(
         [FromQuery] DataSetFileListRequest request,
         CancellationToken cancellationToken = default)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataImportGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataImportGeneratorExtensions.cs
@@ -24,8 +24,9 @@ public static class DataImportGeneratorExtensions
     
     public static Generator<DataImport> WithFiles(
         this Generator<DataImport> generator,
-        string dataFileName)
-        => generator.ForInstance(s => s.SetFiles(dataFileName));
+        string dataFileName,
+        Guid? subjectId = null)
+        => generator.ForInstance(s => s.SetFiles(dataFileName, subjectId));
 
     public static Generator<DataImport> WithStatus(
         this Generator<DataImport> generator,
@@ -46,19 +47,22 @@ public static class DataImportGeneratorExtensions
     
     public static InstanceSetters<DataImport> SetFiles(
         this InstanceSetters<DataImport> setters,
-        string dataFileName)
+        string dataFileName,
+        Guid? subjectId = null)
         => setters
             .Set(d => d.File, new File
             {
                 Id = Guid.NewGuid(),
                 Filename = $"{dataFileName}.csv",
-                Type = FileType.Data
+                Type = FileType.Data,
+                SubjectId = subjectId,
             })
             .Set(d => d.MetaFile, new File
             {
                 Id = Guid.NewGuid(),
                 Filename = $"{dataFileName}.meta.csv",
-                Type = FileType.Metadata
+                Type = FileType.Metadata,
+                SubjectId = subjectId,
             });
 
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataImportGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataImportGeneratorExtensions.cs
@@ -24,9 +24,8 @@ public static class DataImportGeneratorExtensions
     
     public static Generator<DataImport> WithFiles(
         this Generator<DataImport> generator,
-        string dataFileName,
-        Guid? subjectId = null)
-        => generator.ForInstance(s => s.SetFiles(dataFileName, subjectId));
+        string dataFileName)
+        => generator.ForInstance(s => s.SetFiles(dataFileName));
 
     public static Generator<DataImport> WithStatus(
         this Generator<DataImport> generator,
@@ -47,22 +46,21 @@ public static class DataImportGeneratorExtensions
     
     public static InstanceSetters<DataImport> SetFiles(
         this InstanceSetters<DataImport> setters,
-        string dataFileName,
-        Guid? subjectId = null)
+        string dataFileName)
         => setters
-            .Set(d => d.File, new File
+            .Set(d => d.File, (_, dataImport) => new File
             {
                 Id = Guid.NewGuid(),
                 Filename = $"{dataFileName}.csv",
                 Type = FileType.Data,
-                SubjectId = subjectId,
+                SubjectId = dataImport.SubjectId,
             })
-            .Set(d => d.MetaFile, new File
+            .Set(d => d.MetaFile, (_, dataImport) => new File
             {
                 Id = Guid.NewGuid(),
                 Filename = $"{dataFileName}.meta.csv",
                 Type = FileType.Metadata,
-                SubjectId = subjectId,
+                SubjectId = dataImport.SubjectId,
             });
 
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+
+public static class DataSetFileMetaGeneratorExtensions
+{
+    public static Generator<DataSetFileMeta> DefaultDataSetFileMeta(this DataFixture fixture)
+        => fixture.Generator<DataSetFileMeta>().WithDefaults();
+
+    public static Generator<DataSetFileMeta> WithDefaults(this Generator<DataSetFileMeta> generator)
+        => generator.ForInstance(d => d.SetDefaults());
+
+    public static InstanceSetters<DataSetFileMeta> SetDefaults(this InstanceSetters<DataSetFileMeta> setters)
+        => setters
+            .SetGeographicLevels(new List<string> { "National " })
+            .SetTimeIdentifier(TimeIdentifier.AcademicYear)
+            .SetYears(new List<int> { 2000, 2001 })
+            .SetFilters(new List<FilterMeta> { new() { Label = "Filter 1" }, })
+            .SetIndicators(new List<IndicatorMeta> { new() { Label = "Indicator 1" }, });
+
+    public static Generator<DataSetFileMeta> WithGeographicLevels(
+        this Generator<DataSetFileMeta> generator,
+        List<string> geographicLevels)
+        => generator.ForInstance(s => s.SetGeographicLevels(geographicLevels));
+
+    public static Generator<DataSetFileMeta> WithTimeIdentifier(
+        this Generator<DataSetFileMeta> generator,
+        TimeIdentifier timeIdentifier)
+        => generator.ForInstance(s => s.SetTimeIdentifier(timeIdentifier));
+
+    public static Generator<DataSetFileMeta> WithYears(
+        this Generator<DataSetFileMeta> generator,
+        List<int> years)
+        => generator.ForInstance(s => s.SetYears(years));
+
+    public static Generator<DataSetFileMeta> WithFilters(
+        this Generator<DataSetFileMeta> generator,
+        List<FilterMeta> filters)
+        => generator.ForInstance(s => s.SetFilters(filters));
+
+    public static InstanceSetters<DataSetFileMeta> SetGeographicLevels(
+        this InstanceSetters<DataSetFileMeta> setters,
+        List<string> geographicLevels)
+        => setters.Set(s => s.GeographicLevels, geographicLevels);
+
+    public static InstanceSetters<DataSetFileMeta> SetTimeIdentifier(
+        this InstanceSetters<DataSetFileMeta> setters,
+        TimeIdentifier timeIdentifier)
+        => setters.Set(s => s.TimeIdentifier, timeIdentifier);
+
+    public static InstanceSetters<DataSetFileMeta> SetYears(
+        this InstanceSetters<DataSetFileMeta> setters,
+        List<int> years)
+        => setters.Set(s => s.Years, years);
+
+    public static InstanceSetters<DataSetFileMeta> SetFilters(
+        this InstanceSetters<DataSetFileMeta> setters,
+        List<FilterMeta> filters)
+        => setters.Set(s => s.Filters, filters);
+
+    public static InstanceSetters<DataSetFileMeta> SetIndicators(
+        this InstanceSetters<DataSetFileMeta> setters,
+        List<IndicatorMeta> indicators)
+        => setters.Set(s => s.Indicators, indicators);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
@@ -40,6 +40,11 @@ public static class DataSetFileMetaGeneratorExtensions
         List<FilterMeta> filters)
         => generator.ForInstance(s => s.SetFilters(filters));
 
+    public static Generator<DataSetFileMeta> WithIndicators(
+        this Generator<DataSetFileMeta> generator,
+        List<IndicatorMeta> indicators)
+        => generator.ForInstance(s => s.SetIndicators(indicators));
+
     public static InstanceSetters<DataSetFileMeta> SetGeographicLevels(
         this InstanceSetters<DataSetFileMeta> setters,
         List<string> geographicLevels)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
@@ -1,5 +1,7 @@
 using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
@@ -21,6 +23,14 @@ public static class FileGeneratorExtensions
             .SetContentType("text/csv")
             .SetType(FileType.Data)
             .SetDefault(f => f.Filename)
+            .SetDataSetFileMeta(new DataSetFileMeta
+            {
+                GeographicLevels = [GeographicLevel.Country.GetEnumLabel()],
+                TimeIdentifier = TimeIdentifier.CalendarYear,
+                Years = [ 2000, 2001 ],
+                Filters = [new() { Id = Guid.NewGuid(), Label = "Filter 1", }],
+                Indicators = [new() { Id = Guid.NewGuid(), }],
+            })
             .Set(f => f.Filename, (_, f) => $"{f.Filename}.csv");
 
     public static Generator<File> WithContentLength(
@@ -87,6 +97,11 @@ public static class FileGeneratorExtensions
         this Generator<File> generator,
         FileType type)
         => generator.ForInstance(s => s.SetType(type));
+
+    public static Generator<File> WithDataSetFileMeta(
+        this Generator<File> generator,
+        DataSetFileMeta dataSetFileMeta)
+        => generator.ForInstance(s => s.SetDataSetFileMeta(dataSetFileMeta));
 
     public static InstanceSetters<File> SetContentLength(
         this InstanceSetters<File> setters,
@@ -155,4 +170,9 @@ public static class FileGeneratorExtensions
         this InstanceSetters<File> setters,
         FileType type)
         => setters.Set(f => f.Type, type);
+
+    public static InstanceSetters<File> SetDataSetFileMeta(
+        this InstanceSetters<File> setters,
+        DataSetFileMeta dataSetFileMeta)
+        => setters.Set(f => f.DataSetFileMeta, dataSetFileMeta);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseFileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseFileGeneratorExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
-using InterpolatedSql.SqlBuilders;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseFileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseFileGeneratorExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using InterpolatedSql.SqlBuilders;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 
@@ -73,6 +74,16 @@ public static class ReleaseFileGeneratorExtensions
         string summary)
         => generator.ForInstance(s => s.SetSummary(summary));
 
+    public static Generator<ReleaseFile> WithFilterSequence(
+        this Generator<ReleaseFile> generator,
+        List<FilterSequenceEntry> sequence)
+        => generator.ForInstance(s => s.SetFilterSequence(sequence));
+
+    public static Generator<ReleaseFile> WithIndicatorSequence(
+        this Generator<ReleaseFile> generator,
+        List<IndicatorGroupSequenceEntry> sequence)
+        => generator.ForInstance(s => s.SetIndicatorSequence(sequence));
+
     public static InstanceSetters<ReleaseFile> SetFile(
         this InstanceSetters<ReleaseFile> setters,
         File file)
@@ -109,4 +120,14 @@ public static class ReleaseFileGeneratorExtensions
         this InstanceSetters<ReleaseFile> setters,
         string summary)
         => setters.Set(rf => rf.Summary, summary);
+
+    public static InstanceSetters<ReleaseFile> SetFilterSequence(
+        this InstanceSetters<ReleaseFile> setters,
+        List<FilterSequenceEntry> sequence)
+        => setters.Set(rf => rf.FilterSequence, sequence);
+
+    public static InstanceSetters<ReleaseFile> SetIndicatorSequence(
+        this InstanceSetters<ReleaseFile> setters,
+        List<IndicatorGroupSequenceEntry> sequence)
+        => setters.Set(rf => rf.IndicatorSequence, sequence);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+public class DataSetFileMeta
+{
+    public List<string> GeographicLevels { get; set; } = new();
+
+    [JsonConverter(typeof(TimeIdentifierJsonConverter))]
+    public TimeIdentifier TimeIdentifier { get; set; }
+
+    public List<int> Years { get; set; } = new();
+
+    public List<FilterMeta> Filters { get; set; } = new();
+
+    public List<IndicatorMeta> Indicators { get; set; } = new();
+}
+
+public class FilterMeta
+{
+    public Guid Id { get; set; }
+    public string Label { get; set; }
+}
+
+public class IndicatorMeta
+{
+    public Guid Id { get; set; }
+    public string Label { get; set; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -31,3 +31,10 @@ public class IndicatorMeta
     public Guid Id { get; set; }
     public string Label { get; set; }
 }
+
+public class TimePeriodMeta
+{
+    public int Year;
+    public TimeIdentifier TimeIdentifier;
+}
+

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -24,12 +24,18 @@ public class FilterMeta
 {
     public Guid Id { get; set; }
     public string Label { get; set; }
+
+    public string? Hint { get; set; }
+
+    public string ColumnName { get; set; }
 }
 
 public class IndicatorMeta
 {
     public Guid Id { get; set; }
     public string Label { get; set; }
+
+    public string ColumnName { get; set; }
 }
 
 public class TimePeriodMeta

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -425,7 +425,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 entity.Property(f => f.Created)
                     .HasConversion(
                         v => v,
-                        v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
+                        v => v.HasValue
+                            ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
+                            : null);
+                entity.Property(p => p.DataSetFileMeta)
+                    .HasConversion(
+                        v => JsonConvert.SerializeObject(v),
+                        v => JsonConvert.DeserializeObject<DataSetFileMeta>(v));
                 entity.HasIndex(f => f.PublicDataSetVersionId);
             });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -22,6 +22,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public int? DataSetFileVersion { get; set; }
 
+        public DataSetFileMeta?  DataSetFileMeta { get; set; }
+
         public Guid? PublicDataSetVersionId { get; set; }
 
         public Guid? ReplacedById { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseDataFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseDataFileRepository.cs
@@ -64,6 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                     DataSetFileVersion = type != Data
                         ? null
                         : replacingDataFile?.DataSetFileVersion + 1 ?? 0,
+                    DataSetFileMeta = null, // If FileType.Data, this is set by Data.Processor when import is complete
                     Filename = filename,
                     ContentLength = contentLength,
                     ContentType = "text/csv",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -138,8 +138,6 @@ public class DataSetFileService : IDataSetFileService
             .ToListAsync();
     }
 
-    // ReSharper disable EntityFramework.NPlusOne.IncompleteDataQuery
-    // ReSharper disable EntityFramework.NPlusOne.IncompleteDataUsage
     public async Task<Either<ActionResult, DataSetFileViewModel>> GetDataSetFile(
         Guid dataSetId)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
@@ -1,0 +1,16 @@
+namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+
+public record DataSetFileMetaViewModel
+{
+    public List<string> GeographicLevels { get; init; } = new();
+    public DataSetFileTimePeriodViewModel TimePeriod { get; init; } = new();
+    public List<string> Filters { get; init; } = new();
+    public List<string> Indicators { get; init; } = new();
+}
+
+public record DataSetFileTimePeriodViewModel
+{
+    public string TimeIdentifier { get; init; } = string.Empty;
+    public string From { get; init; } = string.Empty;
+    public string To { get; init; } = string.Empty;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileSummaryViewModel.cs
@@ -1,4 +1,4 @@
-using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+﻿using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 
@@ -29,4 +29,6 @@ public record DataSetFileSummaryViewModel
     public DateTime Published { get; init; }
 
     public bool HasApiDataSet { get; init; }
+
+    public DataSetFileMetaViewModel Meta { get; init; } = null!;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileViewModel.cs
@@ -15,6 +15,8 @@ public record DataSetFileViewModel
     public DataSetFileFileViewModel File { get; init; } = null!;
 
     public DataSetFileReleaseViewModel Release { get; init; } = null!;
+
+    public DataSetFileMetaViewModel Meta { get; init; } = null!;
 }
 
 public record DataSetFilePublicationViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/FilterGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/FilterGeneratorExtensions.cs
@@ -30,6 +30,9 @@ public static class FilterGeneratorExtensions
     public static Generator<Filter> WithLabel(this Generator<Filter> generator, string label)
         => generator.ForInstance(s => s.SetLabel(label));
 
+    public static Generator<Filter> WithHint(this Generator<Filter> generator, string? hint)
+        => generator.ForInstance(s => s.SetHint(hint));
+
     public static Generator<Filter> WithGroupCsvColumn(this Generator<Filter> generator, string groupCsvColumn)
         => generator.ForInstance(s => s.SetGroupCsvColumn(groupCsvColumn));
 
@@ -62,6 +65,12 @@ public static class FilterGeneratorExtensions
         => setters
             .Set(f => f.Label, label)
             .Set(f => f.Name, label.SnakeCase());
+
+    public static InstanceSetters<Filter> SetHint(
+        this InstanceSetters<Filter> setters,
+        string? hint)
+        => setters
+            .Set(f => f.Hint, hint);
 
     public static InstanceSetters<Filter> SetGroupCsvColumn(
         this InstanceSetters<Filter> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -106,7 +106,7 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("small-csv", _subject.Id)
+            .WithFiles("small-csv")
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
@@ -324,7 +324,7 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("small-csv", subjectId: _subject.Id)
+            .WithFiles("small-csv")
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
@@ -458,7 +458,7 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("small-csv", _subject.Id)
+            .WithFiles("small-csv")
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
@@ -613,7 +613,7 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("small-csv", _subject.Id)
+            .WithFiles("small-csv")
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
@@ -763,7 +763,7 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("ignored-school-rows", _subject.Id)
+            .WithFiles("ignored-school-rows")
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
@@ -913,7 +913,7 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("ignored-school-rows", _subject.Id)
+            .WithFiles("ignored-school-rows")
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
@@ -1361,7 +1361,7 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("additional-filters-and-indicators", _subject.Id)
+            .WithFiles("additional-filters-and-indicators")
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
@@ -1535,7 +1535,7 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(subject.Id)
-            .WithFiles("small-csv-with-special-data", subject.Id)
+            .WithFiles("small-csv-with-special-data")
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 5,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -68,6 +68,7 @@ public class ProcessorStage3Tests
                 .DefaultFilter()
                 .ForIndex(0, s => s
                     .SetLabel("Filter one")
+                    .SetHint("Hint 1")
                     .SetFilterGroups(_fixture
                         .DefaultFilterGroup()
                         .WithFilterItems(_fixture
@@ -77,6 +78,7 @@ public class ProcessorStage3Tests
                         .Generate(1)))
                 .ForIndex(1, s => s
                     .SetLabel("Filter two")
+                    .SetHint(null)
                     .SetFilterGroups(_fixture
                         .DefaultFilterGroup()
                         .WithFilterItems(_fixture
@@ -294,21 +296,25 @@ public class ProcessorStage3Tests
 
             Assert.NotNull(file.DataSetFileMeta);
 
-            // Checking against contents of small-csv.csv in Resources directory
+            // Checking against contents of small-csv.csv in Resources directory / _subject
             var geographicLevel = Assert.Single(file.DataSetFileMeta.GeographicLevels);
             Assert.Equal("Local authority", geographicLevel);
             Assert.Equal(TimeIdentifier.CalendarYear, file.DataSetFileMeta.TimeIdentifier);
             file.DataSetFileMeta.Years
                 .AssertDeepEqualTo([2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025]);
 
-            // Checking against contents of small-csv.meta.csv
+            // Checking against contents of small-csv.meta.csv / _subject
             file.DataSetFileMeta.Filters
-                .Select(f => f.Label).ToList()
-                .AssertDeepEqualTo(new List<string> { "Filter one", "Filter two", });
+                .Select(f => (f.Label, f.Hint, f.ColumnName)).ToList()
+                .AssertDeepEqualTo([
+                    ("Filter one", "Hint 1", "filter_one"),
+                    ("Filter two", null, "filter_two")]);
 
             file.DataSetFileMeta.Indicators
-                .Select(i => i.Label).ToList()
-                .AssertDeepEqualTo(new List<string> { "Indicator one", "Indicator two", });
+                .Select(i => (i.Label, i.ColumnName)).ToList()
+                .AssertDeepEqualTo([
+                    ("Indicator one", "indicator_one"),
+                    ("Indicator two", "indicator_two")]);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -104,15 +104,13 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("small-csv")
+            .WithFiles("small-csv", _subject.Id)
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
                 expectedImportedRows: 16
             )
             .Generate();
-
-        import.File.SubjectId = _subject.Id;
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(_statisticsDbContextId))
@@ -294,25 +292,23 @@ public class ProcessorStage3Tests
                 .Single(f => f.Type == FileType.Data
                              && f.SubjectId == import.File.SubjectId);
 
-            Assert.NotNull(file.DataSetFileMeta!);
+            Assert.NotNull(file.DataSetFileMeta);
 
             // Checking against contents of small-csv.csv in Resources directory
             var geographicLevel = Assert.Single(file.DataSetFileMeta.GeographicLevels);
             Assert.Equal("Local authority", geographicLevel);
             Assert.Equal(TimeIdentifier.CalendarYear, file.DataSetFileMeta.TimeIdentifier);
-            new List<int> { 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 }
-                .AssertDeepEqualTo(file.DataSetFileMeta.Years);
+            file.DataSetFileMeta.Years
+                .AssertDeepEqualTo([2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025]);
 
             // Checking against contents of small-csv.meta.csv
-            new List<string> { "Filter one", "Filter two", }
-                .AssertDeepEqualTo(
-                    file.DataSetFileMeta.Filters
-                        .Select(f => f.Label).ToList());
+            file.DataSetFileMeta.Filters
+                .Select(f => f.Label).ToList()
+                .AssertDeepEqualTo(new List<string> { "Filter one", "Filter two", });
 
-            new List<string> { "Indicator one", "Indicator two", }
-                .AssertDeepEqualTo(
-                    file.DataSetFileMeta.Indicators
-                        .Select(i => i.Label).ToList());
+            file.DataSetFileMeta.Indicators
+                .Select(i => i.Label).ToList()
+                .AssertDeepEqualTo(new List<string> { "Indicator one", "Indicator two", });
         }
     }
 
@@ -322,15 +318,13 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("small-csv")
+            .WithFiles("small-csv", subjectId: _subject.Id)
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
                 expectedImportedRows: 16
             )
             .Generate();
-
-        import.File.SubjectId = _subject.Id;
 
         var unexpectedImportedObservation = _fixture
             .DefaultObservation()
@@ -458,7 +452,7 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("small-csv")
+            .WithFiles("small-csv", _subject.Id)
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
@@ -467,8 +461,6 @@ public class ProcessorStage3Tests
                 lastProcessedRowIndex: 3
             )
             .Generate();
-
-        import.File.SubjectId = _subject.Id;
 
         var alreadyImportedObservations = _fixture
             .DefaultObservation()
@@ -615,7 +607,7 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("small-csv")
+            .WithFiles("small-csv", _subject.Id)
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
@@ -624,8 +616,6 @@ public class ProcessorStage3Tests
                 lastProcessedRowIndex: 9
             )
             .Generate();
-
-        import.File.SubjectId = _subject.Id;
 
         var alreadyImportedObservations = _fixture
             .DefaultObservation()
@@ -767,15 +757,13 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("ignored-school-rows")
+            .WithFiles("ignored-school-rows", _subject.Id)
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
                 expectedImportedRows: 8
             )
             .Generate();
-
-        import.File.SubjectId = _subject.Id;
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(_statisticsDbContextId))
@@ -919,7 +907,7 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("ignored-school-rows")
+            .WithFiles("ignored-school-rows", _subject.Id)
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
@@ -928,8 +916,6 @@ public class ProcessorStage3Tests
                 lastProcessedRowIndex: 6
             )
             .Generate();
-
-        import.File.SubjectId = _subject.Id;
 
         // Generate already-imported Observations with alternating CsvRow numbers
         // e.g. 2, 4, 6, 8
@@ -1369,15 +1355,13 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(_subject.Id)
-            .WithFiles("additional-filters-and-indicators")
+            .WithFiles("additional-filters-and-indicators", _subject.Id)
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 16,
                 expectedImportedRows: 16
             )
             .Generate();
-
-        import.File.SubjectId = _subject.Id;
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(_statisticsDbContextId))
@@ -1545,15 +1529,13 @@ public class ProcessorStage3Tests
         var import = _fixture
             .DefaultDataImport()
             .WithSubjectId(subject.Id)
-            .WithFiles("small-csv-with-special-data")
+            .WithFiles("small-csv-with-special-data", subject.Id)
             .WithStatus(STAGE_3)
             .WithRowCounts(
                 totalRows: 5,
                 expectedImportedRows: 5
             )
             .Generate();
-
-        import.File.SubjectId = subject.Id;
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(_statisticsDbContextId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -261,7 +261,7 @@ public class ProcessorStage3Tests
                 Assert.Equal(i + 2, observations[i].CsvRow));
 
             // Thoroughly check the first Observation row for correct details.
-            var firstObservation = observations[0];
+            var firstObservation = observations.First();
             var expectedLocation = _locations.Single(l => l.LocalAuthority!.Name == "Birmingham");
             Assert.Equal(expectedLocation.Id, firstObservation.LocationId);
             Assert.Equal(2018, firstObservation.Year);
@@ -276,7 +276,7 @@ public class ProcessorStage3Tests
             Assert.Equal("2", firstObservation.Measures[_subject.IndicatorGroups[0].Indicators[1].Id]);
 
             // Thoroughly check the last Observation row for correct details.
-            var lastObservation = observations[15];
+            var lastObservation = observations.Last();
             var expectedLocation2 = _locations.Single(l => l.LocalAuthority!.Name == "Camden");
             Assert.Equal(expectedLocation2.Id, lastObservation.LocationId);
             Assert.Equal(2025, lastObservation.Year);
@@ -293,7 +293,26 @@ public class ProcessorStage3Tests
             var file = contentDbContext.Files
                 .Single(f => f.Type == FileType.Data
                              && f.SubjectId == import.File.SubjectId);
-            Assert.NotNull(file.DataSetFileMeta);
+
+            Assert.NotNull(file.DataSetFileMeta!);
+
+            // Checking against contents of small-csv.csv in Resources directory
+            var geographicLevel = Assert.Single(file.DataSetFileMeta.GeographicLevels);
+            Assert.Equal("Local authority", geographicLevel);
+            Assert.Equal(TimeIdentifier.CalendarYear, file.DataSetFileMeta.TimeIdentifier);
+            new List<int> { 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 }
+                .AssertDeepEqualTo(file.DataSetFileMeta.Years);
+
+            // Checking against contents of small-csv.meta.csv
+            new List<string> { "Filter one", "Filter two", }
+                .AssertDeepEqualTo(
+                    file.DataSetFileMeta.Filters
+                        .Select(f => f.Label).ToList());
+
+            new List<string> { "Indicator one", "Indicator two", }
+                .AssertDeepEqualTo(
+                    file.DataSetFileMeta.Indicators
+                        .Select(i => i.Label).ToList());
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -112,6 +112,8 @@ public class ProcessorStage3Tests
             )
             .Generate();
 
+        import.File.SubjectId = _subject.Id;
+
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(_statisticsDbContextId))
         {
@@ -287,6 +289,11 @@ public class ProcessorStage3Tests
                 lastObservation.FilterItems[1].FilterItemId);
             Assert.Equal("16", lastObservation.Measures[_subject.IndicatorGroups[0].Indicators[0].Id]);
             Assert.Equal("32", lastObservation.Measures[_subject.IndicatorGroups[0].Indicators[1].Id]);
+
+            var file = contentDbContext.Files
+                .Single(f => f.Type == FileType.Data
+                             && f.SubjectId == import.File.SubjectId);
+            Assert.NotNull(file.DataSetFileMeta);
         }
     }
 
@@ -303,6 +310,8 @@ public class ProcessorStage3Tests
                 expectedImportedRows: 16
             )
             .Generate();
+
+        import.File.SubjectId = _subject.Id;
 
         var unexpectedImportedObservation = _fixture
             .DefaultObservation()
@@ -439,6 +448,8 @@ public class ProcessorStage3Tests
                 lastProcessedRowIndex: 3
             )
             .Generate();
+
+        import.File.SubjectId = _subject.Id;
 
         var alreadyImportedObservations = _fixture
             .DefaultObservation()
@@ -595,6 +606,8 @@ public class ProcessorStage3Tests
             )
             .Generate();
 
+        import.File.SubjectId = _subject.Id;
+
         var alreadyImportedObservations = _fixture
             .DefaultObservation()
             .WithSubject(_subject)
@@ -742,6 +755,8 @@ public class ProcessorStage3Tests
                 expectedImportedRows: 8
             )
             .Generate();
+
+        import.File.SubjectId = _subject.Id;
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(_statisticsDbContextId))
@@ -894,6 +909,8 @@ public class ProcessorStage3Tests
                 lastProcessedRowIndex: 6
             )
             .Generate();
+
+        import.File.SubjectId = _subject.Id;
 
         // Generate already-imported Observations with alternating CsvRow numbers
         // e.g. 2, 4, 6, 8
@@ -1341,6 +1358,8 @@ public class ProcessorStage3Tests
             )
             .Generate();
 
+        import.File.SubjectId = _subject.Id;
+
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(_statisticsDbContextId))
         {
@@ -1514,6 +1533,8 @@ public class ProcessorStage3Tests
                 expectedImportedRows: 5
             )
             .Generate();
+
+        import.File.SubjectId = subject.Id;
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(_statisticsDbContextId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Resources/small-csv.meta.csv
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Resources/small-csv.meta.csv
@@ -1,5 +1,5 @@
 col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
 ind_one,Indicator,Indicator one,,,,,
-filter_one,Filter,Filter one,,,,,
+filter_one,Filter,Filter one,,,,Hint 1,
 ind_two,Indicator,Indicator two,,,,,
 filter_two,Filter,Filter two,,,,,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
@@ -32,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             .ToList();
 
         [Fact]
-        public async Task CheckComplete()
+        public async Task CompleteImport()
         {
             var file = new File
             {
@@ -87,14 +87,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 var service = BuildFileImportService(dataImportService: dataImportService.Object);
-                await service.CheckComplete(import, statisticsDbContext);
+                await service.CompleteImport(import, statisticsDbContext);
             }
 
             VerifyAllMocks(dataImportService);
         }
 
         [Fact]
-        public async Task CheckComplete_Errors()
+        public async Task CompleteImport_Errors()
         {
             var file = new File
             {
@@ -140,14 +140,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 var service = BuildFileImportService(dataImportService: dataImportService.Object);
-                await service.CheckComplete(import, statisticsDbContext);
+                await service.CompleteImport(import, statisticsDbContext);
             }
 
             VerifyAllMocks(dataImportService);
         }
 
         [Fact]
-        public async Task CheckComplete_IncorrectObservationCount()
+        public async Task CompleteImport_IncorrectObservationCount()
         {
             var file = new File
             {
@@ -193,14 +193,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
                 var service = BuildFileImportService(dataImportService: dataImportService.Object);
-                await service.CheckComplete(import, statisticsDbContext);
+                await service.CompleteImport(import, statisticsDbContext);
             }
 
             VerifyAllMocks(dataImportService);
         }
 
         [Fact]
-        public async Task CheckComplete_AlreadyFinished()
+        public async Task CompleteImport_AlreadyFinished()
         {
             // We don't expect to see any further import status updates if the current status is in
             // any "finished" state  
@@ -225,21 +225,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                         ExpectedImportedRows = 2
                     };
 
-                    var statisticsDbContextId = Guid.NewGuid().ToString();
-
-                    await using var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId);
-
                     var dataImportService = new Mock<IDataImportService>(Strict);
-                    dataImportService.Setup(mock => mock.WriteDataSetFileMeta(import.SubjectId))
-                        .Returns(Task.CompletedTask);
+                    if (finishedStatus == COMPLETE)
+                    {
+                        dataImportService.Setup(mock => mock.WriteDataSetFileMeta(import.SubjectId))
+                            .Returns(Task.CompletedTask);
+                    }
 
-                    var service = BuildFileImportService(dataImportService: dataImportService.Object);
-                    await service.CheckComplete(import, statisticsDbContext);
+                    var statisticsDbContextId = Guid.NewGuid().ToString();
+                    await using var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId);
+                    {
+                        var service = BuildFileImportService(dataImportService: dataImportService.Object);
+                        await service.CompleteImport(import, statisticsDbContext);
+                    }
+
+                    VerifyAllMocks(dataImportService);
                 });
         }
 
         [Fact]
-        public async Task CheckComplete_Aborting()
+        public async Task CompleteImport_Aborting()
         {
             // We expect to see a final import status update if the current status is in an
             // "aborting" state, updating the import status to be in the associated final
@@ -277,7 +282,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
                     {
                         var service = BuildFileImportService(dataImportService: dataImportService.Object);
-                        await service.CheckComplete(import, statisticsDbContext);
+                        await service.CompleteImport(import, statisticsDbContext);
                     }
 
                     VerifyAllMocks(dataImportService);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
@@ -58,6 +58,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     import.Id, COMPLETE, 100))
                 .Returns(Task.CompletedTask);
 
+            dataImportService
+                .Setup(s => s.WriteDataSetFileMeta(
+                    import.SubjectId))
+                .Returns(Task.CompletedTask);
+
             var statisticsDbContextId = Guid.NewGuid().ToString();
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -206,7 +211,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     var file = new File
                     {
                         Id = Guid.NewGuid(),
-                        Filename = "my_data_file.csv"
+                        Filename = "my_data_file.csv",
                     };
 
                     var import = new DataImport
@@ -223,7 +228,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     var statisticsDbContextId = Guid.NewGuid().ToString();
 
                     await using var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId);
-                    var service = BuildFileImportService();
+
+                    var dataImportService = new Mock<IDataImportService>(Strict);
+                    dataImportService.Setup(mock => mock.WriteDataSetFileMeta(import.SubjectId))
+                        .Returns(Task.CompletedTask);
+
+                    var service = BuildFileImportService(dataImportService: dataImportService.Object);
                     await service.CheckComplete(import, statisticsDbContext);
                 });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -173,6 +174,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 .OrderBy(tp => tp.Year)
                 .ToList();
 
+            var filters = await statisticsDbContext.Filter
+                .AsNoTracking()
+                .Where(f => f.SubjectId == subjectId)
+                .OrderBy(f => f.Label)
+                .Select(f => new FilterMeta
+                {
+                    Id = f.Id,
+                    Label = f.Label,
+                    Hint = f.Hint,
+                    ColumnName = f.Name,
+                })
+                .ToListAsync();
+
             var indicators = await statisticsDbContext.Indicator
                 .AsNoTracking()
                 .Where(i => i.IndicatorGroup.SubjectId == subjectId)
@@ -180,15 +194,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 {
                     Id = i.Id,
                     Label = i.Label,
+                    ColumnName = i.Name,
                 })
                 .OrderBy(i => i.Label)
-                .ToListAsync();
-
-            var filters = await statisticsDbContext.Filter
-                .AsNoTracking()
-                .Where(f => f.SubjectId == subjectId)
-                .Select(f => new FilterMeta { Id = f.Id, Label = f.Label, })
-                .OrderBy(f => f.Label)
                 .ToListAsync();
 
             var dataSetFileMeta = new DataSetFileMeta

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -3,10 +3,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -147,6 +150,64 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             import.Status = newStatus;
             context.DataImports.Update(import);
             await context.SaveChangesAsync();
+        }
+
+        public async Task WriteDataSetFileMeta(Guid subjectId)
+        {
+            await using var contentDbContext = _dbContextSupplier.CreateDbContext<ContentDbContext>();
+            await using var statisticsDbContext = _dbContextSupplier.CreateDbContext<StatisticsDbContext>();
+
+            var observations = await statisticsDbContext.Observation
+                .AsNoTracking()
+                .Where(o => o.SubjectId == subjectId)
+                .Select(o => new { o.Location.GeographicLevel, o.Year, o.TimeIdentifier })
+                .Distinct()
+                .ToListAsync();
+
+            var geographicLevels = observations
+                .Select(o => o.GeographicLevel.GetEnumLabel())
+                .Distinct()
+                .OrderBy(gl => gl)
+                .ToList();
+
+            var timePeriods = observations
+                .Select(o => (o.Year, o.TimeIdentifier))
+                .Distinct()
+                .OrderBy(tp => tp.Year)
+                .ToList();
+
+            var indicators = await statisticsDbContext.Indicator
+                .AsNoTracking()
+                .Where(i => i.IndicatorGroup.SubjectId == subjectId)
+                .Select(i => new IndicatorMeta
+                {
+                    Id = i.Id,
+                    Label = i.Label,
+                })
+                .OrderBy(i => i.Label)
+                .ToListAsync();
+
+            var filters = await statisticsDbContext.Filter
+                .AsNoTracking()
+                .Where(f => f.SubjectId == subjectId)
+                .Select(f => new FilterMeta { Id = f.Id, Label = f.Label, })
+                .OrderBy(f => f.Label)
+                .ToListAsync();
+
+            var dataSetFileMeta = new DataSetFileMeta
+            {
+                GeographicLevels = geographicLevels,
+                TimeIdentifier = timePeriods[0].TimeIdentifier,
+                Years = timePeriods.Select(tp => tp.Year).ToList(),
+                Filters = filters,
+                Indicators = indicators,
+            };
+
+            var file = contentDbContext.Files
+                .Single(f => f.Type == FileType.Data
+                             && f.SubjectId == subjectId);
+            file.DataSetFileMeta = dataSetFileMeta;
+            await contentDbContext.SaveChangesAsync();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -74,7 +74,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             );
 
             var completedImport = await _dataImportService.GetImport(import.Id);
-            await CheckComplete(completedImport, context);
+            await CompleteImport(completedImport, context);
         }
 
         public async Task ImportFiltersAndLocations(
@@ -93,7 +93,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 context);
         }
 
-        public async Task CheckComplete(DataImport import, StatisticsDbContext context)
+        public async Task CompleteImport(DataImport import, StatisticsDbContext context)
         {
             if (import.Status.IsFinished())
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -102,6 +102,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     "mark as completed or failed",
                     import.File.Filename,
                     import.Status);
+
+                if (import.Status == COMPLETE)
+                {
+                    await _dataImportService.WriteDataSetFileMeta(import.SubjectId);
+                }
+
                 return;
             }
 
@@ -133,6 +139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 if (import.Errors.Count == 0)
                 {
                     await _dataImportService.UpdateStatus(import.Id, COMPLETE, 100);
+                    await _dataImportService.WriteDataSetFileMeta(import.SubjectId);
                 }
                 else
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
@@ -19,6 +19,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Int
 
         Task UpdateStatus(Guid id, DataImportStatus newStatus, double percentageComplete);
 
+        Task WriteDataSetFileMeta(Guid subjectId);
+
         Task Update(
             Guid id,
             int? expectedImportedRows = null,

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -105,12 +105,9 @@ export default function DataSetFilePage({ dataSetFileId }: Props) {
 
   const {
     file,
-    filters,
-    geographicLevels,
-    indicators,
     release,
     summary,
-    timePeriods,
+    meta: { timePeriod, filters, geographicLevels, indicators },
     title,
   } = dataSetFile;
 
@@ -255,9 +252,9 @@ export default function DataSetFilePage({ dataSetFileId }: Props) {
                       </CollapsibleList>
                     </SummaryListItem>
                   )}
-                  {timePeriods && (timePeriods.from || timePeriods.to) && (
+                  {timePeriod && (timePeriod.from || timePeriod.to) && (
                     <SummaryListItem term="Time period">
-                      {getTimePeriodString(timePeriods)}
+                      {getTimePeriodString(timePeriod)}
                     </SummaryListItem>
                   )}
                 </SummaryList>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
@@ -11,9 +11,16 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     fileId: 'file-id-1',
     filename: 'file-name-1',
     fileSize: '100 kb',
-    filters: ['Filter 1', 'Filter 2'],
-    geographicLevels: ['National', 'Regional'],
-    indicators: ['Indicator 1', 'Indicator 2'],
+    meta: {
+      timePeriod: {
+        timeIdentifier: 'Calendar year',
+        from: '2010',
+        to: '2020',
+      },
+      filters: ['Filter 1', 'Filter 2'],
+      geographicLevels: ['National', 'Regional'],
+      indicators: ['Indicator 1', 'Indicator 2'],
+    },
     latestData: true,
     publication: {
       id: 'publication-1',
@@ -29,10 +36,6 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
       id: 'theme-1',
       title: 'Theme 1',
     },
-    timePeriods: {
-      from: '2010',
-      to: '2020',
-    },
     title: 'Data set 1',
   },
   {
@@ -42,9 +45,16 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     fileId: 'file-id-2',
     filename: 'file-name-2',
     fileSize: '100 kb',
-    filters: ['Filter 1', 'Filter 2'],
-    geographicLevels: ['National', 'Regional'],
-    indicators: ['Indicator 1', 'Indicator 2'],
+    meta: {
+      timePeriod: {
+        timeIdentifier: 'Calendar year',
+        from: '2010',
+        to: '2020',
+      },
+      filters: ['Filter 1', 'Filter 2'],
+      geographicLevels: ['National', 'Regional'],
+      indicators: ['Indicator 1', 'Indicator 2'],
+    },
     latestData: true,
     publication: {
       id: 'publication-1',
@@ -60,10 +70,6 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
       id: 'theme-2',
       title: 'Theme 2',
     },
-    timePeriods: {
-      from: '2010',
-      to: '2020',
-    },
     title: 'Data set 2',
   },
   {
@@ -72,9 +78,16 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     fileId: 'file-id-3',
     filename: 'file-name-3',
     fileSize: '100 kb',
-    filters: ['Filter 1', 'Filter 2'],
-    geographicLevels: ['National', 'Regional'],
-    indicators: ['Indicator 1', 'Indicator 2'],
+    meta: {
+      timePeriod: {
+        timeIdentifier: 'Calendar year',
+        from: '2010',
+        to: '2020',
+      },
+      filters: ['Filter 1', 'Filter 2'],
+      geographicLevels: ['National', 'Regional'],
+      indicators: ['Indicator 1', 'Indicator 2'],
+    },
     latestData: true,
     publication: {
       id: 'publication-2',
@@ -89,10 +102,6 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     theme: {
       id: 'theme-2',
       title: 'Theme 2',
-    },
-    timePeriods: {
-      from: '2010',
-      to: '2020',
     },
     title: 'Data set 3',
   },
@@ -117,12 +126,14 @@ export const testDataSet: DataSetFile = {
   },
   summary: 'Data set 1 summary',
   title: 'Data set 1',
-  // These aren't in the backend yet, so may change.
-  filters: ['Filter 1', 'Filter 2'],
-  geographicLevels: ['Local authority', 'National'],
-  indicators: ['Indicator 1', 'Indicator 2'],
-  timePeriods: {
-    from: '2023',
-    to: '2024',
+  meta: {
+    timePeriod: {
+      timeIdentifier: 'Calendar year',
+      from: '2023',
+      to: '2024',
+    },
+    filters: ['Filter 1', 'Filter 2'],
+    geographicLevels: ['Local authority', 'National'],
+    indicators: ['Indicator 1', 'Indicator 2'],
   },
 };

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetFilePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetFilePage.test.tsx
@@ -49,24 +49,24 @@ describe('DataSetFilePage', () => {
       }),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByTestId('Geographic levels-value')).getByText(
+      within(screen.getByTestId('Geographic levels')).getByText(
         'Local authority, National',
       ),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByTestId('Indicators-value')).getByText('Indicator 1'),
+      within(screen.getByTestId('Indicators')).getByText('Indicator 1'),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByTestId('Indicators-value')).getByText('Indicator 2'),
+      within(screen.getByTestId('Indicators')).getByText('Indicator 2'),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByTestId('Filters-value')).getByText('Filter 1'),
+      within(screen.getByTestId('Filters')).getByText('Filter 1'),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByTestId('Filters-value')).getByText('Filter 2'),
+      within(screen.getByTestId('Filters')).getByText('Filter 2'),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByTestId('Time period-value')).getByText('2023 to 2024'),
+      within(screen.getByTestId('Time period')).getByText('2023 to 2024'),
     ).toBeInTheDocument();
 
     expect(

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetFilePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetFilePage.test.tsx
@@ -48,6 +48,26 @@ describe('DataSetFilePage', () => {
         name: /National statistics/,
       }),
     ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('Geographic levels-value')).getByText(
+        'Local authority, National',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('Indicators-value')).getByText('Indicator 1'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('Indicators-value')).getByText('Indicator 2'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('Filters-value')).getByText('Filter 1'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('Filters-value')).getByText('Filter 2'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('Time period-value')).getByText('2023 to 2024'),
+    ).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', { name: 'Download data set (ZIP)' }),

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
@@ -38,16 +38,22 @@ export default function DataSetFileSummary({
     id: dataSetFileId,
     content,
     fileId,
-    filters = [],
+    meta: {
+      timePeriod = {
+        timeIdentifier: undefined,
+        from: undefined,
+        to: undefined,
+      },
+      filters = [],
+      geographicLevels = [],
+      indicators = [],
+    },
     hasApiDataSet,
-    geographicLevels = [],
-    indicators = [],
     latestData,
     publication,
     published,
     release,
     theme,
-    timePeriods = {},
     title,
   } = dataSetFile;
   const [showMoreContent, toggleMoreContent] = useToggle(false);
@@ -183,14 +189,14 @@ export default function DataSetFileSummary({
             </CollapsibleList>
           </SummaryListItem>
         )}
-        {(timePeriods.from || timePeriods.to) && (
+        {(timePeriod.from || timePeriod.to) && (
           <SummaryListItem
             className={classNames({
               'dfe-js-hidden': !showDetails,
             })}
             term="Time period"
           >
-            {getTimePeriodString(timePeriods)}
+            {getTimePeriodString(timePeriod)}
           </SummaryListItem>
         )}
         <SummaryListItem

--- a/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
+++ b/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
@@ -5,6 +5,8 @@ import { SortDirection } from '@common/services/types/sort';
 
 export interface DataSetFile {
   id: string;
+  title: string;
+  summary: string;
   file: { id: string; name: string; size: string };
   hasApiDataSet?: boolean;
   release: {
@@ -21,27 +23,27 @@ export interface DataSetFile {
     title: string;
     type: ReleaseType;
   };
-  summary: string;
-  title: string;
-  // These aren't in the backend yet, so may change.
-  filters: string[];
-  geographicLevels: string[];
-  indicators: string[];
-  timePeriods: {
-    from?: string;
-    to?: string;
+  meta: {
+    geographicLevels: string[];
+    timePeriod: {
+      timeIdentifier: string;
+      from: string;
+      to: string;
+    };
+    filters: string[];
+    indicators: string[];
   };
 }
 
 export interface DataSetFileSummary {
   id: string;
-  content: string;
   fileId: string;
   filename: string;
   fileSize: string;
   fileExtension: string;
   hasApiDataSet?: boolean;
   title: string;
+  content: string;
   theme: {
     id: string;
     title: string;
@@ -56,14 +58,16 @@ export interface DataSetFileSummary {
   };
   latestData: boolean;
   published: Date;
-  // These aren't in the backend yet, so may change.
-  timePeriods: {
-    from?: string;
-    to?: string;
+  meta: {
+    geographicLevels: string[];
+    timePeriod: {
+      timeIdentifier: string;
+      from: string;
+      to: string;
+    };
+    filters: string[];
+    indicators: string[];
   };
-  geographicLevels: string[];
-  filters: string[];
-  indicators: string[];
 }
 
 export const dataSetFileSortOptions = [


### PR DESCRIPTION
This PR adds `DataSetFile` meta data to the Data catalogue and Data set pages.

The data is stored in the Files table. This is temporary in order to completely this feature quickly. The future plan is to migrate all `FileType.Data/Meta` files out of `Files/ReleaseFiles` into `DataSetFile/DataSetFileVersion` tables (and possibly a `ReleaseVersionDataSetFileVersion` table).

The `File.DataSetFileMeta` column cannot be set when the File is originally created, as the CSVs haven't yet been processed. So it is initially set to null and then set at the end of Data.Processor's Stage 3. I investigated setting `DataSetFileMeta` as the file was being imported for efficiency, but I think any efficiency gain would have been outweighed by the confusion of having the meta set in various places.

While I have hooked up the backend to the frontend in this ticket - most of the frontend work was already done - I haven't done much more than just that. The rest will be done in EES-4781.

:rotating_light: There is a faffy deploy ticket EES-5081 to trigger a migration to set `DataSetFile` meta for existing data files. :rotating_light: 

