### PR TITLE
Ees xxxx/resolve no html link for pages error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -155,7 +155,7 @@
       "extends": ["plugin:@next/next/recommended"],
       "rules": {
         "@next/next/no-img-element": "off",
-        "@next/next/no-html-link-for-pages": ["error", "src/pages/"]
+        "@next/next/no-html-link-for-pages": ["error", ["src/pages/", "src/explore-education-statistics-frontend/src/pages/"]]
       }
     }
   ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -154,7 +154,8 @@
       },
       "extends": ["plugin:@next/next/recommended"],
       "rules": {
-        "@next/next/no-img-element": "off"
+        "@next/next/no-img-element": "off",
+        "@next/next/no-html-link-for-pages": ["error", "src/pages/"]
       }
     }
   ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -155,7 +155,7 @@
       "extends": ["plugin:@next/next/recommended"],
       "rules": {
         "@next/next/no-img-element": "off",
-        "@next/next/no-html-link-for-pages": ["error", ["src/pages/", "src/explore-education-statistics-frontend/src/pages/"]]
+        "@next/next/no-html-link-for-pages": ["error", ["src/pages", "src/explore-education-statistics-frontend/src/pages"]]
       }
     }
   ]


### PR DESCRIPTION
We currently see a warning when running `pnpm lint` or `pnpm start frontend`, telling us that the "Pages directory cannot be found at .". This is because of a rule in the `@next/next/recommended` plugin which requires the root of the pages directory in a NextJS app. If the pages directory does not live in the project route, it needs to be given a manual path.

We have to configure two paths in our case, because `pnpm lint` runs from the repository root, but `pnpm start frontend` will ultimately end up running from `src/explore-education-statistics-frontend/`. Luckily, it's smart enough to accept an array and not complain about incorrect paths so long as one of them finds a `pages` directory.  

https://nextjs.org/docs/messages/no-html-link-for-pages#options