### PR TITLE
EES-5082 Replacing `DataSetVersion.CsvFileId` with `DataSetVersion.ReleaseFileId`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
@@ -42,10 +42,10 @@ public static class DataSetVersionGeneratorExtensions
         Guid dataSetId)
         => generator.ForInstance(s => s.SetDataSetId(dataSetId));
 
-    public static Generator<DataSetVersion> WithCsvFileId(
+    public static Generator<DataSetVersion> WithReleaseFileId(
         this Generator<DataSetVersion> generator,
-        Guid csvFileId)
-        => generator.ForInstance(s => s.SetCsvFileId(csvFileId));
+        Guid releaseFileId)
+        => generator.ForInstance(s => s.SetReleaseFileId(releaseFileId));
 
     public static Generator<DataSetVersion> WithVersionNumber(
         this Generator<DataSetVersion> generator,
@@ -178,7 +178,7 @@ public static class DataSetVersionGeneratorExtensions
         => setters
             .SetDefault(dsv => dsv.Id)
             .SetDefault(dsv => dsv.DataSetId)
-            .SetDefault(dsv => dsv.CsvFileId)
+            .SetDefault(dsv => dsv.ReleaseFileId)
             .SetDefault(dsv => dsv.Notes)
             .Set(dsv => dsv.VersionMajor, 1)
             .Set(dsv => dsv.VersionMinor, (_, _, context) => context.Index)
@@ -197,10 +197,10 @@ public static class DataSetVersionGeneratorExtensions
         Guid dataSetId)
         => instanceSetter.Set(dsv => dsv.DataSetId, dataSetId);
 
-    public static InstanceSetters<DataSetVersion> SetCsvFileId(
+    public static InstanceSetters<DataSetVersion> SetReleaseFileId(
         this InstanceSetters<DataSetVersion> instanceSetter,
-        Guid csvFileId)
-        => instanceSetter.Set(dsv => dsv.CsvFileId, csvFileId);
+        Guid releaseFileId)
+        => instanceSetter.Set(dsv => dsv.ReleaseFileId, releaseFileId);
 
     public static InstanceSetters<DataSetVersion> SetVersionNumber(
         this InstanceSetters<DataSetVersion> instanceSetter,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -17,7 +17,7 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public required DataSetVersionStatus Status { get; set; }
 
-    public required Guid CsvFileId { get; set; }
+    public required Guid ReleaseFileId { get; set; }
 
     public required int VersionMajor { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240424090205_InitialMigration.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240424090205_InitialMigration.Designer.cs
@@ -13,7 +13,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
 {
     [DbContext(typeof(PublicDataDbContext))]
-    [Migration("20240416122016_InitialMigration")]
+    [Migration("20240424090205_InitialMigration")]
     partial class InitialMigration
     {
         /// <inheritdoc />
@@ -200,9 +200,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Property<DateTimeOffset>("Created")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<Guid>("CsvFileId")
-                        .HasColumnType("uuid");
-
                     b.Property<Guid>("DataSetId")
                         .HasColumnType("uuid");
 
@@ -212,6 +209,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
                     b.Property<DateTimeOffset?>("Published")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("ReleaseFileId")
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Status")
                         .IsRequired()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240424090205_InitialMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240424090205_InitialMigration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -54,7 +54,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
                     Changes = table.Column<string>(type: "jsonb", nullable: true),
                     Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
                 },
                 constraints: table =>
                 {
@@ -69,7 +69,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
                     Changes = table.Column<string>(type: "jsonb", nullable: true),
                     Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
                 },
                 constraints: table =>
                 {
@@ -84,7 +84,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
                     Changes = table.Column<string>(type: "jsonb", nullable: true),
                     Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
                 },
                 constraints: table =>
                 {
@@ -99,7 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
                     Changes = table.Column<string>(type: "jsonb", nullable: true),
                     Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
                 },
                 constraints: table =>
                 {
@@ -114,7 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
                     Changes = table.Column<string>(type: "jsonb", nullable: true),
                     Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
                 },
                 constraints: table =>
                 {
@@ -155,7 +155,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     DataSetId = table.Column<Guid>(type: "uuid", nullable: false),
                     Status = table.Column<string>(type: "text", nullable: false),
-                    CsvFileId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ReleaseFileId = table.Column<Guid>(type: "uuid", nullable: false),
                     VersionMajor = table.Column<int>(type: "integer", nullable: false),
                     VersionMinor = table.Column<int>(type: "integer", nullable: false),
                     Notes = table.Column<string>(type: "text", nullable: false),
@@ -164,7 +164,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     Published = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
                     Withdrawn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
                     Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
                 },
                 constraints: table =>
                 {
@@ -569,6 +569,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                 principalTable: "DataSetVersions",
                 principalColumn: "Id");
 
+
             // Grant permissions on database tables created by this resource's database user to the
             // Admin App Service and Data Processor Function App users.
             var adminAppServiceIdentityName = Environment.GetEnvironmentVariable("AdminAppServiceIdentityName");
@@ -577,7 +578,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                 migrationBuilder.Sql(
                     $"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO \"{adminAppServiceIdentityName}\"");
             }
-
             var dataProcessorFunctionAppIdentityName = Environment.GetEnvironmentVariable("DataProcessorFunctionAppIdentityName");
             if (dataProcessorFunctionAppIdentityName != null)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
@@ -197,9 +197,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Property<DateTimeOffset>("Created")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<Guid>("CsvFileId")
-                        .HasColumnType("uuid");
-
                     b.Property<Guid>("DataSetId")
                         .HasColumnType("uuid");
 
@@ -209,6 +206,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
                     b.Property<DateTimeOffset?>("Published")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("ReleaseFileId")
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Status")
                         .IsRequired()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
@@ -307,7 +307,7 @@ public class SeedDataCommand : ICommand
                 VersionMinor = 0,
                 Status = DataSetVersionStatus.Published,
                 Notes = string.Empty,
-                CsvFileId = Guid.NewGuid(),
+                ReleaseFileId = Guid.NewGuid(),
                 DataSetId = _seed.DataSet.Id,
                 TotalResults = totalResults,
                 MetaSummary = new DataSetVersionMetaSummary


### PR DESCRIPTION
The aim of this ticket is to remove the `CsvFileId` column from the `DataSetVersions` table in the Public Data DB and replace it with a `ReleaseFileId` column which represents the ID (primary key) of the `ReleaseFiles` table in the Content DB.

This gives us everything we need in order to be able to link from a Public API `DataSetVersion` back to it’s associated `File` AND `ReleaseFile` AND `ReleaseVersion` in the Content DB.

Previously we were only able to link back to the `File` from the `CsvFileId` relation.