### PR TITLE
EES-5083 Update scheduled UI tests' runs

### DIFF
--- a/azure-pipelines-ui-tests.dfe.yml
+++ b/azure-pipelines-ui-tests.dfe.yml
@@ -1,7 +1,7 @@
 variables:
   SPN_NAME: s101d-datahub-spn-ees-dfe-gov-uk
 schedules:
-- cron: 0 5,7,19 * * 1,2,3,4,5
+- cron: 0 6 * * 1,2,3,4,5
   branches:
     include:
     - dev

--- a/tests/robot-tests/tests/general_public/notifications_absence.robot
+++ b/tests/robot-tests/tests/general_public/notifications_absence.robot
@@ -27,8 +27,7 @@ Go to Notify me page for Absence publication
     user checks nth breadcrumb contains    4    Notify me
 
 Sign up for email alerts
-    [Documentation]    EES-716    EES-1265
-    [Tags]    NotAgainstPreProd    NotAgainstLocal
+    [Tags]    NotAgainstLocal
     user clicks element    id:subscriptionForm-email
     press keys    id:subscriptionForm-email    mark@hiveit.co.uk
     user clicks button    Subscribe


### PR DESCRIPTION
This PR updates Cron schedules for automated UI test runs to be triggered only once a day during weekdays. 
Re instated 'subscription notification' UI tests to run against Pre-prod. 