### PR TITLE
EES-5085 Fix incorrect slugs for updated publication titles with dashes and spaces

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/NamingUtilTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/NamingUtilTests.cs
@@ -1,37 +1,36 @@
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.NamingUtils;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests;
+
+public abstract class NamingUtilTests
 {
-    public class NamingUtilTests
+    public class SlugFromTitleTests
     {
-        
         [Fact]
-        public void ReleaseSlugFromTitle_CalendarYear()
+        public void CalendarYearTitle()
         {
-            var slug = SlugFromTitle("calendar year 2019");
-            Assert.Equal("calendar-year-2019", slug);
+            Assert.Equal("calendar-year-2019", SlugFromTitle("calendar year 2019"));
         }
-        
+
         [Fact]
-        public void ReleaseSlugFromTitle_NonCalendarYear()
+        public void NonCalendarYearTitle()
         {
-            var slug = SlugFromTitle("tax year 2019/20");
-            Assert.Equal("tax-year-2019-20", slug);
+            Assert.Equal("tax-year-2019-20", SlugFromTitle("tax year 2019/20"));
         }
-        
-        
-        [Fact]
-        public void GenerateSlugFromTitle()
+
+        [Theory]
+        [InlineData("title", "title")]
+        [InlineData("TITLE", "title")]
+        [InlineData("A sentence with spaces", "a-sentence-with-spaces")]
+        [InlineData("A - sentence -  with - - dashes  -  and -- spaces", "a-sentence-with-dashes-and-spaces")]
+        [InlineData("A sentence with !@£('\\) non alpha numeric characters", "a-sentence-with-non-alpha-numeric-characters")]
+        [InlineData("A sentence with non alpha numeric characters at the end !@£('\\)", "a-sentence-with-non-alpha-numeric-characters-at-the-end")]
+        [InlineData("a sentence with      big     spaces   ", "a-sentence-with-big-spaces")]
+        [InlineData("a sentence with numbers 1 2 3 and 4", "a-sentence-with-numbers-1-2-3-and-4")]
+        public void EdgeCaseTitles(string title, string expectedSlug)
         {
-            Assert.Equal("title", SlugFromTitle("title"));
-            Assert.Equal("title", SlugFromTitle("TITLE"));
-            Assert.Equal("a-sentence-with-spaces",SlugFromTitle("A sentence with spaces"));
-            Assert.Equal("a-sentence-with-non-alpha-numeric-characters",SlugFromTitle("A sentence with !@£('\\) non alpha numeric characters"));
-            Assert.Equal("a-sentence-with-non-alpha-numeric-characters-at-the-end", SlugFromTitle("A sentence with non alpha numeric characters at the end !@£('\\)"));
-            Assert.Equal("a-sentence-with-big-spaces", SlugFromTitle("a sentence with      big     spaces   "));
-            Assert.Equal("a-sentence-with-numbers-1-2-3-and-4", SlugFromTitle("a sentence with numbers 1 2 3 and 4"));
+            Assert.Equal(expectedSlug, SlugFromTitle(title));
         }
-        
     }
 }

--- a/src/explore-education-statistics-common/src/utils/__tests__/slugFromTitle.test.tsx
+++ b/src/explore-education-statistics-common/src/utils/__tests__/slugFromTitle.test.tsx
@@ -23,6 +23,12 @@ describe('slugFromTitle', () => {
     );
   });
 
+  test('converts a sentence with dashes and spaces', () => {
+    expect(
+      slugFromTitle('A - sentence -  with - - dashes  -  and -- spaces'),
+    ).toEqual('a-sentence-with-dashes-and-spaces');
+  });
+
   test('converts a sentence with non alphanumeric characters', () => {
     expect(
       slugFromTitle("A sentence with !@£('\\) non alpha numeric characters"),

--- a/src/explore-education-statistics-common/src/utils/slugFromTitle.ts
+++ b/src/explore-education-statistics-common/src/utils/slugFromTitle.ts
@@ -4,9 +4,5 @@
  * Duplicates NamingUtils#SlugFromTitle in the backend
  */
 export default function slugFromTitle(title: string) {
-  return title
-    .replace(/[^\w-]+/g, ' ')
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, '-');
+  return title.replace(/\W+/g, ' ').trim().toLowerCase().replace(/\s+/g, '-');
 }

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_methodology_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_methodology_publication_update.robot
@@ -12,10 +12,10 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=                            UI tests-publish publication update %{RUN_IDENTIFIER}
-${PUBLIC_METHODOLOGY_URL_ENDING}=               /methodology/ui-tests-publish-publication-update-%{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=                            UI tests - publish methodology publication update %{RUN_IDENTIFIER}
+${PUBLIC_METHODOLOGY_URL_ENDING}=               /methodology/ui-tests-publish-methodology-publication-update-%{RUN_IDENTIFIER}
 ${PUBLICATION_NAME_UPDATED}=                    ${PUBLICATION_NAME} updated
-${PUBLIC_PUBLICATION_URL_ENDING}=               /find-statistics/ui-tests-publish-publication-update-%{RUN_IDENTIFIER}
+${PUBLIC_PUBLICATION_URL_ENDING}=               /find-statistics/ui-tests-publish-methodology-publication-update-%{RUN_IDENTIFIER}
 ${EXPECTED_PUBLIC_PUBLICATION_URL_ENDING}=      %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}
 ${RELEASE_NAME}=                                Academic year Q1
 ${ACADEMIC_YEAR}=                               /2046-47


### PR DESCRIPTION
This PR fixes incorrect slugs being shown when updating publication titles. Previously, titles like `My test - publication` would result in a slug like `my-test---publication`. With the fix, this is now `my-test-publication`.

As part of this, we've also updated the `publish_methodology_publication_update.robot` suite, which would previously fail on parallel test runs due to having a publication title that is a duplicate of another test suite (`publish_publication_update.robot`). It's likely that the publication title used in `publish_methodology_publication_update.robot` had previously been non-standard to avoid this slug issue.