### PR TITLE
EES-3192: Add error page redirection to Notifier on verification failure

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/SubscriptionManager.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/SubscriptionManager.cs
@@ -1,16 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Configuration;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Cosmos.Table;
-using Microsoft.Extensions.Logging;
-using Notify.Exceptions;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Notify.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Functions
@@ -254,7 +254,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier.Functions
                 }
             }
 
-            return new BadRequestObjectResult("Unable to verify subscription");
+            return new RedirectResult(
+                $"{_appSettingOptions.PublicAppUrl}/subscriptions/verification-error",
+                true);
         }
 
         [Function("RemoveNonVerifiedSubscriptions")]

--- a/src/explore-education-statistics-frontend/src/modules/subscriptions/VerificationErrorPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/subscriptions/VerificationErrorPage.tsx
@@ -1,0 +1,26 @@
+import Page from '@frontend/components/Page';
+import { NextPage } from 'next';
+import React from 'react';
+
+const VerificationErrorPage: NextPage = () => {
+  return (
+    <Page title="Verification failed">
+      <div className="govuk-panel__body">
+        <p>
+          Your subscription verification token has expired. You can try again by
+          re-subscribing from the publication's main screen.
+        </p>
+        <p>
+          If this issue persists, please contact{' '}
+          <a href="mailto:explore.statistics@education.gov.uk">
+            explore.statistics@education.gov.uk
+          </a>{' '}
+          for support with details of the publication you are trying to
+          subscribe to.
+        </p>
+      </div>
+    </Page>
+  );
+};
+
+export default VerificationErrorPage;

--- a/src/explore-education-statistics-frontend/src/pages/subscriptions/verification-error.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/subscriptions/verification-error.tsx
@@ -1,0 +1,1 @@
+export { default } from '@frontend/modules/subscriptions/VerificationErrorPage';


### PR DESCRIPTION
Public website users subscribing to publication notifications were presented with a generic, non-user-friendly error message if they attempted to verify their email address after the verification token had expired.

This change adds an error page matching existing error page format and style (and meeting the GDS standards) to inform users of the issue, and how to resolve it.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/77351705/f3685a02-3308-43b3-9f8e-3ff72917407a)