### PR TITLE
EES-4995 show API data sets tag and allow filtering

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
@@ -8,6 +8,7 @@ export interface FormFieldsetProps {
   children?: ReactNode;
   className?: string;
   error?: string;
+  formGroupClass?: string;
   hint?: string | ReactNode;
   id: string;
   legend: ReactNode | string;
@@ -28,6 +29,7 @@ const FormFieldset = ({
   children,
   className,
   error,
+  formGroupClass,
   hint,
   id,
   legend,
@@ -43,7 +45,7 @@ const FormFieldset = ({
   const fieldId = useFormId ? prefixFormId(id) : id;
 
   return (
-    <FormGroup hasError={!!error}>
+    <FormGroup className={formGroupClass} hasError={!!error}>
       <fieldset
         aria-describedby={
           classNames({

--- a/src/explore-education-statistics-common/test/render.tsx
+++ b/src/explore-education-statistics-common/test/render.tsx
@@ -4,8 +4,13 @@ import {
   RenderOptions,
   RenderResult,
 } from '@testing-library/react';
+import userEvent, { UserEvent } from '@testing-library/user-event';
 import noop from 'lodash/noop';
 import React, { FC, ReactElement, ReactNode } from 'react';
+
+interface CustomRenderResult extends RenderResult {
+  user: UserEvent;
+}
 
 const DefaultWrapper: FC = ({ children }: { children?: ReactNode }) => {
   const queryClient = new QueryClient({
@@ -36,9 +41,12 @@ const DefaultWrapper: FC = ({ children }: { children?: ReactNode }) => {
 export default function render(
   ui: ReactElement,
   options?: Omit<RenderOptions, 'queries'>,
-): RenderResult {
-  return baseRender(ui, {
-    wrapper: DefaultWrapper,
-    ...options,
-  });
+): CustomRenderResult {
+  return {
+    ...(baseRender(ui, {
+      wrapper: DefaultWrapper,
+      ...options,
+    }) as RenderResult),
+    user: userEvent.setup(),
+  };
 }

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePageNew.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePageNew.tsx
@@ -23,6 +23,7 @@ import { logEvent } from '@frontend/services/googleAnalyticsService';
 import {
   DataSetFileFilter,
   DataSetFileSortOption,
+  DataSetType,
   dataSetFileFilters,
 } from '@frontend/services/dataSetFileService';
 import Filters from '@frontend/modules/data-catalogue/components/Filters';
@@ -42,6 +43,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 
 export interface DataCataloguePageQuery {
+  dataSetType?: DataSetType;
   latestOnly?: string;
   page?: number;
   publicationId?: string;
@@ -57,8 +59,15 @@ export default function DataCataloguePageNew() {
   const queryClient = useQueryClient();
   const { isMedia: isMobileMedia } = useMobileMedia();
 
-  const { latestOnly, sortBy, publicationId, releaseId, searchTerm, themeId } =
-    getParamsFromQuery(router.query);
+  const {
+    dataSetType,
+    latestOnly,
+    sortBy,
+    publicationId,
+    releaseId,
+    searchTerm,
+    themeId,
+  } = getParamsFromQuery(router.query);
 
   const {
     data: dataSetsData,
@@ -288,24 +297,19 @@ export default function DataCataloguePageNew() {
           {!isMobileMedia && (
             <LoadingSpinner loading={isLoadingThemes}>
               <Filters
+                dataSetType={dataSetType}
                 latestOnly={latestOnly}
                 publicationId={publicationId}
                 publications={publications}
                 releaseId={releaseId}
                 releases={releases}
+                showClearFiltersButton={!isMobileMedia && isFiltered}
                 themeId={themeId}
                 themes={themes}
                 onChange={handleChangeFilter}
+                onClearFilters={() => handleClearFilter({ filterType: 'all' })}
               />
             </LoadingSpinner>
-          )}
-
-          {!isMobileMedia && isFiltered && (
-            <ButtonText
-              onClick={() => handleClearFilter({ filterType: 'all' })}
-            >
-              Clear filters
-            </ButtonText>
           )}
         </div>
         <div className="govuk-grid-column-two-thirds">
@@ -396,6 +400,7 @@ export default function DataCataloguePageNew() {
                 totalResults={totalResults}
               >
                 <Filters
+                  dataSetType={dataSetType}
                   latestOnly={latestOnly}
                   publicationId={publicationId}
                   publications={publications}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
@@ -5,6 +5,7 @@ import {
 
 export const testDataSetFileSummaries: DataSetFileSummary[] = [
   {
+    hasApiDataSet: true,
     id: 'datasetfile-id-1',
     fileExtension: 'csv',
     fileId: 'file-id-1',
@@ -35,6 +36,7 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     title: 'Data set 1',
   },
   {
+    hasApiDataSet: false,
     id: 'datasetfile-id-2',
     fileExtension: 'csv',
     fileId: 'file-id-2',

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
@@ -6,6 +6,7 @@ import FormattedDate from '@common/components/FormattedDate';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import Tag from '@common/components/Tag';
+import TagGroup from '@common/components/TagGroup';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import useToggle from '@common/hooks/useToggle';
 import getTimePeriodString from '@common/modules/table-tool/utils/getTimePeriodString';
@@ -38,6 +39,7 @@ export default function DataSetFileSummary({
     content,
     fileId,
     filters = [],
+    hasApiDataSet,
     geographicLevels = [],
     indicators = [],
     latestData,
@@ -95,15 +97,6 @@ export default function DataSetFileSummary({
           <VisuallyHidden> about {title}</VisuallyHidden>
         </ButtonText>
       )}
-      {showLatestDataTag && (
-        <p className="govuk-!-margin-top-4">
-          <Tag colour={latestData ? undefined : 'orange'}>
-            {latestData
-              ? 'This is the latest data'
-              : 'This is not the latest data'}
-          </Tag>
-        </p>
-      )}
 
       <SummaryList
         ariaLabel={`Details list for ${title}`}
@@ -112,6 +105,20 @@ export default function DataSetFileSummary({
         compact
         noBorder
       >
+        {(showLatestDataTag || hasApiDataSet) && (
+          <SummaryListItem term="Status">
+            <TagGroup>
+              {showLatestDataTag && (
+                <Tag colour={latestData ? undefined : 'orange'}>
+                  {latestData
+                    ? 'This is the latest data'
+                    : 'This is not the latest data'}
+                </Tag>
+              )}
+              {hasApiDataSet && <Tag colour="grey">Available by API</Tag>}
+            </TagGroup>
+          </SummaryListItem>
+        )}
         <SummaryListItem term="Theme">{theme.title}</SummaryListItem>
         <SummaryListItem term="Published">
           <FormattedDate format="d MMM yyyy">{published}</FormattedDate>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/Filters.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/Filters.module.scss
@@ -3,7 +3,7 @@
 .form {
   margin-top: govuk-spacing(5);
 
-  :global(label) {
+  :global(.govuk-form-group) {
     margin-top: govuk-spacing(2);
   }
 

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/Filters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/Filters.tsx
@@ -4,17 +4,30 @@ import {
   Theme,
 } from '@common/services/publicationService';
 import Button from '@common/components/Button';
-import { FormFieldset, FormGroup, FormSelect } from '@common/components/form';
-import { DataSetFileFilter } from '@frontend/services/dataSetFileService';
+import {
+  FormFieldset,
+  FormGroup,
+  FormRadioGroup,
+  FormSelect,
+} from '@common/components/form';
+import {
+  DataSetFileFilter,
+  DataSetType,
+} from '@frontend/services/dataSetFileService';
 import styles from '@frontend/modules/data-catalogue/components/Filters.module.scss';
 import React from 'react';
+import ButtonText from '@common/components/ButtonText';
+
+const formId = 'filters-form';
 
 interface Props {
+  dataSetType?: DataSetType;
   latestOnly?: string;
   publicationId?: string;
   publications?: PublicationTreeSummary[];
   releaseId?: string;
   releases?: ReleaseSummary[];
+  showClearFiltersButton?: boolean;
   themeId?: string;
   themes: Theme[];
   onChange: ({
@@ -24,23 +37,27 @@ interface Props {
     filterType: DataSetFileFilter;
     nextValue: string;
   }) => void;
+  onClearFilters?: () => void;
 }
 
 export default function Filters({
+  dataSetType = 'all',
   latestOnly = 'true',
   publications = [],
   publicationId,
   releaseId,
   releases = [],
+  showClearFiltersButton,
   themeId,
   themes,
   onChange,
+  onClearFilters,
 }: Props) {
   const latestValue = latestOnly === 'true' ? 'latest' : 'all';
   return (
-    <form className={styles.form} id="filters-form">
+    <form className={styles.form} id={formId}>
       <FormFieldset
-        id="filters"
+        id={`${formId}-filters`}
         legend="Filter data sets"
         legendSize="m"
         className="govuk-fieldset "
@@ -48,7 +65,7 @@ export default function Filters({
         <FormGroup>
           <FormSelect
             className="govuk-!-width-full"
-            id="theme"
+            id={`${formId}-theme`}
             label="Theme"
             name="themeId"
             options={[
@@ -70,7 +87,7 @@ export default function Filters({
           <FormSelect
             className="govuk-!-width-full"
             disabled={!themeId}
-            id="publication"
+            id={`${formId}-publication`}
             label="Publication"
             name="publicationId"
             options={[
@@ -94,7 +111,7 @@ export default function Filters({
         <FormGroup>
           <FormSelect
             className="govuk-!-width-full"
-            id="release"
+            id={`${formId}-release`}
             label="Releases"
             name="releaseId"
             options={[
@@ -116,6 +133,33 @@ export default function Filters({
             }}
           />
         </FormGroup>
+
+        {showClearFiltersButton && (
+          <ButtonText onClick={onClearFilters}>Clear filters</ButtonText>
+        )}
+
+        <FormRadioGroup<DataSetType>
+          formGroupClass="dfe-border-top govuk-!-padding-top-4 govuk-!-margin-top-2"
+          id={`${formId}-dataSetType`}
+          legend="Type of data"
+          legendSize="s"
+          name="dataSetType"
+          options={[
+            { label: 'All data', value: 'all' },
+            {
+              label: 'API data sets only',
+              value: 'api',
+            },
+          ]}
+          small
+          value={dataSetType}
+          onChange={e => {
+            onChange({
+              filterType: 'dataSetType',
+              nextValue: e.target.value,
+            });
+          }}
+        />
       </FormFieldset>
 
       <Button className="dfe-js-hidden" type="submit">

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetSummary.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetSummary.test.tsx
@@ -38,9 +38,10 @@ describe('DataSetFileSummary', () => {
   });
 
   test('renders the expanded view when show more details is clicked', async () => {
+    const user = userEvent.setup();
     render(<DataSetFileSummary dataSetFile={testDataSetFileSummaries[0]} />);
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: 'Show more details about Data set 1',
       }),
@@ -153,5 +154,21 @@ describe('DataSetFileSummary', () => {
     expect(
       screen.queryByText('This is the latest data'),
     ).not.toBeInTheDocument();
+  });
+
+  test('renders the `Available by API` tag when it is available by API', () => {
+    render(
+      <DataSetFileSummary dataSetFile={testDataSetFileSummaries[0]} expanded />,
+    );
+
+    expect(screen.getByText('Available by API')).toBeInTheDocument();
+  });
+
+  test('does not render the `Available by API` tag when it is not available by API', () => {
+    render(
+      <DataSetFileSummary dataSetFile={testDataSetFileSummaries[1]} expanded />,
+    );
+
+    expect(screen.queryByText('Available by API')).not.toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/Filters.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/Filters.test.tsx
@@ -3,7 +3,6 @@ import { testReleases } from '@frontend/modules/data-catalogue/__data__/testRele
 import { testThemes } from '@frontend/modules/data-catalogue/__data__/testThemes';
 import { screen, within } from '@testing-library/react';
 import render from '@common-test/render';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
 import noop from 'lodash/noop';
 
@@ -52,6 +51,14 @@ describe('Filters', () => {
     expect(releases[1]).toHaveTextContent('All releases');
     expect(releases[1]).toHaveValue('all');
     expect(releases[1].selected).toBe(false);
+
+    const apiFilter = within(
+      screen.getByRole('group', {
+        name: 'Type of data',
+      }),
+    );
+    expect(apiFilter.getByLabelText('All data')).toBeChecked();
+    expect(apiFilter.getByLabelText('API data sets only')).not.toBeChecked();
   });
 
   test('populates the release filter with all & releases when there is a publicationId', () => {
@@ -98,11 +105,13 @@ describe('Filters', () => {
 
   test('calls the onChange handler when the theme filter is changed', async () => {
     const handleChange = jest.fn();
-    render(<Filters themes={testThemes} onChange={handleChange} />);
+    const { user } = render(
+      <Filters themes={testThemes} onChange={handleChange} />,
+    );
 
     expect(handleChange).not.toHaveBeenCalled();
 
-    await userEvent.selectOptions(screen.getByLabelText('Theme'), ['theme-1']);
+    await user.selectOptions(screen.getByLabelText('Theme'), ['theme-1']);
 
     expect(handleChange).toHaveBeenCalledWith({
       filterType: 'themeId',
@@ -112,7 +121,7 @@ describe('Filters', () => {
 
   test('calls the onChange handler when the publication filter is changed', async () => {
     const handleChange = jest.fn();
-    render(
+    const { user } = render(
       <Filters
         publications={testThemes[1].topics[0].publications}
         themeId="theme-2"
@@ -123,7 +132,7 @@ describe('Filters', () => {
 
     expect(handleChange).not.toHaveBeenCalled();
 
-    await userEvent.selectOptions(screen.getByLabelText('Publication'), [
+    await user.selectOptions(screen.getByLabelText('Publication'), [
       'publication-2',
     ]);
 
@@ -135,7 +144,7 @@ describe('Filters', () => {
 
   test('calls the onChange handler when the release filter is changed', async () => {
     const handleChange = jest.fn();
-    render(
+    const { user } = render(
       <Filters
         publicationId="publication-2"
         releases={testReleases}
@@ -147,13 +156,33 @@ describe('Filters', () => {
 
     expect(handleChange).not.toHaveBeenCalled();
 
-    await userEvent.selectOptions(screen.getByLabelText('Releases'), [
-      'release-1',
-    ]);
+    await user.selectOptions(screen.getByLabelText('Releases'), ['release-1']);
 
     expect(handleChange).toHaveBeenCalledWith({
       filterType: 'releaseId',
       nextValue: 'release-1',
+    });
+  });
+
+  test('calls the onChange handler when the type of data filter is changed', async () => {
+    const handleChange = jest.fn();
+    const { user } = render(
+      <Filters
+        publicationId="publication-2"
+        releases={testReleases}
+        themes={testThemes}
+        themeId="theme-2"
+        onChange={handleChange}
+      />,
+    );
+
+    expect(handleChange).not.toHaveBeenCalled();
+
+    await user.click(screen.getByLabelText('API data sets only'));
+
+    expect(handleChange).toHaveBeenCalledWith({
+      filterType: 'dataSetType',
+      nextValue: 'api',
     });
   });
 

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/createDataSetFileListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/createDataSetFileListRequest.ts
@@ -15,6 +15,7 @@ export default function createDataSetFileListRequest(
   query: DataCataloguePageQuery,
 ): DataSetFileListRequest {
   const {
+    dataSetType,
     latestOnly,
     sortBy,
     publicationId,
@@ -31,6 +32,7 @@ export default function createDataSetFileListRequest(
 
   return omitBy(
     {
+      dataSetType,
       latestOnly,
       page: parseNumber(query.page) ?? 1,
       publicationId,
@@ -74,6 +76,7 @@ function getSortParams(orderBy: DataSetFileSortOption): {
 
 export function getParamsFromQuery(query: DataCataloguePageQuery) {
   return {
+    dataSetType: getFirst(query.dataSetType),
     latestOnly: getFirst(query.latestOnly),
     sortBy:
       query.sortBy && isOneOf(query.sortBy, dataSetFileSortOptions)

--- a/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
+++ b/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
@@ -6,6 +6,7 @@ import { SortDirection } from '@common/services/types/sort';
 export interface DataSetFile {
   id: string;
   file: { id: string; name: string; size: string };
+  hasApiDataSet?: boolean;
   release: {
     id: string;
     isLatestPublishedRelease: boolean;
@@ -39,6 +40,7 @@ export interface DataSetFileSummary {
   filename: string;
   fileSize: string;
   fileExtension: string;
+  hasApiDataSet?: boolean;
   title: string;
   theme: {
     id: string;
@@ -76,6 +78,7 @@ export type DataSetFileSortOption = (typeof dataSetFileSortOptions)[number];
 export type DataSetFileSortParam = 'published' | 'title' | 'relevance';
 
 export const dataSetFileFilters = [
+  'dataSetType',
   'latest',
   'publicationId',
   'releaseId',
@@ -85,7 +88,10 @@ export const dataSetFileFilters = [
 
 export type DataSetFileFilter = (typeof dataSetFileFilters)[number];
 
+export type DataSetType = 'all' | 'api';
+
 export interface DataSetFileListRequest {
+  dataSetType?: DataSetType;
   latestOnly?: 'true' | 'false';
   page?: number;
   pageSize?: number;

--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -209,30 +209,30 @@ Validate sort controls exist
     user checks page contains radio    A to Z
 
 Validate theme filter exists
-    user checks select contains option    id:theme    All themes
-    user checks select contains option    id:theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
-    user checks select contains option    id:theme    ${ROLE_PERMISSIONS_THEME_TITLE}
+    user checks select contains option    id:filters-form-theme    All themes
+    user checks select contains option    id:filters-form-theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
+    user checks select contains option    id:filters-form-theme    ${ROLE_PERMISSIONS_THEME_TITLE}
 
 Validate publication filter exists
-    user checks select contains option    id:publication    All publications
+    user checks select contains option    id:filters-form-publication    All publications
 
 Validate release filter exists
-    user checks select contains option    id:release    Latest releases
-    user checks select contains option    id:release    All releases
+    user checks select contains option    id:filters-form-release    Latest releases
+    user checks select contains option    id:filters-form-release    All releases
 
 Filter by theme
-    user chooses select option    id:theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
+    user chooses select option    id:filters-form-theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
     user checks page contains button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
 
 Filter by publication
-    user chooses select option    id:publication    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
+    user chooses select option    id:filters-form-publication    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user waits until page contains button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user waits until page contains button    ${PUPIL_ABSENCE_RELEASE_NAME}
     user checks page contains button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user checks page contains button    ${PUPIL_ABSENCE_RELEASE_NAME}
 
 Filter by all releases
-    user chooses select option    id:release    All releases
+    user chooses select option    id:filters-form-release    All releases
     user checks page contains button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user checks page does not contain button    ${PUPIL_ABSENCE_RELEASE_NAME}
 
@@ -242,16 +242,16 @@ Remove theme filter
     user checks page does not contain button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
 
 Remove publication filter
-    user chooses select option    id:theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
-    user chooses select option    id:publication    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
+    user chooses select option    id:filters-form-theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
+    user chooses select option    id:filters-form-publication    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user clicks button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user checks page contains button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
     user checks page does not contain button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user checks page does not contain button    ${PUPIL_ABSENCE_RELEASE_NAME}
 
 Remove release filter
-    user chooses select option    id:theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
-    user chooses select option    id:publication    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
+    user chooses select option    id:filters-form-theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
+    user chooses select option    id:filters-form-publication    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user clicks button    ${PUPIL_ABSENCE_RELEASE_NAME}
     user checks page contains button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
     user checks page contains button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
@@ -261,7 +261,7 @@ Clear all filters
     user clicks element    id:searchForm-search
     user presses keys    pupil
     user clicks button    Search
-    user chooses select option    id:theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
+    user chooses select option    id:filters-form-theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
 
     user checks page contains button    pupil
     user checks page contains button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}


### PR DESCRIPTION
- Adds an 'Available by API' tag to data sets with APIs on the data catalogue page. 
- Adds a filter to toggle between all data sets and only those with APIs
- Needs to be tested with the backend once that's ready