### PR TITLE
EES-5090 Fix failing UI test

### DIFF
--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -396,6 +396,7 @@ Verify help and support section is correct
 Verify Dates data block accordion section
     user opens accordion section    Dates data block    id:content
     user scrolls to accordion section    Dates data block    id:content
+    user waits until page finishes loading
     ${section}=    user gets accordion section content element    Dates data block    id:content
 
     user checks chart title contains    ${section}    Updated dates table title

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -343,10 +343,10 @@ def is_webelement(variable: object) -> bool:
 def _normalise_child_locator(child_locator: str) -> str:
     if isinstance(child_locator, str):
         # the below substitution is necessary in order to correctly find the parent's descendants.  Without the
-        # preceding dot, the double forward sl()ash breaks out of the parent container and returns the xpath query
+        # preceding dot, the double forward slash breaks out of the parent container and returns the xpath query
         # to the root of the DOM, leading to false positives or incorrectly found DOM elements.  The below
         # substitution covers both child selectors beginning with "xpath://" and "//", as the double forward
-        # sl()ashes without the "xpath:" prefix are inferred as being xpath expressions.
+        # slashes without the "xpath:" prefix are inferred as being xpath expressions.
         return re.sub(r"^(xpath:)?//", "xpath:.//", child_locator)
 
     raise_assertion_error(f"Child locator was not a str - {child_locator}")


### PR DESCRIPTION
This PR fixes a failing test in `publish_release_and_amend.robot` - specifically `Verify Dates data block accordion section`.

What I believe was happening was that `${section}` was being loaded before the accordion content section had finished loading. This meant that when it went to check for the chart title inside `${section}` it failed.

The fix is to ensure that the accordion content section has loaded.

I also fixed an amusing mistake in a comment - I'll leave it as a puzzle for the reader as to how the brackets made their way into the comment.