### PR TITLE
EES-5002 Add content security headers to the Content API for SEO reasons

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -47,6 +48,13 @@ public static class HttpResponseMessageTestExtensions
         Assert.Equal(Created, message.StatusCode);
         Assert.Equal(new Uri(expectedLocation), message.Headers.Location);
         return message.AssertBodyEqualTo(expectedBody, useSystemJson);
+    }
+
+    public static void AssertHasHeader(this HttpResponseMessage message, string headerKey, string expectedHeaderValue)
+    {
+        message.Headers.TryGetValues(headerKey, out var headerValue);
+        Assert.NotNull(headerValue);
+        Assert.Equal(headerValue.FirstOrDefault(), expectedHeaderValue);
     }
 
     public static void AssertNoContent(this HttpResponseMessage message)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/SecurityHeadersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/SecurityHeadersTests.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers;
+
+public class SecurityHeadersTests
+{
+    [Fact]
+    public async Task SeoSecurityHeaderMiddleware_AddsRequiredHeadersToResponse()
+    {
+        using var host = await new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder
+                    .UseTestServer()
+                    .Configure(app =>
+                    {
+                        app.UseMiddleware(typeof(SeoSecurityHeaderMiddleware));
+                    });
+            })
+            .StartAsync();
+
+        var response = await host.GetTestClient().GetAsync("/");
+
+        response.AssertNotFound();
+        response.AssertHasHeader("X-Frame-Options", "DENY");
+        response.AssertHasHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+        response.AssertHasHeader("X-Content-Type-Options", "nosniff");
+        response.AssertHasHeader("Content-Security-Policy", "default-src 'self'");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/SeoSecurityHeaderMiddleware.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/SeoSecurityHeaderMiddleware.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api;
+
+public class SeoSecurityHeaderMiddleware(RequestDelegate next)
+{
+    public async Task Invoke(HttpContext context)
+    {
+        context.Response.OnStarting(state =>
+        {
+            var httpContext = (HttpContext)state;
+            httpContext.Response.Headers.Append("X-Frame-Options", "DENY");
+            httpContext.Response.Headers.Append("Referrer-Policy", "strict-origin-when-cross-origin");
+            httpContext.Response.Headers.Append("X-Content-Type-Options", "nosniff");
+            httpContext.Response.Headers.Append("Content-Security-Policy", "default-src 'self'");
+
+            return Task.CompletedTask;
+        }, context);
+
+        await next(context);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -232,6 +232,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
                 .AllowAnyMethod()
                 .AllowAnyHeader());
 
+            app.UseMiddleware(typeof(SeoSecurityHeaderMiddleware));
             app.UseMvc();
             app.UseHealthChecks("/api/health");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.sln.DotSettings
+++ b/src/GovUk.Education.ExploreEducationStatistics.sln.DotSettings
@@ -6,6 +6,7 @@
     <s:Boolean x:Key="/Default/UserDictionary/Words/=approvers/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=lsip/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=nosniff/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=pcon/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=rscr/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=ukprn/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
One of Michael's briefs from the SEO document asks us to implement security headers in [these urls](https://docs.google.com/spreadsheets/d/1Hqha2UHV-0L0dqOFFIo-UJRsLUgzFK3Lhz9Uq57k_6U/edit#gid=1737967479). 

They all come from the Content API, and are links that Google has picked up on whilst trawling the site. 
I don't think adding these headers actually makes a lick of difference to an API that just returns JSON, but if it makes the SEO gods happy :shrug: 