### PR TITLE
EES-4979 Remove meta-guidance and data-guidance redirects

### DIFF
--- a/src/explore-education-statistics-frontend/server.js
+++ b/src/explore-education-statistics-frontend/server.js
@@ -100,15 +100,6 @@ async function startServer() {
     // https://support.google.com/webmasters/thread/253569816/google-crawler-adding-a-1000-to-the-end-of-a-ton-of-urls?hl=en
     // newUri = replaceLastOccurance(newUri, '/1000', '');
 
-    // TODO: Remove these redirects after Google's index is updated (will happen within 6 months)
-    // https://dfedigital.atlassian.net/browse/EES-4979
-    newUri = replaceLastOccurance(newUri, '/meta-guidance', '/data-guidance');
-    newUri = replaceLastOccurance(
-      newUri,
-      '/download-latest-data',
-      '/data-catalogue',
-    );
-
     if (newUri !== req.url) {
       return res.redirect(301, newUri);
     }

--- a/tests/playwright-tests/tests/public/redirects.spec.ts
+++ b/tests/playwright-tests/tests/public/redirects.spec.ts
@@ -48,32 +48,6 @@ test.describe('Redirect behaviour', () => {
     await expect(page).toHaveURL(`${PUBLIC_URL}/`);
   });
 
-  test('meta-guidance is redirected to data-guidance', async ({ page }) => {
-    await page.goto(
-      `${PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance`,
-    );
-    await expect(page).toHaveURL(
-      `${PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance`,
-    );
-
-    await page.goto(
-      `${PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance/`,
-    );
-    await expect(page).toHaveURL(
-      `${PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance`,
-    );
-  });
-
-  test('download-latest-data is redirected to data-catalogue', async ({
-    page,
-  }) => {
-    await page.goto(`${PUBLIC_URL}/download-latest-data`);
-    await expect(page).toHaveURL(`${PUBLIC_URL}/data-catalogue`);
-
-    await page.goto(`${PUBLIC_URL}/download-latest-data/`);
-    await expect(page).toHaveURL(`${PUBLIC_URL}/data-catalogue`);
-  });
-
   // Not ideal, I'd rather it.each like Jest has. But from the docs:
   // https://playwright.dev/docs/test-parameterize
   for (const redirect of seoRedirects) {

--- a/tests/robot-tests/tests/general_public/redirects.robot
+++ b/tests/robot-tests/tests/general_public/redirects.robot
@@ -42,21 +42,3 @@ Verify that routes without an absolute path still permit trailing slashes
     user navigates to public frontend    %{PUBLIC_URL}
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
-
-Verify that meta-guidance is redirected to data-guidance
-    user navigates to public frontend    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance
-    user waits until page contains    Seed publication - Release Approver
-    user checks url equals    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance
-
-    user navigates to public frontend    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/meta-guidance/
-    user waits until page contains    Seed publication - Release Approver
-    user checks url equals    %{PUBLIC_URL}/find-statistics/seed-publication-release-approver/data-guidance
-
-Verify that download-latest-data is redirected to data-catalogue
-    user navigates to public frontend    %{PUBLIC_URL}/download-latest-data
-    user waits until page contains    Browse our open data
-    user checks url equals    %{PUBLIC_URL}/data-catalogue
-
-    user navigates to public frontend    %{PUBLIC_URL}/download-latest-data/
-    user waits until page contains    Browse our open data
-    user checks url equals    %{PUBLIC_URL}/data-catalogue


### PR DESCRIPTION
These redirects have been present on the site for several months now (much longer if you count the time for which they were 307s/308s). This should've been long enough for Google to pick up the new canonical address.