### PR TITLE
EES-4881 adjust view release link position on data catalogue

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePageNew.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePageNew.tsx
@@ -473,24 +473,21 @@ export default function DataCataloguePageNew() {
                           <h3>{`${selectedPublication.title} - ${selectedRelease?.title} downloads`}</h3>
                           {selectedRelease && (
                             <>
-                              <div className="dfe-flex dfe-justify-content--space-between dfe-flex-wrap govuk-!-margin-bottom-6">
-                                <TagGroup className="govuk-!-margin-right-2">
-                                  <Tag>
-                                    {releaseTypes[selectedRelease.type]}
-                                  </Tag>
-                                  <Tag
-                                    colour={
-                                      selectedRelease.latestRelease
-                                        ? undefined
-                                        : 'orange'
-                                    }
-                                  >
-                                    {selectedRelease.latestRelease
-                                      ? 'This is the latest data'
-                                      : 'This is not the latest data'}
-                                  </Tag>
-                                </TagGroup>
-
+                              <TagGroup>
+                                <Tag>{releaseTypes[selectedRelease.type]}</Tag>
+                                <Tag
+                                  colour={
+                                    selectedRelease.latestRelease
+                                      ? undefined
+                                      : 'orange'
+                                  }
+                                >
+                                  {selectedRelease.latestRelease
+                                    ? 'This is the latest data'
+                                    : 'This is not the latest data'}
+                                </Tag>
+                              </TagGroup>
+                              <div className="govuk-!-margin-bottom-5 govuk-!-margin-top-3">
                                 <Link
                                   to={`/find-statistics/${selectedPublication.slug}/${selectedRelease.slug}`}
                                 >


### PR DESCRIPTION
Adjusts the position of the 'View this release' link on the new data catalogue page so it's always positioned under the tags.

![Screenshot 2024-05-01 111052](https://github.com/dfe-analytical-services/explore-education-statistics/assets/81572860/3fa3b6dd-9c59-4659-8e06-ed7eaa7cf216)
