### PR TITLE
EES-4353: Trim whitespace and convert fields from CKEditor to textareas.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/FootnoteCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/FootnoteCreateRequest.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Generic;
 
@@ -6,7 +6,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
 public record FootnoteCreateRequest
 {
-    public string Content { get; init; } = string.Empty;
+    private string _content = string.Empty;
+
+    public string Content
+    {
+        get => _content;
+        init => _content = value.Trim();
+    }
 
     public IReadOnlySet<Guid> Filters { get; init; } = new HashSet<Guid>();
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
@@ -1,7 +1,3 @@
-import { toolbarConfigSimple } from '@admin/config/ckEditorConfig';
-import RHFFormFieldEditor from '@admin/components/form/RHFFormFieldEditor';
-import toHtml from '@admin/utils/markdown/toHtml';
-import toMarkdown from '@admin/utils/markdown/toMarkdown';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import styles from '@common/modules/find-statistics/components/KeyStat.module.scss';
@@ -9,6 +5,7 @@ import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile'
 import FormProvider from '@common/components/form/rhf/FormProvider';
 import RHFForm from '@common/components/form/rhf/RHFForm';
 import RHFFormFieldTextInput from '@common/components/form/rhf/RHFFormFieldTextInput';
+import RHFFormFieldTextArea from '@common/components/form/rhf/RHFFormFieldTextArea';
 import { KeyStatisticDataBlock } from '@common/services/publicationService';
 import Yup from '@common/validation/yup';
 import React from 'react';
@@ -42,7 +39,7 @@ export default function EditableKeyStatDataBlockForm({
     onSubmit({
       ...values,
       guidanceTitle: values.guidanceTitle,
-      guidanceText: toMarkdown(values.guidanceText),
+      guidanceText: values.guidanceText,
     });
   };
 
@@ -51,7 +48,7 @@ export default function EditableKeyStatDataBlockForm({
       initialValues={{
         trend: keyStat.trend ?? '',
         guidanceTitle: keyStat.guidanceTitle ?? 'Help',
-        guidanceText: keyStat.guidanceText ? toHtml(keyStat.guidanceText) : '',
+        guidanceText: keyStat.guidanceText,
       }}
       validationSchema={Yup.object<KeyStatDataBlockFormValues>({
         trend: Yup.string().max(230),
@@ -84,10 +81,10 @@ export default function EditableKeyStatDataBlockForm({
               label="Guidance title"
             />
 
-            <RHFFormFieldEditor<KeyStatDataBlockFormValues>
-              name="guidanceText"
-              toolbarConfig={toolbarConfigSimple}
+            <RHFFormFieldTextArea<KeyStatDataBlockFormValues>
               label="Guidance text"
+              name="guidanceText"
+              rows={3}
             />
 
             <ButtonGroup>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
@@ -1,15 +1,9 @@
-import RHFFormFieldEditor from '@admin/components/form/RHFFormFieldEditor';
-import {
-  pluginsConfigSimple,
-  toolbarConfigSimple,
-} from '@admin/config/ckEditorConfig';
-import toHtml from '@admin/utils/markdown/toHtml';
-import toMarkdown from '@admin/utils/markdown/toMarkdown';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import FormProvider from '@common/components/form/rhf/FormProvider';
 import RHFForm from '@common/components/form/rhf/RHFForm';
 import RHFFormFieldTextInput from '@common/components/form/rhf/RHFFormFieldTextInput';
+import RHFFormFieldTextArea from '@common/components/form/rhf/RHFFormFieldTextArea';
 import styles from '@common/modules/find-statistics/components/KeyStat.module.scss';
 import { KeyStatisticText } from '@common/services/publicationService';
 import React from 'react';
@@ -43,7 +37,7 @@ export default function EditableKeyStatTextForm({
     await onSubmit({
       ...values,
       guidanceTitle: values.guidanceTitle,
-      guidanceText: toMarkdown(values.guidanceText),
+      guidanceText: values.guidanceText,
     });
   };
 
@@ -55,9 +49,7 @@ export default function EditableKeyStatTextForm({
           statistic: keyStat?.statistic ?? '',
           trend: keyStat?.trend ?? '',
           guidanceTitle: keyStat?.guidanceTitle ?? 'Help',
-          guidanceText: keyStat?.guidanceText
-            ? toHtml(keyStat.guidanceText)
-            : '',
+          guidanceText: keyStat?.guidanceText,
         }}
         validationSchema={Yup.object<KeyStatTextFormValues>({
           title: Yup.string().required('Enter a title').max(60),
@@ -110,11 +102,10 @@ export default function EditableKeyStatTextForm({
                 label="Guidance title"
               />
 
-              <RHFFormFieldEditor<KeyStatTextFormValues>
-                name="guidanceText"
-                includePlugins={pluginsConfigSimple}
-                toolbarConfig={toolbarConfigSimple}
+              <RHFFormFieldTextArea<KeyStatTextFormValues>
                 label="Guidance text"
+                name="guidanceText"
+                rows={3}
               />
 
               <ButtonGroup>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlockForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlockForm.test.tsx
@@ -41,7 +41,7 @@ describe('EditableKeyStatDataBlockForm', () => {
     expect(screen.getByLabelText('Guidance title')).toHaveValue(
       'DataBlock guidance title',
     );
-    expect(screen.getByLabelText('Guidance text')).toHaveTextContent(
+    expect(screen.getByLabelText('Guidance text')).toHaveValue(
       'DataBlock guidance text',
     );
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
@@ -162,7 +162,7 @@ describe('EditableKeyStatText', () => {
     expect(screen.getByLabelText('Guidance title')).toHaveValue(
       'Text guidance title',
     );
-    expect(screen.getByLabelText('Guidance text')).toHaveTextContent(
+    expect(screen.getByLabelText('Guidance text')).toHaveValue(
       'Text guidance text',
     );
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatTextForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatTextForm.test.tsx
@@ -55,7 +55,7 @@ describe('EditableKeyStatTextForm', () => {
     expect(screen.getByLabelText('Guidance title')).toHaveValue(
       'Text guidance title',
     );
-    expect(screen.getByLabelText('Guidance text')).toHaveTextContent(
+    expect(screen.getByLabelText('Guidance text')).toHaveValue(
       'Text guidance text',
     );
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
@@ -1,14 +1,10 @@
-import {
-  pluginsConfigSimple,
-  toolbarConfigSimple,
-} from '@admin/config/ckEditorConfig';
 import releaseDataGuidanceService from '@admin/services/releaseDataGuidanceService';
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
-import RHFFormFieldEditor from '@admin/components/form/RHFFormFieldEditor';
+import RHFFormFieldTextArea from '@common/components/form/rhf/RHFFormFieldTextArea';
 import FormProvider from '@common/components/form/rhf/FormProvider';
 import RHFForm from '@common/components/form/rhf/RHFForm';
 import InsetText from '@common/components/InsetText';
@@ -141,9 +137,10 @@ const ReleaseDataGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
                   return (
                     <RHFForm id={formId} onSubmit={handleSubmit}>
                       {isEditing ? (
-                        <RHFFormFieldEditor<DataGuidanceFormValues>
-                          name="content"
+                        <RHFFormFieldTextArea<DataGuidanceFormValues>
                           label="Main guidance content"
+                          name="content"
+                          rows={3}
                         />
                       ) : (
                         <>
@@ -178,12 +175,10 @@ const ReleaseDataGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
                                   dataSet={dataSet}
                                   renderContent={() =>
                                     isEditing ? (
-                                      <RHFFormFieldEditor<DataGuidanceFormValues>
-                                        includePlugins={pluginsConfigSimple}
-                                        toolbarConfig={toolbarConfigSimple}
-                                        name={`dataSets.${index}.content`}
+                                      <RHFFormFieldTextArea<DataGuidanceFormValues>
                                         label="File guidance content"
-                                        testId="fileGuidanceContent"
+                                        name={`dataSets.${index}.content`}
+                                        rows={3}
                                       />
                                     ) : (
                                       <ContentHtml


### PR DESCRIPTION
- Trim whitespace from release footnotes
- Convert key stat guidance fields (text and data block) from CKEditor to standard textareas to remove formatting options and enforce simple text content.