### PR TITLE
EES-5121 Refactor data set query string validators into POST request model validators

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Converters/SystemJson/EnumToEnumLabelJsonConverterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Converters/SystemJson/EnumToEnumLabelJsonConverterTests.cs
@@ -59,6 +59,6 @@ public class EnumToEnumLabelJsonConverterTests
     {
         const string jsonText = "{\"SampleField\":\"Invalid label\"}";
 
-        Assert.Throws<ArgumentException>(() => JsonSerializer.Deserialize<SampleClass>(jsonText));
+        Assert.Throws<ArgumentOutOfRangeException>(() => JsonSerializer.Deserialize<SampleClass>(jsonText));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Converters/SystemJson/EnumToEnumValueJsonConverterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Converters/SystemJson/EnumToEnumValueJsonConverterTests.cs
@@ -59,6 +59,6 @@ public class EnumToEnumValueJsonConverterTests
     {
         const string jsonText = "{\"SampleField\":\"Invalid label\"}";
 
-        Assert.Throws<ArgumentException>(() => JsonSerializer.Deserialize<SampleClass>(jsonText));
+        Assert.Throws<ArgumentOutOfRangeException>(() => JsonSerializer.Deserialize<SampleClass>(jsonText));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumUtilsTests.cs
@@ -21,10 +21,10 @@ public static class EnumUtilsTests
         [Fact]
         public void WithLabelValue_UsingLabel_Invalid()
         {
-            var exception = Assert.Throws<ArgumentException>(
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
                 () => EnumUtil.GetFromEnumValue<TestEnum>("With label value"));
 
-            Assert.Equal(
+            Assert.StartsWith(
                 $"The value 'With label value' is not a valid {nameof(TestEnum)}",
                 exception.Message);
         }
@@ -32,10 +32,10 @@ public static class EnumUtilsTests
         [Fact]
         public void NoMatch_Invalid()
         {
-            var exception = Assert.Throws<ArgumentException>(
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
                 () => EnumUtil.GetFromEnumValue<TestEnum>("Invalid label"));
 
-            Assert.Equal(
+            Assert.StartsWith(
                 $"The value 'Invalid label' is not a valid {nameof(TestEnum)}",
                 exception.Message);
         }
@@ -74,10 +74,10 @@ public static class EnumUtilsTests
         [Fact]
         public void WithLabelValue_UsingValue_Invalid()
         {
-            var exception = Assert.Throws<ArgumentException>(
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
                 () => EnumUtil.GetFromEnumLabel<TestEnum>("with-label-value"));
 
-            Assert.Equal(
+            Assert.StartsWith(
                 $"The label 'with-label-value' is not a valid {nameof(TestEnum)}",
                 exception.Message);
         }
@@ -85,10 +85,10 @@ public static class EnumUtilsTests
         [Fact]
         public void NoMatch_Invalid()
         {
-            var exception = Assert.Throws<ArgumentException>(
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
                 () => EnumUtil.GetFromEnumLabel<TestEnum>("Invalid label"));
 
-            Assert.Equal(
+            Assert.StartsWith(
                 $"The label 'Invalid label' is not a valid {nameof(TestEnum)}",
                 exception.Message);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/ValidatorTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/ValidatorTestExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Validators;
+
+public static class ValidatorTestExtensions
+{
+    public static ITestValidationWith WithCustomState<T>(
+        this ITestValidationContinuation failures,
+        Func<T, bool> predicate)
+    {
+        return failures.When(
+            failure => failure.CustomState is T customState && predicate(customState),
+            $"Expected custom state to be of type '{typeof(T).GetPrettyFullName()}' and match the predicate."
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/ValidatorTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/ValidatorTestExtensions.cs
@@ -6,6 +6,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Validators;
 
 public static class ValidatorTestExtensions
 {
+    public static ITestValidationWith WithAttemptedValue<T>(
+        this ITestValidationContinuation failures,
+        T value)
+    {
+        return failures.When(
+            failure => failure.AttemptedValue is T attemptedValue && attemptedValue.Equals(value),
+            $"Expected attempted value of '{value}'. Actual attempted value was '{{MessageArgument:PropertyValue}}'."
+        );
+    }
+
     public static ITestValidationWith WithCustomState<T>(
         this ITestValidationContinuation failures,
         Func<T, bool> predicate)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/EnumUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/EnumUtil.cs
@@ -37,7 +37,9 @@ public static class EnumUtil
             return enumValue;
         }
 
-        throw new ArgumentException($"The value '{value}' is not a valid {typeof(TEnum).Name}");
+        throw new ArgumentOutOfRangeException(
+            paramName: nameof(value),
+            message: $"The value '{value}' is not a valid {typeof(TEnum).Name}");
     }
 
     public static bool TryGetFromEnumValue<TEnum>(
@@ -62,7 +64,9 @@ public static class EnumUtil
             return enumValue;
         }
 
-        throw new ArgumentException($"The label '{label}' is not a valid {typeof(TEnum).Name}");
+        throw new ArgumentOutOfRangeException(
+            paramName: nameof(label),
+            message: $"The label '{label}' is not a valid {typeof(TEnum).Name}");
     }
 
     public static bool TryGetFromEnumLabel<TEnum>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerQueryTests.cs
@@ -1613,6 +1613,8 @@ public abstract class DataSetsControllerQueryTests(TestApplicationFactory testAp
                                 "SCH|code|12345",
                                 "PROV|oldCode|12345",
                                 "RSC|code|12345",
+                                "NAT|id| ",
+                                "LA|code| ",
                                 $"NAT|id|{new string('a', 11)}",
                                 $"LA|code|{new string('a', 26)}",
                                 $"SCH|urn|{new string('a', 7)}",
@@ -1626,7 +1628,7 @@ public abstract class DataSetsControllerQueryTests(TestApplicationFactory testAp
 
             var validationProblem = response.AssertValidationProblem();
 
-            Assert.Equal(15, validationProblem.Errors.Count);
+            Assert.Equal(17, validationProblem.Errors.Count);
 
             validationProblem.AssertHasNotEmptyError(expectedPath: $"{path}[0]");
             validationProblem.AssertHasLocationFormatError(expectedPath: $"{path}[1]", value: "invalid");
@@ -1660,31 +1662,33 @@ public abstract class DataSetsControllerQueryTests(TestApplicationFactory testAp
                 property: "code",
                 allowedProperties: ["id"]
             );
+            validationProblem.AssertHasLocationValueNotEmptyError(expectedPath: $"{path}[10]", property: "id");
+            validationProblem.AssertHasLocationValueNotEmptyError(expectedPath: $"{path}[11]", property: "code");
 
-            validationProblem.AssertHasLocationMaxValueLengthError(
-                expectedPath: $"{path}[10]",
-                value: new string('a', 11),
-                maxValueLength: 10
-            );
-            validationProblem.AssertHasLocationMaxValueLengthError(
-                expectedPath: $"{path}[11]",
-                value: new string('a', 26),
-                maxValueLength: 25
-            );
-            validationProblem.AssertHasLocationMaxValueLengthError(
+            validationProblem.AssertHasLocationValueMaxLengthError(
                 expectedPath: $"{path}[12]",
-                value: new string('a', 7),
-                maxValueLength: 6
+                property: "id",
+                maxLength: 10
             );
-            validationProblem.AssertHasLocationMaxValueLengthError(
+            validationProblem.AssertHasLocationValueMaxLengthError(
                 expectedPath: $"{path}[13]",
-                value: new string('a', 9),
-                maxValueLength: 8
+                property: "code",
+                maxLength: 25
             );
-            validationProblem.AssertHasLocationMaxValueLengthError(
+            validationProblem.AssertHasLocationValueMaxLengthError(
                 expectedPath: $"{path}[14]",
-                value: new string('a', 11),
-                maxValueLength: 10
+                property: "urn",
+                maxLength: 6
+            );
+            validationProblem.AssertHasLocationValueMaxLengthError(
+                expectedPath: $"{path}[15]",
+                property: "ukprn",
+                maxLength: 8
+            );
+            validationProblem.AssertHasLocationValueMaxLengthError(
+                expectedPath: $"{path}[16]",
+                property: "id",
+                maxLength: 10
             );
         }
 
@@ -1697,6 +1701,7 @@ public abstract class DataSetsControllerQueryTests(TestApplicationFactory testAp
             [
                 "",
                 "||",
+                "NAT|id| ",
                 $"NAT|id|{new string('a', 11)}",
             ];
 
@@ -1722,7 +1727,7 @@ public abstract class DataSetsControllerQueryTests(TestApplicationFactory testAp
 
             var validationProblem = response.AssertValidationProblem();
 
-            Assert.Equal(6, validationProblem.Errors.Count);
+            Assert.Equal(7, validationProblem.Errors.Count);
 
             validationProblem.AssertHasLocationAllowedLevelError(expectedPath: "locations.eq", level: "LADD");
             validationProblem.AssertHasLocationAllowedPropertyError(
@@ -1732,10 +1737,14 @@ public abstract class DataSetsControllerQueryTests(TestApplicationFactory testAp
             );
             validationProblem.AssertHasNotEmptyError(expectedPath: "locations.in[0]");
             validationProblem.AssertHasLocationFormatError(expectedPath: "locations.in[1]", value: "||");
-            validationProblem.AssertHasLocationMaxValueLengthError(
+            validationProblem.AssertHasLocationValueNotEmptyError(
                 expectedPath: "locations.in[2]",
-                value: new string('a', 11),
-                maxValueLength: 10
+                property: "id"
+            );
+            validationProblem.AssertHasLocationValueMaxLengthError(
+                expectedPath: "locations.in[3]",
+                property: "id",
+                maxLength: 10
             );
             validationProblem.AssertHasNotEmptyError("locations.notIn");
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerQueryTests.cs
@@ -1839,7 +1839,7 @@ public abstract class DataSetsControllerQueryTests(TestApplicationFactory testAp
 
             validationProblem.AssertHasNotEmptyError($"{path}[0]");
             validationProblem.AssertHasTimePeriodFormatError(expectedPath: $"{path}[1]", value: "invalid");
-            validationProblem.AssertHasTimePeriodFormatError(expectedPath: $"{path}[2]", value: "|");
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{path}[2]", code: "");
 
             validationProblem.AssertHasTimePeriodYearRangeError(expectedPath: $"{path}[3]", period: "2020/2019");
             validationProblem.AssertHasTimePeriodYearRangeError(expectedPath: $"{path}[4]", period: "2020/2022");
@@ -1892,7 +1892,7 @@ public abstract class DataSetsControllerQueryTests(TestApplicationFactory testAp
             validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: "timePeriods.notEq", code: "W10");
             validationProblem.AssertHasNotEmptyError(expectedPath: "timePeriods.in[0]");
             validationProblem.AssertHasTimePeriodFormatError(expectedPath: "timePeriods.in[1]", value: "invalid");
-            validationProblem.AssertHasTimePeriodFormatError(expectedPath: "timePeriods.in[2]", value: "|");
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: "timePeriods.in[2]", code: "");
             validationProblem.AssertHasNotEmptyError(expectedPath: "timePeriods.notIn");
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerQueryTests.cs
@@ -1507,6 +1507,7 @@ public abstract class DataSetsControllerQueryTests(TestApplicationFactory testAp
                     "",
                     "invalid",
                     "|",
+                    "test|",
                     "test|invalid",
                     "test|asc",
                     "test|desc",
@@ -1519,22 +1520,25 @@ public abstract class DataSetsControllerQueryTests(TestApplicationFactory testAp
 
             var validationProblem = response.AssertValidationProblem();
 
-            Assert.Equal(8, validationProblem.Errors.Count);
+            Assert.Equal(10, validationProblem.Errors.Count);
 
             validationProblem.AssertHasNotEmptyError(expectedPath: "sorts[0]");
             validationProblem.AssertHasSortFormatError(expectedPath: "sorts[1]", value: "invalid");
-            validationProblem.AssertHasSortFormatError(expectedPath: "sorts[2]", value: "|");
 
-            validationProblem.AssertHasSortDirectionError(expectedPath: "sorts[3]", direction: "invalid");
-            validationProblem.AssertHasSortDirectionError(expectedPath: "sorts[4]", direction: "asc");
-            validationProblem.AssertHasSortDirectionError(expectedPath: "sorts[5]", direction: "desc");
+            validationProblem.AssertHasSortFieldNotEmptyError(expectedPath: "sorts[2]");
 
-            validationProblem.AssertHasSortMaxFieldLengthError(
-                expectedPath: "sorts[6]",
+            validationProblem.AssertHasSortDirectionError(expectedPath: "sorts[2]", direction: "");
+            validationProblem.AssertHasSortDirectionError(expectedPath: "sorts[3]", direction: "");
+            validationProblem.AssertHasSortDirectionError(expectedPath: "sorts[4]", direction: "invalid");
+            validationProblem.AssertHasSortDirectionError(expectedPath: "sorts[5]", direction: "asc");
+            validationProblem.AssertHasSortDirectionError(expectedPath: "sorts[6]", direction: "desc");
+
+            validationProblem.AssertHasSortFieldMaxLengthError(
+                expectedPath: "sorts[7]",
                 field: new string('a', 41)
             );
-            validationProblem.AssertHasSortMaxFieldLengthError(
-                expectedPath: "sorts[7]",
+            validationProblem.AssertHasSortFieldMaxLengthError(
+                expectedPath: "sorts[8]",
                 field: new string('b', 41)
             );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryRequestValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryRequestValidatorTests.cs
@@ -294,7 +294,7 @@ public abstract class DataSetGetQueryRequestValidatorTests
 
             result
                 .ShouldHaveValidationErrorFor("Sorts[3]")
-                .WithErrorCode(ValidationMessages.SortMaxFieldLength.Code);
+                .WithErrorCode(ValidationMessages.SortFieldMaxLength.Code);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryTimePeriodsValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryTimePeriodsValidatorTests.cs
@@ -44,7 +44,6 @@ public abstract class DataSetGetQueryTimePeriodsValidatorTests
             ["2022"],
             ["2022/2023"],
             ["20222"],
-            ["20222|AY"],
             ["2022|ay"],
             ["2022/2020|AY"],
             ["2000/1999|AY"],
@@ -60,7 +59,7 @@ public abstract class DataSetGetQueryTimePeriodsValidatorTests
             [],
             ["", ""],
             ["Invalid", "2022", "2022/2023"],
-            ["20222", "20222|AY", "2022|ay"],
+            ["20222", "2022|ay"],
             ["2022/2020|AY", "2000/1999|AY"],
             ["2022|YY", "2022|WEEK12", "2022/2023|ZZ"]
         ];

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryLocationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryLocationTests.cs
@@ -1,0 +1,129 @@
+using System.Reflection;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public abstract class DataSetQueryLocationTests
+{
+    public class ParseTests
+    {
+        public static readonly TheoryData<string> LocationLevelCodes = new(EnumUtil.GetEnumValues<GeographicLevel>());
+
+        [Theory]
+        [MemberData(nameof(LocationLevelCodes))]
+        public void IdProperty_ReturnsLocationId(string level)
+        {
+            const string id = "12345";
+            var location = DataSetQueryLocation.Parse($"{level}|id|{id}");
+
+            var locationId = Assert.IsType<DataSetQueryLocationId>(location);
+
+            Assert.Equal(level, locationId.Level);
+            Assert.Equal(id, locationId.Id);
+        }
+
+        [Theory]
+        [InlineData("NAT", "code", typeof(DataSetQueryLocationCode))]
+        [InlineData("REG", "code", typeof(DataSetQueryLocationCode))]
+        [InlineData("LA", "code", typeof(DataSetQueryLocationLocalAuthorityCode))]
+        [InlineData("LA", "oldCode", typeof(DataSetQueryLocationLocalAuthorityOldCode))]
+        [InlineData("PROV", "ukprn", typeof(DataSetQueryLocationProviderUkprn))]
+        [InlineData("SCH", "laEstab", typeof(DataSetQueryLocationSchoolLaEstab))]
+        [InlineData("SCH", "urn", typeof(DataSetQueryLocationSchoolUrn))]
+        public void OtherProperty_ReturnsCorrectLocationType(string level, string property, Type expectedType)
+        {
+            const string expectedValue = "12345";
+
+            var location = DataSetQueryLocation.Parse($"{level}|{property}|{expectedValue}");
+
+            Assert.IsType(expectedType, location);
+
+            var value = location.GetType()
+                .GetProperty(property.ToUpperFirst())!
+                .GetValue(location);
+
+            Assert.Equal(expectedValue, value);
+        }
+
+        [Theory]
+        [InlineData("Invalid")]
+        [InlineData("NATT")]
+        [InlineData("LADD")]
+        [InlineData("nat")]
+        [InlineData("la")]
+        [InlineData("0")]
+        [InlineData("1")]
+        public void InvalidLevel_Throws(string level)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                DataSetQueryLocation.Parse($"{level}|id|12345"));
+        }
+
+        [Theory]
+        [InlineData("NAT", "invalid")]
+        [InlineData("NAT", "laEstab")]
+        [InlineData("NAT", "oldCode")]
+        [InlineData("NAT", "urn")]
+        [InlineData("NAT", "ukprn")]
+        [InlineData("LA", "invalid")]
+        [InlineData("LA", "laEstab")]
+        [InlineData("LA", "urn")]
+        [InlineData("LA", "ukprn")]
+        [InlineData("PROV", "invalid")]
+        [InlineData("PROV", "code")]
+        [InlineData("PROV", "oldCode")]
+        [InlineData("PROV", "laEstab")]
+        [InlineData("PROV", "urn")]
+        [InlineData("SCH", "invalid")]
+        [InlineData("SCH", "code")]
+        [InlineData("SCH", "oldCode")]
+        [InlineData("SCH", "ukprn")]
+        public void InvalidProperty_Throws(string level, string property)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                DataSetQueryLocation.Parse($"{level}|{property}|12345"));
+        }
+
+        public static readonly TheoryData<Type> LocationTypes = new(
+            Assembly
+                .GetAssembly(typeof(DataSetQueryLocation))!
+                .GetTypes()
+                .Where(type => type != typeof(DataSetQueryLocation))
+                .Where(type => typeof(DataSetQueryLocation).IsAssignableFrom(type))
+        );
+
+        [Theory]
+        [MemberData(nameof(LocationTypes))]
+        public void AllTypesCanBeParsed(Type locationType)
+        {
+            string[] locationStrings =
+            [
+                "NAT|id|12345",
+                "REG|code|12345",
+                "LA|code|12345",
+                "LA|oldCode|12345",
+                "PROV|ukprn|12345",
+                "SCH|laEstab|12345",
+                "SCH|urn|12345",
+            ];
+
+            var parsedLocationTypes = locationStrings
+                .Select(DataSetQueryLocation.Parse)
+                .Select(l => l.GetType())
+                .ToHashSet();
+
+            Assert.True(
+                parsedLocationTypes.Contains(locationType),
+                $"""
+                  The location type could not be parsed. Ensure that:
+                  
+                  - There is a branch for this type in '{nameof(DataSetQueryLocation)}.{nameof(DataSetQueryLocation.Parse)}'
+                  - There is a corresponding string for this in the '{nameof(locationStrings)}' variable
+                  """
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryLocationValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryLocationValidatorTests.cs
@@ -1,0 +1,133 @@
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public class DataSetQueryLocationValidatorTests
+{
+    public static readonly TheoryData<DataSetQueryLocation> ValidLocations = new()
+    {
+        new DataSetQueryLocationId { Level = "NAT", Id = "12345"},
+        new DataSetQueryLocationCode { Level = "NAT", Code = "12345"},
+        new DataSetQueryLocationId { Level = "REG", Id = "12345"},
+        new DataSetQueryLocationCode { Level = "REG", Code = "12345"},
+        new DataSetQueryLocationId { Level = "LA", Id = "12345"},
+        new DataSetQueryLocationLocalAuthorityCode { Code = "12345"},
+        new DataSetQueryLocationLocalAuthorityCode { Code = "E08000019"},
+        new DataSetQueryLocationLocalAuthorityCode { Code = "E09000021 / E09000027"},
+        new DataSetQueryLocationLocalAuthorityOldCode { OldCode = "373"},
+        new DataSetQueryLocationLocalAuthorityOldCode { OldCode = "314 / 318"},
+        new DataSetQueryLocationId { Level = "LA", Id = "12345" },
+        new DataSetQueryLocationSchoolUrn { Urn = "107029" },
+        new DataSetQueryLocationSchoolLaEstab { LaEstab = "3732060" },
+        new DataSetQueryLocationId { Level = "PROV", Id = "12345" },
+        new DataSetQueryLocationProviderUkprn { Ukprn = "3732060" },
+    };
+
+    [Theory]
+    [MemberData(nameof(ValidLocations))]
+    public void Success(DataSetQueryLocation location)
+    {
+        var validator = location.CreateValidator();
+
+        var result = validator.Validate(new ValidationContext<DataSetQueryLocation>(location));
+
+        Assert.Empty(result.Errors);
+    }
+
+    public static readonly TheoryData<DataSetQueryLocation> InvalidLocationLevels = new()
+    {
+        new DataSetQueryLocationId { Level = "NA", Id = "12345" },
+        new DataSetQueryLocationCode { Level = "NA", Code = "12345" },
+        new DataSetQueryLocationId { Level = "NT", Id = "12345" },
+        new DataSetQueryLocationCode { Level = "LAA", Code = "12345" },
+        new DataSetQueryLocationCode { Level = "LADD", Code = "12345" }
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidLocationLevels))]
+    public void Failure_InvalidLevel(DataSetQueryLocation location)
+    {
+        var validator = location.CreateValidator();
+
+        var result = validator.Validate(new ValidationContext<DataSetQueryLocation>(location));
+
+        var error = Assert.Single(result.Errors);
+
+        Assert.Equal(nameof(DataSetQueryLocation.Level), error.PropertyName);
+        Assert.Equal(ValidationMessages.AllowedValue.Code, error.ErrorCode);
+        Assert.Equal(ValidationMessages.AllowedValue.Message, error.ErrorMessage);
+
+        var state = Assert.IsType<AllowedValueValidator.AllowedErrorDetail<string>>(error.CustomState);
+
+        Assert.Equal(location.Level, state.Value);
+        Assert.Equal(GeographicLevelUtils.OrderedCodes, state.Allowed);
+    }
+
+    public static readonly TheoryData<DataSetQueryLocation> EmptyLocationValues = new()
+    {
+        new DataSetQueryLocationId { Level = "NAT", Id = "" },
+        new DataSetQueryLocationId { Level = "NAT", Id = "  " },
+        new DataSetQueryLocationCode { Level = "NAT", Code = "" },
+        new DataSetQueryLocationId { Level = "LA", Id = "" },
+        new DataSetQueryLocationLocalAuthorityCode { Code = "" },
+        new DataSetQueryLocationLocalAuthorityOldCode { OldCode = "" },
+        new DataSetQueryLocationId { Level = "RSC", Id = "" },
+        new DataSetQueryLocationId { Level = "SCH", Id = "" },
+        new DataSetQueryLocationSchoolUrn { Urn = "" },
+        new DataSetQueryLocationSchoolLaEstab { LaEstab = "" },
+        new DataSetQueryLocationId { Level = "PROV", Id = "" },
+        new DataSetQueryLocationProviderUkprn { Ukprn = "" },
+    };
+
+    [Theory]
+    [MemberData(nameof(EmptyLocationValues))]
+    public void Failure_EmptyValue(DataSetQueryLocation location)
+    {
+        var validator = location.CreateValidator();
+
+        var result = validator.Validate(new ValidationContext<DataSetQueryLocation>(location));
+
+        var error = Assert.Single(result.Errors);
+
+        Assert.Equal(FluentValidationKeys.NotEmptyValidator, error.ErrorCode);
+
+        Assert.Equal(location.KeyProperty, error.PropertyName);
+        Assert.Equal(location.KeyValue, error.AttemptedValue);
+    }
+
+    public static readonly TheoryData<DataSetQueryLocation> InvalidLocationValueLengths = new()
+    {
+        new DataSetQueryLocationId { Level = "NAT", Id = new string('X', 11) },
+        new DataSetQueryLocationCode { Level = "NAT", Code = new string('X', 26) },
+        new DataSetQueryLocationId { Level = "LA", Id = new string('X', 11) },
+        new DataSetQueryLocationLocalAuthorityCode { Code = new string('X', 26) },
+        new DataSetQueryLocationLocalAuthorityOldCode { OldCode = new string('X', 11) },
+        new DataSetQueryLocationId { Level = "RSC", Id = new string('X', 11) },
+        new DataSetQueryLocationId { Level = "SCH", Id = new string('X', 11) },
+        new DataSetQueryLocationSchoolUrn { Urn = new string('X', 7) },
+        new DataSetQueryLocationSchoolLaEstab { LaEstab = new string('X', 8) },
+        new DataSetQueryLocationId { Level = "PROV", Id = new string('X', 11) },
+        new DataSetQueryLocationProviderUkprn { Ukprn = new string('X', 9) },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidLocationValueLengths))]
+    public void Failure_InvalidValueLength(DataSetQueryLocation location)
+    {
+        var validator = location.CreateValidator();
+
+        var result = validator.Validate(new ValidationContext<DataSetQueryLocation>(location));
+
+        var error = Assert.Single(result.Errors);
+
+        Assert.Equal(FluentValidationKeys.MaximumLengthValidator, error.ErrorCode);
+
+        Assert.Equal(location.KeyProperty, error.PropertyName);
+
+        Assert.Equal(location.KeyValue, error.AttemptedValue);
+        Assert.Equal(location.KeyValue.Length - 1, error.FormattedMessagePlaceholderValues["MaxLength"]);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQuerySortTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQuerySortTests.cs
@@ -1,0 +1,21 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public abstract class DataSetQuerySortTests
+{
+    public class ParseTests
+    {
+        [Theory]
+        [InlineData("time_period", "Asc")]
+        [InlineData("time_period", "Desc")]
+        [InlineData("location|NAT", "Asc")]
+        public void Success(string field, string direction)
+        {
+            var sort = DataSetQuerySort.Parse($"{field}|{direction}");
+
+            Assert.Equal(field, sort.Field);
+            Assert.Equal(direction, sort.Direction);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQuerySortValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQuerySortValidatorTests.cs
@@ -1,0 +1,101 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public class DataSetQuerySortValidatorTests
+{
+    private readonly DataSetQuerySort.Validator _validator = new();
+
+    public static readonly TheoryData<string, string> ValidSorts = new()
+    {
+        { "timePeriod", "Asc" },
+        { "timePeriod", "Desc" },
+        { "geographicLevel", "Asc" },
+        { "geographicLevel", "Desc" },
+        { "locations|REG", "Desc" },
+        { "locations|LA", "Desc" },
+        { "characteristic", "Asc" },
+        { "characteristic", "Desc" },
+        { "school_type", "Asc" },
+        { "school_type", "Desc" },
+        { "ssa_tier_1", "Asc" },
+        { "ssa_tier_2", "Desc" },
+    };
+
+    [Theory]
+    [MemberData(nameof(ValidSorts))]
+    public void Success(string field, string direction)
+    {
+        var sort = new DataSetQuerySort
+        {
+            Field = field,
+            Direction = direction
+        };
+
+        _validator.TestValidate(sort).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("  ")]
+    [InlineData("\n")]
+    public void Failure_EmptyField(string field)
+    {
+        var sort = new DataSetQuerySort
+        {
+            Field = field,
+            Direction = "Asc"
+        };
+
+        var result = _validator.TestValidate(sort);
+
+        result.ShouldHaveValidationErrorFor(s => s.Field)
+            .WithErrorCode(FluentValidationKeys.NotEmptyValidator)
+            .Only();
+    }
+
+    [Fact]
+    public void Failure_InvalidFieldLength()
+    {
+        var sort = new DataSetQuerySort
+        {
+            Field = new string('a', 41),
+            Direction = "Asc"
+        };
+
+        var result = _validator.TestValidate(sort);
+
+        result.ShouldHaveValidationErrorFor(s => s.Field)
+            .WithErrorCode(FluentValidationKeys.MaximumLengthValidator)
+            .WithMessageArgument("MaxLength", 40)
+            .Only();
+    }
+
+    [Theory]
+    [InlineData("Invalid")]
+    [InlineData("asc")]
+    [InlineData("desc")]
+    public void Failure_InvalidDirection(string direction)
+    {
+        var sort = new DataSetQuerySort
+        {
+            Field = "timePeriod",
+            Direction = direction
+        };
+
+        var result = _validator.TestValidate(sort);
+
+        result.ShouldHaveValidationErrorFor(s => s.Direction)
+            .WithErrorCode(ValidationMessages.AllowedValue.Code)
+            .WithErrorMessage(ValidationMessages.AllowedValue.Message)
+            .WithCustomState<AllowedValueValidator.AllowedErrorDetail<string>>(s => s.Value == direction)
+            .WithCustomState<AllowedValueValidator.AllowedErrorDetail<string>>(s =>
+                s.Allowed.SequenceEqual([SortDirection.Asc.ToString(), SortDirection.Desc.ToString()]))
+            .Only();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryTimePeriodTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryTimePeriodTests.cs
@@ -1,0 +1,127 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public abstract class DataSetQueryTimePeriodTests
+{
+    public class FromStringTests
+    {
+        [Theory]
+        [InlineData("2020", "AY")]
+        [InlineData("2020/2021", "AY")]
+        [InlineData("2020", "CY")]
+        public void Success(string period, string code)
+        {
+            var timePeriod = DataSetQueryTimePeriod.FromString($"{period}|{code}");
+
+            Assert.Equal(period, timePeriod.Period);
+            Assert.Equal(code, timePeriod.Code);
+        }
+    }
+
+    public class ParsedPeriodTests
+    {
+        [Theory]
+        [InlineData("2021", "CY")]
+        [InlineData("2021", "CYQ1")]
+        [InlineData("2021", "RY")]
+        [InlineData("2021", "W5")]
+        [InlineData("2021", "M3")]
+        public void YearPeriod_DefaultYearFormatIdentifier(string period, string code)
+        {
+            var timePeriod = new DataSetQueryTimePeriod
+            {
+                Period = period,
+                Code = code
+            };
+
+            Assert.Equal(period, timePeriod.ParsedPeriod());
+        }
+
+        [Theory]
+        [InlineData("AY")]
+        [InlineData("AYQ1")]
+        [InlineData("T1")]
+        [InlineData("T1T2")]
+        [InlineData("FY")]
+        [InlineData("FYQ1")]
+        [InlineData("P1")]
+        [InlineData("TY")]
+        [InlineData("TYQ1")]
+        public void InvalidYearPeriod_RangeIdentifier_Throws(string code)
+        {
+            var timePeriod = new DataSetQueryTimePeriod
+            {
+                Period = "invalid",
+                Code = code
+            };
+
+            Assert.Throws<ArgumentOutOfRangeException>(timePeriod.ParsedPeriod);
+        }
+
+        [Theory]
+        [InlineData("2021/2022", "CY")]
+        [InlineData("2021/2022", "CYQ1")]
+        [InlineData("2021/2022", "RY")]
+        [InlineData("2021/2022", "W5")]
+        [InlineData("2021/2022", "M3")]
+        public void RangePeriod_DefaultYearIdentifier_Throws(string period, string code)
+        {
+            var timePeriod = new DataSetQueryTimePeriod
+            {
+                Period = period,
+                Code = code
+            };
+
+            Assert.Throws<ArgumentOutOfRangeException>(timePeriod.ParsedPeriod);
+        }
+
+        [Theory]
+        [InlineData("2021/2022", "AY", "2021/2022")]
+        [InlineData("2021/2022", "AYQ1", "2021/2022")]
+        [InlineData("2021/2022", "T1", "2021/2022")]
+        [InlineData("2021/2022", "T1T2", "2021/2022")]
+        [InlineData("2021", "AY", "2021/2022")]
+        [InlineData("2021", "AYQ1", "2021/2022")]
+        [InlineData("2021", "T1", "2021/2022")]
+        [InlineData("2021", "T1T2", "2021/2022")]
+        public void YearOrRangePeriod_AcademicYearIdentifier_ReturnsRangedPeriod(
+            string period,
+            string code,
+            string parsedPeriod)
+        {
+            var timePeriod = new DataSetQueryTimePeriod
+            {
+                Period = period,
+                Code = code
+            };
+
+            Assert.Equal(parsedPeriod, timePeriod.ParsedPeriod());
+        }
+
+        [Theory]
+        [InlineData("2021/2022", "FY", "2021/2022")]
+        [InlineData("2021/2022", "FYQ1", "2021/2022")]
+        [InlineData("2021/2022", "P1", "2021/2022")]
+        [InlineData("2021/2022", "TY", "2021/2022")]
+        [InlineData("2021/2022", "TYQ1", "2021/2022")]
+        [InlineData("2021", "FY", "2021/2022")]
+        [InlineData("2021", "FYQ1", "2021/2022")]
+        [InlineData("2021", "P1", "2021/2022")]
+        [InlineData("2021", "TY", "2021/2022")]
+        [InlineData("2021", "TYQ1", "2021/2022")]
+        public void YearOrRangePeriod_FiscalYearIdentifier_ReturnsRangedPeriod(
+            string period,
+            string code,
+            string parsedPeriod)
+        {
+            var timePeriod = new DataSetQueryTimePeriod
+            {
+                Period = period,
+                Code = code
+            };
+
+            Assert.Equal(parsedPeriod, timePeriod.ParsedPeriod());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryTimePeriodTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryTimePeriodTests.cs
@@ -4,7 +4,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Reque
 
 public abstract class DataSetQueryTimePeriodTests
 {
-    public class FromStringTests
+    public class ParseTests
     {
         [Theory]
         [InlineData("2020", "AY")]
@@ -12,7 +12,7 @@ public abstract class DataSetQueryTimePeriodTests
         [InlineData("2020", "CY")]
         public void Success(string period, string code)
         {
-            var timePeriod = DataSetQueryTimePeriod.FromString($"{period}|{code}");
+            var timePeriod = DataSetQueryTimePeriod.Parse($"{period}|{code}");
 
             Assert.Equal(period, timePeriod.Period);
             Assert.Equal(code, timePeriod.Code);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryTimePeriodValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryTimePeriodValidatorTests.cs
@@ -1,0 +1,210 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ErrorDetails;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ValidationMessages;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public class DataSetQueryTimePeriodValidatorTests
+{
+    private readonly DataSetQueryTimePeriod.Validator _validator = new();
+
+    public static TheoryData<string, string> ValidTimePeriods => new()
+    {
+        { "2020", "AY" },
+        { "2020/2021", "AY" },
+        { "2020/2021", "AYQ1" },
+        { "2020/2021", "AYQ3" },
+        { "2020", "FY" },
+        { "2021", "CY" },
+        { "2021", "CYQ1" },
+        { "2021", "CYQ2" },
+        { "2021", "RY" },
+        { "2021", "M1" },
+        { "2021", "M12" },
+        { "2021", "W20" },
+        { "2021", "W40" },
+        { "2021", "T1" },
+        { "2021", "T1T2" },
+        { "2021", "T3" },
+        { "2021/2022", "T1" },
+        { "2021/2022", "T1T2" },
+        { "2021/2022", "T3" },
+        { "2021", "P1" },
+        { "2021", "P2" },
+        { "2021/2022", "P1" },
+        { "2021/2022", "P2" },
+        { "2019", "FYQ4" },
+        { "2019/2020", "FYQ4" }
+    };
+
+    [Theory]
+    [MemberData(nameof(ValidTimePeriods))]
+    public void Success(string period, string code)
+    {
+        var timePeriod = new DataSetQueryTimePeriod
+        {
+            Code = code,
+            Period = period
+        };
+
+        _validator.TestValidate(timePeriod).ShouldNotHaveAnyValidationErrors();
+    }
+
+    public static TheoryData<string, string> InvalidTimePeriodYears => new()
+    {
+        { "Invalid", "CY" },
+        { "2022-", "CY" },
+        { "-2022", "CY" },
+        { "2022Invalid", "CY" },
+        { "2022 ", "AY" },
+        { " 2022", "AY" },
+        { " 2022 ", "AY" },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidTimePeriodYears))]
+    public void Failure_InvalidYear(string period, string code)
+    {
+        var timePeriod = new DataSetQueryTimePeriod
+        {
+            Code = code,
+            Period = period
+        };
+
+        var result = _validator.TestValidate(timePeriod);
+
+        Assert.Single(result.Errors);
+
+        result.ShouldHaveValidationErrorFor(t => t.Period)
+            .WithErrorCode(ValidationMessages.TimePeriodInvalidYear.Code)
+            .WithErrorMessage(ValidationMessages.TimePeriodInvalidYear.Message)
+            .WithCustomState<InvalidErrorDetail<string>>(s => s.Value == period)
+            .Only();
+    }
+
+    public static TheoryData<string, string> InvalidTimePeriodYearRanges => new()
+    {
+        { "Invalid/2024", "AY" },
+        { "2023/Invalid", "AY" },
+        { "2023Invalid/2024", "AY" },
+        { "2023/2024Invalid", "AY" },
+        { "2022/2020", "AY" },
+        { "2000/1999", "AY" },
+        { "2000/2002", "AY" },
+        { "2022-/2023", "FYQ2" },
+        { "-2022/2023", "FYQ2" },
+        { "2022/2023-", "FYQ2" },
+        { "2022/-2023", "FYQ2" },
+        { "-2022/-2023", "FYQ2" },
+        { "2022 /2023", "FYQ2" },
+        { " 2022/2023", "FYQ2" },
+        { " 2022 /2023", "FYQ2" },
+        { "2022/2023 ", "FYQ2" },
+        { "2022/ 2023 ", "FYQ2" },
+        { "2022/ 2023", "FYQ2" },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidTimePeriodYearRanges))]
+    public void Failure_InvalidYearRange(string period, string code)
+    {
+        var timePeriod = new DataSetQueryTimePeriod
+        {
+            Code = code,
+            Period = period
+        };
+
+        var result = _validator.TestValidate(timePeriod);
+
+        Assert.Single(result.Errors);
+
+        result.ShouldHaveValidationErrorFor(t => t.Period)
+            .WithErrorCode(ValidationMessages.TimePeriodInvalidYearRange.Code)
+            .WithErrorMessage(ValidationMessages.TimePeriodInvalidYearRange.Message)
+            .WithCustomState<InvalidErrorDetail<string>>(s => s.Value == period)
+            .Only();
+    }
+
+    public static TheoryData<string, string> InvalidTimePeriodCodes => new()
+    {
+        { "2022", "INVALID" },
+        { "2022", "YY" },
+        { "2022", "WEEK12" },
+        { "2022", "JANUARY" },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidTimePeriodCodes))]
+    public void Failure_InvalidCode(string period, string code)
+    {
+        var timePeriod = new DataSetQueryTimePeriod
+        {
+            Code = code,
+            Period = period
+        };
+
+        var result = _validator.TestValidate(timePeriod);
+
+        result.ShouldHaveValidationErrorFor(t => t.Code)
+            .WithErrorCode(ValidationMessages.TimePeriodAllowedCode.Code)
+            .WithErrorMessage(ValidationMessages.TimePeriodAllowedCode.Message)
+            .WithCustomState<TimePeriodAllowedCodeErrorDetail>(s => s.Value == code)
+            .WithCustomState<TimePeriodAllowedCodeErrorDetail>(s =>
+                s.AllowedCodes.SequenceEqual(TimeIdentifierUtils.DataCodes.Order()))
+            .Only();
+    }
+
+    public static TheoryData<string, string> InvalidTimePeriodRangeCodes => new()
+    {
+        { "2022/2023", "INVALID" },
+        { "2022/2023", "AY1" },
+        { "2022/2023", "ZZ" },
+        { "2022/2023", "CY" },
+        { "2022/2023", "CYQ1" },
+        { "2022/2023", "CYQ3" },
+        { "2022/2023", "RY" },
+        { "2022/2023", "W12" },
+        { "2022/2023", "W40" },
+        { "2022/2023", "M1" },
+        { "2022/2023", "M12" },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidTimePeriodRangeCodes))]
+    public void Failure_InvalidCodeForRange(string period, string code)
+    {
+        var timePeriod = new DataSetQueryTimePeriod
+        {
+            Code = code,
+            Period = period
+        };
+
+        var result = _validator.TestValidate(timePeriod);
+
+        result.ShouldHaveValidationErrorFor(t => t.Code)
+            .WithErrorCode(ValidationMessages.TimePeriodAllowedCode.Code)
+            .WithErrorMessage(ValidationMessages.TimePeriodAllowedCode.Message)
+            .WithCustomState<TimePeriodAllowedCodeErrorDetail>(d => d.Value == code)
+            .WithCustomState<TimePeriodAllowedCodeErrorDetail>(d => d.AllowedCodes.All(allowedCode =>
+            {
+                var yearFormat = EnumUtil
+                    .GetFromEnumValue<TimeIdentifier>(allowedCode)
+                    .GetEnumAttribute<TimeIdentifierMetaAttribute>()
+                    .YearFormat;
+
+                var isValidYearFormat = yearFormat is TimePeriodYearFormat.Academic or TimePeriodYearFormat.Fiscal;
+
+                Assert.True(isValidYearFormat);
+
+                return isValidYearFormat;
+            }))
+            .Only();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/SortStringValidatorsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Validators/SortStringValidatorsTests.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using FluentValidation.TestHelper;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
@@ -55,100 +56,88 @@ public class SortStringValidatorsTests
         {
             var testObj = new TestClass { Sort = sort! };
 
-            var result = _validator.Validate(testObj);
+            var result = _validator.TestValidate(testObj);
 
-            Assert.False(result.IsValid);
-
-            var error = Assert.Single(result.Errors);
-
-            Assert.Equal(nameof(TestClass.Sort), error.PropertyName);
-            Assert.Equal(FluentValidationKeys.NotEmptyValidator, error.ErrorCode);
+            result.ShouldHaveValidationErrorFor(t => t.Sort)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator)
+                .Only();
         }
 
         [Theory]
         [InlineData("Invalid")]
         [InlineData("Asc")]
-        [InlineData("|Asc")]
-        [InlineData(" |Asc")]
         [InlineData("timePeriod:Asc")]
-        [InlineData("timePeriod|")]
-        [InlineData(" timePeriod|Asc")]
-        [InlineData("timePeriod| ")]
-        [InlineData("timePeriod| Asc")]
-        [InlineData(" timePeriod|Asc ")]
-        [InlineData("timePeriod |Asc ")]
-        [InlineData("timePeriod|Asc1")]
-        [InlineData("locations||Asc")]
-        [InlineData("locations| |Asc")]
-        [InlineData("locations| |")]
-        [InlineData("school-type|Asc")]
-        [InlineData("school_type| Asc")]
-        [InlineData("school_type|Asc ")]
+        [InlineData("locations|||Asc")]
+        [InlineData("locations| ||Asc")]
+        [InlineData("locations| | |Asc")]
+        [InlineData("locations|LA||Asc")]
+        [InlineData("locations|LA| |Asc")]
+        [InlineData("locations|LA|Asc|")]
+        [InlineData("locations|LA| Asc|")]
         public void Failure_InvalidFormat(string sort)
         {
             var testObj = new TestClass { Sort = sort };
 
-            var result = _validator.Validate(testObj);
+            var result = _validator.TestValidate(testObj);
 
-            Assert.False(result.IsValid);
-
-            var error = Assert.Single(result.Errors);
-
-            Assert.Equal(nameof(TestClass.Sort), error.PropertyName);
-            Assert.Equal(ValidationMessages.SortFormat.Code, error.ErrorCode);
-            Assert.Equal(ValidationMessages.SortFormat.Message, error.ErrorMessage);
-
-            var state = Assert.IsType<FormatErrorDetail>(error.CustomState);
-
-            Assert.Equal(sort, state.Value);
-            Assert.Equal("{field}|{order}", state.ExpectedFormat);
+            result.ShouldHaveValidationErrorFor(t => t.Sort)
+                .WithErrorCode(ValidationMessages.SortFormat.Code)
+                .WithErrorMessage(ValidationMessages.SortFormat.Message)
+                .WithCustomState<FormatErrorDetail>(s => s.Value == sort)
+                .WithCustomState<FormatErrorDetail>(s => s.ExpectedFormat == "{field}|{direction}")
+                .Only();
         }
 
         [Theory]
-        [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|Asc")]
-        [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|Desc")]
-        public void Failure_InvalidFieldLength(string sort)
+        [InlineData(" ")]
+        [InlineData("  ")]
+        [InlineData("\n")]
+        public void Failure_EmptyField(string field)
         {
-            var testObj = new TestClass { Sort = sort };
+            var testObj = new TestClass { Sort = $"{field}|Asc" };
 
-            var result = _validator.Validate(testObj);
+            var result = _validator.TestValidate(testObj);
 
-            Assert.False(result.IsValid);
-
-            var error = Assert.Single(result.Errors);
-
-            Assert.Equal(nameof(TestClass.Sort), error.PropertyName);
-            Assert.Equal(ValidationMessages.SortMaxFieldLength.Code, error.ErrorCode);
-            Assert.Equal(ValidationMessages.SortMaxFieldLength.Message, error.ErrorMessage);
-
-            var state = Assert.IsType<SortStringValidators.MaxFieldLengthErrorDetail>(error.CustomState);
-
-            Assert.Equal(sort, $"{state.Value.Field}|{state.Value.Direction}");
-            Assert.Equal(40, state.MaxFieldLength);
+            result.ShouldHaveValidationErrorFor(t => t.Sort)
+                .WithErrorCode(ValidationMessages.SortFieldNotEmpty.Code)
+                .WithErrorMessage(ValidationMessages.SortFieldNotEmpty.Message)
+                .WithMessageArgument("Property", "field")
+                .Only();
         }
 
         [Theory]
-        [InlineData("timePeriod|Invalid")]
-        [InlineData("timePeriod|asc")]
-        [InlineData("timePeriod|desc")]
-        public void Failure_InvalidDirection(string sort)
+        [InlineData("Asc")]
+        [InlineData("Desc")]
+        public void Failure_InvalidFieldLength(string direction)
         {
-            var testObj = new TestClass { Sort = sort };
+            var testObj = new TestClass { Sort = $"{new string('a', 41)}|{direction}" };
 
-            var result = _validator.Validate(testObj);
+            var result = _validator.TestValidate(testObj);
 
-            Assert.False(result.IsValid);
+            result.ShouldHaveValidationErrorFor(t => t.Sort)
+                .WithErrorCode(ValidationMessages.SortFieldMaxLength.Code)
+                .WithMessageArgument("MaxLength", 40)
+                .WithMessageArgument("Property", "field")
+                .Only();
+        }
 
-            var error = Assert.Single(result.Errors);
+        [Theory]
+        [InlineData("Invalid")]
+        [InlineData("asc")]
+        [InlineData("desc")]
+        public void Failure_InvalidDirection(string direction)
+        {
+            var testObj = new TestClass { Sort = $"timePeriod|{direction}" };
 
-            Assert.Equal(nameof(TestClass.Sort), error.PropertyName);
-            Assert.Equal(ValidationMessages.SortDirection.Code, error.ErrorCode);
-            Assert.Equal(ValidationMessages.SortDirection.Message, error.ErrorMessage);
+            var result = _validator.TestValidate(testObj);
 
-            var state = Assert.IsType<SortStringValidators.DirectionErrorDetail>(error.CustomState);
-
-            Assert.Equal(sort, $"{state.Value.Field}|{state.Value.Direction}");
-            Assert.Equal([SortDirection.Asc.ToString(), SortDirection.Desc.ToString()], state.AllowedDirections);
+            result.ShouldHaveValidationErrorFor(t => t.Sort)
+                .WithErrorCode(ValidationMessages.SortDirection.Code)
+                .WithErrorMessage(ValidationMessages.SortDirection.Message)
+                .WithCustomState<AllowedValueValidator.AllowedErrorDetail<string>>(s => s.Value == direction)
+                .WithCustomState<AllowedValueValidator.AllowedErrorDetail<string>>(s =>
+                    s.Allowed.SequenceEqual([SortDirection.Asc.ToString(), SortDirection.Desc.ToString()]))
+                .Only();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/ViewModels/ValidationProblemViewModelTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/ViewModels/ValidationProblemViewModelTestExtensions.cs
@@ -1,10 +1,12 @@
 using System.Text.Json;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ErrorDetails;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ValidationMessages;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.ViewModels;
 
@@ -133,21 +135,38 @@ public static class ValidationProblemViewModelTestExtensions
         return error;
     }
 
-    public static ErrorViewModel AssertHasSortMaxFieldLengthError(
+    public static ErrorViewModel AssertHasSortFieldNotEmptyError(
         this ValidationProblemViewModel validationProblem,
-        string expectedPath,
-        string field,
-        int maxFieldLength = 40)
+        string expectedPath)
     {
         var error = validationProblem.AssertHasError(
             expectedPath: expectedPath,
-            expectedCode: ValidationMessages.SortMaxFieldLength.Code
+            expectedCode: ValidationMessages.SortFieldNotEmpty.Code
         );
 
-        var errorDetail = error.GetDetail<SortStringValidators.MaxFieldLengthErrorDetail>();
+        var errorDetail = error.GetDetail<Dictionary<string, JsonElement>>();
 
-        Assert.Equal(field, errorDetail.Value.Field);
-        Assert.Equal(maxFieldLength, errorDetail.MaxFieldLength);
+        Assert.Equal("field", errorDetail["property"].GetString());
+
+        return error;
+    }
+    
+    public static ErrorViewModel AssertHasSortFieldMaxLengthError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath,
+        string field,
+        int maxLength = 40)
+    {
+        var error = validationProblem.AssertHasError(
+            expectedPath: expectedPath,
+            expectedCode: ValidationMessages.SortFieldMaxLength.Code
+        );
+
+        var errorDetail = error.GetDetail<Dictionary<string, JsonElement>>();
+
+        Assert.Equal("field", errorDetail["property"].GetString());
+        Assert.Equal(field, errorDetail["value"].GetString());
+        Assert.Equal(maxLength, errorDetail["maxLength"].GetInt32());
 
         return error;
     }
@@ -162,9 +181,9 @@ public static class ValidationProblemViewModelTestExtensions
             expectedCode: ValidationMessages.SortDirection.Code
         );
 
-        var errorDetail = error.GetDetail<SortStringValidators.DirectionErrorDetail>();
+        var errorDetail = error.GetDetail<AllowedValueValidator.AllowedErrorDetail<string>>();
 
-        Assert.Equal(direction, errorDetail.Value.Direction);
+        Assert.Equal(direction, errorDetail.Value);
 
         return error;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/ViewModels/ValidationProblemViewModelTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/ViewModels/ValidationProblemViewModelTestExtensions.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ErrorDetails;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.ViewModels;
 
@@ -201,6 +202,23 @@ public static class ValidationProblemViewModelTestExtensions
         return error;
     }
 
+    public static ErrorViewModel AssertHasTimePeriodInvalidYearError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath,
+        string period)
+    {
+        var error = validationProblem.AssertHasError(
+            expectedPath: expectedPath,
+            expectedCode: ValidationMessages.TimePeriodInvalidYear.Code
+        );
+
+        var errorDetail = error.GetDetail<InvalidErrorDetail<string>>();
+
+        Assert.Equal(period, errorDetail.Value);
+
+        return error;
+    }
+
     public static ErrorViewModel AssertHasTimePeriodYearRangeError(
         this ValidationProblemViewModel validationProblem,
         string expectedPath,
@@ -208,12 +226,12 @@ public static class ValidationProblemViewModelTestExtensions
     {
         var error = validationProblem.AssertHasError(
             expectedPath: expectedPath,
-            expectedCode: ValidationMessages.TimePeriodYearRange.Code
+            expectedCode: ValidationMessages.TimePeriodInvalidYearRange.Code
         );
 
-        var errorDetail = error.GetDetail<TimePeriodStringValidators.RangeErrorDetail>();
+        var errorDetail = error.GetDetail<InvalidErrorDetail<string>>();
 
-        Assert.Equal(period, errorDetail.Value.Period);
+        Assert.Equal(period, errorDetail.Value);
 
         return error;
     }
@@ -228,9 +246,9 @@ public static class ValidationProblemViewModelTestExtensions
             expectedCode: ValidationMessages.TimePeriodAllowedCode.Code
         );
 
-        var errorDetail = error.GetDetail<TimePeriodStringValidators.AllowedCodeErrorDetail>();
+        var errorDetail = error.GetDetail<TimePeriodAllowedCodeErrorDetail>();
 
-        Assert.Equal(code, errorDetail.Value.Code);
+        Assert.Equal(code, errorDetail.Value);
 
         return error;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/ViewModels/ValidationProblemViewModelTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/ViewModels/ValidationProblemViewModelTestExtensions.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
@@ -53,9 +54,9 @@ public static class ValidationProblemViewModelTestExtensions
             expectedCode: ValidationMessages.LocationAllowedLevel.Code
         );
 
-        var errorDetail = error.GetDetail<LocationStringValidators.AllowedLevelErrorDetail>();
+        var errorDetail = error.GetDetail<LocationAllowedLevelErrorDetail>();
 
-        Assert.Equal(level, errorDetail.Value.Level);
+        Assert.Equal(level, errorDetail.Value);
 
         return error;
     }
@@ -71,29 +72,46 @@ public static class ValidationProblemViewModelTestExtensions
             expectedCode: ValidationMessages.LocationAllowedProperty.Code
         );
 
-        var errorDetail = error.GetDetail<LocationStringValidators.AllowedPropertyErrorDetail>();
+        var errorDetail = error.GetDetail<LocationAllowedPropertyErrorDetail>();
 
-        Assert.Equal(property, errorDetail.Value.Property);
+        Assert.Equal(property, errorDetail.Value);
         Assert.Equal(allowedProperties, errorDetail.AllowedProperties);
 
         return error;
     }
 
-    public static ErrorViewModel AssertHasLocationMaxValueLengthError(
+    public static ErrorViewModel AssertHasLocationValueNotEmptyError(
         this ValidationProblemViewModel validationProblem,
         string expectedPath,
-        string value,
-        int maxValueLength)
+        string property)
     {
         var error = validationProblem.AssertHasError(
             expectedPath: expectedPath,
-            expectedCode: ValidationMessages.LocationMaxValueLength.Code
+            expectedCode: ValidationMessages.LocationValueNotEmpty.Code
         );
 
-        var errorDetail = error.GetDetail<LocationStringValidators.MaxValueLengthErrorDetail>();
+        var errorDetail = error.GetDetail<Dictionary<string, JsonElement>>();
 
-        Assert.Equal(value, errorDetail.Value.Value);
-        Assert.Equal(maxValueLength, errorDetail.MaxValueLength);
+        Assert.Equal(property, errorDetail["property"].GetString());
+
+        return error;
+    }
+
+    public static ErrorViewModel AssertHasLocationValueMaxLengthError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath,
+        string property,
+        int maxLength)
+    {
+        var error = validationProblem.AssertHasError(
+            expectedPath: expectedPath,
+            expectedCode: ValidationMessages.LocationValueMaxLength.Code
+        );
+
+        var errorDetail = error.GetDetail<Dictionary<string, JsonElement>>();
+
+        Assert.Equal(property, errorDetail["property"].GetString());
+        Assert.Equal(maxLength, errorDetail["maxLength"].GetInt32());
 
         return error;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -248,8 +248,8 @@ public class DataSetsController(
     ///
     /// ### Examples
     ///
-    /// - `time_period|Desc` sorts by time period in descending order
-    /// - `geographic_level|Asc` sorts by geographic level in ascending order
+    /// - `timePeriod|Desc` sorts by time period in descending order
+    /// - `geographicLevel|Asc` sorts by geographic level in ascending order
     /// - `location|REG|Asc` sorts by regions in ascending order
     /// </remarks>
     [HttpGet("{dataSetId:guid}/query")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetLocationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetLocationRepository.cs
@@ -37,7 +37,7 @@ public class ParquetLocationRepository(
         CancellationToken cancellationToken = default)
     {
         var locationsByLevel = locations
-            .GroupBy(location => location.ParsedLevel)
+            .GroupBy(location => location.ParsedLevel())
             .ToList();
 
         var allOptions = new List<ParquetLocationOption>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetTimePeriodRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Repository/ParquetTimePeriodRepository.cs
@@ -56,7 +56,7 @@ public class ParquetTimePeriodRepository(
             .AppendRange(
                 timePeriodsList.Select(
                     tp => (FormattableString)
-                        $"({TimePeriodFormatter.FormatToCsv(tp.ParsedPeriod)}, {tp.ParsedCode.GetEnumLabel()})"
+                        $"({TimePeriodFormatter.FormatToCsv(tp.ParsedPeriod())}, {tp.ParsedCode().GetEnumLabel()})"
                 ),
                 joinString: ", "
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryTimePeriods.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryTimePeriods.cs
@@ -57,14 +57,14 @@ public record DataSetGetQueryTimePeriods
     {
         return new DataSetQueryCriteriaTimePeriods
         {
-            Eq = Eq is not null ? DataSetQueryTimePeriod.FromString(Eq) : null,
-            NotEq = NotEq is not null ? DataSetQueryTimePeriod.FromString(NotEq) : null,
-            In = In?.Select(DataSetQueryTimePeriod.FromString).ToList(),
-            NotIn = NotIn?.Select(DataSetQueryTimePeriod.FromString).ToList(),
-            Gt = Gt is not null ? DataSetQueryTimePeriod.FromString(Gt) : null,
-            Gte = Gte is not null ? DataSetQueryTimePeriod.FromString(Gte) : null,
-            Lt = Lt is not null ? DataSetQueryTimePeriod.FromString(Lt) : null,
-            Lte = Lte is not null ? DataSetQueryTimePeriod.FromString(Lte) : null
+            Eq = Eq is not null ? DataSetQueryTimePeriod.Parse(Eq) : null,
+            NotEq = NotEq is not null ? DataSetQueryTimePeriod.Parse(NotEq) : null,
+            In = In?.Select(DataSetQueryTimePeriod.Parse).ToList(),
+            NotIn = NotIn?.Select(DataSetQueryTimePeriod.Parse).ToList(),
+            Gt = Gt is not null ? DataSetQueryTimePeriod.Parse(Gt) : null,
+            Gte = Gte is not null ? DataSetQueryTimePeriod.Parse(Gte) : null,
+            Lt = Lt is not null ? DataSetQueryTimePeriod.Parse(Lt) : null,
+            Lte = Lte is not null ? DataSetQueryTimePeriod.Parse(Lte) : null
         };
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQuerySort.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQuerySort.cs
@@ -1,6 +1,7 @@
-using System.Text.Json.Serialization;
+using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
@@ -30,8 +31,7 @@ public record DataSetQuerySort
     /// </summary>
     public required string Direction { get; init; }
 
-    [JsonIgnore]
-    public SortDirection ParsedDirection => EnumUtil.GetFromEnumValue<SortDirection>(Direction);
+    public SortDirection ParsedDirection() => EnumUtil.GetFromEnumValue<SortDirection>(Direction);
 
     public string ToSortString() => $"{Field}|{Direction}";
 
@@ -44,5 +44,23 @@ public record DataSetQuerySort
             Field = sort[..directionDelimiter],
             Direction = sort[(directionDelimiter + 1)..]
         };
+    }
+
+    public class Validator : AbstractValidator<DataSetQuerySort>
+    {
+        private static readonly HashSet<string> AllowedDirections = [
+            SortDirection.Asc.ToString(),
+            SortDirection.Desc.ToString()
+        ];
+
+        public Validator()
+        {
+            RuleFor(t => t.Field)
+                .NotEmpty()
+                .MaximumLength(40);
+
+            RuleFor(t => t.Direction)
+                .AllowedValue(AllowedDirections);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQuerySort.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQuerySort.cs
@@ -35,7 +35,7 @@ public record DataSetQuerySort
 
     public string ToSortString() => $"{Field}|{Direction}";
 
-    public static DataSetQuerySort FromString(string sort)
+    public static DataSetQuerySort Parse(string sort)
     {
         var directionDelimiter = sort.LastIndexOf('|');
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryTimePeriod.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryTimePeriod.cs
@@ -1,8 +1,13 @@
-using System.Text.Json.Serialization;
+using System.Globalization;
+using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ErrorDetails;
+using ArgumentOutOfRangeException = System.ArgumentOutOfRangeException;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
@@ -57,11 +62,11 @@ public record DataSetQueryTimePeriod
     /// </summary>
     public required string Code { get; init; }
 
-    [JsonIgnore]
-    public string ParsedPeriod => GetParsedPeriod(Period, ParsedCode);
+    public string ParsedPeriod() => GetParsedPeriod(Period, ParsedCode());
 
-    [JsonIgnore]
-    public TimeIdentifier ParsedCode => EnumUtil.GetFromEnumValue<TimeIdentifier>(Code);
+    public TimeIdentifier ParsedCode() => EnumUtil.GetFromEnumValue<TimeIdentifier>(Code);
+
+    public bool HasRangePeriod() => Period.Contains('/');
 
     public string ToTimePeriodString()
     {
@@ -87,7 +92,11 @@ public record DataSetQueryTimePeriod
 
         if (metaAttribute.YearFormat == TimePeriodYearFormat.Default)
         {
-            return period;
+            return !period.Contains('/')
+                ? period
+                : throw new ArgumentOutOfRangeException(
+                    paramName: nameof(period),
+                    message: "Period should be a single year and not a range.");
         }
 
         if (period.Contains('/'))
@@ -95,8 +104,91 @@ public record DataSetQueryTimePeriod
             return period;
         }
 
-        var year = int.Parse(period);
+        return int.TryParse(period, out var year)
+            ? $"{year}/{year + 1}"
+            : throw new ArgumentOutOfRangeException(
+                paramName: nameof(period),
+                message: "Period should be a numeric year");
+    }
 
-        return $"{year}/{year + 1}";
+    private static bool TryParseYear(string year, out int parsedYear)
+        => int.TryParse(year, style: NumberStyles.None, provider: null, result: out parsedYear);
+
+    private static bool IsValidPeriodYear(string period) => TryParseYear(period, out _);
+
+    public class Validator : AbstractValidator<DataSetQueryTimePeriod>
+    {
+        public Validator()
+        {
+            RuleFor(tp => tp.Code)
+                .Must((tp, _) => IsAllowedCode(tp))
+                .WithErrorCode(ValidationMessages.TimePeriodAllowedCode.Code)
+                .WithMessage(ValidationMessages.TimePeriodAllowedCode.Message)
+                .WithState(tp => new TimePeriodAllowedCodeErrorDetail(
+                    Value: tp.Code,
+                    AllowedCodes: tp.HasRangePeriod() ? AllowedRangeCodes : AllowedCodes
+                ))
+                .DependentRules(() =>
+                {
+                    RuleFor(tp => tp.Period)
+                        .Must(IsValidPeriodYear)
+                        .WithErrorCode(ValidationMessages.TimePeriodInvalidYear.Code)
+                        .WithMessage(ValidationMessages.TimePeriodInvalidYear.Message)
+                        .WithState(tp => new InvalidErrorDetail<string>(tp.Period))
+                        .When(tp => !tp.HasRangePeriod());
+
+                    RuleFor(tp => tp.Period)
+                        .Must(IsValidPeriodYearRange)
+                        .WithErrorCode(ValidationMessages.TimePeriodInvalidYearRange.Code)
+                        .WithMessage(ValidationMessages.TimePeriodInvalidYearRange.Message)
+                        .WithState(tp => new InvalidErrorDetail<string>(tp.Period))
+                        .When(tp => tp.HasRangePeriod());
+                });
+        }
+
+        private static readonly HashSet<TimeIdentifier> AllowedTimeIdentifiers =
+            TimeIdentifierUtils.DataEnums.ToHashSet();
+
+        private static readonly HashSet<TimeIdentifier> AllowedRangeTimeIdentifiers =
+            AllowedTimeIdentifiers
+                .Where(
+                    identifier => identifier.GetEnumAttribute<TimeIdentifierMetaAttribute>().YearFormat
+                        is TimePeriodYearFormat.Academic or TimePeriodYearFormat.Fiscal
+                )
+                .ToHashSet();
+
+        private static readonly IReadOnlyList<string> AllowedCodes =
+            TimeIdentifierUtils.DataCodes
+                .Order()
+                .ToList();
+
+        private static readonly IReadOnlyList<string> AllowedRangeCodes =
+            AllowedRangeTimeIdentifiers
+                .Select(identifier => identifier.GetEnumValue())
+                .Order()
+                .ToList();
+
+        private static bool IsValidPeriodYearRange(string period)
+        {
+            var rangeParts = period.Split('/');
+            var start = rangeParts[0];
+            var end = rangeParts[1];
+
+            return TryParseYear(start, out var startYear)
+                   && TryParseYear(end, out var endYear)
+                   && endYear == startYear + 1;
+        }
+
+        private static bool IsAllowedCode(DataSetQueryTimePeriod timePeriod)
+        {
+            if (!EnumUtil.TryGetFromEnumValue<TimeIdentifier>(timePeriod.Code, out var code))
+            {
+                return false;
+            }
+
+            return timePeriod.HasRangePeriod()
+                ? AllowedRangeTimeIdentifiers.Contains(code)
+                : AllowedTimeIdentifiers.Contains(code);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryTimePeriod.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryTimePeriod.cs
@@ -73,7 +73,7 @@ public record DataSetQueryTimePeriod
         return $"{Period}|{Code}";
     }
 
-    public static DataSetQueryTimePeriod FromString(string timePeriod)
+    public static DataSetQueryTimePeriod Parse(string timePeriod)
     {
         var parts = timePeriod.Split('|');
         var period = parts[0];

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
@@ -73,7 +73,7 @@ internal class DataSetQueryService(
                 TimePeriods = request.TimePeriods?.ToCriteria(),
             },
             Indicators = request.Indicators,
-            Sorts = request.Sorts?.Select(DataSetQuerySort.FromString).ToList()
+            Sorts = request.Sorts?.Select(DataSetQuerySort.Parse).ToList(),
         };
 
         return await FindDataSetVersion(dataSetId, dataSetVersion, cancellationToken)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
@@ -301,13 +301,13 @@ internal class DataSetQueryService(
         {
             if (fieldColumnMap.TryGetValue(sort.Field, out var field))
             {
-                sorts.Add(new Sort(Field: field, Direction: sort.ParsedDirection));
+                sorts.Add(new Sort(Field: field, Direction: sort.ParsedDirection()));
                 continue;
             }
 
             if (otherFields.Contains(sort.Field))
             {
-                sorts.Add(new Sort(Field: sort.Field, Direction: sort.ParsedDirection));
+                sorts.Add(new Sort(Field: sort.Field, Direction: sort.ParsedDirection()));
                 continue;
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/LocationFacetsParser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/LocationFacetsParser.cs
@@ -99,7 +99,7 @@ internal class LocationFacetsParser : IFacetsParser
                 .Build();
         }
 
-        builder += $"{DataTable.Ref().LocationId(location.ParsedLevel):raw} {(negate ? "!=" : "="):raw} {option.Id}";
+        builder += $"{DataTable.Ref().LocationId(location.ParsedLevel()):raw} {(negate ? "!=" : "="):raw} {option.Id}";
 
         return builder.Build();
     }
@@ -168,7 +168,7 @@ internal class LocationFacetsParser : IFacetsParser
     {
         locationOption = null;
 
-        if (!_allowedLocationOptionsByLevel.TryGetValue(queryLocation.ParsedLevel, out var options))
+        if (!_allowedLocationOptionsByLevel.TryGetValue(queryLocation.ParsedLevel(), out var options))
         {
             return false;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/TimePeriodFacetsParser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/TimePeriodFacetsParser.cs
@@ -216,8 +216,8 @@ internal class TimePeriodFacetsParser : IFacetsParser
 
         public TimePeriodKey(DataSetQueryTimePeriod timePeriod)
         {
-            Period = TimePeriodFormatter.FormatToCsv(timePeriod.ParsedPeriod);
-            Identifier = timePeriod.ParsedCode;
+            Period = TimePeriodFormatter.FormatToCsv(timePeriod.ParsedPeriod());
+            Identifier = timePeriod.ParsedCode();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ErrorDetails/LocationAllowedLevelErrorDetail.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ErrorDetails/LocationAllowedLevelErrorDetail.cs
@@ -1,0 +1,6 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ErrorDetails;
+
+public record LocationAllowedLevelErrorDetail(string Value, IReadOnlyList<string> AllowedLevels)
+    : InvalidErrorDetail<string>(Value);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ErrorDetails/LocationAllowedPropertyErrorDetail.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ErrorDetails/LocationAllowedPropertyErrorDetail.cs
@@ -1,0 +1,6 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ErrorDetails;
+
+public record LocationAllowedPropertyErrorDetail(string Value, IEnumerable<string> AllowedProperties)
+        : InvalidErrorDetail<string>(Value);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ErrorDetails/TimePeriodAllowedCodeErrorDetail.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ErrorDetails/TimePeriodAllowedCodeErrorDetail.cs
@@ -1,0 +1,6 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ErrorDetails;
+
+public record TimePeriodAllowedCodeErrorDetail(string Value, IReadOnlyList<string> AllowedCodes)
+    : InvalidErrorDetail<string>(Value);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/LocationStringValidators.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/LocationStringValidators.cs
@@ -3,7 +3,10 @@ using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ErrorDetails;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
@@ -30,159 +33,122 @@ public static partial class LocationStringValidators
                 return;
             }
 
-            var location = ParsedLocation.Parse(value);
+            var parts = value.Split('|');
+            var level = parts[0];
+            var property = parts[1];
 
-            if (!HasAllowedLevel(location))
+            if (!HasAllowedLevel(level))
             {
                 context.AddFailure(
                     message: ValidationMessages.LocationAllowedLevel,
-                    detail: new AllowedLevelErrorDetail(
-                        Value: location,
+                    detail: new LocationAllowedLevelErrorDetail(
+                        Value: level,
                         AllowedLevels: EnumUtil.GetEnumValues<GeographicLevel>().Order().ToList()
                     )
                 );
                 return;
             }
 
-            if (!HasAllowedProperty(location))
+            if (!HasAllowedProperty(level: level, property: property))
             {
                 context.AddFailure(
                     message: ValidationMessages.LocationAllowedProperty,
-                    detail: new AllowedPropertyErrorDetail(location, GetAllowedProperties(location))
+                    detail: new LocationAllowedPropertyErrorDetail(property, GetAllowedProperties(level: level))
                 );
+                return;
             }
 
-            if (!HasValidValueLength(location))
-            {
-                var maxValueLength = GetMaxValueLength(location);
+            var queryLocation = DataSetQueryLocation.Parse(value);
 
-                context.AddFailure(
-                    message: ValidationMessages.LocationMaxValueLength,
-                    detail: new MaxValueLengthErrorDetail(location, maxValueLength),
-                    messagePlaceholders: new Dictionary<string, object>
-                    {
-                        {
-                            "MaxValueLength", maxValueLength
-                        }
-                    }
-                );
+            var validator = queryLocation.CreateValidator();
+            var result = validator.Validate(new ValidationContext<DataSetQueryLocation>(queryLocation));
+
+            if (result.IsValid)
+            {
+                return;
+            }
+
+            foreach (var error in result.Errors)
+            {
+                var propertyName = error.PropertyName.ToLowerFirst();
+
+                switch (error.ErrorCode)
+                {
+                    case FluentValidationKeys.NotEmptyValidator:
+                        error.ErrorCode = ValidationMessages.LocationValueNotEmpty.Code;
+                        error.ErrorMessage = context.MessageFormatter
+                            .AppendArgument("Property", propertyName)
+                            .BuildMessage(ValidationMessages.LocationValueNotEmpty.Message);
+                        break;
+
+                    case FluentValidationKeys.MaximumLengthValidator:
+                        error.ErrorCode = ValidationMessages.LocationValueMaxLength.Code;
+                        error.ErrorMessage = context.MessageFormatter
+                            .AppendArgument("Property", propertyName)
+                            .AppendArgument("MaxLength", error.FormattedMessagePlaceholderValues["MaxLength"])
+                            .BuildMessage(ValidationMessages.LocationValueMaxLength.Message);;
+                        break;
+                }
+
+                error.FormattedMessagePlaceholderValues["Property"] = propertyName;
+                error.PropertyName = context.PropertyPath;
+
+                context.AddFailure(error);
             }
         });
     }
 
-    [GeneratedRegex(@"^[A-Z]{2,4}\|[A-Za-z]+\|\w+( \/ )?\w+$", RegexOptions.Compiled, matchTimeoutMilliseconds: 200)]
+    // Note this regex only does basic checks on delimiters to allow other
+    // validations to provide more specific error messages on what is invalid.
+    [GeneratedRegex(@"^[^|]*\|[^|]+\|[^|]*$", RegexOptions.Compiled, matchTimeoutMilliseconds: 200)]
     private static partial Regex FormatRegexGenerated();
 
     private static readonly Regex FormatRegex = FormatRegexGenerated();
 
     private static bool HasValidFormat(string value) => FormatRegex.IsMatch(value);
 
-    private static bool HasAllowedLevel(ParsedLocation location)
-    {
-        return EnumUtil.TryGetFromEnumValue<GeographicLevel>(location.Level, out _);
-    }
+    private static bool HasAllowedLevel(string level)
+        => EnumUtil.TryGetFromEnumValue<GeographicLevel>(level, out _);
 
-    private static bool HasAllowedProperty(ParsedLocation location)
-    {
-        return GetAllowedProperties(location).Contains(location.Property);
-    }
+    private static bool HasAllowedProperty(string level, string property)
+        => GetAllowedProperties(level).Contains(property);
 
-    private static bool HasValidValueLength(ParsedLocation location)
+    private static string[] GetAllowedProperties(string level)
     {
-        return location.Value.Length <= GetMaxValueLength(location);
-    }
-
-    private static string[] GetAllowedProperties(ParsedLocation location)
-    {
-        var geographicLevel = EnumUtil.GetFromEnumValue<GeographicLevel>(location.Level);
+        var geographicLevel = EnumUtil.GetFromEnumValue<GeographicLevel>(level);
 
         string[] properties = geographicLevel switch
         {
             GeographicLevel.LocalAuthority =>
             [
-                "id",
-                nameof(LocationLocalAuthorityOptionMeta.Code),
-                nameof(LocationLocalAuthorityOptionMeta.OldCode)
+                nameof(DataSetQueryLocationId.Id),
+                nameof(DataSetQueryLocationLocalAuthorityCode.Code),
+                nameof(DataSetQueryLocationLocalAuthorityOldCode.OldCode)
             ],
             GeographicLevel.School =>
             [
-                "id",
+                nameof(DataSetQueryLocationId.Id),
                 nameof(LocationSchoolOptionMeta.Urn),
                 nameof(LocationSchoolOptionMeta.LaEstab)
             ],
             GeographicLevel.Provider =>
             [
-                "id",
+                nameof(DataSetQueryLocationId.Id),
                 nameof(LocationProviderOptionMeta.Ukprn)
             ],
-            GeographicLevel.RscRegion => ["id"],
-            _ => ["id", "code"]
+            GeographicLevel.RscRegion =>
+            [
+                nameof(DataSetQueryLocationId.Id)
+            ],
+            _ =>
+            [
+                nameof(DataSetQueryLocationId.Id),
+                nameof(DataSetQueryLocationCode.Code)
+            ]
         };
 
         return properties
             .Select(property => property.ToLowerFirst())
             .ToArray();
-    }
-
-    private static int GetMaxValueLength(ParsedLocation location)
-    {
-        var geographicLevel = EnumUtil.GetFromEnumValue<GeographicLevel>(location.Level);
-        var property = location.Property.ToUpperFirst();
-
-        return geographicLevel switch
-        {
-            GeographicLevel.LocalAuthority => property switch
-            {
-                nameof(LocationLocalAuthorityOptionMeta.Code) => 25,
-                nameof(LocationLocalAuthorityOptionMeta.OldCode) => 10,
-                _ => 10
-            },
-            GeographicLevel.School => property switch
-            {
-                nameof(LocationSchoolOptionMeta.Urn) => 6,
-                nameof(LocationSchoolOptionMeta.LaEstab) => 7,
-                _ => 10
-            },
-            GeographicLevel.Provider => property switch
-            {
-                nameof(LocationProviderOptionMeta.Ukprn) => 8,
-                _ => 10
-            },
-            _ => property switch
-            {
-                nameof(LocationCodedOptionMeta.Code) => 25,
-                _ => 10
-            }
-        };
-    }
-
-    public record AllowedLevelErrorDetail(ParsedLocation Value, IEnumerable<string> AllowedLevels)
-        : InvalidErrorDetail<ParsedLocation>(Value);
-
-    public record AllowedPropertyErrorDetail(ParsedLocation Value, IEnumerable<string> AllowedProperties)
-        : InvalidErrorDetail<ParsedLocation>(Value);
-
-    public record MaxValueLengthErrorDetail(ParsedLocation Value, int MaxValueLength)
-        : InvalidErrorDetail<ParsedLocation>(Value);
-
-    public record ParsedLocation
-    {
-        public string Level { get; init; }
-
-        public string Property { get; init; }
-
-        public string Value { get; init; }
-
-        public static ParsedLocation Parse(string value)
-        {
-            var parts = value.Split('|');
-
-            return new ParsedLocation
-            {
-                Level = parts[0],
-                Property = parts[1],
-                Value = parts[2],
-            };
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/TimePeriodStringValidators.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/TimePeriodStringValidators.cs
@@ -30,7 +30,7 @@ public static partial class TimePeriodStringValidators
             }
 
             var validator = new DataSetQueryTimePeriod.Validator();
-            var result = validator.Validate(DataSetQueryTimePeriod.FromString(value));
+            var result = validator.Validate(DataSetQueryTimePeriod.Parse(value));
 
             if (result.IsValid)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/TimePeriodStringValidators.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/TimePeriodStringValidators.cs
@@ -1,10 +1,8 @@
 using System.Text.RegularExpressions;
 using FluentValidation;
-using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
 
@@ -12,7 +10,8 @@ public static partial class TimePeriodStringValidators
 {
     private const string ExpectedFormat = "{period}|{code}";
 
-    public static IRuleBuilderOptionsConditions<T, string> TimePeriodString<T>(this IRuleBuilder<T, string> rule)
+    public static IRuleBuilderOptionsConditions<T, string> TimePeriodString<T>(
+        this IRuleBuilder<T, string> rule)
     {
         return rule.NotEmpty().Custom((value, context) =>
         {
@@ -30,109 +29,30 @@ public static partial class TimePeriodStringValidators
                 return;
             }
 
-            var timePeriod = ParsedTimePeriod.Parse(value);
+            var validator = new DataSetQueryTimePeriod.Validator();
+            var result = validator.Validate(DataSetQueryTimePeriod.FromString(value));
 
-            if (!HasValidYearRange(timePeriod))
+            if (result.IsValid)
             {
-                context.AddFailure(
-                    message: ValidationMessages.TimePeriodYearRange,
-                    detail: new RangeErrorDetail(timePeriod)
-                );
+                return;
             }
 
-            if (!HasAllowedCode(timePeriod))
+            foreach (var error in result.Errors)
             {
-                context.AddFailure(
-                    message: ValidationMessages.TimePeriodAllowedCode,
-                    detail: new AllowedCodeErrorDetail(
-                        Value: timePeriod,
-                        AllowedCodes: timePeriod.HasRangePeriod() ? AllowedRangeCodes : AllowedCodes
-                    )
-                );
+                error.FormattedMessagePlaceholderValues["Property"] = error.PropertyName.ToLowerFirst();
+                error.PropertyName = context.PropertyPath;
+                
+                context.AddFailure(error);
             }
         });
     }
 
-    private static readonly IReadOnlySet<TimeIdentifier> AllowedTimeIdentifiers =
-        TimeIdentifierUtils.DataEnums.ToHashSet();
-
-    private static readonly IReadOnlySet<TimeIdentifier> AllowedRangeTimeIdentifiers =
-        AllowedTimeIdentifiers
-            .Where(
-                identifier => identifier.GetEnumAttribute<TimeIdentifierMetaAttribute>().YearFormat
-                    is TimePeriodYearFormat.Academic or TimePeriodYearFormat.Fiscal
-            )
-            .ToHashSet();
-
-    private static readonly IReadOnlyList<string> AllowedCodes =
-        TimeIdentifierUtils.DataCodes
-            .Order()
-            .ToList();
-
-    private static readonly IReadOnlyList<string> AllowedRangeCodes =
-        AllowedRangeTimeIdentifiers
-            .Select(identifier => identifier.GetEnumValue())
-            .Order()
-            .ToList();
-
-    [GeneratedRegex(@"^[0-9]{4}(\/[0-9]{4})?\|[A-Z0-9]+$", RegexOptions.Compiled, matchTimeoutMilliseconds: 200)]
+    // Note this regex only does basic checks on the delimiter to allow
+    // other validations to provide more detailed error messages.
+    [GeneratedRegex(@"^[^\|]*\|[^\|]*$", RegexOptions.Compiled, matchTimeoutMilliseconds: 200)]
     private static partial Regex FormatRegexGenerated();
 
     private static readonly Regex FormatRegex = FormatRegexGenerated();
 
     private static bool HasValidFormat(string value) => FormatRegex.IsMatch(value);
-
-    private static bool HasValidYearRange(ParsedTimePeriod timePeriod)
-    {
-        // The period is not a range.
-        if (!timePeriod.HasRangePeriod())
-        {
-            return true;
-        }
-
-        var rangeParts = timePeriod.Period.Split('/');
-        var start = rangeParts[0];
-        var end = rangeParts[1];
-
-        return int.TryParse(start, out var startYear)
-               && int.TryParse(end, out var endYear)
-               && endYear == startYear + 1;
-    }
-
-    private static bool HasAllowedCode(ParsedTimePeriod timePeriod)
-    {
-        if (!EnumUtil.TryGetFromEnumValue<TimeIdentifier>(timePeriod.Code, out var code))
-        {
-            return false;
-        }
-
-        return timePeriod.HasRangePeriod()
-            ? AllowedRangeTimeIdentifiers.Contains(code)
-            : AllowedTimeIdentifiers.Contains(code);
-    }
-
-    public record RangeErrorDetail(ParsedTimePeriod Value) : InvalidErrorDetail<ParsedTimePeriod>(Value);
-
-    public record AllowedCodeErrorDetail(ParsedTimePeriod Value, IReadOnlyList<string> AllowedCodes)
-        : InvalidErrorDetail<ParsedTimePeriod>(Value);
-
-    public record ParsedTimePeriod
-    {
-        public string Period { get; init; }
-        
-        public string Code { get; init; }
-
-        public static ParsedTimePeriod Parse(string value)
-        {
-            var parts = value.Split('|');
-
-            return new ParsedTimePeriod
-            {
-                Period = parts[0],
-                Code = parts[1]
-            };
-        }
-
-        public bool HasRangePeriod() => Period.Contains('/');
-    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
@@ -54,8 +54,13 @@ public static class ValidationMessages
         Message: "Must be a time period in the correct format."
     );
 
-    public static readonly LocalizableMessage TimePeriodYearRange = new(
-        Code: "TimePeriodYearRange",
+    public static readonly LocalizableMessage TimePeriodInvalidYear = new(
+        Code: "TimePeriodInvalidYear",
+        Message: "Must be a time period for a valid year."
+    );
+
+    public static readonly LocalizableMessage TimePeriodInvalidYearRange = new(
+        Code: "TimePeriodInvalidYearRange",
         Message: "Must be a valid time period range where the start year is one year before the end year."
     );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
@@ -38,10 +38,15 @@ public static class ValidationMessages
         Code: "LocationAllowedProperty",
         Message: "Must be a location with an allowed identifying property."
     );
+    
+    public static readonly LocalizableMessage LocationValueNotEmpty = new(
+        Code: "LocationValueNotEmpty",
+        Message: "Must be a location with '{Property}' that is not empty."
+    );
 
-    public static readonly LocalizableMessage LocationMaxValueLength = new(
-        Code: "LocationMaxLengthValue",
-        Message: "Must be a location with an identifying value that is {MaxValueLength} characters or fewer."
+    public static readonly LocalizableMessage LocationValueMaxLength = new(
+        Code: "LocationValueMaxLength",
+        Message: "Must be a location with '{Property}' that is {MaxLength} characters or fewer."
     );
 
     public static readonly LocalizableMessage LocationsNotFound = new(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Validators/ValidationMessages.cs
@@ -89,9 +89,14 @@ public static class ValidationMessages
         Message: "Must be a sort in the correct format."
     );
 
-    public static readonly LocalizableMessage SortMaxFieldLength = new(
-        Code: "SortMaxFieldLength",
-        Message: "Must be a sort with a field that is {MaxFieldLength} characters or fewer."
+    public static readonly LocalizableMessage SortFieldNotEmpty = new(
+        Code: "SortFieldNotEmpty",
+        Message: "Must be a sort with a field that is not empty."
+    );
+
+    public static readonly LocalizableMessage SortFieldMaxLength = new(
+        Code: "SortFieldMaxLength",
+        Message: "Must be a sort with a field that is {MaxLength} characters or fewer."
     );
 
     public static readonly LocalizableMessage SortDirection = new(


### PR DESCRIPTION
This PR refactors the facet string validators used by the data set GET query endpoint to re-use validators for the equivalent facet request models i.e.

- `LocationStringValidators` → `DataSetQueryLocation`
- `TimePeriodStringValidators` → `DataSetQueryTimePeriod`
- `SortStringValidators` → `DataSetQuerySort`

This has mostly involved separating out as much logic relevant to the facet strings and the facet request models. 

After the facet strings have been parsed and their own validations have been ran, we then parse the string into its facet request model and run its validations as well. Any errors from the facet request model are then re-mapped to validation errors for the facet string.

As part of this, we've also done a bunch of tweaks and cleanup including:

- Changes to the various error details for the string validators. These have been simplified and now just provide a `value` containing the portion of the string that was invalid.
- Updates to the relevant validation error messages to:
  - Cover various not empty errors
  - Make the error codes more consistent
- Updates test assertions for checking validation errors
- Re-using as much test data as possible between test suites for the facet strings and facet request models.
- Refactored most of the tests to leverage FluentValidation's test assertion extensions. We've also implemented some additional extensions to augment this, particularly when checking custom state.