### PR TITLE
EES-5122 allow linking to step 3 of table tool

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxGroupsMenu.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxGroupsMenu.tsx
@@ -22,7 +22,7 @@ interface Props<TFormValues extends FieldValues>
 export default function RHFFormFieldCheckboxGroupsMenu<
   TFormValues extends FieldValues,
 >(props: Props<TFormValues>) {
-  const { hiddenText, legend, name, open = false, onToggle } = props;
+  const { hiddenText, legend, name, open = false, id, onToggle } = props;
 
   const {
     formState: { errors },
@@ -39,6 +39,7 @@ export default function RHFFormFieldCheckboxGroupsMenu<
 
   return (
     <DetailsMenu
+      id={`details-${id}`}
       open={open}
       hiddenText={hiddenText}
       jsRequired

--- a/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxMenu.tsx
+++ b/src/explore-education-statistics-common/src/components/form/rhf/RHFFormFieldCheckboxMenu.tsx
@@ -16,9 +16,8 @@ interface Props<TFormValues extends FieldValues>
 export default function RHFFormFieldCheckboxMenu<
   TFormValues extends FieldValues,
 >(props: Props<TFormValues>) {
-  const { name, open: defaultOpen = false, options, legend } = props;
+  const { name, open: defaultOpen = false, options, legend, id } = props;
   const [open, setOpen] = useState(defaultOpen);
-
   const {
     formState: { errors },
   } = useFormContext();
@@ -31,6 +30,7 @@ export default function RHFFormFieldCheckboxMenu<
 
   return (
     <DetailsMenu
+      id={`details-${id}`}
       open={open}
       jsRequired
       summary={legend}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -180,6 +180,7 @@ const LocationFiltersForm = ({
 
                     return hasSubGroups && !searchOnly ? (
                       <RHFFormFieldCheckboxGroupsMenu
+                        id={`locations-${levelKey}`}
                         key={levelKey}
                         name={`locations.${levelKey}`}
                         disabled={formState.isSubmitting}
@@ -198,6 +199,7 @@ const LocationFiltersForm = ({
                       />
                     ) : (
                       <RHFFormFieldCheckboxMenu
+                        id={`locations-${levelKey}`}
                         key={levelKey}
                         name={`locations.${levelKey}`}
                         disabled={formState.isSubmitting}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
@@ -426,6 +426,40 @@ describe('TableToolPage', () => {
     expect(screen.getByLabelText('Test subject')).toBeInTheDocument();
   });
 
+  test('renders the page correctly with pre-selected data set', async () => {
+    render(
+      <TableToolPage
+        selectedPublication={testSelectedPublicationWithLatestRelease}
+        selectedSubjectId={testSubjects[0].id}
+        subjectMeta={testSubjectMeta}
+        subjects={testSubjects}
+        themeMeta={testThemeMeta}
+      />,
+    );
+
+    // Check we are on step 3
+    expect(screen.getByTestId('wizardStep-1')).not.toHaveAttribute(
+      'aria-current',
+      'step',
+    );
+    expect(screen.getByTestId('wizardStep-2')).not.toHaveAttribute(
+      'aria-current',
+      'step',
+    );
+    expect(screen.getByTestId('wizardStep-3')).toHaveAttribute(
+      'aria-current',
+      'step',
+    );
+
+    expect(screen.getByTestId('Publication')).toHaveTextContent(
+      'Test publication',
+    );
+
+    expect(screen.getByTestId('Data set')).toHaveTextContent('Test subject');
+    expect(screen.getByText('Choose Countries')).toBeInTheDocument();
+    expect(screen.getByLabelText('Great Britain')).toBeInTheDocument();
+  });
+
   test('renders the page correctly with pre-built table when a fast track is provided', async () => {
     render(
       <TableToolPage


### PR DESCRIPTION
Allows you to link directly to the table tool at step 3 (locations) with the publication, release (optional) and data set pre-selected. 
- `/data-tables/<publication-slug>?subjectId=<subject-id>`
- `/data-tables/<publication-slug>/<release-slug>?subjectId=<subject-id>`

I've added ids to `RHFFormFieldCheckboxGroupsMenu` and `RHFFormFieldCheckboxMenu` as without them the generated ids on the `Details` component cause a hydration error.