### PR TITLE
EES-5095 Add ability to create ErrorViewModels from ValidationFailure directly

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationFailureExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationFailureExtensionsTests.cs
@@ -1,0 +1,283 @@
+#nullable enable
+using System.Collections.Generic;
+using FluentValidation.Results;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class ValidationFailureExtensionsTests
+{
+    public class GetErrorDetailTests
+    {
+        [Fact]
+        public void AttemptedValueIsNull()
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = null,
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Single(detail);
+            Assert.Null(detail["value"]);
+        }
+
+        [Fact]
+        public void MessagePlaceholdersNotNull()
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = "Test value",
+                FormattedMessagePlaceholderValues = new Dictionary<string, object>
+                {
+                    { "MaxLength", 6 },
+                    { "MinLength", 3 }
+                }
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Equal(3, detail.Count);
+            Assert.Equal("Test value", detail["value"]);
+            Assert.Equal(6, detail["maxLength"]);
+            Assert.Equal(3, detail["minLength"]);
+        }
+
+        [Fact]
+        public void RedundantMessagePlaceholdersIgnored()
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = "Test value",
+                FormattedMessagePlaceholderValues = new Dictionary<string, object>
+                {
+                    { "PropertyName", "test" },
+                    { "PropertyPath", "my.test" },
+                    { "PropertyValue", "Test value" },
+                    { "CollectionIndex", 0 }
+                }
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Single(detail);
+            Assert.Equal("Test value", detail["value"]);
+        }
+
+        [Fact]
+        public void CustomStateIsNull()
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = "Test value",
+                CustomState = null
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Single(detail);
+            Assert.Equal("Test value", detail["value"]);
+        }
+
+        [Fact]
+        public void CustomStateIsAnonymousObject()
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = "Test value",
+                CustomState = new
+                {
+                    Name = "Test name",
+                    Age = 30
+                }
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Equal(3, detail.Count);
+            Assert.Equal("Test value", detail["value"]);
+            Assert.Equal("Test name", detail["name"]);
+            Assert.Equal(30, detail["age"]);
+        }
+
+        [Fact]
+        public void CustomStateAnonymousObject_WithMessagePlaceholders()
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = "Test value",
+                FormattedMessagePlaceholderValues = new Dictionary<string, object>
+                {
+                    { "MaxLength", 6 },
+                    { "MinLength", 3 }
+                },
+                CustomState = new
+                {
+                    Name = "Test name",
+                    Age = 30
+                }
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Equal(5, detail.Count);
+            Assert.Equal("Test value", detail["value"]);
+            Assert.Equal("Test name", detail["name"]);
+            Assert.Equal(30, detail["age"]);
+            Assert.Equal(6, detail["maxLength"]);
+            Assert.Equal(3, detail["minLength"]);
+        }
+
+        [Fact]
+        public void CustomStateIsClass()
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = "Test value",
+                CustomState = new TestErrorDetail
+                {
+                    Name = "Test name",
+                    Age = 30
+                }
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Equal(3, detail.Count);
+            Assert.Equal("Test value", detail["value"]);
+            Assert.Equal("Test name", detail["name"]);
+            Assert.Equal(30, detail["age"]);
+        }
+
+        [Fact]
+        public void CustomStateIsClass_WithMessagePlaceholders()
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = "Test value",
+                FormattedMessagePlaceholderValues = new Dictionary<string, object>
+                {
+                    { "MaxLength", 6 },
+                    { "MinLength", 3 }
+                },
+                CustomState = new TestErrorDetail
+                {
+                    Name = "Test name",
+                    Age = 30
+                }
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Equal(5, detail.Count);
+            Assert.Equal("Test value", detail["value"]);
+            Assert.Equal("Test name", detail["name"]);
+            Assert.Equal(30, detail["age"]);
+            Assert.Equal(6, detail["maxLength"]);
+            Assert.Equal(3, detail["minLength"]);
+        }
+
+        [Theory]
+        [InlineData(123)]
+        [InlineData(false)]
+        [InlineData(TestEnum.Test)]
+        public void CustomStateIsPrimitive(object customState)
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = "Test value",
+                CustomState = customState
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Equal(2, detail.Count);
+            Assert.Equal("Test value", detail["value"]);
+            Assert.Equal(customState, detail["state"]);
+        }
+
+        [Theory]
+        [InlineData(123)]
+        [InlineData(false)]
+        [InlineData(TestEnum.Test)]
+        public void CustomStateIsPrimitive_WithMessagePlaceholders(object customState)
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = "Test value",
+                FormattedMessagePlaceholderValues = new Dictionary<string, object>
+                {
+                    { "MaxLength", 6 },
+                    { "MinLength", 3 }
+                },
+                CustomState = customState
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Equal(4, detail.Count);
+            Assert.Equal("Test value", detail["value"]);
+            Assert.Equal(customState, detail["state"]);
+            Assert.Equal(6, detail["maxLength"]);
+            Assert.Equal(3, detail["minLength"]);
+        }
+
+        [Fact]
+        public void CustomStateOverridesMessagePlaceholders()
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = "Test value",
+                FormattedMessagePlaceholderValues = new Dictionary<string, object>
+                {
+                    { "MaxLength", 6 },
+                    { "MinLength", 3 }
+                },
+                CustomState = new
+                {
+                    MaxLength = 10,
+                    MinLength = 5
+                }
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Equal(3, detail.Count);
+            Assert.Equal("Test value", detail["value"]);
+            Assert.Equal(10, detail["maxLength"]);
+            Assert.Equal(5, detail["minLength"]);
+        }
+
+        [Fact]
+        public void CustomStateWithValueOverridesAttemptedValue()
+        {
+            var failure = new ValidationFailure
+            {
+                AttemptedValue = "Test value",
+                CustomState = new
+                {
+                    Value = "Test value override"
+                }
+            };
+
+            var detail = failure.GetErrorDetail();
+
+            Assert.Single(detail);
+            Assert.Equal("Test value override", detail["value"]);
+        }
+
+        private enum TestEnum
+        {
+            Test
+        }
+
+        private record TestErrorDetail
+        {
+            public required string Name { get; init; }
+
+            public required int Age { get; init; }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ViewModels/ErrorViewModelTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ViewModels/ErrorViewModelTests.cs
@@ -1,0 +1,51 @@
+#nullable enable
+using System.Collections.Generic;
+using FluentValidation.Results;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.ViewModels;
+
+public static class ErrorViewModelTests
+{
+    public class CreateFromValidationFailureTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var failure = new ValidationFailure
+            {
+                ErrorCode = "TestCode",
+                ErrorMessage = "Test message",
+                PropertyName = "testProperty",
+                AttemptedValue = "Test value"
+            };
+
+            var error = ErrorViewModel.Create(failure);
+
+            Assert.Equal("TestCode", error.Code);
+            Assert.Equal("Test message", error.Message);
+            Assert.Equal("testProperty", error.Path);
+
+            var detail = Assert.IsType<Dictionary<string, object>>(error.Detail);
+
+            Assert.Single(detail);
+            Assert.Equal("Test value", detail["value"]);
+        }
+
+        [Fact]
+        public void ValidatorCodeIsTrimmed()
+        {
+            var failure = new ValidationFailure
+            {
+                ErrorCode = "TestCodeValidator",
+                ErrorMessage = "Test message",
+                PropertyName = "testProperty"
+            };
+
+            var error = ErrorViewModel.Create(failure);
+
+            Assert.Equal("TestCode", error.Code);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/FluentValidationExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/FluentValidationExtensions.cs
@@ -1,13 +1,34 @@
 #nullable enable
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentValidation;
 using FluentValidation.Results;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
 public static class FluentValidationRuleExtensions
 {
+    public static async Task<Either<ActionResult, T>> Validate<T>(
+        this IValidator<T> validator,
+        T instance,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await validator.ValidateAsync(instance, cancellationToken);
+
+        if (result.IsValid)
+        {
+            return instance;
+        }
+
+        return ValidationUtils.ValidationResult(result.Errors.Select(ErrorViewModel.Create));
+    }
+
     public static IRuleBuilderOptions<T, TProperty> WithMessage<T, TProperty>(
         this IRuleBuilderOptions<T, TProperty> rule,
         LocalizableMessage localizableMessage)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ValidationFailureExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ValidationFailureExtensions.cs
@@ -1,0 +1,57 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using FluentValidation.Results;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class ValidationFailureExtensions
+{
+    private static readonly HashSet<string> IgnoredMessagePlaceholders =
+    [
+        "PropertyName",
+        "PropertyPath",
+        "PropertyValue",
+        "CollectionIndex"
+    ];
+
+    public static Dictionary<string, object?> GetErrorDetail(this ValidationFailure failure)
+    {
+        var detail = (failure.FormattedMessagePlaceholderValues ?? [])
+            .Where(kv => !IgnoredMessagePlaceholders.Contains(kv.Key))
+            .ToDictionary(kv => kv.Key.ToLowerFirst(), kv => kv.Value)
+            as Dictionary<string, object?>;
+
+        if (!detail.ContainsKey("value"))
+        {
+            detail["value"] = failure.AttemptedValue;
+        }
+
+        if (failure.CustomState is null)
+        {
+            return detail;
+        }
+
+        var type = failure.CustomState.GetType();
+
+        if (type is { IsClass: true, IsPrimitive: false, IsEnum: false, IsValueType: false })
+        {
+            var customKeyValues = failure.CustomState
+                .ToDictionary()
+                .ToDictionary(
+                    kv => kv.Key.CamelCase(),
+                    kv => kv.Value);
+
+            foreach (var keyValue in customKeyValues)
+            {
+                detail[keyValue.Key] = keyValue.Value;
+            }
+        }
+        else
+        {
+            detail["state"] = failure.CustomState;
+        }
+
+        return detail;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ErrorViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ErrorViewModel.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using FluentValidation.Results;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 
@@ -32,4 +34,17 @@ public record ErrorViewModel
     /// more context to users. May be omitted if there is none.
     /// </summary>
     public object? Detail { get; init; }
+
+    public static ErrorViewModel Create(ValidationFailure failure)
+    {
+        var detail = failure.GetErrorDetail();
+
+        return new ErrorViewModel
+        {
+            Path = failure.PropertyName,
+            Code = failure.ErrorCode.Replace("Validator", ""),
+            Message = failure.ErrorMessage,
+            Detail = detail.Count > 0 ? detail : null
+        };
+    }
 }


### PR DESCRIPTION
This PR adds the ability to construct `ErrorViewModel` directly from FluentValidation's `ValidationFailure` outside of `FluentValidationActionFilter` i.e. when calling `IValidator.Validate` manually.

We've also added an extension for `IValidator<T>` that returns a `Task<Either<ActionResult, T>`, which allows the validation call to integrate into Either returning chains.

