### PR TITLE
EES-5130 Add `InvalidRequestInputResultFilter` to handle invalid input

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
@@ -321,6 +321,41 @@ public static class ValidationProblemViewModelTestExtensions
         return error;
     }
 
+    public static ErrorViewModel AssertHasNotEmptyBodyError(
+        this ValidationProblemViewModel validationProblem)
+    {
+        var error = validationProblem.AssertHasError(
+            expectedPath: null,
+            expectedCode: ValidationMessages.NotEmptyBody.Code
+        );
+
+        return error;
+    }
+
+    public static ErrorViewModel AssertHasInvalidInputError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+    {
+        var error = validationProblem.AssertHasError(
+            expectedPath: expectedPath,
+            expectedCode: ValidationMessages.InvalidInput.Code
+        );
+
+        return error;
+    }
+
+    public static ErrorViewModel AssertHasRequiredFieldError(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath)
+    {
+        var error = validationProblem.AssertHasError(
+            expectedPath: expectedPath,
+            expectedCode: ValidationMessages.RequiredField.Code
+        );
+
+        return error;
+    }
+
     public static ErrorViewModel AssertHasError(
         this ValidationProblemViewModel validationProblem,
         string? expectedPath,

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/JsonPathUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/JsonPathUtilsTests.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+
+public static class JsonPathUtilsTests
+{
+    public class ConcatTests
+    {
+        [Theory]
+        [InlineData("path.to.something", "path", "to", "something")]
+        [InlineData("path.to.something", "$.path", "$.to", "$.something")]
+        [InlineData("path.to.something", "$.path", "to", "something")]
+        [InlineData("path.to.something", "$.path", "$.to", "something")]
+        [InlineData("path.to.something", "path", "to", "$.something")]
+        [InlineData("a.b.c.d[0].e", "a", "b.c", "d[0].e")]
+        [InlineData("a.b.c.d[0].e", "$.a", "$.b.c", "$.d[0].e")]
+        [InlineData("a.b[0].c[1].d", "$.a", "$.b[0]", "$.c[1].d")]
+        [InlineData("a[0].b[1].c[2].d", "$.a[0]", "$.b[1]", "$.c[2].d")]
+        [InlineData("a[0].b[1].c", "$", "$.a[0]", "$.b[1].c")]
+        public void Success(string expectedPath, params string[] inputPaths)
+        {
+            Assert.Equal(expectedPath, JsonPathUtils.Concat(inputPaths));
+        }
+
+        [Theory]
+        [InlineData(" path ", " to ", " something ")]
+        [InlineData("   path", "  to ", "  something")]
+        [InlineData("  path  ", "  to ", "something  ")]
+        public void TrimsPaths(params string[] inputPaths)
+        {
+            Assert.Equal("path.to.something", JsonPathUtils.Concat(inputPaths));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/JsonPathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/JsonPathUtils.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public static class JsonPathUtils
+{
+    public static string Concat(params string[] paths) => Concat(paths.ToList());
+
+    public static string Concat(IEnumerable<string> paths)
+    {
+        return paths.Aggregate(
+            string.Empty,
+            (acc, inputPath) =>
+            {
+                var path = inputPath.Trim();
+
+                if (path == "$")
+                {
+                    return acc;
+                }
+
+                if (path.StartsWith("$."))
+                {
+                    return acc == string.Empty
+                        ? acc + path[2..]
+                        : acc + path[1..];
+                }
+
+                return acc == string.Empty ? path : $"{acc}.{path}";
+            }
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationMessages.cs
@@ -10,4 +10,19 @@ public static class ValidationMessages
         Code: "AllowedValue",
         Message: "Must be one of the allowed values."
     );
+
+    public static readonly LocalizableMessage InvalidInput = new(
+        Code: "InvalidInput",
+        Message: "The input is not valid. Check that it is in the expected format."
+    );
+
+    public static readonly LocalizableMessage NotEmptyBody = new(
+        Code: "NotEmptyBody",
+        Message: "The request body must not be empty."
+    );
+
+    public static readonly LocalizableMessage RequiredField = new(
+        Code: "RequiredField",
+        Message: "The field is required."
+    );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerQueryTests.cs
@@ -1088,10 +1088,9 @@ public abstract class DataSetsControllerQueryTests(TestApplicationFactory testAp
         {
             var dataSetVersion = await SetupDefaultDataSetVersion();
 
-            var response = await QueryDataSet(
-                dataSetId: dataSetVersion.DataSetId,
-                indicators: []
-            );
+            var client = BuildApp().CreateClient();
+
+            var response = await client.GetAsync($"{BaseUrl}/{dataSetVersion.DataSetId}/query?indicators[]=");
 
             var validationProblem = response.AssertValidationProblem();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Filters/InvalidRequestInputResultFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Filters/InvalidRequestInputResultFilterTests.cs
@@ -1,0 +1,191 @@
+using System.Net.Http.Json;
+using System.Text;
+using Asp.Versioning;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Fixture;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Filters;
+
+public class InvalidRequestInputResultFilterTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+{
+    [Fact]
+    public async Task TestPersonBody_Returns200()
+    {
+        var client = BuildApp().CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            requestUri: nameof(TestController.TestPersonBody),
+            value: new TestPerson
+            {
+                Name = "Test name"
+            });
+
+        response.AssertOk();
+    }
+
+    [Theory]
+    [InlineData("{}", "")]
+    [InlineData("{ \"name\": 123 }", "name")]
+    [InlineData("{ \"name\": true }", "name")]
+    [InlineData("{ \"firstName\": \"test\" }", "")]
+    [InlineData("{ \"firstName\": 123 }", "")]
+    public async Task TestPersonBody_InvalidJson_Returns400(string body, string path)
+    {
+        var client = BuildApp().CreateClient();
+
+        var response = await client.PostAsync(
+            requestUri: nameof(TestController.TestPersonBody),
+            content: new StringContent(body, mediaType: "application/json", encoding: Encoding.UTF8));
+
+        var validationProblem = response.AssertValidationProblem();
+
+        Assert.Single(validationProblem.Errors);
+
+        var error = validationProblem.AssertHasInvalidInputError(path);
+
+        Assert.Equal(ValidationMessages.InvalidInput.Message, error.Message);
+    }
+
+    [Fact]
+    public async Task TestPersonBody_EmptyBody_Returns400()
+    {
+        var client = BuildApp().CreateClient();
+
+        var response = await client.PostAsync(
+            requestUri: nameof(TestController.TestPersonBody),
+            content: new StringContent("", mediaType: "application/json", encoding: Encoding.UTF8));
+
+        var validationProblem = response.AssertValidationProblem();
+
+        Assert.Single(validationProblem.Errors);
+
+        var error = validationProblem.AssertHasNotEmptyBodyError();
+
+        Assert.Equal(ValidationMessages.NotEmptyBody.Message, error.Message);
+    }
+
+    [Fact]
+    public async Task TestPersonBody_RequiredField_Returns400()
+    {
+        var client = BuildApp().CreateClient();
+
+        var response = await client.PostAsync(
+            requestUri: nameof(TestController.TestPersonBody),
+            content: new StringContent(
+                "{ \"name\": null }",
+                mediaType: "application/json",
+                encoding: Encoding.UTF8));
+
+        var validationProblem = response.AssertValidationProblem();
+
+        Assert.Single(validationProblem.Errors);
+
+        var error = validationProblem.AssertHasRequiredFieldError("name");
+
+        Assert.Equal(ValidationMessages.RequiredField.Message, error.Message);
+    }
+
+    [Theory]
+    [InlineData("{}", "")]
+    [InlineData("{ \"owner\": 123 }", "owner")]
+    [InlineData("{ \"owner\": {} }", "owner")]
+    [InlineData("{ \"owner\": { \"name\": 123 } }", "owner.name")]
+    [InlineData("{ \"owner\": { \"name\": true } }", "owner.name")]
+    [InlineData("{ \"owner\": { \"firstName\": \"test\" } }", "owner")]
+    [InlineData("{ \"owner\": { \"firstName\": 123 } }", "owner")]
+    public async Task TestGroupBody_InvalidJson_Returns400(string body, string path)
+    {
+        var client = BuildApp().CreateClient();
+
+        var response = await client.PostAsync(
+            requestUri: nameof(TestController.TestGroupBody),
+            content: new StringContent(body, mediaType: "application/json", encoding: Encoding.UTF8));
+
+        var validationProblem = response.AssertValidationProblem();
+
+        Assert.Single(validationProblem.Errors);
+
+        var error = validationProblem.AssertHasInvalidInputError(path);
+
+        Assert.Equal(ValidationMessages.InvalidInput.Message, error.Message);
+    }
+
+    [Fact]
+    public async Task TestGroupBody_EmptyBody_Returns400()
+    {
+        var client = BuildApp().CreateClient();
+
+        var response = await client.PostAsync(
+            requestUri: nameof(TestController.TestGroupBody),
+            content: new StringContent("", mediaType: "application/json", encoding: Encoding.UTF8));
+
+        var validationProblem = response.AssertValidationProblem();
+
+        Assert.Single(validationProblem.Errors);
+
+        var error = validationProblem.AssertHasNotEmptyBodyError();
+
+        Assert.Equal(ValidationMessages.NotEmptyBody.Message, error.Message);
+    }
+
+    [Fact]
+    public async Task TestGroupBody_RequiredField_Returns400()
+    {
+        var client = BuildApp().CreateClient();
+
+        var response = await client.PostAsync(
+            requestUri: nameof(TestController.TestGroupBody),
+            content: new StringContent(
+                content: "{ \"owner\": { \"name\": null } }",
+                mediaType: "application/json",
+                encoding: Encoding.UTF8));
+
+        var validationProblem = response.AssertValidationProblem();
+
+        Assert.Single(validationProblem.Errors);
+
+        var error = validationProblem.AssertHasRequiredFieldError("owner.name");
+
+        Assert.Equal(ValidationMessages.RequiredField.Message, error.Message);
+    }
+
+    [ApiController]
+    private class TestController : ControllerBase
+    {
+        [HttpPost(nameof(TestPersonBody))]
+        public ActionResult TestPersonBody([FromBody] TestPerson testPerson)
+        {
+            return Ok(testPerson);
+        }
+
+        [HttpPost(nameof(TestGroupBody))]
+        public ActionResult TestGroupBody([FromBody] TestGroup testGroup)
+        {
+            return Ok(testGroup);
+        }
+    }
+
+    private class TestPerson
+    {
+        public required string Name { get; init; }
+    }
+
+    private class TestGroup
+    {
+        public required TestPerson Owner { get; init; }
+    }
+
+    private WebApplicationFactory<Startup> BuildApp()
+    {
+        return TestApp
+            .WithWebHostBuilder(builder => builder.WithAdditionalControllers(typeof(TestController)))
+            .ConfigureServices(s =>
+            {
+                s.Configure<ApiVersioningOptions>(options => options.AssumeDefaultVersionWhenUnspecified = true);
+            });
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/MvcOptionsExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/MvcOptionsExtensions.cs
@@ -1,0 +1,16 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Filters;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Extensions;
+
+public static class MvcOptionsExtensions
+{
+    public static void AddInvalidRequestInputResultFilter(this MvcOptions options)
+    {
+        options.ModelBindingMessageProvider
+            .SetMissingRequestBodyRequiredValueAccessor(() => ValidationMessages.NotEmptyBody.Message);
+
+        options.Filters.Add<InvalidRequestInputResultFilter>();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Filters/InvalidRequestInputResultFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Filters/InvalidRequestInputResultFilter.cs
@@ -1,0 +1,178 @@
+using System.Diagnostics.CodeAnalysis;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using JsonException = System.Text.Json.JsonException;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Filters;
+
+/// <summary>
+/// Filter to convert errors caused by invalid request input into a standard
+/// validation error response. Importantly, this filter fixes the error paths to
+/// point to invalid part of the request and adds error codes
+/// </summary>
+public class InvalidRequestInputResultFilter : IResultFilter
+{
+    public void OnResultExecuting(ResultExecutingContext context)
+    {
+        if (context.ModelState.IsValid)
+        {
+            return;
+        }
+
+        // A filter or endpoint has already created our standard
+        // validation error response. We can bail early.
+        if (context.Result is BadRequestObjectResult { Value: ValidationProblemViewModel })
+        {
+            return;
+        }
+
+        var errorEntries = context.ModelState
+            .Where(kv => kv.Value?.ValidationState is ModelValidationState.Invalid)
+            .Cast<KeyValuePair<string, ModelStateEntry>>()
+            .ToList();
+
+        var errors = new List<ErrorViewModel>();
+
+        if (TryGetJsonError(errorEntries, out var jsonError))
+        {
+            errors.Add(jsonError);
+        }
+
+        if (TryGetEmptyBodyError(errorEntries, out var emptyBodyError))
+        {
+            errors.Add(emptyBodyError);
+        }
+
+        if (TryGetRequiredFieldError(errorEntries, context.ActionDescriptor, out var requiredFieldError))
+        {
+            errors.Add(requiredFieldError);
+        }
+
+        if (errors.Count == 0)
+        {
+            return;
+        }
+
+        var problemDetailsFactory = context.HttpContext.RequestServices.GetRequiredService<ProblemDetailsFactory>();
+
+        var problemDetails = problemDetailsFactory.CreateValidationProblemDetails(
+            context.HttpContext,
+            new ModelStateDictionary()
+        );
+
+        context.Result = new BadRequestObjectResult(ValidationProblemViewModel.Create(problemDetails, errors));
+    }
+
+    public void OnResultExecuted(ResultExecutedContext context)
+    {
+    }
+
+    private static bool TryGetJsonError(
+        IEnumerable<KeyValuePair<string, ModelStateEntry>> errorEntries,
+        [NotNullWhen(true)] out ErrorViewModel? error)
+    {
+        var modelError = errorEntries
+            .SelectMany(entry => entry.Value.Errors)
+            .FirstOrDefault(error => error.Exception is JsonException);
+
+        if (modelError is null)
+        {
+            error = null;
+            return false;
+        }
+
+        error = new ErrorViewModel
+        {
+            Code = ValidationMessages.InvalidInput.Code,
+            Message = ValidationMessages.InvalidInput.Message,
+            Path = GetJsonPath(modelError)
+        };
+
+        return true;
+    }
+
+    private static string GetJsonPath(ModelError error)
+    {
+        List<string> paths = [];
+
+        var currentException = error.Exception;
+
+        while (currentException is not null)
+        {
+            if (currentException is JsonException { Path: not null } jsonException)
+            {
+                paths.Add(jsonException.Path);
+            }
+
+            currentException = currentException.InnerException;
+        }
+
+        return JsonPathUtils.Concat(paths);
+    }
+
+    private static bool TryGetEmptyBodyError(
+        IEnumerable<KeyValuePair<string, ModelStateEntry>> errorEntries,
+        [NotNullWhen(true)] out ErrorViewModel? error)
+    {
+        if (!errorEntries.Any(entry => entry.Value.Errors
+                .Any(e => e.ErrorMessage == ValidationMessages.NotEmptyBody.Message)))
+        {
+            error = null;
+            return false;
+        }
+
+        error = new ErrorViewModel
+        {
+            Code = ValidationMessages.NotEmptyBody.Code,
+            Message = ValidationMessages.NotEmptyBody.Message,
+        };
+
+        return true;
+    }
+
+    private static bool TryGetRequiredFieldError(
+        IEnumerable<KeyValuePair<string, ModelStateEntry>> errorEntries,
+        ActionDescriptor actionDescriptor,
+        [NotNullWhen(true)] out ErrorViewModel? error)
+    {
+        var actionParams = actionDescriptor.Parameters
+            .Where(param => param.BindingInfo?.BindingSource == BindingSource.Body
+                            || param.BindingInfo?.BindingSource == BindingSource.Form)
+            .Select(param => param.Name)
+            .ToHashSet();
+
+        var requiredFieldError = errorEntries
+            // There are entries for the controller method's parameters which
+            // need to be filtered out first. We don't want to show errors
+            // for these parameters as they leak internals to API users.
+            .Where(entry => !actionParams.Contains(entry.Key))
+            // This isn't the ideal way of determining if we have a required field error.
+            // Despite trying a few things (including using localization files), there didn't
+            // seem to be an easy way to change the default error message for `RequiredAttribute`.
+            // In the interest of time, this approach will have to do.
+            // TODO: Work out better way to modify default data annotation error messages
+            .FirstOrDefault(entry => entry.Value.Errors
+                .Any(e => e.ErrorMessage.StartsWith("The") && e.ErrorMessage.EndsWith("field is required.")));
+
+        if (requiredFieldError.Equals(default(KeyValuePair<string, ModelStateEntry>)))
+        {
+            error = null;
+            return false;
+        }
+
+        error = new ErrorViewModel
+        {
+            Code = ValidationMessages.RequiredField.Code,
+            Message = ValidationMessages.RequiredField.Message,
+            Path = requiredFieldError.Key
+        };
+
+        return true;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -8,17 +8,19 @@ using GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
 using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Rules;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Options;
 using MicroElements.Swashbuckle.FluentValidation.AspNetCore;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -62,20 +64,21 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
 
         // MVC
 
-        services.AddMvcCore(options =>
-        {
-            options.Filters.Add(new OperationCancelledExceptionFilter());
-            options.RespectBrowserAcceptHeader = true;
-            options.ReturnHttpNotAcceptable = true;
-            options.EnableEndpointRouting = false;
-        });
-
         services
             .AddControllers(options =>
             {
-                options.Filters.Add(new ProblemDetailsResultFilter());
+                options.RespectBrowserAcceptHeader = true;
+                options.ReturnHttpNotAcceptable = true;
+                options.EnableEndpointRouting = false;
+
+                options.Filters.Add<OperationCancelledExceptionFilter>();
+                options.Filters.Add<ProblemDetailsResultFilter>();
+                options.AddInvalidRequestInputResultFilter();
                 options.AddCommaSeparatedQueryModelBinderProvider();
                 options.AddTrimStringBinderProvider();
+
+                // Adds correct camelCased paths for model errors
+                options.ModelMetadataDetailsProviders.Add(new SystemTextJsonValidationMetadataProvider());
             })
             .ConfigureApiBehaviorOptions(options =>
             {
@@ -85,6 +88,11 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
             .AddJsonOptions(options =>
             {
                 options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+
+                // This must be false to allow `JsonExceptionResultFilter` to work correctly,
+                // otherwise, JsonExceptions can't be identified. Also, this prevents
+                // error messages from accidentally leaking internals to users.
+                options.AllowInputFormatterExceptionMessages = false;
             });
 
         services.AddProblemDetails();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/Converters/LocationOptionMetaJsonConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/Converters/LocationOptionMetaJsonConverter.cs
@@ -14,39 +14,46 @@ public class LocationOptionMetaJsonConverter : JsonConverter<LocationOptionMetaV
     {
         if (!JsonDocument.TryParseValue(ref reader, out var doc))
         {
-            throw new JsonException("Failed to parse JsonDocument");
+            throw new JsonException();
         }
 
-        var rootElement = doc.RootElement.GetRawText();
-
-        var propertyNames = doc.RootElement
-            .EnumerateObject()
-            .Select(p => char.ToUpper(p.Name[0]) + p.Name[1..])
-            .ToHashSet();
-
-        if (propertyNames.Contains(nameof(LocationSchoolOptionMetaViewModel.Urn))
-            && propertyNames.Contains(nameof(LocationSchoolOptionMetaViewModel.LaEstab)))
+        try
         {
-            return JsonSerializer.Deserialize<LocationSchoolOptionMetaViewModel>(rootElement, options)!;
-        }
+            var rootElement = doc.RootElement.GetRawText();
 
-        if (propertyNames.Contains(nameof(LocationProviderOptionMetaViewModel.Ukprn)))
+            var propertyNames = doc.RootElement
+                .EnumerateObject()
+                .Select(p => char.ToUpper(p.Name[0]) + p.Name[1..])
+                .ToHashSet();
+
+            if (propertyNames.Contains(nameof(LocationSchoolOptionMetaViewModel.Urn))
+                && propertyNames.Contains(nameof(LocationSchoolOptionMetaViewModel.LaEstab)))
+            {
+                return JsonSerializer.Deserialize<LocationSchoolOptionMetaViewModel>(rootElement, options)!;
+            }
+
+            if (propertyNames.Contains(nameof(LocationProviderOptionMetaViewModel.Ukprn)))
+            {
+                return JsonSerializer.Deserialize<LocationProviderOptionMetaViewModel>(rootElement, options)!;
+            }
+
+            if (propertyNames.Contains(nameof(LocationLocalAuthorityOptionMetaViewModel.Code))
+                && propertyNames.Contains(nameof(LocationLocalAuthorityOptionMetaViewModel.OldCode)))
+            {
+                return JsonSerializer.Deserialize<LocationLocalAuthorityOptionMetaViewModel>(rootElement, options)!;
+            }
+
+            if (propertyNames.Contains(nameof(LocationCodedOptionMetaViewModel.Code)))
+            {
+                return JsonSerializer.Deserialize<LocationCodedOptionMetaViewModel>(rootElement, options)!;
+            }
+
+            return JsonSerializer.Deserialize<LocationRscRegionOptionMetaViewModel>(rootElement, options)!;
+        }
+        catch (JsonException exception)
         {
-            return JsonSerializer.Deserialize<LocationProviderOptionMetaViewModel>(rootElement, options)!;
+            throw new JsonException(message: null, exception);
         }
-
-        if (propertyNames.Contains(nameof(LocationLocalAuthorityOptionMetaViewModel.Code))
-            && propertyNames.Contains(nameof(LocationLocalAuthorityOptionMetaViewModel.OldCode)))
-        {
-            return JsonSerializer.Deserialize<LocationLocalAuthorityOptionMetaViewModel>(rootElement, options)!;
-        }
-
-        if (propertyNames.Contains(nameof(LocationCodedOptionMetaViewModel.Code)))
-        {
-            return JsonSerializer.Deserialize<LocationCodedOptionMetaViewModel>(rootElement, options)!;
-        }
-
-        return JsonSerializer.Deserialize<LocationRscRegionOptionMetaViewModel>(rootElement, options)!;
     }
 
     public override void Write(Utf8JsonWriter writer, LocationOptionMetaViewModel? value, JsonSerializerOptions options)
@@ -57,30 +64,30 @@ public class LocationOptionMetaJsonConverter : JsonConverter<LocationOptionMetaV
             return;
         }
 
-        var jsonSerializerOptions = new JsonSerializerOptions(options)
+        try
         {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
-        switch (value)
+            switch (value)
+            {
+                case LocationSchoolOptionMetaViewModel:
+                    JsonSerializer.Serialize(writer, value, typeof(LocationSchoolOptionMetaViewModel), options);
+                    break;
+                case LocationRscRegionOptionMetaViewModel:
+                    JsonSerializer.Serialize(writer, value, typeof(LocationRscRegionOptionMetaViewModel), options);
+                    break;
+                case LocationProviderOptionMetaViewModel:
+                    JsonSerializer.Serialize(writer, value, typeof(LocationProviderOptionMetaViewModel), options);
+                    break;
+                case LocationLocalAuthorityOptionMetaViewModel:
+                    JsonSerializer.Serialize(writer, value, typeof(LocationLocalAuthorityOptionMetaViewModel), options);
+                    break;
+                case LocationCodedOptionMetaViewModel:
+                    JsonSerializer.Serialize(writer, value, typeof(LocationCodedOptionMetaViewModel), options);
+                    break;
+            }
+        }
+        catch (JsonException exception)
         {
-            case LocationSchoolOptionMetaViewModel:
-                JsonSerializer.Serialize(writer, value, typeof(LocationSchoolOptionMetaViewModel), jsonSerializerOptions);
-                break;
-            case LocationRscRegionOptionMetaViewModel:
-                JsonSerializer.Serialize(writer, value, typeof(LocationRscRegionOptionMetaViewModel), jsonSerializerOptions);
-                break;
-            case LocationProviderOptionMetaViewModel:
-                JsonSerializer.Serialize(writer, value, typeof(LocationProviderOptionMetaViewModel), jsonSerializerOptions);
-                break;
-            case LocationLocalAuthorityOptionMetaViewModel:
-                JsonSerializer.Serialize(writer, value, typeof(LocationLocalAuthorityOptionMetaViewModel), jsonSerializerOptions);
-                break;
-            case LocationCodedOptionMetaViewModel:
-                JsonSerializer.Serialize(writer, value, typeof(LocationCodedOptionMetaViewModel), jsonSerializerOptions);
-                break;
-            default:
-                throw new JsonException();
+            throw new JsonException(message: null, exception);
         }
     }
 }


### PR DESCRIPTION
This PR adds an `InvalidRequestInputFilter` to the public API. This filter can convert errors that were caused by invalid request input into a standard validation error response.

The out-of-the-box errors are not adequate as they:

- Leak internals by reporting types that could not be deserialized from the JSON
- Don't have full paths to the part of the request causing the error (typically only reported partial paths)
- Don't have error codes

Importantly, fixing these issues provides a better user experience for the public API's data set query POST endpoint. As users can create highly nested queries, it's crucial that they get detailed validation errors that pinpoint precisely where any mistakes have been made.

## Other changes

- Fixed incorrect error paths in `LocationOptionMetaJsonConverter` when `JsonExceptions` thrown during conversion. We now re-throw these exceptions whilst capturing the original `JsonException` so that we can construct the full JSON path in the subsequent invalid input error.