### PR TITLE
EES-4909 - defaulting PublicDataDbExists to false, and allowing overriding in Admin and Publisher

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -121,6 +121,13 @@
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Publisher.Model\GovUk.Education.ExploreEducationStatistics.Publisher.Model.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="appsettings.Local.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+
   <PropertyGroup>
     <NoWarn>NU1605</NoWarn>
   </PropertyGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -39,5 +39,5 @@
     "PublishReleasesCronSchedule": "0 0-58/2 * * * *",
     "PublishReleaseContentCronSchedule": "0 1-59/2 * * * *"
   },
-  "PublicDataDbExists": true
+  "PublicDataDbExists": false
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/appsettings.json
@@ -3,5 +3,5 @@
   "NotificationStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;QueueEndpoint=http://data-storage:10001/devstoreaccount1;",
   "PublicStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;TableEndpoint=http://data-storage:10002/devstoreaccount1;",
   "PublisherStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;QueueEndpoint=http://data-storage:10001/devstoreaccount1;TableEndpoint=http://data-storage:10002/devstoreaccount1;",
-  "PublicDataDbExists": true
+  "PublicDataDbExists": false
 }


### PR DESCRIPTION
This PR:
- defaults "PublicDataDbExists" to false in local development
- allows overriding by adding the following to a new `appsettings.Local.json` in Admin and Publisher:

```
{
  "PublicDataDbExists": true
}
``` 