### PR TITLE
Ees 5052 add private endpoint to connect psql to vnet

### DIFF
--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -17,7 +17,7 @@ parameters:
 variables:
   - group: Public API Infrastructure - common
   - name: isDev
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/EES-5052-add-private-endpoint-to-connect-psql-to-vnet')]
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
   - name: isTest
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/test')]
   - name: isMaster

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -17,7 +17,7 @@ parameters:
 variables:
   - group: Public API Infrastructure - common
   - name: isDev
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/EES-5052-add-private-endpoint-to-connect-psql-to-vnet')]
   - name: isTest
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/test')]
   - name: isMaster

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -37,6 +37,11 @@ resource containerAppEnvironmentSubnet 'Microsoft.Network/virtualNetworks/subnet
   parent: vNet
 }
 
+resource psqlFlexibleServerSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' existing = {
+  name: '${subscription}-ees-snet-psql-flexibleserver'
+  parent: vNet
+}
+
 @description('The fully qualified Azure resource ID of the Network.')
 output vNetRef string = resourceId('Microsoft.Network/VirtualNetworks', vNetName)
 
@@ -69,3 +74,12 @@ output publisherFunctionAppSubnetStartIpAddress string = parseCidr(publisherSubn
 
 @description('The last usable IP address for the Publisher Function App Subnet.')
 output publisherFunctionAppSubnetEndIpAddress string = parseCidr(publisherSubnet.properties.addressPrefix).lastUsable
+
+@description('The fully qualified Azure resource ID of the PSQL Flexible Server Subnet.')
+output psqlFlexibleServerSubnetRef string = psqlFlexibleServerSubnet.id
+
+@description('The first usable IP address for the PSQL Flexible Server Subnet.')
+output psqlFlexibleServerSubnetStartIpAddress string = parseCidr(psqlFlexibleServerSubnet.properties.addressPrefix).firstUsable
+
+@description('The last usable IP address for the PSQL Flexible Server Subnet.')
+output psqlFlexibleServerSubnetEndIpAddress string = parseCidr(psqlFlexibleServerSubnet.properties.addressPrefix).lastUsable

--- a/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
+++ b/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
@@ -75,6 +75,12 @@ param tagValues object
 ])
 param createMode string = 'Default'
 
+@description('The id of the VNet to which this database server will be connected via a private endpoint')
+param vnetId string
+
+@description('The id of the subnet which will be used to install the private endpoint for allowing secure connection to the database server over the VNet')
+param subnetId string
+
 var databaseServerName = empty(serverName)
   ? '${resourcePrefix}-psql-flexibleserver'
   : '${resourcePrefix}-psql-flexibleserver-${serverName}'
@@ -122,6 +128,64 @@ resource postgreSQLDatabase 'Microsoft.DBforPostgreSQL/flexibleServers@2023-03-0
   }]
 
   tags: tagValues
+}
+
+var privateLinkDnsZoneName = 'privatelink.postgres.database.azure.com'
+
+var privateEndpointName = '${databaseServerName}-plink'
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2021-05-01' = {
+  name: privateEndpointName
+  location: location
+  properties: {
+    subnet: {
+      id: subnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: privateEndpointName
+        properties: {
+          privateLinkServiceId: postgreSQLDatabase.id
+          groupIds: [
+            'postgresqlServer'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: privateLinkDnsZoneName
+  location: 'global'
+  properties: {}
+}
+
+resource privateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: privateDnsZone
+  name: '${privateLinkDnsZoneName}-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnetId
+    }
+  }
+}
+
+resource privateEndpointDnsGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2021-05-01' = {
+  name: 'default'
+  parent: privateEndpoint
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: replace(privateLinkDnsZoneName, '.', '-')
+        properties: {
+          privateDnsZoneId: privateDnsZone.id
+        }
+      }
+    ]
+  }
 }
 
 @description('The fully qualified Azure resource ID of the Database Server.')

--- a/infrastructure/templates/public-api/deploy-stage-template.yml
+++ b/infrastructure/templates/public-api/deploy-stage-template.yml
@@ -81,13 +81,21 @@ stages:
               scriptLocation: inlineScript
               inlineScript: |
                 set -e
+                
                 az functionapp config appsettings set \
                   --name '$(dataProcessorFunctionAppName)' \
                   --resource-group '$(resourceGroupName)' \
                   --slot 'staging' \
                   --settings \
-                    "ConnectionStrings__PublicDataDb=@Microsoft.KeyVault(VaultName=$(keyVaultName); SecretName=$(dataProcessorPsqlConnectionStringSecretKey))" \
                     "CoreStorage=@Microsoft.KeyVault(VaultName=$(keyVaultName); SecretName=$(coreStorageConnectionStringSecretKey))"
+                
+                az webapp config connection-string set \
+                  --name '$(dataProcessorFunctionAppName)' \
+                  --resource-group '$(resourceGroupName)' \
+                  --slot 'staging' \
+                  --connection-string-type=PostgreSQL \
+                  --settings \
+                    "PublicDataDb=@Microsoft.KeyVault(VaultName=$(keyVaultName); SecretName=$(dataProcessorPsqlConnectionStringSecretKey))"
 
           - task: AzureCLI@2
             displayName: 'Deploy Data Processor Function App - deploy to staging slot'

--- a/infrastructure/templates/public-api/deploy-stage-template.yml
+++ b/infrastructure/templates/public-api/deploy-stage-template.yml
@@ -93,7 +93,7 @@ stages:
                   --name '$(dataProcessorFunctionAppName)' \
                   --resource-group '$(resourceGroupName)' \
                   --slot 'staging' \
-                  --connection-string-type=PostgreSQL \
+                  --connection-string-type 'PostgreSQL' \
                   --settings \
                     "PublicDataDb=@Microsoft.KeyVault(VaultName=$(keyVaultName); SecretName=$(dataProcessorPsqlConnectionStringSecretKey))"
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -24,6 +24,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
 using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Functions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -210,7 +211,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             // cause the data source builder to throw a host exception.
             if (!hostEnvironment.IsIntegrationTest())
             {
-                var publicDataDbConnectionString = configuration.GetConnectionString("PublicDataDb")!;
+                var publicDataDbConnectionString = ConnectionUtils.GetPostgreSqlConnectionString("PublicDataDb")!;
 
                 if (hostEnvironment.IsDevelopment())
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Functions/ConnectionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Functions/ConnectionUtils.cs
@@ -59,7 +59,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Functions
                     ConnectionTypes.AZURE_SQL, "SQLAZURECONNSTR"
                 },
                 {
-                    ConnectionTypes.AZURE_POSTGRESQL, "CUSTOMCONNSTR"
+                    ConnectionTypes.AZURE_POSTGRESQL, "POSTGRESQLCONNSTR"
                 }
             }; 
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Functions/ConnectionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Functions/ConnectionUtils.cs
@@ -7,7 +7,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Functions
     public enum ConnectionTypes
     {
         AZURE_STORAGE,
-        AZURE_SQL
+        AZURE_SQL,
+        AZURE_POSTGRESQL
     }
 
     public static class ConnectionUtils
@@ -23,6 +24,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Functions
         {
             return GetConnectionString(name,
                 $"{ConnectionTypeValues[ConnectionTypes.AZURE_SQL]}");
+        }
+        
+        public static string GetPostgreSqlConnectionString(string name)
+        {
+            return GetConnectionString(name,
+                $"{ConnectionTypeValues[ConnectionTypes.AZURE_POSTGRESQL]}");
         }
         
         private static string GetConnectionString(string name, string connectionTypeValue)
@@ -50,6 +57,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Functions
                 },
                 {
                     ConnectionTypes.AZURE_SQL, "SQLAZURECONNSTR"
+                },
+                {
+                    ConnectionTypes.AZURE_POSTGRESQL, "CUSTOMCONNSTR"
                 }
             }; 
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -7,6 +7,7 @@ using Dapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
 using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Functions;
 using GovUk.Education.ExploreEducationStatistics.Common.Rules;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Repository;
@@ -98,12 +99,12 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         // cause the data source builder to throw a host exception.
         if (!hostEnvironment.IsIntegrationTest())
         {
-            var connectionString = configuration.GetConnectionString("PublicDataDb")!;
+            var connectionString = ConnectionUtils.GetPostgreSqlConnectionString("PublicDataDb")!;
 
             if (hostEnvironment.IsDevelopment())
             {
                 var dataSourceBuilder = new NpgsqlDataSourceBuilder(
-                    configuration.GetConnectionString("PublicDataDb"));
+                    ConnectionUtils.GetPostgreSqlConnectionString("PublicDataDb"));
 
                 // Set up the data source outside the `AddDbContext` action as this
                 // prevents `ManyServiceProvidersCreatedWarning` warnings due to EF

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -103,8 +103,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
 
             if (hostEnvironment.IsDevelopment())
             {
-                var dataSourceBuilder = new NpgsqlDataSourceBuilder(
-                    ConnectionUtils.GetPostgreSqlConnectionString("PublicDataDb"));
+                var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);
 
                 // Set up the data source outside the `AddDbContext` action as this
                 // prevents `ManyServiceProvidersCreatedWarning` warnings due to EF

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CountDataSetsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CountDataSetsFunction.cs
@@ -14,7 +14,8 @@ public class CountDataSetsFunction(
         [ActivityTrigger] object? input,
         FunctionContext executionContext)
     {
-        logger.LogInformation("Counting datasets.");
-        return $"Found {await publicDataDbContext.DataSets.CountAsync()} datasets.";
+        var message = $"Found {await publicDataDbContext.DataSets.CountAsync()} datasets.";
+        logger.LogInformation(message);
+        return message;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/ProcessorHostBuilder.cs
@@ -2,6 +2,7 @@ using Azure.Core;
 using Azure.Identity;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Functions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.Azure.Functions.Worker;
@@ -41,7 +42,7 @@ public static class ProcessorHostBuilder
                 // cause the data source builder to throw a host exception.
                 if (!hostEnvironment.IsIntegrationTest())
                 {
-                    var connectionString = configuration.GetConnectionString("PublicDataDb")!;
+                    var connectionString = ConnectionUtils.GetPostgreSqlConnectionString("PublicDataDb");
 
                     if (hostEnvironment.IsDevelopment())
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
@@ -162,7 +162,7 @@ public static class PublisherHostBuilderExtensions
                 // cause the data source builder to throw a host exception.
                 if (!hostEnvironment.IsIntegrationTest())
                 {
-                    var connectionString = configuration.GetConnectionString("PublicDataDb")!;
+                    var connectionString = ConnectionUtils.GetPostgreSqlConnectionString("PublicDataDb")!;
 
                     if (hostEnvironment.IsDevelopment())
                     {


### PR DESCRIPTION
This PR:
- Adds a private endpoint to allow PSQL Flexible Server to be access securely directly from the VNet.
- Corrects the feeding of connection strings to the Data Processor function on deploy.
- Corrects the lookup of PSQL connection strings in Azure environment in the codebase by adding additional helpers to ConnectionUtils.

The resulting deployment shows that the `CountDataSets` Function can successfully look up the connection string and use it to query PSQL over the VNet.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/12444316/41e97e8e-637d-499b-a8b2-3726a3d56101)
