### PR TITLE
EES-4353 use ckeditor for main data guidance field

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
@@ -1,4 +1,5 @@
 import releaseDataGuidanceService from '@admin/services/releaseDataGuidanceService';
+import RHFFormFieldEditor from '@admin/components/form/RHFFormFieldEditor';
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
 import Button from '@common/components/Button';
@@ -137,10 +138,9 @@ const ReleaseDataGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
                   return (
                     <RHFForm id={formId} onSubmit={handleSubmit}>
                       {isEditing ? (
-                        <RHFFormFieldTextArea<DataGuidanceFormValues>
-                          label="Main guidance content"
+                        <RHFFormFieldEditor<DataGuidanceFormValues>
                           name="content"
-                          rows={3}
+                          label="Main guidance content"
                         />
                       ) : (
                         <>


### PR DESCRIPTION
The main data guidance field was inadvertently changed in https://github.com/dfe-analytical-services/explore-education-statistics/pull/4819 to remove CKEditor, this reverts that change. 

The individual file data guidance fields should still use normal text fields not CKEditor.