### PR TITLE
Fix data guidance and data catalogue UI tests

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -183,7 +183,7 @@ Validate Related information section and links exist
     ...    ${relatedInformation}
 
 Validate data sets list
-    user checks list has x items    testid:data-set-file-list    10
+    user checks element count is x    css:[data-testid="data-set-file-list"] li:first-child    10
 
     ${dataSet}=    user gets testid element    data-set-file-summary-${SUBJECT_NAME_3}
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -542,7 +542,7 @@ Verify existing data guidance for amendment
     user checks summary list contains    Time period    2020 Week 13 to 2021 Week 24
 
     ${editor}=    user gets data guidance data file content editor    Dates test subject
-    user waits until element contains    ${editor}    Dates test subject test data guidance content
+    user checks element value should be    ${editor}    Dates test subject test data guidance content
 
 Update existing data guidance for amendment
     user enters text into element    id:dataGuidanceForm-content    Amended test data guidance content

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -899,8 +899,7 @@ user updates free text key stat
     user enters text into element    xpath://*[@data-testid="keyStat"][${tile_num}]//input[@name="guidanceTitle"]
     ...    ${guidance_title}
 
-    user clears element text    xpath://*[@data-testid="keyStat"][${tile_num}]//*[contains(@class, "ck-content")]
-    user presses keys    ${guidance_text}
+    user enters text into element    xpath://*[@data-testid="keyStat"][${tile_num}]//textarea[@name="guidanceText"]    ${guidance_text}
 
     user clicks button    Save
     user waits until page does not contain button    Save
@@ -941,9 +940,7 @@ user adds key statistic from data block
     user clicks element    xpath://*[@data-testid="keyStat"][last()]//button[contains(text(), "Edit")]
     user enters text into element    xpath://input[@name="trend"]    ${trend}
     user enters text into element    xpath://input[@name="guidanceTitle"]    ${guidance_title}
-
-    user clears element text    xpath://*[@data-testid="keyStat"][last()]//*[contains(@class, "ck-content")]
-    user presses keys    ${guidance_text}
+    user enters text into element    xpath://textarea[@name="guidanceText"]    ${guidance_text}
 
     user clicks button    Save
     user waits until page does not contain button    Save


### PR DESCRIPTION
Fixes some more UI tests for data guidance (now ckeditor has been removed) and data catalogue (now the indicators etc are populated).