### PR TITLE
EES-4722 Add data set query POST endpoint

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
@@ -305,6 +305,23 @@ public static class ValidationProblemViewModelTestExtensions
     public static ErrorViewModel AssertHasAllowedValueError<TValue>(
         this ValidationProblemViewModel validationProblem,
         string expectedPath,
+        TValue? value)
+    {
+        var error = validationProblem.AssertHasError(
+            expectedPath: expectedPath,
+            expectedCode: ValidationMessages.AllowedValue.Code
+        );
+
+        var errorDetail = error.GetDetail<AllowedErrorDetail<TValue>>();
+
+        Assert.Equal(value, errorDetail.Value);
+
+        return error;
+    }
+
+    public static ErrorViewModel AssertHasAllowedValueError<TValue>(
+        this ValidationProblemViewModel validationProblem,
+        string expectedPath,
         TValue? value,
         IEnumerable<TValue> allowed)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
@@ -1021,13 +1021,17 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
         }
 
         [Theory]
-        [InlineData(1, 50, 5)]
-        [InlineData(2, 50, 5)]
-        [InlineData(3, 50, 5)]
-        [InlineData(1, 150, 2)]
-        [InlineData(2, 150, 2)]
-        [InlineData(1, 216, 1)]
-        public async Task MultiplePages_Returns200_PaginatedCorrectly(int page, int pageSize, int totalPages)
+        [InlineData(1, 50, 5, 50)]
+        [InlineData(2, 50, 5, 50)]
+        [InlineData(3, 50, 5, 50)]
+        [InlineData(1, 150, 2, 150)]
+        [InlineData(2, 150, 2, 66)]
+        [InlineData(1, 216, 1, 216)]
+        public async Task MultiplePages_Returns200_PaginatedCorrectly(
+            int page,
+            int pageSize,
+            int totalPages,
+            int pageResults)
         {
             var dataSetVersion = await SetupDefaultDataSetVersion();
 
@@ -1040,6 +1044,7 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
 
             var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
 
+            Assert.Equal(pageResults, viewModel.Results.Count);
             Assert.Equal(page, viewModel.Paging.Page);
             Assert.Equal(pageSize, viewModel.Paging.PageSize);
             Assert.Equal(totalPages, viewModel.Paging.TotalPages);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
@@ -1,0 +1,2878 @@
+using System.Net.Http.Json;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Fixture;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Controllers;
+
+public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+{
+    private const string BaseUrl = "api/v1/data-sets";
+
+    private readonly TestParquetPathResolver _parquetPathResolver = new()
+    {
+        Directory = "AbsenceSchool"
+    };
+
+    public class AccessTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Theory]
+        [InlineData(DataSetVersionStatus.Processing)]
+        [InlineData(DataSetVersionStatus.Failed)]
+        [InlineData(DataSetVersionStatus.Draft)]
+        [InlineData(DataSetVersionStatus.Mapping)]
+        [InlineData(DataSetVersionStatus.Withdrawn)]
+        [InlineData(DataSetVersionStatus.Cancelled)]
+        public async Task VersionNotAvailable_Returns403(DataSetVersionStatus versionStatus)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion(versionStatus);
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"]
+                }
+            );
+
+            response.AssertForbidden();
+        }
+
+        [Theory]
+        [InlineData(DataSetVersionStatus.Published)]
+        [InlineData(DataSetVersionStatus.Deprecated)]
+        public async Task VersionAvailable_Returns200(DataSetVersionStatus versionStatus)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion(versionStatus);
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"]
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(1, viewModel.Paging.Page);
+            Assert.Equal(1, viewModel.Paging.TotalPages);
+            Assert.Equal(216, viewModel.Paging.TotalResults);
+
+            Assert.Empty(viewModel.Warnings);
+
+            Assert.Equal(216, viewModel.Results.Count);
+        }
+
+        [Fact]
+        public async Task DataSetDoesNotExist_Returns404()
+        {
+            var response = await QueryDataSet(
+                dataSetId: Guid.NewGuid(),
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"]
+                }
+            );
+
+            response.AssertNotFound();
+        }
+
+        [Fact]
+        public async Task VersionDoesNotExist_Returns404()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                dataSetVersion: "2.0",
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"]
+                }
+            );
+
+            response.AssertNotFound();
+        }
+    }
+
+    public class IndicatorValidationTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Fact]
+        public async Task Empty_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = []
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasNotEmptyError("indicators");
+        }
+
+        [Fact]
+        public async Task Blank_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["", " ", "  "]
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Equal(3, validationProblem.Errors.Count);
+
+            validationProblem.AssertHasNotEmptyError("indicators[0]");
+            validationProblem.AssertHasNotEmptyError("indicators[1]");
+            validationProblem.AssertHasNotEmptyError("indicators[2]");
+        }
+
+        [Fact]
+        public async Task TooLong_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = [new string('a', 41), new string('a', 42)]
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Equal(2, validationProblem.Errors.Count);
+
+            validationProblem.AssertHasMaximumLengthError("indicators[0]", maxLength: 40);
+            validationProblem.AssertHasMaximumLengthError("indicators[1]", maxLength: 40);
+        }
+
+        [Fact]
+        public async Task MissingParam_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var client = BuildApp().CreateClient();
+
+            var response = await client.PostAsJsonAsync(
+                $"{BaseUrl}/{dataSetVersion.DataSetId}/query",
+                new {}
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasNotEmptyError("indicators");
+        }
+
+        [Fact]
+        public async Task NotFound_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            string[] notFoundIndicators = ["invalid1", "invalid2", "invalid3"];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = notFoundIndicators
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasIndicatorsNotFoundError("indicators", notFoundIndicators);
+        }
+    }
+
+    public class FiltersValidationTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Theory]
+        [InlineData("In")]
+        [InlineData("NotIn")]
+        public async Task Empty_Returns400(string comparator)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Filters = DataSetQueryCriteriaFilters.Create(comparator, [])
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasNotEmptyError($"criteria.filters.{comparator.ToLowerFirst()}");
+        }
+
+        [Theory]
+        [InlineData("In")]
+        [InlineData("NotIn")]
+        public async Task InvalidMix_Returns400(string comparator)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            string[] invalidFilters =
+            [
+                "",
+                " ",
+                "  ",
+                new string('a', 11),
+                new string('a', 12),
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Filters = DataSetQueryCriteriaFilters.Create(comparator, invalidFilters)
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Equal(5, validationProblem.Errors.Count);
+
+            var basePath = $"criteria.filters.{comparator.ToLowerFirst()}";
+
+            validationProblem.AssertHasNotEmptyError($"{basePath}[0]");
+            validationProblem.AssertHasNotEmptyError($"{basePath}[1]");
+            validationProblem.AssertHasNotEmptyError($"{basePath}[2]");
+            validationProblem.AssertHasMaximumLengthError($"{basePath}[3]", maxLength: 10);
+            validationProblem.AssertHasMaximumLengthError($"{basePath}[4]", maxLength: 10);
+        }
+
+        [Fact]
+        public async Task AllComparatorsInvalid_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            string[] invalidFilters =
+            [
+                new string('a', 11),
+                ""
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetQueryCriteriaFilters
+                        {
+                            Eq = new string('a', 11),
+                            NotEq = new string('a', 12),
+                            In = [],
+                            NotIn = invalidFilters
+                        }
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Equal(5, validationProblem.Errors.Count);
+
+            validationProblem.AssertHasMaximumLengthError("criteria.filters.eq", maxLength: 10);
+            validationProblem.AssertHasMaximumLengthError("criteria.filters.notEq", maxLength: 10);
+            validationProblem.AssertHasNotEmptyError("criteria.filters.in");
+            validationProblem.AssertHasMaximumLengthError("criteria.filters.notIn[0]", maxLength: 10);
+            validationProblem.AssertHasNotEmptyError("criteria.filters.notIn[1]");
+        }
+
+        [Fact]
+        public async Task NotFound_Returns200_HasWarning()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            string[] notFoundFilters =
+            [
+                "invalid",
+                "9999999"
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetQueryCriteriaFilters
+                        {
+                            Eq = notFoundFilters[0],
+                            NotEq = notFoundFilters[1],
+                            In = ["IzBzg", ..notFoundFilters],
+                            NotIn = ["IzBzg", ..notFoundFilters]
+                        }
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(5, viewModel.Warnings.Count);
+
+            viewModel.AssertHasFiltersNotFoundWarning("criteria.filters.eq", [notFoundFilters[0]]);
+            viewModel.AssertHasFiltersNotFoundWarning("criteria.filters.notEq", [notFoundFilters[1]]);
+            viewModel.AssertHasFiltersNotFoundWarning("criteria.filters.in", notFoundFilters);
+            viewModel.AssertHasFiltersNotFoundWarning("criteria.filters.notIn", notFoundFilters);
+        }
+    }
+
+    public class GeographicLevelsValidationTests(TestApplicationFactory testApp)
+        : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Fact]
+        public async Task Empty_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        GeographicLevels = new DataSetGetQueryGeographicLevels
+                        {
+                            In = [],
+                            NotIn = []
+                        }
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Equal(2, validationProblem.Errors.Count);
+
+            validationProblem.AssertHasNotEmptyError("criteria.geographicLevels.in");
+            validationProblem.AssertHasNotEmptyError("criteria.geographicLevels.in");
+        }
+
+        [Theory]
+        [InlineData("In")]
+        [InlineData("NotIn")]
+        public async Task InvalidMix_Returns400(string comparator)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            string[] invalidLevels =
+            [
+                "",
+                " ",
+                "LADD",
+                "NATT",
+                "National",
+                "Local authority",
+                "LocalAuthority"
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create(comparator, invalidLevels)
+                    }
+                }
+            );
+
+            var allowed = GeographicLevelUtils.OrderedCodes;
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Equal(7, validationProblem.Errors.Count);
+
+            var path = $"criteria.geographicLevels.{comparator.ToLowerFirst()}";
+
+            validationProblem.AssertHasAllowedValueError(expectedPath: $"{path}[0]", value: invalidLevels[0], allowed);
+            validationProblem.AssertHasAllowedValueError(expectedPath: $"{path}[1]", value: invalidLevels[1], allowed);
+            validationProblem.AssertHasAllowedValueError(expectedPath: $"{path}[2]", value: invalidLevels[2], allowed);
+            validationProblem.AssertHasAllowedValueError(expectedPath: $"{path}[3]", value: invalidLevels[3], allowed);
+            validationProblem.AssertHasAllowedValueError(expectedPath: $"{path}[4]", value: invalidLevels[4], allowed);
+            validationProblem.AssertHasAllowedValueError(expectedPath: $"{path}[5]", value: invalidLevels[5], allowed);
+            validationProblem.AssertHasAllowedValueError(expectedPath: $"{path}[6]", value: invalidLevels[6], allowed);
+        }
+
+        [Theory]
+        [InlineData("In")]
+        [InlineData("NotIn")]
+        public async Task NotFound_Returns200_HasWarning(string comparator)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            GeographicLevel[] notFoundGeographicLevels =
+            [
+                GeographicLevel.Ward,
+                GeographicLevel.OpportunityArea,
+                GeographicLevel.PlanningArea,
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create(comparator,  [
+                            GeographicLevel.LocalAuthority,
+                            ..notFoundGeographicLevels
+                        ])
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Single(viewModel.Warnings);
+
+            viewModel.AssertHasGeographicLevelsNotFoundWarning(
+                $"criteria.geographicLevels.{comparator.ToLowerFirst()}",
+                notFoundGeographicLevels.Select(l => l.GetEnumValue()));
+        }
+
+        [Fact]
+        public async Task AllComparatorsInvalid_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            string[] invalidLevels =
+            [
+                "  ",
+                "National",
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        GeographicLevels = new DataSetQueryCriteriaGeographicLevels
+                        {
+                            Eq = "NATT",
+                            NotEq = "LADD",
+                            In = invalidLevels,
+                            NotIn = []
+                        }
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            var allowed = GeographicLevelUtils.OrderedCodes;
+
+            Assert.Equal(5, validationProblem.Errors.Count);
+
+            validationProblem.AssertHasAllowedValueError(
+                expectedPath: "criteria.geographicLevels.eq",
+                value: "NATT",
+                allowed: allowed
+            );
+            validationProblem.AssertHasAllowedValueError(
+                expectedPath: "criteria.geographicLevels.notEq",
+                value: "LADD",
+                allowed: allowed
+            );
+            validationProblem.AssertHasAllowedValueError(
+                expectedPath: "criteria.geographicLevels.in[0]",
+                value: invalidLevels[0],
+                allowed: allowed
+            );
+            validationProblem.AssertHasAllowedValueError(
+                expectedPath: "criteria.geographicLevels.in[1]",
+                value: invalidLevels[1],
+                allowed: allowed
+            );
+            validationProblem.AssertHasNotEmptyError("criteria.geographicLevels.notIn");
+        }
+    }
+
+    public class LocationsValidationTests(TestApplicationFactory testApp)
+        : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Theory]
+        [InlineData("In")]
+        [InlineData("NotIn")]
+        public async Task Empty_Returns400(string comparator)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Locations = DataSetQueryCriteriaLocations.Create(comparator, [])
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasNotEmptyError($"criteria.locations.{comparator.ToLowerFirst()}");
+        }
+
+        [Theory]
+        [InlineData("In")]
+        [InlineData("NotIn")]
+        public async Task InvalidMix_Returns400(string comparator)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Locations = DataSetQueryCriteriaLocations.Create(comparator, [
+                            new DataSetQueryLocationCode { Level = "LADD", Code = "12345" },
+                            new DataSetQueryLocationCode { Level = "NATT", Code = "12345" },
+                            new DataSetQueryLocationId { Level = "NAT", Id = "" },
+                            new DataSetQueryLocationId { Level = "NAT", Id = " " },
+                            new DataSetQueryLocationCode { Level = "REG", Code = "" },
+                            new DataSetQueryLocationLocalAuthorityCode { Code = "" },
+                            new DataSetQueryLocationId { Level = "NAT", Id = new string('a', 11) },
+                            new DataSetQueryLocationLocalAuthorityCode { Code = new string('a', 26) },
+                            new DataSetQueryLocationLocalAuthorityOldCode { OldCode = new string('a', 11) },
+                            new DataSetQueryLocationProviderUkprn { Ukprn = new string('a', 9) },
+                            new DataSetQueryLocationSchoolUrn { Urn = new string('a', 7) },
+                            new DataSetQueryLocationSchoolLaEstab { LaEstab = new string('a', 8) }
+                        ])
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Equal(12, validationProblem.Errors.Count);
+
+            var path = $"criteria.locations.{comparator.ToLowerFirst()}";
+
+            validationProblem.AssertHasAllowedValueError(
+                expectedPath: $"{path}[0].level",
+                value: "LADD",
+                allowed: GeographicLevelUtils.OrderedCodes);
+            validationProblem.AssertHasAllowedValueError(
+                expectedPath: $"{path}[1].level",
+                value: "NATT",
+                allowed: GeographicLevelUtils.OrderedCodes);
+
+            validationProblem.AssertHasNotEmptyError($"{path}[2].id");
+            validationProblem.AssertHasNotEmptyError($"{path}[3].id");
+            validationProblem.AssertHasNotEmptyError($"{path}[4].code");
+            validationProblem.AssertHasNotEmptyError($"{path}[5].code");
+
+            validationProblem.AssertHasMaximumLengthError($"{path}[6].id", maxLength: 10);
+            validationProblem.AssertHasMaximumLengthError($"{path}[7].code", maxLength: 25);
+            validationProblem.AssertHasMaximumLengthError($"{path}[8].oldCode", maxLength: 10);
+            validationProblem.AssertHasMaximumLengthError($"{path}[9].ukprn", maxLength: 8);
+            validationProblem.AssertHasMaximumLengthError($"{path}[10].urn", maxLength: 6);
+            validationProblem.AssertHasMaximumLengthError($"{path}[11].laEstab", maxLength: 7);
+        }
+
+        [Fact]
+        public async Task AllComparatorsInvalid_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            DataSetQueryLocation[] invalidLocations =
+            [
+                new DataSetQueryLocationId { Level = "", Id = "" },
+                new DataSetQueryLocationId { Level = "NAT", Id = " " },
+                new DataSetQueryLocationId { Level = "NAT", Id = new string('a', 11) },
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Locations = new DataSetQueryCriteriaLocations
+                        {
+                            Eq = new DataSetQueryLocationCode { Level = "LADD", Code = "12345" },
+                            NotEq = new DataSetQueryLocationId { Level = "NAT", Id = " " },
+                            In = invalidLocations,
+                            NotIn = []
+                        }
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Equal(8, validationProblem.Errors.Count);
+
+            validationProblem.AssertHasAllowedValueError(
+                expectedPath: "criteria.locations.eq.level",
+                value: "LADD",
+                allowed: GeographicLevelUtils.OrderedCodes
+            );
+            validationProblem.AssertHasNotEmptyError(expectedPath: "criteria.locations.notEq.id");
+            validationProblem.AssertHasNotEmptyError(expectedPath: "criteria.locations.in[0].id");
+            validationProblem.AssertHasNotEmptyError(expectedPath: "criteria.locations.in[0].level");
+            validationProblem.AssertHasNotEmptyError(expectedPath: "criteria.locations.in[1].id");
+            validationProblem.AssertHasMaximumLengthError(expectedPath: "criteria.locations.in[2].id", maxLength: 10);
+            validationProblem.AssertHasNotEmptyError("criteria.locations.notIn");
+        }
+
+        [Theory]
+        [InlineData("In")]
+        [InlineData("NotIn")]
+        public async Task NotFound_Returns200_HasWarning(string comparator)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            DataSetQueryLocation[] notFoundLocations =
+            [
+                new DataSetQueryLocationId { Level = "NAT", Id = "11111111" },
+                new DataSetQueryLocationCode { Level = "NAT", Code = "11111111" },
+                new DataSetQueryLocationId { Level = "REG", Id = "22222222" },
+                new DataSetQueryLocationLocalAuthorityCode { Code = "4444444" },
+                new DataSetQueryLocationLocalAuthorityOldCode { OldCode= "333" },
+                new DataSetQueryLocationProviderUkprn { Ukprn = "88888888" },
+                new DataSetQueryLocationSchoolUrn { Urn = "666666" },
+                new DataSetQueryLocationSchoolLaEstab { LaEstab = "7777777" },
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Locations = DataSetQueryCriteriaLocations.Create(comparator,
+                        [
+                            new DataSetQueryLocationLocalAuthorityCode { Code = "E08000016" },
+                            ..notFoundLocations
+                        ])
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Single(viewModel.Warnings);
+
+            viewModel.AssertHasLocationsNotFoundWarning(
+                $"criteria.locations.{comparator.ToLowerFirst()}",
+                notFoundLocations);
+        }
+    }
+
+    public class TimePeriodsValidationTests(TestApplicationFactory testApp)
+        : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Theory]
+        [InlineData("In")]
+        [InlineData("NotIn")]
+        public async Task Empty_Returns400(string comparator)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = DataSetQueryCriteriaTimePeriods.Create(comparator, [])
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasNotEmptyError($"criteria.timePeriods.{comparator.ToLowerFirst()}");
+        }
+
+        [Theory]
+        [InlineData("In")]
+        [InlineData("NotIn")]
+        public async Task InvalidMix_Returns400(string comparator)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            DataSetQueryTimePeriod[] invalidTimePeriods =
+            [
+                new DataSetQueryTimePeriod { Code = "", Period = "" },
+                new DataSetQueryTimePeriod { Code = "AY", Period = "2020/2019" },
+                new DataSetQueryTimePeriod { Code = "AY", Period = "2020/2022" },
+                new DataSetQueryTimePeriod { Code = "INVALID", Period = "2020" },
+                new DataSetQueryTimePeriod { Code = "CY", Period = "2020/2021" },
+                new DataSetQueryTimePeriod { Code = "CYQ2", Period = "2020/2021" },
+                new DataSetQueryTimePeriod { Code = "RY", Period = "2020/2021" },
+                new DataSetQueryTimePeriod { Code = "W10", Period = "2020/2021" },
+                new DataSetQueryTimePeriod { Code = "M5", Period = "2020/2021" }
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = DataSetQueryCriteriaTimePeriods.Create(comparator, invalidTimePeriods)
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Equal(9, validationProblem.Errors.Count);
+
+            var path = $"criteria.timePeriods.{comparator.ToLowerFirst()}";
+
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{path}[0].code", code: "");
+
+            validationProblem.AssertHasTimePeriodYearRangeError(expectedPath: $"{path}[1].period", period: "2020/2019");
+            validationProblem.AssertHasTimePeriodYearRangeError(expectedPath: $"{path}[2].period", period: "2020/2022");
+
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{path}[3].code", code: "INVALID");
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{path}[4].code", code: "CY");
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{path}[5].code", code: "CYQ2");
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{path}[6].code", code: "RY");
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{path}[7].code", code: "W10");
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{path}[8].code", code: "M5");
+        }
+
+        [Fact]
+        public async Task AllComparatorsInvalid_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            DataSetQueryTimePeriod[] invalidTimePeriods =
+            [
+                new DataSetQueryTimePeriod { Code = "INVALID", Period = "2020" },
+                new DataSetQueryTimePeriod { Code = "CY", Period = "" },
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = new DataSetQueryCriteriaTimePeriods
+                        {
+                            Eq = new DataSetQueryTimePeriod { Code = "AY", Period = "2020/2019" },
+                            NotEq = new DataSetQueryTimePeriod { Code = "W10", Period = "2020/2021" },
+                            In = invalidTimePeriods,
+                            NotIn = [],
+                            Gt = new DataSetQueryTimePeriod { Code = "CY", Period = "2020/2021" },
+                            Gte = new DataSetQueryTimePeriod { Code = "AY", Period = "2020/" },
+                            Lt = new DataSetQueryTimePeriod { Code = "", Period = "2020" },
+                            Lte = new DataSetQueryTimePeriod { Code = "", Period = "2020/2021" }
+                        }
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Equal(9, validationProblem.Errors.Count);
+
+            const string basePath = "criteria.timePeriods";
+
+            validationProblem.AssertHasTimePeriodYearRangeError($"{basePath}.eq.period", period: "2020/2019");
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{basePath}.notEq.code", code: "W10");
+            validationProblem.AssertHasTimePeriodAllowedCodeError(
+                expectedPath: $"{basePath}.in[0].code",
+                code: "INVALID"
+            );
+            validationProblem.AssertHasTimePeriodInvalidYearError(
+                expectedPath: $"{basePath}.in[1].period",
+                period: ""
+            );
+            validationProblem.AssertHasNotEmptyError(expectedPath: $"{basePath}.notIn");
+
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{basePath}.gt.code", code: "CY");
+            validationProblem.AssertHasTimePeriodYearRangeError(expectedPath: $"{basePath}.gte.period", period: "2020/");
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{basePath}.lt.code", code: "");
+            validationProblem.AssertHasTimePeriodAllowedCodeError(expectedPath: $"{basePath}.lte.code", code: "");
+        }
+
+        [Theory]
+        [InlineData("In")]
+        [InlineData("NotIn")]
+        public async Task NotFound_Returns200_HasWarning(string comparator)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            DataSetQueryTimePeriod[] notFoundTimePeriods =
+            [
+                new DataSetQueryTimePeriod { Code = "CY", Period = "2021" },
+                new DataSetQueryTimePeriod { Code = "CY", Period = "2022" },
+                new DataSetQueryTimePeriod { Code = "CY", Period = "2030" },
+                new DataSetQueryTimePeriod { Code = "AY", Period = "2023/2024" },
+                new DataSetQueryTimePeriod { Code = "AY", Period = "2018/2019" },
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = DataSetQueryCriteriaTimePeriods.Create(comparator, [
+                            new DataSetQueryTimePeriod
+                            {
+                                Code = "AY",
+                                Period = "2020/2021"
+                            },
+                            ..notFoundTimePeriods
+                        ])
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Single(viewModel.Warnings);
+
+            viewModel.AssertHasTimePeriodsNotFoundWarning(
+                $"criteria.timePeriods.{comparator.ToLowerFirst()}",
+                notFoundTimePeriods);
+        }
+    }
+
+    public class SortsValidationTests(TestApplicationFactory testApp)
+        : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Fact]
+        public async Task Empty_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Sorts = []
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasNotEmptyError("sorts");
+        }
+
+        [Fact]
+        public async Task InvalidMix_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Sorts =
+                    [
+                        new DataSetQuerySort { Field = "", Direction = "asc" },
+                        new DataSetQuerySort { Field = "test", Direction = "" },
+                        new DataSetQuerySort { Field = "test", Direction = "invalid" },
+                        new DataSetQuerySort { Field = "test", Direction = "asc" },
+                        new DataSetQuerySort { Field = "test", Direction = "desc" },
+                        new DataSetQuerySort { Field = $"{new string('a', 41)}", Direction = "Asc" },
+                        new DataSetQuerySort { Field = $"{new string('b', 41)}", Direction = "Desc" },
+                    ]
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Equal(8, validationProblem.Errors.Count);
+
+            validationProblem.AssertHasNotEmptyError(expectedPath: "sorts[0].field");
+            validationProblem.AssertHasAllowedValueError(expectedPath: "sorts[0].direction", value: "asc");
+
+            validationProblem.AssertHasAllowedValueError(expectedPath: "sorts[1].direction", value: "");
+            validationProblem.AssertHasAllowedValueError(expectedPath: "sorts[2].direction", value: "invalid");
+            validationProblem.AssertHasAllowedValueError(expectedPath: "sorts[3].direction", value: "asc");
+            validationProblem.AssertHasAllowedValueError(expectedPath: "sorts[4].direction", value: "desc");
+
+            validationProblem.AssertHasMaximumLengthError(
+                expectedPath: "sorts[5].field",
+                maxLength: 40
+            );
+            validationProblem.AssertHasMaximumLengthError(
+                expectedPath: "sorts[6].field",
+                maxLength: 40
+            );
+        }
+
+        [Fact]
+        public async Task FieldsNotFound_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            DataSetQuerySort[] notFoundSorts =
+            [
+                new DataSetQuerySort { Field = "invalid1", Direction = "Asc" },
+                new DataSetQuerySort { Field = "invalid2", Direction = "Desc" },
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Sorts =
+                    [
+                        new() { Field = "timePeriod", Direction = "Asc" },
+                        ..notFoundSorts,
+                    ]
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasSortFieldsNotFoundError("sorts", notFoundSorts);
+        }
+    }
+
+    public class PaginationTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public async Task PageTooSmall_Returns400(int page)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Page = page
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasGreaterThanOrEqualError("page", comparisonValue: 1);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10001)]
+        public async Task PageSizeOutOfBounds_Returns400(int pageSize)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    PageSize = pageSize
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasInclusiveBetweenError("pageSize", from: 1, to: 10000);
+        }
+
+        [Theory]
+        [InlineData(1, 50, 5, 50)]
+        [InlineData(2, 50, 5, 50)]
+        [InlineData(3, 50, 5, 50)]
+        [InlineData(1, 150, 2, 150)]
+        [InlineData(2, 150, 2, 66)]
+        [InlineData(1, 216, 1, 216)]
+        public async Task MultiplePages_Returns200_PaginatedCorrectly(
+            int page,
+            int pageSize,
+            int totalPages,
+            int pageResults)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Page = page,
+                    PageSize = pageSize
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(pageResults, viewModel.Results.Count);
+            Assert.Equal(page, viewModel.Paging.Page);
+            Assert.Equal(pageSize, viewModel.Paging.PageSize);
+            Assert.Equal(totalPages, viewModel.Paging.TotalPages);
+            Assert.Equal(216, viewModel.Paging.TotalResults);
+        }
+    }
+
+    public class FiltersQueryTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Theory]
+        [InlineData("Eq", 54)]
+        [InlineData("NotEq", 162)]
+        [InlineData("In", 54)]
+        [InlineData("NotIn", 162)]
+        public async Task SingleOption_Returns200(string comparator, int expectedResults)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            // Year 4
+            const string filterOptionId = "IzBzg";
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Filters = DataSetQueryCriteriaFilters.Create(comparator, [filterOptionId])
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(expectedResults, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            switch (comparator)
+            {
+                case "Eq":
+                case "In":
+                    Assert.Single(meta.Filters["ncyear"]);
+                    Assert.Contains(filterOptionId, meta.Filters["ncyear"]);
+                    break;
+                case "NotEq":
+                case "NotIn":
+                    Assert.Equal(3, meta.Filters["ncyear"].Count);
+                    Assert.DoesNotContain(filterOptionId, meta.Filters["ncyear"]);
+                    break;
+            }
+        }
+
+        [Theory]
+        [InlineData("In", 108)]
+        [InlineData("NotIn", 108)]
+        public async Task MultipleOptionsInSameFilter_Returns200(string comparator, int expectedResults)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            // Year 4 and 8
+            string[] filterOptionIds = ["IzBzg", "7zXob"];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Filters = DataSetQueryCriteriaFilters.Create(comparator, filterOptionIds)
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(expectedResults, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            Assert.Equal(2, meta.Indicators.Count);
+            Assert.Contains("enrolments", meta.Indicators);
+            Assert.Contains("sess_authorised", meta.Indicators);
+
+            switch (comparator)
+            {
+                case "In":
+                    Assert.Equal(2, meta.Filters["ncyear"].Count);
+                    Assert.Contains(filterOptionIds[0], meta.Filters["ncyear"]);
+                    Assert.Contains(filterOptionIds[1], meta.Filters["ncyear"]);
+                    break;
+                case "NotIn":
+                    Assert.Equal(2, meta.Filters["ncyear"].Count);
+                    Assert.DoesNotContain(filterOptionIds[0], meta.Filters["ncyear"]);
+                    Assert.DoesNotContain(filterOptionIds[1], meta.Filters["ncyear"]);
+                    break;
+            }
+        }
+        
+        [Theory]
+        [InlineData("In", 150)]
+        [InlineData("NotIn", 66)]
+        public async Task MultipleOptionsInDifferentFilters_Returns200(string comparator, int expectedResults)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            // Total and secondary school type
+            // Secondary free school and secondary sponsor led academy types
+            string[] filterOptionIds = ["0kT5D", "6jrfe", "9U4vZ", "O7CLF"];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Filters = DataSetQueryCriteriaFilters.Create(comparator, filterOptionIds)
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(expectedResults, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            switch (comparator)
+            {
+                case "In":
+                    Assert.Equal(2, meta.Filters["school_type"].Count);
+                    Assert.Contains(filterOptionIds[0], meta.Filters["school_type"]);
+                    Assert.Contains(filterOptionIds[1], meta.Filters["school_type"]);
+
+                    Assert.Equal(2, meta.Filters["academy_type"].Count);
+                    Assert.Contains(filterOptionIds[2], meta.Filters["academy_type"]);
+                    Assert.Contains(filterOptionIds[3], meta.Filters["academy_type"]);
+                    break;
+                case "NotIn":
+                    Assert.Single(meta.Filters["school_type"]);
+                    Assert.DoesNotContain(filterOptionIds[0], meta.Filters["school_type"]);
+                    Assert.DoesNotContain(filterOptionIds[1], meta.Filters["school_type"]);
+
+                    Assert.Single(meta.Filters["academy_type"]);
+                    Assert.DoesNotContain(filterOptionIds[2], meta.Filters["academy_type"]);
+                    Assert.DoesNotContain(filterOptionIds[3], meta.Filters["academy_type"]);
+                    break;
+            }
+        }
+    }
+
+    public class GeographicLevelsQueryTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Theory]
+        [InlineData("Eq", 132)]
+        [InlineData("NotEq", 84)]
+        [InlineData("In", 132)]
+        [InlineData("NotIn", 84)]
+        public async Task SingleOption_Returns200(string comparator, int expectedResults)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            const GeographicLevel geographicLevel = GeographicLevel.LocalAuthority;
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create(comparator, [geographicLevel])
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(expectedResults, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            switch (comparator)
+            {
+                case "Eq":
+                case "In":
+                    Assert.Single(meta.GeographicLevels);
+                    Assert.Contains(geographicLevel, meta.GeographicLevels);
+                    break;
+                case "NotEq":
+                case "NotIn":
+                    Assert.Equal(3, meta.GeographicLevels.Count);
+                    Assert.DoesNotContain(geographicLevel, meta.GeographicLevels);
+                    break;
+            }
+        }
+
+        [Theory]
+        [InlineData("In", 180)]
+        [InlineData("NotIn", 36)]
+        public async Task MultipleOptions_Returns200(string comparator, int expectedResults)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            GeographicLevel[] geographicLevels = [GeographicLevel.Region, GeographicLevel.LocalAuthority];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create(comparator, geographicLevels)
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(expectedResults, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            switch (comparator)
+            {
+                case "In":
+                    Assert.Equal(2, meta.GeographicLevels.Count);
+                    Assert.Contains(geographicLevels[0], meta.GeographicLevels);
+                    Assert.Contains(geographicLevels[1], meta.GeographicLevels);
+                    break;
+                case "NotIn":
+                    Assert.Equal(2, meta.GeographicLevels.Count);
+                    Assert.DoesNotContain(geographicLevels[0], meta.GeographicLevels);
+                    Assert.DoesNotContain(geographicLevels[1], meta.GeographicLevels);
+                    break;
+            }
+        }
+    }
+
+    public class LocationsQueryTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Theory]
+        [InlineData("Eq", 36)]
+        [InlineData("NotEq", 180)]
+        [InlineData("In", 36)]
+        [InlineData("NotIn", 180)]
+        public async Task SingleOption_Returns200(string comparator, int expectedResults)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            // Sheffield
+            var location = new DataSetQueryLocationLocalAuthorityCode { Code = "E08000019" };
+            const string locationId = "7zXob";
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Locations = DataSetQueryCriteriaLocations.Create(comparator, [location])
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(expectedResults, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            switch (comparator)
+            {
+                case "Eq":
+                case "In":
+                    Assert.Single(meta.Locations["LA"]);
+                    Assert.Contains(locationId, meta.Locations["LA"]);
+                    break;
+                case "NotEq":
+                case "NotIn":
+                    Assert.Equal(3, meta.Locations["LA"].Count);
+                    Assert.DoesNotContain(locationId, meta.Locations["LA"]);
+                    break;
+            }
+        }
+
+        [Theory]
+        [InlineData("In", 72)]
+        [InlineData("NotIn", 144)]
+        public async Task MultipleOptionsInSameLevel_Returns200(string comparator, int expectedResults)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            // Sheffield and Barnsley
+            DataSetQueryLocation[] locations =
+            [
+                new DataSetQueryLocationLocalAuthorityCode { Code = "E08000019" },
+                new DataSetQueryLocationId { Level = "LA", Id = "O7CLF" }
+            ];
+            string[] locationIds = ["7zXob", "O7CLF"];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Locations = DataSetQueryCriteriaLocations.Create(comparator, locations)
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(expectedResults, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            switch (comparator)
+            {
+                case "In":
+                    Assert.Equal(2, meta.Locations["LA"].Count);
+                    Assert.Contains(locationIds[0], meta.Locations["LA"]);
+                    Assert.Contains(locationIds[1], meta.Locations["LA"]);
+                    break;
+                case "NotIn":
+                    Assert.Equal(2, meta.Locations["LA"].Count);
+                    Assert.DoesNotContain(locationIds[0], meta.Locations["LA"]);
+                    Assert.DoesNotContain(locationIds[1], meta.Locations["LA"]);
+                    break;
+            }
+        }
+
+        [Theory]
+        [InlineData("In", 84)]
+        [InlineData("NotIn", 132)]
+        public async Task MultipleOptionsInDifferentLevels_Returns200(string comparator, int expectedResults)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            // Sheffield and Barnsley
+            // THe Kingston Academy and King Athelstan Primary School
+            DataSetQueryLocation[] locations =
+            [
+                new DataSetQueryLocationLocalAuthorityCode { Code = "E08000019" },
+                new DataSetQueryLocationId { Level = "LA", Id = "O7CLF" },
+                new DataSetQueryLocationSchoolLaEstab { LaEstab = "3144001" },
+                new DataSetQueryLocationSchoolUrn { Urn = "102579" }
+            ];
+
+            string[] locationIds = ["7zXob", "O7CLF", "0kT5D", "arLPb"];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Locations = DataSetQueryCriteriaLocations.Create(comparator, locations)
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(expectedResults, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            switch (comparator)
+            {
+                case "In":
+                    Assert.Equal(3, meta.Locations["LA"].Count);
+                    Assert.Contains(locationIds[0], meta.Locations["LA"]);
+                    Assert.Contains(locationIds[1], meta.Locations["LA"]);
+
+                    Assert.Equal(6, meta.Locations["SCH"].Count);
+                    Assert.Contains(locationIds[2], meta.Locations["SCH"]);
+                    Assert.Contains(locationIds[3], meta.Locations["SCH"]);
+                    break;
+                case "NotIn":
+                    Assert.Equal(2, meta.Locations["LA"].Count);
+                    Assert.DoesNotContain(locationIds[0], meta.Locations["LA"]);
+                    Assert.DoesNotContain(locationIds[1], meta.Locations["LA"]);
+
+                    Assert.Equal(2, meta.Locations["SCH"].Count);
+                    Assert.DoesNotContain(locationIds[2], meta.Locations["SCH"]);
+                    Assert.DoesNotContain(locationIds[3], meta.Locations["SCH"]);
+                    break;
+            }
+        }
+    }
+
+    public class TimePeriodsQueryTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Theory]
+        [InlineData("Eq", 72)]
+        [InlineData("NotEq", 144)]
+        [InlineData("In", 72)]
+        [InlineData("NotIn", 144)]
+        [InlineData("Gt", 72)]
+        [InlineData("Gte", 144)]
+        [InlineData("Lt", 72)]
+        [InlineData("Lte", 144)]
+        public async Task SingleOption_Returns200(string comparator, int expectedResults)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var queryTimePeriod = new DataSetQueryTimePeriod { Code = "AY", Period = "2021/2022" };
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = DataSetQueryCriteriaTimePeriods.Create(comparator, [queryTimePeriod])
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(expectedResults, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            var timePeriod = new TimePeriodViewModel
+            {
+                Code = TimeIdentifier.AcademicYear,
+                Period = "2021/2022"
+            };
+
+            switch (comparator)
+            {
+                case "Eq":
+                case "In":
+                    Assert.Single(meta.TimePeriods);
+                    Assert.Contains(timePeriod, meta.TimePeriods);
+                    break;
+                case "NotEq":
+                case "NotIn":
+                    Assert.Equal(2, meta.TimePeriods.Count);
+                    Assert.DoesNotContain(timePeriod, meta.TimePeriods);
+                    break;
+                case "Lt":
+                case "Gt":
+                    Assert.Single(meta.TimePeriods);
+                    Assert.DoesNotContain(timePeriod, meta.TimePeriods);
+                    break;
+                case "Lte":
+                case "Gte":
+                    Assert.Equal(2, meta.TimePeriods.Count);
+                    Assert.Contains(timePeriod, meta.TimePeriods);
+                    break;
+            }
+        }
+
+        [Theory]
+        [InlineData("In", 144)]
+        [InlineData("NotIn", 72)]
+        public async Task MultipleOptions_Returns200(string comparator, int expectedResults)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            DataSetQueryTimePeriod[] queryTimePeriods =
+            [
+                new DataSetQueryTimePeriod { Code = "AY", Period = "2021" },
+                new DataSetQueryTimePeriod { Code = "AY", Period = "2022/2023" },
+            ];
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = DataSetQueryCriteriaTimePeriods.Create(comparator, queryTimePeriods)
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(expectedResults, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            TimePeriodViewModel[] timePeriods =
+            [
+                new TimePeriodViewModel { Code = TimeIdentifier.AcademicYear, Period = "2021/2022" },
+                new TimePeriodViewModel { Code = TimeIdentifier.AcademicYear, Period = "2022/2023" }
+            ];
+
+            switch (comparator)
+            {
+                case "In":
+                    Assert.Equal(2, meta.TimePeriods.Count);
+                    Assert.Contains(timePeriods[0], meta.TimePeriods);
+                    Assert.Contains(timePeriods[1], meta.TimePeriods);
+                    break;
+                case "NotIn":
+                    Assert.Single(meta.TimePeriods);
+                    Assert.DoesNotContain(timePeriods[0], meta.TimePeriods);
+                    Assert.DoesNotContain(timePeriods[1], meta.TimePeriods);
+                    break;
+            }
+        }
+    }
+
+    public class FacetsOnlyResultsTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Fact]
+        public async Task NoResults_Returns200_HasWarning()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Locations = new DataSetQueryCriteriaLocations
+                        {
+                            Eq = new DataSetQueryLocationId { Level = "LA", Id = "9U4vZ" }
+                        },
+                        GeographicLevels = new DataSetQueryCriteriaGeographicLevels
+                        {
+                            Eq = "NAT"
+                        }
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(1, viewModel.Paging.Page);
+            Assert.Equal(1000, viewModel.Paging.PageSize);
+            Assert.Equal(1, viewModel.Paging.TotalPages);
+            Assert.Equal(0, viewModel.Paging.TotalResults);
+
+            var warning = Assert.Single(viewModel.Warnings);
+
+            Assert.Equal(ValidationMessages.QueryNoResults.Code, warning.Code);
+            Assert.Equal(ValidationMessages.QueryNoResults.Message, warning.Message);
+        }
+
+        [Fact]
+        public async Task DebugEnabled_Returns200_HasWarning()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"],
+                    Debug = true
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            var warning = Assert.Single(viewModel.Warnings);
+
+            Assert.Equal(ValidationMessages.DebugEnabled.Code, warning.Code);
+            Assert.Equal(ValidationMessages.DebugEnabled.Message, warning.Message);
+        }
+
+        [Fact]
+        public async Task SingleIndicator_Returns200_CorrectViewModel()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["sess_authorised"]
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(1, viewModel.Paging.Page);
+            Assert.Equal(1, viewModel.Paging.TotalPages);
+            Assert.Equal(216, viewModel.Paging.TotalResults);
+
+            Assert.Empty(viewModel.Warnings);
+
+            Assert.Equal(216, viewModel.Results.Count);
+
+            var result = viewModel.Results[0];
+
+            Assert.Equal(2, result.Filters.Count);
+            Assert.Equal("pTSoj", result.Filters["ncyear"]);
+            Assert.Equal("0kT5D", result.Filters["school_type"]);
+
+            Assert.Equal(GeographicLevel.LocalAuthority, result.GeographicLevel);
+
+            Assert.Equal(3, result.Locations.Count);
+            Assert.Equal("dP0Zw", result.Locations["LA"]);
+            Assert.Equal("pTSoj", result.Locations["NAT"]);
+            Assert.Equal("it6Xr", result.Locations["REG"]);
+
+            Assert.Equal(TimeIdentifier.AcademicYear, result.TimePeriod.Code);
+            Assert.Equal("2022/2023", result.TimePeriod.Period);
+
+            Assert.Single(result.Values);
+            Assert.Equal("4064499", result.Values["sess_authorised"]);
+        }
+
+        [Fact]
+        public async Task AllIndicators_Returns200_ResultValuesInAllowedRanges()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators =
+                    [
+                        "enrolments",
+                        "sess_authorised",
+                        "sess_possible",
+                        "sess_unauthorised",
+                        "sess_unauthorised_percent",
+                    ]
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(216, viewModel.Results.Count);
+
+            var values = viewModel.Results
+                .SelectMany(result => result.Values)
+                .GroupBy(kv => kv.Key, kv => kv.Value)
+                .ToDictionary(kv => kv.Key, kv => kv.ToList());
+
+            var enrolments = values["enrolments"].Select(int.Parse).ToList();
+
+            Assert.Equal(216, enrolments.Count);
+            Assert.Equal(999598, enrolments.Max());
+            Assert.Equal(1072, enrolments.Min());
+
+            var sessAuthorised = values["sess_authorised"].Select(int.Parse).ToList();
+
+            Assert.Equal(216, sessAuthorised.Count);
+            Assert.Equal(4967515, sessAuthorised.Max());
+            Assert.Equal(22441, sessAuthorised.Min());
+
+            var sessPossible = values["sess_possible"].Select(int.Parse).ToList();
+
+            Assert.Equal(216, sessPossible.Count);
+            Assert.Equal(9934276, sessPossible.Max());
+            Assert.Equal(18306, sessPossible.Min());
+
+            var sessUnauthorised = values["sess_unauthorised"].Select(int.Parse).ToList();
+
+            Assert.Equal(216, sessUnauthorised.Count);
+            Assert.Equal(494993, sessUnauthorised.Max());
+            Assert.Equal(2883, sessUnauthorised.Min());
+
+            var sessUnauthorisedPercent = values["sess_unauthorised_percent"].Select(float.Parse).ToList();
+
+            Assert.Equal(216, sessUnauthorisedPercent.Count);
+            Assert.Equal(14.8837004f, sessUnauthorisedPercent.Max());
+            Assert.Equal(0.241600007f, sessUnauthorisedPercent.Min());
+        }
+
+        [Fact]
+        public async Task AllIndicators_Returns200_CorrectResultIds()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators =
+                    [
+                        "enrolments",
+                        "sess_authorised",
+                        "sess_possible",
+                        "sess_unauthorised",
+                        "sess_unauthorised_percent",
+                    ]
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(216, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            Assert.Equal(3, meta.Filters.Count);
+
+            Assert.Equal(3, meta.Filters["academy_type"].Count);
+
+            Assert.Contains("dP0Zw", meta.Filters["academy_type"]);
+            Assert.Contains("9U4vZ", meta.Filters["academy_type"]);
+            Assert.Contains("O7CLF", meta.Filters["academy_type"]);
+
+            Assert.Equal(4, meta.Filters["ncyear"].Count);
+            Assert.Contains("IzBzg", meta.Filters["ncyear"]);
+            Assert.Contains("it6Xr", meta.Filters["ncyear"]);
+            Assert.Contains("7zXob", meta.Filters["ncyear"]);
+            Assert.Contains("pTSoj", meta.Filters["ncyear"]);
+
+            Assert.Equal(3, meta.Filters["school_type"].Count);
+            Assert.Contains("LxWjE", meta.Filters["school_type"]);
+            Assert.Contains("6jrfe", meta.Filters["school_type"]);
+            Assert.Contains("0kT5D", meta.Filters["school_type"]);
+
+            Assert.Equal(4, meta.Locations.Count);
+
+            Assert.Single(meta.Locations["NAT"]);
+            Assert.Contains("pTSoj", meta.Locations["NAT"]);
+
+            Assert.Equal(2, meta.Locations["REG"].Count);
+            Assert.Contains("it6Xr", meta.Locations["REG"]);
+            Assert.Contains("IzBzg", meta.Locations["REG"]);
+
+            Assert.Equal(4, meta.Locations["LA"].Count);
+            Assert.Contains("9U4vZ", meta.Locations["LA"]);
+            Assert.Contains("O7CLF", meta.Locations["LA"]);
+            Assert.Contains("dP0Zw", meta.Locations["LA"]);
+            Assert.Contains("7zXob", meta.Locations["LA"]);
+
+            Assert.Equal(8, meta.Locations["SCH"].Count);
+            Assert.Contains("qFjG7", meta.Locations["SCH"]);
+            Assert.Contains("0kT5D", meta.Locations["SCH"]);
+            Assert.Contains("arLPb", meta.Locations["SCH"]);
+            Assert.Contains("6jrfe", meta.Locations["SCH"]);
+            Assert.Contains("HTzLj", meta.Locations["SCH"]);
+            Assert.Contains("LxWjE", meta.Locations["SCH"]);
+            Assert.Contains("CpId1", meta.Locations["SCH"]);
+            Assert.Contains("YPHKM", meta.Locations["SCH"]);
+
+            Assert.Equal(4, meta.GeographicLevels.Count);
+            Assert.Contains(GeographicLevel.Country, meta.GeographicLevels);
+            Assert.Contains(GeographicLevel.Region, meta.GeographicLevels);
+            Assert.Contains(GeographicLevel.LocalAuthority, meta.GeographicLevels);
+            Assert.Contains(GeographicLevel.School, meta.GeographicLevels);
+
+            Assert.Equal(3, meta.TimePeriods.Count);
+            Assert.Contains(
+                new TimePeriodViewModel { Code = TimeIdentifier.AcademicYear, Period = "2020/2021" },
+                meta.TimePeriods
+            );
+            Assert.Contains(
+                new TimePeriodViewModel { Code = TimeIdentifier.AcademicYear, Period = "2021/2022" },
+                meta.TimePeriods
+            );
+            Assert.Contains(
+                new TimePeriodViewModel { Code = TimeIdentifier.AcademicYear, Period = "2022/2023" },
+                meta.TimePeriods
+            );
+
+            Assert.Equal(5, meta.Indicators.Count);
+            Assert.Contains("enrolments", meta.Indicators);
+            Assert.Contains("sess_authorised", meta.Indicators);
+            Assert.Contains("sess_possible", meta.Indicators);
+            Assert.Contains("sess_unauthorised", meta.Indicators);
+            Assert.Contains("sess_unauthorised_percent", meta.Indicators);
+        }
+
+        [Fact]
+        public async Task AllIndicators_Returns200_CorrectDebuggedResultLabels()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators =
+                    [
+                        "enrolments",
+                        "sess_authorised",
+                        "sess_possible",
+                        "sess_unauthorised",
+                        "sess_unauthorised_percent",
+                    ],
+                    Debug = true
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            Assert.Equal(216, viewModel.Results.Count);
+
+            var meta = GatherQueryResultsMeta(viewModel);
+
+            Assert.Equal(3, meta.Filters.Count);
+
+            Assert.Equal(3, meta.Filters["academy_type"].Count);
+
+            Assert.Contains("dP0Zw :: Primary sponsor led academy", meta.Filters["academy_type"]);
+            Assert.Contains("9U4vZ :: Secondary free school", meta.Filters["academy_type"]);
+            Assert.Contains("O7CLF :: Secondary sponsor led academy", meta.Filters["academy_type"]);
+
+            Assert.Equal(4, meta.Filters["ncyear"].Count);
+            Assert.Contains("IzBzg :: Year 4", meta.Filters["ncyear"]);
+            Assert.Contains("it6Xr :: Year 6", meta.Filters["ncyear"]);
+            Assert.Contains("7zXob :: Year 8", meta.Filters["ncyear"]);
+            Assert.Contains("pTSoj :: Year 10", meta.Filters["ncyear"]);
+
+            Assert.Equal(3, meta.Filters["school_type"].Count);
+            Assert.Contains("LxWjE :: State-funded primary", meta.Filters["school_type"]);
+            Assert.Contains("6jrfe :: State-funded secondary", meta.Filters["school_type"]);
+            Assert.Contains("0kT5D :: Total", meta.Filters["school_type"]);
+
+            Assert.Equal(4, meta.Locations.Count);
+
+            Assert.Single(meta.Locations["NAT"]);
+            Assert.Contains("pTSoj :: England (code = E92000001)", meta.Locations["NAT"]);
+
+            Assert.Equal(2, meta.Locations["REG"].Count);
+            Assert.Contains("it6Xr :: Outer London (code = E13000002)", meta.Locations["REG"]);
+            Assert.Contains("IzBzg :: Yorkshire and The Humber (code = E12000003)", meta.Locations["REG"]);
+
+            Assert.Equal(4, meta.Locations["LA"].Count);
+            Assert.Contains("9U4vZ :: Barnet (code = E09000003, oldCode = 302)", meta.Locations["LA"]);
+            Assert.Contains("O7CLF :: Barnsley (code = E08000016, oldCode = 370)", meta.Locations["LA"]);
+            Assert.Contains(
+                "dP0Zw :: Kingston upon Thames / Richmond upon Thames (code = E09000021 / E09000027, oldCode = 314)",
+                meta.Locations["LA"]
+            );
+            Assert.Contains("7zXob :: Sheffield (code = E08000019, oldCode = 373)", meta.Locations["LA"]);
+
+            Assert.Equal(8, meta.Locations["SCH"].Count);
+            Assert.Contains("qFjG7 :: Colindale Primary School (urn = 101269, laEstab = 3022014)", meta.Locations["SCH"]);
+            Assert.Contains("0kT5D :: Greenhill Primary School (urn = 145374, laEstab = 3732341)", meta.Locations["SCH"]);
+            Assert.Contains(
+                "arLPb :: Hoyland Springwood Primary School (urn = 141973, laEstab = 3702039)",
+                meta.Locations["SCH"]
+            );
+            Assert.Contains(
+                "6jrfe :: King Athelstan Primary School (urn = 102579, laEstab = 3142032)",
+                meta.Locations["SCH"]
+            );
+            Assert.Contains("HTzLj :: Newfield Secondary School (urn = 140821, laEstab = 3734008)", meta.Locations["SCH"]);
+            Assert.Contains("LxWjE :: Penistone Grammar School (urn = 106653, laEstab = 3704027)", meta.Locations["SCH"]);
+            Assert.Contains("CpId1 :: The Kingston Academy (urn = 141862, laEstab = 3144001)", meta.Locations["SCH"]);
+            Assert.Contains("YPHKM :: Wren Academy Finchley (urn = 135507, laEstab = 3026906)", meta.Locations["SCH"]);
+
+            Assert.Equal(4, meta.GeographicLevels.Count);
+            Assert.Contains(GeographicLevel.Country, meta.GeographicLevels);
+            Assert.Contains(GeographicLevel.Region, meta.GeographicLevels);
+            Assert.Contains(GeographicLevel.LocalAuthority, meta.GeographicLevels);
+            Assert.Contains(GeographicLevel.School, meta.GeographicLevels);
+
+            Assert.Equal(3, meta.TimePeriods.Count);
+            Assert.Contains(
+                new TimePeriodViewModel { Code = TimeIdentifier.AcademicYear, Period = "2020/2021" },
+                meta.TimePeriods
+            );
+            Assert.Contains(
+                new TimePeriodViewModel { Code = TimeIdentifier.AcademicYear, Period = "2021/2022" },
+                meta.TimePeriods
+            );
+            Assert.Contains(
+                new TimePeriodViewModel { Code = TimeIdentifier.AcademicYear, Period = "2022/2023" },
+                meta.TimePeriods
+            );
+
+            Assert.Equal(5, meta.Indicators.Count);
+            Assert.Contains("enrolments", meta.Indicators);
+            Assert.Contains("sess_authorised", meta.Indicators);
+            Assert.Contains("sess_possible", meta.Indicators);
+            Assert.Contains("sess_unauthorised", meta.Indicators);
+            Assert.Contains("sess_unauthorised_percent", meta.Indicators);
+        }
+
+        [Fact]
+        public async Task AllFacetsMixture_Returns200()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Debug = true,
+                    Criteria = new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetQueryCriteriaFilters
+                        {
+                            NotEq = "7zXob",
+                            In = ["9U4vZ", "O7CLF"]
+                        },
+                        GeographicLevels = new DataSetGetQueryGeographicLevels
+                        {
+                            NotEq = "NAT"
+                        },
+                        Locations = new DataSetQueryCriteriaLocations
+                        {
+                            Eq = new DataSetQueryLocationId { Level = "NAT", Id = "pTSoj" },
+                            NotIn =
+                            [
+                                new DataSetQueryLocationCode { Level = "REG", Code = "E13000002" },
+                                new DataSetQueryLocationLocalAuthorityOldCode { OldCode = "370" },
+                            ]
+                        },
+                        TimePeriods = new DataSetQueryCriteriaTimePeriods
+                        {
+                            Gt = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" },
+                            Lt = new DataSetQueryTimePeriod { Period = "2022/2023", Code = "AY" }
+                        }
+                    }
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            var result = Assert.Single(viewModel.Results);
+
+            Assert.Equal(3, result.Filters.Count);
+            Assert.Equal("pTSoj :: Year 10", result.Filters["ncyear"]);
+            Assert.Equal("6jrfe :: State-funded secondary", result.Filters["school_type"]);
+            Assert.Equal("O7CLF :: Secondary sponsor led academy", result.Filters["academy_type"]);
+
+            Assert.Equal(GeographicLevel.School, result.GeographicLevel);
+
+            Assert.Equal(4, result.Locations.Count);
+            Assert.Equal("pTSoj :: England (code = E92000001)", result.Locations["NAT"]);
+            Assert.Equal("IzBzg :: Yorkshire and The Humber (code = E12000003)", result.Locations["REG"]);
+            Assert.Equal("7zXob :: Sheffield (code = E08000019, oldCode = 373)", result.Locations["LA"]);
+            Assert.Equal(
+                "HTzLj :: Newfield Secondary School (urn = 140821, laEstab = 3734008)",
+                result.Locations["SCH"]
+            );
+
+            Assert.Equal(TimeIdentifier.AcademicYear, result.TimePeriod.Code);
+            Assert.Equal("2021/2022", result.TimePeriod.Period);
+
+            Assert.Equal(2, result.Values.Count);
+            Assert.Equal("752009", result.Values["enrolments"]);
+            Assert.Equal("262396", result.Values["sess_authorised"]);
+        }
+    }
+
+    public class AndConditionTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Fact]
+        public async Task Empty_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Debug = true,
+                    Criteria = new DataSetQueryCriteriaAnd
+                    {
+                        And = []
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasNotEmptyError("criteria.and");
+        }
+
+        private static readonly DataSetQueryCriteriaFacets BaseFacets = new()
+        {
+            Filters = new DataSetQueryCriteriaFilters
+            {
+                NotEq = "7zXob",
+                In = ["9U4vZ", "O7CLF"]
+            },
+            GeographicLevels = new DataSetGetQueryGeographicLevels
+            {
+                NotEq = "NAT"
+            },
+            Locations = new DataSetQueryCriteriaLocations
+            {
+                NotIn =
+                [
+                    new DataSetQueryLocationCode { Level = "REG", Code = "E13000002" },
+                    new DataSetQueryLocationLocalAuthorityOldCode { OldCode = "370" },
+                ]
+            },
+            TimePeriods = new DataSetQueryCriteriaTimePeriods
+            {
+                Eq = new DataSetQueryTimePeriod { Period = "2021/2022", Code = "AY" },
+            }
+        };
+
+        public static readonly TheoryData<DataSetQueryCriteria> EquivalentCriteria = new()
+        {
+            new DataSetQueryCriteriaAnd
+            {
+                And = [BaseFacets]
+            },
+            new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Filters = BaseFacets.Filters
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        GeographicLevels = BaseFacets.GeographicLevels
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Locations = BaseFacets.Locations
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = BaseFacets.TimePeriods
+                    },
+                ]
+            },
+            new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaAnd
+                    {
+                        And = [BaseFacets]
+                    }
+                ]
+            },
+            new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaAnd
+                    {
+                        And =
+                        [
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = BaseFacets.Filters
+                            },
+                            new DataSetQueryCriteriaFacets
+                            {
+                                GeographicLevels = BaseFacets.GeographicLevels
+                            },
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Locations = BaseFacets.Locations
+                            },
+                            new DataSetQueryCriteriaFacets
+                            {
+                                TimePeriods = BaseFacets.TimePeriods
+                            },
+                        ]
+                    }
+                ]
+            },
+            new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaAnd
+                    {
+                        And =
+                        [
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters
+                                {
+                                    NotEq = BaseFacets.Filters!.NotEq,
+                                },
+                            },
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters
+                                {
+                                    In = BaseFacets.Filters!.In
+                                },
+                                Locations = BaseFacets.Locations
+                            },
+                        ]
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        GeographicLevels = BaseFacets.GeographicLevels,
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = BaseFacets.TimePeriods
+                    },
+                ]
+            },
+            new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaAnd
+                    {
+                        And =
+                        [
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters
+                                {
+                                    NotEq = BaseFacets.Filters.NotEq,
+                                },
+                            },
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Locations = BaseFacets.Locations,
+                                TimePeriods = BaseFacets.TimePeriods
+                            },
+                        ]
+                    },
+                    new DataSetQueryCriteriaOr
+                    {
+                        Or =
+                        [
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters
+                                {
+                                    Eq = "9U4vZ",
+                                },
+                            },
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters
+                                {
+                                    Eq = "O7CLF",
+                                },
+                            },
+                        ]
+                    },
+                    new DataSetQueryCriteriaNot
+                    {
+                        Not = new DataSetQueryCriteriaFacets
+                        {
+                            GeographicLevels = new DataSetGetQueryGeographicLevels
+                            {
+                                Eq = "NAT"
+                            },
+                        }
+                    }
+                ]
+            }
+        };
+
+        [Theory]
+        [MemberData(nameof(EquivalentCriteria))]
+        public async Task EquivalentCriteria_Returns200(DataSetQueryCriteria criteria)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Debug = true,
+                    Criteria = criteria
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            var result = Assert.Single(viewModel.Results);
+
+            Assert.Equal(3, result.Filters.Count);
+            Assert.Equal("pTSoj :: Year 10", result.Filters["ncyear"]);
+            Assert.Equal("6jrfe :: State-funded secondary", result.Filters["school_type"]);
+            Assert.Equal("O7CLF :: Secondary sponsor led academy", result.Filters["academy_type"]);
+
+            Assert.Equal(GeographicLevel.School, result.GeographicLevel);
+
+            Assert.Equal(4, result.Locations.Count);
+            Assert.Equal("pTSoj :: England (code = E92000001)", result.Locations["NAT"]);
+            Assert.Equal("IzBzg :: Yorkshire and The Humber (code = E12000003)", result.Locations["REG"]);
+            Assert.Equal("7zXob :: Sheffield (code = E08000019, oldCode = 373)", result.Locations["LA"]);
+            Assert.Equal(
+                "HTzLj :: Newfield Secondary School (urn = 140821, laEstab = 3734008)",
+                result.Locations["SCH"]
+            );
+
+            Assert.Equal(TimeIdentifier.AcademicYear, result.TimePeriod.Code);
+            Assert.Equal("2021/2022", result.TimePeriod.Period);
+
+            Assert.Equal(2, result.Values.Count);
+            Assert.Equal("752009", result.Values["enrolments"]);
+            Assert.Equal("262396", result.Values["sess_authorised"]);
+        }
+    }
+
+    public class OrConditionTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        [Fact]
+        public async Task Empty_Returns400()
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Debug = true,
+                    Criteria = new DataSetQueryCriteriaOr
+                    {
+                        Or = []
+                    }
+                }
+            );
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasNotEmptyError("criteria.or");
+        }
+
+        private static readonly DataSetQueryCriteriaFacets BaseFacets = new()
+        {
+            Filters = new DataSetQueryCriteriaFilters
+            {
+                NotEq = "7zXob",
+                In = ["9U4vZ", "O7CLF"]
+            },
+            GeographicLevels = new DataSetGetQueryGeographicLevels
+            {
+                NotEq = "NAT"
+            },
+            Locations = new DataSetQueryCriteriaLocations
+            {
+                Eq = new DataSetQueryLocationId { Level = "NAT", Id = "pTSoj" },
+                NotIn =
+                [
+                    new DataSetQueryLocationCode { Level = "REG", Code = "E13000002" },
+                    new DataSetQueryLocationLocalAuthorityOldCode { OldCode = "370" },
+                ]
+            }
+        };
+
+        public static readonly TheoryData<DataSetQueryCriteria> EquivalentCriteria = new()
+        {
+            new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    BaseFacets with
+                    {
+                        TimePeriods = new DataSetQueryCriteriaTimePeriods
+                        {
+                            In =
+                            [
+                                new DataSetQueryTimePeriod { Period = "2021/2022", Code = "AY" },
+                                new DataSetQueryTimePeriod { Period = "2022/2023", Code = "AY" }
+                            ],
+                        }
+                    },
+                ],
+            },
+            new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    BaseFacets with
+                    {
+                        TimePeriods = new DataSetQueryCriteriaTimePeriods
+                        {
+                            Eq = new DataSetQueryTimePeriod { Period = "2021/2022", Code = "AY" },
+                        }
+                    },
+                    BaseFacets with
+                    {
+                        TimePeriods = new DataSetQueryCriteriaTimePeriods
+                        {
+                            Eq = new DataSetQueryTimePeriod { Period = "2022/2023", Code = "AY" },
+                        }
+                    }
+                ]
+            },
+            new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    BaseFacets with
+                    {
+                        TimePeriods = new DataSetQueryCriteriaTimePeriods
+                        {
+                            Eq = new DataSetQueryTimePeriod { Period = "2021/2022", Code = "AY" },
+                        }
+                    },
+                    new DataSetQueryCriteriaOr
+                    {
+                        Or =
+                        [
+                            BaseFacets with
+                            {
+                                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                                {
+                                    Eq = new DataSetQueryTimePeriod { Period = "2022/2023", Code = "AY" },
+                                }
+                            },
+                        ]
+                    }
+                ]
+            },
+            new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    new DataSetQueryCriteriaOr
+                    {
+                        Or =
+                        [
+                            BaseFacets with
+                            {
+                                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                                {
+                                    In =
+                                    [
+                                        new DataSetQueryTimePeriod { Period = "2021/2022", Code = "AY" },
+                                        new DataSetQueryTimePeriod { Period = "2022/2023", Code = "AY" },
+                                    ]
+                                }
+                            },
+                        ]
+                    }
+                ]
+            },
+            new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    new DataSetQueryCriteriaOr
+                    {
+                        Or =
+                        [
+                            BaseFacets with
+                            {
+                                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                                {
+                                    Eq = new DataSetQueryTimePeriod { Period = "2021/2022", Code = "AY" },
+                                }
+                            },
+                            BaseFacets with
+                            {
+                                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                                {
+                                    Eq = new DataSetQueryTimePeriod { Period = "2022/2023", Code = "AY" },
+                                }
+                            },
+                        ]
+                    }
+                ]
+            },
+            new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    new DataSetQueryCriteriaAnd
+                    {
+                        And =
+                        [
+                            new DataSetQueryCriteriaFacets { Filters = BaseFacets.Filters },
+                            new DataSetQueryCriteriaFacets { GeographicLevels = BaseFacets.GeographicLevels },
+                            new DataSetQueryCriteriaFacets { Locations = BaseFacets.Locations },
+                            new DataSetQueryCriteriaFacets
+                            {
+                                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                                {
+                                    In =
+                                    [
+                                        new DataSetQueryTimePeriod { Period = "2021/2022", Code = "AY" },
+                                        new DataSetQueryTimePeriod { Period = "2022/2023", Code = "AY" },
+                                    ]
+                                }
+                            },
+                        ]
+                    },
+                    new DataSetQueryCriteriaOr
+                    {
+                        Or =
+                        [
+                            BaseFacets with
+                            {
+                                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                                {
+                                    Eq = new DataSetQueryTimePeriod { Period = "2021/2022", Code = "AY" },
+                                }
+                            },
+                            BaseFacets with
+                            {
+                                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                                {
+                                    Eq = new DataSetQueryTimePeriod { Period = "2022/2023", Code = "AY" },
+                                }
+                            },
+                        ]
+                    }
+                ]
+            },
+        };
+
+        [Theory]
+        [MemberData(nameof(EquivalentCriteria))]
+        public async Task EquivalentCriteria_Returns200(DataSetQueryCriteria criteria)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Debug = true,
+                    Criteria = criteria
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+            var results = viewModel.Results;
+
+            Assert.Equal(2, results.Count);
+
+            // Result 1
+
+            Assert.Equal(3, results[0].Filters.Count);
+            Assert.Equal("pTSoj :: Year 10", results[0].Filters["ncyear"]);
+            Assert.Equal("6jrfe :: State-funded secondary", results[0].Filters["school_type"]);
+            Assert.Equal("O7CLF :: Secondary sponsor led academy", results[0].Filters["academy_type"]);
+
+            Assert.Equal(GeographicLevel.School, results[0].GeographicLevel);
+
+            Assert.Equal(4, results[0].Locations.Count);
+            Assert.Equal("pTSoj :: England (code = E92000001)", results[0].Locations["NAT"]);
+            Assert.Equal("IzBzg :: Yorkshire and The Humber (code = E12000003)", results[0].Locations["REG"]);
+            Assert.Equal("7zXob :: Sheffield (code = E08000019, oldCode = 373)", results[0].Locations["LA"]);
+            Assert.Equal(
+                "HTzLj :: Newfield Secondary School (urn = 140821, laEstab = 3734008)",
+                results[0].Locations["SCH"]
+            );
+
+            Assert.Equal(TimeIdentifier.AcademicYear, results[0].TimePeriod.Code);
+            Assert.Equal("2022/2023", results[0].TimePeriod.Period);
+
+            Assert.Equal(2, results[0].Values.Count);
+            Assert.Equal("751028", results[0].Values["enrolments"]);
+            Assert.Equal("175843", results[0].Values["sess_authorised"]);
+
+            // Result 2
+
+            Assert.Equal(3, results[1].Filters.Count);
+            Assert.Equal("pTSoj :: Year 10", results[1].Filters["ncyear"]);
+            Assert.Equal("6jrfe :: State-funded secondary", results[1].Filters["school_type"]);
+            Assert.Equal("O7CLF :: Secondary sponsor led academy", results[1].Filters["academy_type"]);
+
+            Assert.Equal(GeographicLevel.School, results[1].GeographicLevel);
+
+            Assert.Equal(4, results[1].Locations.Count);
+            Assert.Equal("pTSoj :: England (code = E92000001)", results[1].Locations["NAT"]);
+            Assert.Equal("IzBzg :: Yorkshire and The Humber (code = E12000003)", results[1].Locations["REG"]);
+            Assert.Equal("7zXob :: Sheffield (code = E08000019, oldCode = 373)", results[1].Locations["LA"]);
+            Assert.Equal(
+                "HTzLj :: Newfield Secondary School (urn = 140821, laEstab = 3734008)",
+                results[1].Locations["SCH"]
+            );
+
+            Assert.Equal(TimeIdentifier.AcademicYear, results[1].TimePeriod.Code);
+            Assert.Equal("2021/2022", results[1].TimePeriod.Period);
+
+            Assert.Equal(2, results[1].Values.Count);
+            Assert.Equal("752009", results[1].Values["enrolments"]);
+            Assert.Equal("262396", results[1].Values["sess_authorised"]);
+        }
+    }
+
+    public class NotConditionTests(TestApplicationFactory testApp) : DataSetsControllerPostQueryTests(testApp)
+    {
+        private static readonly DataSetQueryCriteriaFacets BaseFacets = new()
+        {
+            Filters = new DataSetQueryCriteriaFilters
+            {
+                In = ["LxWjE", "7zXob"],
+            },
+            GeographicLevels = new DataSetGetQueryGeographicLevels
+            {
+                In = ["NAT", "REG", "LA"]
+            },
+            Locations = new DataSetQueryCriteriaLocations
+            {
+                In =
+                [
+                    new DataSetQueryLocationLocalAuthorityCode { Code = "E09000003" },
+                    new DataSetQueryLocationLocalAuthorityCode { Code = "E08000016" },
+                    new DataSetQueryLocationLocalAuthorityCode { Code = "E09000021 / E09000027" },
+                ]
+            },
+            TimePeriods = new DataSetQueryCriteriaTimePeriods
+            {
+                In =
+                [
+                    new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" },
+                    new DataSetQueryTimePeriod { Period = "2022/2023", Code = "AY" },
+                ]
+            }
+        };
+
+        public static readonly TheoryData<DataSetQueryCriteria> EquivalentCriteria = new()
+        {
+            new DataSetQueryCriteriaNot
+            {
+                Not = BaseFacets
+            },
+            new DataSetQueryCriteriaNot
+            {
+                Not = new DataSetQueryCriteriaNot
+                {
+                    Not = new DataSetQueryCriteriaNot
+                    {
+                        Not = BaseFacets
+                    }
+                }
+            },
+            new DataSetQueryCriteriaNot
+            {
+                Not = new DataSetQueryCriteriaNot
+                {
+                    Not = new DataSetQueryCriteriaAnd
+                    {
+                        And = [
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters
+                                {
+                                    NotEq = "7zXob",
+                                    In = ["9U4vZ", "O7CLF"]
+                                },
+                                GeographicLevels = new DataSetGetQueryGeographicLevels
+                                {
+                                    NotEq = "NAT"
+                                },
+                                Locations = new DataSetQueryCriteriaLocations
+                                {
+                                    Eq = new DataSetQueryLocationId { Level = "NAT", Id = "pTSoj" },
+                                    NotIn =
+                                    [
+                                        new DataSetQueryLocationCode { Level = "REG", Code = "E13000002" },
+                                        new DataSetQueryLocationLocalAuthorityOldCode { OldCode = "370" },
+                                    ]
+                                },
+                                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                                {
+                                    Eq = new DataSetQueryTimePeriod { Period = "2021/2022", Code = "AY" }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            new DataSetQueryCriteriaNot
+            {
+                Not = new DataSetQueryCriteriaOr
+                {
+                    Or =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                In = ["LxWjE", "7zXob"],
+                            },
+                        },
+                        new DataSetQueryCriteriaFacets
+                        {
+                            GeographicLevels = new DataSetGetQueryGeographicLevels
+                            {
+                                In = ["NAT", "REG", "LA"]
+                            },
+                        },
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Locations = new DataSetQueryCriteriaLocations
+                            {
+                                In =
+                                [
+                                    new DataSetQueryLocationLocalAuthorityCode { Code = "E09000003" },
+                                    new DataSetQueryLocationLocalAuthorityCode { Code = "E08000016" },
+                                    new DataSetQueryLocationLocalAuthorityCode { Code = "E09000021 / E09000027" },
+                                ]
+                            },
+                        },
+                        new DataSetQueryCriteriaFacets
+                        {
+                            TimePeriods = new DataSetQueryCriteriaTimePeriods
+                            {
+                                In =
+                                [
+                                    new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" },
+                                    new DataSetQueryTimePeriod { Period = "2022/2023", Code = "AY" },
+                                ]
+                            },
+                        }
+                    ]
+                }
+            },
+        };
+
+        [Theory]
+        [MemberData(nameof(EquivalentCriteria))]
+        public async Task EquivalentCriteria_Returns200(DataSetQueryCriteria criteria)
+        {
+            var dataSetVersion = await SetupDefaultDataSetVersion();
+
+            var response = await QueryDataSet(
+                dataSetId: dataSetVersion.DataSetId,
+                request: new DataSetQueryRequest
+                {
+                    Indicators = ["enrolments", "sess_authorised"],
+                    Debug = true,
+                    Criteria = criteria
+                }
+            );
+
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+
+            var result = Assert.Single(viewModel.Results);
+
+            Assert.Equal(3, result.Filters.Count);
+            Assert.Equal("pTSoj :: Year 10", result.Filters["ncyear"]);
+            Assert.Equal("6jrfe :: State-funded secondary", result.Filters["school_type"]);
+            Assert.Equal("O7CLF :: Secondary sponsor led academy", result.Filters["academy_type"]);
+
+            Assert.Equal(GeographicLevel.School, result.GeographicLevel);
+
+            Assert.Equal(4, result.Locations.Count);
+            Assert.Equal("pTSoj :: England (code = E92000001)", result.Locations["NAT"]);
+            Assert.Equal("IzBzg :: Yorkshire and The Humber (code = E12000003)", result.Locations["REG"]);
+            Assert.Equal("7zXob :: Sheffield (code = E08000019, oldCode = 373)", result.Locations["LA"]);
+            Assert.Equal(
+                "HTzLj :: Newfield Secondary School (urn = 140821, laEstab = 3734008)",
+                result.Locations["SCH"]
+            );
+
+            Assert.Equal(TimeIdentifier.AcademicYear, result.TimePeriod.Code);
+            Assert.Equal("2021/2022", result.TimePeriod.Period);
+
+            Assert.Equal(2, result.Values.Count);
+            Assert.Equal("752009", result.Values["enrolments"]);
+            Assert.Equal("262396", result.Values["sess_authorised"]);
+        }
+    }
+
+    private async Task<HttpResponseMessage> QueryDataSet(
+        Guid dataSetId,
+        DataSetQueryRequest request,
+        string? dataSetVersion = null)
+    {
+        var query = new Dictionary<string, StringValues>();
+
+        if (dataSetVersion is not null)
+        {
+            query["dataSetVersion"] = dataSetVersion;
+        }
+
+        var client = BuildApp().CreateClient();
+
+        var uri = QueryHelpers.AddQueryString($"{BaseUrl}/{dataSetId}/query", query);
+
+        return await client.PostAsJsonAsync(uri, request);
+    }
+
+    private async Task<DataSetVersion> SetupDefaultDataSetVersion(
+        DataSetVersionStatus versionStatus = DataSetVersionStatus.Published)
+    {
+        DataSet dataSet = DataFixture
+            .DefaultDataSet()
+            .WithStatusPublished();
+
+        await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+        DataSetVersion dataSetVersion = DataFixture
+            .DefaultDataSetVersion()
+            .WithDataSet(dataSet)
+            .WithMetaSummary(
+                DataFixture.DefaultDataSetVersionMetaSummary()
+                    .WithGeographicLevels(
+                        [
+                            GeographicLevel.Country,
+                            GeographicLevel.LocalAuthority,
+                            GeographicLevel.Region,
+                            GeographicLevel.School
+                        ]
+                    )
+            )
+            .WithStatus(versionStatus);
+
+        dataSet.LatestLiveVersion = dataSetVersion;
+
+        await TestApp.AddTestData<PublicDataDbContext>(
+            context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            }
+        );
+
+        return dataSetVersion;
+    }
+
+    private WebApplicationFactory<Startup> BuildApp()
+    {
+        return TestApp.ConfigureServices(services =>
+            services.ReplaceService<IParquetPathResolver>(_parquetPathResolver));
+    }
+
+    private static QueryResultsMeta GatherQueryResultsMeta(DataSetQueryPaginatedResultsViewModel viewModel)
+    {
+        var filters = new Dictionary<string, HashSet<string>>();
+        var locations = new Dictionary<string, HashSet<string>>();
+        var geographicLevels = new HashSet<GeographicLevel>();
+        var timePeriods = new HashSet<TimePeriodViewModel>();
+        var indicators = new HashSet<string>();
+
+        foreach (var result in viewModel.Results)
+        {
+            foreach (var filter in result.Filters)
+            {
+                if (!filters.ContainsKey(filter.Key))
+                {
+                    filters[filter.Key] = [filter.Value];
+                }
+                else
+                {
+                    filters[filter.Key].Add(filter.Value);
+                }
+            }
+
+            foreach (var location in result.Locations)
+            {
+                if (!locations.ContainsKey(location.Key))
+                {
+                    locations[location.Key] = [location.Value];
+                }
+                else
+                {
+                    locations[location.Key].Add(location.Value);
+                }
+            }
+
+            geographicLevels.Add(result.GeographicLevel);
+            timePeriods.Add(result.TimePeriod);
+            indicators.AddRange(result.Values.Keys);
+        }
+
+        return new QueryResultsMeta
+        {
+            Filters = filters,
+            Indicators = indicators,
+            Locations = locations,
+            GeographicLevels = geographicLevels,
+            TimePeriods = timePeriods,
+        };
+    }
+
+    private record QueryResultsMeta
+    {
+        public required Dictionary<string, HashSet<string>> Filters { get; init; } = [];
+        public required Dictionary<string, HashSet<string>> Locations { get; init; } = [];
+        public required HashSet<GeographicLevel> GeographicLevels { get; init; } = [];
+        public required HashSet<TimePeriodViewModel> TimePeriods { get; init; } = [];
+        public required HashSet<string> Indicators { get; init; } = [];
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryTimePeriodsValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetGetQueryTimePeriodsValidatorTests.cs
@@ -9,126 +9,153 @@ public abstract class DataSetGetQueryTimePeriodsValidatorTests
 {
     private readonly DataSetGetQueryTimePeriods.Validator _validator = new();
 
-    public static IEnumerable<object[]> ValidTimePeriodStringsSingle()
-    {
-        return
-        [
-            ["2020|AY"],
-            ["2020/2021|AY"],
-            ["2020|FY"],
-            ["2021|M1"],
-            ["2021|W40"],
-            ["2021|T3"],
-            ["2021/2022|T3"],
-            ["2019|FYQ4"],
-            ["2019/2020|FYQ4"],
-        ];
-    }
+    public static readonly TheoryData<DataSetQueryTimePeriod> ValidTimePeriodQueriesSingle =
+        DataSetQueryCriteriaTimePeriodsValidatorTests.ValidTimePeriodsSingle;
 
-    public static IEnumerable<object[]> ValidTimePeriodStringsMultiple()
-    {
-        return
-        [
-            ["2020|AY", "2020/2021|AY", "2020|FY"],
-            ["2021|M1", "2021|W40", "2021|T3"],
-            ["2021/2022|T3", "2019|FYQ4", "2019/2020|FYQ4"],
-        ];
-    }
+    public static readonly TheoryData<DataSetQueryTimePeriod[]> ValidTimePeriodQueriesMultiple =
+        DataSetQueryCriteriaTimePeriodsValidatorTests.ValidTimePeriodsMultiple;
 
-    public static IEnumerable<object[]> InvalidTimePeriodStringsSingle()
+    public static readonly TheoryData<string> InvalidTimePeriodFormatsSingle = new()
     {
-        return
-        [
-            [""],
-            ["Invalid"],
-            ["2022"],
-            ["2022/2023"],
-            ["20222"],
-            ["2022|ay"],
-            ["2022/2020|AY"],
-            ["2000/1999|AY"],
-            ["2022|YY"],
-            ["2022|WEEK12"],
-        ];
-    }
+        "",
+        "Invalid",
+        "2022",
+        "2022/2023",
+        "20222",
+        "|"
+    };
 
-    public static IEnumerable<object[]> InvalidTimePeriodStringsMultiple()
+    public static readonly TheoryData<string[]> InvalidTimePeriodFormatsMultiple = new()
     {
-        return
-        [
-            [],
-            ["", ""],
-            ["Invalid", "2022", "2022/2023"],
-            ["20222", "2022|ay"],
-            ["2022/2020|AY", "2000/1999|AY"],
-            ["2022|YY", "2022|WEEK12", "2022/2023|ZZ"]
-        ];
-    }
+        new[] { "", " ", null! },
+        new[] { "2022", "2022/2023" },
+        new[] { "Invalid", "|" },
+    };
+
+    public static readonly TheoryData<DataSetQueryTimePeriod> InvalidTimePeriodQueriesSingle =
+        DataSetQueryCriteriaTimePeriodsValidatorTests.InvalidTimePeriodsSingle;
+
+    public static readonly TheoryData<DataSetQueryTimePeriod[]> InvalidTimePeriodQueriesMultiple =
+        DataSetQueryCriteriaTimePeriodsValidatorTests.InvalidTimePeriodsMultiple;
 
     public class EqTests : DataSetGetQueryTimePeriodsValidatorTests
     {
         [Theory]
-        [MemberData(nameof(ValidTimePeriodStringsSingle))]
-        public void Success(string timePeriod)
+        [MemberData(nameof(ValidTimePeriodQueriesSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
         {
-            var query = new DataSetGetQueryTimePeriods { Eq = timePeriod };
+            var query = new DataSetGetQueryTimePeriods { Eq = timePeriod.ToTimePeriodString() };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
 
         [Theory]
-        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
-        public void Failure_InvalidString(string timePeriod)
+        [MemberData(nameof(InvalidTimePeriodFormatsSingle))]
+        public void Failure_InvalidFormat(string timePeriod)
         {
             var query = new DataSetGetQueryTimePeriods { Eq = timePeriod };
 
             _validator.TestValidate(query)
-                .ShouldHaveValidationErrorFor(q => q.Eq);
+                .ShouldHaveValidationErrorFor(q => q.Eq)
+                .Only();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodQueriesSingle))]
+        public void Failure_InvalidQuery(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Eq = timePeriod.ToTimePeriodString() };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Eq)
+                .Only();
         }
     }
 
     public class NotEqTests : DataSetGetQueryTimePeriodsValidatorTests
     {
         [Theory]
-        [MemberData(nameof(ValidTimePeriodStringsSingle))]
-        public void Success(string timePeriod)
+        [MemberData(nameof(ValidTimePeriodQueriesSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
         {
-            var query = new DataSetGetQueryTimePeriods { NotEq = timePeriod };
+            var query = new DataSetGetQueryTimePeriods { NotEq = timePeriod.ToTimePeriodString() };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
 
         [Theory]
-        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
-        public void Failure_InvalidString(string timePeriod)
+        [MemberData(nameof(InvalidTimePeriodFormatsSingle))]
+        public void Failure_InvalidFormat(string timePeriod)
         {
             var query = new DataSetGetQueryTimePeriods { NotEq = timePeriod };
 
             _validator.TestValidate(query)
-                .ShouldHaveValidationErrorFor(q => q.NotEq);
+                .ShouldHaveValidationErrorFor(q => q.NotEq)
+                .Only();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodQueriesSingle))]
+        public void Failure_InvalidQuery(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { NotEq = timePeriod.ToTimePeriodString() };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.NotEq)
+                .Only();
         }
     }
 
     public class InTests : DataSetGetQueryTimePeriodsValidatorTests
     {
         [Theory]
-        [MemberData(nameof(ValidTimePeriodStringsMultiple))]
-        public void Success(params string[] timePeriods)
+        [MemberData(nameof(ValidTimePeriodQueriesMultiple))]
+        public void Success(DataSetQueryTimePeriod[] timePeriods)
         {
-            var testObj = new DataSetGetQueryTimePeriods { In = timePeriods };
+            var query = new DataSetGetQueryTimePeriods
+            {
+                In = [..timePeriods.Select(t => t.ToTimePeriodString())]
+            };
 
-            _validator.TestValidate(testObj).ShouldNotHaveAnyValidationErrors();
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetGetQueryTimePeriods { In = [] };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.In)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
         }
 
         [Theory]
-        [MemberData(nameof(InvalidTimePeriodStringsMultiple))]
-        public void Failure_InvalidStrings(params string[] timePeriods)
+        [MemberData(nameof(InvalidTimePeriodFormatsMultiple))]
+        public void Failure_InvalidFormats(string[] timePeriods)
         {
             var query = new DataSetGetQueryTimePeriods { In = timePeriods };
 
             var result = _validator.TestValidate(query);
 
-            result.ShouldHaveValidationErrorFor(q => q.In);
+            Assert.Equal(timePeriods.Length, result.Errors.Count);
+
+            timePeriods.ForEach((_, index) => result.ShouldHaveValidationErrorFor($"In[{index}]"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodQueriesMultiple))]
+        public void Failure_InvalidQueries(DataSetQueryTimePeriod[] timePeriods)
+        {
+            var query = new DataSetGetQueryTimePeriods
+            {
+                In = [..timePeriods.Select(t => t.ToTimePeriodString())]
+            };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.Equal(timePeriods.Length, result.Errors.Count);
 
             timePeriods.ForEach((_, index) => result.ShouldHaveValidationErrorFor($"In[{index}]"));
         }
@@ -137,23 +164,47 @@ public abstract class DataSetGetQueryTimePeriodsValidatorTests
     public class NotInTests : DataSetGetQueryTimePeriodsValidatorTests
     {
         [Theory]
-        [MemberData(nameof(ValidTimePeriodStringsMultiple))]
-        public void Success(params string[] timePeriods)
+        [MemberData(nameof(ValidTimePeriodQueriesMultiple))]
+        public void Success(DataSetQueryTimePeriod[] timePeriods)
         {
-            var testObj = new DataSetGetQueryTimePeriods { NotIn = timePeriods };
+            var query = new DataSetGetQueryTimePeriods { NotIn = [..timePeriods.Select(t => t.ToTimePeriodString())] };
 
-            _validator.TestValidate(testObj).ShouldNotHaveAnyValidationErrors();
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetGetQueryTimePeriods { NotIn = [] };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
         }
 
         [Theory]
-        [MemberData(nameof(InvalidTimePeriodStringsMultiple))]
-        public void Failure_InvalidStrings(params string[] timePeriods)
+        [MemberData(nameof(InvalidTimePeriodFormatsMultiple))]
+        public void Failure_InvalidFormats(string[] timePeriods)
         {
             var query = new DataSetGetQueryTimePeriods { NotIn = timePeriods };
 
             var result = _validator.TestValidate(query);
 
-            result.ShouldHaveValidationErrorFor(q => q.NotIn);
+            Assert.Equal(timePeriods.Length, result.Errors.Count);
+
+            timePeriods.ForEach((_, index) => result.ShouldHaveValidationErrorFor($"NotIn[{index}]"));
+        }
+        
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodQueriesMultiple))]
+        public void Failure_InvalidQueries(DataSetQueryTimePeriod[] timePeriods)
+        {
+            var query = new DataSetGetQueryTimePeriods { NotIn = [..timePeriods.Select(t => t.ToTimePeriodString())] };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.Equal(timePeriods.Length, result.Errors.Count);
 
             timePeriods.ForEach((_, index) => result.ShouldHaveValidationErrorFor($"NotIn[{index}]"));
         }
@@ -162,88 +213,139 @@ public abstract class DataSetGetQueryTimePeriodsValidatorTests
     public class GtTests : DataSetGetQueryTimePeriodsValidatorTests
     {
         [Theory]
-        [MemberData(nameof(ValidTimePeriodStringsSingle))]
-        public void Success(string timePeriod)
+        [MemberData(nameof(ValidTimePeriodQueriesSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
         {
-            var query = new DataSetGetQueryTimePeriods { Gt = timePeriod };
+            var query = new DataSetGetQueryTimePeriods { Gt = timePeriod.ToTimePeriodString() };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
 
         [Theory]
-        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
-        public void Failure_InvalidString(string timePeriod)
+        [MemberData(nameof(InvalidTimePeriodFormatsSingle))]
+        public void Failure_InvalidFormat(string timePeriod)
         {
             var query = new DataSetGetQueryTimePeriods { Gt = timePeriod };
 
             _validator.TestValidate(query)
-                .ShouldHaveValidationErrorFor(q => q.Gt);
+                .ShouldHaveValidationErrorFor(q => q.Gt)
+                .Only();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodQueriesSingle))]
+        public void Failure_InvalidQuery(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Gt = timePeriod.ToTimePeriodString() };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Gt)
+                .Only();
         }
     }
 
     public class GteTests : DataSetGetQueryTimePeriodsValidatorTests
     {
         [Theory]
-        [MemberData(nameof(ValidTimePeriodStringsSingle))]
-        public void Success(string timePeriod)
+        [MemberData(nameof(ValidTimePeriodQueriesSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
         {
-            var query = new DataSetGetQueryTimePeriods { Gte = timePeriod };
+            var query = new DataSetGetQueryTimePeriods { Gte = timePeriod.ToTimePeriodString() };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
 
         [Theory]
-        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
-        public void Failure_InvalidString(string timePeriod)
+        [MemberData(nameof(InvalidTimePeriodFormatsSingle))]
+        public void Failure_InvalidFormat(string timePeriod)
         {
             var query = new DataSetGetQueryTimePeriods { Gte = timePeriod };
 
             _validator.TestValidate(query)
-                .ShouldHaveValidationErrorFor(q => q.Gte);
+                .ShouldHaveValidationErrorFor(q => q.Gte)
+                .Only();
+        }
+
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodQueriesSingle))]
+        public void Failure_InvalidQuery(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Gte = timePeriod.ToTimePeriodString() };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Gte)
+                .Only();
         }
     }
 
     public class LtTests : DataSetGetQueryTimePeriodsValidatorTests
     {
         [Theory]
-        [MemberData(nameof(ValidTimePeriodStringsSingle))]
-        public void Success(string timePeriod)
+        [MemberData(nameof(ValidTimePeriodQueriesSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
         {
-            var query = new DataSetGetQueryTimePeriods { Lt = timePeriod };
+            var query = new DataSetGetQueryTimePeriods { Lt = timePeriod.ToTimePeriodString() };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
 
         [Theory]
-        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
-        public void Failure_InvalidString(string timePeriod)
+        [MemberData(nameof(InvalidTimePeriodFormatsSingle))]
+        public void Failure_InvalidFormat(string timePeriod)
         {
             var query = new DataSetGetQueryTimePeriods { Lt = timePeriod };
 
             _validator.TestValidate(query)
-                .ShouldHaveValidationErrorFor(q => q.Lt);
+                .ShouldHaveValidationErrorFor(q => q.Lt)
+                .Only();
+        }
+
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodQueriesSingle))]
+        public void Failure_InvalidQuery(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Lt = timePeriod.ToTimePeriodString() };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Lt)
+                .Only();
         }
     }
 
     public class LteTests : DataSetGetQueryTimePeriodsValidatorTests
     {
         [Theory]
-        [MemberData(nameof(ValidTimePeriodStringsSingle))]
-        public void Success(string timePeriod)
+        [MemberData(nameof(ValidTimePeriodQueriesSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
         {
-            var query = new DataSetGetQueryTimePeriods { Lte = timePeriod };
+            var query = new DataSetGetQueryTimePeriods { Lte = timePeriod.ToTimePeriodString() };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
 
         [Theory]
-        [MemberData(nameof(InvalidTimePeriodStringsSingle))]
-        public void Failure_InvalidString(string timePeriod)
+        [MemberData(nameof(InvalidTimePeriodFormatsSingle))]
+        public void Failure_InvalidFormat(string timePeriod)
         {
             var query = new DataSetGetQueryTimePeriods { Lte = timePeriod };
 
             _validator.TestValidate(query)
-                .ShouldHaveValidationErrorFor(q => q.Lte);
+                .ShouldHaveValidationErrorFor(q => q.Lte)
+                .Only();
+        }
+
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodQueriesSingle))]
+        public void Failure_InvalidQuery(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetGetQueryTimePeriods { Lte = timePeriod.ToTimePeriodString() };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Lte)
+                .Only();
         }
     }
 
@@ -265,6 +367,8 @@ public abstract class DataSetGetQueryTimePeriodsValidatorTests
             };
 
             var result = _validator.TestValidate(query);
+
+            Assert.Equal(8, result.Errors.Count);
 
             result.ShouldHaveValidationErrorFor(q => q.Eq)
                 .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
@@ -300,6 +404,8 @@ public abstract class DataSetGetQueryTimePeriodsValidatorTests
             };
 
             var result = _validator.TestValidate(query);
+
+            Assert.Equal(4, result.Errors.Count);
 
             result.ShouldNotHaveValidationErrorFor(q => q.Eq);
             result.ShouldNotHaveValidationErrorFor(q => q.In);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaAndValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaAndValidatorTests.cs
@@ -1,0 +1,390 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public class DataSetQueryCriteriaAndValidatorTests
+{
+    private readonly DataSetQueryCriteriaAnd.Validator _validator = new();
+
+    [Fact]
+    public void Empty_Failure()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And = [],
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor(q => q.And)
+            .WithErrorCode(FluentValidationKeys.NotEmptyValidator)
+            .Only();
+    }
+
+    [Fact]
+    public void Nulls_Failure()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                null!,
+                new DataSetQueryCriteriaFacets()
+            ],
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("And[0]")
+            .WithErrorCode(FluentValidationKeys.NotNullValidator)
+            .Only();
+    }
+
+    [Fact]
+    public void SingleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters
+                    {
+                        Eq = "12345"
+                    },
+                },
+            ],
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void SingleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters
+                    {
+                        Eq = ""
+                    },
+                },
+            ],
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("And[0].Filters.Eq");
+    }
+
+    [Fact]
+    public void MultipleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters
+                    {
+                        Eq = "12345"
+                    }
+                },
+                new DataSetQueryCriteriaFacets
+                {
+                    TimePeriods = new DataSetQueryCriteriaTimePeriods
+                    {
+                        NotEq = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" }
+                    },
+                },
+            ],
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void MultipleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters
+                    {
+                        Eq = ""
+                    },
+                },
+                new DataSetQueryCriteriaFacets
+                {
+                    TimePeriods = new DataSetQueryCriteriaTimePeriods
+                    {
+                        Gte = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "Invalid" }
+                    },
+                },
+            ],
+        };
+
+        var result = _validator.TestValidate(query);
+
+        Assert.Equal(2, result.Errors.Count);
+
+        result.ShouldHaveValidationErrorFor("And[0].Filters.Eq");
+        result.ShouldHaveValidationErrorFor("And[1].TimePeriods.Gte.Code");
+    }
+
+    [Fact]
+    public void SingleCondition_Empty_Failure()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                new DataSetQueryCriteriaOr
+                {
+                    Or = [],
+                },
+            ],
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("And[0].Or")
+            .Only();
+    }
+
+    [Fact]
+    public void SingleCondition_SingleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                new DataSetQueryCriteriaOr
+                {
+                    Or =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = "12345"
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void SingleCondition_SingleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                new DataSetQueryCriteriaOr
+                {
+                    Or =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = new string('x', 11)
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("And[0].Or[0].Filters.Eq")
+            .Only();
+    }
+
+    [Fact]
+    public void MultipleConditions_SingleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                new DataSetQueryCriteriaAnd
+                {
+                    And =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = "12345"
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaOr
+                {
+                    Or =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            TimePeriods = new DataSetQueryCriteriaTimePeriods
+                            {
+                                Gte = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" }
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaNot
+                {
+                    Not =new DataSetQueryCriteriaFacets
+                    {
+                        Locations = new DataSetQueryCriteriaLocations
+                        {
+                            In = [new DataSetQueryLocationId { Level = "NAT", Id = "12345" }],
+                        },
+                    },
+                },
+            ],
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void MultipleConditions_SingleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                new DataSetQueryCriteriaAnd
+                {
+                    And =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = new string('x', 11)
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaOr
+                {
+                    Or =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            TimePeriods = new DataSetQueryCriteriaTimePeriods
+                            {
+                                Gte = new DataSetQueryTimePeriod { Period = "", Code = "AY" }
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaNot
+                {
+                    Not =new DataSetQueryCriteriaFacets
+                    {
+                        Locations = new DataSetQueryCriteriaLocations
+                        {
+                            In = [new DataSetQueryLocationId { Level = "nat", Id = "12345" }],
+                        },
+                    },
+                },
+            ],
+        };
+
+        var result = _validator.TestValidate(query);
+
+        Assert.Equal(3, result.Errors.Count);
+
+        result.ShouldHaveValidationErrorFor("And[0].And[0].Filters.Eq");
+        result.ShouldHaveValidationErrorFor("And[1].Or[0].TimePeriods.Gte.Period");
+        result.ShouldHaveValidationErrorFor("And[2].Not.Locations.In[0].Level");
+    }
+
+    [Fact]
+    public void MixedCriteria_SingleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                new DataSetQueryCriteriaAnd
+                {
+                    And =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = "12345"
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaFacets
+                {
+                    TimePeriods = new DataSetQueryCriteriaTimePeriods
+                    {
+                        Gte = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" }
+                    },
+                },
+            ],
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void MixedCriteria_SingleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaAnd
+        {
+            And =
+            [
+                new DataSetQueryCriteriaAnd
+                {
+                    And =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = new string('x', 11)
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaFacets
+                {
+                    TimePeriods = new DataSetQueryCriteriaTimePeriods
+                    {
+                        Gte = new DataSetQueryTimePeriod { Period = "", Code = "AY" }
+                    },
+                },
+            ],
+        };
+
+        var result = _validator.TestValidate(query);
+
+        Assert.Equal(2, result.Errors.Count);
+
+        result.ShouldHaveValidationErrorFor("And[0].And[0].Filters.Eq");
+        result.ShouldHaveValidationErrorFor("And[1].TimePeriods.Gte.Period");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaFacetsValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaFacetsValidatorTests.cs
@@ -1,0 +1,210 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Validators.ValidationMessages;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public abstract class DataSetQueryCriteriaFacetsValidatorTests
+{
+    private readonly DataSetQueryCriteriaFacets.Validator _validator = new();
+
+    public class FiltersTests : DataSetQueryCriteriaFacetsValidatorTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var facets = new DataSetQueryCriteriaFacets
+            {
+                Filters = new DataSetGetQueryFilters
+                {
+                    Eq = "abc"
+                },
+            };
+
+            _validator.TestValidate(facets).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            var facets = new DataSetQueryCriteriaFacets
+            {
+                Filters = new DataSetGetQueryFilters
+                {
+                    Eq = ""
+                },
+            };
+
+            _validator.TestValidate(facets)
+                .ShouldHaveValidationErrorFor(f => f.Filters!.Eq)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+
+    public class GeographicLevelsTests : DataSetQueryCriteriaFacetsValidatorTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var facets = new DataSetQueryCriteriaFacets
+            {
+                GeographicLevels = new DataSetGetQueryGeographicLevels
+                {
+                    Eq = "NAT"
+                },
+            };
+
+            _validator.TestValidate(facets).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            var facets = new DataSetQueryCriteriaFacets
+            {
+                GeographicLevels = new DataSetGetQueryGeographicLevels
+                {
+                    Eq = "Invalid"
+                },
+            };
+
+            _validator.TestValidate(facets)
+                .ShouldHaveValidationErrorFor(f => f.GeographicLevels!.Eq)
+                .WithErrorCode(Common.Validators.ValidationMessages.AllowedValue.Code);
+        }
+    }
+
+    public class LocationsTests : DataSetQueryCriteriaFacetsValidatorTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var facets = new DataSetQueryCriteriaFacets
+            {
+                Locations = new DataSetQueryCriteriaLocations
+                {
+                    Eq = new DataSetQueryLocationId { Level = "NAT", Id = "12345" },
+                },
+            };
+
+            _validator.TestValidate(facets).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            var facets = new DataSetQueryCriteriaFacets
+            {
+                Locations = new DataSetQueryCriteriaLocations
+                {
+                    Eq = new DataSetQueryLocationId { Level = "Invalid", Id = "12345" },
+                },
+            };
+
+            _validator.TestValidate(facets)
+                .ShouldHaveValidationErrorFor(f => f.Locations!.Eq!.Level)
+                .WithErrorCode(Common.Validators.ValidationMessages.AllowedValue.Code);
+        }
+    }
+
+    public class TimePeriodsTests : DataSetQueryCriteriaFacetsValidatorTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var facets = new DataSetQueryCriteriaFacets
+            {
+                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                {
+                    Eq = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" },
+                },
+            };
+
+            _validator.TestValidate(facets).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            var facets = new DataSetQueryCriteriaFacets
+            {
+                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                {
+                    Eq = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "Invalid" }
+                },
+            };
+
+            _validator.TestValidate(facets)
+                .ShouldHaveValidationErrorFor(f => f.TimePeriods!.Eq!.Code)
+                .WithErrorCode(ValidationMessages.TimePeriodAllowedCode.Code);
+        }
+    }
+
+    public class MixtureTests : DataSetQueryCriteriaFacetsValidatorTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var facets = new DataSetQueryCriteriaFacets
+            {
+                Filters = new DataSetGetQueryFilters
+                {
+                    Eq = "abc"
+                },
+                Locations = new DataSetQueryCriteriaLocations
+                {
+                    Eq = new DataSetQueryLocationId { Level = "NAT", Id = "12345" },
+                },
+                GeographicLevels = new DataSetGetQueryGeographicLevels
+                {
+                    Eq = "NAT"
+                },
+                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                {
+                    Eq = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" },
+                },
+            };
+
+            _validator.TestValidate(facets).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            var facets = new DataSetQueryCriteriaFacets
+            {
+                Filters = new DataSetGetQueryFilters
+                {
+                    Eq = ""
+                },
+                GeographicLevels = new DataSetGetQueryGeographicLevels
+                {
+                    Eq = "Invalid"
+                },
+                Locations = new DataSetQueryCriteriaLocations
+                {
+                    Eq = new DataSetQueryLocationId { Level = "REG", Id = new string('x', 11) },
+                },
+                TimePeriods = new DataSetQueryCriteriaTimePeriods
+                {
+                    Eq = new DataSetQueryTimePeriod { Period = "2020/2018", Code = "AY" },
+                },
+            };
+
+            var result = _validator.TestValidate(facets);
+
+            result.ShouldHaveValidationErrorFor(f => f.Filters!.Eq)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+
+            result.ShouldHaveValidationErrorFor(f => f.GeographicLevels!.Eq)
+                .WithErrorCode(Common.Validators.ValidationMessages.AllowedValue.Code);
+
+            result.ShouldHaveValidationErrorFor("Locations.Eq.Id")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+
+            result.ShouldHaveValidationErrorFor(f => f.TimePeriods!.Eq!.Period)
+                .WithErrorCode(ValidationMessages.TimePeriodInvalidYearRange.Code);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaFiltersValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaFiltersValidatorTests.cs
@@ -4,23 +4,32 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
 
-public abstract class DataSetGetQueryFiltersValidatorTests
+public class DataSetQueryCriteriaFiltersValidatorTests
 {
-    private readonly DataSetGetQueryFilters.Validator _validator = new();
+    private readonly DataSetQueryCriteriaFilters.Validator _validator = new();
 
-    public static readonly TheoryData<string?> ValidFiltersSingle =
-        DataSetQueryCriteriaFiltersValidatorTests.ValidFiltersSingle;
+    public static readonly TheoryData<string?> ValidFiltersSingle = new()
+    {
+       null,
+       "abc",
+       "12345",
+       "123456789",
+       "1234567890",
+    };
 
-    public static readonly TheoryData<string[]> ValidFiltersMultiple =
-        DataSetQueryCriteriaFiltersValidatorTests.ValidFiltersMultiple;
+    public static readonly TheoryData<string[]> ValidFiltersMultiple = new()
+    {
+        new [] { "abc", "12345", "123456789" },
+        new [] { "1234567890", "123", "abcde" },
+    };
 
-    public class EqTests : DataSetGetQueryFiltersValidatorTests
+    public class EqTests : DataSetQueryCriteriaFiltersValidatorTests
     {
         [Theory]
         [MemberData(nameof(ValidFiltersSingle))]
         public void Success(string? filter)
         {
-            var query = new DataSetGetQueryFilters { Eq = filter };
+            var query = new DataSetQueryCriteriaFilters { Eq = filter };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
@@ -28,33 +37,31 @@ public abstract class DataSetGetQueryFiltersValidatorTests
         [Fact]
         public void Failure_Empty()
         {
-            var query = new DataSetGetQueryFilters { Eq = "" };
+            var query = new DataSetQueryCriteriaFilters { Eq = "" };
 
             _validator.TestValidate(query)
                 .ShouldHaveValidationErrorFor(q => q.Eq)
-                .WithErrorCode(FluentValidationKeys.NotEmptyValidator)
-                .Only();
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
         }
 
         [Fact]
         public void Failure_MaxLength()
         {
-            var query = new DataSetGetQueryFilters { Eq = "12345678901" };
+            var query = new DataSetQueryCriteriaFilters { Eq = "12345678901" };
 
             _validator.TestValidate(query)
                 .ShouldHaveValidationErrorFor(q => q.Eq)
-                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator)
-                .Only();
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
         }
     }
 
-    public class NotEqTests : DataSetGetQueryFiltersValidatorTests
+    public class NotEqTests : DataSetQueryCriteriaFiltersValidatorTests
     {
         [Theory]
         [MemberData(nameof(ValidFiltersSingle))]
         public void Success(string? filter)
         {
-            var query = new DataSetGetQueryFilters { NotEq = filter };
+            var query = new DataSetQueryCriteriaFilters { NotEq = filter };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
@@ -62,33 +69,31 @@ public abstract class DataSetGetQueryFiltersValidatorTests
         [Fact]
         public void Failure_Empty()
         {
-            var query = new DataSetGetQueryFilters { NotEq = "" };
+            var query = new DataSetQueryCriteriaFilters { NotEq = "" };
 
             _validator.TestValidate(query)
                 .ShouldHaveValidationErrorFor(q => q.NotEq)
-                .WithErrorCode(FluentValidationKeys.NotEmptyValidator)
-                .Only();
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
         }
 
         [Fact]
         public void Failure_MaxLength()
         {
-            var query = new DataSetGetQueryFilters { NotEq = "12345678901" };
+            var query = new DataSetQueryCriteriaFilters { NotEq = "12345678901" };
 
             _validator.TestValidate(query)
                 .ShouldHaveValidationErrorFor(q => q.NotEq)
-                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator)
-                .Only();
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
         }
     }
 
-    public class InTests : DataSetGetQueryFiltersValidatorTests
+    public class InTests : DataSetQueryCriteriaFiltersValidatorTests
     {
         [Theory]
         [MemberData(nameof(ValidFiltersMultiple))]
         public void Success(params string[] filters)
         {
-            var query = new DataSetGetQueryFilters { In = filters };
+            var query = new DataSetQueryCriteriaFilters { In = filters };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
@@ -96,26 +101,15 @@ public abstract class DataSetGetQueryFiltersValidatorTests
         [Fact]
         public void Success_Null()
         {
-            var query = new DataSetGetQueryFilters { In = null };
+            var query = new DataSetQueryCriteriaFilters { In = null };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
 
         [Fact]
-        public void Failure_Empty()
-        {
-            var query = new DataSetGetQueryFilters { In = [] };
-
-            var result = _validator.TestValidate(query);
-
-            result.ShouldHaveValidationErrorFor(q => q.In)
-                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
-        }
-
-        [Fact]
         public void Failure_EmptyValues()
         {
-            var query = new DataSetGetQueryFilters
+            var query = new DataSetQueryCriteriaFilters
             {
                 In = ["", " ", null!]
             };
@@ -135,7 +129,7 @@ public abstract class DataSetGetQueryFiltersValidatorTests
         [Fact]
         public void Failure_MaxLengths()
         {
-            var query = new DataSetGetQueryFilters
+            var query = new DataSetQueryCriteriaFilters
             {
                 In = ["12345678901", "999999999999999"]
             };
@@ -151,13 +145,13 @@ public abstract class DataSetGetQueryFiltersValidatorTests
         }
     }
 
-    public class NotInTests : DataSetGetQueryFiltersValidatorTests
+    public class NotInTests : DataSetQueryCriteriaFiltersValidatorTests
     {
         [Theory]
         [MemberData(nameof(ValidFiltersMultiple))]
         public void Success(params string[] filters)
         {
-            var query = new DataSetGetQueryFilters { NotIn = filters };
+            var query = new DataSetQueryCriteriaFilters { NotIn = filters };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
@@ -165,26 +159,15 @@ public abstract class DataSetGetQueryFiltersValidatorTests
         [Fact]
         public void Success_Null()
         {
-            var query = new DataSetGetQueryFilters { NotIn = null };
+            var query = new DataSetQueryCriteriaFilters { NotIn = null };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
 
         [Fact]
-        public void Failure_Empty()
-        {
-            var query = new DataSetGetQueryFilters { NotIn = [] };
-
-            var result = _validator.TestValidate(query);
-
-            result.ShouldHaveValidationErrorFor(q => q.NotIn)
-                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
-        }
-
-        [Fact]
         public void Failure_EmptyValues()
         {
-            var query = new DataSetGetQueryFilters
+            var query = new DataSetQueryCriteriaFilters
             {
                 NotIn = ["", " ", null!]
             };
@@ -204,7 +187,7 @@ public abstract class DataSetGetQueryFiltersValidatorTests
         [Fact]
         public void Failure_MaxLengths()
         {
-            var query = new DataSetGetQueryFilters
+            var query = new DataSetQueryCriteriaFilters
             {
                 NotIn = ["12345678901", "999999999999999"]
             };
@@ -220,12 +203,12 @@ public abstract class DataSetGetQueryFiltersValidatorTests
         }
     }
 
-    public class EmptyTests : DataSetGetQueryFiltersValidatorTests
+    public class EmptyTests : DataSetQueryCriteriaFiltersValidatorTests
     {
         [Fact]
         public void AllEmpty_Failure()
         {
-            var query = new DataSetGetQueryFilters
+            var query = new DataSetQueryCriteriaFilters
             {
                 Eq = "",
                 NotEq = "",
@@ -250,7 +233,7 @@ public abstract class DataSetGetQueryFiltersValidatorTests
         [Fact]
         public void SomeEmpty_Failure()
         {
-            var query = new DataSetGetQueryFilters
+            var query = new DataSetQueryCriteriaFilters
             {
                 Eq = "123",
                 NotEq = "",

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaGeographicLevelsValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaGeographicLevelsValidatorTests.cs
@@ -7,29 +7,52 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
 
-public abstract class DataSetGetQueryGeographicLevelsValidatorTests
+public abstract class DataSetQueryCriteriaGeographicLevelsValidatorTests
 {
-    private readonly DataSetGetQueryGeographicLevels.Validator _validator = new();
+    private readonly DataSetQueryCriteriaGeographicLevels.Validator _validator = new();
 
-    public static readonly TheoryData<string?> ValidGeographicLevelsSingle =
-        DataSetQueryCriteriaGeographicLevelsValidatorTests.ValidGeographicLevelsSingle;
+    public static readonly TheoryData<string?> ValidGeographicLevelsSingle = new()
+    {
+        "NAT",
+        "LA",
+        null,
+    };
 
-    public static readonly TheoryData<string[]> ValidGeographicLevelsMultiple =
-        DataSetQueryCriteriaGeographicLevelsValidatorTests.ValidGeographicLevelsMultiple;
+    public static readonly TheoryData<string[]> ValidGeographicLevelsMultiple = new()
+    {
+        new [] { "NAT", "LA", "REG" },
+        new [] { "SCH", "NAT" },
+        new [] { "PROV" },
+    };
 
-    public static readonly TheoryData<string> InvalidGeographicLevelsSingle =
-        DataSetQueryCriteriaGeographicLevelsValidatorTests.InvalidGeographicLevelsSingle;
+    public static readonly  TheoryData<string> InvalidGeographicLevelsSingle = new()
+    {
+        "",
+        " ",
+        "Invalid",
+        "National",
+        "nat",
+        "la",
+        "1",
+    };
 
-    public static readonly TheoryData<string[]> InvalidGeographicLevelsMultiple =
-        DataSetQueryCriteriaGeographicLevelsValidatorTests.InvalidGeographicLevelsMultiple;
+    public static readonly TheoryData<string[]> InvalidGeographicLevelsMultiple = new()
+    {
+        new [] { "", " ", null! },
+        new [] { "Invalid1", "Invalid2" },
+        new [] { "National", "LocalAuthority" },
+        new [] { "nat", "la" },
+        new [] { "Local authority" },
+        new [] { "National" },
+    };
 
-    public class EqTests : DataSetGetQueryGeographicLevelsValidatorTests
+    public class EqTests : DataSetQueryCriteriaGeographicLevelsValidatorTests
     {
         [Theory]
         [MemberData(nameof(ValidGeographicLevelsSingle))]
         public void Success(string? geographicLevel)
         {
-            var query = new DataSetGetQueryGeographicLevels { Eq = geographicLevel };
+            var query = new DataSetQueryCriteriaGeographicLevels { Eq = geographicLevel };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
@@ -38,7 +61,7 @@ public abstract class DataSetGetQueryGeographicLevelsValidatorTests
         [MemberData(nameof(InvalidGeographicLevelsSingle))]
         public void Failure_NotAllowed(string geographicLevel)
         {
-            var query = new DataSetGetQueryGeographicLevels { Eq = geographicLevel };
+            var query = new DataSetQueryCriteriaGeographicLevels { Eq = geographicLevel };
 
             var result = _validator.TestValidate(query);
 
@@ -52,13 +75,13 @@ public abstract class DataSetGetQueryGeographicLevelsValidatorTests
         }
     }
 
-    public class NotEqTests : DataSetGetQueryGeographicLevelsValidatorTests
+    public class NotEqTests : DataSetQueryCriteriaGeographicLevelsValidatorTests
     {
         [Theory]
         [MemberData(nameof(ValidGeographicLevelsSingle))]
         public void Success(string? geographicLevel)
         {
-            var query = new DataSetGetQueryGeographicLevels { NotEq = geographicLevel };
+            var query = new DataSetQueryCriteriaGeographicLevels { NotEq = geographicLevel };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
@@ -67,7 +90,7 @@ public abstract class DataSetGetQueryGeographicLevelsValidatorTests
         [MemberData(nameof(InvalidGeographicLevelsSingle))]
         public void Failure_NotAllowed(string geographicLevel)
         {
-            var query = new DataSetGetQueryGeographicLevels { NotEq = geographicLevel };
+            var query = new DataSetQueryCriteriaGeographicLevels { NotEq = geographicLevel };
 
             var result = _validator.TestValidate(query);
 
@@ -81,13 +104,13 @@ public abstract class DataSetGetQueryGeographicLevelsValidatorTests
         }
     }
 
-    public class InTests : DataSetGetQueryGeographicLevelsValidatorTests
+    public class InTests : DataSetQueryCriteriaGeographicLevelsValidatorTests
     {
         [Theory]
         [MemberData(nameof(ValidGeographicLevelsMultiple))]
         public void Success(params string[] geographicLevels)
         {
-            var query = new DataSetGetQueryGeographicLevels { In = geographicLevels };
+            var query = new DataSetQueryCriteriaGeographicLevels { In = geographicLevels };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
@@ -95,27 +118,16 @@ public abstract class DataSetGetQueryGeographicLevelsValidatorTests
         [Fact]
         public void Success_Null()
         {
-            var query = new DataSetGetQueryGeographicLevels { In = null };
+            var query = new DataSetQueryCriteriaGeographicLevels { In = null };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
-        }
-
-        [Fact]
-        public void Failure_Empty()
-        {
-            var query = new DataSetGetQueryGeographicLevels { In = [] };
-
-            var result = _validator.TestValidate(query);
-
-            result.ShouldHaveValidationErrorFor(q => q.In)
-                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
         }
 
         [Theory]
         [MemberData(nameof(InvalidGeographicLevelsMultiple))]
         public void Failure_NotAllowed(params string[] geographicLevels)
         {
-            var query = new DataSetGetQueryGeographicLevels { In = geographicLevels };
+            var query = new DataSetQueryCriteriaGeographicLevels { In = geographicLevels };
 
             var result = _validator.TestValidate(query);
 
@@ -134,13 +146,13 @@ public abstract class DataSetGetQueryGeographicLevelsValidatorTests
         }
     }
 
-    public class NotInTests : DataSetGetQueryGeographicLevelsValidatorTests
+    public class NotInTests : DataSetQueryCriteriaGeographicLevelsValidatorTests
     {
         [Theory]
         [MemberData(nameof(ValidGeographicLevelsMultiple))]
         public void Success(params string[] geographicLevels)
         {
-            var query = new DataSetGetQueryGeographicLevels { NotIn = geographicLevels };
+            var query = new DataSetQueryCriteriaGeographicLevels { NotIn = geographicLevels };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
@@ -148,7 +160,7 @@ public abstract class DataSetGetQueryGeographicLevelsValidatorTests
         [Fact]
         public void Success_Null()
         {
-            var query = new DataSetGetQueryGeographicLevels { In = null };
+            var query = new DataSetQueryCriteriaGeographicLevels { NotIn = null };
 
             _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
         }
@@ -158,7 +170,7 @@ public abstract class DataSetGetQueryGeographicLevelsValidatorTests
         [MemberData(nameof(InvalidGeographicLevelsMultiple))]
         public void Failure_NotAllowed(params string[] geographicLevels)
         {
-            var query = new DataSetGetQueryGeographicLevels { In = geographicLevels };
+            var query = new DataSetQueryCriteriaGeographicLevels { NotIn = geographicLevels };
 
             var result = _validator.TestValidate(query);
 
@@ -166,7 +178,7 @@ public abstract class DataSetGetQueryGeographicLevelsValidatorTests
 
             foreach (var (error, index) in result.Errors.WithIndex())
             {
-                result.ShouldHaveValidationErrorFor($"In[{index}]")
+                result.ShouldHaveValidationErrorFor($"NotIn[{index}]")
                     .WithErrorCode(ValidationMessages.AllowedValue.Code)
                     .WithErrorMessage(ValidationMessages.AllowedValue.Message)
                     .WithCustomState<AllowedValueValidator.AllowedErrorDetail<string>>(s =>
@@ -177,12 +189,12 @@ public abstract class DataSetGetQueryGeographicLevelsValidatorTests
         }
     }
 
-    public class EmptyTests : DataSetGetQueryGeographicLevelsValidatorTests
+    public class EmptyTests : DataSetQueryCriteriaGeographicLevelsValidatorTests
     {
         [Fact]
         public void AllEmpty_Failure()
         {
-            var query = new DataSetGetQueryGeographicLevels
+            var query = new DataSetQueryCriteriaGeographicLevels
             {
                 Eq = "",
                 NotEq = "",
@@ -207,7 +219,7 @@ public abstract class DataSetGetQueryGeographicLevelsValidatorTests
         [Fact]
         public void SomeEmpty_Failure()
         {
-            var query = new DataSetGetQueryGeographicLevels
+            var query = new DataSetQueryCriteriaGeographicLevels
             {
                 Eq = "NAT",
                 NotEq = "",

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaLocationsValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaLocationsValidatorTests.cs
@@ -1,0 +1,262 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public class DataSetQueryCriteriaLocationsValidatorTests
+{
+    private readonly DataSetQueryCriteriaLocations.Validator _validator = new();
+
+    public static readonly TheoryData<DataSetQueryLocation> ValidLocationsSingle = new()
+    {
+        new DataSetQueryLocationId { Level = "NAT", Id = "12345" },
+        new DataSetQueryLocationId { Level = "REG", Id = "12345" },
+        new DataSetQueryLocationId { Level = "LA", Id = "12345" },
+        new DataSetQueryLocationId { Level = "SCH", Id = "12345" },
+        new DataSetQueryLocationId { Level = "PROV", Id = "12345" },
+        new DataSetQueryLocationCode { Level = "NAT", Code = "E92000001" },
+        new DataSetQueryLocationCode { Level = "REG", Code = "E12000003" },
+        new DataSetQueryLocationLocalAuthorityCode { Code = "E08000019" },
+        new DataSetQueryLocationLocalAuthorityCode { Code = "E09000021 / E09000027" },
+        new DataSetQueryLocationLocalAuthorityOldCode { OldCode = "373" },
+        new DataSetQueryLocationLocalAuthorityOldCode { OldCode = "314 / 318" },
+        new DataSetQueryLocationSchoolUrn { Urn = "107029" },
+        new DataSetQueryLocationSchoolLaEstab { LaEstab = "3732060" },
+        new DataSetQueryLocationProviderUkprn { Ukprn = "10066874" },
+    };
+
+    public static readonly TheoryData<DataSetQueryLocation[]> ValidLocationsMultiple = new()
+    {
+         new DataSetQueryLocation[]
+         {
+             new DataSetQueryLocationId { Level = "NAT", Id = "12345" },
+             new DataSetQueryLocationCode { Level = "NAT", Code = "E92000001" },
+         },
+         new DataSetQueryLocation[]
+         {
+             new DataSetQueryLocationId { Level = "REG", Id = "12345" },
+             new DataSetQueryLocationCode { Level = "REG", Code = "E12000003" },
+         },
+         new DataSetQueryLocation[]
+         {
+             new DataSetQueryLocationId { Level = "LA", Id = "12345" },
+             new DataSetQueryLocationLocalAuthorityCode { Code = "E08000019" },
+             new DataSetQueryLocationLocalAuthorityOldCode { OldCode = "373" },
+         },
+         new DataSetQueryLocation[]
+         {
+             new DataSetQueryLocationId { Level = "SCH", Id = "12345" },
+             new DataSetQueryLocationSchoolUrn { Urn = "107029" },
+             new DataSetQueryLocationSchoolLaEstab { LaEstab = "3732060" },
+         },
+         new DataSetQueryLocation[]
+         {
+             new DataSetQueryLocationId { Level = "PROV", Id = "12345" },
+             new DataSetQueryLocationProviderUkprn { Ukprn = "10066874" },
+         }
+    };
+
+    public static readonly TheoryData<DataSetQueryLocation> InvalidLocationsSingle = new()
+    {
+        new DataSetQueryLocationId { Level = "", Id = "" },
+        new DataSetQueryLocationId { Level = "NAT", Id = "" },
+        new DataSetQueryLocationCode { Level = "REG", Code = "" },
+        new DataSetQueryLocationLocalAuthorityCode { Code = "" },
+        new DataSetQueryLocationId { Level = "NA", Id = "12345" },
+        new DataSetQueryLocationId { Level = "la", Id = "12345" },
+        new DataSetQueryLocationId { Level = "", Id = "12345" },
+        new DataSetQueryLocationId { Level = "NAT", Id = new string('x', 26) },
+        new DataSetQueryLocationCode { Level = "REG", Code = new string('x', 26) },
+        new DataSetQueryLocationProviderUkprn { Ukprn = new string('x', 9) },
+        new DataSetQueryLocationSchoolUrn { Urn = new string('x', 7) },
+    };
+
+    public static readonly TheoryData<DataSetQueryLocation[]> InvalidLocationsMultiple = new()
+    {
+        new DataSetQueryLocation[]
+        {
+            new DataSetQueryLocationId { Level = "", Id = "" },
+            new DataSetQueryLocationId { Level = "NAT", Id = "" },
+            new DataSetQueryLocationCode { Level = "REG", Code = "" },
+            new DataSetQueryLocationLocalAuthorityCode { Code = "" },
+        },
+        new DataSetQueryLocation[]
+        {
+            new DataSetQueryLocationId { Level = "NA", Id = "12345" },
+            new DataSetQueryLocationId { Level = "la", Id = "12345" },
+            new DataSetQueryLocationId { Level = "", Id = "12345" },
+        },
+        new DataSetQueryLocation[]
+        {
+            new DataSetQueryLocationId { Level = "NAT", Id = new string('x', 26) },
+            new DataSetQueryLocationCode { Level = "REG", Code = new string('x', 26) },
+            new DataSetQueryLocationProviderUkprn { Ukprn = new string('x', 9) },
+            new DataSetQueryLocationSchoolUrn { Urn = new string('x', 7) },
+        },
+    };
+
+    public class EqTests : DataSetQueryCriteriaLocationsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidLocationsSingle))]
+        public void Success(DataSetQueryLocation location)
+        {
+            var query = new DataSetQueryCriteriaLocations { Eq = location };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidLocationsSingle))]
+        public void Failure(DataSetQueryLocation location)
+        {
+            var query = new DataSetQueryCriteriaLocations { Eq = location };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.NotEmpty(result.Errors);
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("Eq", error.PropertyName));
+        }
+    }
+
+    public class NotEqTests : DataSetQueryCriteriaLocationsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidLocationsSingle))]
+        public void Success(DataSetQueryLocation location)
+        {
+            var query = new DataSetQueryCriteriaLocations { NotEq = location };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidLocationsSingle))]
+        public void Failure(DataSetQueryLocation location)
+        {
+            var query = new DataSetQueryCriteriaLocations { NotEq = location };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.NotEmpty(result.Errors);
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("NotEq", error.PropertyName));
+        }
+    }
+
+    public class InTests : DataSetQueryCriteriaLocationsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidLocationsMultiple))]
+        public void Success(params DataSetQueryLocation[] locations)
+        {
+            var query = new DataSetQueryCriteriaLocations { In = locations };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidLocationsMultiple))]
+        public void Failure(DataSetQueryLocation[] locations)
+        {
+            var query = new DataSetQueryCriteriaLocations { In = locations };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.True(
+                result.Errors.Count >= locations.Length,
+                "Must have at least as many errors as locations");
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("In", error.PropertyName));
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetQueryCriteriaLocations { In = [] };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.In)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+
+    public class NotInTests : DataSetQueryCriteriaLocationsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidLocationsMultiple))]
+        public void Success(params DataSetQueryLocation[] locations)
+        {
+            var query = new DataSetQueryCriteriaLocations { NotIn = locations };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidLocationsMultiple))]
+        public void Failure(params DataSetQueryLocation[] locations)
+        {
+            var query = new DataSetQueryCriteriaLocations { NotIn = locations };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.True(
+                result.Errors.Count >= locations.Length,
+                "Must have at least as many errors as locations");
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("NotIn", error.PropertyName));
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetQueryCriteriaLocations { NotIn = [] };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+
+    public class EmptyTests : DataSetQueryCriteriaLocationsValidatorTests
+    {
+        [Fact]
+        public void AllNull_Success()
+        {
+            var query = new DataSetQueryCriteriaLocations();
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void SomeEmpty_Failure()
+        {
+            var query = new DataSetQueryCriteriaLocations
+            {
+                Eq = new DataSetQueryLocationId { Level = "NAT", Id = "12345" },
+                NotEq = null,
+                In = [new DataSetQueryLocationCode { Level = "REG", Code = "12345" }],
+                NotIn = []
+            };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.Single(result.Errors);
+
+            result.ShouldNotHaveValidationErrorFor(q => q.Eq);
+            result.ShouldNotHaveValidationErrorFor(q => q.In);
+            result.ShouldNotHaveValidationErrorFor(q => q.NotEq);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaNotValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaNotValidatorTests.cs
@@ -1,0 +1,286 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public class DataSetQueryCriteriaNotValidatorTests
+{
+    private readonly DataSetQueryCriteriaNot.Validator _validator = new();
+
+    [Fact]
+    public void Null_Failure()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = null!
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("Not")
+            .WithErrorCode(FluentValidationKeys.NotNullValidator)
+            .Only();
+    }
+
+    [Fact]
+    public void Facets_Success()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = new DataSetQueryCriteriaFacets
+            {
+                Filters = new DataSetQueryCriteriaFilters
+                {
+                    Eq = "12345"
+                },
+            },
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Facets_Failure()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = new DataSetQueryCriteriaFacets
+            {
+                Filters = new DataSetQueryCriteriaFilters
+                {
+                    Eq = ""
+                },
+            },
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("Not.Filters.Eq")
+            .Only();
+    }
+
+    [Fact]
+    public void Condition_Empty_Failure()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = new DataSetQueryCriteriaOr
+            {
+                Or = [],
+            },
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("Not.Or")
+            .Only();
+    }
+
+    [Fact]
+    public void Condition_SingleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetQueryCriteriaFilters
+                        {
+                            Eq = "12345"
+                        },
+                    },
+                ],
+            },
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Condition_SingleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetQueryCriteriaFilters
+                        {
+                            Eq = new string('x', 11)
+                        },
+                    },
+                ],
+            },
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("Not.Or[0].Filters.Eq")
+            .Only();
+    }
+
+    [Fact]
+    public void Condition_MultipleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetQueryCriteriaFilters
+                        {
+                            Eq = "12345"
+                        },
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = new DataSetQueryCriteriaTimePeriods
+                        {
+                            Gte = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" }
+                        },
+                    },
+                ],
+            },
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Condition_MultipleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetQueryCriteriaFilters
+                        {
+                            Eq = new string('x', 11)
+                        },
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = new DataSetQueryCriteriaTimePeriods
+                        {
+                            Gte = new DataSetQueryTimePeriod { Period = "", Code = "AY" }
+                        },
+                    },
+                ],
+            },
+        };
+
+        var result = _validator.TestValidate(query);
+
+        Assert.Equal(2, result.Errors.Count);
+
+        result.ShouldHaveValidationErrorFor("Not.And[0].Filters.Eq");
+        result.ShouldHaveValidationErrorFor("Not.And[1].TimePeriods.Gte.Period");
+    }
+
+    [Fact]
+    public void Not_SingleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = new DataSetQueryCriteriaNot
+            {
+                Not = new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters
+                    {
+                        Eq = "12345"
+                    },
+                },
+            },
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+
+    [Fact]
+    public void Not_SingleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = new DataSetQueryCriteriaNot
+            {
+                Not = new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters
+                    {
+                        Eq = new string('x', 11)
+                    },
+                },
+            },
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("Not.Not.Filters.Eq")
+            .Only();
+    }
+
+    [Fact]
+    public void Condition_Not_SingleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaNot
+                    {
+                        Not = new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = "12345"
+                            },
+                        },
+                    },
+                ],
+            }
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Condition_Not_SingleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaNot
+        {
+            Not = new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaNot
+                    {
+                        Not = new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = new string('x', 11)
+                            },
+                        },
+                    },
+                ],
+            }
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("Not.And[0].Not.Filters.Eq")
+            .Only();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaOrValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaOrValidatorTests.cs
@@ -1,0 +1,392 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public class DataSetQueryCriteriaOrValidatorTests
+{
+    private readonly DataSetQueryCriteriaOr.Validator _validator = new();
+
+    [Fact]
+    public void Empty_Failure()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or = [],
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor(q => q.Or)
+            .WithErrorCode(FluentValidationKeys.NotEmptyValidator)
+            .Only();
+    }
+
+    [Fact]
+    public void Nulls_Failure()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                null!,
+                new DataSetQueryCriteriaFacets()
+            ],
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("Or[0]")
+            .WithErrorCode(FluentValidationKeys.NotNullValidator)
+            .Only();
+    }
+
+    [Fact]
+    public void SingleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters
+                    {
+                        Eq = "12345"
+                    },
+                },
+            ],
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void SingleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters
+                    {
+                        Eq = ""
+                    },
+                },
+            ],
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("Or[0].Filters.Eq")
+            .Only();
+    }
+
+    [Fact]
+    public void MultipleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters
+                    {
+                        Eq = "12345"
+                    }
+                },
+                new DataSetQueryCriteriaFacets
+                {
+                    TimePeriods = new DataSetQueryCriteriaTimePeriods
+                    {
+                        NotEq = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" }
+                    },
+                },
+            ],
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+
+    [Fact]
+    public void MultipleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters
+                    {
+                        Eq = ""
+                    },
+                },
+                new DataSetQueryCriteriaFacets
+                {
+                    TimePeriods = new DataSetQueryCriteriaTimePeriods
+                    {
+                        Gte = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "Invalid" }
+                    },
+                },
+            ],
+        };
+
+        var result = _validator.TestValidate(query);
+
+        Assert.Equal(2, result.Errors.Count);
+
+        result.ShouldHaveValidationErrorFor("Or[0].Filters.Eq");
+        result.ShouldHaveValidationErrorFor("Or[1].TimePeriods.Gte.Code");
+    }
+
+    [Fact]
+    public void SingleCondition_Empty_Failure()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                new DataSetQueryCriteriaOr
+                {
+                    Or = [],
+                },
+            ],
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("Or[0].Or")
+            .Only();
+    }
+
+    [Fact]
+    public void SingleCondition_SingleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                new DataSetQueryCriteriaOr
+                {
+                    Or =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = "12345"
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void SingleCondition_SingleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                new DataSetQueryCriteriaOr
+                {
+                    Or =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = new string('x', 11)
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        _validator.TestValidate(query)
+            .ShouldHaveValidationErrorFor("Or[0].Or[0].Filters.Eq")
+            .Only();
+    }
+
+    [Fact]
+    public void MultipleConditions_SingleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                new DataSetQueryCriteriaAnd
+                {
+                    And =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = "12345"
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaOr
+                {
+                    Or =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            TimePeriods = new DataSetQueryCriteriaTimePeriods
+                            {
+                                Gte = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" }
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaNot
+                {
+                    Not = new DataSetQueryCriteriaFacets
+                    {
+                        Locations = new DataSetQueryCriteriaLocations
+                        {
+                            In = [new DataSetQueryLocationId { Level = "NAT", Id = "12345" }],
+                        },
+                    },
+                },
+            ],
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void MultipleConditions_SingleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                new DataSetQueryCriteriaAnd
+                {
+                    And =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = new string('x', 11)
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaOr
+                {
+                    Or =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            TimePeriods = new DataSetQueryCriteriaTimePeriods
+                            {
+                                Gte = new DataSetQueryTimePeriod { Period = "", Code = "AY" }
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaNot
+                {
+                    Not = new DataSetQueryCriteriaFacets
+                    {
+                        Locations = new DataSetQueryCriteriaLocations
+                        {
+                            In = [new DataSetQueryLocationId { Level = "nat", Id = "12345" }],
+                        },
+                    },
+                },
+            ],
+        };
+
+        var result = _validator.TestValidate(query);
+
+        Assert.Equal(3, result.Errors.Count);
+
+        result.ShouldHaveValidationErrorFor("Or[0].And[0].Filters.Eq");
+        result.ShouldHaveValidationErrorFor("Or[1].Or[0].TimePeriods.Gte.Period");
+        result.ShouldHaveValidationErrorFor("Or[2].Not.Locations.In[0].Level");
+    }
+
+    [Fact]
+    public void MixedCriteria_SingleFacets_Success()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                new DataSetQueryCriteriaAnd
+                {
+                    And =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = "12345"
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaFacets
+                {
+                    TimePeriods = new DataSetQueryCriteriaTimePeriods
+                    {
+                        Gte = new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" }
+                    },
+                },
+            ],
+        };
+
+        _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void MixedCriteria_SingleFacets_Failure()
+    {
+        var query = new DataSetQueryCriteriaOr
+        {
+            Or =
+            [
+                new DataSetQueryCriteriaAnd
+                {
+                    And =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters
+                            {
+                                Eq = new string('x', 11)
+                            },
+                        },
+                    ],
+                },
+                new DataSetQueryCriteriaFacets
+                {
+                    TimePeriods = new DataSetQueryCriteriaTimePeriods
+                    {
+                        Gte = new DataSetQueryTimePeriod { Period = "", Code = "AY" }
+                    },
+                },
+            ],
+        };
+
+        var result = _validator.TestValidate(query);
+
+        Assert.Equal(2, result.Errors.Count);
+
+        result.ShouldHaveValidationErrorFor("Or[0].And[0].Filters.Eq");
+        result.ShouldHaveValidationErrorFor("Or[1].TimePeriods.Gte.Period");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaTimePeriodsValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryCriteriaTimePeriodsValidatorTests.cs
@@ -1,0 +1,357 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public class DataSetQueryCriteriaTimePeriodsValidatorTests
+{
+    private readonly DataSetQueryCriteriaTimePeriods.Validator _validator = new();
+
+    public static readonly TheoryData<DataSetQueryTimePeriod> ValidTimePeriodsSingle = new()
+    {
+        new DataSetQueryTimePeriod { Period = "2020", Code = "AY" },
+        new DataSetQueryTimePeriod { Period = "2020/2021", Code = "AY" },
+        new DataSetQueryTimePeriod { Period = "2020", Code = "FY" },
+        new DataSetQueryTimePeriod { Period = "2021", Code = "M1" },
+        new DataSetQueryTimePeriod { Period = "2021", Code = "W40" },
+        new DataSetQueryTimePeriod { Period = "2021", Code = "T3" },
+        new DataSetQueryTimePeriod { Period = "2021/2022", Code = "T3" },
+        new DataSetQueryTimePeriod { Period = "2019", Code = "FYQ4" },
+        new DataSetQueryTimePeriod { Period = "2019/2020", Code = "FYQ4" },
+    };
+
+    public static readonly TheoryData<DataSetQueryTimePeriod[]> ValidTimePeriodsMultiple = new()
+    {
+        new DataSetQueryTimePeriod[]
+        {
+            new() { Period = "2020", Code = "AY" },
+            new() { Period = "2020/2021", Code = "AY" },
+            new() { Period = "2020", Code = "FY" },
+        },
+        new DataSetQueryTimePeriod[]
+        {
+            new() { Period = "2021", Code = "M1" },
+            new() { Period = "2021", Code = "W40" },
+            new() { Period = "2021", Code = "T3" },
+        },
+        new DataSetQueryTimePeriod[]
+        {
+            new() { Period = "2021/2022", Code = "T3" },
+            new() { Period = "2019", Code = "FYQ4" },
+            new() { Period = "2019/2020", Code = "FYQ4" },
+        },
+    };
+
+    public static readonly TheoryData<DataSetQueryTimePeriod> InvalidTimePeriodsSingle = new()
+    {
+        new DataSetQueryTimePeriod { Period = "", Code = "AY" },
+        new DataSetQueryTimePeriod { Period = "Invalid", Code = "AY" },
+        new DataSetQueryTimePeriod { Period = "2020/2022", Code = "AY" },
+        new DataSetQueryTimePeriod { Period = "2022/2020", Code = "AY" },
+        new DataSetQueryTimePeriod { Period = "2000/1999", Code = "AY" },
+        new DataSetQueryTimePeriod { Period = "2022", Code = "" },
+        new DataSetQueryTimePeriod { Period = "2022/2023", Code = "" },
+        new DataSetQueryTimePeriod { Period = "2022", Code = "ay" },
+        new DataSetQueryTimePeriod { Period = "2022", Code = "Invalid" },
+        new DataSetQueryTimePeriod { Period = "2022", Code = "1" },
+        new DataSetQueryTimePeriod { Period = "2022", Code = "WEEK12" },
+        new DataSetQueryTimePeriod { Period = "2022/2023", Code = "JANUARY" },
+    };
+
+    public static readonly TheoryData<DataSetQueryTimePeriod[]> InvalidTimePeriodsMultiple = new()
+    {
+        new DataSetQueryTimePeriod[]
+        {
+            new() { Period = "", Code = "AY" },
+            new() { Period = "Invalid", Code = "AY" },
+            new() { Period = "2020/2022", Code = "AY" },
+            new() { Period = "2022/2020", Code = "AY" },
+            new() { Period = "2000/1999", Code = "AY" },
+        },
+        new DataSetQueryTimePeriod[]
+        {
+            new() { Period = "2022", Code = "" },
+            new() { Period = "2022/2023", Code = "" },
+            new() { Period = "2022", Code = "ay" },
+            new() { Period = "2022", Code = "Invalid" },
+            new() { Period = "2022", Code = "1" },
+            new() { Period = "2022", Code = "WEEK12" },
+            new() { Period = "2022/2023", Code = "JANUARY" },
+        },
+    };
+
+    public class EqTests : DataSetQueryCriteriaTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodsSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { Eq = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodsSingle))]
+        public void Failure(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { Eq = timePeriod };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.NotEmpty(result.Errors);
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("Eq", error.PropertyName));
+        }
+    }
+
+    public class NotEqTests : DataSetQueryCriteriaTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodsSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { NotEq = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodsSingle))]
+        public void Failure(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { NotEq = timePeriod };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.NotEmpty(result.Errors);
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("NotEq", error.PropertyName));
+        }
+    }
+
+    public class InTests : DataSetQueryCriteriaTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodsMultiple))]
+        public void Success(DataSetQueryTimePeriod[] timePeriods)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { In = timePeriods };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodsMultiple))]
+        public void Failure(DataSetQueryTimePeriod[] timePeriods)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { In = timePeriods };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.Equal(timePeriods.Length, result.Errors.Count);
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("In", error.PropertyName));
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { In = [] };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.In)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+
+    public class NotInTests : DataSetQueryCriteriaTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodsMultiple))]
+        public void Success(DataSetQueryTimePeriod[] timePeriods)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { NotIn = timePeriods };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodsMultiple))]
+        public void Failure(DataSetQueryTimePeriod[] timePeriods)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { NotIn = timePeriods };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.Equal(timePeriods.Length, result.Errors.Count);
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("NotIn", error.PropertyName));
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { NotIn = [] };
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+
+    public class GtTests : DataSetQueryCriteriaTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodsSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { Gt = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodsSingle))]
+        public void Failure(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { Gt = timePeriod };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.NotEmpty(result.Errors);
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("Gt", error.PropertyName));
+        }
+    }
+
+    public class GteTests : DataSetQueryCriteriaTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodsSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { Gte = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodsSingle))]
+        public void Failure(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { Gte = timePeriod };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.NotEmpty(result.Errors);
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("Gte", error.PropertyName));
+        }
+    }
+
+    public class LtTests : DataSetQueryCriteriaTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodsSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { Lt = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodsSingle))]
+        public void Failure(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { Lt = timePeriod };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.NotEmpty(result.Errors);
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("Lt", error.PropertyName));
+        }
+    }
+
+    public class LteTests : DataSetQueryCriteriaTimePeriodsValidatorTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidTimePeriodsSingle))]
+        public void Success(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { Lte = timePeriod };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTimePeriodsSingle))]
+        public void Failure(DataSetQueryTimePeriod timePeriod)
+        {
+            var query = new DataSetQueryCriteriaTimePeriods { Lte = timePeriod };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.NotEmpty(result.Errors);
+
+            Assert.All(result.Errors, error =>
+                Assert.StartsWith("Lte", error.PropertyName));
+        }
+    }
+
+    public class EmptyTests : DataSetQueryCriteriaTimePeriodsValidatorTests
+    {
+        [Fact]
+        public void AllNull_Success()
+        {
+            var query = new DataSetQueryCriteriaTimePeriods();
+
+            var result = _validator.TestValidate(query);
+
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void SomeEmpty_Failure()
+        {
+            var query = new DataSetQueryCriteriaTimePeriods
+            {
+                Eq = new DataSetQueryTimePeriod { Period = "2020", Code = "AY" },
+                NotEq = null,
+                In = [new DataSetQueryTimePeriod { Period = "2021/2022", Code = "T3" }],
+                NotIn = [],
+                Gt = new DataSetQueryTimePeriod { Period = "2019", Code = "M4" },
+                Gte = null,
+                Lt = null,
+                Lte = new DataSetQueryTimePeriod { Period = "2030", Code = "M7" }
+            };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.Single(result.Errors);
+
+            result.ShouldNotHaveValidationErrorFor(q => q.Eq);
+            result.ShouldNotHaveValidationErrorFor(q => q.NotEq);
+            result.ShouldNotHaveValidationErrorFor(q => q.In);
+            result.ShouldNotHaveValidationErrorFor(q => q.Gt);
+            result.ShouldNotHaveValidationErrorFor(q => q.Gte);
+            result.ShouldNotHaveValidationErrorFor(q => q.Lt);
+            result.ShouldNotHaveValidationErrorFor(q => q.Lte);
+
+            result.ShouldHaveValidationErrorFor(q => q.NotIn)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryRequestValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Requests/DataSetQueryRequestValidatorTests.cs
@@ -1,0 +1,439 @@
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Requests;
+
+public class DataSetQueryRequestValidatorTests
+{
+    private readonly DataSetQueryRequest.Validator _validator = new();
+
+    public class CriteriaTests : DataSetQueryRequestValidatorTests
+    {
+        [Fact]
+        public void Facets_Success()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Criteria = new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetGetQueryFilters
+                    {
+                        Eq = "abc"
+                    },
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Facets_Failure()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Criteria = new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetGetQueryFilters
+                    {
+                        Eq = ""
+                    },
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor("Criteria.Filters.Eq")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator)
+                .Only();
+        }
+
+        [Fact]
+        public void AndCondition_Success()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Criteria = new DataSetQueryCriteriaAnd
+                {
+                    And =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetGetQueryFilters
+                            {
+                                Eq = "abc"
+                            },
+                        }
+                    ]
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void AndCondition_Failure()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Criteria = new DataSetQueryCriteriaAnd
+                {
+                    And =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetGetQueryFilters
+                            {
+                                Eq = ""
+                            },
+                        }
+                    ]
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor("Criteria.And[0].Filters.Eq")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator)
+                .Only();
+        }
+
+        [Fact]
+        public void OrCondition_Success()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Criteria = new DataSetQueryCriteriaOr
+                {
+                    Or =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetGetQueryFilters
+                            {
+                                Eq = "abc"
+                            },
+                        }
+                    ]
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void OrCondition_Failure()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Criteria = new DataSetQueryCriteriaOr
+                {
+                    Or =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetGetQueryFilters
+                            {
+                                Eq = ""
+                            },
+                        }
+                    ]
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor("Criteria.Or[0].Filters.Eq")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator)
+                .Only();
+        }
+
+        [Fact]
+        public void NotCondition_Success()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Criteria = new DataSetQueryCriteriaNot
+                {
+                    Not = new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetGetQueryFilters
+                        {
+                            Eq = "abc"
+                        },
+                    }
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void NotCondition_Failure()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Criteria = new DataSetQueryCriteriaNot
+                {
+                    Not = new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetGetQueryFilters
+                        {
+                            Eq = ""
+                        },
+                    }
+                },
+                Indicators = ["indicator1", "indicator2"],
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor("Criteria.Not.Filters.Eq")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator)
+                .Only();
+        }
+    }
+
+    public class IndicatorsTests : DataSetQueryRequestValidatorTests
+    {
+        [Theory]
+        [InlineData("indicator1")]
+        [InlineData("indicator1111111111111111111111111111111")]
+        [InlineData("indicator1", "indicator2")]
+        public void Success(params string[] indicators)
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = indicators,
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = []
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Indicators)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+
+        [Fact]
+        public void Failure_EmptyValues()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = ["", " ", "  ", null!]
+            };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.Equal(query.Indicators.Count, result.Errors.Count);
+
+            result.ShouldHaveValidationErrorFor("Indicators[0]")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+
+            result.ShouldHaveValidationErrorFor("Indicators[1]")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+
+            result.ShouldHaveValidationErrorFor("Indicators[2]")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+
+            result.ShouldHaveValidationErrorFor("Indicators[3]")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+
+        [Fact]
+        public void Failure_MaxLength()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = [new string('x', 41), new string('x', 42)]
+            };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.Equal(query.Indicators.Count, result.Errors.Count);
+
+            result.ShouldHaveValidationErrorFor("Indicators[0]")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+
+            result.ShouldHaveValidationErrorFor("Indicators[1]")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+        }
+
+        [Fact]
+        public void Failure_Mixture()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = [new string('x', 101), ""]
+            };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.Equal(query.Indicators.Count, result.Errors.Count);
+
+            result
+                .ShouldHaveValidationErrorFor("Indicators[0]")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+
+            result
+                .ShouldHaveValidationErrorFor("Indicators[1]")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+        }
+    }
+
+    public class SortsTests : DataSetQueryRequestValidatorTests
+    {
+        [Fact]
+        public void Success()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                Sorts =
+                [
+                    new DataSetQuerySort { Field = "TimePeriod", Direction = "Asc" },
+                    new DataSetQuerySort { Field = "GeographicLevel", Direction = "Asc" },
+                ],
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void Failure_Empty()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                Sorts = []
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Sorts)
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator)
+                .Only();
+        }
+
+        [Fact]
+        public void Failure_InvalidSorts()
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                Sorts =
+                [
+                    null!,
+                    new DataSetQuerySort { Field = "", Direction = "Asc" },
+                    new DataSetQuerySort { Field = "timePeriod", Direction = "" },
+                    new DataSetQuerySort { Field = "timePeriod", Direction = "asc" },
+                    new DataSetQuerySort { Field = new string('x', 41), Direction = "Asc" },
+                ],
+            };
+
+            var result = _validator.TestValidate(query);
+
+            Assert.Equal(query.Sorts.Count, result.Errors.Count);
+
+            result.ShouldHaveValidationErrorFor("Sorts[0]")
+                .WithErrorCode(FluentValidationKeys.NotNullValidator);
+
+            result.ShouldHaveValidationErrorFor("Sorts[1].Field")
+                .WithErrorCode(FluentValidationKeys.NotEmptyValidator);
+
+            result.ShouldHaveValidationErrorFor("Sorts[2].Direction")
+                .WithErrorCode(ValidationMessages.AllowedValue.Code);
+
+            result.ShouldHaveValidationErrorFor("Sorts[3].Direction")
+                .WithErrorCode(ValidationMessages.AllowedValue.Code);
+
+            result.ShouldHaveValidationErrorFor("Sorts[4].Field")
+                .WithErrorCode(FluentValidationKeys.MaximumLengthValidator);
+        }
+    }
+
+    public class PageTests : DataSetQueryRequestValidatorTests
+    {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(10)]
+        [InlineData(100)]
+        public void Success(int page)
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                Page = page,
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-2)]
+        [InlineData(-10)]
+        public void Failure_LessThanOne(int page)
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                Page = page,
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.Page)
+                .WithErrorCode(FluentValidationKeys.GreaterThanOrEqualValidator)
+                .Only();
+        }
+    }
+
+    public class PageSizeTests : DataSetQueryRequestValidatorTests
+    {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(500)]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        public void Success(int pageSize)
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                PageSize = pageSize,
+            };
+
+            _validator.TestValidate(query).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10001)]
+        public void Failure_OutOfBounds(int pageSize)
+        {
+            var query = new DataSetQueryRequest
+            {
+                Indicators = ["indicator1", "indicator2"],
+                PageSize = pageSize,
+            };
+
+            _validator.TestValidate(query)
+                .ShouldHaveValidationErrorFor(q => q.PageSize)
+                .WithErrorCode(FluentValidationKeys.InclusiveBetweenValidator)
+                .Only();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/DataSetQueryParserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/DataSetQueryParserTests.cs
@@ -139,6 +139,7 @@ public abstract class DataSetQueryParserTests
             Assert.Empty(queryState.Errors);
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"filters.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.FiltersNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.FiltersNotFound.Code, warning.Code);
 
@@ -287,6 +288,7 @@ public abstract class DataSetQueryParserTests
 
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"filters.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.FiltersNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.FiltersNotFound.Code, warning.Code);
 
@@ -323,6 +325,7 @@ public abstract class DataSetQueryParserTests
 
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"filters.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.FiltersNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.FiltersNotFound.Code, warning.Code);
 
@@ -332,11 +335,11 @@ public abstract class DataSetQueryParserTests
         }
     }
 
-    public class ParseCriteriaGeographicLevels : DataSetQueryParserTests
+    public class ParseCriteriaGeographicLevelsTests : DataSetQueryParserTests
     {
         private readonly DataSetVersion _dataSetVersion;
 
-        public ParseCriteriaGeographicLevels()
+        public ParseCriteriaGeographicLevelsTests()
         {
             _dataSetVersion = _dataFixture
                 .DefaultDataSetVersion()
@@ -434,6 +437,7 @@ public abstract class DataSetQueryParserTests
             Assert.Empty(queryState.Errors);
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"geographicLevels.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.GeographicLevelsNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.GeographicLevelsNotFound.Code, warning.Code);
 
@@ -510,6 +514,7 @@ public abstract class DataSetQueryParserTests
 
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"geographicLevels.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.GeographicLevelsNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.GeographicLevelsNotFound.Code, warning.Code);
 
@@ -548,6 +553,7 @@ public abstract class DataSetQueryParserTests
 
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"geographicLevels.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.GeographicLevelsNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.GeographicLevelsNotFound.Code, warning.Code);
 
@@ -633,7 +639,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList(1);
 
             var queryLocation = locationOptions
-                .Select(o => MapOptionToQueryLocation(o, level))
+                .Select(MapOptionToQueryLocation)
                 .ToList();
 
             _locationRepository
@@ -694,6 +700,7 @@ public abstract class DataSetQueryParserTests
             Assert.Empty(queryState.Errors);
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"locations.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.LocationsNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.LocationsNotFound.Code, warning.Code);
 
@@ -723,7 +730,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList(3);
 
             var queryLocations = locationOptions
-                .Select(o => MapOptionToQueryLocation(o, level))
+                .Select(MapOptionToQueryLocation)
                 .ToList();
 
             _locationRepository
@@ -777,7 +784,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList();
 
             var queryLocations = locationOptions
-                .Select(o => MapOptionToQueryLocation(o, EnumUtil.GetFromEnumValue<GeographicLevel>(o.Level)))
+                .Select(MapOptionToQueryLocation)
                 .ToList();
 
             _locationRepository
@@ -830,7 +837,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList();
 
             var queryLocations = locationOptions
-                .Select(o => MapOptionToQueryLocation(o, EnumUtil.GetFromEnumValue<GeographicLevel>(o.Level)))
+                .Select(MapOptionToQueryLocation)
                 .ToList();
 
             _locationRepository
@@ -856,6 +863,7 @@ public abstract class DataSetQueryParserTests
 
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"locations.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.LocationsNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.LocationsNotFound.Code, warning.Code);
 
@@ -877,7 +885,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList();
 
             var queryLocations = locationOptions
-                .Select(o => MapOptionToQueryLocation(o, EnumUtil.GetFromEnumValue<GeographicLevel>(o.Level)))
+                .Select(MapOptionToQueryLocation)
                 .ToList();
 
             _locationRepository
@@ -901,6 +909,7 @@ public abstract class DataSetQueryParserTests
 
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"locations.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.LocationsNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.LocationsNotFound.Code, warning.Code);
 
@@ -973,11 +982,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList(1);
 
             var queryTimePeriods = timePeriods
-                .Select(o => new DataSetQueryTimePeriod
-                {
-                    Code = EnumUtil.GetFromEnumLabel<TimeIdentifier>(o.Identifier).GetEnumValue(),
-                    Period = TimePeriodFormatter.FormatFromCsv(o.Period)
-                })
+                .Select(MapQueryTimePeriod)
                 .ToList();
 
             _timePeriodRepository
@@ -1038,6 +1043,7 @@ public abstract class DataSetQueryParserTests
             Assert.Empty(queryState.Errors);
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"timePeriods.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.TimePeriodsNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.TimePeriodsNotFound.Code, warning.Code);
 
@@ -1060,11 +1066,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList();
 
             var queryTimePeriods = timePeriods
-                .Select(o => new DataSetQueryTimePeriod
-                {
-                    Code = EnumUtil.GetFromEnumLabel<TimeIdentifier>(o.Identifier).GetEnumValue(),
-                    Period = TimePeriodFormatter.FormatFromCsv(o.Period)
-                })
+                .Select(MapQueryTimePeriod)
                 .ToList();
 
             _timePeriodRepository
@@ -1106,11 +1108,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList();
 
             var queryTimePeriods = timePeriods
-                .Select(o => new DataSetQueryTimePeriod
-                {
-                    Code = EnumUtil.GetFromEnumLabel<TimeIdentifier>(o.Identifier).GetEnumValue(),
-                    Period = TimePeriodFormatter.FormatFromCsv(o.Period)
-                })
+                .Select(MapQueryTimePeriod)
                 .ToList();
 
             _timePeriodRepository
@@ -1136,6 +1134,7 @@ public abstract class DataSetQueryParserTests
 
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"timePeriods.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.TimePeriodsNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.TimePeriodsNotFound.Code, warning.Code);
 
@@ -1184,6 +1183,7 @@ public abstract class DataSetQueryParserTests
 
             var warning = Assert.Single(queryState.Warnings);
 
+            Assert.Equal($"timePeriods.{comparator.ToLowerFirst()}", warning.Path);
             Assert.Equal(ValidationMessages.TimePeriodsNotFound.Message, warning.Message);
             Assert.Equal(ValidationMessages.TimePeriodsNotFound.Code, warning.Code);
 
@@ -1193,11 +1193,11 @@ public abstract class DataSetQueryParserTests
         }
     }
 
-    public class ParseCriteriaMixedTest : DataSetQueryParserTests
+    public class ParseCriteriaMixedFacetsTests : DataSetQueryParserTests
     {
         private readonly DataSetVersion _dataSetVersion;
 
-        public ParseCriteriaMixedTest()
+        public ParseCriteriaMixedFacetsTests()
         {
             _dataSetVersion = DefaultDataSetVersion();
         }
@@ -1297,7 +1297,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList(1);
 
             var queryLocations = locationOptions
-                .Select(o => MapOptionToQueryLocation(o, GeographicLevel.Region))
+                .Select(MapOptionToQueryLocation)
                 .ToList();
 
             _locationRepository
@@ -1313,11 +1313,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList(1);
 
             var queryTimePeriods = timePeriods
-                .Select(o => new DataSetQueryTimePeriod
-                {
-                    Code = EnumUtil.GetFromEnumLabel<TimeIdentifier>(o.Identifier).GetEnumValue(),
-                    Period = TimePeriodFormatter.FormatFromCsv(o.Period)
-                })
+                .Select(MapQueryTimePeriod)
                 .ToList();
 
             _timePeriodRepository
@@ -1390,7 +1386,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList();
 
             var queryLocations = locationOptions
-                .Select(o => MapOptionToQueryLocation(o, EnumUtil.GetFromEnumValue<GeographicLevel>(o.Level)))
+                .Select(MapOptionToQueryLocation)
                 .ToList();
 
             _locationRepository
@@ -1407,11 +1403,7 @@ public abstract class DataSetQueryParserTests
                 .GenerateList();
 
             var queryTimePeriods = timePeriods
-                .Select(o => new DataSetQueryTimePeriod
-                {
-                    Code = EnumUtil.GetFromEnumLabel<TimeIdentifier>(o.Identifier).GetEnumValue(),
-                    Period = TimePeriodFormatter.FormatFromCsv(o.Period)
-                })
+                .Select(MapQueryTimePeriod)
                 .ToList();
 
             _timePeriodRepository
@@ -1454,6 +1446,1006 @@ public abstract class DataSetQueryParserTests
 
             Assert.Empty(queryState.Errors);
             Assert.Empty(queryState.Warnings);
+        }
+    }
+
+    public class ParseCriteriaAndTests : DataSetQueryParserTests
+    {
+        private readonly DataSetVersion _dataSetVersion;
+
+        public ParseCriteriaAndTests()
+        {
+            _dataSetVersion = DefaultDataSetVersion();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, Array.Empty<string>(), default))
+                .ReturnsAsync([]);
+
+            _locationRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, Array.Empty<DataSetQueryLocation>(), default))
+                .ReturnsAsync([]);
+
+            _timePeriodRepository
+                .Setup(r => r.List(_dataSetVersion, Array.Empty<DataSetQueryTimePeriod>(), default))
+                .ReturnsAsync([]);
+        }
+
+        [Fact]
+        public async Task Empty()
+        {
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaAnd
+            {
+                And = []
+            };
+
+            var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
+
+            Assert.Empty(parsed.Sql);
+            Assert.Empty(parsed.SqlParameters);
+
+            Assert.Empty(queryState.Errors);
+            Assert.Empty(queryState.Warnings);
+        }
+
+        [Fact]
+        public async Task SingleFacets()
+        {
+            var filterOptions = _dataFixture
+                .DefaultParquetFilterOption()
+                .WithFilterId("field_a")
+                .GenerateList(1);
+
+            var queryFilterOptionIds = filterOptions
+                .Select(o => o.PublicId)
+                .ToList();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryFilterOptionIds.ToHashSet(), default))
+                .ReturnsAsync(filterOptions);
+
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetQueryCriteriaFilters { Eq = queryFilterOptionIds[0] }
+                    }
+                ]
+            };
+
+            var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
+
+            const string expectedSql = """
+                                       data."field_a" = ?
+                                       """;
+
+            Assert.Equal(expectedSql, parsed.Sql);
+
+            var parameter = Assert.Single(parsed.SqlParameters);
+            Assert.Equal(filterOptions[0].Id, parameter.Argument);
+
+            Assert.Empty(queryState.Errors);
+            Assert.Empty(queryState.Warnings);
+        }
+
+        [Fact]
+        public async Task MultipleFacets()
+        {
+            var filterOptions = _dataFixture
+                .DefaultParquetFilterOption()
+                .ForIndex(0, s => s.SetFilterId("field_a"))
+                .ForIndex(1, s => s.SetFilterId("field_b"))
+                .GenerateList();
+
+            var queryFilterOptionIds = filterOptions
+                .Select(o => o.PublicId)
+                .ToList();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryFilterOptionIds.ToHashSet(), default))
+                .ReturnsAsync(filterOptions);
+
+            var locationOptions = _dataFixture
+                .DefaultParquetLocationOption()
+                .ForIndex(0, s => s.SetDefaults(GeographicLevel.Region))
+                .ForIndex(1, s => s.SetDefaults(GeographicLevel.LocalAuthority))
+                .GenerateList();
+
+            var queryLocations = locationOptions
+                .Select(MapOptionToQueryLocation)
+                .ToList();
+
+            _locationRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryLocations.ToHashSet(), default))
+                .ReturnsAsync(locationOptions);
+
+            var timePeriods = _dataFixture
+                .DefaultParquetTimePeriod()
+                .WithPeriod("202324")
+                .WithIdentifier(TimeIdentifier.AcademicYear.GetEnumLabel())
+                .GenerateList(1);
+
+            var queryTimePeriods = timePeriods
+                .Select(MapQueryTimePeriod)
+                .ToList();
+
+            _timePeriodRepository
+                .Setup(r => r.List(_dataSetVersion, queryTimePeriods, default))
+                .ReturnsAsync(timePeriods);
+
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetQueryCriteriaFilters { In = queryFilterOptionIds }
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        GeographicLevels = new DataSetQueryCriteriaGeographicLevels
+                        {
+                            Eq = GeographicLevel.Region.GetEnumValue()
+                        }
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Locations = new DataSetQueryCriteriaLocations { NotIn = queryLocations }
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = new DataSetQueryCriteriaTimePeriods { Gt = queryTimePeriods[0] }
+                    },
+                ]
+            };
+
+            var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
+
+            const string expectedSql = """
+                                       ((data."field_a" IN (?)
+                                        OR data."field_b" IN (?)))
+                                       AND (data.geographic_level = ?)
+                                       AND ((data.locations_reg_id NOT IN (?)
+                                        AND data.locations_la_id NOT IN (?)))
+                                       AND (data.time_period_id > ?)
+                                       """;
+
+            Assert.Equal(expectedSql, parsed.Sql);
+
+            Assert.Equal(6, parsed.SqlParameters.Count);
+            Assert.Equal(filterOptions[0].Id, parsed.SqlParameters[0].Argument);
+            Assert.Equal(filterOptions[1].Id, parsed.SqlParameters[1].Argument);
+            Assert.Equal(GeographicLevel.Region.GetEnumLabel(), parsed.SqlParameters[2].Argument);
+            Assert.Equal(locationOptions[0].Id, parsed.SqlParameters[3].Argument);
+            Assert.Equal(locationOptions[1].Id, parsed.SqlParameters[4].Argument);
+            Assert.Equal(timePeriods[0].Id, parsed.SqlParameters[5].Argument);
+        }
+
+        [Fact]
+        public async Task NestedConditions()
+        {
+            var filterOptions = _dataFixture
+                .DefaultParquetFilterOption()
+                .ForRange(..2, s => s.SetFilterId("field_a"))
+                .ForIndex(2, s => s.SetFilterId("field_b"))
+                .ForRange(3..5, s => s.SetFilterId("field_c"))
+                .GenerateList();
+
+            var queryFilterOptionIds = filterOptions
+                .Select(o => o.PublicId)
+                .ToList();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryFilterOptionIds.ToHashSet(), default))
+                .ReturnsAsync(filterOptions);
+
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaOr
+                    {
+                        Or =
+                        [
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters { Eq = queryFilterOptionIds[0] }
+                            },
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters { Eq = queryFilterOptionIds[1] }
+                            }
+                        ]
+                    },
+                    new DataSetQueryCriteriaAnd
+                    {
+                        And =
+                        [
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters { NotEq = queryFilterOptionIds[2] }
+                            }
+                        ]
+                    },
+                    new DataSetQueryCriteriaNot
+                    {
+                        Not = new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters { In = queryFilterOptionIds[3..] }
+                        }
+                    },
+                ]
+            };
+
+            var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
+
+            const string expectedSql = """
+                                       ((data."field_a" = ?)
+                                       OR (data."field_a" = ?))
+                                       AND (data."field_b" != ?)
+                                       AND (NOT (data."field_c" IN (?, ?)))
+                                       """;
+
+            Assert.Equal(expectedSql, parsed.Sql);
+
+            Assert.Equal(5, parsed.SqlParameters.Count);
+            Assert.Equal(filterOptions[0].Id, parsed.SqlParameters[0].Argument);
+            Assert.Equal(filterOptions[1].Id, parsed.SqlParameters[1].Argument);
+            Assert.Equal(filterOptions[2].Id, parsed.SqlParameters[2].Argument);
+            Assert.Equal(filterOptions[3].Id, parsed.SqlParameters[3].Argument);
+            Assert.Equal(filterOptions[4].Id, parsed.SqlParameters[4].Argument);
+
+            Assert.Empty(queryState.Errors);
+            Assert.Empty(queryState.Warnings);
+        }
+    }
+
+    public class ParseCriteriaOrTests : DataSetQueryParserTests
+    {
+        private readonly DataSetVersion _dataSetVersion;
+
+        public ParseCriteriaOrTests()
+        {
+            _dataSetVersion = DefaultDataSetVersion();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, Array.Empty<string>(), default))
+                .ReturnsAsync([]);
+
+            _locationRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, Array.Empty<DataSetQueryLocation>(), default))
+                .ReturnsAsync([]);
+
+            _timePeriodRepository
+                .Setup(r => r.List(_dataSetVersion, Array.Empty<DataSetQueryTimePeriod>(), default))
+                .ReturnsAsync([]);
+        }
+
+        [Fact]
+        public async Task Empty()
+        {
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaOr
+            {
+                Or = []
+            };
+
+            var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
+
+            Assert.Empty(parsed.Sql);
+            Assert.Empty(parsed.SqlParameters);
+
+            Assert.Empty(queryState.Errors);
+            Assert.Empty(queryState.Warnings);
+        }
+
+        [Fact]
+        public async Task SingleFacets()
+        {
+            var filterOptions = _dataFixture
+                .DefaultParquetFilterOption()
+                .WithFilterId("field_a")
+                .GenerateList(1);
+
+            var queryFilterOptionIds = filterOptions
+                .Select(o => o.PublicId)
+                .ToList();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryFilterOptionIds.ToHashSet(), default))
+                .ReturnsAsync(filterOptions);
+
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetQueryCriteriaFilters { Eq = queryFilterOptionIds[0] }
+                    }
+                ]
+            };
+
+            var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
+
+            const string expectedSql = """
+                                       data."field_a" = ?
+                                       """;
+
+            Assert.Equal(expectedSql, parsed.Sql);
+
+            Assert.Single(parsed.SqlParameters);
+            Assert.Equal(filterOptions[0].Id, parsed.SqlParameters[0].Argument);
+
+            Assert.Empty(queryState.Errors);
+            Assert.Empty(queryState.Warnings);
+        }
+
+        [Fact]
+        public async Task MultipleFacets()
+        {
+            var filterOptions = _dataFixture
+                .DefaultParquetFilterOption()
+                .ForIndex(0, s => s.SetFilterId("field_a"))
+                .ForIndex(1, s => s.SetFilterId("field_b"))
+                .GenerateList();
+
+            var queryFilterOptionIds = filterOptions
+                .Select(o => o.PublicId)
+                .ToList();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryFilterOptionIds.ToHashSet(), default))
+                .ReturnsAsync(filterOptions);
+
+            var locationOptions = _dataFixture
+                .DefaultParquetLocationOption()
+                .ForIndex(0, s => s.SetDefaults(GeographicLevel.Region))
+                .ForIndex(1, s => s.SetDefaults(GeographicLevel.LocalAuthority))
+                .GenerateList();
+
+            var queryLocations = locationOptions
+                .Select(MapOptionToQueryLocation)
+                .ToList();
+
+            _locationRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryLocations.ToHashSet(), default))
+                .ReturnsAsync(locationOptions);
+
+            var timePeriods = _dataFixture
+                .DefaultParquetTimePeriod()
+                .WithPeriod("202324")
+                .WithIdentifier(TimeIdentifier.AcademicYear.GetEnumLabel())
+                .GenerateList(1);
+
+            var queryTimePeriods = timePeriods
+                .Select(MapQueryTimePeriod)
+                .ToList();
+
+            _timePeriodRepository
+                .Setup(r => r.List(_dataSetVersion, queryTimePeriods, default))
+                .ReturnsAsync(timePeriods);
+
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Filters = new DataSetQueryCriteriaFilters { In = queryFilterOptionIds }
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        GeographicLevels = new DataSetQueryCriteriaGeographicLevels
+                        {
+                            Eq = GeographicLevel.Region.GetEnumValue()
+                        }
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Locations = new DataSetQueryCriteriaLocations { NotIn = queryLocations }
+                    },
+                    new DataSetQueryCriteriaFacets
+                    {
+                        TimePeriods = new DataSetQueryCriteriaTimePeriods { Gt = queryTimePeriods[0] }
+                    },
+                ]
+            };
+
+            var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
+
+            const string expectedSql = """
+                                       ((data."field_a" IN (?)
+                                        OR data."field_b" IN (?)))
+                                       OR (data.geographic_level = ?)
+                                       OR ((data.locations_reg_id NOT IN (?)
+                                        AND data.locations_la_id NOT IN (?)))
+                                       OR (data.time_period_id > ?)
+                                       """;
+
+            Assert.Equal(expectedSql, parsed.Sql);
+
+            Assert.Equal(6, parsed.SqlParameters.Count);
+            Assert.Equal(filterOptions[0].Id, parsed.SqlParameters[0].Argument);
+            Assert.Equal(filterOptions[1].Id, parsed.SqlParameters[1].Argument);
+            Assert.Equal(GeographicLevel.Region.GetEnumLabel(), parsed.SqlParameters[2].Argument);
+            Assert.Equal(locationOptions[0].Id, parsed.SqlParameters[3].Argument);
+            Assert.Equal(locationOptions[1].Id, parsed.SqlParameters[4].Argument);
+            Assert.Equal(timePeriods[0].Id, parsed.SqlParameters[5].Argument);
+        }
+
+        [Fact]
+        public async Task NestedConditions()
+        {
+            var filterOptions = _dataFixture
+                .DefaultParquetFilterOption()
+                .ForIndex(0, s => s.SetFilterId("field_a"))
+                .ForIndex(1, s => s.SetFilterId("field_b"))
+                .ForRange(2..5, s => s.SetFilterId("field_c"))
+                .GenerateList();
+
+            var queryFilterOptionIds = filterOptions
+                .Select(o => o.PublicId)
+                .ToList();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryFilterOptionIds.ToHashSet(), default))
+                .ReturnsAsync(filterOptions);
+
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    new DataSetQueryCriteriaAnd
+                    {
+                        And =
+                        [
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters { Eq = queryFilterOptionIds[0] }
+                            },
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters { NotEq = queryFilterOptionIds[1] }
+                            }
+                        ]
+                    },
+                    new DataSetQueryCriteriaOr
+                    {
+                        Or =
+                        [
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters { Eq = queryFilterOptionIds[2] }
+                            }
+                        ]
+                    },
+                    new DataSetQueryCriteriaNot
+                    {
+                        Not = new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters { In = queryFilterOptionIds[3..] }
+                        }
+                    },
+                ]
+            };
+
+            var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
+
+            const string expectedSql = """
+                                       ((data."field_a" = ?)
+                                       AND (data."field_b" != ?))
+                                       OR (data."field_c" = ?)
+                                       OR (NOT (data."field_c" IN (?, ?)))
+                                       """;
+
+            Assert.Equal(expectedSql, parsed.Sql);
+
+            Assert.Equal(5, parsed.SqlParameters.Count);
+            Assert.Equal(filterOptions[0].Id, parsed.SqlParameters[0].Argument);
+            Assert.Equal(filterOptions[1].Id, parsed.SqlParameters[1].Argument);
+            Assert.Equal(filterOptions[2].Id, parsed.SqlParameters[2].Argument);
+            Assert.Equal(filterOptions[3].Id, parsed.SqlParameters[3].Argument);
+            Assert.Equal(filterOptions[4].Id, parsed.SqlParameters[4].Argument);
+
+            Assert.Empty(queryState.Errors);
+            Assert.Empty(queryState.Warnings);
+        }
+    }
+
+    public class ParseCriteriaNotTests : DataSetQueryParserTests
+    {
+        private readonly DataSetVersion _dataSetVersion;
+
+        public ParseCriteriaNotTests()
+        {
+            _dataSetVersion = DefaultDataSetVersion();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, Array.Empty<string>(), default))
+                .ReturnsAsync([]);
+
+            _locationRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, Array.Empty<DataSetQueryLocation>(), default))
+                .ReturnsAsync([]);
+
+            _timePeriodRepository
+                .Setup(r => r.List(_dataSetVersion, Array.Empty<DataSetQueryTimePeriod>(), default))
+                .ReturnsAsync([]);
+        }
+
+        [Fact]
+        public async Task SingleFacets()
+        {
+            var filterOptions = _dataFixture
+                .DefaultParquetFilterOption()
+                .WithFilterId("field_a")
+                .GenerateList(1);
+
+            var queryFilterOptionIds = filterOptions
+                .Select(o => o.PublicId)
+                .ToList();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryFilterOptionIds.ToHashSet(), default))
+                .ReturnsAsync(filterOptions);
+
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaNot
+            {
+                Not = new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters { Eq = queryFilterOptionIds[0] }
+                }
+            };
+
+            var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
+
+            const string expectedSql = """
+                                       NOT (data."field_a" = ?)
+                                       """;
+
+            Assert.Equal(expectedSql, parsed.Sql);
+
+            Assert.Single(parsed.SqlParameters);
+            Assert.Equal(filterOptions[0].Id, parsed.SqlParameters[0].Argument);
+
+            Assert.Empty(queryState.Errors);
+            Assert.Empty(queryState.Warnings);
+        }
+
+        [Fact]
+        public async Task MultipleFacets()
+        {
+            var filterOptions = _dataFixture
+                .DefaultParquetFilterOption()
+                .ForIndex(0, s => s.SetFilterId("field_a"))
+                .ForIndex(1, s => s.SetFilterId("field_b"))
+                .GenerateList();
+
+            var queryFilterOptionIds = filterOptions
+                .Select(o => o.PublicId)
+                .ToList();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryFilterOptionIds.ToHashSet(), default))
+                .ReturnsAsync(filterOptions);
+
+            var locationOptions = _dataFixture
+                .DefaultParquetLocationOption()
+                .ForIndex(0, s => s.SetDefaults(GeographicLevel.Region))
+                .ForIndex(1, s => s.SetDefaults(GeographicLevel.LocalAuthority))
+                .GenerateList();
+
+            var queryLocations = locationOptions
+                .Select(MapOptionToQueryLocation)
+                .ToList();
+
+            _locationRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryLocations.ToHashSet(), default))
+                .ReturnsAsync(locationOptions);
+
+            var timePeriods = _dataFixture
+                .DefaultParquetTimePeriod()
+                .WithPeriod("202324")
+                .WithIdentifier(TimeIdentifier.AcademicYear.GetEnumLabel())
+                .GenerateList(1);
+
+            var queryTimePeriods = timePeriods
+                .Select(MapQueryTimePeriod)
+                .ToList();
+
+            _timePeriodRepository
+                .Setup(r => r.List(_dataSetVersion, queryTimePeriods, default))
+                .ReturnsAsync(timePeriods);
+
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaNot
+            {
+                Not = new DataSetQueryCriteriaFacets
+                {
+                    Filters = new DataSetQueryCriteriaFilters { In = queryFilterOptionIds },
+                    GeographicLevels = new DataSetQueryCriteriaGeographicLevels
+                    {
+                        Eq = GeographicLevel.Region.GetEnumValue()
+                    },
+                    Locations = new DataSetQueryCriteriaLocations { NotIn = queryLocations },
+                    TimePeriods = new DataSetQueryCriteriaTimePeriods { Gt = queryTimePeriods[0] }
+                }
+            };
+
+            var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
+
+            const string expectedSql = """
+                                       NOT ((data."field_a" IN (?)
+                                        OR data."field_b" IN (?))
+                                       OR data.geographic_level = ?
+                                       OR (data.locations_reg_id NOT IN (?)
+                                        AND data.locations_la_id NOT IN (?))
+                                       OR data.time_period_id > ?)
+                                       """;
+
+            Assert.Equal(expectedSql, parsed.Sql);
+
+            Assert.Equal(6, parsed.SqlParameters.Count);
+            Assert.Equal(filterOptions[0].Id, parsed.SqlParameters[0].Argument);
+            Assert.Equal(filterOptions[1].Id, parsed.SqlParameters[1].Argument);
+            Assert.Equal(GeographicLevel.Region.GetEnumLabel(), parsed.SqlParameters[2].Argument);
+            Assert.Equal(locationOptions[0].Id, parsed.SqlParameters[3].Argument);
+            Assert.Equal(locationOptions[1].Id, parsed.SqlParameters[4].Argument);
+            Assert.Equal(timePeriods[0].Id, parsed.SqlParameters[5].Argument);
+        }
+
+        [Fact]
+        public async Task NestedConditions()
+        {
+            var filterOptions = _dataFixture
+                .DefaultParquetFilterOption()
+                .ForIndex(0, s => s.SetFilterId("field_a"))
+                .ForIndex(1, s => s.SetFilterId("field_b"))
+                .ForIndex(2, s => s.SetFilterId("field_c"))
+                .ForRange(3..5, s => s.SetFilterId("field_d"))
+                .GenerateList();
+
+            var queryFilterOptionIds = filterOptions
+                .Select(o => o.PublicId)
+                .ToList();
+
+            _filterRepository
+                .Setup(r => r.ListOptions(_dataSetVersion, queryFilterOptionIds.ToHashSet(), default))
+                .ReturnsAsync(filterOptions);
+
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaNot
+            {
+                Not = new DataSetQueryCriteriaAnd
+                {
+                    And =
+                    [
+                        new DataSetQueryCriteriaFacets
+                        {
+                            Filters = new DataSetQueryCriteriaFilters { NotEq = queryFilterOptionIds[0] }
+                        },
+                        new DataSetQueryCriteriaOr
+                        {
+                            Or =
+                            [
+                                new DataSetQueryCriteriaFacets
+                                {
+                                    Filters = new DataSetQueryCriteriaFilters { Eq = queryFilterOptionIds[1] }
+                                },
+                                new DataSetQueryCriteriaFacets
+                                {
+                                    Filters = new DataSetQueryCriteriaFilters { Eq = queryFilterOptionIds[2] }
+                                }
+                            ]
+                        },
+                        new DataSetQueryCriteriaNot
+                        {
+                            Not = new DataSetQueryCriteriaFacets
+                            {
+                                Filters = new DataSetQueryCriteriaFilters { In = queryFilterOptionIds[3..] }
+                            }
+                        },
+                    ]
+                }
+            };
+
+            var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
+
+            const string expectedSql = """
+                                       NOT ((data."field_a" != ?)
+                                       AND ((data."field_b" = ?)
+                                       OR (data."field_c" = ?))
+                                       AND (NOT (data."field_d" IN (?, ?))))
+                                       """;
+
+            Assert.Equal(expectedSql, parsed.Sql);
+
+            Assert.Equal(5, parsed.SqlParameters.Count);
+            Assert.Equal(filterOptions[0].Id, parsed.SqlParameters[0].Argument);
+            Assert.Equal(filterOptions[1].Id, parsed.SqlParameters[1].Argument);
+            Assert.Equal(filterOptions[2].Id, parsed.SqlParameters[2].Argument);
+            Assert.Equal(filterOptions[3].Id, parsed.SqlParameters[3].Argument);
+            Assert.Equal(filterOptions[4].Id, parsed.SqlParameters[4].Argument);
+
+            Assert.Empty(queryState.Errors);
+            Assert.Empty(queryState.Warnings);
+        }
+    }
+
+    public class ParseCriteriaPathTests : DataSetQueryParserTests
+    {
+        private readonly DataSetVersion _dataSetVersion;
+
+        public ParseCriteriaPathTests()
+        {
+            _dataSetVersion = DefaultDataSetVersion();
+
+            _filterRepository
+                .Setup(r =>
+                    r.ListOptions(_dataSetVersion, It.IsAny<IEnumerable<string>>(), default))
+                .ReturnsAsync([]);
+
+            _locationRepository
+                .Setup(r =>
+                    r.ListOptions(_dataSetVersion, It.IsAny<IEnumerable<DataSetQueryLocation>>(), default))
+                .ReturnsAsync([]);
+
+            _timePeriodRepository
+                .Setup(r =>
+                    r.List(_dataSetVersion, It.IsAny<IEnumerable<DataSetQueryTimePeriod>>(), default))
+                .ReturnsAsync([]);
+        }
+
+        [Theory]
+        [InlineData("criteria")]
+        [InlineData("test.path")]
+        public async Task FacetsOnly_BasePathChanged(string basePath)
+        {
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaFacets
+            {
+                Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
+                Locations = CreateCriteriaLocations(
+                    "In",
+                    [
+                        new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
+                    ]
+                ),
+                TimePeriods = CreateCriteriaTimePeriods(
+                    "In",
+                    [
+                        new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
+                    ]
+                ),
+            };
+
+            await service.ParseCriteria(criteria, _dataSetVersion, queryState, basePath);
+
+            Assert.Equal(3, queryState.Warnings.Count);
+
+            Assert.Equal($"{basePath}.filters.in", queryState.Warnings[0].Path);
+            Assert.Equal($"{basePath}.locations.in", queryState.Warnings[1].Path);
+            Assert.Equal($"{basePath}.timePeriods.in", queryState.Warnings[2].Path);
+        }
+
+        [Theory]
+        [InlineData("criteria")]
+        [InlineData("test.path")]
+        public async Task AndCondition_BasePathChanged(string basePath)
+        {
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaAnd
+            {
+                And =
+                [
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
+                        Locations = CreateCriteriaLocations(
+                            "In",
+                            [
+                                new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
+                            ]
+                        ),
+                        TimePeriods = CreateCriteriaTimePeriods(
+                            "In",
+                            [
+                                new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
+                            ]
+                        ),
+                    }
+                ]
+            };
+
+            await service.ParseCriteria(criteria, _dataSetVersion, queryState, basePath);
+
+            Assert.Equal(3, queryState.Warnings.Count);
+
+            Assert.Equal($"{basePath}.and[0].filters.in", queryState.Warnings[0].Path);
+            Assert.Equal($"{basePath}.and[0].locations.in", queryState.Warnings[1].Path);
+            Assert.Equal($"{basePath}.and[0].timePeriods.in", queryState.Warnings[2].Path);
+        }
+
+        [Theory]
+        [InlineData("criteria")]
+        [InlineData("test.path")]
+        public async Task OrCondition_BasePathChanged(string basePath)
+        {
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    new DataSetQueryCriteriaFacets
+                    {
+                        Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
+                        Locations = CreateCriteriaLocations(
+                            "In",
+                            [
+                                new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
+                            ]
+                        ),
+                        TimePeriods = CreateCriteriaTimePeriods(
+                            "In",
+                            [
+                                new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
+                            ]
+                        ),
+                    }
+                ]
+            };
+
+            await service.ParseCriteria(criteria, _dataSetVersion, queryState, basePath);
+
+            Assert.Equal(3, queryState.Warnings.Count);
+
+            Assert.Equal($"{basePath}.or[0].filters.in", queryState.Warnings[0].Path);
+            Assert.Equal($"{basePath}.or[0].locations.in", queryState.Warnings[1].Path);
+            Assert.Equal($"{basePath}.or[0].timePeriods.in", queryState.Warnings[2].Path);
+        }
+
+        [Theory]
+        [InlineData("criteria")]
+        [InlineData("test.path")]
+        public async Task NotCondition_BasePathChanged(string basePath)
+        {
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaNot
+            {
+                Not = new DataSetQueryCriteriaFacets
+                {
+                    Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
+                    Locations = CreateCriteriaLocations(
+                        "In",
+                        [
+                            new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
+                        ]
+                    ),
+                    TimePeriods = CreateCriteriaTimePeriods(
+                        "In",
+                        [
+                            new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
+                        ]
+                    ),
+                }
+            };
+
+            await service.ParseCriteria(criteria, _dataSetVersion, queryState, basePath);
+
+            Assert.Equal(3, queryState.Warnings.Count);
+
+            Assert.Equal($"{basePath}.not.filters.in", queryState.Warnings[0].Path);
+            Assert.Equal($"{basePath}.not.locations.in", queryState.Warnings[1].Path);
+            Assert.Equal($"{basePath}.not.timePeriods.in", queryState.Warnings[2].Path);
+        }
+
+        [Theory]
+        [InlineData("criteria")]
+        [InlineData("test.path")]
+        public async Task NestedConditionMixture_BasePathChanged(string basePath)
+        {
+            var service = BuildService();
+
+            var queryState = new QueryState();
+            var criteria = new DataSetQueryCriteriaOr
+            {
+                Or =
+                [
+                    new DataSetQueryCriteriaNot
+                    {
+                        Not = new DataSetQueryCriteriaFacets
+                        {
+                            Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
+                            Locations = CreateCriteriaLocations(
+                                "In",
+                                [
+                                    new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
+                                ]
+                            ),
+                            TimePeriods = CreateCriteriaTimePeriods(
+                                "In",
+                                [
+                                    new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
+                                ]
+                            ),
+                        }
+                    },
+                    new DataSetQueryCriteriaAnd
+                    {
+                        And =
+                        [
+                            new DataSetQueryCriteriaFacets
+                            {
+                                Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
+                                Locations = CreateCriteriaLocations(
+                                    "In",
+                                    [
+                                        new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
+                                    ]
+                                ),
+                                TimePeriods = CreateCriteriaTimePeriods(
+                                    "In",
+                                    [
+                                        new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
+                                    ]
+                                ),
+                            }
+                        ],
+                    }
+                ]
+            };
+
+            await service.ParseCriteria(criteria, _dataSetVersion, queryState, basePath);
+
+            Assert.Equal(6, queryState.Warnings.Count);
+
+            Assert.Equal($"{basePath}.or[0].not.filters.in", queryState.Warnings[0].Path);
+            Assert.Equal($"{basePath}.or[0].not.locations.in", queryState.Warnings[1].Path);
+            Assert.Equal($"{basePath}.or[0].not.timePeriods.in", queryState.Warnings[2].Path);
+
+            Assert.Equal($"{basePath}.or[1].and[0].filters.in", queryState.Warnings[3].Path);
+            Assert.Equal($"{basePath}.or[1].and[0].locations.in", queryState.Warnings[4].Path);
+            Assert.Equal($"{basePath}.or[1].and[0].timePeriods.in", queryState.Warnings[5].Path);
         }
     }
 
@@ -1552,8 +2544,11 @@ public abstract class DataSetQueryParserTests
         };
     }
 
-    private static DataSetQueryLocation MapOptionToQueryLocation(ParquetLocationOption option, GeographicLevel level)
-        => level switch
+    private static DataSetQueryLocation MapOptionToQueryLocation(ParquetLocationOption option)
+    {
+        var level = EnumUtil.GetFromEnumValue<GeographicLevel>(option.Level);
+
+        return level switch
         {
             GeographicLevel.LocalAuthority => option switch
             {
@@ -1572,8 +2567,7 @@ public abstract class DataSetQueryParserTests
             },
             GeographicLevel.RscRegion => new DataSetQueryLocationId
             {
-                Level = option.Level,
-                Id  = option.PublicId,
+                Level = option.Level, Id = option.PublicId,
             },
             GeographicLevel.School => option switch
             {
@@ -1591,6 +2585,13 @@ public abstract class DataSetQueryParserTests
                 _ => throw new NullReferenceException($"{nameof(option.Code)} cannot be null")
             }
         };
+    }
+
+    private static DataSetQueryTimePeriod MapQueryTimePeriod(ParquetTimePeriod option) => new()
+    {
+        Code = EnumUtil.GetFromEnumLabel<TimeIdentifier>(option.Identifier).GetEnumValue(),
+        Period = TimePeriodFormatter.FormatFromCsv(option.Period)
+    };
 
     private DataSetQueryParser BuildService(
         IParquetFilterRepository? filterRepository = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/DataSetQueryParserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/DataSetQueryParserTests.cs
@@ -59,7 +59,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Filters = CreateCriteriaFilters(comparator, [])
+                Filters = DataSetQueryCriteriaFilters.Create(comparator, [])
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -96,7 +96,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Filters = CreateCriteriaFilters(comparator, queryFilterOptionIds)
+                Filters = DataSetQueryCriteriaFilters.Create(comparator, queryFilterOptionIds)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -128,7 +128,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Filters = CreateCriteriaFilters(comparator, queryFilterOptionIds)
+                Filters = DataSetQueryCriteriaFilters.Create(comparator, queryFilterOptionIds)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -171,7 +171,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Filters = CreateCriteriaFilters(comparator, queryFilterOptionIds)
+                Filters = DataSetQueryCriteriaFilters.Create(comparator, queryFilterOptionIds)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -222,7 +222,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Filters = CreateCriteriaFilters(comparator, queryFilterOptionIds)
+                Filters = DataSetQueryCriteriaFilters.Create(comparator, queryFilterOptionIds)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -274,7 +274,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Filters = CreateCriteriaFilters(comparator, queryFilterOptionIds)
+                Filters = DataSetQueryCriteriaFilters.Create(comparator, queryFilterOptionIds)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -313,7 +313,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Filters = CreateCriteriaFilters(comparator, queryFilterOptionIds)
+                Filters = DataSetQueryCriteriaFilters.Create(comparator, queryFilterOptionIds)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -371,7 +371,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                GeographicLevels = CreateCriteriaGeographicLevels(comparator, [])
+                GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create(comparator, Array.Empty<string>())
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -399,7 +399,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                GeographicLevels = CreateCriteriaGeographicLevels(comparator, geographicLevels)
+                GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create(comparator, geographicLevels)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -426,7 +426,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                GeographicLevels = CreateCriteriaGeographicLevels(comparator, geographicLevels)
+                GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create(comparator, geographicLevels)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -465,7 +465,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                GeographicLevels = CreateCriteriaGeographicLevels(comparator, geographicLevels)
+                GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create(comparator, geographicLevels)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -500,7 +500,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                GeographicLevels = CreateCriteriaGeographicLevels(comparator, geographicLevels)
+                GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create(comparator, geographicLevels)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -541,7 +541,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                GeographicLevels = CreateCriteriaGeographicLevels(comparator, geographicLevels)
+                GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create(comparator, geographicLevels)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -596,7 +596,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Locations = CreateCriteriaLocations(comparator, [])
+                Locations = DataSetQueryCriteriaLocations.Create(comparator, [])
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -651,7 +651,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Locations = CreateCriteriaLocations(comparator, queryLocation)
+                Locations = DataSetQueryCriteriaLocations.Create(comparator, queryLocation)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -689,7 +689,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Locations = CreateCriteriaLocations(comparator, queryLocation),
+                Locations = DataSetQueryCriteriaLocations.Create(comparator, queryLocation),
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -742,7 +742,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Locations = CreateCriteriaLocations(comparator, queryLocations)
+                Locations = DataSetQueryCriteriaLocations.Create(comparator, queryLocations)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -796,7 +796,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Locations = CreateCriteriaLocations(comparator, queryLocations)
+                Locations = DataSetQueryCriteriaLocations.Create(comparator, queryLocations)
             };
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
 
@@ -849,7 +849,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Locations = CreateCriteriaLocations(comparator, queryLocations)
+                Locations = DataSetQueryCriteriaLocations.Create(comparator, queryLocations)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -897,7 +897,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Locations = CreateCriteriaLocations(comparator, queryLocations)
+                Locations = DataSetQueryCriteriaLocations.Create(comparator, queryLocations)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -956,7 +956,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                TimePeriods = CreateCriteriaTimePeriods(comparator, [])
+                TimePeriods = DataSetQueryCriteriaTimePeriods.Create(comparator, [])
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -994,7 +994,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                TimePeriods = CreateCriteriaTimePeriods(comparator, queryTimePeriods)
+                TimePeriods = DataSetQueryCriteriaTimePeriods.Create(comparator, queryTimePeriods)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -1032,7 +1032,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                TimePeriods = CreateCriteriaTimePeriods(comparator, queryTimePeriods)
+                TimePeriods = DataSetQueryCriteriaTimePeriods.Create(comparator, queryTimePeriods)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -1078,7 +1078,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                TimePeriods = CreateCriteriaTimePeriods(comparator, queryTimePeriods)
+                TimePeriods = DataSetQueryCriteriaTimePeriods.Create(comparator, queryTimePeriods)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -1120,7 +1120,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                TimePeriods = CreateCriteriaTimePeriods(comparator, queryTimePeriods)
+                TimePeriods = DataSetQueryCriteriaTimePeriods.Create(comparator, queryTimePeriods)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -1171,7 +1171,7 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                TimePeriods = CreateCriteriaTimePeriods(comparator, queryTimePeriods)
+                TimePeriods = DataSetQueryCriteriaTimePeriods.Create(comparator, queryTimePeriods)
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -1251,10 +1251,10 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Filters = CreateCriteriaFilters("Eq", []),
-                GeographicLevels = CreateCriteriaGeographicLevels("In", []),
-                Locations = CreateCriteriaLocations("NotEq", []),
-                TimePeriods = CreateCriteriaTimePeriods("Gt", []),
+                Filters = DataSetQueryCriteriaFilters.Create("Eq", []),
+                GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create("In", Array.Empty<string>()),
+                Locations = DataSetQueryCriteriaLocations.Create("NotEq", []),
+                TimePeriods = DataSetQueryCriteriaTimePeriods.Create("Gt", []),
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -1325,10 +1325,10 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Filters = CreateCriteriaFilters("Eq", queryFilterOptionIds),
-                GeographicLevels = CreateCriteriaGeographicLevels("In", geographicLevels),
-                Locations = CreateCriteriaLocations("NotEq", queryLocations),
-                TimePeriods = CreateCriteriaTimePeriods("Gt", queryTimePeriods),
+                Filters = DataSetQueryCriteriaFilters.Create("Eq", queryFilterOptionIds),
+                GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create("In", geographicLevels),
+                Locations = DataSetQueryCriteriaLocations.Create("NotEq", queryLocations),
+                TimePeriods = DataSetQueryCriteriaTimePeriods.Create("Gt", queryTimePeriods),
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -1415,10 +1415,10 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Filters = CreateCriteriaFilters("NotIn", queryFilterOptionIds),
-                GeographicLevels = CreateCriteriaGeographicLevels("NotIn", geographicLevels),
-                Locations = CreateCriteriaLocations("In", queryLocations),
-                TimePeriods = CreateCriteriaTimePeriods("In", queryTimePeriods),
+                Filters = DataSetQueryCriteriaFilters.Create("NotIn", queryFilterOptionIds),
+                GeographicLevels = DataSetQueryCriteriaGeographicLevels.Create("NotIn", geographicLevels),
+                Locations = DataSetQueryCriteriaLocations.Create("In", queryLocations),
+                TimePeriods = DataSetQueryCriteriaTimePeriods.Create("In", queryTimePeriods),
             };
 
             var parsed = await service.ParseCriteria(criteria, _dataSetVersion, queryState);
@@ -2238,14 +2238,14 @@ public abstract class DataSetQueryParserTests
             var queryState = new QueryState();
             var criteria = new DataSetQueryCriteriaFacets
             {
-                Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
-                Locations = CreateCriteriaLocations(
+                Filters = DataSetQueryCriteriaFilters.Create("In", ["invalidFilter"]),
+                Locations = DataSetQueryCriteriaLocations.Create(
                     "In",
                     [
                         new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
                     ]
                 ),
-                TimePeriods = CreateCriteriaTimePeriods(
+                TimePeriods = DataSetQueryCriteriaTimePeriods.Create(
                     "In",
                     [
                         new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
@@ -2276,14 +2276,14 @@ public abstract class DataSetQueryParserTests
                 [
                     new DataSetQueryCriteriaFacets
                     {
-                        Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
-                        Locations = CreateCriteriaLocations(
+                        Filters = DataSetQueryCriteriaFilters.Create("In", ["invalidFilter"]),
+                        Locations = DataSetQueryCriteriaLocations.Create(
                             "In",
                             [
                                 new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
                             ]
                         ),
-                        TimePeriods = CreateCriteriaTimePeriods(
+                        TimePeriods = DataSetQueryCriteriaTimePeriods.Create(
                             "In",
                             [
                                 new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
@@ -2316,14 +2316,14 @@ public abstract class DataSetQueryParserTests
                 [
                     new DataSetQueryCriteriaFacets
                     {
-                        Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
-                        Locations = CreateCriteriaLocations(
+                        Filters = DataSetQueryCriteriaFilters.Create("In", ["invalidFilter"]),
+                        Locations = DataSetQueryCriteriaLocations.Create(
                             "In",
                             [
                                 new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
                             ]
                         ),
-                        TimePeriods = CreateCriteriaTimePeriods(
+                        TimePeriods = DataSetQueryCriteriaTimePeriods.Create(
                             "In",
                             [
                                 new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
@@ -2354,14 +2354,14 @@ public abstract class DataSetQueryParserTests
             {
                 Not = new DataSetQueryCriteriaFacets
                 {
-                    Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
-                    Locations = CreateCriteriaLocations(
+                    Filters = DataSetQueryCriteriaFilters.Create("In", ["invalidFilter"]),
+                    Locations = DataSetQueryCriteriaLocations.Create(
                         "In",
                         [
                             new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
                         ]
                     ),
-                    TimePeriods = CreateCriteriaTimePeriods(
+                    TimePeriods = DataSetQueryCriteriaTimePeriods.Create(
                         "In",
                         [
                             new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
@@ -2395,14 +2395,14 @@ public abstract class DataSetQueryParserTests
                     {
                         Not = new DataSetQueryCriteriaFacets
                         {
-                            Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
-                            Locations = CreateCriteriaLocations(
+                            Filters = DataSetQueryCriteriaFilters.Create("In", ["invalidFilter"]),
+                            Locations = DataSetQueryCriteriaLocations.Create(
                                 "In",
                                 [
                                     new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
                                 ]
                             ),
-                            TimePeriods = CreateCriteriaTimePeriods(
+                            TimePeriods = DataSetQueryCriteriaTimePeriods.Create(
                                 "In",
                                 [
                                     new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
@@ -2416,14 +2416,14 @@ public abstract class DataSetQueryParserTests
                         [
                             new DataSetQueryCriteriaFacets
                             {
-                                Filters = CreateCriteriaFilters("In", ["invalidFilter"]),
-                                Locations = CreateCriteriaLocations(
+                                Filters = DataSetQueryCriteriaFilters.Create("In", ["invalidFilter"]),
+                                Locations = DataSetQueryCriteriaLocations.Create(
                                     "In",
                                     [
                                         new DataSetQueryLocationId { Id = "12345", Level = "NAT" }
                                     ]
                                 ),
-                                TimePeriods = CreateCriteriaTimePeriods(
+                                TimePeriods = DataSetQueryCriteriaTimePeriods.Create(
                                     "In",
                                     [
                                         new DataSetQueryTimePeriod { Period = "2022", Code = "AY" }
@@ -2455,94 +2455,6 @@ public abstract class DataSetQueryParserTests
             _dataFixture.DefaultDataSetVersionMetaSummary()
                 .WithGeographicLevels([GeographicLevel.Country, GeographicLevel.Region])
         );
-
-    private static DataSetQueryCriteriaFilters CreateCriteriaFilters(
-        string comparator,
-        IReadOnlyList<string> filterOptionIds)
-    {
-        return comparator switch
-        {
-            nameof(DataSetQueryCriteriaFilters.Eq) =>
-                new DataSetQueryCriteriaFilters { Eq = filterOptionIds.Count > 0 ? filterOptionIds[0] : null },
-            nameof(DataSetQueryCriteriaFilters.NotEq) =>
-                new DataSetQueryCriteriaFilters { NotEq = filterOptionIds.Count > 0 ? filterOptionIds[0] : null },
-            nameof(DataSetQueryCriteriaFilters.In) =>
-                new DataSetQueryCriteriaFilters { In = filterOptionIds },
-            nameof(DataSetQueryCriteriaFilters.NotIn) =>
-                new DataSetQueryCriteriaFilters { NotIn = filterOptionIds },
-            _ => throw new ArgumentOutOfRangeException(nameof(comparator), comparator, null)
-        };
-    }
-
-    private static DataSetQueryCriteriaGeographicLevels CreateCriteriaGeographicLevels(
-        string comparator,
-        IReadOnlyList<GeographicLevel> geographicLevels)
-    {
-        return comparator switch
-        {
-            nameof(DataSetQueryCriteriaGeographicLevels.Eq) => new DataSetQueryCriteriaGeographicLevels
-            {
-                Eq = geographicLevels.Count > 0 ? geographicLevels[0].GetEnumValue() : null
-            },
-            nameof(DataSetQueryCriteriaGeographicLevels.NotEq) => new DataSetQueryCriteriaGeographicLevels
-            {
-                NotEq = geographicLevels.Count > 0 ? geographicLevels[0].GetEnumValue() : null
-            },
-            nameof(DataSetQueryCriteriaGeographicLevels.In) => new DataSetQueryCriteriaGeographicLevels
-            {
-                In = geographicLevels.Select(l => l.GetEnumValue()).ToList()
-            },
-            nameof(DataSetQueryCriteriaGeographicLevels.NotIn) => new DataSetQueryCriteriaGeographicLevels
-            {
-                NotIn = geographicLevels.Select(l => l.GetEnumValue()).ToList()
-            },
-            _ => throw new ArgumentOutOfRangeException(nameof(comparator), comparator, null)
-        };
-    }
-
-    private static DataSetQueryCriteriaLocations CreateCriteriaLocations(
-        string comparator,
-        IReadOnlyList<DataSetQueryLocation> locations)
-    {
-        return comparator switch
-        {
-            nameof(DataSetQueryCriteriaLocations.Eq) =>
-                new DataSetQueryCriteriaLocations { Eq = locations.Count > 0 ? locations[0] : null },
-            nameof(DataSetQueryCriteriaLocations.NotEq) =>
-                new DataSetQueryCriteriaLocations { NotEq = locations.Count > 0 ? locations[0] : null },
-            nameof(DataSetQueryCriteriaLocations.In) =>
-                new DataSetQueryCriteriaLocations { In = locations },
-            nameof(DataSetQueryCriteriaLocations.NotIn) =>
-                new DataSetQueryCriteriaLocations { NotIn = locations },
-            _ => throw new ArgumentOutOfRangeException(nameof(comparator), comparator, null)
-        };
-    }
-
-    private static DataSetQueryCriteriaTimePeriods CreateCriteriaTimePeriods(
-        string comparator,
-        IReadOnlyList<DataSetQueryTimePeriod> timePeriods)
-    {
-        return comparator switch
-        {
-            nameof(DataSetQueryCriteriaTimePeriods.Eq) =>
-                new DataSetQueryCriteriaTimePeriods { Eq = timePeriods.Count > 0 ? timePeriods[0] : null },
-            nameof(DataSetQueryCriteriaTimePeriods.NotEq) =>
-                new DataSetQueryCriteriaTimePeriods { NotEq = timePeriods.Count > 0 ? timePeriods[0] : null },
-            nameof(DataSetQueryCriteriaTimePeriods.In) =>
-                new DataSetQueryCriteriaTimePeriods { In = timePeriods },
-            nameof(DataSetQueryCriteriaTimePeriods.NotIn) =>
-                new DataSetQueryCriteriaTimePeriods { NotIn = timePeriods },
-            nameof(DataSetQueryCriteriaTimePeriods.Gt) =>
-                new DataSetQueryCriteriaTimePeriods { Gt = timePeriods.Count > 0 ? timePeriods[0] : null },
-            nameof(DataSetQueryCriteriaTimePeriods.Gte) =>
-                new DataSetQueryCriteriaTimePeriods { Gte = timePeriods.Count > 0 ? timePeriods[0] : null },
-            nameof(DataSetQueryCriteriaTimePeriods.Lt) =>
-                new DataSetQueryCriteriaTimePeriods { Lt = timePeriods.Count > 0 ? timePeriods[0] : null },
-            nameof(DataSetQueryCriteriaTimePeriods.Lte) =>
-                new DataSetQueryCriteriaTimePeriods { Lte = timePeriods.Count > 0 ? timePeriods[0] : null },
-            _ => throw new ArgumentOutOfRangeException(nameof(comparator), comparator, null)
-        };
-    }
 
     private static DataSetQueryLocation MapOptionToQueryLocation(ParquetLocationOption option)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -268,4 +268,34 @@ public class DataSetsController(
             .Query(dataSetId, request, dataSetVersion, cancellationToken)
             .HandleFailuresOrOk();
     }
+
+    /// <summary>
+    /// Query a data set (POST)
+    /// </summary>
+    /// <remarks>
+    /// Query a data set using a `POST` request, returning the filtered results.
+    ///
+    /// Note that for simpler queries or exploratory testing, there is also GET variant of this endpoint
+    /// only handles a smaller subset of querying functionality. However, for most use-cases,
+    /// this endpoint is recommended as it provides the complete set of functionality.
+    ///
+    /// Unlike the `GET` endpoint, the `POST` endpoint allows condition criteria (`and`, `or`, `not`)
+    /// and consequently can express more complex queries.
+    /// </remarks>
+    [HttpPost("{dataSetId:guid}/query")]
+    [Produces("application/json")]
+    [SwaggerResponse(200, "The paginated list of query results", type: typeof(DataSetQueryPaginatedResultsViewModel))]
+    [SwaggerResponse(400, type: typeof(ValidationProblemViewModel))]
+    [SwaggerResponse(403, type: typeof(ProblemDetailsViewModel))]
+    [SwaggerResponse(404, type: typeof(ProblemDetailsViewModel))]
+    public async Task<ActionResult<DataSetQueryPaginatedResultsViewModel>> QueryDataSetPost(
+        [SwaggerParameter("The ID of the data set.")] Guid dataSetId,
+        [SwaggerParameter("The version of the data set to use e.g. 2.0, 1.1, etc.")][FromQuery] string? dataSetVersion,
+        [FromBody] DataSetQueryRequest request,
+        CancellationToken cancellationToken)
+    {
+        return await dataSetQueryService
+            .Query(dataSetId, request, dataSetVersion, cancellationToken)
+            .HandleFailuresOrOk();
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/Converters/DataSetQueryCriteriaJsonConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/Converters/DataSetQueryCriteriaJsonConverter.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests.Converters;
+
+public class DataSetQueryCriteriaJsonConverter : JsonConverter<DataSetQueryCriteria>
+{
+    public override bool CanConvert(Type type)
+    {
+        return type.IsAssignableFrom(typeof(DataSetQueryCriteria));
+    }
+
+    public override DataSetQueryCriteria? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (!JsonDocument.TryParseValue(ref reader, out var doc))
+        {
+            throw new JsonException();
+        }
+
+        try
+        {
+            var rootElement = doc.RootElement.GetRawText();
+
+            var propertyNames = doc.RootElement
+                .EnumerateObject()
+                .Select(p => p.Name.ToUpperFirst())
+                .ToHashSet();
+
+            if (propertyNames.Contains(nameof(DataSetQueryCriteriaAnd.And)))
+            {
+                return JsonSerializer.Deserialize<DataSetQueryCriteriaAnd>(rootElement, options);
+            }
+
+            if (propertyNames.Contains(nameof(DataSetQueryCriteriaOr.Or)))
+            {
+                return JsonSerializer.Deserialize<DataSetQueryCriteriaOr>(rootElement, options);
+            }
+
+            if (propertyNames.Contains(nameof(DataSetQueryCriteriaNot.Not)))
+            {
+                return JsonSerializer.Deserialize<DataSetQueryCriteriaNot>(rootElement, options);
+            }
+
+            return JsonSerializer.Deserialize<DataSetQueryCriteriaFacets>(rootElement, options);
+        }
+        catch (JsonException exception)
+        {
+            throw new JsonException(message: null, exception);
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, DataSetQueryCriteria value, JsonSerializerOptions options)
+    {
+        try
+        {
+            switch (value)
+            {
+                case DataSetQueryCriteriaAnd:
+                    JsonSerializer.Serialize(writer, value, typeof(DataSetQueryCriteriaAnd), options);
+                    return;
+                case DataSetQueryCriteriaOr:
+                    JsonSerializer.Serialize(writer, value, typeof(DataSetQueryCriteriaOr), options);
+                    return;
+                case DataSetQueryCriteriaNot:
+                    JsonSerializer.Serialize(writer, value, typeof(DataSetQueryCriteriaNot), options);
+                    return;
+                case DataSetQueryCriteriaFacets:
+                    JsonSerializer.Serialize(writer, value, typeof(DataSetQueryCriteriaFacets), options);
+                    return;
+            }
+        }
+        catch (JsonException exception)
+        {
+            throw new JsonException(message: null, exception);
+        }
+
+        throw new JsonException();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/Converters/DataSetQueryLocationJsonConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/Converters/DataSetQueryLocationJsonConverter.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests.Converters;
+
+public class DataSetQueryLocationJsonConverter : JsonConverter<DataSetQueryLocation>
+{
+    public override bool CanConvert(Type type)
+    {
+        return type.IsAssignableFrom(typeof(DataSetQueryLocation));
+    }
+
+    public override DataSetQueryLocation? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (!JsonDocument.TryParseValue(ref reader, out var doc))
+        {
+            throw new JsonException();
+        }
+
+        var rootElement = doc.RootElement.GetRawText();
+
+        var propertyNames = doc.RootElement
+            .EnumerateObject()
+            .Select(p => p.Name.ToUpperFirst())
+            .ToHashSet();
+
+        if (!doc.RootElement.TryGetProperty(nameof(DataSetQueryLocation.Level).ToLowerFirst(), out var levelProperty))
+        {
+            throw new JsonException();
+        }
+
+        try
+        {
+            var levelString = levelProperty.GetString() ?? string.Empty;
+
+            if (EnumUtil.TryGetFromEnumValue<GeographicLevel>(levelString, out var level))
+            {
+                switch (level)
+                {
+                    case GeographicLevel.LocalAuthority
+                        when propertyNames.Contains(nameof(DataSetQueryLocationLocalAuthorityCode.Code)):
+                        return JsonSerializer.Deserialize<DataSetQueryLocationLocalAuthorityCode>(rootElement, options);
+
+                    case GeographicLevel.LocalAuthority
+                        when propertyNames.Contains(nameof(DataSetQueryLocationLocalAuthorityOldCode.OldCode)):
+                        return JsonSerializer.Deserialize<DataSetQueryLocationLocalAuthorityOldCode>(
+                            rootElement,
+                            options
+                        );
+
+                    case GeographicLevel.School
+                        when propertyNames.Contains(nameof(DataSetQueryLocationSchoolLaEstab.LaEstab)):
+                        return JsonSerializer.Deserialize<DataSetQueryLocationSchoolLaEstab>(rootElement, options);
+
+                    case GeographicLevel.School
+                        when propertyNames.Contains(nameof(DataSetQueryLocationSchoolUrn.Urn)):
+                        return JsonSerializer.Deserialize<DataSetQueryLocationSchoolUrn>(rootElement, options);
+
+                    case GeographicLevel.Provider
+                        when propertyNames.Contains(nameof(DataSetQueryLocationProviderUkprn.Ukprn)):
+                        return JsonSerializer.Deserialize<DataSetQueryLocationProviderUkprn>(rootElement, options);
+                }
+            }
+
+            if (propertyNames.Contains(nameof(DataSetQueryLocationCode.Code)))
+            {
+                return JsonSerializer.Deserialize<DataSetQueryLocationCode>(rootElement, options);
+            }
+
+            return JsonSerializer.Deserialize<DataSetQueryLocationId>(rootElement, options);
+        }
+        catch (JsonException exception)
+        {
+            throw new JsonException(message: null, exception);
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, DataSetQueryLocation value, JsonSerializerOptions options)
+    {
+        try
+        {
+            switch (value)
+            {
+                case DataSetQueryLocationLocalAuthorityCode:
+                    JsonSerializer.Serialize(writer, value, typeof(DataSetQueryLocationLocalAuthorityCode), options);
+                    return;
+                case DataSetQueryLocationLocalAuthorityOldCode:
+                    JsonSerializer.Serialize(writer, value, typeof(DataSetQueryLocationLocalAuthorityOldCode), options);
+                    return;
+                case DataSetQueryLocationProviderUkprn:
+                    JsonSerializer.Serialize(writer, value, typeof(DataSetQueryLocationProviderUkprn), options);
+                    return;
+                case DataSetQueryLocationSchoolLaEstab:
+                    JsonSerializer.Serialize(writer, value, typeof(DataSetQueryLocationSchoolLaEstab), options);
+                    return;
+                case DataSetQueryLocationSchoolUrn:
+                    JsonSerializer.Serialize(writer, value, typeof(DataSetQueryLocationSchoolUrn), options);
+                    return;
+                case DataSetQueryLocationCode:
+                    JsonSerializer.Serialize(writer, value, typeof(DataSetQueryLocationCode), options);
+                    return;
+                case DataSetQueryLocationId:
+                    JsonSerializer.Serialize(writer, value, typeof(DataSetQueryLocationId), options);
+                    return;
+            }
+        }
+        catch (JsonException exception)
+        {
+            throw new JsonException(message: null, exception);
+        }
+
+        throw new JsonException();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryFilters.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryFilters.cs
@@ -1,32 +1,21 @@
-using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
-public record DataSetGetQueryFilters
+public record DataSetGetQueryFilters : DataSetQueryCriteriaFilters
 {
-    /// <summary>
-    /// Filter the results to have a filter option matching this ID.
-    /// </summary>
-    public string? Eq { get; init; }
-
-    /// <summary>
-    /// Filter the results to not have a filter option matching this ID.
-    /// </summary>
-    public string? NotEq { get; init; }
-
     /// <summary>
     /// Filter the results to have a filter option matching at least one of these IDs.
     /// </summary>
     [FromQuery, QuerySeparator]
-    public IReadOnlyList<string>? In { get; init; }
+    public override IReadOnlyList<string>? In { get; init; }
 
     /// <summary>
     /// Filter the results to not have a filter option matching any of these IDs.
     /// </summary>
     [FromQuery, QuerySeparator]
-    public IReadOnlyList<string>? NotIn { get; init; }
+    public override IReadOnlyList<string>? NotIn { get; init; }
 
     public DataSetQueryCriteriaFilters ToCriteria()
     {
@@ -39,39 +28,5 @@ public record DataSetGetQueryFilters
         };
     }
 
-    public class Validator : AbstractValidator<DataSetGetQueryFilters>
-    {
-        public Validator()
-        {
-            RuleFor(q => q.Eq)
-                .NotEmpty()
-                .MaximumLength(10)
-                .When(q => q.Eq is not null);
-
-            RuleFor(q => q.NotEq)
-                .NotEmpty()
-                .MaximumLength(10)
-                .When(q => q.NotEq is not null);
-
-            When(q => q.In is not null, () =>
-            {
-                RuleFor(q => q.In)
-                    .NotEmpty();
-                
-                RuleForEach(q => q.In)
-                    .NotEmpty()
-                    .MaximumLength(10);
-            });
-
-            When(q => q.NotIn is not null, () =>
-            {
-                RuleFor(q => q.NotIn)
-                    .NotEmpty();
-
-                RuleForEach(q => q.NotIn)
-                    .NotEmpty()
-                    .MaximumLength(10);
-            });
-        }
-    }
+    public new class Validator : DataSetQueryCriteriaFilters.Validator;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryGeographicLevels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetGetQueryGeographicLevels.cs
@@ -1,34 +1,19 @@
-using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
-using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
-public record DataSetGetQueryGeographicLevels
+public record DataSetGetQueryGeographicLevels : DataSetQueryCriteriaGeographicLevels
 {
-    /// <summary>
-    /// Filter the results to be in this geographic level.
-    /// </summary>
-    [SwaggerEnum(typeof(GeographicLevel))]
-    public string? Eq { get; init; }
-
-    /// <summary>
-    /// Filter the results to not be in this geographic level.
-    /// </summary>
-    [SwaggerEnum(typeof(GeographicLevel))]
-    public string? NotEq { get; init; }
-
     /// <summary>
     /// Filter the results to be in one of these geographic levels.
     /// </summary>
     [FromQuery]
     [QuerySeparator]
     [SwaggerEnum(typeof(GeographicLevel))]
-    public IReadOnlyList<string>? In { get; init; }
+    public override IReadOnlyList<string>? In { get; init; }
 
     /// <summary>
     /// Filter the results to not be in one of these geographic levels.
@@ -36,7 +21,7 @@ public record DataSetGetQueryGeographicLevels
     [FromQuery]
     [QuerySeparator]
     [SwaggerEnum(typeof(GeographicLevel))]
-    public IReadOnlyList<string>? NotIn { get; init; }
+    public override IReadOnlyList<string>? NotIn { get; init; }
 
     public DataSetQueryCriteriaGeographicLevels ToCriteria()
     {
@@ -49,33 +34,5 @@ public record DataSetGetQueryGeographicLevels
         };
     }
 
-    public class Validator : AbstractValidator<DataSetGetQueryGeographicLevels>
-    {
-        public Validator()
-        {
-            RuleFor(q => q.Eq)
-                .AllowedValue(GeographicLevelUtils.OrderedCodes)
-                .When(q => q.Eq is not null);
-
-            RuleFor(q => q.NotEq)
-                .AllowedValue(GeographicLevelUtils.OrderedCodes)
-                .When(q => q.NotEq is not null);
-
-            When(q => q.In is not null, () =>
-            {
-                RuleFor(q => q.In)
-                    .NotEmpty();
-                RuleForEach(q => q.In)
-                    .AllowedValue(GeographicLevelUtils.OrderedCodes);
-            });
-
-            When(q => q.NotIn is not null, () =>
-            {
-                RuleFor(q => q.NotIn)
-                    .NotEmpty();
-                RuleForEach(q => q.NotIn)
-                    .AllowedValue(GeographicLevelUtils.OrderedCodes);
-            });
-        }
-    }
+    public new class Validator : DataSetQueryCriteriaGeographicLevels.Validator;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteria.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteria.cs
@@ -1,3 +1,19 @@
+using System.Text.Json.Serialization;
+using FluentValidation.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests.Converters;
+
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
-public abstract record DataSetQueryCriteria;
+[JsonConverter(typeof(DataSetQueryCriteriaJsonConverter))]
+public abstract record DataSetQueryCriteria
+{
+    protected static void InheritanceValidator<TCriteria>(
+        PolymorphicValidator<TCriteria, DataSetQueryCriteria> validator)
+        where TCriteria : DataSetQueryCriteria
+    {
+        validator.Add(_ => new DataSetQueryCriteriaAnd.Validator());
+        validator.Add(_ => new DataSetQueryCriteriaOr.Validator());
+        validator.Add(_ => new DataSetQueryCriteriaNot.Validator());
+        validator.Add(_ => new DataSetQueryCriteriaFacets.Validator());
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaAnd.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaAnd.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// A condition criteria where one or more sub-criteria must all resolve
+/// to true for the overall query to match any results.
+///
+/// This is equivalent to the `AND` operator in SQL.
+/// </summary>
+public record DataSetQueryCriteriaAnd : DataSetQueryCriteria
+{
+    /// <summary>
+    /// The sub-criteria which all must resolve to true.
+    /// </summary>
+    public required IReadOnlyList<DataSetQueryCriteria> And { get; init; }
+
+    public class Validator : AbstractValidator<DataSetQueryCriteriaAnd>
+    {
+        public Validator()
+        {
+            RuleFor(q => q.And)
+                .NotEmpty();
+
+            RuleForEach(q => q.And)
+                .NotNull()
+                .SetInheritanceValidator(InheritanceValidator);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFacets.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFacets.cs
@@ -1,7 +1,9 @@
+using FluentValidation;
+
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
 /// <summary>
-/// Criteria outlining the facets of the data to filter results by in the data set query.
+/// A set of criteria specifying which facets the query should match results with.
 ///
 /// All parts of the criteria must resolve to true to match a result.
 /// </summary>
@@ -26,4 +28,26 @@ public record DataSetQueryCriteriaFacets : DataSetQueryCriteria
     /// Query criteria relating to time periods.
     /// </summary>
     public DataSetQueryCriteriaTimePeriods? TimePeriods { get; init; }
+
+    public class Validator : AbstractValidator<DataSetQueryCriteriaFacets>
+    {
+        public Validator()
+        {
+            RuleFor(q => q.Filters)
+                .SetValidator(new DataSetQueryCriteriaFilters.Validator()!)
+                .When(q => q.Filters is not null);
+
+            RuleFor(q => q.GeographicLevels)
+                .SetValidator(new DataSetQueryCriteriaGeographicLevels.Validator()!)
+                .When(q => q.GeographicLevels is not null);
+
+            RuleFor(q => q.Locations)
+                .SetValidator(new DataSetQueryCriteriaLocations.Validator()!)
+                .When(q => q.Locations is not null);
+
+            RuleFor(q => q.TimePeriods)
+                .SetValidator(new DataSetQueryCriteriaTimePeriods.Validator()!)
+                .When(q => q.TimePeriods is not null);
+        }
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFilters.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFilters.cs
@@ -42,6 +42,32 @@ public record DataSetQueryCriteriaFilters
             .ToHashSet();
     }
 
+    public static DataSetQueryCriteriaFilters Create(
+        string comparator,
+        IList<string> optionIds)
+    {
+        return comparator switch
+        {
+            nameof(Eq) => new DataSetQueryCriteriaFilters
+            {
+                Eq = optionIds.Count > 0 ? optionIds[0] : null
+            },
+            nameof(NotEq) => new DataSetQueryCriteriaFilters
+            {
+                NotEq = optionIds.Count > 0 ? optionIds[0] : null
+            },
+            nameof(In) => new DataSetQueryCriteriaFilters
+            {
+                In = optionIds.ToList()
+            },
+            nameof(NotIn) => new DataSetQueryCriteriaFilters
+            {
+                NotIn = optionIds.ToList()
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(comparator), comparator, null)
+        };
+    }
+
     public class Validator : AbstractValidator<DataSetQueryCriteriaFilters>
     {
         public Validator()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFilters.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaFilters.cs
@@ -1,3 +1,5 @@
+using FluentValidation;
+
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
 /// <summary>
@@ -18,12 +20,12 @@ public record DataSetQueryCriteriaFilters
     /// <summary>
     /// Filter the results to have a filter option matching at least one of these IDs.
     /// </summary>
-    public IReadOnlyList<string>? In { get; init; }
+    public virtual IReadOnlyList<string>? In { get; init; }
 
     /// <summary>
     /// Filter the results to not have a filter option matching any of these IDs.
     /// </summary>
-    public IReadOnlyList<string>? NotIn { get; init; }
+    public virtual IReadOnlyList<string>? NotIn { get; init; }
 
     public HashSet<string> GetOptions()
     {
@@ -38,5 +40,41 @@ public record DataSetQueryCriteriaFilters
         return filters
             .OfType<string>()
             .ToHashSet();
+    }
+
+    public class Validator : AbstractValidator<DataSetQueryCriteriaFilters>
+    {
+        public Validator()
+        {
+            RuleFor(q => q.Eq)
+                .NotEmpty()
+                .MaximumLength(10)
+                .When(q => q.Eq is not null);
+
+            RuleFor(q => q.NotEq)
+                .NotEmpty()
+                .MaximumLength(10)
+                .When(q => q.NotEq is not null);
+
+            When(q => q.In is not null, () =>
+            {
+                RuleFor(q => q.In)
+                    .NotEmpty();
+
+                RuleForEach(q => q.In)
+                    .NotEmpty()
+                    .MaximumLength(10);
+            });
+
+            When(q => q.NotIn is not null, () =>
+            {
+                RuleFor(q => q.NotIn)
+                    .NotEmpty();
+
+                RuleForEach(q => q.NotIn)
+                    .NotEmpty()
+                    .MaximumLength(10);
+            });
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaGeographicLevels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaGeographicLevels.cs
@@ -1,6 +1,8 @@
-using System.Text.Json.Serialization;
+using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
@@ -12,51 +14,81 @@ public record DataSetQueryCriteriaGeographicLevels
     /// <summary>
     /// Filter the results to be in this geographic level.
     /// </summary>
+    [SwaggerEnum(typeof(GeographicLevel))]
     public string? Eq { get; init; }
 
     /// <summary>
     /// Filter the results to not be in this geographic level.
     /// </summary>
+    [SwaggerEnum(typeof(GeographicLevel))]
     public string? NotEq { get; init; }
 
     /// <summary>
     /// Filter the results to be in one of these geographic levels.
     /// </summary>
-    public IReadOnlyList<string>? In { get; init; }
+    [SwaggerEnum(typeof(GeographicLevel))]
+    public virtual IReadOnlyList<string>? In { get; init; }
 
     /// <summary>
     /// Filter the results to not be in one of these geographic levels.
     /// </summary>
-    public IReadOnlyList<string>? NotIn { get; init; }
+    [SwaggerEnum(typeof(GeographicLevel))]
+    public virtual IReadOnlyList<string>? NotIn { get; init; }
 
-    [JsonIgnore]
-    public GeographicLevel? ParsedEq
+    public GeographicLevel? ParsedEq()
         => Eq is not null ? EnumUtil.GetFromEnumValue<GeographicLevel>(Eq) : null;
 
-    [JsonIgnore]
-    public GeographicLevel? ParsedNotEq
+    public GeographicLevel? ParsedNotEq()
         => NotEq is not null ? EnumUtil.GetFromEnumValue<GeographicLevel>(NotEq) : null;
 
-    [JsonIgnore]
-    public IReadOnlyList<GeographicLevel>? ParsedIn
+    public IReadOnlyList<GeographicLevel>? ParsedIn()
         => In?.Select(EnumUtil.GetFromEnumValue<GeographicLevel>).ToList();
 
-    [JsonIgnore]
-    public IReadOnlyList<GeographicLevel>? ParsedNotIn
+    public IReadOnlyList<GeographicLevel>? ParsedNotIn()
         => NotIn?.Select(EnumUtil.GetFromEnumValue<GeographicLevel>).ToList();
 
     public HashSet<GeographicLevel> GetOptions()
     {
         List<GeographicLevel?> options =
         [
-            ParsedEq,
-            ParsedNotEq,
-            ..ParsedIn ?? [],
-            ..ParsedNotIn ?? []
+            ParsedEq(),
+            ParsedNotEq(),
+            ..ParsedIn() ?? [],
+            ..ParsedNotIn() ?? []
         ];
 
         return options
             .OfType<GeographicLevel>()
             .ToHashSet();
+    }
+
+    public class Validator : AbstractValidator<DataSetQueryCriteriaGeographicLevels>
+    {
+        public Validator()
+        {
+            RuleFor(q => q.Eq)
+                .AllowedValue(GeographicLevelUtils.OrderedCodes)
+                .When(q => q.Eq is not null);
+
+            RuleFor(q => q.NotEq)
+                .AllowedValue(GeographicLevelUtils.OrderedCodes)
+                .When(q => q.NotEq is not null);
+
+            When(q => q.In is not null, () =>
+            {
+                RuleFor(q => q.In)
+                    .NotEmpty();
+                RuleForEach(q => q.In)
+                    .AllowedValue(GeographicLevelUtils.OrderedCodes);
+            });
+
+            When(q => q.NotIn is not null, () =>
+            {
+                RuleFor(q => q.NotIn)
+                    .NotEmpty();
+                RuleForEach(q => q.NotIn)
+                    .AllowedValue(GeographicLevelUtils.OrderedCodes);
+            });
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaGeographicLevels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaGeographicLevels.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators;
@@ -60,6 +61,37 @@ public record DataSetQueryCriteriaGeographicLevels
         return options
             .OfType<GeographicLevel>()
             .ToHashSet();
+    }
+
+    public static DataSetQueryCriteriaGeographicLevels Create(
+        string comparator,
+        IList<GeographicLevel> geographicLevels)
+        => Create(comparator, geographicLevels.Select(l => l.GetEnumValue()).ToList());
+
+    public static DataSetQueryCriteriaGeographicLevels Create(
+        string comparator,
+        IList<string> geographicLevels)
+    {
+        return comparator switch
+        {
+            nameof(Eq) => new DataSetQueryCriteriaGeographicLevels
+            {
+                Eq = geographicLevels.Count > 0 ? geographicLevels[0] : null
+            },
+            nameof(NotEq) => new DataSetQueryCriteriaGeographicLevels
+            {
+                NotEq = geographicLevels.Count > 0 ? geographicLevels[0] : null
+            },
+            nameof(In) => new DataSetQueryCriteriaGeographicLevels
+            {
+                In = geographicLevels.ToList()
+            },
+            nameof(NotIn) => new DataSetQueryCriteriaGeographicLevels
+            {
+                NotIn = geographicLevels.ToList()
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(comparator), comparator, null)
+        };
     }
 
     public class Validator : AbstractValidator<DataSetQueryCriteriaGeographicLevels>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaLocations.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaLocations.cs
@@ -53,6 +53,32 @@ public record DataSetQueryCriteriaLocations
             .ToHashSet();
     }
 
+    public static DataSetQueryCriteriaLocations Create(
+        string comparator,
+        IList<DataSetQueryLocation> locations)
+    {
+        return comparator switch
+        {
+            nameof(Eq) => new DataSetQueryCriteriaLocations
+            {
+                Eq = locations.Count > 0 ? locations[0] : null
+            },
+            nameof(NotEq) => new DataSetQueryCriteriaLocations
+            {
+                NotEq = locations.Count > 0 ? locations[0] : null
+            },
+            nameof(In) => new DataSetQueryCriteriaLocations
+            {
+                In = locations.ToList()
+            },
+            nameof(NotIn) => new DataSetQueryCriteriaLocations
+            {
+                NotIn = locations.ToList()
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(comparator), comparator, null)
+        };
+    }
+
     public class Validator : AbstractValidator<DataSetQueryCriteriaLocations>
     {
         public Validator()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaLocations.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaLocations.cs
@@ -1,3 +1,6 @@
+using FluentValidation;
+using FluentValidation.Validators;
+
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
 /// <summary>
@@ -48,5 +51,47 @@ public record DataSetQueryCriteriaLocations
         return locations
             .OfType<DataSetQueryLocation>()
             .ToHashSet();
+    }
+
+    public class Validator : AbstractValidator<DataSetQueryCriteriaLocations>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Eq)
+                .SetInheritanceValidator(InheritanceValidator!)
+                .When(request => request.Eq is not null);
+
+            RuleFor(request => request.NotEq)
+                .SetInheritanceValidator(InheritanceValidator!)
+                .When(request => request.NotEq is not null);
+
+            When(q => q.In is not null, () =>
+            {
+                RuleFor(request => request.In)
+                    .NotEmpty();
+                RuleForEach(request => request.In)
+                    .SetInheritanceValidator(InheritanceValidator);
+            });
+
+            When(q => q.NotIn is not null, () =>
+            {
+                RuleFor(request => request.NotIn)
+                    .NotEmpty();
+                RuleForEach(request => request.NotIn)
+                    .SetInheritanceValidator(InheritanceValidator);
+            });
+        }
+
+        private static void InheritanceValidator(
+            PolymorphicValidator<DataSetQueryCriteriaLocations, DataSetQueryLocation> validator)
+        {
+            validator.Add(new DataSetQueryLocationId.Validator());
+            validator.Add(new DataSetQueryLocationCode.Validator());
+            validator.Add(new DataSetQueryLocationLocalAuthorityCode.Validator());
+            validator.Add(new DataSetQueryLocationLocalAuthorityOldCode.Validator());
+            validator.Add(new DataSetQueryLocationProviderUkprn.Validator());
+            validator.Add(new DataSetQueryLocationSchoolLaEstab.Validator());
+            validator.Add(new DataSetQueryLocationSchoolUrn.Validator());
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaNot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaNot.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// A condition criteria where its sub-criteria must resolve
+/// to *false* for the overall query to match any results.
+///
+/// This is equivalent to the `NOT` operator in SQL.
+/// </summary>
+public record DataSetQueryCriteriaNot : DataSetQueryCriteria
+{
+    /// <summary>
+    /// The sub-criteria which must resolve to false.
+    /// </summary>
+    public required DataSetQueryCriteria Not { get; init; }
+
+    public class Validator : AbstractValidator<DataSetQueryCriteriaNot>
+    {
+        public Validator()
+        {
+            RuleFor(q => q.Not)
+                .NotNull()
+                .SetInheritanceValidator(InheritanceValidator);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaOr.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaOr.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+/// <summary>
+/// A condition criteria where at least one sub-criteria must resolve
+/// to true for the overall query to match any results.
+///
+/// This is equivalent to the `OR` operator in SQL.
+/// </summary>
+public record DataSetQueryCriteriaOr : DataSetQueryCriteria
+{
+    /// <summary>
+    /// The sub-criteria where one must resolve to true.
+    /// </summary>
+    public required IReadOnlyList<DataSetQueryCriteria> Or { get; init; }
+
+    public class Validator : AbstractValidator<DataSetQueryCriteriaOr>
+    {
+        public Validator()
+        {
+            RuleFor(q => q.Or)
+                .NotEmpty();
+
+            RuleForEach(q => q.Or)
+                .NotNull()
+                .SetInheritanceValidator(InheritanceValidator);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaTimePeriods.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaTimePeriods.cs
@@ -1,3 +1,5 @@
+using FluentValidation;
+
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
 /// <summary>
@@ -66,5 +68,51 @@ public record DataSetQueryCriteriaTimePeriods
         return timePeriods
             .OfType<DataSetQueryTimePeriod>()
             .ToHashSet();
+    }
+
+    public class Validator : AbstractValidator<DataSetQueryCriteriaTimePeriods>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Eq)
+                .SetValidator(new DataSetQueryTimePeriod.Validator()!)
+                .When(request => request.Eq is not null);
+
+            RuleFor(request => request.NotEq)!
+                .SetValidator(new DataSetQueryTimePeriod.Validator()!)
+                .When(request => request.NotEq is not null);
+
+            When(q => q.In is not null, () =>
+            {
+                RuleFor(request => request.In)
+                    .NotEmpty();
+                RuleForEach(request => request.In)
+                    .SetValidator(new DataSetQueryTimePeriod.Validator());
+            });
+
+            When(q => q.NotIn is not null, () =>
+            {
+                RuleFor(request => request.NotIn)
+                    .NotEmpty();
+                RuleForEach(request => request.NotIn)
+                    .SetValidator(new DataSetQueryTimePeriod.Validator());
+            });
+
+            RuleFor(request => request.Gt)
+                .SetValidator(new DataSetQueryTimePeriod.Validator()!)
+                .When(request => request.Gt is not null);
+
+            RuleFor(request => request.Gte)
+                .SetValidator(new DataSetQueryTimePeriod.Validator()!)
+                .When(request => request.Gte is not null);
+
+            RuleFor(request => request.Lt)
+                .SetValidator(new DataSetQueryTimePeriod.Validator()!)
+                .When(request => request.Lt is not null);
+
+            RuleFor(request => request.Lte)
+                .SetValidator(new DataSetQueryTimePeriod.Validator()!)
+                .When(request => request.Lte is not null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaTimePeriods.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryCriteriaTimePeriods.cs
@@ -70,6 +70,48 @@ public record DataSetQueryCriteriaTimePeriods
             .ToHashSet();
     }
 
+    public static DataSetQueryCriteriaTimePeriods Create(
+        string comparator,
+        IList<DataSetQueryTimePeriod> timePeriods)
+    {
+        return comparator switch
+        {
+            nameof(Eq) => new DataSetQueryCriteriaTimePeriods
+            {
+                Eq = timePeriods.Count > 0 ? timePeriods[0] : null
+            },
+            nameof(NotEq) => new DataSetQueryCriteriaTimePeriods
+            {
+                NotEq = timePeriods.Count > 0 ? timePeriods[0] : null
+            },
+            nameof(In) => new DataSetQueryCriteriaTimePeriods
+            {
+                In = timePeriods.ToList()
+            },
+            nameof(NotIn) => new DataSetQueryCriteriaTimePeriods
+            {
+                NotIn = timePeriods.ToList()
+            },
+            nameof(Gt) => new DataSetQueryCriteriaTimePeriods
+            {
+                Gt = timePeriods.Count > 0 ? timePeriods[0] : null
+            },
+            nameof(Gte) => new DataSetQueryCriteriaTimePeriods
+            {
+                Gte = timePeriods.Count > 0 ? timePeriods[0] : null
+            },
+            nameof(Lt) => new DataSetQueryCriteriaTimePeriods
+            {
+                Lt = timePeriods.Count > 0 ? timePeriods[0] : null
+            },
+            nameof(Lte) => new DataSetQueryCriteriaTimePeriods
+            {
+                Lte = timePeriods.Count > 0 ? timePeriods[0] : null
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(comparator), comparator, null)
+        };
+    }
+
     public class Validator : AbstractValidator<DataSetQueryCriteriaTimePeriods>
     {
         public Validator()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryLocation.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryLocation.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
@@ -17,6 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 /// When using codes, you may get more results than expected so it's recommended
 /// to use IDs where possible to ensure only a single location is matched.
 /// </summary>
+[JsonConverter(typeof(DataSetQueryLocationJsonConverter))]
 public abstract record DataSetQueryLocation
 {
     /// <summary>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryRequest.cs
@@ -16,7 +16,7 @@ public record DataSetQueryRequest
     /// <summary>
     /// The IDs of indicators in the data set to return values for.
     /// </summary>
-    public required IReadOnlyList<string> Indicators { get; init; }
+    public IReadOnlyList<string> Indicators { get; init; } = [];
 
     /// <summary>
     /// The sorts to sort the results by. Sorts at the start of the

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/DataSetQueryRequest.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
 /// <summary>
@@ -22,4 +24,24 @@ public record DataSetQueryRequest
     /// By default, results are sorted by time period in descending order.
     /// </summary>
     public IReadOnlyList<DataSetQuerySort>? Sorts { get; init; }
+
+    /// <summary>
+    /// Enable debug mode. Results will be formatted with human-readable
+    /// labels to assist in identification.
+    ///
+    /// This **should not** be enabled in a production environment.
+    /// </summary>
+    public bool Debug { get; init; }
+
+    /// <summary>
+    /// The page of results to fetch.
+    /// </summary>
+    [DefaultValue(1)]
+    public int Page { get; init; } = 1;
+
+    /// <summary>
+    /// The maximum number of results per page.
+    /// </summary>
+    [DefaultValue(1000)]
+    public int PageSize { get; init; } = 1000;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetQueryParser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetQueryParser.cs
@@ -11,5 +11,6 @@ public interface IDataSetQueryParser
         DataSetQueryCriteria criteria,
         DataSetVersion dataSetVersion,
         QueryState queryState,
+        string basePath = "",
         CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetQueryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IDataSetQueryService.cs
@@ -12,4 +12,10 @@ public interface IDataSetQueryService
         DataSetGetQueryRequest request,
         string? dataSetVersion = null,
         CancellationToken cancellationToken = default);
+
+    Task<Either<ActionResult, DataSetQueryPaginatedResultsViewModel>> Query(
+        Guid dataSetId,
+        DataSetQueryRequest request,
+        string? dataSetVersion,
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/GeographicLevelFacetsParser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Query/GeographicLevelFacetsParser.cs
@@ -20,7 +20,7 @@ internal class GeographicLevelFacetsParser(
     {
         var fragments = new List<IInterpolatedSql>();
 
-        var parsedEq = facets.GeographicLevels?.ParsedEq;
+        var parsedEq = facets.GeographicLevels?.ParsedEq();
 
         if (parsedEq is not null)
         {
@@ -32,7 +32,7 @@ internal class GeographicLevelFacetsParser(
             );
         }
 
-        var parsedNotEq = facets.GeographicLevels?.ParsedNotEq;
+        var parsedNotEq = facets.GeographicLevels?.ParsedNotEq();
 
         if (parsedNotEq is not null)
         {
@@ -45,7 +45,7 @@ internal class GeographicLevelFacetsParser(
             );
         }
 
-        var parsedIn = facets.GeographicLevels?.ParsedIn;
+        var parsedIn = facets.GeographicLevels?.ParsedIn();
 
         if (parsedIn is not null && parsedIn.Count != 0)
         {
@@ -57,7 +57,7 @@ internal class GeographicLevelFacetsParser(
             );
         }
 
-        var parsedNotIn = facets.GeographicLevels?.ParsedNotIn;
+        var parsedNotIn = facets.GeographicLevels?.ParsedNotIn();
 
         if (parsedNotIn is not null && parsedNotIn.Count != 0)
         {


### PR DESCRIPTION
This PR adds the data set query POST endpoint (`/api/v1/data-sets/{dataSetId}/query`). This endpoint provides the ability to compose much more complex queries than the GET endpoint by allowing `and`, `or` and `not` conditions.

Most of the underlying functionality has already been established for the GET endpoint, so most of this PR is just extending this prior work. 

Where possible, we try and re-use as much as possible throughout the source and tests. This should be particularly apparent in the validators, where we have very similar (but different) models for the facet representations of each endpoint (e.g. strings in GET vs JSON objects in POST).

## Other changes

- Added manual opening and closing of DuckDB connections during a query to prevent Dapper opening and closing connections on every single query. The connection is now held open until the request completes.
- Refactored out various `Create` methods for query criteria facets. This is mostly used for tests where we want to be able to provide a string comparator (via theory data) to construct the criteria facets. 