### PR TITLE
EES-XXXX: Frontend housekeeping

### DIFF
--- a/src/explore-education-statistics-frontend/next.config.js
+++ b/src/explore-education-statistics-frontend/next.config.js
@@ -6,7 +6,6 @@ const path = require('path');
  */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: false,
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/src/explore-education-statistics-frontend/src/components/Page.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Page.tsx
@@ -2,14 +2,12 @@ import PhaseBanner from '@common/components/PhaseBanner';
 import CookieBanner from '@frontend/components/CookieBanner';
 import UserTestingBanner from '@frontend/components/UserTestingBanner';
 import classNames from 'classnames';
-import { useRouter } from 'next/router';
 import React, { ReactNode } from 'react';
 import Breadcrumbs, { BreadcrumbsProps } from './Breadcrumbs';
 import PageFooter from './PageFooter';
 import PageHeader from './PageHeader';
 import PageMeta, { PageMetaProps } from './PageMeta';
 import PageTitle from './PageTitle';
-import TemporaryNotice from './TemporaryNotice';
 
 type Props = {
   title: string;
@@ -37,8 +35,6 @@ const Page = ({
   isHomepage = false,
   breadcrumbs = [],
 }: Props) => {
-  const router = useRouter();
-
   return (
     <>
       <CookieBanner wide={wide} />
@@ -50,30 +46,6 @@ const Page = ({
       <PageHeader />
 
       <UserTestingBanner />
-
-      {router.asPath.includes(
-        'find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-outbreak',
-      ) && (
-        <TemporaryNotice
-          start={new Date('2020-12-01T09:30:00Z')}
-          end={new Date('2020-12-15T09:30:00Z')}
-          wide={wide}
-        >
-          <p>
-            1 December 2020: Further breakdowns to be provided within the
-            publication “Attendance in education and early years settings during
-            the coronavirus (COVID-19) outbreak” scheduled for 15 December and
-            subsequent releases
-          </p>
-
-          <p>
-            From 15 December we will include local authority breakdowns
-            including by pupil attendance and an update will be provided
-            half-termly. Additionally school workforce data will be published in
-            the new year.
-          </p>
-        </TemporaryNotice>
-      )}
 
       <div
         className={classNames('govuk-width-container', className, {

--- a/src/explore-education-statistics-frontend/src/components/__tests__/Breadcrumbs.test.tsx
+++ b/src/explore-education-statistics-frontend/src/components/__tests__/Breadcrumbs.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import Breadcrumbs from '../Breadcrumbs';
+import Breadcrumbs from '@frontend/components/Breadcrumbs';
 
 describe('Breadcrumbs', () => {
   test('renders correctly with just home breadcrumb', () => {

--- a/src/explore-education-statistics-frontend/src/components/__tests__/ButtonLink.test.tsx
+++ b/src/explore-education-statistics-frontend/src/components/__tests__/ButtonLink.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import ButtonLink from '../ButtonLink';
+import ButtonLink from '@frontend/components/ButtonLink';
 
 describe('ButtonLink', () => {
   test('renders correctly with required props', () => {

--- a/src/explore-education-statistics-frontend/src/components/__tests__/Link.test.tsx
+++ b/src/explore-education-statistics-frontend/src/components/__tests__/Link.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import Link from '../Link';
+import Link from '@frontend/components/Link';
 
 describe('Link', () => {
   test('renders correctly without `unvisited` state', () => {

--- a/src/explore-education-statistics-frontend/src/modules/ErrorPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/ErrorPage.tsx
@@ -4,7 +4,7 @@ import NotFoundPage from '@frontend/modules/NotFoundPage';
 import { AxiosError } from 'axios';
 import { NextPageContext } from 'next';
 import React, { useEffect } from 'react';
-import Page from '../components/Page';
+import Page from '@frontend/components/Page';
 
 interface Props {
   error?: NextPageContext['err'];

--- a/src/explore-education-statistics-frontend/src/pages/index.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import ButtonLink from '@frontend/components/ButtonLink';
+import Link from '@frontend/components/Link';
+import Page from '@frontend/components/Page';
 import React from 'react';
-import Link from '../components/Link';
-import Page from '../components/Page';
 
 function HomePage() {
   return (


### PR DESCRIPTION
Minor housekeeping in @frontend 

- Disabling SWC minification is no longer necessary, and generates a warning. This has been removed
- The Covid-era temporary notice on the home page has been removed. This also removes the dependency on `useRouter`. 
- Some relative imports in frontend have been replaced with package-relative ones